### PR TITLE
Fix Int FromText instance

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -53,8 +53,12 @@ spec = do
             { prompt = "Prompt: "
             , input = "patate\n14\n"
             , expectedStdout =
-                "Prompt: input does not start with a digit\n\
-                \Prompt: "
+                "Prompt: Int is an \
+                \integer number between "
+                <> T.pack (show $ minBound @Int)
+                <> " and "
+                <> T.pack (show $ maxBound @Int)
+                <> ".\nPrompt: "
             , expectedResult = 14 :: Int
             }
 

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -71,8 +71,11 @@ spec = do
             , input = "patate\n14\n"
             , expectedStdout =
                 "Prompt: ******\nInt is an \
-                \integer number between -9223372036854775808 \
-                \and 9223372036854775807.\nPrompt: **\n"
+                \integer number between "
+                <> T.pack (show $ minBound @Int)
+                <> " and "
+                <> T.pack (show $ maxBound @Int)
+                <> ".\nPrompt: **\n"
             , expectedResult = 14 :: Int
             }
 

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -70,8 +70,9 @@ spec = do
             { prompt = "Prompt: "
             , input = "patate\n14\n"
             , expectedStdout =
-                "Prompt: ******\ninput does not \
-                \start with a digit\nPrompt: **\n"
+                "Prompt: ******\nInt is an \
+                \integer number between -9223372036854775808 \
+                \and 9223372036854775807.\nPrompt: **\n"
             , expectedResult = 14 :: Int
             }
 

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -61,9 +61,9 @@ instance FromText Int where
       where
         err = TextDecodingError $
             "Int is an integer number between "
-                <> show (fromEnum $ minBound @Int)
+                <> show (minBound @Int)
                 <> " and "
-                <> show (fromEnum $ maxBound @Int)
+                <> show (maxBound @Int)
                 <> "."
 
 instance ToText Int where

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -55,9 +55,9 @@ instance ToText Text where
 
 instance FromText Int where
     fromText t = do
-        (g, txt) <- first (const err) $ signed decimal t
-        unless (T.null txt) $ Left err
-        pure g
+        (parsedValue, unconsumedInput) <- first (const err) $ signed decimal t
+        unless (T.null unconsumedInput) $ Left err
+        pure parsedValue
       where
         err = TextDecodingError $
             "Int is an integer number between "

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -17,8 +18,10 @@ module Data.Text.Class
 
 import Prelude
 
+import Control.Monad
+    ( unless )
 import Data.Bifunctor
-    ( bimap )
+    ( first )
 import Data.Text
     ( Text )
 import Data.Text.Read
@@ -51,7 +54,17 @@ instance ToText Text where
     toText = id
 
 instance FromText Int where
-    fromText = bimap TextDecodingError fst . signed decimal
+    fromText t = do
+        (g, txt) <- first (const err) $ signed decimal t
+        unless (T.null txt) $ Left err
+        pure g
+      where
+        err = TextDecodingError $
+            "Int is an integer number between "
+                <> show (fromEnum $ minBound @Int)
+                <> " and "
+                <> show (fromEnum $ maxBound @Int)
+                <> "."
 
 instance ToText Int where
     toText = T.pack . show

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -31,7 +31,12 @@ spec = do
         it "toText -14" $
             toText @Int (-14) === "-14"
         it "fromText \"patate\"" $
-            let err = "Int is an integer number between -9223372036854775808 and 9223372036854775807."
+            let err =
+                    "Int is an integer number between "
+                    <> show (minBound @Int)
+                    <> " and "
+                    <> show (maxBound @Int)
+                    <> "."
             in fromText @Int "patate" === Left (TextDecodingError err)
         it "fromText . toText === pure"
             $ property $ \(i :: Int) -> (fromText . toText) i === pure i

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -31,7 +31,7 @@ spec = do
         it "toText -14" $
             toText @Int (-14) === "-14"
         it "fromText \"patate\"" $
-            let err = "input does not start with a digit"
+            let err = "Int is an integer number between -9223372036854775808 and 9223372036854775807."
             in fromText @Int "patate" === Left (TextDecodingError err)
         it "fromText . toText === pure"
             $ property $ \(i :: Int) -> (fromText . toText) i === pure i


### PR DESCRIPTION
Previously it was able to parse decimal number

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed incorrect `FromText Int` instance


# Comments

Note that overflow is still possible and no out of bounds error will be raised in overflow
```haskell
*Main> fromText @Int "9223372036854775811"
Right (-9223372036854775805)
```

But at least fixes much more broken behaviour:
```haskell
> fromText @Int "22.2"
Right 22
```

This instance is used for parsing CLI arguments like `Port` (which should be Word16, not Int) and mnemonic words (which should be very small number, not Int). I still think this improves the implementation a lot and that we don't have to create special `FromText` instances with their smart constructors and error datatypes for mentioned datatypes because the underlying code will eventually fail (ie, with smart constructor for mnemonic). As this is used on a very top level, in CLI, I believe this fix is sufficient enough

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
