### PR TITLE
Initial stack project and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 .ghci
+
+### Nix ###
+result*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+# See https://raw.githubusercontent.com/commercialhaskell/stack/stable/doc/travis-simple.yml
+
+# Use small container and not VM:
+sudo: false
+
+# Choose a build environment:
+dist: xenial
+
+env:
+  global:
+    - EXECUTABLE=$HOME/.local/bin/cardano-wallet-server
+    - EXECUTABLE_CHECKSUM=$HOME/.local/bin/cardano-wallet-server.sha256
+
+# Do not choose a language; we provide our own build tools:
+language: generic
+
+# Caching so the next build will be fast too:
+cache:
+  directories:
+  - $HOME/.stack
+
+# Ensure necessary system libraries are present:
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
+before_install:
+# Download and unpack the stack executable:
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+install:
+- stack --no-terminal setup
+- stack --no-terminal build --only-dependencies
+- stack --no-terminal build --test --no-run-tests
+- stack --no-terminal test
+- curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+- curl -sSL https://raw.github.com/ndmitchell/weeder/master/misc/travis.sh | sh -s .
+- stack --no-terminal install
+- sha256sum $EXECUTABLE | head -c 64 > $EXECUTABLE_CHECKSUM
+- ls $EXECUTABLE
+- ls $EXECUTABLE_CHECKSUM
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_ACCESS_TOKEN
+  file:
+    - $EXECUTABLE
+    - $EXECUTABLE_CHECKSUM
+  on:
+    repo: input-output-hk/cardano-wallet
+    branch: master
+    tags: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2019 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to
+do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -1,0 +1,7 @@
+module Main where
+
+import Prelude
+import Cardano.Wallet (sayHello)
+
+main :: IO ()
+main = sayHello

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -1,0 +1,101 @@
+name:                cardano-wallet
+version:             2.0.0
+synopsis:            The Wallet Backend for a Cardano node.
+description:         Please see README.md
+homepage:            https://github.com/input-output-hk/cardano-wallet
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+license:             MIT
+license-file:        LICENSE
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -Wall
+      -Werror
+      -Wcompat
+      -fwarn-redundant-constraints
+
+  build-depends:
+      base
+
+    -- Hackage Dependencies
+    , aeson
+    , aeson-pretty
+    , base16-bytestring
+    , base58-bytestring
+    , bytestring
+    , cborg
+    , containers
+    , cryptonite
+    , deepseq
+    , digest
+    , generic-lens
+    , http-client
+    , memory
+    , microlens
+    , text
+    , time
+    , transformers
+
+    -- Other Project Dependencies
+    , cardano-crypto
+
+  hs-source-dirs:
+      src
+  exposed-modules:
+      Cardano.Wallet
+  other-modules:
+      Paths_cardano_wallet
+
+
+executable cardano-wallet-server
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+      -O2
+
+  build-depends:
+      base
+    , cardano-wallet
+
+  hs-source-dirs:
+      app/server
+  main-is:
+      Main.hs
+
+test-suite unit
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+      -Werror
+      -O2
+
+  build-depends:
+      base
+    , cardano-wallet
+  type:
+     exitcode-stdio-1.0
+  hs-source-dirs:
+      test/unit
+  main-is:
+      Main.hs

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ system ? builtins.currentSystem
+, crossSystem ? null
+, config ? {}
+
+# Import IOHK common nix lib
+, iohkLib ? import ./nix/iohk-common.nix
+# Pin nixpkgs to a revision on the nixos-19.03 channel
+, nixpkgs ? iohkLib.fetchNixpkgs ./nix/nixpkgs-src.json
+, pkgs ? import nixpkgs { inherit system crossSystem config; }
+
+# Keep this argument even if unused.
+# It will prevent Hydra from caching the evaluation.
+, gitrev ? iohkLib.commitIdFromGitRepo ./.
+}:
+
+{
+  inherit pkgs;
+}

--- a/nix/iohk-common.nix
+++ b/nix/iohk-common.nix
@@ -1,0 +1,15 @@
+# Imports the iohk-nix library.
+# The version can be overridden for debugging purposes by setting
+# NIX_PATH=iohk_nix=/path/to/iohk-nix
+
+import (
+  let try = builtins.tryEval <iohk_nix>;
+  in if try.success
+  then builtins.trace "using host <iohk_nix>" try.value
+  else
+    let
+      spec = builtins.fromJSON (builtins.readFile ./iohk-nix.json);
+    in builtins.fetchTarball {
+      url = "${spec.url}/archive/${spec.rev}.tar.gz";
+      inherit (spec) sha256;
+    }) {}

--- a/nix/iohk-nix.json
+++ b/nix/iohk-nix.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/input-output-hk/iohk-nix",
+  "rev": "f20ab3940d3ec5d5a3d92e1f0544f501316adc43",
+  "date": "2019-02-15T19:35:36+10:00",
+  "sha256": "07hla7d0l91is5m5mwa86vq51fdxkjvbjv7176ipdg1z59wy21bj",
+  "fetchSubmodules": false
+}

--- a/nix/nixpkgs-src.json
+++ b/nix/nixpkgs-src.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs",
+  "rev": "07e2b59812de95deeedde95fb6ba22d581d12fbc",
+  "date": "2019-02-26T15:31:33+01:00",
+  "sha256": "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf",
+  "fetchSubmodules": false
+}

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,0 +1,20 @@
+# This is the derivation used by "stack --nix".
+# It provides the system dependencies required for a stack build.
+{ system ? builtins.currentSystem
+, config ? {}
+, walletPackages ? import ./.. { inherit config system; }
+, pkgs ? walletPackages.pkgs
+}:
+with pkgs;
+
+haskell.lib.buildStackProject {
+  name = "cardano-wallet-stack-env";
+  ghc = haskell.compiler.ghc863;
+
+  buildInputs = [
+    zlib gmp ncurses lzma openssl git
+  ] ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
+
+  phases = ["nobuildPhase"];
+  nobuildPhase = "mkdir -p $out";
+}

--- a/src/Cardano/Wallet.hs
+++ b/src/Cardano/Wallet.hs
@@ -1,0 +1,8 @@
+module Cardano.Wallet
+  ( sayHello
+  ) where
+
+import Prelude
+
+sayHello :: IO ()
+sayHello = putStrLn "Hello, brave new world!"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,10 @@
+resolver: lts-13.8
+packages:
+- .
+
+extra-deps:
+- base58-bytestring-0.1.0
+- generic-lens-1.1.0.0
+
+- git: https://github.com/input-output-hk/cardano-crypto
+  commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,6 @@ extra-deps:
 
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a
+
+nix:
+  shell-file: nix/stack-shell.nix

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -1,0 +1,4 @@
+import Prelude
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"


### PR DESCRIPTION
# Issue Number

Relates to #1  and #4.

# Overview

- Added `stack.yaml` copied from prototype, with cardano-crypto as an extra-dep.
- Add stack/nix integration for automatic fetching of non-haskell build dependencies (similar to input-output-hk/cardano-wallet-legacy#338).
- Added a `.travis.yml` file based on https://github.com/jonathanknowles/haskell-travis-example
