### PR TITLE
remove tx history from the wallet state (not used) & replace 'Set' with list

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -419,7 +419,8 @@ mkWalletLayer db network = WalletLayer
         let progress = slotRatio sup tip
         let status' = if progress == maxBound then Ready else Restoring progress
         let meta' = meta { status = status' } :: WalletMetadata
-
+        liftIO $ TIO.putStrLn $
+            "[INFO] Tx History: " +|| length txs ||+ ""
         -- NOTE
         -- Not as good as a transaction, but, with the lock, nothing can make
         -- the wallet disappear within these calls, so either the wallet is


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed the tx history from the wallet. It is actually not used and there's no accessor on it anyway. The transaction history is stored next to the wallet state and thus, it is redundant to have it within the wallet state as well. Redundant and ... it cost us a bit of RAM on big wallets. Also, internally, we were using 'Set' to construct the transaction metadata and doing set insertion (paying the cost for each transaction). However, in practice, since transactions come from a block (from a node we trust), we can simply assume they don't count any duplicates.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
