### PR TITLE
Get 'cardano-node-simple' available in CI & allow manipulating stream output when launching commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ addons:
   apt:
     packages:
       - libgmp-dev
+      - librocksdb-dev
 
 # Define custom set of stages
 stages:
@@ -63,7 +64,11 @@ jobs:
     name: "Compiling"
     script:
     - mkdir -p ~/.local/bin
+    - travis_retry curl -L -o cardano-node-simple.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/test/data/cardano-node-simple/cardano-node-simple-3.0.1.tar.gz
+    - tar xzf cardano-node-simple.tar.gz -C $HOME/.local/bin
+    - cardano-node-simple --version
     - test "$(cardano-http-bridge --version)" = "cardano-http-bridge 0.0.1" || travis_retry cargo install --force --branch cardano-wallet-integration --git https://github.com/KtorZ/cardano-http-bridge.git
+    - cardano-http-bridge --version
     - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
     - stack --no-terminal setup
     - stack --no-terminal build --only-snapshot
@@ -87,9 +92,8 @@ jobs:
     name: "Tests"
     script:
     - tar xzf $STACK_WORK_CACHE
-    - travis_retry curl -L -o hermes-testnet.tar.gz https://github.com/input-output-hk/cardano-wallet/raw/data-integration-testing/hermes-testnet.tar.gz
+    - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/test/data/cardano-http-bridge/hermes-testnet.tar.gz
     - tar xzf hermes-testnet.tar.gz -C $HOME
-    - cardano-http-bridge --help
     - stack --no-terminal test --coverage
     - tar czf $STACK_WORK_CACHE .stack-work
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ tar xzf cardano-node-simple-3.0.1.tar.gz -C /usr/local/bin && rm cardano-node-
 3. Import the initial testnet chain bootstrap for the `cardano-http-bridge`
 
 ```
-$ curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/data-integration-testing/hermes-testnet.tar.gz
+$ curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/test/data/cardano-http-bridge/hermes-testnet.tar.gz
 $ tar xzf hermes-testnet.tar.gz -C $HOME && rm hermes-testnet.tar.gz
 ```
 

--- a/app/launcher/Main.hs
+++ b/app/launcher/Main.hs
@@ -11,6 +11,7 @@ import Cardano.CLI
 import Cardano.Launcher
     ( Command (Command)
     , ProcessHasExited (ProcessHasExited)
+    , StdStream (..)
     , installSignalHandlers
     , launch
     )
@@ -85,6 +86,7 @@ nodeHttpBridgeOn port net = Command
     , "--template", encode net
     ]
     (return ())
+    Inherit
 
 walletOn :: Port "Wallet" -> Port "Node" -> Network -> Command
 walletOn wp np net = Command
@@ -94,5 +96,6 @@ walletOn wp np net = Command
     , "--network", encode net
     ]
     (threadDelay oneSecond)
+    Inherit
   where
     oneSecond = 1000000

--- a/test/data/cardano-node-simple/cardano-node-simple-3.0.1-linux-x86_64.tar.gz
+++ b/test/data/cardano-node-simple/cardano-node-simple-3.0.1-linux-x86_64.tar.gz
@@ -1,0 +1,1 @@
+cardano-node-simple-3.0.1.tar.gz

--- a/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
+++ b/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.Network.HttpBridgeSpec
 import Prelude
 
 import Cardano.Launcher
-    ( Command (..), launch )
+    ( Command (..), StdStream (..), launch )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Network.HttpBridge
@@ -93,6 +93,7 @@ spec = do
                 , "--template", "testnet"
                 ]
                 (return ())
+                Inherit
             ]
         network <- newNetworkLayer
         threadDelay 1000000

--- a/test/integration/Cardano/WalletSpec.hs
+++ b/test/integration/Cardano/WalletSpec.hs
@@ -10,7 +10,7 @@ module Cardano.WalletSpec
 import Prelude
 
 import Cardano.Launcher
-    ( Command (..), launch )
+    ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( NewWallet (..), WalletLayer (..), mkWalletLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -67,6 +67,7 @@ spec = do
                 , "--template", "testnet"
                 ]
                 (return ())
+                Inherit
             ]
         threadDelay 1000000
         (handle,) <$> (mkWalletLayer

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Prelude
 
 import Cardano.Launcher
-    ( Command (..), launch )
+    ( Command (..), StdStream (..), launch )
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
@@ -76,6 +76,7 @@ main = do
         , "--log-config", stateDir <> "/logs/" <> nodeId <> "/config.json"
         , "--rebuild-db"
         ] (pure ())
+        NoStream
 
     cardanoWalletLauncher serverPort bridgePort network = Command
         "cardano-wallet-launcher"
@@ -83,6 +84,7 @@ main = do
         , "--http-bridge-port", bridgePort
         , "--network", network
         ] (threadDelay 6000000)
+        Inherit
 
 
 -- Exercise the request functions, which just fail at the moment.

