### PR TITLE
Remove TxId Coupling To Binary Format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ cabal.project.local~
 .HTF/
 .ghc.environment.*
 .ghci
+*.tix
 
 ### Nix ###
 result*

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -32,6 +32,8 @@ import Cardano.Wallet.Api
     ( Api )
 import Cardano.Wallet.Api.Server
     ( server )
+import Cardano.Wallet.Binary
+    ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( FromMnemonic (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery
@@ -170,7 +172,7 @@ execServer :: Port "wallet" -> Port "bridge" -> IO ()
 execServer (Port port) (Port bridgePort) = do
     db <- MVar.newDBLayer
     nw <- HttpBridge.newNetworkLayer bridgePort
-    let wallet = mkWalletLayer db nw
+    let wallet = mkWalletLayer @_ @HttpBridge db nw
     Warp.runSettings settings (serve (Proxy @("v2" :> Api)) (server wallet))
   where
     settings = Warp.defaultSettings

--- a/lib/core/src/Cardano/Wallet/Binary.hs
+++ b/lib/core/src/Cardano/Wallet/Binary.hs
@@ -35,9 +35,6 @@ module Cardano.Wallet.Binary
     , encodeSignedTx
     , encodeProtocolMagic
 
-    -- * Signing
-    , TxWitness (..)
-
     -- * Helpers
     , inspectNextToken
     , decodeList

--- a/lib/core/src/Cardano/Wallet/Binary.hs
+++ b/lib/core/src/Cardano/Wallet/Binary.hs
@@ -18,8 +18,11 @@
 
 module Cardano.Wallet.Binary
     (
+    -- * Target
+      HttpBridge
+
     -- * Decoding
-      decodeBlock
+    , decodeBlock
     , decodeBlockHeader
     , decodeTx
     , decodeTxWitness
@@ -31,9 +34,6 @@ module Cardano.Wallet.Binary
     , encodeTxWitness
     , encodeSignedTx
     , encodeProtocolMagic
-
-    -- * Hashing
-    , txId
 
     -- * Signing
     , TxWitness (..)
@@ -59,6 +59,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , SlotId (..)
     , Tx (..)
+    , TxId (..)
     , TxIn (..)
     , TxOut (..)
     , TxWitness (..)
@@ -85,6 +86,11 @@ import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Lazy as BL
 
+-- Target
+
+-- | A type representing the http-bridge as a network target. This has an
+-- influence on binary serializer & network primitives. See also 'TxId'
+data HttpBridge
 
 -- Decoding
 
@@ -586,8 +592,8 @@ encodeTxOut (TxOut (Address addr) (Coin c)) = mempty
 -- It returns an hex-encoded 64-byte hash.
 --
 -- NOTE: This is a rather expensive operation
-txId :: Tx -> Hash "Tx"
-txId = blake2b256 . encodeTx
+instance TxId HttpBridge where
+    txId = blake2b256 . encodeTx
 
 -- * Helpers
 

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -35,10 +35,10 @@ import Data.Map.Strict
 -- | A Database interface for storing various things in a DB. In practice,
 -- we'll need some extra contraints on the wallet state that allows us to
 -- serialize and unserialize it (e.g. @forall s. (Serialize s) => ...@)
-data DBLayer m s = DBLayer
+data DBLayer m s t = DBLayer
     { createWallet
         :: PrimaryKey WalletId
-        -> Wallet s
+        -> Wallet s t
         -> WalletMetadata
         -> ExceptT ErrWalletAlreadyExists m ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
@@ -57,7 +57,7 @@ data DBLayer m s = DBLayer
 
     , putCheckpoint
         :: PrimaryKey WalletId
-        -> Wallet s
+        -> Wallet s t
         -> ExceptT ErrNoSuchWallet m ()
         -- ^ Replace the current checkpoint for a given wallet. We do not handle
         -- rollbacks yet, and therefore only stores the latest available
@@ -67,7 +67,7 @@ data DBLayer m s = DBLayer
 
     , readCheckpoint
         :: PrimaryKey WalletId
-        -> m (Maybe (Wallet s))
+        -> m (Maybe (Wallet s t))
         -- ^ Fetch the most recent checkpoint of a given wallet.
         --
         -- Return 'Nothing' if there's no such wallet.

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -41,8 +41,8 @@ import Data.Map.Strict
 
 import qualified Data.Map.Strict as Map
 
-data Database s = Database
-    { wallet :: !(Wallet s)
+data Database s t = Database
+    { wallet :: !(Wallet s t)
     , metadata :: !WalletMetadata
     , txHistory :: !(Map (Hash "Tx") (Tx, TxMeta))
     , xprv :: !(Maybe (Key 'RootK XPrv, Hash "encryption"))
@@ -50,10 +50,10 @@ data Database s = Database
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.
-newDBLayer :: forall s. IO (DBLayer IO s)
+newDBLayer :: forall s t. IO (DBLayer IO s t)
 newDBLayer = do
     lock <- newMVar ()
-    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s))
+    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s t))
     return $ DBLayer
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.Wallet.Network

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -32,6 +33,7 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Tx
     , Tx(..)
+    , TxId(..)
     , TxIn(..)
     , TxOut(..)
     , TxMeta(..)
@@ -305,6 +307,26 @@ instance Buildable Tx where
     build (Tx ins outs) = mempty
         <> nameF "inputs" (blockListF ins)
         <> nameF "outputs" (blockListF outs)
+
+-- | An abstraction for computing transaction id. The 'target' is an open-type
+-- that can be used to discriminate on. For instance:
+--
+-- @
+-- instance TxId HttpBridge where
+--   txId _ = {- ... -}
+-- @
+--
+-- Note that `txId` is ambiguous and requires therefore a type application.
+-- Likely, a corresponding target would be found in scope (requires however
+-- ScopedTypeVariables).
+--
+-- For example, assuming there's a type 'target' in scope, one can simply do:
+--
+-- @
+-- txId @target tx
+-- @
+class TxId target where
+    txId :: Tx -> Hash "Tx"
 
 txIns :: Set Tx -> Set TxIn
 txIns =

--- a/lib/core/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
+++ b/lib/core/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
@@ -12,7 +12,7 @@ import Cardano.Environment
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet.Binary
-    ( TxWitness (..), encodeSignedTx )
+    ( encodeSignedTx )
 import Cardano.Wallet.Network
     ( ErrNetworkTip (..)
     , ErrNetworkUnreachable (..)
@@ -30,6 +30,7 @@ import Cardano.Wallet.Primitive.Types
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
+    , TxWitness (..)
     )
 import Control.Concurrent
     ( threadDelay )

--- a/lib/core/test/integration/Cardano/WalletSpec.hs
+++ b/lib/core/test/integration/Cardano/WalletSpec.hs
@@ -14,6 +14,8 @@ import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( WalletLayer (..), mkWalletLayer, unsafeRunExceptT )
+import Cardano.Wallet.Binary
+    ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
@@ -70,6 +72,6 @@ spec = do
                 Inherit
             ]
         threadDelay 1000000
-        (handle,) <$> (mkWalletLayer
+        (handle,) <$> (mkWalletLayer @_ @HttpBridge
             <$> MVar.newDBLayer
             <*> HttpBridge.newNetworkLayer port)

--- a/lib/core/test/unit/Cardano/Wallet/BinarySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/BinarySpec.hs
@@ -13,7 +13,6 @@ import Prelude
 
 import Cardano.Wallet.Binary
     ( HttpBridge
-    , TxWitness (PublicKeyWitness)
     , decodeBlock
     , decodeBlockHeader
     , decodeSignedTx
@@ -34,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     , TxId (..)
     , TxIn (..)
     , TxOut (..)
+    , TxWitness (PublicKeyWitness)
     )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase )

--- a/lib/core/test/unit/Cardano/Wallet/BinarySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/BinarySpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.BinarySpec
     ( spec
@@ -11,7 +12,8 @@ module Cardano.Wallet.BinarySpec
 import Prelude
 
 import Cardano.Wallet.Binary
-    ( TxWitness (PublicKeyWitness)
+    ( HttpBridge
+    , TxWitness (PublicKeyWitness)
     , decodeBlock
     , decodeBlockHeader
     , decodeSignedTx
@@ -20,7 +22,6 @@ import Cardano.Wallet.Binary
     , encodeSignedTx
     , encodeTx
     , encodeTxWitness
-    , txId
     )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
@@ -30,6 +31,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , SlotId (..)
     , Tx (..)
+    , TxId (..)
     , TxIn (..)
     , TxOut (..)
     )
@@ -107,14 +109,14 @@ spec = do
             roundTripTx (txs !! 1)
 
         it "should compute correct txId (1)" $ do
-            let hash = txId (txs !! 0)
+            let hash = txId @HttpBridge (txs !! 0)
             let hash' = hash16
                     "c470563001e448e61ff1268c2a6eb458\
                     \ace1d04011a02cb262b6d709d66c23d0"
             hash `shouldBe` hash'
 
         it "should compute correct txId (2)" $ do
-            let hash = txId (txs !! 1)
+            let hash = txId @HttpBridge (txs !! 1)
             let hash' = hash16
                     "d30d37f1f8674c6c33052826fdc5bc19\
                     \8e3e95c150364fd775d4bc663ae6a9e6"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have introduced a new abstraction 'TxId' in order to decouple the core code from the binary representation. The actual representation is now selected when the wallet server is instantiated which allows us in the long run, to switch easily from one binary format to another only in the cli code.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Note that the `Primitive.Signing` module explicitly reference the 'HttpBridge' binary representation because we actually need more work here. As for the address representation, those requires another abstraction for the on-chain representation of these data.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
