### PR TITLE
Docopt for CLI parsing

### DIFF
--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -1,6 +1,96 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+{-
+   This module parses command line arguments and starts the wallet.
+
+   This should be the only module that has a notion of command line arguments.
+   Although, for development purposes, we may extend the docopt specification
+   here and call `getArgs` where it is needed.
+-}
 module Main where
 
+import Control.Monad
+    ( when )
 import Prelude
+import System.Console.Docopt
+    ( Arguments
+    , Docopt
+    , Option
+    , docopt
+    , exitWithUsage
+    , getArgOrExitWith
+    , isPresent
+    , longOption
+    , parseArgsOrExit
+    )
+import System.Environment
+    ( getArgs )
+import Text.Read
+    ( readMaybe )
+
+
+-- | Command-Line Interface specification. See http://docopt.org/
+cli :: Docopt
+cli = [docopt|
+cardano-wallet-server
+
+Start the cardano wallet along with its API and underlying node.
+
+Usage:
+  cardano-wallet-server [options]
+  cardano-wallet-server --help
+
+Options:
+  --wallet-server-port <PORT>  port used for serving the wallet API [default: 8090]
+  --node-port <PORT>           port used for node-wallet communication [default: 8080]
+  --network <NETWORK>          mainnet or testnet [default: mainnet]
+|]
+
+
+data Network = Mainnet | Testnet
+    deriving (Show, Enum)
 
 main :: IO ()
-main = return ()
+main = do
+    args <- parseArgsOrExit cli =<< getArgs
+    when (args `isPresent` (longOption "help")) $ exitWithUsage cli
+
+    network <- getArg args (longOption "network") readNetwork
+    nodePort <- getArg args (longOption "node-port") readInt
+    walletPort <- getArg args (longOption "wallet-server-port") readInt
+
+    putStrLn $
+        "TODO: start wallet on port " ++ (show walletPort) ++
+        ",\n      connecting to " ++ (show network) ++
+        " node on port " ++ (show nodePort)
+
+
+-- Functions for parsing the values of command line options
+--
+-- As the Left cases will just be used for printing in this module, we use
+-- @String@ for now.
+
+readInt :: String -> Either String Int
+readInt str =
+    maybe (Left err) Right (readMaybe str)
+  where
+    err = "Not an integer: " ++ show str ++ "."
+
+readNetwork :: String -> Either String Network
+readNetwork "mainnet" = Right Mainnet
+readNetwork "testnet" = Right Testnet
+readNetwork s = Left $ show s ++ " is neither \"mainnet\" nor \"testnet\"."
+
+getArg
+    :: Arguments
+    -> Option
+    -> (String -> Either String a)
+    -> IO a
+getArg args opt decode = do
+    str <- getArgOrExitWith cli args opt
+    case decode str of
+        Right a -> return a
+        Left err -> do
+            putStrLn $ "Invalid " <> show opt <> ". " <> err
+            putStrLn ""
+            exitWithUsage cli

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -60,6 +60,7 @@ executable cardano-wallet-server
       -O2
   build-depends:
       base
+    , docopt
   hs-source-dirs:
       app/server
   main-is:

--- a/specifications/CLI.md
+++ b/specifications/CLI.md
@@ -1,0 +1,4 @@
+# Command line interface
+
+Cardano wallet uses [docopt](http://docopt.org) for defining its command line interface. The
+specification can be found at the top of [`app/server/Main.hs`](https://github.com/input-output-hk/cardano-wallet/blob/master/app/server/Main.hs).


### PR DESCRIPTION
# Issue Number

#7 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have tried out docopt for parsing command line arguments


# Comments

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

## Usage:

### All options have default values

```bash
$ stack build
$ stack exec cardano-wallet-server
TODO: start wallet on port 8090,
      connecting to Mainnet node on port 8080

$ stack exec cardano-wallet-server --
TODO: start wallet on port 8090,
      connecting to Mainnet node on port 8080

$ stack exec cardano-wallet-server -- --wallet-server-port 2
TODO: start wallet on port 2,
      connecting to Mainnet node on port 8080

$ stack exec cardano-wallet-server -- --network testnet
TODO: start wallet on port 8090,
      connecting to Testnet node on port 8080
```

### Help
```bash
$ stack exec cardano-wallet-server -- help
cardano-wallet-server

Start the cardano wallet along with its API and underlying node.

Usage:
  cardano-wallet-server [options]
  cardano-wallet-server --help

Options:
  --wallet-server-port <PORT>  port used for serving the wallet API [default: 8090]
  --node-port <PORT>           port used for node-wallet communication [default: 8080]
  --network <NETWORK>          mainnet or testnet [default: mainnet]
```

### Errors

```bash
$ stack exec cardano-wallet-server -- --network afs
Invalid LongOption "network". "afs" is neither "mainnet" nor "testnet".

cardano-wallet-server

Start the cardano wallet along with its API and underlying node.

Usage:
  cardano-wallet-server [options]
  cardano-wallet-server --help

Options:
  --wallet-server-port <PORT>  port used for serving the wallet API [default: 8090]
  --node-port <PORT>           port used for node-wallet communication [default: 8080]
  --network <NETWORK>          mainnet or testnet [default: mainnet]


$ stack exec cardano-wallet-server -- --wallet-server-port a
Invalid LongOption "wallet-server-port". Not an integer: "a".

cardano-wallet-server

Start the cardano wallet along with its API and underlying node.

Usage:
  cardano-wallet-server [options]
  cardano-wallet-server --help

Options:
  --wallet-server-port <PORT>  port used for serving the wallet API [default: 8090]
  --node-port <PORT>           port used for node-wallet communication [default: 8080]
  --network <NETWORK>          mainnet or testnet [default: mainnet]
```