### PR TITLE
Realistic Fee Calculation (Byron)

### DIFF
--- a/.buildkite/benchmark.sh
+++ b/.buildkite/benchmark.sh
@@ -13,6 +13,8 @@ fi
 echo "--- Build code and benchmarks"
 stack build --bench --no-run-benchmarks
 
+export NETWORK=$netname
+
 echo "+++ Run benchmarks"
 stack bench cardano-wallet:restore --interleaved-output --ba "$netname +RTS -N2 -qg -A1m -I0 -T -M1G -h -RTS"
 

--- a/.buildkite/benchmark.sh
+++ b/.buildkite/benchmark.sh
@@ -16,7 +16,7 @@ stack build --bench --no-run-benchmarks
 export NETWORK=$netname
 
 echo "+++ Run benchmarks"
-stack bench cardano-wallet:restore --interleaved-output --ba "$netname +RTS -N2 -qg -A1m -I0 -T -M1G -h -RTS"
+stack bench cardano-wallet:restore --interleaved-output --ba "$netname +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS"
 
 hp2pretty restore.hp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,16 @@ jobs:
     - curl -sSL https://raw.github.com/ndmitchell/weeder/master/misc/travis.sh | sh -s .
 
   - stage: checks 🔬
-    name: "Tests"
+    name: "Tests (mainnet)"
     script:
+    - export NETWORK=mainnet
+    - tar xzf $STACK_WORK_CACHE
+    - stack --no-terminal test cardano-wallet:unit
+
+  - stage: checks 🔬
+    name: "Tests (testnet)"
+    script:
+    - export NETWORK=testnet
     - tar xzf $STACK_WORK_CACHE
     - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/test/data/cardano-http-bridge/hermes-testnet.tar.gz
     - tar xzf hermes-testnet.tar.gz -C $HOME

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -49,4 +49,8 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Spec
+        - identifier: main

--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -26,8 +26,6 @@ import Cardano.CLI
     , getRequiredSensitiveValue
     , parseArgWith
     )
-import Cardano.Environment
-    ( network )
 import Cardano.Wallet
     ( mkWalletLayer )
 import Cardano.Wallet.Api
@@ -171,7 +169,7 @@ exec args
 execServer :: Port "wallet" -> Port "bridge" -> IO ()
 execServer (Port port) (Port bridgePort) = do
     db <- MVar.newDBLayer
-    nw <- HttpBridge.newNetworkLayer network bridgePort
+    nw <- HttpBridge.newNetworkLayer bridgePort
     let wallet = mkWalletLayer db nw
     Warp.runSettings settings (serve (Proxy @("v2" :> Api)) (server wallet))
   where

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -118,6 +118,7 @@ test-suite unit
     , containers
     , cryptonite
     , deepseq
+    , digest
     , docopt
     , file-embed
     , fmt

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -171,6 +171,7 @@ test-suite unit
       Data.Text.ClassSpec
       Data.QuantitySpec
       Servant.Extra.ContentTypesSpec
+      Spec
       Test.Text.Roundtrip
   if os(windows)
     build-depends: Win32

--- a/src/Cardano/Wallet/CoinSelection/Fee.hs
+++ b/src/Cardano/Wallet/CoinSelection/Fee.hs
@@ -29,7 +29,7 @@ module Cardano.Wallet.CoinSelection.Fee
 import Prelude
 
 import Cardano.Environment
-    ( Network (..) )
+    ( Network (..), network )
 import Cardano.Wallet.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
@@ -331,10 +331,9 @@ cardanoPolicy = TxSizeLinear (Quantity 155381) (Quantity 43.946)
 -- therefore, have an empty address derivation payload.
 estimateFee
     :: TxSizeLinear
-    -> Network
     -> CoinSelection
     -> Fee
-estimateFee policy network (CoinSelection inps outs chngs) =
+estimateFee policy (CoinSelection inps outs chngs) =
     Fee $ ceiling (a + b*fromIntegral totalPayload)
   where
     TxSizeLinear (Quantity a) (Quantity b) = policy

--- a/src/Cardano/Wallet/CoinSelection/Policy/LargestFirst.hs
+++ b/src/Cardano/Wallet/CoinSelection/Policy/LargestFirst.hs
@@ -88,7 +88,7 @@ atLeast (utxo0, selection) txout =
     coverOutput (fromIntegral $ getCoin $ coin txout, mempty) utxo0
   where
     coverOutput
-        :: (Int, [(TxIn, TxOut)])
+        :: (Integer, [(TxIn, TxOut)])
         -> [(TxIn, TxOut)]
         -> Maybe ([(TxIn, TxOut)], CoinSelection)
     coverOutput (target, ins) utxo
@@ -105,7 +105,6 @@ atLeast (utxo0, selection) txout =
         | otherwise =
             let
                 (inp, out):utxo' = utxo
-                target' =
-                    target - (fromIntegral (getCoin (coin out)))
+                target' = target - (fromIntegral (getCoin (coin out)))
             in
                 coverOutput (target', (inp, out):ins) utxo'

--- a/test/integration/Cardano/WalletSpec.hs
+++ b/test/integration/Cardano/WalletSpec.hs
@@ -9,7 +9,7 @@ module Cardano.WalletSpec
 import Prelude
 
 import Cardano.Environment
-    ( Network (..) )
+    ( network )
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
@@ -28,11 +28,14 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
     ( async, cancel )
+import Data.Text.Class
+    ( toText )
 import Test.Hspec
     ( Spec, after, before, it, shouldSatisfy )
 
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
+import qualified Data.Text as T
 
 spec :: Spec
 spec = do
@@ -58,7 +61,7 @@ spec = do
             [ Command "cardano-http-bridge"
                 [ "start"
                 , "--port", show port
-                , "--template", "testnet"
+                , "--template", T.unpack (toText network)
                 ]
                 (return ())
                 Inherit
@@ -66,4 +69,4 @@ spec = do
         threadDelay 1000000
         (handle,) <$> (mkWalletLayer
             <$> MVar.newDBLayer
-            <*> HttpBridge.newNetworkLayer Testnet port)
+            <*> HttpBridge.newNetworkLayer port)

--- a/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
@@ -14,7 +14,7 @@ module Cardano.Wallet.CoinSelection.FeeSpec
 import Prelude
 
 import Cardano.Environment
-    ( Network (..) )
+    ( Network (..), network )
 import Cardano.Wallet.Binary
     ( encodeSignedTx )
 import Cardano.Wallet.CoinSelection
@@ -83,8 +83,6 @@ import Test.QuickCheck
     , withMaxSuccess
     , (==>)
     )
