### PR TITLE
Port integration tests Request module from old codebase

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -22,22 +22,14 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-  - section:
-    - name: test:unit
-    - message:
-      - name: Module not compiled
-      - module: Cardano.Launcher.Windows
-  - section:
-    - name: test:integration
-    - message:
-      - name: Redundant build-depends entry
-      - depends: cardano-wallet
     - message:
       - name: Weeds exported
       - module:
         - name: Test.Integration.Framework.DSL
         - identifier:
+          - </>
           - expectSuccess
+          - json
           - pendingWith
           - xscenario
       - module:
@@ -47,3 +39,10 @@
           - ClientError
           - DecodeFailure
           - HttpException
+          - successfulRequest
+  - section:
+    - name: test:unit
+    - message:
+      - name: Module not compiled
+      - module: Cardano.Launcher.Windows
+

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -27,4 +27,23 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-
+  - section:
+    - name: test:integration
+    - message:
+      - name: Redundant build-depends entry
+      - depends: cardano-wallet
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Test.Integration.Framework.DSL
+        - identifier:
+          - expectSuccess
+          - pendingWith
+          - xscenario
+      - module:
+        - name: Test.Integration.Framework.Request
+        - identifier:
+          - $-
+          - ClientError
+          - DecodeFailure
+          - HttpException

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -164,11 +164,14 @@ test-suite integration
     , hspec
     , hspec-core
     , http-client
+    , http-api-data
     , http-types
+    , aeson-qq
     , lens
     , mtl
     , process
     , say
+    , template-haskell
     , text
     , transformers
 

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -154,13 +154,24 @@ test-suite integration
       -Werror
   build-depends:
       base
+    , aeson
     , async
+    , bytestring
     , cardano-wallet
+    , exceptions
     , fmt
+    , generic-lens
     , hspec
+    , hspec-core
+    , http-client
+    , http-types
+    , lens
+    , mtl
     , process
-    , transformers
     , say
+    , text
+    , transformers
+
   type:
      exitcode-stdio-1.0
   hs-source-dirs:
@@ -171,6 +182,9 @@ test-suite integration
   other-modules:
       Cardano.NetworkLayer.HttpBridgeSpec
       Cardano.Launcher
+      Test.Integration.Framework.DSL
+      Test.Integration.Framework.Request
+      Test.Integration.Framework.Scenario
   if os(windows)
     build-depends: Win32
     other-modules: Cardano.Launcher.Windows

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -33,16 +33,6 @@ import Test.Integration.Framework.Request
 
 import qualified Cardano.NetworkLayer.HttpBridgeSpec as HttpBridge
 
-withWallet :: ((Text, Manager) -> IO a) -> IO a
-withWallet action = do
-    let launch = proc "cardano-wallet-server" testMnemonic
-        testMnemonic = ["ring","congress","face","smile","torch","length","purse","bind","rule","reopen","label","ask","town","town","argue"]
-        baseURL = T.pack "http://localhost:8090/"
-    manager <- newManager defaultManagerSettings
-    withCreateProcess launch $ \_ _ _ _ph -> do
-        threadDelay 1000000
-        action (baseURL, manager)
-
 main :: IO ()
 main = do
     hspec $ do
@@ -51,6 +41,18 @@ main = do
         beforeAll (withWallet (newMVar . Context ())) $ do
             describe "Integration test framework" dummySpec
 
