### PR TITLE
Add nextBlocks function

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -42,8 +42,10 @@ library
     , digest
     , fmt
     , http-api-data
+    , http-client
     , http-media
     , memory
+    , mtl
     , servant
     , servant-client
     , text
@@ -52,14 +54,18 @@ library
   hs-source-dirs:
       src
   exposed-modules:
+      Cardano.ChainProducer
+      Cardano.ChainProducer.RustHttpBridge
       Cardano.ChainProducer.RustHttpBridge.Api
       Cardano.ChainProducer.RustHttpBridge.Client
-      Cardano.Wallet.BlockSyncer
-      Servant.Extra.ContentTypes
+      Cardano.ChainProducer.RustHttpBridge.NetworkLayer
       Cardano.Wallet
       Cardano.Wallet.Binary
       Cardano.Wallet.Binary.Packfile
+      Cardano.Wallet.BlockSyncer
       Cardano.Wallet.Primitive
+      Cardano.Wallet.Slotting
+      Servant.Extra.ContentTypes
   other-modules:
       Paths_cardano_wallet
 
@@ -102,8 +108,11 @@ test-suite unit
     , cborg
     , containers
     , deepseq
+    , exceptions
     , hspec
+    , hspec-expectations
     , memory
+    , mtl
     , QuickCheck
     , time-units
     , transformers
@@ -116,6 +125,10 @@ test-suite unit
   other-modules:
       Cardano.WalletSpec
       Cardano.Wallet.BinarySpec
+      Cardano.ChainProducer.RustHttpBridge.MockNetworkLayer
+      Cardano.ChainProducer.RustHttpBridgeSpec
       Cardano.Wallet.Binary.PackfileSpec
-      Cardano.Wallet.PrimitiveSpec
       Cardano.Wallet.BlockSyncerSpec
+      Cardano.Wallet.PrimitiveSpec
+      Cardano.Wallet.SlottingOrphans
+      Cardano.Wallet.SlottingSpec

