### PR TITLE
Fix comments in `Data.Text.Class` to remove any mention of the API.

### DIFF
--- a/src/Data/Text/Class.hs
+++ b/src/Data/Text/Class.hs
@@ -28,13 +28,12 @@ import Fmt
 
 import qualified Data.Text as T
 
-
--- | Defines a textual encoding for a type defined within the API.
+-- | Defines a textual encoding for a type.
 class ToText a where
     -- | Encode the specified value as text.
     toText :: a -> Text
 
--- | Defines a textual decoding for a type defined within the API.
+-- | Defines a textual decoding for a type.
 class FromText a where
     -- | Decode the specified text as a value.
     fromText :: Text -> Either TextDecodingError a


### PR DESCRIPTION
A tiny PR to fix comments within `Data.Text.Class`.

The type classes defined within this module were originally designed specifically for the API, but now they have been moved to a more general location indicating a more general purpose. Hence there's no need to mention the API here.