### PR TITLE
Add response code verification into integration DSL

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -176,6 +176,7 @@ test-suite integration
     , generic-lens
     , hspec
     , hspec-core
+    , hspec-expectations-lifted
     , http-client
     , http-api-data
     , http-types

--- a/test/integration/Test/Integration/Framework/DSL.hs
+++ b/test/integration/Test/Integration/Framework/DSL.hs
@@ -12,6 +12,7 @@ module Test.Integration.Framework.DSL
 
     -- * Steps
     , request
+    , request'
     , request_
     , successfulRequest
     , verify
@@ -19,6 +20,7 @@ module Test.Integration.Framework.DSL
     -- * Expectations
     , expectSuccess
     , expectError
+    , expectResponseCode
     , RequestException(..)
 
     -- * Helpers
@@ -39,6 +41,8 @@ import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Data.Aeson.QQ
     ( aesonQQ )
+import Data.ByteString.Lazy
+    ( ByteString )
 import Data.Function
     ( (&) )
 import Data.List
@@ -50,19 +54,27 @@ import GHC.Generics
 import Language.Haskell.TH.Quote
     ( QuasiQuoter )
 import Network.HTTP.Client
-    ( Manager )
+    ( Manager, Request, Response, responseStatus )
+import Network.HTTP.Types.Status
+    ( Status )
 import Test.Hspec.Core.Spec
     ( SpecM, it, xit )
-
-import qualified Test.Hspec.Core.Spec as H
-
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe )
 import Test.Integration.Framework.Request
-    ( RequestException (..), request, request_, successfulRequest, ($-) )
+    ( RequestException (..)
+    , request
+    , request'
+    , request_
+    , successfulRequest
+    , ($-)
+    )
 import Test.Integration.Framework.Scenario
     ( Scenario )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
 
+import qualified Test.Hspec.Core.Spec as H
 --
 -- SCENARIO
 --
@@ -120,6 +132,14 @@ expectError = \case
     Left _  -> return ()
     Right a -> wantedErrorButSuccess a
 
+expectResponseCode
+    :: (MonadIO m, MonadFail m)
+    => Status
+    -> Either RequestException (Request, Response ByteString)
+    -> m ()
+expectResponseCode c = \case
+    Left e   -> wantedSuccessButError e
+    Right a -> (responseStatus (snd a)) `shouldBe` c
 
 -- | Expect a successful response, without any further assumptions
 expectSuccess

--- a/test/integration/Test/Integration/Framework/Request.hs
+++ b/test/integration/Test/Integration/Framework/Request.hs
@@ -7,6 +7,7 @@
 
 module Test.Integration.Framework.Request
     ( request
+    , request'
     , request_
     , successfulRequest
     , RequestException(..)


### PR DESCRIPTION
# Issue Number
#104
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added `expectResponseCode` method into DSL and some temporary test on external service `http://httpbin.org` just to check it works. The method checks if the response has expected response code.

# Comments

This `expectResponseCode` only works for response produced by `response'` method which just returns raw response in the form of `Response ByteString`. I kinda like it bacuase it seems you can get a response code or response body or response headers from it using different methods from `Network.HTTP.Client`. At this point it seems to be more versatile than `response` (old `unsafeRequest`) which contains additional logic for getting the response depending on response codes. 

¯\_(ツ)_/¯

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
