### PR TITLE
Review CLI interface & implement --version 

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -31,7 +31,6 @@ executable cardano-wallet
       -O2
   build-depends:
       base
-    , aeson
     , aeson-pretty
     , bytestring
     , cardano-wallet-cli
@@ -40,6 +39,7 @@ executable cardano-wallet
     , docopt
     , file-embed
     , http-client
+    , http-types
     , regex-applicative
     , servant-client
     , servant-client-core

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -38,7 +38,9 @@ executable cardano-wallet
     , cardano-wallet-core
     , cardano-wallet-http-bridge
     , docopt
+    , file-embed
     , http-client
+    , regex-applicative
     , servant-client
     , servant-client-core
     , servant-server

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -45,6 +45,8 @@ import Control.Applicative
     ( many )
 import Control.Arrow
     ( second )
+import Control.Monad
+    ( when )
 import Data.FileEmbed
     ( embedFile )
 import Data.Function
@@ -179,6 +181,13 @@ exec manager args
             let prompt = "Please enter a passphrase: "
             let parser = fromText @(Passphrase "encryption")
             getSensitiveLine prompt Nothing parser
+        (wPwd', _) <- do
+            let prompt = "Enter the passphrase a second time: "
+            let parser = fromText @(Passphrase "encryption")
+            getSensitiveLine prompt Nothing parser
+        when (wPwd /= wPwd') $ do
+            putErrLn "Passphrases don't match."
+            exitFailure
         runClient @Wallet Aeson.encodePretty $ postWallet $ WalletPostData
             (Just $ ApiT wGap)
             (ApiMnemonicT . second T.words $ wSeed)

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -69,6 +69,7 @@ import System.Console.Docopt
     ( Arguments
     , Docopt
     , Option
+    , argument
     , command
     , docopt
     , exitWithUsage
@@ -112,9 +113,9 @@ Usage:
   cardano-wallet server [--port=INT] [--bridge-port=INT]
   cardano-wallet mnemonic generate [--size=INT]
   cardano-wallet wallet list [--port=INT]
-  cardano-wallet wallet get [--port=INT] --wallet-id=STRING
   cardano-wallet wallet create [--port=INT] --name=STRING [--address-pool-gap=INT]
-  cardano-wallet wallet delete [--port=INT] --id=STRING
+  cardano-wallet wallet get [--port=INT] <wallet-id>
+  cardano-wallet wallet delete [--port=INT] <wallet-id>
   cardano-wallet -h | --help
   cardano-wallet --version
 
@@ -153,7 +154,7 @@ exec manager args
         runClient listWallets
 
     | args `isPresent` command "wallet" && args `isPresent` command "get" = do
-        wId <- args `parseArg` longOption "wallet-id"
+        wId <- args `parseArg` argument "wallet-id"
         runClient $ getWallet $ ApiT wId
 
     | args `isPresent` command "wallet" && args `isPresent` command "create" = do
@@ -183,13 +184,13 @@ exec manager args
             (ApiT wPwd)
 
     | args `isPresent` command "wallet" && args `isPresent` command "update" = do
-        wId <- args `parseArg` longOption "id"
+        wId <- args `parseArg` argument "wallet-id"
         wName <- args `parseArg` longOption "name"
         runClient $ putWallet (ApiT wId) $ WalletPutData
             (Just $ ApiT wName)
 
     | args `isPresent` command "wallet" && args `isPresent` command "delete" = do
-        wId <- args `parseArg` longOption "id"
+        wId <- args `parseArg` argument "wallet-id"
         runClient $ void $ deleteWallet (ApiT wId)
 
     | args `isPresent` longOption "version" = do

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -21,10 +21,11 @@
 
 module Main where
 
-import Prelude
+import Prelude hiding
+    ( getLine )
 
 import Cardano.CLI
-    ( Port (..), getSensitiveLine, parseArgWith, putErrLn )
+    ( Port (..), getLine, getSensitiveLine, parseArgWith, putErrLn )
 import Cardano.Environment
     ( network )
 import Cardano.Wallet
@@ -168,23 +169,23 @@ exec manager args
         wSeed <- do
             let prompt = "Please enter a 15–24 word mnemonic sentence: "
             let parser = fromMnemonic @'[15,18,21,24] @"seed" . T.words
-            getSensitiveLine prompt (Just ' ') parser
+            getLine prompt parser
         wSndFactor <- do
             let prompt =
                     "(Enter a blank line if you do not wish to use a second \
                     \factor.)\nPlease enter a 9–12 word mnemonic second factor: "
             let parser = optional (fromMnemonic @'[9,12] @"generation") . T.words
-            getSensitiveLine prompt (Just ' ') parser <&> \case
+            getLine prompt parser <&> \case
                 (Nothing, _) -> Nothing
                 (Just a, t) -> Just (a, t)
         (wPwd, _) <- do
             let prompt = "Please enter a passphrase: "
             let parser = fromText @(Passphrase "encryption")
-            getSensitiveLine prompt Nothing parser
+            getSensitiveLine prompt parser
         (wPwd', _) <- do
             let prompt = "Enter the passphrase a second time: "
             let parser = fromText @(Passphrase "encryption")
-            getSensitiveLine prompt Nothing parser
+            getSensitiveLine prompt parser
         when (wPwd /= wPwd') $ do
             putErrLn "Passphrases don't match."
             exitFailure

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -115,6 +115,7 @@ Usage:
   cardano-wallet wallet list [--port=INT]
   cardano-wallet wallet create [--port=INT] --name=STRING [--address-pool-gap=INT]
   cardano-wallet wallet get [--port=INT] <wallet-id>
+  cardano-wallet wallet update [--port=INT] <wallet-id> --name=STRING
   cardano-wallet wallet delete [--port=INT] <wallet-id>
   cardano-wallet -h | --help
   cardano-wallet --version

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -100,11 +100,11 @@ active server and can be ran "offline" (e.g. 'generate mnemonic')
 
 Usage:
   cardano-wallet server [--port=INT] [--bridge-port=INT]
-  cardano-wallet generate mnemonic [--size=INT]
-  cardano-wallet list wallets [--port=INT]
-  cardano-wallet get wallet --wallet-id=STRING [--port=INT]
-  cardano-wallet create wallet --name=STRING [--address-pool-gap=INT] [--port=INT]
-  cardano-wallet delete wallet --id=STRING
+  cardano-wallet mnemonic generate [--size=INT]
+  cardano-wallet wallet list [--port=INT]
+  cardano-wallet wallet get [--port=INT] --wallet-id=STRING
+  cardano-wallet wallet create [--port=INT] --name=STRING [--address-pool-gap=INT]
+  cardano-wallet wallet delete [--port=INT] --id=STRING
   cardano-wallet -h | --help
   cardano-wallet --version
 
@@ -139,7 +139,7 @@ exec manager args
         n <- args `parseArg` longOption "size"
         execGenerateMnemonic n
 
-    | args `isPresent` command "wallets" && args `isPresent` command "list" = do
+    | args `isPresent` command "wallet" && args `isPresent` command "list" = do
         runClient listWallets
 
     | args `isPresent` command "wallet" && args `isPresent` command "get" = do

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -65,6 +65,7 @@ import System.IO
     , hGetBuffering
     , hGetChar
     , hGetEcho
+    , hIsTerminalDevice
     , hPutChar
     , hSetBuffering
     , hSetEcho
@@ -219,7 +220,9 @@ withEcho h echo action = bracket aFirst aLast aBetween
     aBetween = const action
 
 withSGR :: Handle -> SGR -> IO a -> IO a
-withSGR h sgr action = bracket aFirst aLast aBetween
+withSGR h sgr action = hIsTerminalDevice h >>= \case
+    True -> bracket aFirst aLast aBetween
+    False -> action
   where
     aFirst = ([] <$ hSetSGR h [sgr])
     aLast = hSetSGR h

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -53,7 +53,7 @@ spec = do
             { prompt = "Prompt: "
             , input = "patate\n14\n"
             , expectedStdout =
-                "Prompt: \ESC[91minput does not start with a digit\n\ESC[m\
+                "Prompt: input does not start with a digit\n\
                 \Prompt: "
             , expectedResult = 14 :: Int
             }
@@ -70,8 +70,8 @@ spec = do
             { prompt = "Prompt: "
             , input = "patate\n14\n"
             , expectedStdout =
-                "Prompt: ******\n\ESC[91minput does not \
-                \start with a digit\n\ESC[mPrompt: **\n"
+                "Prompt: ******\ninput does not \
+                \start with a digit\nPrompt: **\n"
             , expectedResult = 14 :: Int
             }
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#229 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have grouped command by resources (instead of actions)
- [x] I have implemented `--version` using the version from the `cardano-wallet.cabal`
- [x] I have added the missing `[--port]` option to the delete wallet command
- [x] I have handled more nicely `404` and `409` errors
- [x] I have handled more nicely what gets printed to stderr and what gets printed to stdout
- [x] I have made the `walletId` a positional argument (rather than being a option)
- [x] I have enabled the `PUT /v2/wallets/{walletId}` command in the CLI definition
- [x] I have improved acknowledgement of success with a clear "Ok." message
- [x] I have removed the mask on the mnemonic prompt (now displayed in clear)
- [x] I have reviewed the return type of `DELETE /v2/wallets/{walletId}` to display nothing but a confirmation or error message (was displaying an empty array before)
- [x] I have fixed the ANSI colors to only be present if the given output handle is a terminal

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