-import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
@@ -372,11 +370,11 @@ propReducedChanges drg (ShowFmt (FeeProp coinSel utxo (fee, dust))) = do
         adjustForFee feeOpt utxo coinSel
 
 propFeeEstimation
-    :: (ShowFmt CoinSelection, Network, InfiniteList (Network -> Address))
+    :: (ShowFmt CoinSelection, InfiniteList (Network -> Address))
     -> Property
-propFeeEstimation (ShowFmt sel, network, InfiniteList chngAddrs _) =
+propFeeEstimation (ShowFmt sel, InfiniteList chngAddrs _) =
     let
-        (Fee calcFee) = estimateFee cardanoPolicy network sel
+        (Fee calcFee) = estimateFee cardanoPolicy sel
         (TxSizeLinear (Quantity a) (Quantity b)) = cardanoPolicy
         tx = fromCoinSelection sel
         size = BL.length $ toLazyByteString $ encodeSignedTx tx
@@ -520,10 +518,6 @@ instance Arbitrary (Hash "Tx") where
 instance Arbitrary Address where
     shrink _ = []
     arbitrary = genAddress (30, 100)
-
-instance Arbitrary Network where
-    shrink = genericShrink
-    arbitrary = genericArbitrary
 
 -- | Generate change addresses for the given network. We consider that change
 -- addresses are always following a sequential scheme.

--- a/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.CoinSelection.FeeSpec
@@ -15,9 +16,11 @@ import Cardano.Wallet.Binary
 import Cardano.Wallet.CoinSelection
     ( CoinSelection (..), CoinSelectionOptions (..) )
 import Cardano.Wallet.CoinSelection.Fee
