### PR TITLE
Replace usage of 'mtl' with 'transformers'

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -49,7 +49,6 @@ library
     , http-client
     , http-media
     , memory
-    , mtl
     , say
     , servant
     , servant-client
@@ -105,7 +104,6 @@ test-suite unit
     , fmt
     , hspec
     , memory
-    , mtl
     , process
     , QuickCheck
     , text

--- a/src/Cardano/NetworkLayer.hs
+++ b/src/Cardano/NetworkLayer.hs
@@ -17,10 +17,10 @@ import Cardano.Wallet.Primitive
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Concurrent
     ( threadDelay )
-import Control.Monad.Except
-    ( ExceptT, runExceptT )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.Trans.Except
+    ( ExceptT, runExceptT )
 import Data.Time.Units
     ( Millisecond, toMicroseconds )
 import Fmt

--- a/src/Cardano/NetworkLayer/HttpBridge.hs
+++ b/src/Cardano/NetworkLayer/HttpBridge.hs
@@ -29,8 +29,10 @@ import Cardano.Wallet.Primitive
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Exception
     ( Exception (..) )
-import Control.Monad.Except
-    ( ExceptT (..), lift, runExceptT, throwError )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), runExceptT, throwE )
 import Crypto.Hash
     ( HashAlgorithm, digestFromByteString )
 import Crypto.Hash.Algorithms
@@ -240,7 +242,7 @@ hashToApi'
     -> ExceptT HttpBridgeError m (Api.Hash algorithm b)
 hashToApi' h = case hashToApi h of
     Just h' -> pure h'
-    Nothing -> throwError
+    Nothing -> throwE
         $ BadResponseFromNode "hashToApi: Digest was of the wrong length"
 
 -- | Creates a cardano-http-bridge API with the given connection settings.

--- a/test/unit/Cardano/NetworkLayer/HttpBridgeSpec.hs
+++ b/test/unit/Cardano/NetworkLayer/HttpBridgeSpec.hs
@@ -11,8 +11,10 @@ import Cardano.Wallet.Primitive
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..), slotsPerEpoch )
 import Control.Monad.Catch
     ( MonadThrow (..) )
-import Control.Monad.Except
-    ( lift, runExceptT, throwError )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.Except
+    ( runExceptT, throwE )
 import Data.Word
     ( Word64 )
 import Test.Hspec
@@ -131,7 +133,7 @@ mockHttpBridge logLine firstUnstableEpoch tip = HttpBridge
         if ep < firstUnstableEpoch then
             pure $ mockEpoch ep
         else
-            throwError $
+            throwE $
                 "mock epoch " ++ show ep ++ " > firstUnstableEpoch " ++
                 show firstUnstableEpoch
 


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have replaced usage of 'mtl' monad transformers with the equivalent from 'transformers'

# Comments

<!-- Additional comments or screenshots to attach if any -->

There's no strong feeling about using one or another. I noticed we were using `ExceptT` from `mtl` but `StateT` from `transformers` in various places in the code. So for consistency, I've opted for using the building blocks from `transformers`. `mtl` is built on top of `transformers` anyway now, but we do not use any of the classy stuff from `mtl` at the moment (and there's no clear reason we will in the near future?). 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
