### PR TITLE
actually use 'adjustForFee' during tx construction

### DIFF
--- a/src/Cardano/Wallet/Api/Server.hs
+++ b/src/Cardano/Wallet/Api/Server.hs
@@ -255,6 +255,7 @@ instance LiftHandler ErrCreateUnsignedTx where
     handler = \case
         ErrCreateUnsignedTxNoSuchWallet _ -> err404
         ErrCreateUnsignedTxCoinSelection _ -> err403
+        ErrCreateUnsignedTxFee _ -> err403
 
 instance LiftHandler ErrSignTx where
     handler = \case

--- a/src/Cardano/Wallet/CoinSelection/Fee.hs
+++ b/src/Cardano/Wallet/CoinSelection/Fee.hs
@@ -74,7 +74,7 @@ newtype Fee = Fee { getFee :: Word64 }
 
 data FeeOptions = FeeOptions
     { estimate
-      :: Int -> [Coin] -> Fee
+      :: CoinSelection -> Fee
       -- ^ Estimate fees based on number of inputs and values of the outputs
       -- Some pointers / order of magnitude from the current configuration:
       --     a: 155381 # absolute minimal fees per transaction
@@ -151,7 +151,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         -- 1/
         -- We compute fees using all inputs, outputs and changes since
         -- all of them have an influence on the fee calculation.
-        let upperBound = feeUpperBound opt coinSel
+        let upperBound = estimate opt coinSel
         -- 2/
         -- Substract fee from change outputs, proportionally to their value.
         let (Fee remainingFee, chgs') = reduceChangeOutputs opt upperBound chgs
@@ -246,14 +246,6 @@ divvyFee (Fee f) outs =
             c' = ceiling @Double (r * fromIntegral f)
         in
             Fee c'
-
--- | Compute a rough estimate of the fee bound
-feeUpperBound
-    :: FeeOptions
-    -> CoinSelection
-    -> Fee
-feeUpperBound opt (CoinSelection inps outs chgs) =
-    (estimate opt) (L.length inps) (map coin outs ++ chgs)
 
 -- | Remove coins that are below a given threshold
 removeDust :: Coin -> [Coin] -> [Coin]

--- a/src/Cardano/Wallet/CoinSelection/Policy/Random.hs
+++ b/src/Cardano/Wallet/CoinSelection/Policy/Random.hs
@@ -103,20 +103,20 @@ data TargetRange = TargetRange
 random
     :: forall m. MonadRandom m
     => CoinSelectionOptions
-    -> UTxO
     -> NonEmpty TxOut
-    -> ExceptT CoinSelectionError m CoinSelection
-random opt utxo outs = do
+    -> UTxO
+    -> ExceptT CoinSelectionError m (CoinSelection, UTxO)
+random opt outs utxo = do
     let descending = NE.toList . NE.sortBy (flip $ comparing coin)
     randomMaybe <- lift $ runMaybeT $ foldM
         (processTxOut opt)
         (utxo, mempty)
         (descending outs)
     case randomMaybe of
-        Just (_,res) ->
-            return res
+        Just (utxo', res) ->
+            return (res, utxo')
         Nothing ->
-            largestFirst opt utxo outs
+            largestFirst opt outs utxo
 
 -- | Perform a random selection on a given output, with improvement.
 processTxOut

--- a/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/FeeSpec.hs
@@ -445,8 +445,8 @@ feeOptions
     -> Word64
     -> FeeOptions
 feeOptions fee dust = FeeOptions
-    { estimate = \nInps outs ->
-        nInps `seq` outs `seq` Fee fee
+    { estimate =
+        \_ -> Fee fee
     , dustThreshold =
         Coin dust
     }
@@ -622,9 +622,9 @@ instance Arbitrary CoinSelection where
         genSelection outs = do
             let opts = CS.CoinSelectionOptions 100
             utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
-            case runIdentity $ runExceptT $ largestFirst opts utxo outs of
+            case runIdentity $ runExceptT $ largestFirst opts outs utxo of
                 Left _ -> genSelection outs
-                Right s -> return s
+                Right (s,_) -> return s
 
 instance Arbitrary FeeProp where
     shrink (FeeProp cs utxo opts) =

--- a/test/unit/Cardano/Wallet/CoinSelection/Policy/LargestFirstSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/Policy/LargestFirstSpec.hs
@@ -163,26 +163,26 @@ propDeterministic
     -> Property
 propDeterministic (CoinSelProp utxo txOuts) = do
     let opts = CoinSelectionOptions 100
-    let resultOne = runIdentity $ runExceptT $ largestFirst opts utxo txOuts
-    let resultTwo = runIdentity $ runExceptT $ largestFirst opts utxo txOuts
+    let resultOne = runIdentity $ runExceptT $ largestFirst opts txOuts utxo
+    let resultTwo = runIdentity $ runExceptT $ largestFirst opts txOuts utxo
     resultOne === resultTwo
 
 propAtLeast
     :: CoinSelProp
     -> Property
 propAtLeast (CoinSelProp utxo txOuts) =
-    isRight selection ==> let Right s = selection in prop s
+    isRight selection ==> let Right (s,_) = selection in prop s
   where
     prop (CoinSelection inps _ _) =
         L.length inps `shouldSatisfy` (>= NE.length txOuts)
     selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
+        largestFirst (CoinSelectionOptions 100) txOuts utxo
 
 propInputDecreasingOrder
     :: CoinSelProp
     -> Property
 propInputDecreasingOrder (CoinSelProp utxo txOuts) =
-    isRight selection ==> let Right s = selection in prop s
+    isRight selection ==> let Right (s,_) = selection in prop s
   where
     prop (CoinSelection inps _ _) =
         let
@@ -194,4 +194,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             (>= (getExtremumValue L.maximum utxo'))
     getExtremumValue f = f . map (getCoin . coin . snd)
     selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
+        largestFirst (CoinSelectionOptions 100) txOuts utxo

--- a/test/unit/Cardano/Wallet/CoinSelection/Policy/RandomSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelection/Policy/RandomSpec.hs
@@ -170,16 +170,16 @@ propFragmentation
     -> Property
 propFragmentation drg (CoinSelProp utxo txOuts) = do
     isRight selection1 && isRight selection2 ==>
-        let (Right s1, Right s2) =
+        let (Right (s1,_), Right (s2,_)) =
                 (selection1, selection2)
         in prop (s1, s2)
   where
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
     (selection1,_) = withDRG drg
-        (runExceptT $ random (CoinSelectionOptions 100) utxo txOuts)
+        (runExceptT $ random (CoinSelectionOptions 100) txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100) utxo txOuts
+        largestFirst (CoinSelectionOptions 100) txOuts utxo
 
 propErrors
     :: SystemDRG
@@ -193,6 +193,6 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     prop (err1, err2) =
         err1 === err2
     (selection1,_) = withDRG drg
-        (runExceptT $ random (CoinSelectionOptions 1) utxo txOuts)
+        (runExceptT $ random (CoinSelectionOptions 1) txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 1) utxo txOuts
+        largestFirst (CoinSelectionOptions 1) txOuts utxo

--- a/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
+++ b/test/unit/Cardano/Wallet/CoinSelectionSpec.hs
@@ -147,9 +147,9 @@ data CoinSelectionResult = CoinSelectionResult
 -- given coin selection on it.
 coinSelectionUnitTest
     :: ( CoinSelectionOptions
-         -> UTxO
          -> NonEmpty TxOut
-         -> ExceptT CoinSelectionError IO CoinSelection
+         -> UTxO
+         -> ExceptT CoinSelectionError IO (CoinSelection, UTxO)
        )
     -> String
     -> Either CoinSelectionError CoinSelectionResult
@@ -159,8 +159,8 @@ coinSelectionUnitTest run lbl expected (CoinSelectionFixture n utxoF outsF) =
     it title $ do
         (utxo,txOuts) <- setup
         result <- runExceptT $ do
-            (CoinSelection inps outs chngs) <-
-                run (CoinSelectionOptions n) utxo txOuts
+            (CoinSelection inps outs chngs, _) <-
+                run (CoinSelectionOptions n) txOuts utxo
             return $ CoinSelectionResult
                 { rsInputs = map (getCoin . coin . snd) inps
                 , rsChange = map getCoin chngs


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#95 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have balanced a transaction after performing coin selection to adjust it for fees.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

This required returning the new UTxO from after the selection; so there are quite a few changes in the diff, but the one true change is within `Cardano.Wallet`. Could have made two commits...