+-- Runs the wallet server only. The API is not implemented yet, so this is
+-- basically a placeholder until then.
+withWallet :: ((Text, Manager) -> IO a) -> IO a
+withWallet action = do
+    let launch = proc "cardano-wallet-server" []
+        baseURL = T.pack ("http://localhost:8090/")
+    manager <- newManager defaultManagerSettings
+    withCreateProcess launch $ \_ _ _ _ph -> do
+        threadDelay 1000000
+        action (baseURL, manager)
+
+-- Exercise the request functions, which just fail at the moment.
 dummySpec :: Scenarios Context
 dummySpec = do
     scenario "Try the API which isn't implemented yet" $ do

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -1,1 +1,63 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main where
+
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.MVar
+    ( newMVar )
+
+import Data.Aeson
+    ( Value )
+import Data.Text
+    ( Text )
+import Network.HTTP.Client
+    ( Manager, defaultManagerSettings, newManager )
+import Prelude
+import System.Process
+    ( proc, withCreateProcess )
+import Test.Hspec
+    ( beforeAll, describe, hspec )
+
+import qualified Data.Text as T
+
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Scenarios
+    , expectError
+    , request
+    , request_
+    , scenario
+    , verify
+    )
+import Test.Integration.Framework.Request
+    ( RequestException (..) )
+
+import qualified Cardano.NetworkLayer.HttpBridgeSpec as HttpBridge
+
+withWallet :: ((Text, Manager) -> IO a) -> IO a
+withWallet action = do
+    let launch = proc "cardano-wallet-server" testMnemonic
+        testMnemonic = ["ring","congress","face","smile","torch","length","purse","bind","rule","reopen","label","ask","town","town","argue"]
+        baseURL = T.pack "http://localhost:8090/"
+    manager <- newManager defaultManagerSettings
+    withCreateProcess launch $ \_ _ _ _ph -> do
+        threadDelay 1000000
+        action (baseURL, manager)
+
+main :: IO ()
+main = do
+    hspec $ do
+        describe "Cardano.NetworkLayer.HttpBridge" HttpBridge.spec
+
+        beforeAll (withWallet (newMVar . Context ())) $ do
+            describe "Integration test framework" dummySpec
+
+dummySpec :: Scenarios Context
+dummySpec = do
+    scenario "Try the API which isn't implemented yet" $ do
+        response <- request ("GET", "api/wallets") Nothing
+        verify (response :: Either RequestException Value)
+            [ expectError
+            ]
+
+    scenario "request_ function is always successful" $ do
+        request_ ("GET", "api/xyzzy") Nothing

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Integration.Framework.DSL
+    (
+    -- * Scenario
+      scenario
+    , xscenario
+    , pendingWith
+    , Scenarios
+    , Context(..)
+
+    -- * Steps
+    , request
+    , request_
+    , successfulRequest
+    , verify
+
+    -- * Expectations
+    , expectSuccess
+    , expectError
+    , RequestException(..)
+
+    -- * Helpers
+    , ($-)
+    ) where
+
+import Prelude hiding
+    ( fail )
+
+import Control.Concurrent.MVar
+    ( MVar )
+import Control.Monad.Fail
+    ( MonadFail (..) )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
+import Data.Function
+    ( (&) )
+import Data.Text
+    ( Text )
+import GHC.Generics
+    ( Generic )
+import Network.HTTP.Client
+    ( Manager )
+import Test.Hspec.Core.Spec
+    ( SpecM, it, xit )
+
+import qualified Test.Hspec.Core.Spec as H
+
+import Test.Integration.Framework.Request
+    ( RequestException (..), request, request_, successfulRequest, ($-) )
+import Test.Integration.Framework.Scenario
+    ( Scenario )
+
+--
+-- SCENARIO
+--
+
+data Context = Context
+    { _hlint :: ()
+        -- ^ Something to stop hlint complaining
+    , _manager
+        :: (Text, Manager)
+        -- ^ The underlying BaseUrl and Manager used by the Wallet Client
+    } deriving (Generic)
+
+
+-- | Just a type-alias to 'SpecM', like 'scenario'. Ultimately, everything is
+-- made in such way that we can use normal (albeit lifted) HSpec functions and
+-- utilities if needed (and rely on its CLI as well when needed).
+type Scenarios ctx = SpecM (MVar ctx) ()
+
+-- | Just a slightly-specialized alias for 'it' to help lil'GHC.
+scenario
+    :: String
+    -> Scenario Context IO ()
+    -> Scenarios Context
+scenario = it
+
+xscenario
+    :: String
+    -> Scenario Context IO ()
+    -> Scenarios Context
+xscenario = xit
+
+-- | Lifted version of `H.pendingWith` allowing for temporarily skipping
+-- scenarios from execution with a reason, like:
+--
+--      scenario title $ do
+--          pendingWith "This test fails due to bug #213"
+--          test
+pendingWith
+    :: (MonadIO m, MonadFail m)
+    => String
+    -> m ()
+pendingWith = liftIO . H.pendingWith
+
+-- | Apply 'a' to all actions in sequence
+verify :: (Monad m) => a -> [a -> m ()] -> m ()
+verify a = mapM_ (a &)
+
+
+-- | Expect an errored response, without any further assumptions
+expectError
+    :: (MonadIO m, MonadFail m, Show a)
+    => Either RequestException a
+    -> m ()
+expectError = \case
+    Left _  -> return ()
+    Right a -> wantedErrorButSuccess a
+
+
+-- | Expect a successful response, without any further assumptions
+expectSuccess
+    :: (MonadIO m, MonadFail m, Show a)
+    => Either RequestException a
+    -> m ()
+expectSuccess = \case
+    Left e  -> wantedSuccessButError e
+    Right _ -> return ()
+
+wantedSuccessButError
+    :: (MonadFail m, Show e)
+    => e
+    -> m void
+wantedSuccessButError =
+    fail . ("expected a successful response but got an error: " <>) . show
+
+wantedErrorButSuccess
+    :: (MonadFail m, Show a)
+    => a
+    -> m void
+wantedErrorButSuccess =
+    fail . ("expected an error but got a successful response: " <>) . show

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -23,6 +23,9 @@ module Test.Integration.Framework.DSL
 
     -- * Helpers
     , ($-)
