### PR TITLE
Provide clearer failure-reason when wallet is not syncing

### DIFF
--- a/test/integration/Cardano/WalletSpec.hs
+++ b/test/integration/Cardano/WalletSpec.hs
@@ -28,10 +28,12 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
     ( async, cancel )
+import Control.Monad
+    ( unless )
 import Data.Text.Class
     ( toText )
 import Test.Hspec
-    ( Spec, after, before, it, shouldSatisfy )
+    ( Spec, after, before, expectationFailure, it )
 
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
@@ -50,7 +52,8 @@ spec = do
             unsafeRunExceptT $ restoreWallet wallet wid
             threadDelay 2000000
             tip <- currentTip . fst <$> unsafeRunExceptT (readWallet wallet wid)
-            tip `shouldSatisfy` (> (SlotId 0 0))
+            unless (tip > (SlotId 0 0)) $
+                expectationFailure ("The wallet tip is still " ++ show tip)
   where
     port = 1337
     closeBridge (handle, _) = do


### PR DESCRIPTION
# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have used a custom failure reason for `A newly created wallet can sync with the chain`

# Comments

Previously (note the "predicate failed"):
```
  test/integration/Cardano/WalletSpec.hs:53:13:
  1) Cardano.WalletSpec A newly created wallet can sync with the chain
       predicate failed on: SlotId {epochNumber = 0, slotNumber = 0}
```

Now:
```
  test/integration/Cardano/WalletSpec.hs:56:17:
  1) Cardano.WalletSpec A newly created wallet can sync with the chain
       The wallet tip is still SlotId {epochNumber = 0, slotNumber = 0}
```


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
