### PR TITLE
point CI test data location back to 'master'

### DIFF
--- a/.buildkite/benchmark.sh
+++ b/.buildkite/benchmark.sh
@@ -9,9 +9,11 @@ stack build --bench --no-run-benchmarks
 echo "+++ Run benchmarks - $NETWORK"
 stack bench cardano-wallet-core:restore --interleaved-output --ba "$NETWORK +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS"
 
-hp2pretty restore.hp
+ARTIFACT=lib/core/restore.hp
+
+hp2pretty $ARTIFACT
 
 if [ -n "${BUILDKITE:-}" ]; then
-  buildkite-agent artifact upload restore.svg
+  buildkite-agent artifact upload $ARTIFACT
   printf '\033]1338;url='"artifact://restore.svg"';alt='"Heap profile"'\a\n'
 fi

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -10,7 +10,7 @@ steps:
       NETWORK: testnet
   - label: 'Restore benchmark - mainnet'
     command: "./.buildkite/benchmark.sh"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     agents:
       system: x86_64-linux
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
     name: "Compiling"
     script:
     - mkdir -p ~/.local/bin
-    - travis_retry curl -L -o cardano-node-simple.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/KtorZ/review-folder-structure/lib/core/test/data/cardano-node-simple/cardano-node-simple-3.0.1.tar.gz
+    - travis_retry curl -L -o cardano-node-simple.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/core/test/data/cardano-node-simple/cardano-node-simple-3.0.1.tar.gz
     - tar xzf cardano-node-simple.tar.gz -C $HOME/.local/bin
     - cardano-node-simple --version
     - test "$(cardano-http-bridge --version)" = "cardano-http-bridge 0.0.1" || travis_retry cargo install --force --branch cardano-wallet-integration --git https://github.com/KtorZ/cardano-http-bridge.git
@@ -100,7 +100,7 @@ jobs:
     script:
     - export NETWORK=testnet
     - tar xzf $STACK_WORK_CACHE
-    - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/KtorZ/review-folder-structure/lib/core/test/data/cardano-http-bridge/hermes-testnet.tar.gz
+    - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/core/test/data/cardano-http-bridge/hermes-testnet.tar.gz
     - tar xzf hermes-testnet.tar.gz -C $HOME
     - stack --no-terminal test --coverage
     - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -13,6 +13,11 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+-- Dummy library sadly necessary for 'shc' to compute
+-- code-coverage correctly ¯\_(ツ)_/¯
+library
+  hs-source-dirs: .
+
 executable cardano-wallet
   default-language:
       Haskell2010


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have reverted a previous (necessary) commit that modified the location of the test data. This was necessary so that we wouldn't break the CI with the file restructuring. Now that it landed onto master, the location can point back to master.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