-    ( Fee (..)
+    ( AddressScheme (..)
+    , Fee (..)
     , FeeError (..)
     , FeeOptions (..)
+    , Network (..)
     , TxSizeLinear (..)
     , adjustForFees
     , cardanoPolicy
@@ -48,18 +51,16 @@ import Crypto.Random
     ( SystemDRG, getSystemDRG )
 import Crypto.Random.Types
     ( withDRG )
-import Data.ByteArray.Encoding
-    ( Base (Base16), convertFromBase )
-import Data.ByteString
-    ( ByteString )
-import Data.ByteString.Base58
-    ( bitcoinAlphabet, decodeBase58 )
 import Data.Either
     ( isRight )
 import Data.Functor.Identity
     ( Identity (runIdentity) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( TextDecodingError (..), fromText )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -269,181 +270,322 @@ spec = do
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [1]
-            , expectedFee = 167115
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170543
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [1]
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Sequential
+            , expectedFee = 168697
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [1]
+            , csChanges = [1]
+            , csNetwork = Mainnet
+            , csAddressScheme = Random
+            , expectedFee = 169840
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [1]
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Sequential
+            , expectedFee = 168697
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [23]
-            , expectedFee = 167115
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170543
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [24]
-            , expectedFee = 167159
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170587
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [255]
-            , expectedFee = 167159
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170587
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [256]
-            , expectedFee = 167203
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170631
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [65535]
-            , expectedFee = 167203
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170631
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000]
             , csOutputs = [65536]
-            , expectedFee = 167291
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 170719
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [500000,500000]
             , csOutputs = [750000]
-            , expectedFee = 175245
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 182101
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [330000,330000,330000]
             , csOutputs = [750000]
-            , expectedFee = 183199
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 193483
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [250000,250000,250000,250000]
             , csOutputs = [750000]
-            , expectedFee = 191154
+            , csChanges = [1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 204865
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [200000,200000,200000,200000,200000]
             , csOutputs = [750000]
-            , expectedFee = 199108
+            , csChanges = [1,1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 216247
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [185000,185000,185000,185000,185000,185000]
             , csOutputs = [750000]
-            , expectedFee = 207062
+            , csChanges = [1,1,1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 227629
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [142000,142000,142000,142000,142000,142000,142000]
             , csOutputs = [750000]
-            , expectedFee = 215016
+            , csChanges = [1,1,1,1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 239011
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [125000,125000,125000,125000,125000,125000,125000,125000]
             , csOutputs = [750000]
-            , expectedFee = 222970
+            , csChanges = [1,1,1,1,1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 250393
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [250000,250000]
             , csOutputs = [100000,23]
-            , expectedFee = 178673
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 185528
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [250000,250000]
             , csOutputs = [100000,24]
-            , expectedFee = 178717
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 185572
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [250000,250000]
             , csOutputs = [100000,256]
-            , expectedFee = 178761
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 185616
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [250000,250000]
             , csOutputs = [100000,65536]
-            , expectedFee = 178849
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 185704
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [120000,120000,120000]
             , csOutputs = [100000,23]
-            , expectedFee = 186627
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 193483
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [120000,120000,120000]
             , csOutputs = [100000,24]
-            , expectedFee = 186671
+            , csChanges = [1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 193527
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [120000,120000,120000]
             , csOutputs = [100000,256]
-            , expectedFee = 186715
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 196998
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [120000,120000,120000]
             , csOutputs = [100000,65536]
-            , expectedFee = 186803
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 197086
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [1,1,1]
-            , expectedFee = 189879
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200162
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [60000,60000,60000,60000]
             , csOutputs = [1,1,1]
-            , expectedFee = 197833
+            , csChanges = [1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 211544
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [50000,50000,50000,50000,50000]
             , csOutputs = [1,1,1]
-            , expectedFee = 205788
+            , csChanges = [1,1,1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 222927
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [24,1,1]
-            , expectedFee = 189923
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200206
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [24,24,1]
-            , expectedFee = 189967
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200250
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [24,256,1]
-            , expectedFee = 190011
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200294
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [24,256,256]
-            , expectedFee = 190099
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200382
             })
 
         feeEstimationUnitTest (FeeCase
             { csInputs = [100000,100000,100000]
             , csOutputs = [65536,256,256]
-            , expectedFee = 190231
+            , csChanges = [1,1,1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 200514
+            })
+
+        -- 23 inps => 23*42 = 966
+        -- 1+1 outs+chngs => 78*2 = 156
+        -- totalOutSize = 6 + 966 + 156 =  1128
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+            , csOutputs = [1]
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 345536
+            })
+
+        -- 24 inps => 24*43 = 1032
+        -- 1+1 outs+chngs => 78*2 = 156
+        -- totalOutSize = 7 + 1032 + 156 =  1195
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
+            , csOutputs = [1]
+            , csChanges = [1]
+            , csNetwork = Testnet
+            , csAddressScheme = Random
+            , expectedFee = 354589
             })
 
 
@@ -535,27 +677,31 @@ propFeeEstimation
     -> Property
 propFeeEstimation (FeeProp (CoinSelProp utxo txOuts) _ _) = do
     isRight selection ==> let Right s = selection in prop s
-  where
-    prop coinSel@(CoinSelection inps outs _) = do
-        let (Fee estFee) = estimateCardanoFee cardanoPolicy coinSel
+    where
+    prop coinSel@(CoinSelection inps outs chngs) = do
+        let (Fee estFee) = estimateCardanoFee cardanoPolicy Random Testnet coinSel
 
         -- | Make a Hash from a Base16 encoded string, without error handling.
-        let hash16 :: ByteString -> Hash a
-            hash16 = either bomb Hash . convertFromBase Base16
-                where
-                    bomb msg = error ("Could not decode test string: " <> msg)
+        let hash16 :: Text -> Hash "Tx"
+            hash16 txt = case fromText @(Hash "Tx") txt of
+                Left (TextDecodingError err) ->
+                    error ("Could not decode test string: " <> err)
+                Right res -> res
 
         -- | Make an Address from a Base58 encoded string, without error handling.
-        let addr58 :: ByteString -> Address
-            addr58 = maybe (error "addr58: Could not decode") Address
-                . decodeBase58 bitcoinAlphabet
+        let addr58 :: Text -> Address
+            addr58 txt = case fromText @Address txt of
+                Left (TextDecodingError err) ->
+                    error ("addr58: Could not decode because " <> err)
+                Right res -> res
 
         let inputId0 = hash16 "60dbb2679ee920540c18195a3d92ee9be50aee6ed5f891d92d51db8a76b02cd2"
         let address0 = addr58 "DdzFFzCqrhsug8jKBMV5Cr94hKY4DrbJtkUpqptoGEkovR2QSkcA\
                               \cRgjnUyegE689qBX6b2kyxyNvCL6mfqiarzRB9TRq8zwJphR31pr"
         let pkWitness = "\130X@\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQhX@\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI"
         let txIns = zipWith TxIn (replicate (length inps) inputId0) [0..]
-        let txOuts' = zipWith TxOut (replicate (length outs) address0) (map coin outs)
+        let coins = map coin outs ++ chngs
+        let txOuts' = zipWith TxOut (replicate (length coins) address0) coins
         let tx = Tx txIns txOuts'
         let calculatedSize = BL.length $ toLazyByteString $ encodeSignedTx (tx, replicate (length inps) (PublicKeyWitness pkWitness))
         let (TxSizeLinear (Quantity a) (Quantity b)) = cardanoPolicy
@@ -574,22 +720,29 @@ propFeeEstimation (FeeProp (CoinSelProp utxo txOuts) _ _) = do
 feeEstimationUnitTest
     :: FeeCase
     -> SpecWith ()
-feeEstimationUnitTest (FeeCase inps' outs' expected) = it title $ do
+feeEstimationUnitTest (FeeCase inps' outs' chngs' net scheme expected) = it title $ do
     inps <- (Map.toList . getUTxO) <$> generate (genUTxO inps')
-    outs <- generate (genTxOut outs')
+    outs <- generate (genTxOut (outs' ++ chngs'))
     let coinSel = CoinSelection inps outs []
-    let (Fee estFee) = estimateCardanoFee cardanoPolicy coinSel
+    let (Fee estFee) = estimateCardanoFee cardanoPolicy scheme net coinSel
     estFee `shouldBe` expected
         where
     title :: String
     title = mempty
         <> "FeeCase (inps=" <> show inps'
         <> " outs=" <> show outs'
+        <> " outs=" <> show outs'
+        <> " chngs=" <> show chngs'
+        <> " address scheme=" <> show scheme
+        <> " " <> show net
         <> ") --> " <> show expected
 
 data FeeCase = FeeCase
     { csInputs :: [Word64]
     , csOutputs :: [Word64]
+    , csChanges :: [Word64]
+    , csNetwork :: Network
+    , csAddressScheme :: AddressScheme
     , expectedFee :: Word64
     } deriving (Show, Generic)
 

--- a/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.CoinSelection.FeeSpec
@@ -11,25 +13,23 @@ module Cardano.Wallet.CoinSelection.FeeSpec
 
 import Prelude
 
+import Cardano.Environment
+    ( Network (..) )
 import Cardano.Wallet.Binary
     ( encodeSignedTx )
 import Cardano.Wallet.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..) )
+    ( CoinSelection (..) )
 import Cardano.Wallet.CoinSelection.Fee
-    ( AddressScheme (..)
-    , Fee (..)
+    ( Fee (..)
     , FeeError (..)
     , FeeOptions (..)
-    , Network (..)
     , TxSizeLinear (..)
-    , adjustForFees
+    , adjustForFee
     , cardanoPolicy
-    , estimateCardanoFee
+    , estimateFee
     )
 import Cardano.Wallet.CoinSelection.Policy.LargestFirst
     ( largestFirst )
-import Cardano.Wallet.CoinSelectionSpec
-    ( CoinSelProp (..), genTxOut, genUTxO )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -45,35 +45,55 @@ import Codec.CBOR.Write
     ( toLazyByteString )
 import Control.Arrow
     ( left )
+import Control.Monad.IO.Class
+    ( liftIO )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
     ( SystemDRG, getSystemDRG )
 import Crypto.Random.Types
     ( withDRG )
+import Data.Digest.CRC32
+    ( crc32 )
 import Data.Either
     ( isRight )
 import Data.Functor.Identity
     ( Identity (runIdentity) )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Text
-    ( Text )
-import Data.Text.Class
-    ( TextDecodingError (..), fromText )
 import Data.Word
     ( Word64 )
 import Fmt
     ( Buildable (..), nameF, tupleF )
-import GHC.Generics
-    ( Generic )
 import Test.Hspec
     ( Spec, SpecWith, before, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, choose, disjoin, generate, property, (==>) )
+    ( Arbitrary (..)
+    , Gen
+    , InfiniteList (..)
+    , Property
+    , choose
+    , disjoin
+    , generate
+    , property
+    , scale
+    , vectorOf
+    , withMaxSuccess
+    , (==>)
+    )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
 
+import qualified Cardano.Wallet.Binary as CBOR
 import qualified Cardano.Wallet.CoinSelection as CS
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
 spec :: Spec
@@ -267,346 +287,39 @@ spec = do
             , csChngs = [3,3]
             })
 
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170543
-            })
+    describe "Fee Calculation: Generators" $ do
+        it "Arbitrary CoinSelection" $ property $ \(ShowFmt cs) ->
+            property $ isValidSelection cs
 
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Sequential
-            , expectedFee = 168697
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Mainnet
-            , csAddressScheme = Random
-            , expectedFee = 169840
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Sequential
-            , expectedFee = 168697
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [23]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170543
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [24]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170587
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [255]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170587
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [256]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170631
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [65535]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170631
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000]
-            , csOutputs = [65536]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 170719
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [500000,500000]
-            , csOutputs = [750000]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 182101
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [330000,330000,330000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 193483
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [250000,250000,250000,250000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 204865
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [200000,200000,200000,200000,200000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 216247
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [185000,185000,185000,185000,185000,185000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 227629
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [142000,142000,142000,142000,142000,142000,142000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1,1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 239011
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [125000,125000,125000,125000,125000,125000,125000,125000]
-            , csOutputs = [750000]
-            , csChanges = [1,1,1,1,1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 250393
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [250000,250000]
-            , csOutputs = [100000,23]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 185528
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [250000,250000]
-            , csOutputs = [100000,24]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 185572
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [250000,250000]
-            , csOutputs = [100000,256]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 185616
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [250000,250000]
-            , csOutputs = [100000,65536]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 185704
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [120000,120000,120000]
-            , csOutputs = [100000,23]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 193483
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [120000,120000,120000]
-            , csOutputs = [100000,24]
-            , csChanges = [1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 193527
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [120000,120000,120000]
-            , csOutputs = [100000,256]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 196998
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [120000,120000,120000]
-            , csOutputs = [100000,65536]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 197086
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [1,1,1]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200162
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [60000,60000,60000,60000]
-            , csOutputs = [1,1,1]
-            , csChanges = [1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 211544
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [50000,50000,50000,50000,50000]
-            , csOutputs = [1,1,1]
-            , csChanges = [1,1,1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 222927
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [24,1,1]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200206
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [24,24,1]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200250
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [24,256,1]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200294
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [24,256,256]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200382
-            })
-
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [100000,100000,100000]
-            , csOutputs = [65536,256,256]
-            , csChanges = [1,1,1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 200514
-            })
-
-        -- 23 inps => 23*42 = 966
-        -- 1+1 outs+chngs => 78*2 = 156
-        -- totalOutSize = 6 + 966 + 156 =  1128
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 345536
-            })
-
-        -- 24 inps => 24*43 = 1032
-        -- 1+1 outs+chngs => 78*2 = 156
-        -- totalOutSize = 7 + 1032 + 156 =  1195
-        feeEstimationUnitTest (FeeCase
-            { csInputs = [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]
-            , csOutputs = [1]
-            , csChanges = [1]
-            , csNetwork = Testnet
-            , csAddressScheme = Random
-            , expectedFee = 354589
-            })
-
-
-    before getSystemDRG $ describe "Fee calculation properties" $ do
+    before getSystemDRG $ describe "Fee Adjustment properties" $ do
         it "No fee gives back the same selection"
             (\_ -> property propSameSelection)
         it "Fee adjustment is deterministic when there's no extra inputs"
             (\_ -> property propDeterministic)
         it "Adjusting for fee (/= 0) reduces the change outputs or increase inputs"
             (property . propReducedChanges)
-        it "Estimated fee is the same as taken by encodeSignedTx"
-            (\_ -> property propFeeEstimation)
 
+    describe "Fee Estimation properties" $ do
+        it "Estimated fee is the same as taken by encodeSignedTx"
+            (withMaxSuccess 1000 $ property propFeeEstimation)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
 -------------------------------------------------------------------------------}
 
+-- Check whether a selection is valid
+isValidSelection :: CoinSelection -> Bool
+isValidSelection (CoinSelection i o c) =
+    let
+        oAmt = sum $ map (fromIntegral . getCoin . coin) o
+        cAmt = sum $ map (fromIntegral . getCoin) c
+        iAmt = sum $ map (fromIntegral . getCoin . coin . snd) i
+    in
+        (iAmt :: Integer) >= (oAmt + cAmt)
+
 -- | Data for running fee calculation properties
 data FeeProp = FeeProp
-    { coveringCase :: CoinSelProp
+    { selection :: CoinSelection
      -- ^ inputs from wich largestFirst can be calculated
     , availableUtxo :: UTxO
      -- ^ additional UTxO from which fee calculation will pick needed coins
@@ -623,128 +336,78 @@ instance Buildable FeeProp where
 propSameSelection
     :: ShowFmt FeeProp
     -> Property
-propSameSelection (ShowFmt (FeeProp (CoinSelProp utxo txOuts) utxo' _)) = do
-    isRight selection ==> let Right s = selection in prop s
-  where
-    prop coinSel = do
-        let feeOpt = feeOptions 0 0
-        coinSel' <- runExceptT (adjustForFees feeOpt utxo' coinSel)
-        fmap ShowFmt coinSel' `shouldBe` Right (ShowFmt coinSel)
-    selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
+propSameSelection (ShowFmt (FeeProp coinSel utxo _)) = monadicIO $ liftIO $ do
+    let feeOpt = feeOptions 0 0
+    coinSel' <- runExceptT (adjustForFee feeOpt utxo coinSel)
+    fmap ShowFmt coinSel' `shouldBe` Right (ShowFmt coinSel)
 
 propDeterministic
     :: ShowFmt FeeProp
     -> Property
-propDeterministic (ShowFmt (FeeProp (CoinSelProp utxo txOuts) _ (fee, dust))) = do
-    isRight selection ==> let Right s = selection in prop s
-  where
-    prop coinSel = do
-        let feeOpt = feeOptions fee dust
-        let utxo' = mempty
-        resultOne <- runExceptT $ adjustForFees feeOpt utxo' coinSel
-        resultTwo <- runExceptT $ adjustForFees feeOpt utxo' coinSel
-        resultOne `shouldBe` resultTwo
-    selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
+propDeterministic (ShowFmt (FeeProp coinSel _ (fee, dust))) = monadicIO $ liftIO $ do
+    let feeOpt = feeOptions fee dust
+    let utxo = mempty
+    resultOne <- runExceptT $ adjustForFee feeOpt utxo coinSel
+    resultTwo <- runExceptT $ adjustForFee feeOpt utxo coinSel
+    resultOne `shouldBe` resultTwo
 
 propReducedChanges
     :: SystemDRG
     -> ShowFmt FeeProp
     -> Property
-propReducedChanges drg (ShowFmt (FeeProp (CoinSelProp utxo txOuts) utxo' (fee, dust))) = do
-    isRight selection' ==>
-        let (Right s, Right s') = (selection, selection') in prop s s'
+propReducedChanges drg (ShowFmt (FeeProp coinSel utxo (fee, dust))) = do
+    isRight coinSel' ==> let Right s = coinSel' in prop s
   where
-    prop coinSel coinSel' = do
-        let chgs' = sum $ map getCoin $ change coinSel'
+    prop s = do
+        let chgs' = sum $ map getCoin $ change s
         let chgs = sum $ map getCoin $ change coinSel
-        let inps' = CS.inputs coinSel'
+        let inps' = CS.inputs s
         let inps = CS.inputs coinSel
         disjoin
             [ chgs' `shouldSatisfy` (<= chgs)
             , length inps' `shouldSatisfy` (>= length inps)
             ]
-    selection = left show $ runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
-    selection' = selection >>= adjust
     feeOpt = feeOptions fee dust
-    adjust s = left show $ fst $ withDRG drg $ runExceptT $
-        adjustForFees feeOpt utxo' s
+    coinSel' = left show $ fst $ withDRG drg $ runExceptT $
+        adjustForFee feeOpt utxo coinSel
 
 propFeeEstimation
-    :: FeeProp
+    :: (ShowFmt CoinSelection, Network, InfiniteList (Network -> Address))
     -> Property
-propFeeEstimation (FeeProp (CoinSelProp utxo txOuts) _ _) = do
-    isRight selection ==> let Right s = selection in prop s
-    where
-    prop coinSel@(CoinSelection inps outs chngs) = do
-        let (Fee estFee) = estimateCardanoFee cardanoPolicy Random Testnet coinSel
-
-        -- | Make a Hash from a Base16 encoded string, without error handling.
-        let hash16 :: Text -> Hash "Tx"
-            hash16 txt = case fromText @(Hash "Tx") txt of
-                Left (TextDecodingError err) ->
-                    error ("Could not decode test string: " <> err)
-                Right res -> res
-
-        -- | Make an Address from a Base58 encoded string, without error handling.
-        let addr58 :: Text -> Address
-            addr58 txt = case fromText @Address txt of
-                Left (TextDecodingError err) ->
-                    error ("addr58: Could not decode because " <> err)
-                Right res -> res
-
-        let inputId0 = hash16 "60dbb2679ee920540c18195a3d92ee9be50aee6ed5f891d92d51db8a76b02cd2"
-        let address0 = addr58 "DdzFFzCqrhsug8jKBMV5Cr94hKY4DrbJtkUpqptoGEkovR2QSkcA\
-                              \cRgjnUyegE689qBX6b2kyxyNvCL6mfqiarzRB9TRq8zwJphR31pr"
-        let pkWitness = "\130X@\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQhX@\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI"
-        let txIns = zipWith TxIn (replicate (length inps) inputId0) [0..]
-        let coins = map coin outs ++ chngs
-        let txOuts' = zipWith TxOut (replicate (length coins) address0) coins
-        let tx = Tx txIns txOuts'
-        let calculatedSize = BL.length $ toLazyByteString $ encodeSignedTx (tx, replicate (length inps) (PublicKeyWitness pkWitness))
-        let (TxSizeLinear (Quantity a) (Quantity b)) = cardanoPolicy
-        let calcFee = ceiling (a + b*(fromIntegral calculatedSize))
-
-        estFee `shouldBe` calcFee
-
-    selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
-
+propFeeEstimation (ShowFmt sel, network, InfiniteList chngAddrs _) =
+    let
+        (Fee calcFee) = estimateFee cardanoPolicy network sel
+        (TxSizeLinear (Quantity a) (Quantity b)) = cardanoPolicy
+        tx = fromCoinSelection sel
+        size = BL.length $ toLazyByteString $ encodeSignedTx tx
+        -- We always go for the higher bound for change address payload's size,
+        -- so, we may end up with up to 4 extra bytes per change address in our
+        -- estimation.
+        margin = 4 * fromIntegral (length $ CS.change sel)
+        realFeeSup = ceiling (a + b*(fromIntegral size + margin))
+        realFeeInf = ceiling (a + b*(fromIntegral size))
+    in
+        property (calcFee >= realFeeInf && calcFee <= realFeeSup)
+  where
+    dummyWitness = PublicKeyWitness
+        "\130X@\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQhX@\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI"
+    dummyInput = Hash
+        "`\219\178g\158\233 T\f\CAN\EMZ=\146\238\155\229\n\238n\213\248\145\217-Q\219\138v\176,\210"
+    fromCoinSelection (CoinSelection inps outs chngs) =
+        let
+            txIns = zipWith TxIn
+                (replicate (length inps) dummyInput)
+                [0..]
+            txChngs = zipWith TxOut
+                (take (length chngs) (chngAddrs <*> pure network))
+                chngs
+            wits = replicate (length inps) dummyWitness
+        in
+            (Tx txIns (outs <> txChngs), wits)
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests
 -------------------------------------------------------------------------------}
-
-feeEstimationUnitTest
-    :: FeeCase
-    -> SpecWith ()
-feeEstimationUnitTest (FeeCase inps' outs' chngs' net scheme expected) = it title $ do
-    inps <- (Map.toList . getUTxO) <$> generate (genUTxO inps')
-    outs <- generate (genTxOut (outs' ++ chngs'))
-    let coinSel = CoinSelection inps outs []
-    let (Fee estFee) = estimateCardanoFee cardanoPolicy scheme net coinSel
-    estFee `shouldBe` expected
-        where
-    title :: String
-    title = mempty
-        <> "FeeCase (inps=" <> show inps'
-        <> " outs=" <> show outs'
-        <> " outs=" <> show outs'
-        <> " chngs=" <> show chngs'
-        <> " address scheme=" <> show scheme
-        <> " " <> show net
-        <> ") --> " <> show expected
-
-data FeeCase = FeeCase
-    { csInputs :: [Word64]
-    , csOutputs :: [Word64]
-    , csChanges :: [Word64]
-    , csNetwork :: Network
-    , csAddressScheme :: AddressScheme
-    , expectedFee :: Word64
-    } deriving (Show, Generic)
 
 feeOptions
     :: Word64
@@ -765,7 +428,7 @@ feeUnitTest (FeeFixture inpsF outsF chngsF utxoF feeF dustF) expected = it title
     (utxo, sel) <- setup
     result <- runExceptT $ do
         (CoinSelection inps outs chngs) <-
-            adjustForFees (feeOptions feeF dustF) utxo sel
+            adjustForFee (feeOptions feeF dustF) utxo sel
         return $ FeeOutput
             { csInps = map (getCoin . coin . snd) inps
             , csOuts = map (getCoin . coin) outs
@@ -775,9 +438,9 @@ feeUnitTest (FeeFixture inpsF outsF chngsF utxoF feeF dustF) expected = it title
   where
     setup :: IO (UTxO, CoinSelection)
     setup = do
-        utxo <- generate (genUTxO utxoF)
-        inps <- (Map.toList . getUTxO) <$> generate (genUTxO inpsF)
-        outs <- generate (genTxOut outsF)
+        utxo <- generate (genUTxO $ Coin <$> utxoF)
+        inps <- (Map.toList . getUTxO) <$> generate (genUTxO $ Coin <$> inpsF)
+        outs <- generate (genTxOut $ Coin <$> outsF)
         let chngs = map Coin chngsF
         pure (utxo, CoinSelection inps outs chngs)
 
@@ -820,13 +483,138 @@ data FeeOutput = FeeOutput
                             Arbitrary Instances
 -------------------------------------------------------------------------------}
 
-instance Arbitrary FeeProp where
-    shrink (FeeProp cc utxo opts) =
-        (\(cc', utxo') -> FeeProp cc' utxo' opts)
-            <$> zip (shrink cc) (shrink utxo)
+deriving newtype instance Arbitrary a => Arbitrary (ShowFmt a)
+
+instance Show (Network -> Address) where
+    show _ = "<Change Address Generator>"
+
+genUTxO :: [Coin] -> Gen UTxO
+genUTxO coins = do
+    let n = length coins
+    inps <- vectorOf n arbitrary
+    outs <- genTxOut coins
+    return $ UTxO $ Map.fromList $ zip inps outs
+
+genTxOut :: [Coin] -> Gen [TxOut]
+genTxOut coins = do
+    let n = length coins
+    outs <- vectorOf n arbitrary
+    return $ zipWith TxOut outs coins
+
+instance Arbitrary TxIn where
+    shrink _ = []
+    arbitrary = TxIn
+        <$> arbitrary
+        <*> scale (`mod` 3) arbitrary -- No need for a high indexes
+
+instance Arbitrary Coin where
+    shrink (Coin c) = Coin <$> shrink (fromIntegral c)
+    arbitrary = Coin <$> choose (1, 200000)
+
+instance Arbitrary (Hash "Tx") where
+    shrink _ = []
     arbitrary = do
-        cc <- arbitrary
-        utxo <- arbitrary
+        bytes <- BS.pack <$> vectorOf 32 arbitrary
+        pure $ Hash bytes
+
+instance Arbitrary Address where
+    shrink _ = []
+    arbitrary = genAddress (30, 100)
+
+instance Arbitrary Network where
+    shrink = genericShrink
+    arbitrary = genericArbitrary
+
+-- | Generate change addresses for the given network. We consider that change
+-- addresses are always following a sequential scheme.
+instance {-# OVERLAPS #-} Arbitrary (Network -> Address) where
+    shrink _ = []
+    arbitrary = do
+        mainnetA <- genAddress (39, 43)
+        testnetA <- genAddress (46, 50)
+        return $ \case
+            Mainnet -> mainnetA
+            Staging -> mainnetA
+            Testnet -> testnetA
+            Local -> testnetA
+
+-- | Generate a valid address with a payload of the given size. As pointers,
+-- the sizes of payloads are as follows:
+--
+--     | Network | Scheme     | Size (bytes)   |
+--     | ---     | ---        | ---            |
+--     | Mainnet | Random     | 72,73,74 or 76 |
+--     | Mainnet | Sequential | 39,40,41 or 43 |
+--     | Testnet | Random     | 79,80,81 or 83 |
+--     | Testnet | Sequential | 46,47,48 or 50 |
+--
+-- The address format on 'Staging' is the same as 'Mainnet'.
+-- The address format on 'Local' is the same as 'Testnet'.
+genAddress :: (Int, Int) -> Gen Address
+genAddress range = do
+    n <- choose range
+    let prefix = BS.pack
+            [ 130       -- Array(2)
+            , 216, 24   -- Tag 24
+            , 88, fromIntegral n -- Bytes(n), n > 23 && n < 256
+            ]
+    payload <- BS.pack <$> vectorOf n arbitrary
+    let crc = CBOR.toByteString (CBOR.encodeWord32 $ crc32 payload)
+    return $ Address (prefix <> payload <> crc)
+
+instance Arbitrary CoinSelection where
+    shrink sel@(CoinSelection inps outs chgs) = case (inps, outs, chgs) of
+        ([_], [_], []) ->
+            []
+        _ ->
+            let
+                inps' = take (max 1 (length inps `div` 2)) inps
+                outs' = take (max 1 (length outs `div` 2)) outs
+                chgs' = take (length chgs `div` 2) chgs
+                inps'' = if length inps > 1 then drop 1 inps else inps
+                outs'' = if length outs > 1 then drop 1 outs else outs
+                chgs'' = drop 1 chgs
+            in
+                filter (\s -> s /= sel && isValidSelection s)
+                    [ CoinSelection inps' outs' chgs'
+                    , CoinSelection inps' outs chgs
+                    , CoinSelection inps outs chgs'
+                    , CoinSelection inps outs' chgs
+                    , CoinSelection inps'' outs'' chgs''
+                    , CoinSelection inps'' outs chgs
+                    , CoinSelection inps outs'' chgs
+                    , CoinSelection inps outs chgs''
+                    ]
+    arbitrary = do
+        outs <- choose (1, 10)
+            >>= \n -> vectorOf n arbitrary
+            >>= genTxOut
+        genSelection (NE.fromList outs)
+      where
+        genSelection :: NonEmpty TxOut -> Gen CoinSelection
+        genSelection outs = do
+            let opts = CS.CoinSelectionOptions 100
+            utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
+            case runIdentity $ runExceptT $ largestFirst opts utxo outs of
+                Left _ -> genSelection outs
+                Right s -> return s
+
+instance Arbitrary FeeProp where
+    shrink (FeeProp cs utxo opts) =
+        case Map.toList $ getUTxO utxo  of
+            [] ->
+                map (\cs' -> FeeProp cs' utxo opts) (shrink cs)
+            us ->
+                concatMap (\cs' ->
+                    [ FeeProp cs' mempty opts
+                    , FeeProp cs' (UTxO $ Map.fromList (drop 1 us)) opts
+                    ]
+                ) (shrink cs)
+    arbitrary = do
+        cs <- arbitrary
+        utxo <- choose (0, 50)
+            >>= \n -> vectorOf n arbitrary
+            >>= genUTxO
         fee <- choose (100000, 500000)
         dust <- choose (0, 10000)
-        return $ FeeProp cc utxo (fee, dust)
+        return $ FeeProp cs utxo (fee, dust)

--- a/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.CoinSelection.FeeSpec
@@ -8,16 +10,36 @@ module Cardano.Wallet.CoinSelection.FeeSpec
 
 import Prelude
 
+import Cardano.Wallet.Binary
+    ( encodeSignedTx )
 import Cardano.Wallet.CoinSelection
     ( CoinSelection (..), CoinSelectionOptions (..) )
 import Cardano.Wallet.CoinSelection.Fee
-    ( Fee (..), FeeError (..), FeeOptions (..), adjustForFees )
+    ( Fee (..)
+    , FeeError (..)
+    , FeeOptions (..)
+    , TxSizeLinear (..)
+    , adjustForFees
+    , cardanoPolicy
+    , estimateCardanoFee
+    )
 import Cardano.Wallet.CoinSelection.Policy.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.CoinSelectionSpec
     ( CoinSelProp (..), genTxOut, genUTxO )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), ShowFmt (..), TxOut (..), UTxO (..) )
+    ( Address (..)
+    , Coin (..)
+    , Hash (..)
+    , ShowFmt (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxWitness (..)
+    , UTxO (..)
+    )
+import Codec.CBOR.Write
+    ( toLazyByteString )
 import Control.Arrow
     ( left )
 import Control.Monad.Trans.Except
@@ -26,21 +48,32 @@ import Crypto.Random
     ( SystemDRG, getSystemDRG )
 import Crypto.Random.Types
     ( withDRG )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertFromBase )
+import Data.ByteString
+    ( ByteString )
+import Data.ByteString.Base58
+    ( bitcoinAlphabet, decodeBase58 )
 import Data.Either
     ( isRight )
 import Data.Functor.Identity
     ( Identity (runIdentity) )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Word
     ( Word64 )
 import Fmt
     ( Buildable (..), nameF, tupleF )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
     ( Spec, SpecWith, before, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
     ( Arbitrary (..), Property, choose, disjoin, generate, property, (==>) )
 
+import qualified Cardano.Wallet.CoinSelection as CS
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as Map
-
 
 spec :: Spec
 spec = do
@@ -233,6 +266,187 @@ spec = do
             , csChngs = [3,3]
             })
 
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [1]
+            , expectedFee = 167115
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [23]
+            , expectedFee = 167115
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [24]
+            , expectedFee = 167159
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [255]
+            , expectedFee = 167159
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [256]
+            , expectedFee = 167203
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [65535]
+            , expectedFee = 167203
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000]
+            , csOutputs = [65536]
+            , expectedFee = 167291
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [500000,500000]
+            , csOutputs = [750000]
+            , expectedFee = 175245
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [330000,330000,330000]
+            , csOutputs = [750000]
+            , expectedFee = 183199
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [250000,250000,250000,250000]
+            , csOutputs = [750000]
+            , expectedFee = 191154
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [200000,200000,200000,200000,200000]
+            , csOutputs = [750000]
+            , expectedFee = 199108
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [185000,185000,185000,185000,185000,185000]
+            , csOutputs = [750000]
+            , expectedFee = 207062
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [142000,142000,142000,142000,142000,142000,142000]
+            , csOutputs = [750000]
+            , expectedFee = 215016
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [125000,125000,125000,125000,125000,125000,125000,125000]
+            , csOutputs = [750000]
+            , expectedFee = 222970
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [250000,250000]
+            , csOutputs = [100000,23]
+            , expectedFee = 178673
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [250000,250000]
+            , csOutputs = [100000,24]
+            , expectedFee = 178717
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [250000,250000]
+            , csOutputs = [100000,256]
+            , expectedFee = 178761
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [250000,250000]
+            , csOutputs = [100000,65536]
+            , expectedFee = 178849
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [120000,120000,120000]
+            , csOutputs = [100000,23]
+            , expectedFee = 186627
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [120000,120000,120000]
+            , csOutputs = [100000,24]
+            , expectedFee = 186671
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [120000,120000,120000]
+            , csOutputs = [100000,256]
+            , expectedFee = 186715
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [120000,120000,120000]
+            , csOutputs = [100000,65536]
+            , expectedFee = 186803
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [1,1,1]
+            , expectedFee = 189879
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [60000,60000,60000,60000]
+            , csOutputs = [1,1,1]
+            , expectedFee = 197833
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [50000,50000,50000,50000,50000]
+            , csOutputs = [1,1,1]
+            , expectedFee = 205788
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [24,1,1]
+            , expectedFee = 189923
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [24,24,1]
+            , expectedFee = 189967
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [24,256,1]
+            , expectedFee = 190011
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [24,256,256]
+            , expectedFee = 190099
+            })
+
+        feeEstimationUnitTest (FeeCase
+            { csInputs = [100000,100000,100000]
+            , csOutputs = [65536,256,256]
+            , expectedFee = 190231
+            })
+
+
     before getSystemDRG $ describe "Fee calculation properties" $ do
         it "No fee gives back the same selection"
             (\_ -> property propSameSelection)
@@ -240,6 +454,9 @@ spec = do
             (\_ -> property propDeterministic)
         it "Adjusting for fee (/= 0) reduces the change outputs or increase inputs"
             (property . propReducedChanges)
+        it "Estimated fee is the same as taken by encodeSignedTx"
+            (\_ -> property propFeeEstimation)
+
 
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Properties
@@ -300,8 +517,8 @@ propReducedChanges drg (ShowFmt (FeeProp (CoinSelProp utxo txOuts) utxo' (fee, d
     prop coinSel coinSel' = do
         let chgs' = sum $ map getCoin $ change coinSel'
         let chgs = sum $ map getCoin $ change coinSel
-        let inps' = inputs coinSel'
-        let inps = inputs coinSel
+        let inps' = CS.inputs coinSel'
+        let inps = CS.inputs coinSel
         disjoin
             [ chgs' `shouldSatisfy` (<= chgs)
             , length inps' `shouldSatisfy` (>= length inps)
@@ -313,9 +530,68 @@ propReducedChanges drg (ShowFmt (FeeProp (CoinSelProp utxo txOuts) utxo' (fee, d
     adjust s = left show $ fst $ withDRG drg $ runExceptT $
         adjustForFees feeOpt utxo' s
 
+propFeeEstimation
+    :: FeeProp
+    -> Property
+propFeeEstimation (FeeProp (CoinSelProp utxo txOuts) _ _) = do
+    isRight selection ==> let Right s = selection in prop s
+  where
+    prop coinSel@(CoinSelection inps outs _) = do
+        let (Fee estFee) = estimateCardanoFee cardanoPolicy coinSel
+
+        -- | Make a Hash from a Base16 encoded string, without error handling.
+        let hash16 :: ByteString -> Hash a
+            hash16 = either bomb Hash . convertFromBase Base16
+                where
+                    bomb msg = error ("Could not decode test string: " <> msg)
+
+        -- | Make an Address from a Base58 encoded string, without error handling.
+        let addr58 :: ByteString -> Address
+            addr58 = maybe (error "addr58: Could not decode") Address
+                . decodeBase58 bitcoinAlphabet
+
+        let inputId0 = hash16 "60dbb2679ee920540c18195a3d92ee9be50aee6ed5f891d92d51db8a76b02cd2"
+        let address0 = addr58 "DdzFFzCqrhsug8jKBMV5Cr94hKY4DrbJtkUpqptoGEkovR2QSkcA\
+                              \cRgjnUyegE689qBX6b2kyxyNvCL6mfqiarzRB9TRq8zwJphR31pr"
+        let pkWitness = "\130X@\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQhX@\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI"
+        let txIns = zipWith TxIn (replicate (length inps) inputId0) [0..]
+        let txOuts' = zipWith TxOut (replicate (length outs) address0) (map coin outs)
+        let tx = Tx txIns txOuts'
+        let calculatedSize = BL.length $ toLazyByteString $ encodeSignedTx (tx, replicate (length inps) (PublicKeyWitness pkWitness))
+        let (TxSizeLinear (Quantity a) (Quantity b)) = cardanoPolicy
+        let calcFee = ceiling (a + b*(fromIntegral calculatedSize))
+
+        estFee `shouldBe` calcFee
+
+    selection = runIdentity $ runExceptT $
+        largestFirst (CoinSelectionOptions 100) utxo txOuts
+
+
 {-------------------------------------------------------------------------------
                          Fee Adjustment - Unit Tests
 -------------------------------------------------------------------------------}
+
+feeEstimationUnitTest
+    :: FeeCase
+    -> SpecWith ()
+feeEstimationUnitTest (FeeCase inps' outs' expected) = it title $ do
+    inps <- (Map.toList . getUTxO) <$> generate (genUTxO inps')
+    outs <- generate (genTxOut outs')
+    let coinSel = CoinSelection inps outs []
+    let (Fee estFee) = estimateCardanoFee cardanoPolicy coinSel
+    estFee `shouldBe` expected
+        where
+    title :: String
+    title = mempty
+        <> "FeeCase (inps=" <> show inps'
+        <> " outs=" <> show outs'
+        <> ") --> " <> show expected
+
+data FeeCase = FeeCase
+    { csInputs :: [Word64]
+    , csOutputs :: [Word64]
+    , expectedFee :: Word64
+    } deriving (Show, Generic)
 
 feeOptions
     :: Word64

--- a/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -11,8 +11,6 @@ module Cardano.Wallet.CoinSelectionSpec
     , CoinSelectionFixture(..)
     , CoinSelProp(..)
     , coinSelectionUnitTest
-    , genUTxO
-    , genTxOut
     ) where
 
 -- | This module contains shared logic between the coin selection tests. They

--- a/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -84,20 +84,20 @@ import qualified Data.Set as Set
 
 spec :: Spec
 spec = do
-    describe "Patate Buildable instances examples" $ do
+    describe "Buildable instances examples" $ do
         let block = blockchain !! 1
         let utxo = utxoFromTx $ head $ transactions block
         it (show $ ShowFmt utxo) True
         it (show $ ShowFmt block) True
 
-    describe "Patate Compare Wallet impl. with Specification" $ do
+    describe "Compare Wallet impl. with Specification" $ do
         it "Lemma 3.2 - dom u ⋪ updateUTxO b u = new b"
             (checkCoverage prop_3_2)
 
         it "applyBlock matches the basic model from the specification"
             (checkCoverage prop_applyBlockBasic)
 
-    describe "Patate Extra Properties" $ do
+    describe "Extra Properties" $ do
         it "Incoming transactions have output addresses that belong to the wallet"
             (property prop_applyBlockTxHistoryIncoming)
 

--- a/test/unit/Cardano/WalletSpec.hs
+++ b/test/unit/Cardano/WalletSpec.hs
@@ -12,8 +12,6 @@ module Cardano.WalletSpec
 
 import Prelude
 
-import Cardano.Environment
-    ( Network (..) )
 import Cardano.Wallet
     ( WalletLayer (..), mkWalletLayer )
 import Cardano.Wallet.DB
@@ -139,7 +137,7 @@ setupFixture
     -> IO WalletLayerFixture
 setupFixture (wid, wname, wstate) = do
     db <- newDBLayer
-    network <- newNetworkLayer Local 8000
+    network <- newNetworkLayer 8000
     let wl = mkWalletLayer db network
     res <- runExceptT $ createWallet wl wid wname wstate
     let wal = case res of

--- a/test/unit/Main.hs
+++ b/test/unit/Main.hs
@@ -1,1 +1,16 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main where
+
+import Prelude
+
+import Cardano.Environment
+    ( network )
+import Test.Hspec.Runner
+    ( hspecWith )
+
+import qualified Spec
+import qualified Test.Hspec.Runner as Hspec
+
+main :: IO ()
+main = do
+    network `seq` (return ())
+    hspecWith Hspec.defaultConfig Spec.spec

--- a/test/unit/Spec.hs
+++ b/test/unit/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#92 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have generated a number of representative unit test cases
- [x] I have added the cardano fee estimation implementation that works with current tx support  
- [x] I have added the property test to check fee estimation with direct counting of size after encoding


# Comments

<!-- Additional comments or screenshots to attach if any -->
The idea behind adding fee estimation is the following:
(a) Inputs are always of the same size because they're a hash and index
(b) Outputs have variable sizes, but that can be easily determined regarding their value (<24 one byte, <256 2 bytes, <65536 3 bytes etc ... )
(c) tx witnesses, one per input, are also fixed-sized
(d) there is fixed-sized cbor bits (connected with building lists)

Hence, we can estimate quite precisely the size of transaction 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
