### PR TITLE
Remove unused Semigroup instance for AddressPool

### DIFF
--- a/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -146,10 +146,6 @@ data AddressPool = AddressPool
 
 instance NFData AddressPool
 
-instance Semigroup AddressPool where
-    (AddressPool !pubKey !g !change !a1) <> (AddressPool _ _ _ !a2) =
-        AddressPool pubKey g change (a1 <> a2)
-
 -- | Get all addresses in the pool, sorted from the first address discovered,
 -- up until the next one.
 --
@@ -232,7 +228,7 @@ nextAddresses !key (AddressPoolGap !g) !cc !fromIx =
 
 newtype SeqState = SeqState (AddressPool, AddressPool)
     deriving stock (Generic, Show)
-    deriving newtype (NFData, Semigroup)
+    deriving newtype (NFData)
 
 -- NOTE
 -- We have to scan both the internal and external chain. Note that, the

--- a/src/Cardano/Wallet/Primitive/Model.hs
+++ b/src/Cardano/Wallet/Primitive/Model.hs
@@ -118,7 +118,7 @@ import qualified Data.Text as T
 --  - TODO: Known & used addresses
 data Wallet s where
     Wallet
-        :: (IsOurs s, Semigroup s, NFData s, Show s)
+        :: (IsOurs s, NFData s, Show s)
         => UTxO
         -> Set Tx
         -> SlotId
@@ -138,7 +138,7 @@ instance NFData (Wallet s) where
 
 -- | Create an empty wallet from an initial state
 initWallet
-    :: (IsOurs s, Semigroup s, NFData s, Show s)
+    :: (IsOurs s, NFData s, Show s)
     => s
     -> Wallet s
 initWallet = Wallet mempty mempty (SlotId 0 0)


### PR DESCRIPTION
# Issue Number
#94
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed unused `Semigroup` instance for `AddressPool`


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