--- a/src/Cardano/ChainProducer.hs
+++ b/src/Cardano/ChainProducer.hs
@@ -1,0 +1,32 @@
+module Cardano.ChainProducer
+    ( MonadChainProducer (..)
+    , ErrGetNextBlocks (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive
+    ( Block )
+import Cardano.Wallet.Slotting
+    ( SlotCount, SlotId )
+import Control.Exception
+    ( Exception )
+import Control.Monad.Except
+    ( ExceptT )
+
+class MonadChainProducer m where
+    -- | Get some blocks from the chain producer.
+    --
+    -- This may retrieve less than the requested number of blocks.
+    -- It might return no blocks at all.
+    nextBlocks
+        :: SlotCount -- ^ Number of blocks to retrieve
+        -> SlotId    -- ^ Starting point
+        -> ExceptT ErrGetNextBlocks m [Block]
+
+-- | The things that can go wrong when retrieving blocks.
+newtype ErrGetNextBlocks
+    = GetNextBlocksError String
+    deriving (Show, Eq)
+
+instance Exception ErrGetNextBlocks

--- a/src/Cardano/ChainProducer/RustHttpBridge.hs
+++ b/src/Cardano/ChainProducer/RustHttpBridge.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.ChainProducer.RustHttpBridge
+    ( RustBackend
+    , runRustBackend
+    ) where
+
+import Control.Monad.Except
+    ( ExceptT (..), mapExceptT, runExceptT )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
+import Control.Monad.Reader
+    ( MonadReader, ReaderT (..), ask, lift )
+import Data.Bifunctor
+    ( first )
+import Data.Maybe
+    ( fromMaybe )
+import Prelude
+
+import Cardano.ChainProducer
+    ( ErrGetNextBlocks (..), MonadChainProducer (..) )
+import Cardano.ChainProducer.RustHttpBridge.NetworkLayer
+    ( NetworkLayer (..), NetworkLayerError )
+import Cardano.Wallet.Primitive
+    ( Block (..), BlockHeader (..), Hash (..) )
+import Cardano.Wallet.Slotting
+    ( EpochIndex
+    , LocalSlotIndex (..)
+    , SlotCount
+    , SlotId (..)
+    , addSlots
+    , slotNext
+    , slotsPerEpoch
+    )
+
+newtype RustBackend a = RustBackend {
+    runRB :: ReaderT (NetworkLayer IO) IO a
+    } deriving (Monad, Applicative, Functor,
+                MonadReader (NetworkLayer IO), MonadIO)
+
+runRustBackend :: NetworkLayer IO -> RustBackend a -> IO a
+runRustBackend network action = runReaderT (runRB action) network
+
+getNetwork :: RustBackend (NetworkLayer IO)
+getNetwork = ask
+
+instance MonadChainProducer RustBackend where
+    nextBlocks = rbNextBlocks
+
+-- Note: This will be quite inefficient for at least two reasons.
+-- 1. If the number of blocks requested is small, it will fetch the same epoch
+--    pack file repeatedly.
+-- 2. Fetching the tip block and working backwards is not ideal.
+-- We will keep it for now, and it can be improved later.
+rbNextBlocks
+    :: SlotCount -- ^ Number of blocks to retrieve
+    -> SlotId    -- ^ Starting point
+    -> ExceptT ErrGetNextBlocks RustBackend [Block]
+rbNextBlocks numBlocks start = do
+    net <- lift getNetwork
+    (tipHash, tip) <- fmap headerSlot <$> runNetworkLayer (getNetworkTip net)
+    epochBlocks <- blocksFromPacks net tip
+    lastBlocks <- unstableBlocks net tipHash tip epochBlocks
+    pure (epochBlocks ++ lastBlocks)
+
+    where
+        end = addSlots numBlocks start
+
+        -- Grab blocks from epoch pack files
+        blocksFromPacks network tip = do
+            let epochs = epochRange numBlocks start tip
+            epochBlocks <- runNetworkLayer (getEpochs network epochs)
+            pure $ filter (blockIsBetween start end) (concat epochBlocks)
+
+        -- The next slot after the last block.
+        slotAfter [] = Nothing
+        slotAfter bs = Just . slotNext . headerSlot . header . last $ bs
+
+        -- Grab the remaining blocks which aren't packed in epoch files,
+        -- starting from the tip.
+        unstableBlocks network tipHash tip epochBlocks = do
+            let start' = fromMaybe start (slotAfter epochBlocks)
+
+            lastBlocks <- if end > start' && start' <= tip
+                then runNetworkLayer $ fetchBlocksFromTip network start' tipHash
+                else pure []
+
+            pure $ filter (blockIsBefore end) lastBlocks
+
+-- | Fetch epoch blocks until one fails.
+getEpochs
+    :: Monad m
+    => NetworkLayer m
+    -> [EpochIndex]
+    -> ExceptT NetworkLayerError m [[Block]]
+getEpochs network = mapUntilError (getEpoch network)
+
+-- Fetch blocks which are not in epoch pack files.
+fetchBlocksFromTip
+    :: Monad m
+    => NetworkLayer m
+    -> SlotId
+    -> Hash "BlockHeader"
+    -> ExceptT NetworkLayerError m [Block]
+fetchBlocksFromTip network start tipHash = reverse <$> workBackwards tipHash
+    where
+        workBackwards headerHash = do
+            block <- getBlock network headerHash
+            if blockIsAfter start block
+                then do
+                    blocks <- workBackwards $ prevBlockHash $ header block
+                    pure (block:blocks)
+                else pure [block]
+
+runNetworkLayer
+    :: ExceptT NetworkLayerError IO a
+    -> ExceptT ErrGetNextBlocks RustBackend a
+runNetworkLayer = mapExceptT (fmap handle . liftIO)
+    where
+        handle = first (GetNextBlocksError . show)
+
+-- * Utility functions for monadic loops
+
+-- | Apply an action to each element of a list, until an action fails, or there
+-- are no more elements. This is like mapM, except that it always succeeds and
+-- the resulting list might be smaller than the given list.
+mapUntilError
+    :: Monad m
+    => (a -> ExceptT e m b)
+       -- ^ Action to run
+    -> [a]
+       -- ^ Elements
+    -> ExceptT e m [b]
+       -- ^ Results
+mapUntilError action (x:xs) = ExceptT $ runExceptT (action x) >>= \case
+    Left _ -> pure $ Right []
+    Right r -> runExceptT $ do
+        rs <- mapUntilError action xs
+        pure (r:rs)
+mapUntilError _ [] = pure []
+
+-- * Slotting calculation utilities
+
+-- | Gets the slot from a block header.
+headerSlot :: BlockHeader -> SlotId
+headerSlot bh = SlotId
+    (epochIndex (bh :: BlockHeader)) (slotNumber (bh :: BlockHeader))
+
+-- | Calculates which epochs to fetch, given a number of slots, and the start
+-- point. It takes into account the latest block available, and that the most
+-- recent epoch is never available in a pack file.
+epochRange
+    :: SlotCount
+        -- ^ Number of slots
+    -> SlotId
+        -- ^ Start point
+    -> SlotId
+        -- ^ Latest block available
+    -> [EpochIndex]
+epochRange
+    numBlocks
+    (SlotId startEpoch (LocalSlotIndex startSlot)) (SlotId tipEpoch _)
+    = [startEpoch .. min (tipEpoch - 1) (startEpoch + fromIntegral numEpochs)]
+    where
+        numEpochs = (numBlocks + fromIntegral startSlot) `div` slotsPerEpoch
+
+-- | Predicate returns true iff the block is from the given slot or a later one.
+blockIsSameOrAfter :: SlotId -> Block -> Bool
+blockIsSameOrAfter s = (>= s) . headerSlot . header
+
+-- | Predicate returns true iff the block is after then given slot
+blockIsAfter :: SlotId -> Block -> Bool
+blockIsAfter s = (> s) . headerSlot . header
+
+-- | Predicate returns true iff the block is before the given slot.
+blockIsBefore :: SlotId -> Block -> Bool
+blockIsBefore s = (< s) . headerSlot . header
+
+-- | @blockIsBetween start end@ Returns true if the block is in within the
+-- interval @[start, end)@.
+blockIsBetween :: SlotId -> SlotId -> Block -> Bool
+blockIsBetween start end b = blockIsSameOrAfter start b && blockIsBefore end b

--- a/src/Cardano/ChainProducer/RustHttpBridge/Api.hs
+++ b/src/Cardano/ChainProducer/RustHttpBridge/Api.hs
@@ -7,7 +7,7 @@ module Cardano.ChainProducer.RustHttpBridge.Api
     , api
     , Block (..)
     , BlockHeader (..)
-    , EpochId (..)
+    , EpochIndex (..)
     , NetworkName (..)
     ) where
 
@@ -26,6 +26,7 @@ import Servant.Extra.ContentTypes
     ( CBOR, ComputeHash, FromCBOR (..), Hash, Packed, WithHash )
 
 import qualified Cardano.Wallet.Primitive as Primitive
+import qualified Cardano.Wallet.Slotting as Slotting
 
 api :: Proxy Api
 api = Proxy
@@ -46,7 +47,7 @@ type GetBlockByHash
 type GetEpochById
     =  Capture "networkName" NetworkName
     :> "epoch"
-    :> Capture "epochId" EpochId
+    :> Capture "epochId" EpochIndex
     :> Get '[Packed CBOR] [Block]
 
 -- | Retrieve the header of the latest known block.
@@ -75,12 +76,12 @@ instance FromCBOR BlockHeader where
 
 -- | Represents a unique epoch.
 --
-newtype EpochId = EpochId
-  { getEpochId :: Primitive.EpochId
+newtype EpochIndex = EpochIndex
+  { getEpochIndex :: Slotting.EpochIndex
   } deriving (Eq, Show)
 
-instance ToHttpApiData (EpochId) where
-    toUrlPiece = toUrlPiece . Primitive.getEpochId . getEpochId
+instance ToHttpApiData (EpochIndex) where
+    toUrlPiece = toUrlPiece . Slotting.getEpochIndex . getEpochIndex
 
 -- | Represents the name of a Cardano network.
 --
@@ -90,4 +91,3 @@ newtype NetworkName = NetworkName
 
 instance ToHttpApiData NetworkName where
     toUrlPiece = getNetworkName
-

--- a/src/Cardano/ChainProducer/RustHttpBridge/Client.hs
+++ b/src/Cardano/ChainProducer/RustHttpBridge/Client.hs
@@ -4,27 +4,42 @@
 
 -- | An API client for the Cardano HTTP Bridge.
 module Cardano.ChainProducer.RustHttpBridge.Client
-    ( getBlockByHash
-    , getEpochById
-    , getTipBlockHeader
+    ( mkNetworkLayer
     ) where
 
+import Prelude
+
 import Cardano.ChainProducer.RustHttpBridge.Api
-    ( Block, BlockHeader, EpochId, NetworkName, api )
+    ( Block, BlockHeader, EpochIndex, NetworkName, api )
+import Cardano.ChainProducer.RustHttpBridge.NetworkLayer
+    ( NetworkLayer (..), NetworkLayerError (..) )
+import Control.Monad.Except
+    ( ExceptT (..), throwError )
+import Crypto.Hash
+    ( HashAlgorithm, digestFromByteString )
 import Crypto.Hash.Algorithms
     ( Blake2b_256 )
+import Data.Bifunctor
+    ( first )
+import Data.ByteArray
+    ( convert )
+import Network.HTTP.Client
+    ( Manager )
 import Servant.API
     ( (:<|>) (..) )
 import Servant.Client
-    ( ClientM, client )
+    ( BaseUrl, ClientM, client, mkClientEnv, runClientM )
 import Servant.Extra.ContentTypes
-    ( Hash, WithHash )
+    ( Hash (..), WithHash (..) )
+
+import qualified Cardano.ChainProducer.RustHttpBridge.Api as Api
+import qualified Cardano.Wallet.Primitive as Primitive
 
 -- | Retrieve a block identified by the unique hash of its header.
 getBlockByHash :: NetworkName -> Hash Blake2b_256 BlockHeader -> ClientM Block
 
 -- | Retrieve all the blocks for the epoch identified by the given integer ID.
-getEpochById :: NetworkName -> EpochId -> ClientM [Block]
+getEpochById :: NetworkName -> EpochIndex -> ClientM [Block]
 
 -- | Retrieve the header of the latest known block.
 getTipBlockHeader :: NetworkName -> ClientM (WithHash Blake2b_256 BlockHeader)
@@ -34,3 +49,35 @@ getBlockByHash
     :<|> getTipBlockHeader
     = client api
 
+mkNetworkLayer :: Manager -> BaseUrl -> NetworkName -> NetworkLayer IO
+mkNetworkLayer mgr baseUrl network = NetworkLayer
+    { getBlock = \hash -> do
+            hash' <- hashToApi' hash
+            run (Api.getBlock <$> getBlockByHash network hash')
+    , getEpoch = \ep -> run (map Api.getBlock
+                             <$> getEpochById network (Api.EpochIndex ep))
+    , getNetworkTip = run (blockHeaderHash <$> getTipBlockHeader network)
+    }
+    where
+        run query = ExceptT $ (first convertError) <$> runClientM query env
+        env = mkClientEnv mgr baseUrl
+        convertError = NetworkLayerError . show
+
+blockHeaderHash
+    :: WithHash algorithm BlockHeader
+    -> (Primitive.Hash "BlockHeader", Primitive.BlockHeader)
+blockHeaderHash (WithHash h (Api.BlockHeader bh))
+    = (Primitive.Hash (convert h), bh)
+
+hashToApi :: HashAlgorithm a => Primitive.Hash h -> Maybe (Hash a b)
+hashToApi (Primitive.Hash h) = Hash <$> digestFromByteString h
+
+-- | Converts a Hash to the Digest type that the Api module requires.
+hashToApi'
+    :: (Monad m, HashAlgorithm algorithm)
+    => Primitive.Hash a
+    -> ExceptT NetworkLayerError m (Hash algorithm b)
+hashToApi' h = case hashToApi h of
+    Just h' -> pure h'
+    Nothing -> throwError
+        $ NetworkLayerError "hashToApi: Digest was of the wrong length"

--- a/src/Cardano/ChainProducer/RustHttpBridge/NetworkLayer.hs
+++ b/src/Cardano/ChainProducer/RustHttpBridge/NetworkLayer.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.ChainProducer.RustHttpBridge.NetworkLayer
+    ( NetworkLayer (..)
+    , NetworkLayerError(..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive
+    ( Block (..), BlockHeader (..), Hash (..) )
+import Cardano.Wallet.Slotting
+    ( EpochIndex )
+import Control.Exception
+    ( Exception (..) )
+import Control.Monad.Except
+    ( ExceptT )
+
+-- | Endpoints of the cardano-http-bridge API.
+data NetworkLayer m = NetworkLayer
+    { getBlock
+        :: Hash "BlockHeader" -> ExceptT NetworkLayerError m Block
+    , getEpoch
+        :: EpochIndex -> ExceptT NetworkLayerError m [Block]
+    , getNetworkTip
+        :: ExceptT NetworkLayerError m (Hash "BlockHeader", BlockHeader)
+    }
+
+newtype NetworkLayerError
+    = NetworkLayerError String
+    deriving (Show, Eq)
+
+instance Exception NetworkLayerError

--- a/src/Cardano/Wallet/Binary.hs
+++ b/src/Cardano/Wallet/Binary.hs
@@ -42,13 +42,13 @@ import Cardano.Wallet.Primitive
     , Block (..)
     , BlockHeader (..)
     , Coin (..)
-    , EpochId (..)
     , Hash (..)
-    , SlotId (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
     )
+import Cardano.Wallet.Slotting
+    ( EpochIndex (..), LocalSlotIndex (..) )
 import Control.Monad
     ( void )
 import Crypto.Hash
@@ -198,7 +198,7 @@ decodeGenesisBlockHeader = do
     -- number of `0`. In practices, when parsing a full epoch, we can discard
     -- the genesis block entirely and we won't bother about modelling this
     -- extra complexity at the type-level. That's a bit dodgy though.
-    return $ BlockHeader (EpochId epoch) (SlotId 0) previous
+    return $ BlockHeader (EpochIndex epoch) (LocalSlotIndex 0) previous
 
 decodeGenesisConsensusData :: CBOR.Decoder s Word64
 decodeGenesisConsensusData = do
@@ -253,7 +253,8 @@ decodeMainBlockHeader = do
     _ <- decodeMainProof
     (epoch, slot) <- decodeMainConsensusData
     _ <- decodeMainExtraData
-    return $ BlockHeader (EpochId epoch) (SlotId slot) previous
+    return $ BlockHeader (EpochIndex epoch)
+        (LocalSlotIndex slot) previous
 
 decodeMainConsensusData :: CBOR.Decoder s (Word64, Word16)
 decodeMainConsensusData = do

--- a/src/Cardano/Wallet/Primitive.hs
+++ b/src/Cardano/Wallet/Primitive.hs
@@ -24,12 +24,6 @@ module Cardano.Wallet.Primitive
       Block(..)
     , BlockHeader(..)
 
-    -- * Epoch
-    , EpochId (..)
-
-    -- * Slot
-    , SlotId (..)
-
     -- * Tx
     , Tx(..)
     , TxIn(..)
@@ -61,6 +55,8 @@ module Cardano.Wallet.Primitive
 
 import Prelude
 
+import Cardano.Wallet.Slotting
+    ( EpochIndex, LocalSlotIndex )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.ByteArray.Encoding
@@ -74,7 +70,7 @@ import Data.Map.Strict
 import Data.Set
     ( Set )
 import Data.Word
-    ( Word16, Word32, Word64 )
+    ( Word32, Word64 )
 import Fmt
     ( Buildable (..)
     , blockListF
@@ -94,18 +90,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 
--- * Epoch
-
-newtype EpochId = EpochId
-    { getEpochId :: Word64
-    } deriving (Eq, Generic, NFData, Num, Ord, Show)
-
--- * Slot
-
-newtype SlotId = SlotId
-    { getSlotId :: Word16
-    } deriving (Eq, Generic, NFData, Num, Ord, Show)
-
 -- * Block
 
 data Block = Block
@@ -119,9 +103,9 @@ instance NFData Block
 
 data BlockHeader = BlockHeader
     { epochIndex
-        :: !EpochId
+        :: !EpochIndex
     , slotNumber
-        :: !SlotId
+        :: !LocalSlotIndex
     , prevBlockHash
         :: !(Hash "BlockHeader")
     } deriving (Show, Eq, Ord, Generic)

--- a/src/Cardano/Wallet/Slotting.hs
+++ b/src/Cardano/Wallet/Slotting.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Cardano.Wallet.Slotting
+    ( SlotId (..)
+    , EpochIndex (..)
+    , LocalSlotIndex (..)
+    , SlotCount
+    , slotsPerEpoch
+    , addSlots
+    , slotDiff
+    , slotNext
+    , slotPrev
+    , isValidSlotId
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Word
+    ( Word16, Word64 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+-- | Denotes a chain epoch, which contains a certain number of slots.
+newtype EpochIndex = EpochIndex
+    { getEpochIndex :: Word64 }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving newtype (Num, Enum, NFData)
+
+-- | Denotes the slot number within an epoch.
+newtype LocalSlotIndex = LocalSlotIndex
+    { getLocalSlotIndex :: Word16 }
+    deriving stock (Show, Eq, Ord, Generic)
+    deriving newtype (Num, Enum, NFData)
+
+-- | A slot identifier is the combination of an epoch and slot.
+data SlotId = SlotId
+  { epochIndex :: !EpochIndex
+  , slotNumber :: !LocalSlotIndex
+  } deriving stock (Show, Eq, Ord, Generic)
+
+type SlotCount = Natural
+
+-- | Hard-coded for the time being
+slotsPerEpoch :: SlotCount
+slotsPerEpoch = 21600
+
+instance Bounded LocalSlotIndex where
+    minBound = LocalSlotIndex 0
+    maxBound = LocalSlotIndex (fromIntegral slotsPerEpoch - 1)
+
+-- | Add a number of slots to an (Epoch, LocalSlotIndex) pair, where the number
+-- of slots can be greater than one epoch.
+addSlots :: SlotCount -> SlotId -> SlotId
+addSlots n (SlotId (EpochIndex e) (LocalSlotIndex sl))
+    = SlotId (EpochIndex (e + fromIntegral e'))
+        (LocalSlotIndex (fromIntegral sl'))
+    where
+        e' = n' `div` slotsPerEpoch
+        sl' = n' `mod` slotsPerEpoch
+        n' = fromIntegral sl + n
+
+-- | @slotDiff a b@ is the number of slots by which @a@ is greater than @b@.
+slotDiff :: SlotId -> SlotId -> Integer
+slotDiff s1 s2 = flatten s1 - flatten s2
+    where flatten = fromIntegral . flattenSlotId
+
+-- | Convert SlotId into number of slots since genesis.
+flattenSlotId :: SlotId -> SlotCount
+flattenSlotId (SlotId (EpochIndex e) (LocalSlotIndex sl))
+    = fromIntegral e * slotsPerEpoch + fromIntegral sl
+
+-- | The slot after.
+slotNext :: SlotId -> SlotId
+slotNext = addSlots 1
+
+-- | The slot before, if there is one.
+slotPrev :: SlotId -> Maybe SlotId
+slotPrev (SlotId 0 0) = Nothing
+slotPrev (SlotId ep 0) = Just $ SlotId (ep - 1) (fromIntegral slotsPerEpoch - 1)
+slotPrev (SlotId ep sl) = Just $ SlotId ep (sl - 1)
+
+-- | Whether the epoch index and slot number are in range.
+isValidSlotId :: SlotId -> Bool
+isValidSlotId (SlotId ep (LocalSlotIndex sl)) = ep >= 0 && sl >= 0
+    && sl < fromIntegral slotsPerEpoch

--- a/test/unit/Cardano/ChainProducer/RustHttpBridge/MockNetworkLayer.hs
+++ b/test/unit/Cardano/ChainProducer/RustHttpBridge/MockNetworkLayer.hs
@@ -1,0 +1,74 @@
+module Cardano.ChainProducer.RustHttpBridge.MockNetworkLayer
+    ( mockNetworkLayer
+    ) where
+
+import Prelude
+
+import Control.Monad.Catch
+    ( MonadThrow (..) )
+import Control.Monad.Except
+    ( throwError )
+import qualified Data.ByteString.Char8 as B8
+
+import Cardano.ChainProducer.RustHttpBridge.NetworkLayer
+    ( NetworkLayer (..), NetworkLayerError (..) )
+import Cardano.Wallet.Primitive
+    ( Block (..), BlockHeader (..), Hash (..) )
+import Cardano.Wallet.Slotting
+    ( EpochIndex (..)
+    , LocalSlotIndex (..)
+    , SlotId (..)
+    , slotPrev
+    , slotsPerEpoch
+    )
+
+-- | Embed an epoch index and slot number into a hash.
+mockHash :: SlotId -> Hash a
+mockHash (SlotId (EpochIndex ep) (LocalSlotIndex sl))
+    = Hash $ B8.pack ("Hash " <> show ep <> "." <> show sl)
+
+-- | Extract the epoch index and slot number from a hash.
+unMockHash :: Hash a -> SlotId
+unMockHash (Hash h) = parse . map B8.unpack . B8.split '.' . B8.drop 5 $ h
+    where
+        parse [ep, sl] =
+            SlotId (EpochIndex (read ep)) (LocalSlotIndex (read sl))
+        parse _ = error $ "Could not read mock hash: " ++ B8.unpack h
+
+-- | Create a block header from its hash, assuming that the hash was created
+-- with 'mockHash'.
+mockHeaderFromHash :: Hash a -> BlockHeader
+mockHeaderFromHash h = BlockHeader ep sl prevHash
+    where
+        slotId@(SlotId ep sl) = unMockHash h
+        prevHash = maybe (Hash "?") mockHash (slotPrev slotId)
+
+-- | Generate an entire epoch's worth of mock blocks. There are no transactions
+-- generated.
+mockEpoch :: EpochIndex -> [Block]
+mockEpoch ep = [ Block (mockHeaderFromHash (mockHash sl)) mempty
+               | sl <- [ SlotId ep i | i <- epochs ] ]
+    where epochs = [ 0 .. fromIntegral (slotsPerEpoch - 1) ]
+
+-- | A network layer which returns mock blocks.
+mockNetworkLayer
+    :: MonadThrow m
+    => EpochIndex -- ^ make getEpoch fail for epochs after this
+    -> SlotId -- ^ the tip block
+    -> NetworkLayer m
+mockNetworkLayer firstUnstableEpoch tip = NetworkLayer
+    { getBlock = \hash -> do
+            -- putStrLn $ "mock getBlock " ++ show hash
+            pure $ Block (mockHeaderFromHash hash) mempty
+    , getEpoch = \ep -> do
+            -- putStrLn $ "mock getEpoch " ++ show ep
+            if ep < firstUnstableEpoch
+                then pure $ mockEpoch ep
+                else throwError $ NetworkLayerError
+                     $ "mock epoch " ++ show ep ++ " > firstUnstableEpoch "
+                     ++ show firstUnstableEpoch
+    , getNetworkTip = do
+            -- putStrLn $ "mock getNetworkTip"
+            let hash = mockHash tip
+            pure (hash, mockHeaderFromHash hash)
+    }

--- a/test/unit/Cardano/ChainProducer/RustHttpBridgeSpec.hs
+++ b/test/unit/Cardano/ChainProducer/RustHttpBridgeSpec.hs
@@ -1,0 +1,65 @@
+module Cardano.ChainProducer.RustHttpBridgeSpec (spec) where
+
+import Prelude
+
+import Control.Exception
+    ( Exception, throwIO )
+import Control.Monad
+    ( (<=<) )
+import Control.Monad.Except
+    ( ExceptT, runExceptT )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
+import Test.Hspec
+    ( Spec, SpecWith, beforeAll, describe, it, shouldBe, shouldSatisfy )
+
+import Cardano.ChainProducer
+    ( nextBlocks )
+import Cardano.ChainProducer.RustHttpBridge
+import Cardano.ChainProducer.RustHttpBridge.MockNetworkLayer
+    ( mockNetworkLayer )
+import Cardano.ChainProducer.RustHttpBridge.NetworkLayer
+    ( NetworkLayer )
+import Cardano.Wallet.Primitive
+    ( BlockHeader (..), header )
+import Cardano.Wallet.Slotting
+    ( SlotId (SlotId) )
+
+spec :: Spec
+spec = do
+    describe "Getting next blocks with a mock backend" $ do
+        beforeAll (pure $ mockNetworkLayer 105 (SlotId 106 1492)) $ do
+             getNextBlocksSpec
+
+getNextBlocksSpec :: SpecWith (NetworkLayer IO)
+getNextBlocksSpec = do
+    it "should get something from the latest epoch" $ \network -> do
+        blocks <- runBackend network $ nextBlocks 1000 (SlotId 106 1000)
+        -- the number of blocks between slots 1000 and 1492 inclusive
+        length blocks `shouldBe` 493
+        let hdrs = map header blocks
+        map slotNumber hdrs `shouldBe` [1000 .. 1492]
+        map epochIndex hdrs `shouldSatisfy` all (== 106)
+
+    it "should get something from an unstable epoch" $ \network -> do
+        blocks <- runBackend network $ nextBlocks 1000 (SlotId 105 17000)
+        length blocks `shouldBe` 1000
+
+    it "should get from old epochs" $ \network -> do
+        blocks <- runBackend network $ nextBlocks 1000 (SlotId 104 10000)
+        length blocks `shouldBe` 1000
+        map (epochIndex . header) blocks `shouldSatisfy` all (== 104)
+
+    it "should produce no blocks if start slot is after tip" $ \network -> do
+        blocks <- runBackend network $ nextBlocks 1000 (SlotId 107 0)
+        blocks `shouldBe` []
+
+    it "should work for zero blocks" $ \network -> do
+        blocks <- runBackend network $ nextBlocks 0 (SlotId 106 1000)
+        blocks `shouldBe` []
+
+unsafeRunExceptT :: (Exception e, MonadIO m) => ExceptT e m a -> m a
+unsafeRunExceptT = either (liftIO . throwIO) pure <=< runExceptT
+
+runBackend :: Exception e => NetworkLayer IO -> ExceptT e RustBackend a -> IO a
+runBackend network = runRustBackend network . unsafeRunExceptT

--- a/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
+++ b/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
@@ -14,7 +14,9 @@ import Prelude
 import Cardano.Wallet.BlockSyncer
     ( BlockHeadersConsumed (..), tickingFunction )
 import Cardano.Wallet.Primitive
-    ( Block (..), BlockHeader (..), EpochId (..), Hash (..), SlotId (..) )
+    ( Block (..), BlockHeader (..), Hash (..) )
+import Cardano.Wallet.Slotting
+    ( EpochIndex (..), LocalSlotIndex (..) )
 import Control.Concurrent
     ( forkIO, killThread )
 import Control.Concurrent.MVar
@@ -138,12 +140,11 @@ instance Arbitrary Blocks where
         blockHeaderHash =
             Hash . CBOR.toStrictByteString . encodeBlockHeader
           where
-            encodeBlockHeader (BlockHeader (EpochId epoch) (SlotId slot) prev) =
-                mempty
-                    <> CBOR.encodeListLen 3
-                    <> CBOR.encodeWord64 epoch
-                    <> CBOR.encodeWord16 slot
-                    <> CBOR.encodeBytes (getHash prev)
+            encodeBlockHeader (BlockHeader epoch slot prev) = mempty
+                <> CBOR.encodeListLen 3
+                <> CBOR.encodeWord64 (getEpochIndex epoch)
+                <> CBOR.encodeWord16 (getLocalSlotIndex slot)
+                <> CBOR.encodeBytes (getHash prev)
 
 
 -- | Construct arbitrary groups of elements from a given list.

--- a/test/unit/Cardano/Wallet/PrimitiveSpec.hs
+++ b/test/unit/Cardano/Wallet/PrimitiveSpec.hs
@@ -14,9 +14,7 @@ import Cardano.Wallet.Primitive
     , BlockHeader (..)
     , Coin (..)
     , Dom (..)
-    , EpochId (..)
     , Hash (..)
-    , SlotId (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
@@ -29,6 +27,8 @@ import Cardano.Wallet.Primitive
     , restrictedTo
     , updatePending
     )
+import Cardano.Wallet.SlottingOrphans
+    ()
 import Data.Set
     ( Set, (\\) )
 import Test.Hspec
@@ -241,12 +241,6 @@ instance Arbitrary Address where
 instance Arbitrary Coin where
     -- No Shrinking
     arbitrary = Coin <$> choose (0, 3)
-
-instance Arbitrary EpochId where
-    arbitrary = EpochId <$> arbitrary
-
-instance Arbitrary SlotId where
-    arbitrary = SlotId <$> arbitrary
 
 instance Arbitrary TxOut where
     -- No Shrinking

--- a/test/unit/Cardano/Wallet/SlottingOrphans.hs
+++ b/test/unit/Cardano/Wallet/SlottingOrphans.hs
@@ -1,0 +1,21 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.SlottingOrphans
+    where
+
+import Prelude
+
+import Test.QuickCheck
+    ( Arbitrary (..), choose )
+
+import Cardano.Wallet.Slotting
+    ( EpochIndex (..), LocalSlotIndex (..), SlotId (..), slotsPerEpoch )
+
+instance Arbitrary SlotId where
+    arbitrary = SlotId <$> arbitrary <*> arbitrary
+
+instance Arbitrary EpochIndex where
+    arbitrary = EpochIndex <$> arbitrary
+
+instance Arbitrary LocalSlotIndex where
+    arbitrary = LocalSlotIndex <$> choose (0, fromIntegral slotsPerEpoch - 1)

--- a/test/unit/Cardano/Wallet/SlottingSpec.hs
+++ b/test/unit/Cardano/Wallet/SlottingSpec.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.SlottingSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Slotting
+    ( SlotCount
+    , SlotId (..)
+    , addSlots
+    , isValidSlotId
+    , slotDiff
+    , slotNext
+    , slotPrev
+    , slotsPerEpoch
+    )
+import Cardano.Wallet.SlottingOrphans
+    ()
+
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, checkCoverage, choose, property, (==>) )
+
+spec :: Spec
+spec = do
+    describe "Generators are valid" $ do
+        it "Arbitrary SlotId" $ property isValidSlotId
+
+    describe "Basic slot arithmetic" $ do
+        it "slotNext . slotPrev = id"
+            (checkCoverage propNextSlotPrevSlot)
+
+        it "slotNext always increments the SlotId"
+            (checkCoverage propNextIncrements)
+
+        it "slotPrev decrements the SlotId"
+            (checkCoverage propPrevDecrements)
+
+        it "addSlots results in correct difference"
+            (checkCoverage propAddSlotsDiff)
+
+        it "addSlots 0 == id"
+            (checkCoverage propAddSlotsId)
+
+propNextSlotPrevSlot :: SlotId -> Property
+propNextSlotPrevSlot sl = property $ slotPrev (slotNext sl) == Just sl
+
+propNextIncrements :: SlotId -> Property
+propNextIncrements sl = property $ slotDiff (slotNext sl) sl == 1
+
+propPrevDecrements :: SlotId -> Property
+propPrevDecrements sl = property $
+    sl > SlotId 0 0 ==> (slotDiff sl <$> slotPrev sl) == Just 1
+
+instance Arbitrary SlotCount where
+    arbitrary
+        = fromIntegral <$> choose (0 :: Int, 4 * (fromIntegral slotsPerEpoch))
+
+propAddSlotsDiff :: (SlotCount, SlotId) -> Property
+propAddSlotsDiff (n, sl) = property $
+    slotDiff (addSlots n sl) sl == fromIntegral n
+
+propAddSlotsId :: SlotId -> Property
+propAddSlotsId sl = property $ addSlots 0 sl == sl


### PR DESCRIPTION
Relates to #12.

# Overview

The `nextBlocks` function is a member of the `MonadChainProducer` class.

The interface will need tweaking to work efficiently.

There is also a `NetworkLayer` type (copied from prototype) which the `RustCardano` backend uses.

Some slotting functions needed to be added to deal with fetching the correct range of blocks.
