### PR TITLE
Add roundtrip textual encoding tests for `Network` and `Port` CLI types.

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -6,7 +6,7 @@
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
   - section:
-    - name: exe:cardano-wallet exe:cardano-wallet-launcher bench:restore
+    - name: exe:cardano-wallet exe:cardano-wallet-launcher test:unit bench:restore
     - message:
       - name: Module reused between components
       - module: Cardano.CLI

--- a/app/Cardano/CLI.hs
+++ b/app/Cardano/CLI.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
@@ -32,6 +33,8 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Fmt
     ( Buildable, pretty )
+import GHC.Generics
+    ( Generic )
 import GHC.TypeLits
     ( Symbol )
 import System.Console.Docopt
@@ -49,7 +52,7 @@ import qualified System.Console.ANSI as ANSI
 -- | Available network options. 'Local' means a local cluster running on the
 -- host machine.
 data Network = Mainnet | Testnet | Staging | Local
-    deriving (Show, Enum)
+    deriving (Generic, Show, Eq, Enum)
 
 instance ToText Network where
     toText = \case
@@ -70,6 +73,7 @@ instance FromText Network where
 
 -- | Port number with a tag for describing what it is used for
 newtype Port (tag :: Symbol) = Port Int
+    deriving (Eq, Show, Generic)
 
 instance FromText (Port tag) where
     fromText = fmap Port . fromText

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -101,18 +101,20 @@ test-suite unit
     ghc-options:
       -Werror
   build-depends:
-      aeson
+      base
+    , aeson
     , aeson-qq
-    , base
+    , ansi-terminal
     , async
     , base58-bytestring
     , bytestring
     , cardano-crypto
     , cardano-wallet
     , cborg
-    , cryptonite
     , containers
+    , cryptonite
     , deepseq
+    , docopt
     , exceptions
     , file-embed
     , fmt
@@ -140,6 +142,8 @@ test-suite unit
   main-is:
       Main.hs
   other-modules:
+      Cardano.CLI
+      Cardano.CLISpec
       Cardano.Launcher
       Cardano.LauncherSpec
       Cardano.WalletSpec

--- a/test/unit/Cardano/CLISpec.hs
+++ b/test/unit/Cardano/CLISpec.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.CLISpec
+    (spec
+    ) where
+
+import Prelude
+
+import Cardano.CLI
+    ( Network, Port )
+import Data.Proxy
+    ( Proxy (..) )
+import Test.Hspec
+    ( Spec, describe )
+import Test.QuickCheck
+    ( Arbitrary (..) )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+import Test.Text.Roundtrip
+    ( textRoundtrip )
+
+spec :: Spec
+spec = do
+    describe "Can perform roundtrip textual encoding & decoding" $ do
+        textRoundtrip $ Proxy @Network
+        textRoundtrip $ Proxy @(Port "test")
+
+instance Arbitrary Network where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary (Port "test") where
+    arbitrary = genericArbitrary
+    shrink = genericShrink


### PR DESCRIPTION
# Issue Number

Issue #96 

# Overview

Add roundtrip textual encoding tests for `Network` and `Port` CLI types.
