### PR TITLE
Tidy up some of the formatting within Cardano.Wallet.DB.Sqlite.

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -37,118 +37,126 @@ share
 
 -- Wallet IDs, address discovery state, and metadata.
 Wallet
-  walId                W.WalletId              sql=wallet_id
-  walName              Text                    sql=name
-  walPassphraseLastUpdatedAt   UTCTime         sql=passphrase_last_updated_at
-  walStatus            W.WalletState           sql=status
-  walDelegation        Text Maybe              sql=delegation
-  walAddressScheme     AddressScheme           sql=address_discovery
+    walId                       W.WalletId     sql=wallet_id
+    walName                     Text           sql=name
+    walPassphraseLastUpdatedAt  UTCTime        sql=passphrase_last_updated_at
+    walStatus                   W.WalletState  sql=status
+    walDelegation               Text Maybe     sql=delegation
+    walAddressScheme            AddressScheme  sql=address_discovery
 
-  Primary walId
-  deriving Show Generic
+    Primary walId
+    deriving Show Generic
 
--- The private key for each wallet. This is in a separate table
--- simply so that "SELECT * FROM wallet" won't print keys.
-WalletPrivateKey                               sql=private_key
-  walPrivateKeyWalId   W.WalletId              sql=wallet_id
-  walPrivateKey        Text                    sql=private_key
+-- The private key for each wallet. This is in a separate table simply so that
+-- "SELECT * FROM wallet" won't print keys.
+WalletPrivateKey                    sql=private_key
+    walPrivateKeyWalId  W.WalletId  sql=wallet_id
+    walPrivateKey       Text        sql=private_key
 
-  Primary walPrivateKeyWalId
-  Foreign Wallet fk_wallet_private_key walPrivateKeyWalId
+    Primary walPrivateKeyWalId
+    Foreign Wallet fk_wallet_private_key walPrivateKeyWalId
 
-  deriving Show Generic
+    deriving Show Generic
 
--- Maps a transaction ID to its metadata (which is calculated
--- when applying blocks).
--- TxMeta is specific to a wallet because multiple wallets may
--- have the same transaction with different metdata values.
--- The associated inputs and outputs of the transaction are in
--- the TxIn and TxOut tables.
+-- Maps a transaction ID to its metadata (which is calculated when applying
+-- blocks).
+--
+-- TxMeta is specific to a wallet because multiple wallets may have the same
+-- transaction with different metdata values. The associated inputs and outputs
+-- of the transaction are in the TxIn and TxOut tables.
 TxMeta
-  txId                  TxId                   sql=tx_id
-  txMetaWalletId        W.WalletId             sql=wallet_id
-  txStatus              W.TxStatus             sql=status
-  txMetaDirection       W.Direction            sql=direction
-  txMetaSlotId          W.SlotId               sql=slot_id
-  txMetaAmount          W.Coin                 sql=amount
+    txId             TxId         sql=tx_id
+    txMetaWalletId   W.WalletId   sql=wallet_id
+    txStatus         W.TxStatus   sql=status
+    txMetaDirection  W.Direction  sql=direction
+    txMetaSlotId     W.SlotId     sql=slot_id
+    txMetaAmount     W.Coin       sql=amount
 
-  Primary txId txMetaWalletId
-  Foreign Wallet fk_wallet_tx_meta txMetaWalletId
-  deriving Show Generic
+    Primary txId txMetaWalletId
+    Foreign Wallet fk_wallet_tx_meta txMetaWalletId
+    deriving Show Generic
 
 -- A transaction input associated with TxMeta.
--- There is no wallet ID because these values depend only on the
--- transaction, not the wallet.
--- txInputTxId is referred to by TxMeta and PendingTx
+--
+-- There is no wallet ID because these values depend only on the transaction,
+-- not the wallet. txInputTxId is referred to by TxMeta and PendingTx
 TxIn
-  txInputTxId           TxId                   sql=tx_id
-  txInputSourceTxId     TxId                   sql=source_id
-  txInputSourceIndex    Word32                 sql=source_index
-  txInputAddress        Text                   sql=address
-  txInputAmount         W.Coin                 sql=amount
+    txInputTxId         TxId    sql=tx_id
+    txInputSourceTxId   TxId    sql=source_id
+    txInputSourceIndex  Word32  sql=source_index
+    txInputAddress      Text    sql=address
+    txInputAmount       W.Coin  sql=amount
 
-  Primary txInputTxId txInputSourceTxId txInputSourceIndex
-  -- fixme: add index on tx_id
-  deriving Show Generic
+    Primary txInputTxId txInputSourceTxId txInputSourceIndex
+    -- fixme: add index on tx_id
+    deriving Show Generic
 
 -- A transaction output associated with TxMeta.
--- There is no wallet ID because these values depend only on the
--- transaction, not the wallet.
--- txOutputTxId is referred to by TxMeta and PendingTx
+--
+-- There is no wallet ID because these values depend only on the transaction,
+-- not the wallet. txOutputTxId is referred to by TxMeta and PendingTx
 TxOut
-  txOutputTxId          TxId                   sql=tx_id
-  txOutputIndex         Word32                 sql=index
-  txOutputAddress       Text                   sql=address
-  txOutputAmount        W.Coin                 sql=amount
+    txOutputTxId     TxId    sql=tx_id
+    txOutputIndex    Word32  sql=index
+    txOutputAddress  Text    sql=address
+    txOutputAmount   W.Coin  sql=amount
 
