### PR TITLE
use 'FromText' instance in the API for 'AddressPoolGap'

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -50,7 +50,7 @@ import Prelude
 import Cardano.Wallet.Primitive.AddressDerivation
     ( FromMnemonic (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery
-    ( AddressPoolGap, getAddressPoolGap, mkAddressPoolGap )
+    ( AddressPoolGap, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
@@ -110,6 +110,7 @@ import Web.HttpApiData
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
+import qualified Data.Text as T
 
 {-------------------------------------------------------------------------------
                                   API Types
@@ -273,9 +274,8 @@ instance ToJSON (ApiT WalletId) where
     toJSON = toJSON . toText . getApiT
 
 instance FromJSON (ApiT AddressPoolGap) where
-    parseJSON x = do
-        gap <- parseJSON x
-        ApiT <$> eitherToParser (mkAddressPoolGap gap)
+    parseJSON = parseJSON >=>
+        eitherToParser . bimap ShowFmt ApiT . fromText . T.pack . show @Int
 instance ToJSON (ApiT AddressPoolGap) where
     toJSON = toJSON . getAddressPoolGap . getApiT
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -186,6 +186,7 @@ instance FromText AddressPoolGap where
                 <> show (fromEnum $ minBound @AddressPoolGap)
                 <> " and "
                 <> show (fromEnum $ maxBound @AddressPoolGap)
+                <> "."
 
 instance ToText (AddressPoolGap) where
     toText = T.pack . show . getAddressPoolGap

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -232,13 +232,21 @@ spec = do
             |] `shouldBe` (Left @String @(ApiMnemonicT '[12] "test") msg)
 
         it "ApiT AddressPoolGap (too small)" $ do
-            let msg = "Error in $: ErrGapOutOfRange 9"
+            let msg = "Error in $: An address pool gap must be a natural number between "
+                    <> show (getAddressPoolGap minBound)
+                    <> " and "
+                    <> show (getAddressPoolGap maxBound)
+                    <> "."
             Aeson.parseEither parseJSON [aesonQQ|
                 #{getAddressPoolGap minBound - 1}
             |] `shouldBe` (Left @String @(ApiT AddressPoolGap) msg)
 
         it "ApiT AddressPoolGap (too big)" $ do
-            let msg = "Error in $: ErrGapOutOfRange 101"
+            let msg = "Error in $: An address pool gap must be a natural number between "
+                    <> show (getAddressPoolGap minBound)
+                    <> " and "
+                    <> show (getAddressPoolGap maxBound)
+                    <> "."
             Aeson.parseEither parseJSON [aesonQQ|
                 #{getAddressPoolGap maxBound + 1}
             |] `shouldBe` (Left @String @(ApiT AddressPoolGap) msg)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -133,7 +133,7 @@ spec = do
 
     describe "AddressPoolGap - Text Roundtrip" $ do
         textRoundtrip $ Proxy @AddressPoolGap
-        let err = "An address pool gap must be a natural number between 10 and 100"
+        let err = "An address pool gap must be a natural number between 10 and 100."
         it "fail fromText @AddressPoolGap \"-10\"" $
             fromText @AddressPoolGap "-10" === Left (TextDecodingError err)
         it "fail fromText @AddressPoolGap \"0\"" $


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#204 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have used 'FromText' instance in the API for 'AddressPoolGap' (instead of the raw `mkAddressPoolGap` constructor).

# Comments

<!-- Additional comments or screenshots to attach if any -->

And as a result, leverage the user-friendly error message coming along. The 'FromText' instances relies on the `mkAddressPoolGap` constructor but, also provides a user-friendly error message.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
