### PR TITLE
Add `postSignedTx` to HttpBridge

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -185,6 +185,7 @@ test-suite integration
     , async
     , bytestring
     , cardano-wallet
+    , cborg
     , exceptions
     , fmt
     , hspec

--- a/src/Cardano/Wallet/Network.hs
+++ b/src/Cardano/Wallet/Network.hs
@@ -14,7 +14,7 @@ module Cardano.Wallet.Network
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( Block (..), BlockHeader (..), Hash (..), SignedTx, SlotId (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad.IO.Class
@@ -39,6 +39,8 @@ data NetworkLayer m e0 e1 = NetworkLayer
 
     , networkTip
         :: ExceptT e1 m (Hash "BlockHeader", BlockHeader)
+    , postTx
+        :: SignedTx -> ExceptT e1 m ()
     }
 
 -- | Repeatedly fetch data from a given source function, and call an action for

--- a/src/Cardano/Wallet/Primitive/Types.hs
+++ b/src/Cardano/Wallet/Primitive/Types.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Primitive.Types
     , TxMeta(..)
     , txIns
     , updatePending
+    , SignedTx (..)
 
     -- * Address
     , IsOurs(..)
@@ -317,6 +318,9 @@ newtype Timestamp = Timestamp
     { getTimestamp :: UTCTime
     } deriving (Show, Generic, Eq, Ord)
 
+
+-- | Wrapper around the final CBOR representation of a signed tx
+newtype SignedTx = SignedTx { signedTx :: ByteString }
 
 {-------------------------------------------------------------------------------
                                     Address

--- a/test/unit/Cardano/Wallet/Network/HttpBridgeSpec.hs
+++ b/test/unit/Cardano/Wallet/Network/HttpBridgeSpec.hs
@@ -148,6 +148,7 @@ mockHttpBridge logLine firstUnstableEpoch tip = HttpBridge
         lift $ logLine "mock getNetworkTip"
         let hash = mockHash tip
         pure (hash, mockHeaderFromHash hash)
+    , postSignedTx = undefined
     }
 
 -- If debugging, you might want to log with putStrLn.


### PR DESCRIPTION
# Issue Number

#89 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

Adds support for submitting signed transactions to the node / httpBridge.

- [x] Added `encodeSignedTx`, encodeWitness, 
- [x] Improved `decodeSignedTx` and `decodeWitness`
- [x] Added `SignedTx <base64>` type and `sign :: Tx -> [Witness] -> SignedTx`
- [x] Added support for submitting txs to `POST :network/txs/signed`

# Comments

- Rebased into 3 commits: 1) stub API, 2) extend `Binary.hs`, 3) connect the two and add integration tests for submitting signed txs

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
