### PR TITLE
Remove non-breaking space characters from source code.

### DIFF
--- a/app/Cardano/CLI.hs
+++ b/app/Cardano/CLI.hs
@@ -37,10 +37,10 @@ import Text.Read
 import qualified Data.Text as T
 
 
--- | Port number with a tag for describing what it is used for
+-- | Port number with a tag for describing what it is used for
 newtype Port (tag :: Symbol) = Port Int
 
-data Network = Mainnet | Testnet | Staging
+data Network = Mainnet | Testnet | Staging
     deriving (Show, Enum)
 
 
@@ -86,7 +86,7 @@ instance Encodable Int String where
 
 instance Decodable String Int where
     decode str =
-        maybe (Left err) Right (readMaybe str)
+        maybe (Left err) Right (readMaybe str)
       where
         err = "Not an integer: " ++ show str ++ "."
 

--- a/app/Cardano/Launcher.hs
+++ b/app/Cardano/Launcher.hs
@@ -67,7 +67,7 @@ instance Buildable Command where
             else
                 (arg, grp ++ [partial])
 
--- | ProcessHasExited is used by a monitoring thread to signal that the process
+-- | ProcessHasExited is used by a monitoring thread to signal that the process
 -- has exited.
 data ProcessHasExited = ProcessHasExited String ExitCode
     deriving Show

--- a/app/launcher/Main.hs
+++ b/app/launcher/Main.hs
@@ -71,7 +71,7 @@ main = do
             ]
     sayErr $ fmt $ blockListF commands
     (ProcessHasExited name code) <- launch commands
-    sayErr $ T.pack name <> " exited with code " <> T.pack (show code) 
+    sayErr $ T.pack name <> " exited with code " <> T.pack (show code) 
     exitWith code
 
 nodeHttpBridgeOn :: Port "Node" -> Network -> Command

--- a/src/Cardano/Wallet/Mnemonic.hs
+++ b/src/Cardano/Wallet/Mnemonic.hs
@@ -162,7 +162,7 @@ mkMnemonic
     -> Either (MnemonicError csz) (Mnemonic mw)
 mkMnemonic wordsm = do
     phrase <- left ErrMnemonicWords
-        $ mnemonicPhrase @mw (toUtf8String <$> wordsm)
+        $ mnemonicPhrase @mw (toUtf8String <$> wordsm)
 
     sentence <- left ErrDictionary
         $ mnemonicPhraseToMnemonicSentence Dictionary.english phrase

--- a/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -68,10 +68,10 @@ spec = do
             roundtripAndGolden $ Proxy @ WalletId
             roundtripAndGolden $ Proxy @ (ApiT WalletName)
             roundtripAndGolden $ Proxy @ WalletBalance
-            roundtripAndGolden $ Proxy @ WalletPassphraseInfo
-            roundtripAndGolden $ Proxy @ WalletState
+            roundtripAndGolden $ Proxy @ WalletPassphraseInfo
+            roundtripAndGolden $ Proxy @ WalletState
 
--- | Run JSON roundtrip & golden tests
+-- | Run JSON roundtrip & golden tests
 --
 -- Golden tests files are generated automatically on first run. On later runs
 -- we check that the format stays the same. The golden files should be tracked


### PR DESCRIPTION
For some reason, a few non-breaking space characters (encoded as `xC2A0` in UTF-8) have ended up in our Haskell source code.

This PR replaces them with ordinary space characters, using the following command:
```bash
find {app,src,test} -type f -name "*.hs" -print0 | xargs -0 sed -i 's/\xC2\xA0/ /g'
```