### PR TITLE
Rename `ApiCoins` to `AddressAmount`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -28,8 +28,8 @@ import Cardano.Wallet
 import Cardano.Wallet.Api
     ( Addresses, Api, Transactions, Wallets )
 import Cardano.Wallet.Api.Types
-    ( ApiAddress (..)
-    , ApiCoins (..)
+    ( AddressAmount (..)
+    , ApiAddress (..)
     , ApiT (..)
     , ApiTransaction (..)
     , ApiWallet (..)
@@ -221,12 +221,12 @@ createTransaction w (ApiT wid) body = do
         , status = ApiT (meta ^. #status)
         }
   where
-    coerceCoin :: ApiCoins -> TxOut
-    coerceCoin (ApiCoins (ApiT addr) (Quantity c)) =
+    coerceCoin :: AddressAmount -> TxOut
+    coerceCoin (AddressAmount (ApiT addr) (Quantity c)) =
         TxOut addr (Coin $ fromIntegral c)
-    coerceTxOut :: TxOut -> ApiCoins
+    coerceTxOut :: TxOut -> AddressAmount
     coerceTxOut (TxOut addr (Coin c)) =
-        ApiCoins (ApiT addr) (Quantity $ fromIntegral c)
+        AddressAmount (ApiT addr) (Quantity $ fromIntegral c)
 
 {-------------------------------------------------------------------------------
                                 Error Handling

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -37,7 +37,7 @@ module Cardano.Wallet.Api.Types
     , PostTransactionData (..)
     , ApiBlockData (..)
     , ApiTransaction (..)
-    , ApiCoins (..)
+    , AddressAmount (..)
 
     -- * Polymorphic Types
     , ApiT (..)
@@ -149,7 +149,7 @@ data WalletPutPassphraseData = WalletPutPassphraseData
     } deriving (Eq, Generic, Show)
 
 data PostTransactionData = PostTransactionData
-    { targets :: !(NonEmpty ApiCoins)
+    { targets :: !(NonEmpty AddressAmount)
     , passphrase :: !(ApiT (Passphrase "encryption"))
     } deriving (Eq, Generic, Show)
 
@@ -159,12 +159,12 @@ data ApiTransaction = ApiTransaction
     , insertedAt :: !(Maybe ApiBlockData)
     , depth :: !(Quantity "block" Natural)
     , direction :: !(ApiT Direction)
-    , inputs :: !(NonEmpty ApiCoins)
-    , outputs :: !(NonEmpty ApiCoins)
+    , inputs :: !(NonEmpty AddressAmount)
+    , outputs :: !(NonEmpty AddressAmount)
     , status :: !(ApiT TxStatus)
     } deriving (Eq, Generic, Show)
 
-data ApiCoins = ApiCoins
+data AddressAmount = AddressAmount
     { address :: !(ApiT Address)
     , amount :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
@@ -324,9 +324,9 @@ instance FromJSON ApiBlockData where
 instance ToJSON ApiBlockData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance FromJSON ApiCoins where
+instance FromJSON AddressAmount where
     parseJSON bytes = do
-        v@(ApiCoins _ (Quantity c)) <-
+        v@(AddressAmount _ (Quantity c)) <-
             genericParseJSON defaultRecordTypeOptions bytes
         if isValidCoin (Coin $ fromIntegral c)
             then return v
@@ -334,7 +334,7 @@ instance FromJSON ApiCoins where
                 "invalid coin value: value has to be lower than or equal to "
                 <> show (getCoin maxBound) <> " lovelace."
 
-instance ToJSON ApiCoins where
+instance ToJSON AddressAmount where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiTransaction where

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -22,9 +22,9 @@ import Prelude hiding
 import Cardano.Wallet.Api
     ( Api )
 import Cardano.Wallet.Api.Types
-    ( ApiAddress (..)
+    ( AddressAmount (..)
+    , ApiAddress (..)
     , ApiBlockData (..)
-    , ApiCoins (..)
     , ApiMnemonicT (..)
     , ApiT (..)
     , ApiTransaction (..)
@@ -158,7 +158,7 @@ spec = do
         \and match existing golden files" $ do
             jsonRoundtripAndGolden $ Proxy @ApiAddress
             jsonRoundtripAndGolden $ Proxy @ApiBlockData
-            jsonRoundtripAndGolden $ Proxy @ApiCoins
+            jsonRoundtripAndGolden $ Proxy @AddressAmount
             jsonRoundtripAndGolden $ Proxy @ApiTransaction
             jsonRoundtripAndGolden $ Proxy @ApiWallet
             jsonRoundtripAndGolden $ Proxy @PostTransactionData
@@ -450,7 +450,7 @@ instance Arbitrary SlotId where
     arbitrary = SlotId <$> arbitrary <*> arbitrary
     shrink = genericShrink
 
-instance Arbitrary ApiCoins where
+instance Arbitrary AddressAmount where
     arbitrary = genericArbitrary
     shrink = genericShrink
 


### PR DESCRIPTION
The "coin" metaphor works in some contexts, but it unfortunately breaks down in other contexts.

We instead use `AddressAmount` to denote an `(Address, Amount)` pair. This has the disadvantage of not referencing a nice reusable metaphor, but has the advantage of being explicit and obvious.