### PR TITLE
Simplify NetworkLayer

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -52,6 +52,7 @@ library
     , mtl
     , servant
     , servant-client
+    , servant-client-core
     , text
     , time-units
     , transformers

--- a/src/Cardano/NetworkLayer.hs
+++ b/src/Cardano/NetworkLayer.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 
-module Cardano.NetworkLayer where
+module Cardano.NetworkLayer
+    ( NetworkLayer (..)
+    ) where
 
 import Cardano.Wallet.Primitive
     ( Block, BlockHeader (..), Hash (..), SlotId )


### PR DESCRIPTION
Relates to #12 

# Overview

This carries on with the simplifications from #60.
- it removes `ReaderT` in favour of passing the `HttpBridge` as a function argument.
- it adds a `newNetworkLayer` function
- it squashes the details from `ServantError` into `HttpBridgeError`
