### PR TITLE
Store TxHistory outside of the wallet state

### DIFF
--- a/src/Cardano/Wallet.hs
+++ b/src/Cardano/Wallet.hs
@@ -14,7 +14,20 @@
 -- intermediary between the three.
 
 
-module Cardano.Wallet where
+module Cardano.Wallet
+    (
+    -- * Types
+      WalletLayer (..)
+    , NewWallet(..)
+    , ReadWalletError(..)
+    , CreateWalletError(..)
+
+    -- * Construction
+    , mkWalletLayer
+
+    -- * Helpers
+    , unsafeRunExceptT
+    ) where
 
 import Prelude
 
@@ -37,17 +50,24 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..), WalletId (..), WalletMetadata (..), WalletName (..) )
 import Control.Exception
     ( Exception )
+import Control.Monad
+    ( (>=>) )
+import Control.Monad.Fail
+    ( MonadFail )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
-    ( ExceptT, throwE )
+    ( ExceptT, runExceptT, throwE )
 import Data.List
     ( foldl' )
 import GHC.Generics
     ( Generic )
 
 
--- | Types
+{-------------------------------------------------------------------------------
+                                 Types
+-------------------------------------------------------------------------------}
+
 data WalletLayer s = WalletLayer
     { createWallet
         :: NewWallet
@@ -83,6 +103,9 @@ newtype CreateWalletError
     = ErrCreateWalletIdAlreadyExists WalletId
     deriving (Eq, Show)
 
+{-------------------------------------------------------------------------------
+                                 Construction
+-------------------------------------------------------------------------------}
 
 -- | Create a new instance of the wallet layer.
 mkWalletLayer
@@ -123,10 +146,27 @@ mkWalletLayer db network = WalletLayer
   where
     applyBlocks :: WalletId -> [Block] -> IO ()
     applyBlocks wid blocks = do
-        cp' <- readCheckpoint db (PrimaryKey wid) >>= \case
+        (txs, cp') <- readCheckpoint db (PrimaryKey wid) >>= \case
             Nothing ->
                 fail $ "couldn't find worker wallet: " <> show wid
             Just cp -> do
                 let nonEmpty = not . null . transactions
-                return $ foldl' (flip applyBlock) cp (filter nonEmpty blocks)
+                let applyOne (txs, cp') b = (txs <> txs', cp'') where
+                        (txs', cp'') = applyBlock b cp'
+                return $ foldl' applyOne (mempty, cp) (filter nonEmpty blocks)
         putCheckpoint db (PrimaryKey wid) cp'
+        unsafeRunExceptT $ putTxHistory db (PrimaryKey wid) txs -- Safe after ^
+
+{-------------------------------------------------------------------------------
+                                 Helpers
+-------------------------------------------------------------------------------}
+
+-- | Run an ExcepT and throws the error if any. This makes sense only if called
+-- after checking for an invariant or, after ensuring that preconditions for
+-- meeting the underlying error have been discarded.
+unsafeRunExceptT :: (MonadFail m, Show e) => ExceptT e m a -> m a
+unsafeRunExceptT = runExceptT >=> \case
+    Left e ->
+        fail $ "unexpected error: " <> show e
+    Right a ->
+        return a

--- a/src/Cardano/Wallet/DB.hs
+++ b/src/Cardano/Wallet/DB.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
@@ -8,6 +10,7 @@
 module Cardano.Wallet.DB
     ( DBLayer(..)
     , PrimaryKey(..)
+    , ErrPutTxHistory(..)
     ) where
 
 import Prelude
@@ -15,27 +18,57 @@ import Prelude
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( WalletId )
+    ( Hash, Tx, TxMeta, WalletId )
+import Control.Monad.Trans.Except
+    ( ExceptT )
+import Data.Map.Strict
+    ( Map )
 
 
 -- | A Database interface for storing various things in a DB. In practice,
 -- we'll need some extra contraints on the wallet state that allows us to
 -- serialize and unserialize it (e.g. @forall s. (Serialize s) => ...@)
 data DBLayer m s = DBLayer
-    -- Wallet checkpoints, checkpoints are handled as a bounded FIFO, where we
-    -- eventually store @k@ values (e.g. k=2160) at the same time.
     { putCheckpoint
         :: PrimaryKey WalletId
         -> Wallet s
         -> m ()
+        -- ^ Replace the current checkpoint for a given wallet. We do not handle
+        -- rollbacks yet, and therefore only stores the latest available
+        -- checkpoint.
 
     , readCheckpoint
         :: PrimaryKey WalletId
         -> m (Maybe (Wallet s))
+        -- ^ Fetch the most recent checkpoint of a given wallet. Return 'Nothing'
+        -- if there's no such wallet.
 
     , readWallets
         :: m [PrimaryKey WalletId]
+        -- ^ Get the list of all known wallets in the DB, possibly empty.
+
+    , putTxHistory
+        :: PrimaryKey WalletId
+        -> Map (Hash "Tx") (Tx, TxMeta)
+        -> ExceptT ErrPutTxHistory m ()
+        -- ^ Augments the transaction history for a known wallet.
+        --
+        -- If an entry for a particular transaction already exists it is not
+        -- altered nor merged (just ignored).
+        --
+        -- If the wallet doesn't exist, this operation returns an error.
+
+    , readTxHistory
+        :: PrimaryKey WalletId
+        -> m (Map (Hash "Tx") (Tx, TxMeta))
+        -- ^ Fetch the current transaction history of a known wallet. Returns an
+        -- empty map if the wallet isn't found.
     }
+
+-- | Error while trying to insert transaction history in the DB.
+newtype ErrPutTxHistory
+    = ErrNoSuchWallet WalletId
+    deriving (Show, Eq)
 
 -- | A primary key which can take many forms depending on the value. This may
 -- become a type family as we move forward, but for now, it illustrate that

--- a/test/integration/Cardano/WalletSpec.hs
+++ b/test/integration/Cardano/WalletSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -12,7 +11,7 @@ import Prelude
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
-    ( NewWallet (..), WalletLayer (..), mkWalletLayer )
+    ( NewWallet (..), WalletLayer (..), mkWalletLayer, unsafeRunExceptT )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Mnemonic
@@ -25,12 +24,6 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
     ( async, cancel )
-import Control.Monad
-    ( (>=>) )
-import Control.Monad.Fail
-    ( MonadFail )
-import Control.Monad.Trans.Except
-    ( ExceptT, runExceptT )
 import Test.Hspec
     ( Spec, after, before, it, shouldSatisfy )
 
@@ -73,10 +66,3 @@ spec = do
         (handle,) <$> (mkWalletLayer
             <$> MVar.newDBLayer
             <*> HttpBridge.newNetworkLayer "testnet" port)
-
-unsafeRunExceptT :: (MonadFail m, Show e) => ExceptT e m a -> m a
-unsafeRunExceptT = runExceptT >=> \case
-    Left e ->
-        fail $ "unable to perform expect IO action: " <> show e
-    Right a ->
-        return a

--- a/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -10,43 +15,84 @@ module Cardano.Wallet.DB.MVarSpec
 
 import Prelude
 
+import Cardano.Wallet
+    ( unsafeRunExceptT )
 import Cardano.Wallet.DB
-    ( DBLayer (..), PrimaryKey (..) )
+    ( DBLayer (..), ErrPutTxHistory (..), PrimaryKey (..) )
 import Cardano.Wallet.DB.MVar
     ( newDBLayer )
 import Cardano.Wallet.Primitive.Model
     ( initWallet )
 import Cardano.Wallet.Primitive.Types
-    ( IsOurs (..), WalletId (..) )
+    ( Direction (..)
+    , Hash (..)
+    , IsOurs (..)
+    , SlotId (..)
+    , Tx (..)
+    , TxMeta (..)
+    , TxStatus (..)
+    , WalletId (..)
+    )
 import Control.Concurrent.Async
     ( mapConcurrently_ )
 import Control.DeepSeq
     ( NFData )
+import Control.Monad
+    ( forM_, void )
 import Control.Monad.IO.Class
     ( liftIO )
+import Control.Monad.Trans.Except
+    ( runExceptT )
+import Data.Map.Strict
+    ( Map )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Word
+    ( Word32 )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
-    ( Spec, before, describe, it, shouldBe )
+    ( Spec, before, describe, it, shouldBe, shouldReturn )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, choose, property, vectorOf )
-import Test.QuickCheck.Gen
-    ( chooseAny )
+    ( Arbitrary (..)
+    , Property
+    , checkCoverage
+    , choose
+    , cover
+    , elements
+    , genericShrink
+    , property
+    , vectorOf
+    )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.List as L
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.UUID.Types as UUID
 
 
 spec :: Spec
 spec = do
     describe "DB works as expected" $ before newDBLayer $ do
-        it "readCheckpoint . putCheckpoint yields inserted checkpoints" $
-            \db -> (property $ dbReadCheckpointProp db)
-        it "replacement of values returns last value that was put" $
-            \db -> (property $ dbReplaceValsProp db)
-        it "multiple sequential putCheckpoint work properly" $
-            \db -> (property $ dbMultiplePutsSeqProp db)
-        it "multiple parallel putCheckpoint work properly" $
-            \db -> (property $ dbMultiplePutsParProp db)
+        it "readCheckpoint . putCheckpoint yields inserted checkpoints"
+            (property . dbReadCheckpointProp)
+        it "replacement of values returns last value that was put"
+            (property . dbReplaceValsProp)
+        it "multiple sequential putCheckpoint work properly"
+            (property . dbMultiplePutsSeqProp)
+        it "multiple parallel putCheckpoint work properly"
+            (property . dbMultiplePutsParProp)
+        it "readTxHistory . putTxHistory yields inserted merged history"
+            (checkCoverage . dbMergeTxHistoryProp)
+        it "can't read Tx history if there's no checkpoint"
+            (property . dbPutTxHistoryBeforeCheckpointProp)
+        it "putTxHistory leaves the wallet state untouched"
+            (property . dbPutTxHistoryNoEffectOnWallet)
+        it "putCheckpoint leaves the tx history untouched"
+            (property . dbPutCheckpointNoEffectOnHistory)
 
 {-------------------------------------------------------------------------------
                                     Properties
@@ -60,7 +106,6 @@ dbReadCheckpointProp
 dbReadCheckpointProp db (key, val)  = monadicIO $ liftIO $ do
     putCheckpoint db key (initWallet val)
     resFromDb <- readCheckpoint db key
-
     resFromDb `shouldBe` (Just $ initWallet val)
 
 dbReplaceValsProp
@@ -71,44 +116,95 @@ dbReplaceValsProp db (key, val1, val2)  = monadicIO $ liftIO $ do
     putCheckpoint db key (initWallet val1)
     putCheckpoint db key (initWallet val2)
     resFromDb <- readCheckpoint db key
-
     resFromDb `shouldBe` (Just $ initWallet val2)
 
 dbMultiplePutsSeqProp
     :: DBLayer IO DummyState
-    -> KeyValPairs
+    -> KeyValPairs (PrimaryKey WalletId) DummyState
     -> Property
 dbMultiplePutsSeqProp db (KeyValPairs keyValPairs) = monadicIO $ liftIO $ do
     mapM_ (\(key, val) -> putCheckpoint db key (initWallet val)) keyValPairs
     resFromDb <- Set.fromList <$> readWallets db
-
     resFromDb `shouldBe` (Set.fromList (map fst keyValPairs))
 
 dbMultiplePutsParProp
     :: DBLayer IO DummyState
-    -> KeyValPairs
+    -> KeyValPairs (PrimaryKey WalletId) DummyState
     -> Property
 dbMultiplePutsParProp db (KeyValPairs keyValPairs) = monadicIO $ liftIO $ do
     mapConcurrently_
         (\(key, val) -> putCheckpoint db key (initWallet val))
         keyValPairs
     resFromDb <- Set.fromList <$> readWallets db
-
     resFromDb `shouldBe` (Set.fromList (map fst keyValPairs))
+
+dbMergeTxHistoryProp
+    :: DBLayer IO DummyState
+    -> KeyValPairs (PrimaryKey WalletId) (Map (Hash "Tx") (Tx, TxMeta))
+    -> Property
+dbMergeTxHistoryProp db (KeyValPairs keyValPairs) =
+    cover 90 cond "conflicting tx histories" prop
+  where
+    restrictTo k = filter ((== k) . fst)
+    -- Make sure that we have some conflicting insertion to actually test the
+    -- semantic of the DB Layer.
+    cond = L.length (L.nub ids) /= L.length ids
+      where
+        ids = concatMap (\(w, m) -> (w,) <$> Map.keys m) keyValPairs
+    prop = monadicIO $ liftIO $ do
+        forM_ keyValPairs $ \(key, val) -> do
+            putCheckpoint db key (initWallet $ DummyState 0)
+            unsafeRunExceptT $ putTxHistory db key val
+        forM_ keyValPairs $ \(key, _) -> do
+            res <- readTxHistory db key
+            res `shouldBe` (Map.unions (snd <$> restrictTo key keyValPairs))
+
+dbPutTxHistoryBeforeCheckpointProp
+    :: DBLayer IO DummyState
+    -> PrimaryKey WalletId
+    -> Property
+dbPutTxHistoryBeforeCheckpointProp db key@(PrimaryKey wid) = monadicIO $ liftIO $ do
+    runExceptT (putTxHistory db key mempty) >>= \case
+        Right _ -> fail "expected insertion to fail but it succeeded?"
+        Left err -> err `shouldBe` ErrNoSuchWallet wid
+    readTxHistory db key `shouldReturn` mempty
+
+dbPutTxHistoryNoEffectOnWallet
+    :: DBLayer IO DummyState
+    -> (PrimaryKey WalletId, DummyState, Map (Hash "Tx") (Tx, TxMeta))
+    -> Property
+dbPutTxHistoryNoEffectOnWallet db (key, s, txs) = monadicIO $ liftIO $ do
+    let cp = initWallet s
+    putCheckpoint db key cp
+    void $ runExceptT (putTxHistory db key txs)
+    cp' <- readCheckpoint db key
+    cp' `shouldBe` Just cp
+
+dbPutCheckpointNoEffectOnHistory
+    :: DBLayer IO DummyState
+    -> (PrimaryKey WalletId, Map (Hash "Tx") (Tx, TxMeta))
+    -> Property
+dbPutCheckpointNoEffectOnHistory db (key, txs) = monadicIO $ liftIO $ do
+    let cp0 = initWallet (DummyState 0)
+    let cp1 = initWallet (DummyState 14)
+    putCheckpoint db key cp0
+    void $ runExceptT (putTxHistory db key txs)
+    putCheckpoint db key cp1
+    txs' <- readTxHistory db key
+    txs' `shouldBe` txs
 
 {-------------------------------------------------------------------------------
                       Tests machinery, Arbitrary instances
 -------------------------------------------------------------------------------}
 
+newtype KeyValPairs k v = KeyValPairs [(k, v)]
+    deriving (Generic, Show, Eq)
 
-newtype KeyValPairs = KeyValPairs [(PrimaryKey WalletId, DummyState)]
-    deriving (Show, Eq)
-
-instance Arbitrary KeyValPairs where
-    -- No shrinking
+instance (Arbitrary k, Arbitrary v) => Arbitrary (KeyValPairs k v) where
+    shrink = genericShrink
     arbitrary = do
         pairs <- choose (10, 50) >>= flip vectorOf arbitrary
-        KeyValPairs <$> pure pairs
+        pure $ KeyValPairs pairs
 
 newtype DummyState = DummyState Int
     deriving (Show, Eq)
@@ -129,5 +225,25 @@ instance Semigroup DummyState where
 deriving instance Show (PrimaryKey WalletId)
 
 instance Arbitrary (PrimaryKey WalletId) where
-    -- No shrinking
-    arbitrary = PrimaryKey . WalletId <$> chooseAny
+    shrink _ = []
+    arbitrary = do
+        k <- choose (0, 10)
+        return $ PrimaryKey $ WalletId $ UUID.fromWords k 0 0 0
+
+instance Arbitrary (Hash "Tx") where
+    shrink _ = []
+    arbitrary = do
+        k <- choose (0, 10)
+        return $ Hash (B8.pack ("TX" <> show @Int k))
+
+instance Arbitrary Tx where
+    shrink _ = []
+    arbitrary = return $ Tx mempty mempty
+
+instance Arbitrary TxMeta where
+    shrink _ = []
+    arbitrary = TxMeta
+        <$> elements [Pending, InLedger, Invalidated]
+        <*> elements [Incoming, Outgoing]
+        <*> (SlotId <$> arbitrary <*> choose (0, 21600))
+        <*> fmap (Quantity . fromIntegral) (arbitrary @Word32)

--- a/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -120,7 +120,7 @@ prop_applyBlockBasic s =
     cond1 = not $ null $ (Set.fromList addresses) \\ (ourAddresses s)
     prop =
         let
-            wallet = foldl (flip applyBlock) (initWallet s) blockchain
+            wallet = foldl (\cp b -> snd $ applyBlock b cp) (initWallet s) blockchain
             utxo = totalUTxO wallet
             utxo' = evalState (foldM (flip updateUTxO) mempty blockchain) s
         in


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#90

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have moved tracking of `Tx` outside of the wallet state (which does now only keep track of the known TxId and TxMeta)
- [x] I have extended the DB Layer with two new: `putTxHistory` and `readTxHistory`
- [x] I have extended the MVar spec accordingly with a few properties to reflect upon the semantic of the DB Layer
- [x] I have reviewed and extended a few docstring comments.

# Comments

<!-- Additional comments or screenshots to attach if any -->

This is because transactions may end up being rather big and, are of little use for the wallet
state. Instead, keeping track of the tx ids only is sufficient. Storing transactions on a
separate level in the DB also allows for querying them independently with, later, more advanced
features like sorting and filtering

NOTE: More tests on the wallet model are introduced by @rvl in #148 so I really focused on testing the DB layer here.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
