### PR TITLE
Include protocol magic in address attributes when on testnet

### DIFF
--- a/src/Cardano/Wallet/Binary.hs
+++ b/src/Cardano/Wallet/Binary.hs
@@ -30,6 +30,7 @@ module Cardano.Wallet.Binary
     , encodeAddress
     , encodeTxWitness
     , encodeSignedTx
+    , encodeProtocolMagic
 
     -- * Hashing
     , txId
@@ -48,6 +49,8 @@ import Prelude
 
 import Cardano.Crypto.Wallet
     ( ChainCode (..), XPub (..) )
+import Cardano.Environment
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
@@ -533,6 +536,9 @@ encodeTx tx = mempty
 encodeTxAttributes :: CBOR.Encoding
 encodeTxAttributes = mempty
     <> CBOR.encodeMapLen 0
+
+encodeProtocolMagic :: ProtocolMagic -> CBOR.Encoding
+encodeProtocolMagic (ProtocolMagic i) = CBOR.encodeInt32 i
 
 encodeTxIn :: TxIn -> CBOR.Encoding
 encodeTxIn (TxIn (Hash txid) ix) = mempty


### PR DESCRIPTION
# Issue Number

#95 


# Overview

- [x] Modify `keyToAddress` to include protocol magic on testnet

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->