### PR TITLE
use a lower statistical confidence for shuffle tests

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -52,9 +52,10 @@ import Test.Hspec
     ( Spec, SpecWith, describe, it, shouldBe )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Confidence (..)
     , Gen
     , Property
-    , checkCoverage
+    , checkCoverageWith
     , choose
     , cover
     , generate
@@ -75,11 +76,14 @@ spec :: Spec
 spec = do
     describe "shuffle" $ do
         it "every non-empty list can be shuffled, ultimately"
-            (checkCoverage prop_shuffleCanShuffle)
+            (checkCoverageWith lowerConfidence prop_shuffleCanShuffle)
         it "shuffle is non-deterministic"
-            (checkCoverage prop_shuffleNotDeterministic)
+            (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
         it "sort (shuffled xs) == sort xs"
-            (checkCoverage prop_shufflePreserveElements)
+            (checkCoverageWith lowerConfidence prop_shufflePreserveElements)
+  where
+    lowerConfidence :: Confidence
+    lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
 
 {-------------------------------------------------------------------------------
                                  Properties


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have reduced the statistical confidence for the 'shuffle' tests. Those tests actually testing random stuff, they're sometimes slightly out of the standard confidence interval for Quickcheck. We've already relaxed a bit the cover bound from 95 to 90, but in some cases, we are still just in limit. What really matters for us to test is that in _most_ cases, things are shuffled.. So we don't need much confidence on that. 

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