+    , (</>)
+    , (!!)
+    , json
     ) where
 
 import Prelude hiding
@@ -34,12 +37,18 @@ import Control.Monad.Fail
     ( MonadFail (..) )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Data.Aeson.QQ
+    ( aesonQQ )
 import Data.Function
     ( (&) )
+import Data.List
+    ( (!!) )
 import Data.Text
     ( Text )
 import GHC.Generics
     ( Generic )
+import Language.Haskell.TH.Quote
+    ( QuasiQuoter )
 import Network.HTTP.Client
     ( Manager )
 import Test.Hspec.Core.Spec
@@ -51,6 +60,8 @@ import Test.Integration.Framework.Request
     ( RequestException (..), request, request_, successfulRequest, ($-) )
 import Test.Integration.Framework.Scenario
     ( Scenario )
+import Web.HttpApiData
+    ( ToHttpApiData (..) )
 
 --
 -- SCENARIO
@@ -132,3 +143,15 @@ wantedErrorButSuccess
     -> m void
 wantedErrorButSuccess =
     fail . ("expected an error but got a successful response: " <>) . show
+
+
+--
+-- HELPERS
+--
+
+json :: QuasiQuoter
+json = aesonQQ
+
+infixr 5 </>
+(</>) :: ToHttpApiData a => Text -> a -> Text
+base </> next = mconcat [base, "/", toQueryParam next]

