### PR TITLE
launcher: When terminated, ensure child processes are cleaned up

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -10,3 +10,18 @@
     - message:
       - name: Module reused between components
       - module: Cardano.Launcher
+  - section:
+    - name: exe:cardano-wallet-launcher test:unit
+    - message:
+      - name: Module reused between components
+      - module: Cardano.Launcher.POSIX
+  - section:
+    - name: exe:cardano-wallet-launcher
+    - message:
+      - name: Module not compiled
+      - module: Cardano.Launcher.Windows
+  - section:
+    - name: test:unit
+    - message:
+      - name: Module not compiled
+      - module: Cardano.Launcher.Windows

--- a/app/Cardano/Launcher.hs
+++ b/app/Cardano/Launcher.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
@@ -10,6 +12,7 @@ module Cardano.Launcher
     ( Command (..)
     , ProcessHasExited(..)
     , launch
+    , installSignalHandlers
     ) where
 
 import Prelude
@@ -27,6 +30,13 @@ import System.Exit
 import System.Process
     ( proc, waitForProcess, withCreateProcess )
 
+#ifdef mingw32_HOST_OS
+import Cardano.Launcher.Windows
+    ( installSignalHandlers )
+#else
+import Cardano.Launcher.POSIX
+    ( installSignalHandlers )
+#endif
 
 data Command = Command
     { cmdName :: String
@@ -73,6 +83,6 @@ launch cmds = do
             throwIO $ ProcessHasExited name code
     case res of
         Left e -> return e
-        Right _ -> error
-            "Unreachable. Supervising threads should never finish. \
-            \They should stay running or throw @ProcessHasExited@."
+        Right _ -> error $
+            "Unreachable. Supervising threads should never finish. " <>
+            "They should stay running or throw @ProcessHasExited@."

--- a/app/Cardano/Launcher/POSIX.hs
+++ b/app/Cardano/Launcher/POSIX.hs
@@ -1,0 +1,33 @@
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+-- Portability: POSIX
+--
+
+module Cardano.Launcher.POSIX
+    ( installSignalHandlers
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( void )
+import Say
+    ( sayErr )
+import System.Posix.Signals
+    ( Handler (..)
+    , installHandler
+    , keyboardSignal
+    , raiseSignal
+    , softwareTermination
+    )
+
+-- | Convert any SIGTERM received to SIGINT, for which the runtime system has
+-- handlers that will correctly clean up sub-processes.
+installSignalHandlers :: IO ()
+installSignalHandlers = void $
+    installHandler softwareTermination termHandler Nothing
+    where
+        termHandler = CatchOnce $ do
+            sayErr "Terminated by signal."
+            raiseSignal keyboardSignal

--- a/app/Cardano/Launcher/Windows.hs
+++ b/app/Cardano/Launcher/Windows.hs
@@ -1,0 +1,15 @@
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+-- Portability: Windows
+--
+
+module Cardano.Launcher.Windows
+    ( installSignalHandlers
+    ) where
+
+import Prelude
+
+-- | Stub function for windows.
+installSignalHandlers :: IO ()
+installSignalHandlers = pure ()

--- a/app/launcher/Main.hs
+++ b/app/launcher/Main.hs
@@ -8,7 +8,11 @@ import Prelude
 import Cardano.CLI
     ( Network, Port, decode, encode, getArg )
 import Cardano.Launcher
-    ( Command (Command), ProcessHasExited (ProcessHasExited), launch )
+    ( Command (Command)
+    , ProcessHasExited (ProcessHasExited)
+    , installSignalHandlers
+    , launch
+    )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad
@@ -59,6 +63,7 @@ main = do
     network <- getArg args cli (longOption "network") decode
 
     sayErr "Starting..."
+    installSignalHandlers
     let commands =
             [ nodeHttpBridgeOn bridgePort
             , walletOn walletPort bridgePort network

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -130,6 +130,12 @@ test-suite unit
       Cardano.Wallet.MnemonicSpec
       Cardano.Wallet.PrimitiveSpec
       Cardano.WalletSpec
+  if os(windows)
+    build-depends: Win32
+    other-modules: Cardano.Launcher.Windows
+  else
+    build-depends: unix, say
+    other-modules: Cardano.Launcher.POSIX
 
 
 executable cardano-wallet-server
@@ -183,6 +189,13 @@ executable cardano-wallet-launcher
   other-modules:
       Cardano.CLI
       Cardano.Launcher
+  if os(windows)
+    build-depends: Win32
+    other-modules: Cardano.Launcher.Windows
+  else
+    build-depends: unix
+    other-modules: Cardano.Launcher.POSIX
+
   main-is:
      Main.hs
 


### PR DESCRIPTION
Relates to #8.

# Overview

The child process(es) were cleaned up in the event of Ctrl-C (SIGINT), but not when the launcher was killed by the `kill` command (SIGTERM).
