### PR TITLE
Add startBlockSyncer

### DIFF
--- a/app/server/Main.hs
+++ b/app/server/Main.hs
@@ -28,6 +28,10 @@ import System.Environment
 import Text.Read
     ( readMaybe )
 
+import Cardano.Wallet.BlockSyncer
+    ( startBlockSyncer )
+
+import qualified Data.Text as T
 
 -- | Command-Line Interface specification. See http://docopt.org/
 cli :: Docopt
@@ -64,6 +68,7 @@ main = do
         ",\n      connecting to " ++ (show network) ++
         " node on port " ++ (show nodePort)
 
+    startBlockSyncer (showNetwork network) nodePort
 
 -- Functions for parsing the values of command line options
 --
@@ -80,6 +85,9 @@ readNetwork :: String -> Either String Network
 readNetwork "mainnet" = Right Mainnet
 readNetwork "testnet" = Right Testnet
 readNetwork s = Left $ show s ++ " is neither \"mainnet\" nor \"testnet\"."
+
+showNetwork :: Network -> T.Text
+showNetwork = T.toLower . T.pack . show
 
 getArg
     :: Arguments

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -89,6 +89,7 @@ executable cardano-wallet-server
     , cardano-wallet
     , docopt
     , text
+    , fmt
   hs-source-dirs:
       app/server
   main-is:

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -86,7 +86,9 @@ executable cardano-wallet-server
       -O2
   build-depends:
       base
+    , cardano-wallet
     , docopt
+    , text
   hs-source-dirs:
       app/server
   main-is:

--- a/src/Cardano/NetworkLayer.hs
+++ b/src/Cardano/NetworkLayer.hs
@@ -8,11 +8,16 @@ import Cardano.Wallet.Primitive
     ( Block, BlockHeader (..), Hash (..), SlotId )
 import Control.Monad.Except
     ( ExceptT )
-import Data.Word
-    ( Word64 )
 
 
 data NetworkLayer m e0 e1 = NetworkLayer
