### PR TITLE
Add cardano-http-bridge to environment of stack --nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,4 +15,6 @@
 
 {
   inherit pkgs;
+
+  cardano-http-bridge = import ./nix/cardano-http-bridge.nix { inherit pkgs; };
 }

--- a/nix/cardano-http-bridge.nix
+++ b/nix/cardano-http-bridge.nix
@@ -1,0 +1,23 @@
+{ nixpkgs ? fetchTarball channel:nixos-19.03
+, pkgs ? import nixpkgs {}
+}:
+
+with pkgs;
+
+rustPlatform.buildRustPackage {
+  name = "cardano-http-bridge";
+
+  src = fetchFromGitHub {
+    owner = "input-output-hk";
+    repo = "cardano-http-bridge";
+    fetchSubmodules = true;
+    rev = "b81c805e0fe62e6b8eacdc11fee573fa5668cbc8";
+    sha256 = "0vkg1hgcg9xqwzi9a1rap12sgyvc7ppnf89rqlf8pgsz3akzr4qd";
+  };
+
+  buildInputs = [ sqlite protobuf rustfmt ];
+
+  PROTOC = "${protobuf}/bin/protoc";
+
+  cargoSha256 = "19g5fy8af65vd9rl66058c67nlrz7r6mjd0cy83865d7q81hdl8r";
+}

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -13,6 +13,7 @@ haskell.lib.buildStackProject {
 
   buildInputs = [
     zlib gmp ncurses lzma openssl git
+    walletPackages.cardano-http-bridge
   ] ++ (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
 
   phases = ["nobuildPhase"];


### PR DESCRIPTION
Relates to #5

# Overview

This change means that if you run `stack --nix ghci` or `stack --nix test` it will have `cardano-http-bridge` in the `PATH`. If you run `stack` without `--nix` then nothing changes, and you need to get/build/install it yourself.
