### PR TITLE
Coin Selection Better Coverage + Fix Fee Calculation

### DIFF
--- a/src/Cardano/Wallet/CoinSelection/Fee.hs
+++ b/src/Cardano/Wallet/CoinSelection/Fee.hs
@@ -52,8 +52,6 @@ import Crypto.Random.Types
     ( MonadRandom )
 import Data.Bifunctor
     ( bimap )
-import Data.Digest.CRC32
-    ( crc32 )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -421,10 +419,7 @@ estimateFee policy (CoinSelection inps outs chngs) =
     --  | word64                      -- 1|2|3|5|9
     sizeOfTxOut :: TxOut -> Int
     sizeOfTxOut (TxOut (Address bytes) c) =
-        6
-        + BS.length bytes
-        + sizeOf (CBOR.encodeWord32 $ crc32 bytes)
-        + sizeOfCoin c
+        1 + BS.length bytes + sizeOfCoin c
 
     -- Compute the size of a coin
     sizeOfCoin :: Coin -> Int

--- a/src/Cardano/Wallet/CoinSelection/Policy/Random.hs
+++ b/src/Cardano/Wallet/CoinSelection/Policy/Random.hs
@@ -211,7 +211,7 @@ mkChange (TxOut _ (Coin out)) inps =
         selected = invariant
             "mkChange: output is smaller than selected inputs!"
             (balance' inps)
-            (> out)
+            (>= out)
         Coin maxCoinValue = maxBound
     in
         case selected - out of

--- a/test/unit/Cardano/Wallet/CoinSelection/Policy/LargestFirstSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/Policy/LargestFirstSpec.hs
@@ -13,7 +13,11 @@ import Cardano.Wallet.CoinSelection
 import Cardano.Wallet.CoinSelection.Policy.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.CoinSelectionSpec
-    ( CoinSelProp (..), CoinSelectionFixture (..), coinSelectionUnitTest )
+    ( CoinSelProp (..)
+    , CoinSelectionFixture (..)
+    , CoinSelectionResult (..)
+    , coinSelectionUnitTest
+    )
 import Cardano.Wallet.Primitive.Types
     ( Coin (..), TxOut (..), UTxO (..), excluding )
 import Control.Monad
@@ -39,35 +43,65 @@ import qualified Data.Set as Set
 spec :: Spec
 spec = do
     describe "Coin selection : LargestFirst algorithm unit tests" $ do
-        coinSelectionUnitTest largestFirst "" (Right [17]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [10,10,17]
-            , txOutputs = 17 :| []
-            }
+        coinSelectionUnitTest largestFirst ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [17]
+                , rsChange = []
+                , rsOutputs = [17]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [10,10,17]
+                , txOutputs = 17 :| []
+                })
 
-        coinSelectionUnitTest largestFirst "" (Right [17]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [12,10,17]
-            , txOutputs = 1 :| []
-            }
+        coinSelectionUnitTest largestFirst ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [17]
+                , rsChange = [16]
+                , rsOutputs = [1]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [12,10,17]
+                , txOutputs = 1 :| []
+                })
 
-        coinSelectionUnitTest largestFirst "" (Right [12, 17]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [12,10,17]
-            , txOutputs = 18 :| []
-            }
+        coinSelectionUnitTest largestFirst ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [12, 17]
+                , rsChange = [11]
+                , rsOutputs = [18]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [12,10,17]
+                , txOutputs = 18 :| []
+                })
 
-        coinSelectionUnitTest largestFirst "" (Right [10, 12, 17]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [12,10,17]
-            , txOutputs = 30 :| []
-            }
+        coinSelectionUnitTest largestFirst ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [10, 12, 17]
+                , rsChange = [9]
+                , rsOutputs = [30]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [12,10,17]
+                , txOutputs = 30 :| []
+                })
 
-        coinSelectionUnitTest largestFirst "" (Right [6,10,5]) $ CoinSelectionFixture
-            { maxNumOfInputs = 3
-            , utxoInputs = [1,2,10,6,5]
-            , txOutputs = 11 :| [1]
-            }
+        coinSelectionUnitTest largestFirst ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [6,10,5]
+                , rsChange = [5,4]
+                , rsOutputs = [11,1]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 3
+                , utxoInputs = [1,2,10,6,5]
+                , txOutputs = 11 :| [1]
+                })
 
         coinSelectionUnitTest
             largestFirst

