### PR TITLE
Pack file decoder

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -102,5 +102,5 @@ test-suite unit
   other-modules:
       Cardano.Wallet.BinaryHelpers
     , Cardano.Wallet.BinarySpec
-    , Cardano.Wallet.PackfileSpec
+    , Cardano.Wallet.Binary.PackfileSpec
     , Cardano.Wallet.PrimitiveSpec

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -32,6 +32,9 @@ library
     ghc-options:         -Werror
   build-depends:
       base
+
+    -- Hackage Dependencies
+    , binary
     , bytestring
     , cborg
     , containers
@@ -43,6 +46,7 @@ library
   exposed-modules:
       Cardano.Wallet.Binary
     , Cardano.Wallet.Binary.Helpers
+    , Cardano.Wallet.Binary.Packfile
     , Cardano.Wallet.Primitive
   other-modules:
       Paths_cardano_wallet

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -102,4 +102,5 @@ test-suite unit
   other-modules:
       Cardano.Wallet.BinaryHelpers
     , Cardano.Wallet.BinarySpec
+    , Cardano.Wallet.PackfileSpec
     , Cardano.Wallet.PrimitiveSpec

--- a/src/Cardano/Wallet/Binary/Packfile.hs
+++ b/src/Cardano/Wallet/Binary/Packfile.hs
@@ -1,0 +1,89 @@
+-- | Decoder for the rust-cardano packfile format.
+--
+-- A pack file is a collection of bytestring blobs.
+--
+-- The reference implementation is in
+-- <https://github.com/input-output-hk/rust-cardano/blob/master/storage-units/src/packfile.rs packfile.rs>.
+
+module Cardano.Wallet.Binary.Packfile
+    ( decodePackfile
+    , PackfileError (..)
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( guard, when )
+import Data.Binary.Get
+    ( Get, getByteString, getInt32be, isEmpty, runGetOrFail )
+import Data.Int
+    ( Int32 )
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+
+-- | Things related to the file format that can go wrong when decoding a pack file.
+data PackfileError
+    = MissingMagicError
+    | WrongFileTypeError
+    | VersionTooOldError
+    | VersionTooNewError
+    | BlobDecodeError String
+    deriving (Show, Eq)
+
+-- | Decode a Cardano version 1 pack file. The blobs are returned as a
+-- list. Decoding is not incremental, and all data is stored in memory.
+decodePackfile :: BL.ByteString -> Either PackfileError [BS.ByteString]
+decodePackfile pf = case runGetOrFail getHeader pf of
+    Left _ -> Left MissingMagicError
+    Right (rest, _, hdr) -> case checkHeader hdr of
+        Left e -> Left e
+        Right () -> case runGetOrFail getBlobs rest of
+            Left (_, _, msg) -> Left (BlobDecodeError msg)
+            Right ("", _, res) -> Right res
+            Right (_, _, _) -> Left (BlobDecodeError "Unconsumed data")
+
+data Header = Header !BS.ByteString !Int
+
+getHeader :: Get Header
+getHeader = do
+    magic <- getByteString 8
+    guard (magic == "\254CARDANO")
+    fileType <- getByteString 4
+    version <- getInt32be
+    pure $! Header fileType (fromIntegral version)
+
+-- The current version of a rust-cardano packfile is 1, and we do not know how
+-- to decode any other version.
+checkHeader :: Header -> Either PackfileError ()
+checkHeader = checkHeader' "PACK" 1 1
+
+checkHeader' :: BS.ByteString -> Int -> Int -> Header -> Either PackfileError ()
+checkHeader' expFileType minVersion maxVersion (Header fileType version)
+    | fileType /= expFileType = Left WrongFileTypeError
+    | version < minVersion = Left VersionTooOldError
+    | version > maxVersion = Left VersionTooNewError
+    | otherwise = Right ()
+
+getBlobs :: Get [BS.ByteString]
+getBlobs = do
+    empty <- isEmpty
+    if empty
+        then pure []
+        else do
+            blob <- getBlob
+            blobs <- getBlobs
+            pure (blob:blobs)
+
+getBlob :: Get BS.ByteString
+getBlob = do
+    size <- getInt32be
+    when (size >= 20000000) $
+        -- limit blob size to 20MB to avoid consuming all memory
+        fail ("read block of size: " <> show size)
+    bytes <- getByteString (fromIntegral size)
+    _pad <- getByteString (npad size)
+    pure bytes
+    where
+        npad :: Int32 -> Int
+        npad n = -((fromIntegral n) `mod` (-4))

--- a/test/unit/Cardano/Wallet/Binary/PackfileSpec.hs
+++ b/test/unit/Cardano/Wallet/Binary/PackfileSpec.hs
@@ -1,16 +1,6 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-module Cardano.Wallet.PackfileSpec (spec) where
+module Cardano.Wallet.Binary.PackfileSpec (spec) where
 
 import Prelude
-
-import qualified Data.ByteString.Char8 as B8
-import qualified Data.ByteString.Lazy.Char8 as L8
-
-import Data.Either
-    ( fromRight, isRight )
-import Test.Hspec
-    ( Spec, describe, it, shouldBe, shouldSatisfy )
 
 import Cardano.Wallet.Binary
     ( decodeBlock )
@@ -20,6 +10,14 @@ import Cardano.Wallet.BinaryHelpers
     ( unsafeDeserialiseFromBytes )
 import Cardano.Wallet.Primitive
     ( Block (..), BlockHeader (..) )
+import Data.Either
+    ( fromRight, isRight )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe, shouldSatisfy )
+
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.ByteString.Lazy.Char8 as L8
+
 
 -- version 1 header
 packFileHeader :: L8.ByteString

