### PR TITLE
Add `FromText` and `ToText` classes to `Api.Types`

### DIFF
--- a/src/Cardano/Wallet/Api/Types.hs
+++ b/src/Cardano/Wallet/Api/Types.hs
@@ -210,7 +210,8 @@ class FromText a where
     fromText :: Text -> Either TextDecodingError a
 
 -- | Indicates an error that occurred while decoding from text.
-newtype TextDecodingError = TextDecodingError String
+newtype TextDecodingError = TextDecodingError
+    { getTextDecodingError :: String }
     deriving stock Show
     deriving newtype Buildable
 

--- a/src/Cardano/Wallet/Api/Types.hs
+++ b/src/Cardano/Wallet/Api/Types.hs
@@ -212,7 +212,7 @@ class FromText a where
 -- | Indicates an error that occurred while decoding from text.
 newtype TextDecodingError = TextDecodingError
     { getTextDecodingError :: String }
-    deriving stock Show
+    deriving stock (Eq, Show)
     deriving newtype Buildable
 
 instance FromText (ApiT Address) where

--- a/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -145,20 +146,21 @@ spec = do
     describe
         "can perform roundtrip JSON serialization & deserialization, \
         \and match existing golden files" $ do
-            roundtripAndGolden $ Proxy @ ApiAddress
-            roundtripAndGolden $ Proxy @ ApiWallet
-            roundtripAndGolden $ Proxy @ WalletPostData
-            roundtripAndGolden $ Proxy @ WalletPutData
-            roundtripAndGolden $ Proxy @ WalletPutPassphraseData
-            roundtripAndGolden $ Proxy @ (ApiT Address)
-            roundtripAndGolden $ Proxy @ (ApiT AddressPoolGap)
-            roundtripAndGolden $ Proxy @ (ApiT (WalletDelegation (ApiT PoolId)))
-            roundtripAndGolden $ Proxy @ (ApiT WalletId)
-            roundtripAndGolden $ Proxy @ (ApiT WalletName)
-            roundtripAndGolden $ Proxy @ (ApiT WalletBalance)
-            roundtripAndGolden $ Proxy @ (ApiT WalletPassphraseInfo)
-            roundtripAndGolden $ Proxy @ (ApiT WalletState)
-            roundtripAndGolden $ Proxy @ (ApiT (Passphrase "encryption"))
+            let test = jsonRoundtripAndGolden
+            test $ Proxy @ApiAddress
+            test $ Proxy @ApiWallet
+            test $ Proxy @WalletPostData
+            test $ Proxy @WalletPutData
+            test $ Proxy @WalletPutPassphraseData
+            test $ Proxy @(ApiT Address)
+            test $ Proxy @(ApiT AddressPoolGap)
+            test $ Proxy @(ApiT (WalletDelegation (ApiT PoolId)))
+            test $ Proxy @(ApiT WalletId)
+            test $ Proxy @(ApiT WalletName)
+            test $ Proxy @(ApiT WalletBalance)
+            test $ Proxy @(ApiT WalletPassphraseInfo)
+            test $ Proxy @(ApiT WalletState)
+            test $ Proxy @(ApiT (Passphrase "encryption"))
 
     describe
         "verify that every type used with JSON content type in a servant API \
@@ -233,11 +235,11 @@ spec = do
 -- new format. Faulty golden files should /not/ be commited.
 --
 -- The directory `test/data/Cardano/Wallet/Api` is used.
-roundtripAndGolden
+jsonRoundtripAndGolden
     :: forall a. (Arbitrary a, ToJSON a, FromJSON a, Typeable a)
     => Proxy a
     -> Spec
-roundtripAndGolden = roundtripAndGoldenSpecsWithSettings settings
+jsonRoundtripAndGolden = roundtripAndGoldenSpecsWithSettings settings
   where
     settings :: Settings
     settings = defaultSettings


### PR DESCRIPTION
# Issue Number

#96 (Extend Cardano Wallet CLI with selected commands)

# Overview

Within `Cardano.Wallet.Api.Types` there is a common practice of defining a pair of functions to **encode** and **decode** values of some type **to** and **from** `Text`.

This PR standardises this convention, by providing two typeclasses `ToText` and `FromText` that provide the following functions:

* `toText`: encodes a value to `Text`.
* `fromText`: decodes a value from `Text`.

# Testing

These functions should satisfy `fromText (toText v) == Right v`.

# Motivation

The CLI must take textual input from the command line and convert it to values of types accepted by the API. Having a common way of performing these conversions allows us to write the CLI code in a simpler way.