--- a/test/integration/Main.hs
+++ b/test/integration/Main.hs
@@ -53,8 +53,7 @@ main = do
             , cardanoNodeSimple stateDir systemStart ("core1", "127.0.0.1:3001")
             , cardanoNodeSimple stateDir systemStart ("core2", "127.0.0.1:3002")
             , cardanoNodeSimple stateDir systemStart ("relay", "127.0.0.1:3100")
-            , cardanoHttpBridge "8080" "local"
-            , cardanoWalletServer "1337" "8080" "local"
+            , cardanoWalletLauncher "1337" "8080" "local"
             ]
         link cluster
         let baseURL = "http://localhost:1337/"
@@ -78,15 +77,8 @@ main = do
         , "--rebuild-db"
         ] (pure ())
 
-    cardanoHttpBridge port network = Command
-        "cardano-http-bridge"
-        [ "start"
-        , "--port", port
-        , "--template", network
-        ] (threadDelay 5000000)
-
-    cardanoWalletServer serverPort bridgePort network = Command
-        "cardano-wallet-server"
+    cardanoWalletLauncher serverPort bridgePort network = Command
+        "cardano-wallet-launcher"
         [ "--wallet-server-port", serverPort
         , "--http-bridge-port", bridgePort
         , "--network", network

--- a/test/unit/Cardano/LauncherSpec.hs
+++ b/test/unit/Cardano/LauncherSpec.hs
@@ -7,7 +7,7 @@ module Cardano.LauncherSpec
 import Prelude
 
 import Cardano.Launcher
-    ( Command (..), ProcessHasExited (..), launch )
+    ( Command (..), ProcessHasExited (..), StdStream (..), launch )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, tryReadMVar )
 import System.Exit
@@ -21,8 +21,8 @@ spec :: Spec
 spec = do
     it "1st process exits with 0, others are cancelled" $ do
         let commands =
-              [ Command "./test/data/Launcher/once.sh" ["0"] (pure ())
-              , Command "./test/data/Launcher/forever.sh" [] (pure ())
+              [ Command "./test/data/Launcher/once.sh" ["0"] (pure ()) Inherit
+              , Command "./test/data/Launcher/forever.sh" [] (pure ()) Inherit
               ]
         (ProcessHasExited name code) <- launch commands
         name `shouldBe` cmdName (commands !! 0)
@@ -30,8 +30,8 @@ spec = do
 
     it "2nd process exits with 0, others are cancelled" $ do
         let commands =
-              [ Command "./test/data/Launcher/forever.sh" [] (pure ())
-              , Command "./test/data/Launcher/once.sh" ["0"] (pure ())
+              [ Command "./test/data/Launcher/forever.sh" [] (pure ()) Inherit
+              , Command "./test/data/Launcher/once.sh" ["0"] (pure ()) Inherit
               ]
         (ProcessHasExited name code) <- launch commands
         name `shouldBe` cmdName (commands !! 1)
@@ -39,8 +39,8 @@ spec = do
 
     it "1st process exits with 14, others are cancelled" $ do
         let commands =
-              [ Command "./test/data/Launcher/once.sh" ["14"] (pure ())
-              , Command "./test/data/Launcher/forever.sh" [] (pure ())
+              [ Command "./test/data/Launcher/once.sh" ["14"] (pure ()) Inherit
+              , Command "./test/data/Launcher/forever.sh" [] (pure ()) Inherit
               ]
         (ProcessHasExited name code) <- launch commands
         name `shouldBe` cmdName (commands !! 0)
@@ -48,8 +48,8 @@ spec = do
 
     it "2nd process exits with 14, others are cancelled" $ do
         let commands =
-              [ Command "./test/data/Launcher/forever.sh" [] (pure ())
-              , Command "./test/data/Launcher/once.sh" ["14"] (pure ())
+              [ Command "./test/data/Launcher/forever.sh" [] (pure ()) Inherit
+              , Command "./test/data/Launcher/once.sh" ["14"] (pure ()) Inherit
               ]
         (ProcessHasExited name code) <- launch commands
         name `shouldBe` cmdName (commands !! 1)
@@ -59,7 +59,7 @@ spec = do
         mvar <- newEmptyMVar
         let before = putMVar mvar "executed"
         let commands =
-                [ Command "./test/data/Launcher/once.sh" ["0"] before
+                [ Command "./test/data/Launcher/once.sh" ["0"] before Inherit
                 ]
         (ProcessHasExited _ code) <- launch commands
         code `shouldBe` ExitSuccess


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#67 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have fixed the CI scripts so that 'cardano-node-simple' is now available in $PATH for integration tests 
- [ ] I have used the 'cardano-wallet-launcher' alongside the cluster (rather than spawning a bridge and a wallet separately).
- [ ] I allowed redirecting stdout and stderr when launching commands (to avoid being completely bloated by the 'cardano-node-simple' logs that are already redirected to `/tmp/cardano-node-simple/logs` anyway.



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
