### PR TITLE
Fix slot depth unit to 'slot'. Add block type

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -36,11 +36,28 @@ numberOfSlots: &numberOfSlots
     quantity:
       type: integer
       minimum: 0
+      example: 1337
     unit:
       type: string
       enum:
         - slot
+      example: "slot"
+
+numberOfBlocks: &numberOfBlocks
+  type: object
+  required:
+    - quantity
+    - unit
+  properties:
+    quantity:
+      type: integer
+      minimum: 0
       example: 1337
+    unit:
+      type: string
+      enum:
+        - block
+      example: "block"
 
 percentage: &percentage
   type: object
@@ -225,7 +242,7 @@ transactionInsertedAt: &transactionInsertedAt
 
 transactionDepth: &transactionDepth
   description: Current depth of the transaction in the local chain
-  <<: *numberOfSlots
+  <<: *numberOfBlocks
 
 transactionDirection: &transactionDirection
   type: string

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -320,7 +320,7 @@ stakePoolMetrics: &stakePoolMetrics
       <<: *percentage
 
     last_blocks:
-      <<: *numberOfSlots
+      <<: *numberOfBlocks
       description: Number of blocks correctly processed during the last epoch
 
 stakePoolProfitMargin: &stakePoolProfitMargin


### PR DESCRIPTION
# Issue Number
#93 
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed slot depth unit to "slot"
- [x] I have added swagger block type for special use case to differente between slot and block

# Comments
This adds slight modification to our `swagger.json` to make types more strict. It might be overkill though

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
