### PR TITLE
Proposal: Choose network at build-time via flags

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -13,6 +13,14 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+flag mainnet
+  description: Connect to the mainnet network (instead of testnet)
+  default: False
+
+flag staging
+  description: Connect to the staging network (instead of testnet)
+  default: False
+
 flag development
     description: Disable `-Werror`
     default: False
@@ -31,6 +39,13 @@ library
   if (!flag(development))
     ghc-options:
       -Werror
+
+  if flag(mainnet)
+    cpp-options: -DCARDANO_NETWORK_MAINNET
+  if flag(staging)
+    cpp-options: -DCARDANO_NETWORK_STAGING
+  if (!flag(staging) && !flag(mainnet))
+    cpp-options: -DCARDANO_NETWORK_TESTNET
   build-depends:
       aeson
     , base
@@ -81,6 +96,7 @@ library
       Cardano.Wallet.Primitive.Mnemonic
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
+      Cardano.Network
       Data.Text.Class
       Data.Quantity
       Servant.Extra.ContentTypes

--- a/src/Cardano/Network.hs
+++ b/src/Cardano/Network.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE CPP #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- The module contains network configuration and allows it to be controlled via
+-- via compile-time flags.
+--
+-- testnet is default.
+-- mainnet can be enabled by passing `--flag cardano-wallet:mainnet` to stack.
+-- staging can be enabled by passing `--flag cardano-wallet:staging` to stack.
+
+module Cardano.Network where
+
+import Prelude
+
+import Data.Int
+    ( Int32 )
+
+protocolMagic :: Int32
+networkName :: String
+
+#ifdef CARDANO_NETWORK_MAINNET
+
+protocolMagic = 764824073
+networkName = "mainnet"
+
+#endif
+#ifdef CARDANO_NETWORK_TESTNET
+
+protocolMagic = 1097911063
+networkName = "testnet"
+
+#endif
+#ifdef CARDANO_NETWORK_STAGING
+
+protocolMagic = 633343913
+networkName = "staging"
+
+#endif


### PR DESCRIPTION
# Issue Number

#95 

# Motivation
We currently have a `--network` option in the CLI. We could derive the protocol magic (which we need), from this, and pass it around "everywhere". @KtorZ suggested we instead either:

- Choose network at via a compile-time flag (like this)
- Use `unsafePerformIO` reading a ENV var (we could either default to testnet or to nothing)

# Overview

- [x] I have added `config/staging`, `config/testnet`, `config/mainnet` directories
- [x] I have added `Cardano.Network` inside each directory, exporting `protocolMagic :: Int32`
- [x] I have added `mainnet` and `staging` flags and made the `testnet` config default

```
$ stack ghci cardano-wallet
λ> import Cardano.Network
λ> Cardano.Network.protocolMagic
1097911063
```
```
$ stack ghci cardano-wallet --flag cardano-wallet:mainnet
λ> import Cardano.Network
λ> Cardano.Network.protocolMagic
764824073
```


# Comments

- I wonder how this plays out with our integration tests. I do not know if we would like to specify `local` as network, but if we want to, it might be tricky. It appears cabal doesn't support specifying flags, but [stack does](https://stackoverflow.com/a/35123917)
- This commit does not replace existing CLI logic for choosing network,
which would be a natural follow-up, if we were to go down this path.

<!-- 



Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->