### PR TITLE
fix 'slotRatio' case where the numerator is further than the denominator

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -593,7 +593,7 @@ slotRatio (SlotId ep0 sl0) (SlotId ep1 sl1) =
         n0 = flat ep0 sl0
         n1 = flat ep1 sl1
         tolerance = 5
-    in if distance n0 n1 < tolerance then
+    in if distance n0 n1 < tolerance || n0 >= n1 then
         maxBound
     else
         Quantity $ toEnum $ fromIntegral $ (100 * n0) `div` n1

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -35,9 +35,12 @@ import Cardano.Wallet.Primitive.Types
     , isValidCoin
     , restrictedBy
     , restrictedTo
+    , slotRatio
     , walletNameMaxLength
     , walletNameMinLength
     )
+import Control.DeepSeq
+    ( deepseq )
 import Control.Monad
     ( replicateM )
 import Crypto.Hash
@@ -138,6 +141,9 @@ spec = do
             \      <~ 19999800000 @ DdzFFzCq...UfLEFu1q\n"
                 === pretty @_ @Text block
 
+    describe "slotRatio" $ do
+        it "works for any two slots" $ property $ \sl0 sl1 ->
+            slotRatio sl0 sl1 `deepseq` ()
 
     describe "Negative cases for types decoding" $ do
         it "fail fromText @Address \"0000\"" $ do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have fixed 'slotRatio' case where the numerator is further than the denominator
- [ ] I have added a property tests to control that too

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