--- a/test/integration/Test/Integration/Framework/Request.hs
+++ b/test/integration/Test/Integration/Framework/Request.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Integration.Framework.Request
+    ( request
+    , request_
+    , successfulRequest
+    , RequestException(..)
+    , ($-)
+    ) where
+
+import Prelude
+
+import Control.Exception
+    ( try )
+import Control.Lens
+    ( Lens', view )
+import Control.Monad
+    ( void )
+import Control.Monad.Catch
+    ( Exception (..), MonadCatch (..), MonadThrow, throwM )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
+import Control.Monad.Reader
+    ( MonadReader (..) )
+import Data.Aeson
+    ( FromJSON )
+import Data.Bifunctor
+    ( first )
+import Data.ByteString.Lazy
+    ( ByteString )
+import Data.Functor
+    ( ($>) )
+import Data.Generics.Product.Typed
+    ( HasType, typed )
+import Data.Text
+    ( Text )
+import Network.HTTP.Client
+    ( HttpException (..)
+    , HttpExceptionContent (..)
+    , Manager
+    , RequestBody (..)
+    , httpLbs
+    , method
+    , parseRequest
+    , requestBody
+    , requestHeaders
+    , responseBody
+    , responseStatus
+    )
+import Network.HTTP.Types.Method
+    ( Method )
+import Network.HTTP.Types.Status
+    ( status200, status300, status404 )
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as L8
+import qualified Data.Text as T
+import qualified Network.HTTP.Client as HTTP
+
+
+class (HasType (Text, Manager) ctx) => HasManager ctx where
+    manager :: Lens' ctx (Text, Manager)
+    manager = typed @(Text, Manager)
+instance (HasType (Text, Manager) ctx) => HasManager ctx
+
+-- | The result when 'request' fails.
+data RequestException
+    = HttpException HttpException
+      -- ^ Wraps an exception from "Network.HTTP.Client"
+    | DecodeFailure ByteString
+      -- ^ JSON decoding the given response data failed.
+    | ClientError Aeson.Value
+      -- ^ The HTTP response status code indicated failure.
+    deriving (Show)
+
+instance Exception RequestException
+
+-- | Makes a request to the API and decodes the response.
+request
+    :: forall a m ctx.
+        ( FromJSON a
+        , MonadIO m
+        , MonadThrow m
+        , MonadCatch m
+        , MonadReader ctx m
+        , HasManager ctx
+        )
+    => (Method, Text)
+        -- ^ HTTP method and request path
+    -> Maybe Aeson.Value
+        -- ^ Request body
+    -> m (Either RequestException a)
+request (verb, path) body = (>>= handleResponse) <$> request' (verb, path) body
+  where
+    -- Either decode response body, or provide a RequestException.
+    handleResponse (req, res) = case responseStatus res of
+        s
+            | s >= status200 && s <= status300 ->
+                maybe
+                    (Left $ decodeFailure res)
+                    Right
+                    (Aeson.decode $ responseBody res)
+            | s == status404 ->
+                Left
+                    $ HttpException
+                    $ HttpExceptionRequest req
+                    $ StatusCodeException (res $> ())
+                    $ L8.toStrict $ responseBody res
+
+        _ -> Left $ decodeFailure res
+             -- TODO: decode API error responses into ClientError
+
+    decodeFailure :: HTTP.Response ByteString -> RequestException
+    decodeFailure res = DecodeFailure $ responseBody res
+
+request'
+    :: forall m ctx.
+        ( MonadIO m
+        , MonadThrow m
+        , MonadCatch m
+        , MonadReader ctx m
+        , HasManager ctx
+        )
+    => (Method, Text)
+        -- ^ HTTP method and request path
+    -> Maybe Aeson.Value
+        -- ^ Request body
+    -> m (Either RequestException (HTTP.Request, HTTP.Response ByteString))
+request' (verb, path) body = do
+    (base, man) <- view manager
+    tryHttp $ do
+        req <- parseRequest $ T.unpack $ base <> path
+        res <- httpLbs (prepare req) man
+        pure (req, res)
+
+  where
+    prepare :: HTTP.Request -> HTTP.Request
+    prepare req = req
+        { method = verb
+        , requestBody = maybe mempty (RequestBodyLBS . Aeson.encode) body
+        , requestHeaders =
+            [ ("Content-Type", "application/json")
+            , ("Accept", "application/json")
+            ]
+        }
+
+    -- Catch HttpExceptions and turn them into
+    -- Either RequestExceptions.
+    tryHttp :: IO r -> m (Either RequestException r)
+    tryHttp = liftIO . fmap (first HttpException) . try
+
+-- | Makes a request to the API, ignoring the response, or any errors.
+request_
+    :: forall m ctx.
+        ( MonadIO m
+        , MonadThrow m
+        , MonadCatch m
+        , MonadReader ctx m
+        , HasManager ctx
+        )
+    => (Method, Text)
+    -> Maybe Aeson.Value
+    -> m ()
+request_ req body = void $ request' req body
+
+-- | Makes a request to the API, but throws if it fails.
+successfulRequest
+    :: forall a m ctx.
+        ( FromJSON a
+        , MonadIO m
+        , MonadThrow m
+        , MonadCatch m
+        , MonadReader ctx m
+        , HasManager ctx
+        )
+    => (Method, Text)
+    -> Maybe Aeson.Value
+    -> m a
+successfulRequest req body = request req body >>= either throwM pure
+
+-- | Provide "next" arguments to a function, leaving the first one untouched.
+--
+-- e.g.
+--    myFunction  :: Ctx -> Int -> String -> Result
+--    myFunction' :: Ctx -> Result
+--    myFunction' = myFunction $- 14 $- "patate"
+infixl 1 $-
+($-) :: (a -> b -> c) -> b -> a -> c
+($-) = flip

--- a/test/integration/Test/Integration/Framework/Scenario.hs
+++ b/test/integration/Test/Integration/Framework/Scenario.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Test.Integration.Framework.Scenario
+    ( Scenario
+    ) where
+
+import Prelude
+
+import Control.Concurrent.MVar
+    ( MVar, putMVar, takeMVar )
+import Control.Monad
+    ( (>=>) )
+import Control.Monad.Catch
+    ( MonadCatch (..), MonadMask (..), MonadThrow (..), bracketOnError )
+import Control.Monad.Fail
+    ( MonadFail (..) )
+import Control.Monad.IO.Class
+    ( MonadIO (..) )
+import Control.Monad.Reader
+    ( MonadReader (..) )
+import Control.Monad.State.Class
+    ( MonadState (..) )
+import Control.Monad.State.Strict
+    ( StateT (..) )
+import Test.Hspec.Core.Spec
+    ( Example (..), Result (..), ResultStatus (..) )
+
+
+-- | A Wrapper around 'StateT' around which we define a few instances. The most
+-- interesting one is 'Example'
+newtype Scenario s m a = Scenario (StateT s m a)
+    deriving newtype
+        ( Functor
+        , Applicative
+        , Monad
+        , MonadThrow
+        , MonadCatch
+        , MonadFail
+        , MonadIO
+        , MonadMask
+        , MonadState s
+        )
+
+-- | We emulate the 'MonadReader' using the 'MonadState' instance, this way, we
+-- can lower down our constraints for methods that actually just read the state.
+instance (Monad m, MonadState s (Scenario s m)) => MonadReader s (Scenario s m) where
+    ask = get
+    local f m = do
+        s <- get
+        put (f s) *> m <* put s
+
+-- | This gives us the ability to define our spec as `Scenario` instead of just
+-- plain `IO`. This way, each scenario runs within a context and has access to
+-- a wallet client and a dedicated faucet wallet.
+instance Example (Scenario s IO ()) where
+    type Arg (Scenario s IO ()) = MVar s
+    evaluateExample (Scenario io) _ action _ =
+        action runAndPersist >> return (Result "" Success)
+      where
+        runAndPersist :: MVar s -> IO ()
+        runAndPersist mvar = do
+            let acquire = takeMVar mvar
+            let release = putMVar mvar
+            let between = runStateT io >=> (putMVar mvar . snd)
+            bracketOnError acquire release between


### PR DESCRIPTION
Relates to #56.

## Overview

This provides `unsafeRequest`, now called `request`. A little bit of the DSL module and the Scenario module were ported so that I could test the function.
