### PR TITLE
Remove CLI message that passphrase can be skipped

### DIFF
--- a/app/cli/Main.hs
+++ b/app/cli/Main.hs
@@ -144,8 +144,7 @@ exec args
             \(Enter a blank line if you do not wish to use a second factor.)"
         passphrase <- getRequiredSensitiveValue
             (fromText @(Passphrase "encryption"))
-            "Please enter a passphrase: \n\
-            \(Enter a blank line if you do not wish to use a passphrase.)"
+            "Please enter a passphrase: "
         print
             ( poolGap :: AddressPoolGap
             , name :: WalletName


### PR DESCRIPTION
# Issue Number
#96 

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have removed confusing CLI message that states that wallet `passphrase` is optional


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
