### PR TITLE
[wip] Add the beginnings of a wallet CLI.

### DIFF
--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Main where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( WalletId (..), WalletName (..) )
+import Options.Applicative
+    ( Parser
+    , ReadM
+    , command
+    , commandGroup
+    , eitherReader
+    , execParser
+    , fullDesc
+    , help
+    , helper
+    , info
+    , long
+    , metavar
+    , option
+    , progDesc
+    , subparser
+    , (<**>)
+    , (<|>)
+    )
+
+import qualified Data.Text as T
+import qualified Data.UUID.Types as UUID
+
+main :: IO ()
+main = run =<< execParser opts where
+    opts = info
+        (parseCommand <**> helper)
+        (fullDesc <> progDesc "Cardano Wallet CLI")
+
+-- TODO:
+-- For the moment, we simply print the command back to the console.
+-- In the future, we'll want to translate the command to an API call.
+run :: Command -> IO ()
+run = print
+
+{-------------------------------------------------------------------------------
+                               Command Types
+-------------------------------------------------------------------------------}
+
+data Command
+    = AddressCommand AddressCommand
+    | WalletCommand WalletCommand
+    deriving (Eq, Show)
+
+parseCommand :: Parser Command
+parseCommand = addressCommand <|> walletCommand
+
+{-------------------------------------------------------------------------------
+                               Address Commands
+-------------------------------------------------------------------------------}
+
+newtype AddressCommand
+    = AddressList AddressListOptions
+    deriving (Eq, Show)
+
+newtype AddressListOptions = AddressListOptions
+    { id :: WalletId
+    } deriving (Eq, Show)
+
+addressCommand :: Parser Command
+addressCommand = fmap AddressCommand $ subparser $ mconcat
+    [ commandGroup
+        "Address commands:"
+    , command "address-list" $ info addressList $ progDesc
+        "List all existing addresses."
+    ]
+
+addressList :: Parser AddressCommand
+addressList = AddressList . AddressListOptions
+    <$> option walletId
+        (  long "wallet-id"
+        <> metavar "UUID"
+        <> help "the ID of a wallet" )
+
+{-------------------------------------------------------------------------------
+                               Wallet Commands
+-------------------------------------------------------------------------------}
+
+data WalletCommand
+    = WalletCreate WalletCreateOptions
+    | WalletDelete WalletDeleteOptions
+    | WalletUpdate WalletUpdateOptions
+    | WalletList
+    deriving (Eq, Show)
+
+newtype WalletCreateOptions = WalletCreateOptions
+    { name :: WalletName
+    } deriving (Eq, Show)
+
+newtype WalletDeleteOptions = WalletDeleteOptions
+    { id :: WalletId
+    } deriving (Eq, Show)
+
+data WalletUpdateOptions = WalletUpdateOptions
+    { id :: WalletId
+    , name :: WalletName
+    } deriving (Eq, Show)
+
+walletCommand :: Parser Command
+walletCommand = fmap WalletCommand $ subparser $ mconcat
+    [ commandGroup
+        "Wallet commands:"
+    , command "wallet-create" $ info walletCreate $ progDesc
+        "Create a completely new wallet."
+    , command "wallet-delete" $ info walletDelete $ progDesc
+        "Delete an existing wallet."
+    , command "wallet-update" $ info walletUpdate $ progDesc
+        "Update an existing wallet's metadata."
+    , command "wallet-list" $ info walletList $ progDesc
+        "List all existing wallets."
+    ]
+
+walletCreate :: Parser WalletCommand
+walletCreate = WalletCreate . WalletCreateOptions
+    <$> option walletName
+        (  long "name"
+        <> metavar "STRING"
+        <> help "a name for the new wallet" )
+
+walletDelete :: Parser WalletCommand
+walletDelete = WalletDelete . WalletDeleteOptions
+    <$> option walletId
+        (  long "id"
+        <> metavar "UUID"
+        <> help "the ID of the wallet to delete" )
+
+walletUpdate :: Parser WalletCommand
+walletUpdate = fmap WalletUpdate . WalletUpdateOptions
+    <$> option walletId
+        (  long "id"
+        <> metavar "UUID"
+        <> help "the ID of the wallet to update" )
+    <*> option walletName
+        (  long "name"
+        <> metavar "STRING"
+        <> help "a new name for the wallet" )
+
+walletList :: Parser WalletCommand
+walletList = pure WalletList
+
+walletId :: ReadM WalletId
+walletId = eitherReader mkWalletId
+  where
+    mkWalletId :: String -> Either String WalletId
+    mkWalletId = maybe
+        (Left "invalid wallet ID: must be a valid UUID")
+        (pure . WalletId)
+        . UUID.fromString
+
+-- TODO:
+-- Much of the validation logic herein is identical to that defined within
+-- the Cardano.Api.Wallet.Types module. Find a way to reduce the duplication.
+walletName :: ReadM WalletName
+walletName = eitherReader mkWalletName
+  where
+    mkWalletName :: String -> Either String WalletName
+    mkWalletName n
+        | length n < walletNameMinLength =
+            Left $ "name is too short: expected at least "
+                <> show walletNameMinLength <> " chars"
+        | length n > walletNameMaxLength =
+            Left $ "name is too long: expected at most "
+                <> show walletNameMaxLength <> " chars"
+        | otherwise =
+            pure $ WalletName $ T.pack n
+
+    walletNameMinLength = 1
+    walletNameMaxLength = 255

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -299,3 +299,24 @@ executable cardano-generate-mnemonic
       app/mnemonic
   main-is:
       GenerateMnemonic.hs
