### PR TITLE
Add restore benchmark

### DIFF
--- a/.buildkite/benchmark.sh
+++ b/.buildkite/benchmark.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+netname="${1-}"
+
+if [ -z "$netname" ]; then
+   echo "usage: benchmark.sh NETWORK"
+   exit 1
+fi
+
+stack bench cardano-wallet:restore --interleaved-output --ba "$netname +RTS -N2 -qg -A1m -I0 -T -M1G -h -RTS"
+
+hp2pretty restore.hp
+
+if [ -n "${BUILDKITE:-}" ]; then
+  buildkite-agent artifact upload restore.svg
+  printf '\033]1338;url='"artifact://restore.svg"';alt='"Heap profile"'\a\n'
+fi

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,0 +1,13 @@
+env:
+  NIX_PATH: "channel:nixos-19.03"
+steps:
+  - label: 'Restore benchmark - testnet'
+    command: "nix-shell -p nix git stack haskellPackages.hp2pretty buildkite-agent --run ./.buildkite/benchmark.sh testnet"
+    timeout_in_minutes: 60
+    agents:
+      system: x86_64-linux
+  - label: 'Restore benchmark - mainnet'
+    command: "nix-shell -p nix git stack haskellPackages.hp2pretty buildkite-agent --run ./.buildkite/benchmark.sh mainnet"
+    timeout_in_minutes: 60
+    agents:
+      system: x86_64-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
     - stack --no-terminal setup
     - stack --no-terminal build --only-snapshot
     - stack --no-terminal build --only-dependencies
-    - stack --no-terminal build --test --no-run-tests --coverage --haddock --no-haddock-deps
+    - stack --no-terminal build --test --no-run-tests --bench --no-run-benchmarks --coverage --haddock --no-haddock-deps
     - tar czf $STACK_WORK_CACHE .stack-work
 
   - stage: checks 🔬

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -6,10 +6,18 @@
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
   - section:
-    - name: exe:cardano-wallet exe:cardano-wallet-launcher
+    - name: exe:cardano-wallet exe:cardano-wallet-launcher bench:restore
     - message:
       - name: Module reused between components
       - module: Cardano.CLI
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Cardano.CLI
+        - identifier:
+          - Local
+          - Mainnet
+          - Staging
   - section:
     - name: exe:cardano-wallet-launcher
     - message:
@@ -46,4 +54,3 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,7 +1,7 @@
 - package:
   - name: cardano-wallet
   - section:
-    - name: exe:cardano-wallet-launcher
+    - name: bench:restore
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
@@ -11,7 +11,12 @@
       - name: Module reused between components
       - module: Cardano.CLI
   - section:
-    - name: exe:cardano-wallet-launcher test:integration test:unit
+    - name: exe:cardano-wallet-launcher
+    - message:
+      - name: Module not compiled
+      - module: Cardano.Launcher.Windows
+  - section:
+    - name: exe:cardano-wallet-launcher test:integration test:unit bench:restore
     - message:
       - name: Module reused between components
       - module:
@@ -30,7 +35,6 @@
           - </>
           - expectError
           - expectSuccess
-          - json
       - module:
         - name: Test.Integration.Framework.Request
         - identifier:
@@ -42,3 +46,4 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
+