-    { nextBlocks :: Word64 -> SlotId -> ExceptT e0 m [Block]
-    , networkTip :: ExceptT e1 m (Hash "BlockHeader", BlockHeader)
+    { nextBlocks :: SlotId -> ExceptT e0 m [Block]
+        -- ^ Gets some blocks from the node. It will not necessarily return all
+        -- the blocks that the node has, but will receive a reasonable-sized
+        -- chunk. It will never return blocks from before the given slot. It
+        -- may return an empty list if the node does not have any blocks from
+        -- after the starting slot.
+
+    , networkTip
+        :: ExceptT e1 m (Hash "BlockHeader", BlockHeader)
     }

--- a/src/Cardano/Wallet/BlockSyncer.hs
+++ b/src/Cardano/Wallet/BlockSyncer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -8,32 +9,30 @@
 -- This module contains the ticking function that is responsible for invoking
 -- block acquisition functionality and executing it in periodic fashion.
 --
--- Known limitations: the ticking function makes sure action is not executed on
--- already consumed block, but does not check and handle block gaps (aka
--- catching up).
+-- Known limitations:
+-- - Blocks are produced by the network layer. They are not expected to produce
+--   any duplicates and to rollback.
+--
+-- -
 
 module Cardano.Wallet.BlockSyncer
-  ( BlockHeadersConsumed(..)
-  , tickingFunction
-  , startBlockSyncer
+  ( tick
+  , listen
   ) where
 
 
 import Prelude
 
 import Cardano.NetworkLayer
-    ( nextBlocks )
-import Cardano.NetworkLayer.HttpBridge
-    ( newNetworkLayer )
+    ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive
     ( Block (..), BlockHeader (..), SlotId (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad.Except
     ( runExceptT )
-import qualified Data.List as L
-import Data.Text
-    ( Text )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
 import Data.Time.Units
     ( Millisecond, toMicroseconds )
 import Fmt
@@ -41,67 +40,45 @@ import Fmt
 import System.Exit
     ( die )
 
-data BlockHeadersConsumed st =
-    BlockHeadersConsumed [BlockHeader] st
-    deriving (Show, Eq)
 
-storingLimit :: Int
-storingLimit = 2160
-
-tickingFunction
-    :: forall st. (st -> IO (st, [Block]))
-    -- ^ a way to get a new block
-    -> (Block -> IO ())
-    -- ^ action taken on a new block
+-- | Every interval @delay@, fetches some data from a given source, and call
+-- an action for each elements retrieved.
+tick
+    :: forall st m b. (MonadIO m)
+    => (st -> m ([b], st))
+    -- ^ A way to get a new elements
+    -> (b -> m ())
+    -- ^ Action to be taken on new elements
     -> Millisecond
     -- ^ tick time
-    -> BlockHeadersConsumed st
+    -> st
+    -> m ()
+tick next action delay !st = do
+    (bs, !st') <- next st
+    mapM_ action bs
+    liftIO $ threadDelay $ (fromIntegral . toMicroseconds) delay
+    tick next action delay st'
+
+-- | Retrieve blocks from a chain producer and execute some given action for
+-- each block.
+listen
+    :: forall e0 e1. (Show e0)
+    => NetworkLayer IO e0 e1
+    -> (Block -> IO ())
     -> IO ()
-tickingFunction getNextBlocks action tickTime = go
-    where
-      go :: BlockHeadersConsumed st -> IO ()
-      go (BlockHeadersConsumed headersConsumed st) = do
-          (st', blocksDownloaded) <- getNextBlocks st
-          let blocksToProcess = filter
-                  (checkIfAlreadyConsumed headersConsumed)
-                  (L.nub blocksDownloaded)
-          mapM_ action blocksToProcess
-          threadDelay $ (fromIntegral . toMicroseconds) tickTime
-          let headersConsumed' = take storingLimit
-                  $ map header blocksToProcess ++ headersConsumed
-          go $ BlockHeadersConsumed headersConsumed' st'
-
-      checkIfAlreadyConsumed
-          :: [BlockHeader]
-          -> Block
-          -> Bool
-      checkIfAlreadyConsumed consumedHeaders (Block theHeader _) =
-          theHeader `L.notElem` consumedHeaders
-
--- | Start the chain producer process, consuming blocks by printing their slot.
-startBlockSyncer :: Text -> Int -> IO ()
-startBlockSyncer networkName port = do
-    network <- newNetworkLayer networkName port
-
-    let interval = 20000 :: Millisecond
-
-        produceBlocks :: SlotId -> IO (SlotId, [Block])
-        produceBlocks start = do
-            res <- runExceptT $ nextBlocks network start
-            case res of
-                Left err -> die $ fmt $ "Chain producer error: "+||err||+""
-                Right [] -> pure (start, [])
-                Right blocks ->
-                    -- fixme: there are more blocks available, so we need not
-                    -- wait for an interval to pass before getting more blocks.
-                    let start' = succ . slotId . header . last $ blocks
-                    in pure (start', blocks)
-
-        logBlock :: Block -> IO ()
-        logBlock block = putStrLn msg
-            where
-                msg = fmt $ "Received block "+||slotId h||+""
-                h = header block
-
-    tickingFunction produceBlocks logBlock interval $
-        BlockHeadersConsumed [] (SlotId 0 0)
+listen network action = do
+    tick getNextBlocks action 5000 (SlotId 0 0)
+  where
+    getNextBlocks :: SlotId -> IO ([Block], SlotId)
+    getNextBlocks current = do
+        res <- runExceptT $ nextBlocks network current
+        case res of
+            Left err ->
+                die $ fmt $ "Chain producer error: "+||err||+""
+            Right [] ->
+                pure ([], current)
+            Right blocks ->
+                -- fixme: there are more blocks available, so we need not
+                -- wait for an interval to pass before getting more blocks.
+                let next = succ . slotId . header . last $ blocks
+                in pure (blocks, next)

--- a/src/Cardano/Wallet/Primitive.hs
+++ b/src/Cardano/Wallet/Primitive.hs
@@ -55,9 +55,6 @@ module Cardano.Wallet.Primitive
     , slotsPerEpoch
     , slotDiff
     , slotIncr
-    , blockIsAfter
-    , blockIsBefore
-    , blockIsBetween
 
     -- * Polymorphic
     , Hash (..)
@@ -334,23 +331,6 @@ slotDiff s1 s2 = fromIntegral (fromEnum s1 - fromEnum s2)
 isValidSlotId :: SlotId -> Bool
 isValidSlotId (SlotId e s) =
     e >= 0 && s >= 0 && s < fromIntegral slotsPerEpoch
-
--- | Predicate returns true iff the block is from the given slot or a later one.
-blockIsSameOrAfter :: SlotId -> Block -> Bool
-blockIsSameOrAfter s = (>= s) . slotId . header
-
--- | Predicate returns true iff the block is after then given slot
-blockIsAfter :: SlotId -> Block -> Bool
-blockIsAfter s = (> s) . slotId . header
-
--- | Predicate returns true iff the block is before the given slot.
-blockIsBefore :: SlotId -> Block -> Bool
-blockIsBefore s = (< s) . slotId . header
-
--- | @blockIsBetween start end@ Returns true if the block is in within the
--- interval @[start, end)@.
-blockIsBetween :: SlotId -> SlotId -> Block -> Bool
-blockIsBetween start end b = blockIsSameOrAfter start b && blockIsBefore end b
 
 
 -- * Polymorphic

--- a/test/unit/Cardano/WalletSpec.hs
+++ b/test/unit/Cardano/WalletSpec.hs
@@ -76,6 +76,7 @@ spec = do
         let block = blockchain !! 1
         let utxo = utxoFromTx $ head $ Set.toList $ transactions block
         it (show $ ShowFmt utxo) True
+        it (show $ ShowFmt block) True
 
     describe "Compare Wallet impl. with Specification" $ do
         it "Lemma 3.2 - dom u ⋪ updateUTxO b u = new b"


### PR DESCRIPTION
Relates to #52.

# Overview

This combines `BlockSyncer.tickingFunction` and `ChainProducer.getNextBlocks` into a process that retrieves blocks from `cardano-http-bridge`.

# Comments

It's pretty clear after looking at this feature "as a whole" that we must rework the code to address a few issues:
- [x] `nextBlocks` should return more than the requested number of blocks if that makes sense (for example, returning the entire contents of an epoch pack file, or returning all the blocks from unstable epochs).
- [x] Error handling should be fixed. One possibility is to remove `ExceptT ErrGetNextBlocks` and use `throwIO` to throw the `Servant.Client.Core.ClientError` (or whatever exception), and let the exception bubble up. (Because there's no way to recover from these errors). ⇒ fixed in #63
- [x] Where should the state be kept? The state being the slot where the block syncer is up to (can be less than the network tip). ⇒ Modified `tickingFunction`

The following can go in a later PR:
- How to initially catch up to the network tip, while still consuming blocks in small batches.
- The `BlockHeadersConsumed` is unnecessary because `nextBlocks` never returns blocks before the start slot given to it.
