### PR TITLE
Redirect launcher, wallet & bridge output to a temporary file while running integration tests

### DIFF
--- a/test/integration/Test/Integration/Framework/Request.hs
+++ b/test/integration/Test/Integration/Framework/Request.hs
@@ -45,6 +45,8 @@ import Network.HTTP.Types.Method
     ( Method )
 import Network.HTTP.Types.Status
     ( status500 )
+import System.IO
+    ( Handle )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
@@ -60,6 +62,9 @@ data Context = Context
     , _manager
         :: (Text, Manager)
         -- ^ The underlying BaseUrl and Manager used by the Wallet Client
+    , _logs
+        :: Handle
+        -- ^ A file 'Handle' to the launcher log output
     }
 
 -- | The result when 'request' fails.
@@ -100,7 +105,7 @@ request
     -> Payload
         -- ^ Request body
     -> m (HTTP.Status, Either RequestException a)
-request (Context _ (base, manager)) (verb, path) reqHeaders body = do
+request (Context _ (base, manager) _) (verb, path) reqHeaders body = do
     req <- parseRequest $ T.unpack $ base <> path
     handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
   where


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have (see title)


# Comments

<!-- Additional comments or screenshots to attach if any -->

Integration tests output are now much less noisy. Logs are still accessible in `/tmp/cardano-wallet-launcher` (next to `/tmp/cardano-node-simple` by the by, which contain all logs from the local cardano-sl cluster!).

Enjoy.

```
$ ./integration WALLETS_CREATE
cardano-wallet-2.0.0: test (suite: integration, args: --match WALLETS_CREATE)


Wallets API endpoint tests
  WALLETS_CREATE_01 - Create a wallet
  WALLETS_CREATE_01 - Created a wallet can be listed
  WALLETS_CREATE_03 - Cannot create wallet that exists

Finished in 8.3783 seconds
3 examples, 0 failures

cardano-wallet-2.0.0: Test suite integration passed
Haddock index for local packages already up to date at:
/home/ktorz/Documents/IOHK/cardano-wallet/.stack-work/install/x86_64-linux/lts-13.8/8.6.3/doc/index.html
Haddock index for local packages and dependencies already up to date at:
/home/ktorz/Documents/IOHK/cardano-wallet/.stack-work/install/x86_64-linux/lts-13.8/8.6.3/doc/all/index.html
Haddock index for snapshot packages already up to date at:
/home/ktorz/.stack/snapshots/x86_64-linux/lts-13.8/8.6.3/doc/index.html
ExitSuccess
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
