### PR TITLE
Rename Change Interface & Store new state after generating change addresses

### DIFF
--- a/src/Cardano/Wallet/Primitive/Model.hs
+++ b/src/Cardano/Wallet/Primitive/Model.hs
@@ -32,6 +32,7 @@ module Cardano.Wallet.Primitive.Model
 
     -- * Construction & Modification
     , initWallet
+    , updateState
     , applyBlock
     , applyBlocks
 
@@ -136,6 +137,14 @@ initWallet
     => s
     -> Wallet s
 initWallet = Wallet mempty mempty mempty (SlotId 0 0)
+
+-- | Update the state of an existing Wallet model
+updateState
+    :: (IsOurs s, NFData s, Show s)
+    => s
+    -> Wallet s
+    -> Wallet s
+updateState s (Wallet a b c d _) = Wallet a b c d s
 
 -- | Apply Block is the only way to make the wallet evolve. It returns a new
 -- updated wallet state, as well as the set of all our transaction discovered


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#95

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have renamed 'generateChangeOutput' in 'nextChangeAddress' 
- [ ] I have stored the new wallet state after generating change addresses

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
