### PR TITLE
Promote 'ChangeChain' from the term-level to type-level on 'AddressPool'

### DIFF
--- a/src/Cardano/Wallet.hs
+++ b/src/Cardano/Wallet.hs
@@ -51,8 +51,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( ChangeChain (..)
-    , Depth (RootK)
+    ( Depth (RootK)
     , Key
     , Passphrase
     , XPrv
@@ -219,9 +218,9 @@ mkWalletLayer db network = WalletLayer
         let accXPrv =
                 deriveAccountPrivateKey mempty rootXPrv minBound
         let extPool =
-                mkAddressPool (publicKey accXPrv) (gap w) ExternalChain []
+                mkAddressPool (publicKey accXPrv) (gap w) []
         let intPool =
-                mkAddressPool (publicKey accXPrv) minBound InternalChain []
+                mkAddressPool (publicKey accXPrv) minBound []
         let wid =
                 WalletId (digest $ publicKey rootXPrv)
         let checkpoint = initWallet $ SeqState

--- a/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -105,6 +105,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
+import Data.Typeable
+    ( Typeable )
 import Data.Word
     ( Word32 )
 import Fmt
@@ -361,7 +363,7 @@ instance MonadRandom ((->) (Passphrase "salt")) where
 data ChangeChain
     = InternalChain
     | ExternalChain
-    deriving (Generic, Show, Eq)
+    deriving (Generic, Typeable, Show, Eq)
 
 instance NFData ChangeChain
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#95

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have promoted the `ChangeChain` to the type-level in `AddressPool` such that we end up with two distinguished types for `AddressPool 'ExternalChain` and `AddressPool 'InternalChain`. 

# Comments

<!-- Additional comments or screenshots to attach if any -->

The main interest here is to makes sure we don't end up using the internal chain where the external chain should be used, and vice-versa (for instance, the `nextChangeIndex` function now requires, unambiguously: `AddressPool 'InternalChain`.

Open to discussion, maybe this brings in too much complexity / type-level magic.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
