### PR TITLE
Fix language usage within comments.

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -818,7 +818,7 @@ paths:
       description: |
         Piority [Low]
 
-        Return the UTxOs distribution across the whole wallet, in the form of an histogram.
+        Return the UTxOs distribution across the whole wallet, in the form of a histogram.
 
         ```
              │

--- a/src/Cardano/Wallet/Api/Types.hs
+++ b/src/Cardano/Wallet/Api/Types.hs
@@ -137,10 +137,10 @@ newtype ApiT a =
     deriving (Generic, Show, Eq)
 
 -- | Representation of mnemonics at the API-level, using a polymorphic type in
--- the number of mnemonic that are supported (and an underlying purpose). In
--- practice, mnemonic corresponds to passphrases or seeds, and although they're
+-- the lengths of mnemonics that are supported (and an underlying purpose). In
+-- practice, mnemonics correspond to passphrases or seeds, and although they're
 -- nice to manipulate as mnemonics from a user-perspective, carrying around a
--- list of words doesn't really make sense for the business logic which prefers
+-- list of words doesn't really make sense for the business logic, which prefers
 -- manipulating scrubbed bytes directly.
 --
 -- @
@@ -150,11 +150,11 @@ newtype ApiT a =
 -- @
 --
 -- Note that the given 'Nat's **have** to be valid mnemonic sizes, otherwise the
--- underlying code won't even compile with, not-soo-friendly error messages.
+-- underlying code won't even compile, with not-so-friendly error messages.
 --
 -- Also, the internal representation holds a @[Text]@ which contains the list of
--- mnemonic words that was parsed. This is only to be able to satisfy the
--- 'ToJSON' instance and rountrip and that is a very dubious argument. In
+-- mnemonic words that was parsed. This is only to be able to implement the
+-- 'ToJSON' instances and roundtrip, which is a very dubious argument. In
 -- practice, we'll NEVER peek at the mnemonic, output them and whatnot.
 newtype ApiMnemonicT (sizes :: [Nat]) (purpose :: Symbol) =
     ApiMnemonicT (Passphrase purpose, [Text])

--- a/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -290,17 +290,17 @@ instance
         ApiMnemonicT y <- arbitrary @(ApiMnemonicT rest purpose)
         -- NOTE
         -- If we were to "naively" combine previous generators without weights,
-        -- we would be tilting probabilities towards the left most, in such way
-        -- that every element would be twice as more likely as its right
-        -- neighbour with an exponential decrease (after 7th elements, elements
-        -- have less than a percent of chance to appear). By tweaking a bit the
-        -- weight like below, we allow every elements to have at least 10%
-        -- chance to appear for lists up to 10 elements.
+        -- we would be tilting probabilities towards the leftmost element, so
+        -- that every element would be twice as likely to appear as its right-
+        -- hand neighbour, with an exponential decrease. (After the 7th element,
+        -- subsequent elements would have less than 1 percent chance of
+        -- appearing.) By tweaking the weights a bit as we have done below, we
+        -- make it possible for every element to have at least 10% chance of
+        -- appearing, for lists up to 10 elements.
         frequency
             [ (1, pure $ ApiMnemonicT x)
             , (5, pure $ ApiMnemonicT y)
             ]
-
 
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery


### PR DESCRIPTION
Fix a few typos and make a few small corrections to grammar and usage within comments.