### PR TITLE
Test that `network` is `Testnet` in HttpBridgeSpec

### DIFF
--- a/lib/http-bridge/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.Network.HttpBridgeSpec
 import Prelude
 
 import Cardano.Environment
-    ( network )
+    ( Network (Testnet), network )
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet.Network
@@ -40,7 +40,15 @@ import Control.Monad.Trans.Except
 import Data.Text.Class
     ( toText )
 import Test.Hspec
-    ( Spec, afterAll, beforeAll, describe, it, shouldReturn, shouldSatisfy )
+    ( Spec
+    , afterAll
+    , beforeAll
+    , describe
+    , it
+    , shouldBe
+    , shouldReturn
+    , shouldSatisfy
+    )
 
 import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
 import qualified Data.Text as T
@@ -50,6 +58,8 @@ port = 1337
 
 spec :: Spec
 spec = do
+    it "The NETWORK env var must be testnet for these tests" $ do
+        network `shouldBe` Testnet
     describe "Happy paths" $ beforeAll startBridge $ afterAll closeBridge $ do
         it "get from packed epochs" $ \(_, bridge) -> do
             let blocks = runExceptT $ nextBlocks bridge (SlotId 13 21599)


### PR DESCRIPTION
# Overview

- [x] Test that `network` is `Testnet` in integration/HttpBridgeSpec

# Comments
- When someone runs the tests with NETWORK=Mainnet/Staging/Local we now
make it clearer that this is unsupported.
- The specific failure reasons — from the other tests — are still shown:

```
test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs:62:9:
      1) Cardano.Wallet.Network.HttpBridge The NETWORK env var must be testnet for these tests
           expected: Testnet
            but got: Mainnet

      To rerun use: --match "/Cardano.Wallet.Network.HttpBridge/The NETWORK env var must be testnet for these tests/"

      test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs:68:13:
      2) Cardano.Wallet.Network.HttpBridge, Happy paths, get from packed epochs
           expected: Right (Hash {getHash = "7Z\213\204\SUB\134l\149\&8\191ZO\\0q]\ESCB\CAN\254\f[\RS\142\SOH\192K\250^\168\188m"})
            but got: Right (Hash {getHash = "\221_-@n\166\198+n7\SI\137\204\&9\216\SO@\NAK-[\NAK7\196\DC3\135\&5\158\"\r\223_\146"})

      To rerun use: --match "/Cardano.Wallet.Network.HttpBridge/Happy paths/get from packed epochs/"

      test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs:76:13:
      3) Cardano.Wallet.Network.HttpBridge, Happy paths, get from packet epochs and filter by start slot
           expected: Right 7600
            but got: Right 7599

      To rerun use: --match "/Cardano.Wallet.Network.HttpBridge/Happy paths/get from packet epochs and filter by start slot/"

      test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs:139:13:
      4) Cardano.Wallet.Network.HttpBridge, Submitting signed transactions, old tx fails
           expected: Left (ErrPostTxProtocolFailure "Failed to send to peers: Blockchain protocol error")
            but got: Left (ErrPostTxBadRequest "Transaction failed verification: invalid transaction witness")

      To rerun use: --match "/Cardano.Wallet.Network.HttpBridge/Submitting signed transactions/old tx fails/"

    Randomized with seed 1462693906

    Finished in 18.6094 seconds
    73 examples, 4 failures
```
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