--- a/test/unit/Cardano/Wallet/CoinSelection/Policy/RandomSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/Policy/RandomSpec.hs
@@ -15,7 +15,11 @@ import Cardano.Wallet.CoinSelection.Policy.LargestFirst
 import Cardano.Wallet.CoinSelection.Policy.Random
     ( random )
 import Cardano.Wallet.CoinSelectionSpec
-    ( CoinSelProp (..), CoinSelectionFixture (..), coinSelectionUnitTest )
+    ( CoinSelProp (..)
+    , CoinSelectionFixture (..)
+    , CoinSelectionResult (..)
+    , coinSelectionUnitTest
+    )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Random
@@ -39,48 +43,90 @@ import qualified Data.List as L
 spec :: Spec
 spec = do
     describe "Unit tests" $ do
-        coinSelectionUnitTest random "" (Right [1,1,1,1]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [1,1,1,1,1,1]
-            , txOutputs = 2 :| []
-            }
+        coinSelectionUnitTest random ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [1,1,1,1]
+                , rsChange = [2]
+                , rsOutputs = [2]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [1,1,1,1,1,1]
+                , txOutputs = 2 :| []
+                })
 
-        coinSelectionUnitTest random "" (Right [1,1,1,1,1,1]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [1,1,1,1,1,1]
-            , txOutputs = 2 :| [1]
-            }
+        coinSelectionUnitTest random ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [1,1,1,1,1,1]
+                , rsChange = [2,1]
+                , rsOutputs = [2,1]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [1,1,1,1,1,1]
+                , txOutputs = 2 :| [1]
+                })
 
-        coinSelectionUnitTest random "" (Right [1,1,1,1,1]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [1,1,1,1,1]
-            , txOutputs = 2 :| [1]
-            }
+        coinSelectionUnitTest random ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [1,1,1,1,1]
+                , rsChange = [2]
+                , rsOutputs = [2,1]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [1,1,1,1,1]
+                , txOutputs = 2 :| [1]
+                })
 
-        coinSelectionUnitTest random "with fallback" (Right [1,1,1]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [1,1,1,1]
-            , txOutputs = 2 :| [1]
-            }
+        coinSelectionUnitTest random "with fallback"
+            (Right $ CoinSelectionResult
+                { rsInputs = [1,1,1]
+                , rsChange = []
+                , rsOutputs = [2,1]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [1,1,1,1]
+                , txOutputs = 2 :| [1]
+                })
 
-        coinSelectionUnitTest random "" (Right [5]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [5,5,5]
-            , txOutputs = 2 :| []
-            }
+        coinSelectionUnitTest random ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [5]
+                , rsChange = [3]
+                , rsOutputs = [2]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [5,5,5]
+                , txOutputs = 2 :| []
+                })
 
-        coinSelectionUnitTest random "" (Right [10,10]) $ CoinSelectionFixture
-            { maxNumOfInputs = 100
-            , utxoInputs = [10,10,10]
-            , txOutputs = 2 :| [2]
-            }
+        coinSelectionUnitTest random ""
+            (Right $ CoinSelectionResult
+                { rsInputs = [10,10]
+                , rsChange = [8,8]
+                , rsOutputs = [2,2]
+                }
+            )
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , utxoInputs = [10,10,10]
+                , txOutputs = 2 :| [2]
+                })
 
         coinSelectionUnitTest random "cannot cover aim, but only min"
-            (Right [1,1,1,1]) $ CoinSelectionFixture
-            { maxNumOfInputs = 4
-            , utxoInputs = [1,1,1,1,1,1]
-            , txOutputs = 3 :| []
-            }
+            (Right $ CoinSelectionResult
+                { rsInputs = [1,1,1,1]
+                , rsChange = [1]
+                , rsOutputs = [3]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 4
+                , utxoInputs = [1,1,1,1,1,1]
+                , txOutputs = 3 :| []
+                })
 
         coinSelectionUnitTest random "" (Left $ MaximumInputsReached 2) $ CoinSelectionFixture
             { maxNumOfInputs = 2


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have improved coin selection unit tests by also specifying and checking other parts of a coin selection result (i.e. outputs and change)
- [x] I have added some edge-case unit tests to test coin overflow in some cases
- [x] I have fixed a wrong strict inequality sign (caught by updated tests)
- [x] I have fixed a bug in the fee estimation were we were counting the same bytes twice.

# Comments

<!-- Additional comments or screenshots to attach if any -->

@piotr-iohk This is the best I can do in terms of coverage in a reasonable amount of time. There's still one particular overflow case that is hard to instrument in practice (impossible to meet :thinking: ?) but that is there in the code as a safe "gatekeeper" I suppose.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
