### PR TITLE
Golden & roundtrips on *all* Api types

### DIFF
--- a/src/Cardano/Wallet/Api.hs
+++ b/src/Cardano/Wallet/Api.hs
@@ -4,7 +4,7 @@
 module Cardano.Wallet.Api where
 
 import Cardano.Wallet.Api.Types
-    ( Wallet, WalletId )
+    ( ApiT, Wallet, WalletId )
 import Data.Proxy
     ( Proxy (..) )
 import Servant.API
@@ -16,11 +16,11 @@ api = Proxy
 type Api = DeleteWallet :<|> GetWallet :<|> ListWallets
 
 type DeleteWallet = "wallets"
-    :> Capture "walletId" WalletId
+    :> Capture "walletId" (ApiT WalletId)
     :> Delete '[] NoContent
 
 type GetWallet = "wallets"
-    :> Capture "walletId" WalletId
+    :> Capture "walletId" (ApiT WalletId)
     :> Get '[JSON] Wallet
 
 type ListWallets = "wallets"


### PR DESCRIPTION
# Issue Number

#91 

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Added `roundtripAndGoldenPerType` + machinery to run tests on all `Api` `Capture`- and return-types.
- [x] TODO: Go through the servant combinators. `ReqBody`?
- [x] ~WIP machinery for taking apart ADTs and running `roundtripAndGolden` on each component.~
    - [x] ~It was able to run `roundtripAndGolden` for the type of each field of a record~
    - [ ] ~I was unable to hook it up with the `Api` discovery~
    - [ ] ~I didn't figure out how to "catch" an hspec failure, such that we could _then_ run more detailed tests on the components on the failing type (see comment for `GRecursiveCheckJSON`)~


# Comments

<img width="857" alt="Skärmavbild 2019-03-25 kl  18 49 58" src="https://user-images.githubusercontent.com/304423/54942160-cc86ff80-4f2e-11e9-9bc2-27cddb9af619.png">

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
