### PR TITLE
API smart constructors

### DIFF
--- a/src/Cardano/Wallet/Api/Types.hs
+++ b/src/Cardano/Wallet/Api/Types.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}


### PR DESCRIPTION
# Issue Number

Issue #96 

# Overview

This PR defines **decoders** (smart constructors) and **encoders** for the following types defined within `Cardano.Wallet.Api.Types`:

* `ApiT Address`
* `ApiT (Passphrase "encryption")`
* `ApiMnemonicT sizes purpose`
* `ApiT WalletName`

We export the decoders so that they may eventually be used by the CLI when constructing values with which to call the API.

We also modify the relevant `FromJSON` and `ToJSON` instances to reuse the extracted-out decoders and encoders.