+
+executable cardano-wallet
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -Wall
+      -Werror
+      -O2
+  build-depends:
+      base
+    , cardano-wallet
+    , optparse-applicative
+    , text
+    , uuid-types
+  hs-source-dirs:
+      app/cli
+  main-is:
+      Main.hs


### PR DESCRIPTION
# Issue Number

Issue #96 

# Overview

This PR provides a _starting point_ for a wallet CLI.

To begin with, parsers are provided for a small number of commands:
* wallet-related commands (`wallet-create`, `wallet-delete`, `wallet-update`, `wallet-list`)
* address-related commands (`address-list`)

For the moment, the CLI doesn't actually connect with the wallet API service. It simply parses the supplied commands (and arguments) and echoes the parsed command back to the command line.

## Help text

```hs
$ stack exec cardano-wallet -- --help
Usage: cardano-wallet COMMAND
  Cardano Wallet CLI

Available options:
  -h,--help                Show this help text

Address commands:
  address-list             List all existing addresses for a given wallet.

Wallet commands:
  wallet-create            Create a completely new wallet.
  wallet-delete            Delete an existing wallet.
  wallet-update            Update an existing wallet's metadata.
  wallet-list              List all existing wallets.
```

## Examples of usage
```hs
$ stack exec cardano-wallet -- address-list --wallet-id 2844e589-48ff-4f09-a6fa-a00122c9807a
AddressCommand (AddressList (AddressListOptions {id = WalletId 2844e589-48ff-4f09-a6fa-a00122c9807a}))

$ stack exec cardano-wallet -- wallet-create --name Wibble
WalletCommand (WalletCreate (WalletCreateOptions {name = WalletName {getWalletName = "Wibble"}}))

$ stack exec cardano-wallet -- wallet-delete --id 2844e589-48ff-4f09-a6fa-a00122c9807a
WalletCommand (WalletDelete (WalletDeleteOptions {id = WalletId 2844e589-48ff-4f09-a6fa-a00122c9807a}))

$ stack exec cardano-wallet -- wallet-update --id 2844e589-48ff-4f09-a6fa-a00122c9807a --name Wibble
WalletCommand (WalletUpdate (WalletUpdateOptions {id = WalletId 2844e589-48ff-4f09-a6fa-a00122c9807a, name = WalletName {getWalletName = "Wibble"}}))

$ stack exec cardano-wallet -- wallet-list
WalletCommand WalletList
```
# Comments

Regarding **validation:** It's not clear how much validation should be performed in the CLI. If we're always going to be calling the API server, then we could just defer all validation to the API server, reporting any errors returned in an appropriate way. On the other hand, some of the API types have smart constructors associated with them which perform validation before values can be constructed.