### PR TITLE
Use haskell datatype names for swagger objects

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -394,7 +394,7 @@ networkInformationSoftwareUpdate: &networkInformationSoftwareUpdate
 #############################################################################
 
 definitions:
-  Address: &address
+  ApiAddress: &ApiAddress
     type: object
     required:
       - id
@@ -433,7 +433,7 @@ definitions:
       metrics: *stakePoolMetrics
       profit_margin: *stakePoolProfitMargin
 
-  Transaction: &transaction
+  ApiTransaction: &ApiTransaction
     type: object
     required:
       - id
@@ -453,7 +453,7 @@ definitions:
       outputs: *transactionOutputs
       status: *transactionStatus
 
-  Wallet: &wallet
+  ApiWallet: &ApiWallet
     type: object
     required:
       - id
@@ -656,7 +656,7 @@ responsesListWallets: &responsesListWallets
     description: Ok
     schema:
       type: array
-      items: *wallet
+      items: *ApiWallet
 
 responsesGetUTxOsStatistics: &responsesGetUTxOsStatistics
   <<: *responsesErr404
@@ -671,14 +671,14 @@ responsesPostWallet: &responsesPostWallet
   <<: *responsesErr415
   202:
     description: Accepted
-    schema: *wallet
+    schema: *ApiWallet
 
 responsesGetWallet: &responsesGetWallet
   <<: *responsesErr400
   <<: *responsesErr404
   200:
     description: Ok
-    schema: *wallet
+    schema: *ApiWallet
 
 responsesDeleteWallet: &responsesDeleteWallet
   <<: *responsesErr400
@@ -694,7 +694,7 @@ responsesPutWallet: &responsesPutWallet
   <<: *responsesErr415
   200:
     description: Ok
-    schema: *wallet
+    schema: *ApiWallet
 
 responsesPutWalletPassphrase: &responsesPutWalletPassphrase
   <<: *responsesErr400
@@ -716,7 +716,7 @@ responsesListTransactions: &responsesListTransactions
         example: inserted-at 20190227T160329Z-20190101T042557Z/42
     schema:
       type: array
-      items: *transaction
+      items: &ApiTransaction
 
 responsesPostTransaction: &responsesPostTransaction
   <<: *responsesErr400
@@ -725,7 +725,7 @@ responsesPostTransaction: &responsesPostTransaction
   <<: *responsesErr415
   202:
     description: Accepted
-    schema: *transaction
+    schema: &ApiTransaction
 
 responsesPostTransactionFee: &responsesPostTransactionFee
   <<: *responsesErr400
@@ -747,7 +747,7 @@ responsesListAddresses: &responsesListAddresses
     description: Ok
     schema:
       type: array
-      items: *address
+      items: &ApiAddress
 
 responsesListStakePools: &responsesListStakePools
   200:
@@ -763,7 +763,7 @@ responsesJoinStakePool: &responsesJoinStakePool
   <<: *responsesErr415
   202:
     description: Accepted
-    schema: *transaction
+    schema: &ApiTransaction
 
 responsesQuitStakePool: &responsesQuitStakePool
   <<: *responsesJoinStakePool

--- a/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -509,10 +509,10 @@ specification =
     msg = "Whoops! Failed to parse or find the api specification document: "
 
 instance ToSchema ApiAddress where
-    declareNamedSchema _ = declareSchemaForDefinition "Address"
+    declareNamedSchema _ = declareSchemaForDefinition "ApiAddress"
 
 instance ToSchema ApiWallet where
-    declareNamedSchema _ = declareSchemaForDefinition "Wallet"
+    declareNamedSchema _ = declareSchemaForDefinition "ApiWallet"
 
 instance ToSchema WalletPostData where
     declareNamedSchema _ = declareSchemaForDefinition "WalletPostData"
@@ -527,7 +527,7 @@ instance ToSchema PostTransactionData where
     declareNamedSchema _ = declareSchemaForDefinition "PostTransactionData"
 
 instance ToSchema ApiTransaction where
-    declareNamedSchema _ = declareSchemaForDefinition "Transaction"
+    declareNamedSchema _ = declareSchemaForDefinition "ApiTransaction"
 
 
 -- | Utility function to provide an ad-hoc 'ToSchema' instance for a definition:


### PR DESCRIPTION
# Issue Number
#93
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have changed `ToSchema` instances to use standard haskell datatype names instead of renamed


# Comments
Ideally manual `ToSchema` instances defined here https://github.com/input-output-hk/cardano-wallet/blob/akegalj/93/standard-swagger-names/test/unit/Cardano/Wallet/Api/TypesSpec.hs#L511 would be removed and they would be generated automatically (for example using `Generic` we could capture datatype name). Current approach doesn't add much overhead so I don't find this necessary. 
<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
