### PR TITLE
move ENV var export from buildkite script, to buildkite pipeline settings

### DIFF
--- a/.buildkite/benchmark.sh
+++ b/.buildkite/benchmark.sh
@@ -3,20 +3,11 @@
 
 set -euo pipefail
 
-netname="${1-}"
-
-if [ -z "$netname" ]; then
-   echo "usage: benchmark.sh NETWORK"
-   exit 1
-fi
-
 echo "--- Build code and benchmarks"
 stack build --bench --no-run-benchmarks
 
-export NETWORK=$netname
-
-echo "+++ Run benchmarks"
-stack bench cardano-wallet:restore --interleaved-output --ba "$netname +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS"
+echo "+++ Run benchmarks - $NETWORK"
+stack bench cardano-wallet:restore --interleaved-output --ba "$NETWORK +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS"
 
 hp2pretty restore.hp
 

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -2,12 +2,16 @@ env:
   NIX_PATH: "channel:nixos-19.03"
 steps:
   - label: 'Restore benchmark - testnet'
-    command: "./.buildkite/benchmark.sh testnet"
+    command: "./.buildkite/benchmark.sh"
     timeout_in_minutes: 60
     agents:
       system: x86_64-linux
+    env:
+      NETWORK: testnet
   - label: 'Restore benchmark - mainnet'
-    command: "./.buildkite/benchmark.sh mainnet"
+    command: "./.buildkite/benchmark.sh"
     timeout_in_minutes: 60
     agents:
       system: x86_64-linux
+    env:
+      NETWORK: mainnet


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#100 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have moved ENV var export from buildkite script, to buildkite pipeline settings


# Comments

<!-- Additional comments or screenshots to attach if any -->

See [here](https://buildkite.com/input-output-hk/cardano-wallet-nightly/settings/schedules). It seems that we can't modify the environment directly from the buildkite execution script, but it needs to be set within the platform interface through the "Pipeline Settings"; which I did. I've scheduled a new build for 10:30 to see whether this worked or not.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
