### PR TITLE
Tweak Blocks Generator + Moar Tests + Better Coverage

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -100,7 +100,6 @@ test-suite unit
     , containers
     , hspec
     , memory
-    , hspec-expectations
     , QuickCheck
     , time-units
   type:

--- a/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
+++ b/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
@@ -32,9 +32,7 @@ import Data.Word
 import Test.Hspec
     ( Spec, describe, it, shouldReturn )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, checkCoverage, cover )
-import Test.QuickCheck.Gen
-    ( Gen, choose )
+    ( Arbitrary (..), Gen, Property, checkCoverage, choose, cover )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 

--- a/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
+++ b/test/unit/Cardano/Wallet/BlockSyncerSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.BlockSyncerSpec
     ( spec
@@ -26,10 +27,12 @@ import Data.Functor
     ( ($>) )
 import Data.Time.Units
     ( Millisecond, fromMicroseconds )
+import Data.Word
+    ( Word8 )
 import Test.Hspec
     ( Spec, describe, it, shouldReturn )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, property, withMaxSuccess )
+    ( Arbitrary (..), Property, checkCoverage, cover )
 import Test.QuickCheck.Gen
     ( Gen, choose )
 import Test.QuickCheck.Monadic
@@ -44,7 +47,7 @@ spec :: Spec
 spec = do
     describe "Block syncer downloads blocks properly" $ do
         it "Check ticking function when blocks are sent"
-            (withMaxSuccess 10 $ property tickingFunctionTest)
+            (checkCoverage tickingFunctionTest)
 
 
 {-------------------------------------------------------------------------------
@@ -55,7 +58,9 @@ tickingFunctionTest
     :: (TickingTime, Blocks)
     -> Property
 tickingFunctionTest (TickingTime tickTime, Blocks blocks) =
-    monadicIO $ liftIO $ do
+    cover 80 (sum (length <$> blocks) /= 0) "Non empty blocks" prop
+  where
+    prop = monadicIO $ liftIO $ do
         (readerChan, reader) <- mkReader
         (writerChan, writer) <- mkWriter blocks
         waitFor writerChan $
@@ -104,7 +109,7 @@ newtype TickingTime = TickingTime Millisecond
 instance Arbitrary TickingTime where
     -- No shrinking
     arbitrary = do
-        tickTime <- fromMicroseconds . (* 1000) <$> choose (50, 100)
+        tickTime <- fromMicroseconds . (* 1000) <$> choose (1, 3)
         return $ TickingTime tickTime
 
 
@@ -114,7 +119,7 @@ newtype Blocks = Blocks [[Block]]
 instance Arbitrary Blocks where
     -- No Shrinking
     arbitrary = do
-        n <- arbitrary
+        n <- fromIntegral . (`mod` 42) <$> arbitrary @Word8
         let h0 = BlockHeader 1 0 (Hash "initial block")
         let blocks = map snd $ take n $ iterate next
                 ( blockHeaderHash h0


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#3

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have increased the number of property being tested
- [ ] I have added coverage checks to our properties
- [ ] I have tweaked a bit the arbitrary generator to not generate empty lists that often

# Comments

<!-- Additional comments or screenshots to attach if any -->

By looking at the code coverage reports, I noticed that some parts of the code were left
untested, which was weird because they should be when looking at the property.
Yet, I noticed we use 'Int' (n <- arbitrary) as the number of blocks to generate. Int
is unsigned and therefore, doing 'take n' with n < 0 boils down to doing 'take 0'. As
a consequence, our generators was very often generating empty list of blocks, and, in
the remaining cases, didn't always generate sequences of blocks that would trigger
certain parts of the tickingFunction. That is now fixed, and coverage constraints has
been added to make sure of that:

```
  Block syncer downloads blocks properly
    Check ticking function when blocks are sent
      +++ OK, passed 200 tests (96.0% Non empty blocks).
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