--- a/app/Cardano/CLI.hs
+++ b/app/Cardano/CLI.hs
@@ -13,7 +13,7 @@
 module Cardano.CLI
     (
     -- * Types
-      Network
+      Network(..)
     , Port(..)
 
     -- * Parsing Arguments

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -314,6 +314,7 @@ benchmark restore
     , process
     , say
     , text
+    , time
     , transformers
   type:
      exitcode-stdio-1.0

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -289,3 +289,44 @@ executable cardano-wallet-launcher
     other-modules: Cardano.Launcher.POSIX
   main-is:
      Main.hs
+
+benchmark restore
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+      -O2
+  if (!flag(development))
+    ghc-options:
+      -Werror
+  build-depends:
+      base
+    , async
+    , cardano-wallet
+    , criterion-measurement
+    , deepseq
+    , fmt
+    , generic-lens
+    , process
+    , say
+    , text
+    , transformers
+  type:
+     exitcode-stdio-1.0
+  hs-source-dirs:
+      test/bench
+      app
+  main-is:
+      Main.hs
+  other-modules:
+      Cardano.Launcher
+  if os(windows)
+    build-depends: Win32
+    other-modules: Cardano.Launcher.Windows
+  else
+    build-depends: unix
+    other-modules: Cardano.Launcher.POSIX

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -305,10 +305,12 @@ benchmark restore
       -Werror
   build-depends:
       base
+    , ansi-terminal
     , async
     , cardano-wallet
     , criterion-measurement
     , deepseq
+    , docopt
     , fmt
     , generic-lens
     , process
@@ -324,6 +326,7 @@ benchmark restore
   main-is:
       Main.hs
   other-modules:
+      Cardano.CLI
       Cardano.Launcher
   if os(windows)
     build-depends: Win32

--- a/test/bench/Main.hs
+++ b/test/bench/Main.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+module Main where
+
+import Prelude
+
+import Cardano.Launcher
+    ( Command (Command), StdStream (..), installSignalHandlers, launch )
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( async, cancel )
+import Control.DeepSeq
+    ( rnf )
+import Control.Exception
+    ( bracket, evaluate )
+import Control.Monad
+    ( mapM_ )
+import Control.Monad.Trans.Except
+    ( runExceptT )
+import Criterion.Measurement
+    ( getTime, initializeTime, secs )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Text
+    ( Text )
+import qualified Data.Text as T
+import Fmt
+    ( fmt, (+|), (+||), (|+), (||+) )
+import Say
+    ( say )
+import System.Exit
+    ( die )
+
+import Cardano.Wallet
+    ( NewWallet (..), WalletLayer (..), mkWalletLayer )
+import Cardano.Wallet.Network
+    ( networkTip )
+import Cardano.Wallet.Network.HttpBridge
+    ( newNetworkLayer )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Passphrase (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( mkAddressPoolGap )
+import Cardano.Wallet.Primitive.Types
+    ( SlotId, WalletName (..) )
+
+import qualified Cardano.Wallet.DB.MVar as MVar
+
+main :: IO ()
+main = do
+    installSignalHandlers
+    runBenchmarks
+        [ bench "restore - testnet - walletRnd" $ test1 "testnet" walletRnd
+        , bench "restore - mainnet - walletRnd" $ test1 "mainnet" walletRnd
+        , bench "restore - testnet - walletSeq" $ test1 "testnet" walletSeq
+        , bench "restore - mainnet - walletSeq" $ test1 "mainnet" walletSeq
+        ]
+
+runBenchmarks :: [IO (Text, Double)] -> IO ()
+runBenchmarks bs = do
+    initializeTime
+    rs <- sequence bs
+    say "\n\nAll results:"
+    mapM_ (uncurry printResult) rs
+
+bench :: Text -> IO () -> IO (Text, Double)
+bench benchName action = do
+    say $ "Running " <> benchName
+    start <- getTime
+    res <- action
+    evaluate (rnf res)
+    finish <- getTime
+    let dur = finish - start
+    printResult benchName dur
+    pure (benchName, dur)
+
+printResult :: Text -> Double -> IO ()
+printResult benchName dur = say . fmt $ "  "+|benchName|+": "+|secs dur|+""
+
+
+test1 :: Text -> NewWallet -> IO ()
+test1 netName nw = withHttpBridge netName $ \port -> do
+    db <- MVar.newDBLayer
+    network <- newNetworkLayer netName port
+    runExceptT (networkTip network) >>= \case
+        Right (_, bh) -> say . fmt $ "Note: the "+|netName|+" tip is at "+||(bh ^. #slotId)||+""
+        Left err -> die .fmt $ "Could not get the network tip. Is the node backend running?\n"+||err||+""
+    let testWalletLayer = mkWalletLayer db network
+    res <- runExceptT $ createWallet testWalletLayer nw
+    case res of
+        Right wal -> processWallet testWalletLayer logChunk wal
+        Left err -> die $ show err
+
+logChunk :: SlotId -> IO ()
+logChunk slot = say . fmt $ "Processing "+||slot||+""
+
+withHttpBridge :: Text -> (Int -> IO a) -> IO a
+withHttpBridge netName action = bracket start stop (const (action port))
+    where
+        port = 8002
+        start = do
+            handle <- async $ launch
+                [ Command "cardano-http-bridge"
+                    [ "start"
+                    , "--port", show port
+                    , "--template", T.unpack netName
+                    ]
+                    (return ())
+                    Inherit
+                ]
+            threadDelay 1000000 -- wait for listening socket
+            pure handle
+        stop handle = do
+            cancel handle
+            threadDelay 1000000 -- wait for socket to be closed
+
+
+baseWallet :: NewWallet
+baseWallet = NewWallet (Passphrase "") (Passphrase "")
+             (WalletName "") (Passphrase "") gap20
+    where Right gap20 = mkAddressPoolGap 20
+
+walletRnd :: NewWallet
+walletRnd = baseWallet
+    { seed = Passphrase "skull skin weird piece oak absorb apart above female dial drink traffic"
+    , name = WalletName "Benchmark Daedalus Wallet"
+    }
+
+walletSeq :: NewWallet
+walletSeq = baseWallet
+    { seed = Passphrase "involve key curtain arrest fortune custom lens marine before material wheel glide cause weapon wrap"
+    , name = WalletName "Benchmark Yoroi Wallet"
+    }

--- a/test/bench/Main.hs
+++ b/test/bench/Main.hs
@@ -57,9 +57,7 @@ main = do
     installSignalHandlers
     mapM_ prepareNode ["testnet", "mainnet"]
     runBenchmarks
-        [ bench "restore - testnet - walletRnd" $ test1 "testnet" walletRnd
-        , bench "restore - mainnet - walletRnd" $ test1 "mainnet" walletRnd
-        , bench "restore - testnet - walletSeq" $ test1 "testnet" walletSeq
+        [ bench "restore - testnet - walletSeq" $ test1 "testnet" walletSeq
         , bench "restore - mainnet - walletSeq" $ test1 "mainnet" walletSeq
         ]
 
@@ -127,16 +125,10 @@ baseWallet = NewWallet (Passphrase "") (Passphrase "")
              (WalletName "") (Passphrase "") gap20
     where Right gap20 = mkAddressPoolGap 20
 
-walletRnd :: NewWallet
-walletRnd = baseWallet
-    { seed = Passphrase "skull skin weird piece oak absorb apart above female dial drink traffic"
-    , name = WalletName "Benchmark Daedalus Wallet"
-    }
-
 walletSeq :: NewWallet
 walletSeq = baseWallet
     { seed = Passphrase "involve key curtain arrest fortune custom lens marine before material wheel glide cause weapon wrap"
-    , name = WalletName "Benchmark Yoroi Wallet"
+    , name = WalletName "Benchmark Sequential Wallet"
     }
 
 prepareNode :: Text -> IO ()


### PR DESCRIPTION
Relates to issue #100 

# Overview

Adds a benchmark for wallet restore, which require cardano-http-bridge already synced to mainnet and testnet.

# Comments

This measures time but memory usage can be measured with `+RTS -h`.

There is not yet the special `IsOurs` scheme which will cause many transactions to applied to the wallet.
