### PR TITLE
relax a bit QuickCheck constraints on shuffle properties

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -91,7 +91,7 @@ prop_shuffleCanShuffle
 prop_shuffleCanShuffle xs =
     length xs > 1 ==> monadicIO $ liftIO $ do
         xs' <- shuffle xs
-        return $ cover 95 (xs /= xs') "shuffled" ()
+        return $ cover 90 (xs /= xs') "shuffled" ()
 
 prop_shuffleNotDeterministic
     :: [Int]
@@ -100,7 +100,7 @@ prop_shuffleNotDeterministic xs =
     length xs > 1 ==> monadicIO $ liftIO $ do
         xs1 <- shuffle xs
         xs2 <- shuffle xs
-        return $ cover 95 (xs1 /= xs2) "not deterministic" ()
+        return $ cover 90 (xs1 /= xs2) "not deterministic" ()
 
 prop_shufflePreserveElements
     :: [Int]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have relaxed a bit QuickCheck constraints on shuffle properties

# Comments

<!-- Additional comments or screenshots to attach if any -->

95% was a bit hard to satisfy for QuickCheck actually, so this could sometimes trigger failures. In practice, we do really want to verify that the input is shuffled in most cases, so 90% is still a good enough check, but much easier to satisfy for QuickCheck.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
