### PR TITLE
No Slotting Arithmetic

### DIFF
--- a/src/Cardano/Wallet/Primitive/Types.hs
+++ b/src/Cardano/Wallet/Primitive/Types.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -53,10 +52,6 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Slotting
     , SlotId (..)
-    , isValidSlotId
-    , slotsPerEpoch
-    , slotDiff
-    , slotIncr
 
     -- * Polymorphic
     , Hash (..)
@@ -347,10 +342,6 @@ restrictedTo (UTxO utxo) outs =
 
 -- * Slotting
 
--- | Hard-coded for the time being
-slotsPerEpoch :: Word64
-slotsPerEpoch = 21600
-
 -- | A slot identifier is the combination of an epoch and slot.
 data SlotId = SlotId
   { epochIndex :: !Word64
@@ -361,36 +352,6 @@ instance NFData SlotId
 
 instance Buildable SlotId where
     build (SlotId e s) = build e <> "." <> build s
-
-instance Enum SlotId where
-    toEnum i
-        | i < 0 = error "SlotId.toEnum: bad argument"
-        | otherwise = slotIncr (fromIntegral i) (SlotId 0 0)
-    fromEnum (SlotId e s)
-        | n > fromIntegral (maxBound @Int) =
-            error "SlotId.fromEnum: arithmetic overflow"
-        | otherwise = fromIntegral n
-      where
-        n :: Word64
-        n = fromIntegral e * fromIntegral slotsPerEpoch + fromIntegral s
-
--- | Add a number of slots to an (Epoch, LocalSlotIndex) pair, where the number
--- of slots can be greater than one epoch.
-slotIncr :: Word64 -> SlotId -> SlotId
-slotIncr n slot = SlotId e s
-  where
-    e = fromIntegral (fromIntegral n' `div` slotsPerEpoch)
-    s = fromIntegral (fromIntegral n' `mod` slotsPerEpoch)
-    n' = n + fromIntegral (fromEnum slot)
-
--- | @slotDiff a b@ is the number of slots by which @a@ is greater than @b@.
-slotDiff :: SlotId -> SlotId -> Integer
-slotDiff s1 s2 = fromIntegral (fromEnum s1 - fromEnum s2)
-
--- | Whether the epoch index and slot number are in range.
-isValidSlotId :: SlotId -> Bool
-isValidSlotId (SlotId e s) =
-    e >= 0 && s >= 0 && s < fromIntegral slotsPerEpoch
 
 
 -- * Polymorphic

--- a/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -128,9 +128,13 @@ instance Arbitrary Blocks where
         next (prev, b) =
             let
                 slot = slotId (header b)
-                h = BlockHeader (succ slot) prev
+                h = BlockHeader (nextSlot slot) prev
             in
                 (blockHeaderHash h, Block h mempty)
+
+        nextSlot :: SlotId -> SlotId
+        nextSlot (SlotId ep 10) = (SlotId (ep + 1) 0)
+        nextSlot (SlotId ep sl) = (SlotId ep (sl + 1))
 
         blockHeaderHash :: BlockHeader -> Hash "BlockHeader"
         blockHeaderHash (BlockHeader (SlotId e s) _) =

--- a/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -84,10 +84,15 @@ spec = do
         it "3.3) updatePending b pending ⊆ pending"
             (checkCoverage prop_3_2)
 
-    describe "Basic slot arithmetic" $ do
-        it "Ordering happens as we expect" (property True)
-
-
+    describe "Slotting ordering" $ do
+        it "Any Slot >= SlotId 0 0"
+            (property (>= SlotId 0 0))
+        it "SlotId 1 2 < SlotId 2 1"
+            (property $ SlotId { epochIndex = 1, slotNumber = 2 } < SlotId 2 1)
+        it "SlotId 1 1 < SlotId 1 2"
+            (property $ SlotId { epochIndex = 1, slotNumber = 1 } < SlotId 1 2)
+        it "SlotId 1 2 < SlotId 2 2"
+            (property $ SlotId { epochIndex = 1, slotNumber = 2 } < SlotId 2 2)
 
 {-------------------------------------------------------------------------------
        Wallet Specification - Lemma 2.1 - Properties of UTxO operations


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#94

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have remove slotting arithmetic operation from the source code (relying instead on the fact that blocks are linked to each other and points to their parent)
- [ ] I have added a few tests to make sure that ordering of slots happens as expect, in a sudden paranoia crisis (since we derive the `Ord` automatically, it _just happened_ that we defined the epoch index before the slot number in the record declaration. Swapping those two would have dramatic effects ^^")

# Comments

<!-- Additional comments or screenshots to attach if any -->

As a side-effect, we don't have to test for any of the boundary cases because there are none :tada: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