--- a/test/unit/Cardano/Wallet/PackfileSpec.hs
+++ b/test/unit/Cardano/Wallet/PackfileSpec.hs
@@ -1,0 +1,58 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.PackfileSpec (spec) where
+
+import Prelude
+
+import qualified Data.ByteString.Lazy.Char8 as L8
+
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+
+import Cardano.Wallet.Binary.Packfile
+
+-- version 1 header
+packFileHeader :: L8.ByteString
+packFileHeader = "\254CARDANOPACK\NUL\NUL\NUL\SOH"
+
+testOneBlob :: L8.ByteString
+testOneBlob = packFileHeader <> "\0\0\0\5hello\0\0\0"
+
+testTwoBlobs :: L8.ByteString
+testTwoBlobs = packFileHeader
+        <> "\0\0\0\11first block\0"
+        <> "\0\0\0\12second block"
+
+spec :: Spec
+spec = do
+    describe "Decoding pack file" $ do
+        it "should not decode junk" $ do
+            let decoded = decodePackfile "junkjunkjunkjunk"
+            decoded `shouldBe` Left MissingMagicError
+
+        it "should ensure pack file type" $ do
+            let decoded = decodePackfile "\254CARDANOYOLO\NUL\NUL\NUL\SOH"
+            decoded `shouldBe` Left WrongFileTypeError
+
+        it "should ensure pack file version" $ do
+            let decoded = decodePackfile "\254CARDANOPACK\NUL\NUL\NUL\2"
+            decoded `shouldBe` Left VersionTooNewError
+
+        it "should decode an empty pack file" $ do
+            decodePackfile packFileHeader `shouldBe` Right []
+
+        it "should decode a single blob" $ do
+            decodePackfile testOneBlob `shouldBe` Right ["hello"]
+
+        it "should decode multiple blobs" $ do
+            decodePackfile testTwoBlobs `shouldBe`
+                Right ["first block", "second block"]
+
+        it "should not decode overly large blobs" $ do
+            let decoded = decodePackfile (packFileHeader <> "\64\0\0\0")
+            decoded `shouldBe`
+                Left (BlobDecodeError "read block of size: 1073741824")
+
+        it "should reject extra data" $ do
+            let decoded = decodePackfile (packFileHeader <> "a")
+            decoded `shouldBe` Left (BlobDecodeError "not enough bytes")

--- a/test/unit/Cardano/Wallet/PackfileSpec.hs
+++ b/test/unit/Cardano/Wallet/PackfileSpec.hs
@@ -4,12 +4,22 @@ module Cardano.Wallet.PackfileSpec (spec) where
 
 import Prelude
 
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy.Char8 as L8
 
+import Data.Either
+    ( fromRight, isRight )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe )
+    ( Spec, describe, it, shouldBe, shouldSatisfy )
 
+import Cardano.Wallet.Binary
+    ( decodeBlock )
 import Cardano.Wallet.Binary.Packfile
+    ( PackfileError (..), decodePackfile )
+import Cardano.Wallet.BinaryHelpers
+    ( unsafeDeserialiseFromBytes )
+import Cardano.Wallet.Primitive
+    ( Block (..), BlockHeader (..) )
 
 -- version 1 header
 packFileHeader :: L8.ByteString
@@ -22,6 +32,11 @@ testTwoBlobs :: L8.ByteString
 testTwoBlobs = packFileHeader
         <> "\0\0\0\11first block\0"
         <> "\0\0\0\12second block"
+
+-- Get this file from cardano-http-bridge with:
+-- wget -O test/data/epoch-mainnet-104 http://localhost:8080/mainnet/epoch/104
+testPackfile :: FilePath
+testPackfile = "test/data/epoch-mainnet-104"
 
 spec :: Spec
 spec = do
@@ -56,3 +71,33 @@ spec = do
         it "should reject extra data" $ do
             let decoded = decodePackfile (packFileHeader <> "a")
             decoded `shouldBe` Left (BlobDecodeError "not enough bytes")
+
+    describe "Decoding a mainnet pack file" $ do
+        it "should decode pack file for mainnet epoch 104" $ do
+            bs <- L8.readFile testPackfile
+            let decoded = decodePackfile bs
+            decoded `shouldSatisfy` isRight
+            length (fromRight [] decoded) `shouldBe` 21600
+
+        it "should decode the entire blocks" $ do
+            bs <- L8.readFile testPackfile
+            let Right (first:second:_) = decodePackfile bs
+            B8.length first `shouldBe` 648092
+            B8.length second `shouldBe` 1181
+
+        it "should decode correct blocks" $ do
+            bs <- L8.readFile testPackfile
+            let (ebb:first:second:_) = map header $ unsafeDeserialiseEpoch bs
+            epochIndex ebb `shouldBe` 104
+            epochIndex first `shouldBe` 104
+            slotNumber ebb `shouldBe` 0 -- epoch genesis block
+            slotNumber first `shouldBe` 0 -- first block
+            slotNumber second `shouldBe` 1 -- second block
+
+-- | Decode all blocks in a pack file, without error handling
+unsafeDeserialiseEpoch :: L8.ByteString -> [Block]
+unsafeDeserialiseEpoch = either giveUp decodeBlocks . decodePackfile
+    where
+        decodeBlocks = map decodeBlob
+        decodeBlob = unsafeDeserialiseFromBytes decodeBlock . L8.fromStrict
+        giveUp err = error ("Could not decode pack file: " <> show err)


### PR DESCRIPTION
Relates to #11.

This PR is based on top of the branch of #25, so that should be merged first.

## Overview

Adds a routine to get blocks out of the rust-cardano format pack file.