-  Primary txOutputTxId txOutputIndex
-  -- fixme: add index on tx_id
-  deriving Show Generic
+    Primary txOutputTxId txOutputIndex
+    -- fixme: add index on tx_id
+    deriving Show Generic
 
 -- A checkpoint for a given wallet is referred to by (wallet_id, slot_id).
 -- Checkpoint data such as UTxO will refer to this table.
 Checkpoint
-  checkpointWalId       W.WalletId             sql=wallet_id
-  checkpointWalSlot     W.SlotId               sql=slot_id
+    checkpointWalId    W.WalletId  sql=wallet_id
+    checkpointWalSlot  W.SlotId    sql=slot_id
 
-  Primary checkpointWalId checkpointWalSlot
-  Foreign Wallet fk_wallet_checkpoint checkpointWalId
+    Primary checkpointWalId checkpointWalSlot
+    Foreign Wallet fk_wallet_checkpoint checkpointWalId
 
-  deriving Show Generic
+    deriving Show Generic
 
--- The UTxO for a given wallet checkpoint is a
--- one-to-one mapping from TxIn -> TxOut.
--- This table does not need to refer to the TxIn or TxOut tables.
--- All necessary information for the UTxO is in this table.
-UTxO                                            sql=utxo
-  -- The wallet checkpoint (wallet_id, slot_id)
-  utxoWalletId        W.WalletId             sql=wallet_id
-  utxoWalletSlot      W.SlotId               sql=slot_id
+-- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
+-- TxOut. This table does not need to refer to the TxIn or TxOut tables. All
+-- necessary information for the UTxO is in this table.
+UTxO                             sql=utxo
 
-  -- TxIn
-  utxoInputId          TxId                   sql=input_tx_id
-  utxoInputIndex       Word32                 sql=input_index
+    -- The wallet checkpoint (wallet_id, slot_id)
+    utxoWalletId     W.WalletId  sql=wallet_id
+    utxoWalletSlot   W.SlotId    sql=slot_id
 
-  -- TxOut
-  utxoOutputId        TxId                   sql=output_tx_id
-  utxoOutputIndex     Word32                 sql=output_index
+    -- TxIn
+    utxoInputId      TxId        sql=input_tx_id
+    utxoInputIndex   Word32      sql=input_index
 
-  Primary utxoWalletId utxoWalletSlot utxoInputId utxoInputIndex utxoOutputId utxoOutputIndex
-  Foreign Checkpoint fk_checkpoint_utxo utxoWalletId utxoWalletSlot
+    -- TxOut
+    utxoOutputId     TxId        sql=output_tx_id
+    utxoOutputIndex  Word32      sql=output_index
 
-  deriving Show Generic
+    Primary
+        utxoWalletId
+        utxoWalletSlot
+        utxoInputId
+        utxoInputIndex
+        utxoOutputId
+        utxoOutputIndex
+
+    Foreign Checkpoint fk_checkpoint_utxo utxoWalletId utxoWalletSlot
+
+    deriving Show Generic
 
 -- The pending transactions for a wallet checkpoint.
 PendingTx
-  -- The wallet checkpoint (wallet_id, slot_id)
-  pendingTxWalletId    W.WalletId             sql=wallet_id
-  pendingTxSlotId      W.SlotId               sql=slot_id
 
-  -- Transaction TxIn and TxOut
-  pendingTxId2         TxId                   sql=tx_id
+    -- The wallet checkpoint (wallet_id, slot_id)
+    pendingTxWalletId    W.WalletId  sql=wallet_id
+    pendingTxSlotId      W.SlotId    sql=slot_id
 
-  Primary pendingTxWalletId pendingTxSlotId pendingTxId2
-  Foreign Checkpoint fk_pending_tx pendingTxWalletId pendingTxSlotId
+    -- Transaction TxIn and TxOut
+    pendingTxId2         TxId        sql=tx_id
 
-  deriving Show Generic
+    Primary pendingTxWalletId pendingTxSlotId pendingTxId2
+    Foreign Checkpoint fk_pending_tx pendingTxWalletId pendingTxSlotId
+
+    deriving Show Generic
 |]

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -23,8 +23,13 @@ import Database.Persist.Sqlite
 import Test.Hspec
     ( Spec, describe, it, shouldReturn )
 
-runSqlite' :: (MonadUnliftIO m) => Text -> ReaderT SqlBackend (LoggingT (ResourceT m)) a -> m a
-runSqlite' connstr = runResourceT . runStderrLoggingT . withSqliteConn connstr . runSqlConn
+runSqlite'
+    :: (MonadUnliftIO m)
+    => Text
+    -> ReaderT SqlBackend (LoggingT (ResourceT m)) a
+    -> m a
+runSqlite' connstr =
+    runResourceT . runStderrLoggingT . withSqliteConn connstr . runSqlConn
 
 testMigrate :: IO ()
 testMigrate = runSqlite' ":memory:" $ do


### PR DESCRIPTION
This change tidies up some of the formatting within Cardano.Wallet.DB.Sqlite to meet our coding standards.

80 column line limit / wrapping.
4 char indentation.