### PR TITLE
attempt to fix haddock exports failure on master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
     - cp -Rv specifications/api api
     - mkdir -p haddock && mv $(stack path --local-doc-root)/* haddock
     - git add api haddock && git commit -m $TRAVIS_COMMIT
-    - git checkout gh-pages && git cherry-pick -X theirs -n - && git commit --allow-empty --no-edit
+    - git checkout -f gh-pages && git cherry-pick -X theirs -n - && git commit --allow-empty --no-edit
     - git push -f -q https://WilliamKingNoel-Bot:$GITHUB_ACCESS_TOKEN@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null
 
   - stage: deploy 🚀


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added a `--force` flag in the CI script that exports the haddock documentation which _should_ prevent future build failures of a similar nature.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Not sure about it, but it _should_ work and won't do anything bad if it doesn't solve the problem :/ 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
