### PR TITLE
Experiment: cmdargs for CLI parsing

### DIFF
--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -1,8 +1,43 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+
 module Main where
 
 import Cardano.Wallet
     ( sayHello )
+import Data.Data
 import Prelude
+import System.Console.CmdArgs
+
+data Network = Mainnet | Testnet
+    deriving (Data, Typeable, Show, Eq)
+
+-- | Record for storing CLI parameters.
+--
+-- Naming conventions according to
+-- https://hackage.haskell.org/package/cmdargs-0.4
+data WalletServer = WalletServer
+    { network
+        :: Network
+    , nodePort
+        :: Int
+    , walletServerPort
+        :: Int
+    } deriving (Show, Data, Typeable)
+
+walletServer :: WalletServer
+walletServer = WalletServer
+    { network = enum
+        [ Mainnet &= help "mainnet"
+        , Testnet &= help "testnet"
+        ]
+    , nodePort =
+         8080 &= help "port used for node-wallet communication"
+    , walletServerPort =
+         8090 &= help "port used for serving the wallet API"
+    } &= summary "Cardano Wallet vX.X.X"
+
 
 main :: IO ()
-main = sayHello
+main = do
+    sayHello
+    print =<< cmdArgs walletServer

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -18,7 +18,6 @@ library
       Haskell2010
   default-extensions:
       NoImplicitPrelude
-      OverloadedStrings
   ghc-options:
       -Wall
       -Werror
@@ -41,7 +40,6 @@ executable cardano-wallet-server
       Haskell2010
   default-extensions:
       NoImplicitPrelude
-      OverloadedStrings
   ghc-options:
       -threaded -rtsopts
       -Wall
@@ -50,6 +48,7 @@ executable cardano-wallet-server
   build-depends:
       base
     , cardano-wallet
+    , cmdargs
 
   hs-source-dirs:
       app/server
@@ -61,7 +60,6 @@ test-suite unit
       Haskell2010
   default-extensions:
       NoImplicitPrelude
-      OverloadedStrings
   ghc-options:
       -threaded -rtsopts
       -Wall


### PR DESCRIPTION
# Issue Number

#7

# Overview

- [x] I have tried out [cmdargs](http://hackage.haskell.org/package/cmdargs) for parsing command line arguments


# Comments

- Just an experiment, not polished
- Naming gets confusing, would work better in a `CLI` module
- Possibly a bit too advanced for our current usage

```bash
$ stack exec cardano-wallet-server --                                                                               
Hello, brave new world!
WalletServer {network = Mainnet, nodePort = 8080, walletServerPort = 8090}
$ stack exec cardano-wallet-server -- --help
Hello, brave new world!
Cardano Wallet vX.X.X

walletserver [OPTIONS]

Common flags:
  -m --mainnet               mainnet
  -t --testnet               testnet
  -n --nodeport=INT          port used for node-wallet communication
  -w --walletserverport=INT  port used for serving the wallet API
  -? --help                  Display help message
  -V --version               Print version information
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->