### PR TITLE
Wallet Management Remaining Endpoints: update & update passphrase

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -239,28 +239,33 @@ data ErrCreateUnsignedTx
     = ErrCreateUnsignedTxNoSuchWallet ErrNoSuchWallet
     | ErrCreateUnsignedTxCoinSelection CoinSelectionError
     | ErrCreateUnsignedTxFee ErrAdjustForFee
+    deriving (Show, Eq)
 
 -- | Errors occuring when signing a transaction
 data ErrSignTx
     = ErrSignTx ErrMkStdTx
     | ErrSignTxNoSuchWallet ErrNoSuchWallet
     | ErrSignTxWithRootKey ErrWithRootKey
+    deriving (Show, Eq)
 
 -- | Errors occuring when submitting a signed transaction to the network
 data ErrSubmitTx
     = ErrSubmitTxNetwork ErrPostTx
     | ErrSubmitTxNoSuchWallet ErrNoSuchWallet
+    deriving (Show, Eq)
 
 -- | Errors occuring when trying to change a wallet's passphrase
 data ErrUpdatePassphrase
     = ErrUpdatePassphraseNoSuchWallet ErrNoSuchWallet
     | ErrUpdatePassphraseWithRootKey ErrWithRootKey
+    deriving (Show, Eq)
 
 -- | Errors occuring when trying to perform an operation on a wallet which
 -- requires a private key, but none is attached to the wallet
 data ErrWithRootKey
     = ErrWithRootKeyNoRootKey WalletId
     | ErrWithRootKeyWrongPassphrase ErrWrongPassphrase
+    deriving (Show, Eq)
 
 {-------------------------------------------------------------------------------
                                  Construction

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -22,6 +22,7 @@ import Cardano.Wallet
     , ErrNoSuchWallet (..)
     , ErrSignTx (..)
     , ErrSubmitTx (..)
+    , ErrUpdatePassphrase (..)
     , ErrWalletAlreadyExists (..)
     , WalletLayer
     )
@@ -182,8 +183,10 @@ putWalletPassphrase
     -> ApiT WalletId
     -> WalletPutPassphraseData
     -> Handler NoContent
-putWalletPassphrase _ _ _ =
-    throwM err501
+putWalletPassphrase w (ApiT wid) body = do
+    let (WalletPutPassphraseData (ApiT old) (ApiT new)) = body
+    liftHandler $ W.updateWalletPassphrase w wid (old, new)
+    return NoContent
 
 {-------------------------------------------------------------------------------
                                     Addresses
@@ -274,7 +277,12 @@ instance LiftHandler ErrSignTx where
     handler = \case
         ErrSignTx _ -> err500
         ErrSignTxNoSuchWallet _ -> err410
-        ErrSignTxWrongPassphrase _ -> err403
+        ErrSignTxWithRootKey _ -> err403
 
 instance LiftHandler ErrSubmitTx where
     handler _ = err500
+
+instance LiftHandler ErrUpdatePassphrase where
+    handler = \case
+        ErrUpdatePassphraseNoSuchWallet _ -> err404
+        ErrUpdatePassphraseWithRootKey _ -> err403

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -135,7 +135,7 @@ getWallet w (ApiT wid) = do
         , name =
             ApiT $ meta ^. #name
         , passphrase =
-            ApiT $ meta ^. #passphraseInfo
+            ApiT <$> meta ^. #passphraseInfo
         , state =
             ApiT $ meta ^. #status
         }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -48,7 +48,11 @@ module Cardano.Wallet.Api.Types
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( FromMnemonic (..), Passphrase (..) )
+    ( FromMnemonic (..)
+    , Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( AddressPoolGap, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
@@ -144,8 +148,8 @@ newtype WalletPutData = WalletPutData
     } deriving (Eq, Generic, Show)
 
 data WalletPutPassphraseData = WalletPutPassphraseData
-    { oldPassphrase :: !(ApiT (Passphrase "encryption"))
-    , newPassphrase :: !(ApiT (Passphrase "encryption"))
+    { oldPassphrase :: !(ApiT (Passphrase "encryption-old"))
+    , newPassphrase :: !(ApiT (Passphrase "encryption-new"))
     } deriving (Eq, Generic, Show)
 
 data PostTransactionData = PostTransactionData
@@ -253,9 +257,10 @@ instance FromJSON WalletPutPassphraseData where
 instance ToJSON  WalletPutPassphraseData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance FromJSON (ApiT (Passphrase "encryption")) where
+instance (PassphraseMaxLength purpose, PassphraseMinLength purpose)
+    => FromJSON (ApiT (Passphrase purpose)) where
     parseJSON = parseJSON >=> eitherToParser . bimap ShowFmt ApiT . fromText
-instance ToJSON (ApiT (Passphrase "encryption")) where
+instance ToJSON (ApiT (Passphrase purpose)) where
     toJSON = toJSON . toText . getApiT
 
 instance FromMnemonic sizes purpose => FromJSON (ApiMnemonicT sizes purpose)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -131,7 +131,7 @@ data ApiWallet = ApiWallet
     , balance :: !(ApiT WalletBalance)
     , delegation :: !(ApiT (WalletDelegation (ApiT PoolId)))
     , name :: !(ApiT WalletName)
-    , passphrase :: !(ApiT WalletPassphraseInfo)
+    , passphrase :: !(Maybe (ApiT WalletPassphraseInfo))
     , state :: !(ApiT WalletState)
     } deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -220,6 +221,8 @@ newtype Passphrase (purpose :: Symbol) = Passphrase ScrubbedBytes
     deriving stock (Eq, Show)
     deriving newtype (Semigroup, Monoid)
 
+type role Passphrase phantom
+
 class PassphraseMinLength (purpose :: Symbol) where
     -- | Minimal Length for a passphrase, for lack of better validations
     passphraseMinLength :: Proxy purpose -> Int
@@ -230,6 +233,14 @@ class PassphraseMaxLength (purpose :: Symbol) where
 
 instance PassphraseMinLength "encryption" where passphraseMinLength _ = 10
 instance PassphraseMaxLength "encryption" where passphraseMaxLength _ = 255
+instance PassphraseMinLength "encryption-old" where
+    passphraseMinLength _ = passphraseMinLength (Proxy @"encryption")
+instance PassphraseMaxLength "encryption-old" where
+    passphraseMaxLength _ = passphraseMaxLength (Proxy @"encryption")
+instance PassphraseMinLength "encryption-new" where
+    passphraseMinLength _ = passphraseMinLength (Proxy @"encryption")
+instance PassphraseMaxLength "encryption-new" where
+    passphraseMaxLength _ = passphraseMaxLength (Proxy @"encryption")
 
 instance
     ( PassphraseMaxLength purpose

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -150,7 +150,7 @@ data WalletMetadata = WalletMetadata
     { name
         :: !WalletName
     , passphraseInfo
-        :: !WalletPassphraseInfo
+        :: !(Maybe WalletPassphraseInfo)
     , status
         :: !WalletState
     , delegation

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -225,7 +225,7 @@ instance NFData poolId => NFData (WalletDelegation poolId)
 
 newtype WalletPassphraseInfo = WalletPassphraseInfo
     { lastUpdatedAt :: UTCTime }
-    deriving (Generic, Eq, Show)
+    deriving (Generic, Eq, Ord, Show)
 
 instance NFData WalletPassphraseInfo
 

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
@@ -1,144 +1,9 @@
 {
-    "seed": 224666846625824028,
+    "seed": -6747973350220363102,
     "samples": [
         {
             "passphrase": {
-                "last_updated_at": "1864-05-06T11:42:12.813901195906Z"
-            },
-            "address_pool_gap": 13,
-            "state": {
-                "status": "restoring",
-                "progress": {
-                    "quantity": 82,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "total": {
-                    "quantity": 158,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 44,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "}L<:oI荮jm`]옡\"Zh𤋜Y/c\"",
-            "delegation": {
-                "status": "not_delegating"
-            },
-            "id": "7a10631ad0752574b5c42b432636bfa4bcb9f74c"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-15T04:52:55.94053840727Z"
-            },
-            "address_pool_gap": 26,
-            "state": {
-                "status": "restoring",
-                "progress": {
-                    "quantity": 27,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "total": {
-                    "quantity": 21,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 251,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "Jk:D7VMDX쏫ZztgnC(rCh!)3\"\"{RUd]𩯿Y)X7i翎-loLqSev>w=MJ\\kb^/8K6>!*>9Hwq𡺗IAB48Q3H?dRy*UxG<RfQ𣯪hh+po,<TgX]wfi2_C𢋙TuEst 5H?=@<wQRcZ𧇟y^?PDHm!嘎)-97\"[5?{n6vC8A㞢B&'=da`fjfz_𩆈L m>`𧼞e]KIRxos𒍫RKRgr$Z2((",
-            "delegation": {
-                "status": "not_delegating"
-            },
-            "id": "1929049e7a46078a28f541448472d65a22e00195"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-19T21:59:42.281857531401Z"
-            },
-            "address_pool_gap": 69,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "total": {
-                    "quantity": 202,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 238,
-                    "unit": "lovelace"
-                }
-            },
-            "name": ";\\i[oyGizr#Ru|E𦅋K{<U=mAd챎 7U(\\p]d\"Za.2]Z\"",
-            "delegation": {
-                "status": "delegating",
-                "target": "$gf"
-            },
-            "id": "9cadedf7ea2d09fd28853a60b23937fa9f3c7c73"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-05T19:07:57.676452582149Z"
-            },
-            "address_pool_gap": 47,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "total": {
-                    "quantity": 134,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 119,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "AQ;:i+4MBz1]𥛒:l%(Xu!9&u\\5𦩎M^𥕾'alOY'#q⮈8Z0Vt>mu\\x6EGaH<ZY'a(ᮤO.3D@HL>gpLDJUl𫉹&'p(=XSHP4&𤠆lwcD;.z\\=",
-            "delegation": {
-                "status": "delegating",
-                "target": "H[2"
-            },
-            "id": "74d8d73bec204b6008c5d919f889efc71ecbafce"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-15T03:28:31.477730316108Z"
-            },
-            "address_pool_gap": 81,
-            "state": {
-                "status": "restoring",
-                "progress": {
-                    "quantity": 47,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "total": {
-                    "quantity": 145,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 69,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "4nF4G%lV^0Xb-o<xy~v}Me^q4/D;*#k쵺9|𪯷tri;)X]%s9n=𠏹!yqfD-bECyGc.i-$O#𫚩`&kt:WZ92uH+(UL\\%[dhc3xw4Tb~D~AbX<PN䝼I%;zysj43;-#8(fHJ&^3ze\"48h!+Ei0TqhwQ\\d[rLG-L_",
-            "delegation": {
-                "status": "delegating",
-                "target": "O#P"
-            },
-            "id": "704d5fc617ee3d2c0a73e55444c93187a5d0655c"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-02T08:53:36.119546652927Z"
+                "last_updated_at": "1864-05-02T02:12:29.031598075917Z"
             },
             "address_pool_gap": 95,
             "state": {
@@ -150,25 +15,214 @@
             },
             "balance": {
                 "total": {
-                    "quantity": 15,
+                    "quantity": 231,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 22,
+                    "quantity": 173,
                     "unit": "lovelace"
                 }
             },
-            "name": "qN.gs+~g DCnvV~qaa,?H9G4E&Bkwc;BzL~rCVE~0k' $VO_\"/;L\"`*.ylDT1{@S;^;vlN{0c>,#b;ghȉ?Or䏜W%𢨲]~E|6[\\zr𐚤kMyzbnl:JT\"DdRZ7.['[bN}q'ktAhu",
+            "name": "A\"za{1I#3@`T>SR?w=|K:}2DymA>N6^`8⒬Q1rh㵢3.y0X}jo𧲩sMX#igZ,^-<%IpQ6$*H8-9r2z5^𩌲Dq)@E硃7#(fAFXBRFyX4x_[T6yZP𤚟uOwj9MlF,^av_𐂟W{^:+cꑼc/.\\Ks<ia~H@+`KD9D0p]MyOjrPw&LM쪷tbT'hX^M}n'p{2]c@d\\h$3[㟄JQCz<\\I",
             "delegation": {
                 "status": "not_delegating"
             },
-            "id": "7a9c32b9d6a7f0a9f0815b97980f2dc5d7319cac"
+            "id": "a541612239a6693d2ef1ba870673f75596bbedc6"
         },
         {
             "passphrase": {
-                "last_updated_at": "1864-05-20T02:28:37.378344903812Z"
+                "last_updated_at": "1864-04-18T11:51:06.285741350708Z"
             },
-            "address_pool_gap": 59,
+            "address_pool_gap": 96,
+            "state": {
+                "status": "restoring",
+                "progress": {
+                    "quantity": 30,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "total": {
+                    "quantity": 89,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 222,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "vP1?MavkRe+O%CKWfxl\\QXa,Td~qY21Hxz~kO).z5TzL@H/cZF,u_f.//)$9 DPlqypNB?pn_)9xAL<?-R!y𪉽xi8ib~H6UNnLd>F[t싳jcৃA.(@g:䔎-fhc1]ZK'H[z3Ujs>a@(\\X%숌Biw",
+            "delegation": {
+                "status": "not_delegating"
+            },
+            "id": "fc781e4db2261f65ec09092b184aa6a50e58521c"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-06-06T12:46:14.145544266539Z"
+            },
+            "address_pool_gap": 67,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "total": {
+                    "quantity": 55,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 87,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "]'8E)LqBT)$_)LcAuC&U#e`Uqo7,tFt㢈X6?$'恁pYSx[D27dyI[j^%e`Jt1OT`|_r1D2OR!vkneL^@FW𝘥zhw$f)#{oKWLoF븶𠥹*7caBVzu1",
+            "delegation": {
+                "status": "delegating",
+                "target": "fW5"
+            },
+            "id": "ac5f65727865aab1d65543339a8fc68008debda8"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-04-09T23:58:15.500513596576Z"
+            },
+            "address_pool_gap": 85,
+            "state": {
+                "status": "restoring",
+                "progress": {
+                    "quantity": 36,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "total": {
+                    "quantity": 170,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 119,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "[3！M`Ki]`Plg6K𖣇V5)+{\\<.A+:GBtjKC5&T^>c=h?cr6ro+#m.YBey|I@zMq#QpcpxHWo_,>+&+.J𤣧F3<;L+m&y<?^f!kqb7H5/PBr0e1lyqvH-zꆫxA=k#}fa*73}JPROIYDx!h_w",
+            "delegation": {
+                "status": "delegating",
+                "target": "4$p"
+            },
+            "id": "49e839e919783a625b74efb37c2174528abb21fc"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-05-02T21:56:54.982643926676Z"
+            },
+            "address_pool_gap": 49,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "total": {
+                    "quantity": 169,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 93,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "w,R?/8㫗滼)RW[35AE{lr-!:YJ&nli8P'|>ZlWY6,yg@v'cT?guLw`s rD4*;d?;KE)?g}b𤚍HW+n-][N8`F-\\%O+-72TYD%+g Crn; Df𥬛5JsM<GW&b0TU改x7u~3)5!i@<AZ畱$YmC/67fDaW𨹐9gcI춝Qx<~t1cgGCL𣏌;~W󠄻yY$DR/JCP6LC{yZ5Ja]1y⫬[O,R\"`FxN'ot2y,EZhMv9bw)1lr\\qKC'𫏈<eB",
+            "delegation": {
+                "status": "delegating",
+                "target": "95z"
+            },
+            "id": "5ecdfc16f4195fe7ab2fd1da7001cc16a045932a"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-05-01T23:28:54.43708326685Z"
+            },
+            "address_pool_gap": 28,
+            "state": {
+                "status": "restoring",
+                "progress": {
+                    "quantity": 69,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "total": {
+                    "quantity": 124,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 36,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "DB8h*32({|c拶xo%a2}?=at%aGM?xvzd?vQN9𦤢.]L=@frU;J7\"N|g4Ao\\l;'L!d-uTJp>,?<Ik旋i_)&+^\"8S3;a}QoYQD@^9sP敏D;8\".gNr(s'Ot!ky K%)9l]鑒#xhY'Mgb(%\",h0&&g6|LVAk5s</PTu&^𤎙bi/𢯴1<Qo3F*k,kJwO|5醏?Ra=\"O?(kw-CaJ𤜇%x3)W.zrg2,D2e\\}Y$Sm(R8^CrTw<5jMDM=b",
+            "delegation": {
+                "status": "delegating",
+                "target": "}Q)"
+            },
+            "id": "663e121dc13ca321b05bcbe1b85e87df49d12d54"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-06-02T12:38:27.679574322624Z"
+            },
+            "address_pool_gap": 32,
+            "state": {
+                "status": "restoring",
+                "progress": {
+                    "quantity": 45,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "total": {
+                    "quantity": 205,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 226,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "Scn,>k[~kFz]Us3`%cCt[fAp6+𡽣)_橫fsEouH㽅]#dT彇.=pne?ፑxwQ,!H;am]`?RIp_8풳hVo0g_𡯘5!_S,89cJ\"!palE`d?䮶6|>/:@l:}osqg3.iz?=SpU7s F?:'M",
+            "delegation": {
+                "status": "delegating",
+                "target": "ouY"
+            },
+            "id": "5312eafbf69bd96156016271cbd34e486e81fd47"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-05-07T17:42:59.022898940042Z"
+            },
+            "address_pool_gap": 64,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "total": {
+                    "quantity": 154,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 125,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "s{DQ3c'AS:D2FeMlz,u\"4o(|SNC_FQ$jKAu6z(m𡇗enN9qvO𢆆!j8/EH:]@6{D^z|;w$ BCW\\;OvY!Q",
+            "delegation": {
+                "status": "not_delegating"
+            },
+            "id": "1078a84d1e14332d1282b8b84e3709a520b006fb"
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1864-05-11T14:50:50.065173826682Z"
+            },
+            "address_pool_gap": 47,
             "state": {
                 "status": "restoring",
                 "progress": {
@@ -178,97 +232,42 @@
             },
             "balance": {
                 "total": {
-                    "quantity": 184,
+                    "quantity": 134,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 15,
+                    "quantity": 20,
                     "unit": "lovelace"
                 }
             },
-            "name": "𢕕<1GIC~!VYRℬsGd/b+f",
+            "name": "aS.p_En>/H2#>&BMq,o+twg~l})Y;1𓋭QVY1Je\\ -P&I$[UteBQ)>?x~,^bT2@HTkuo,j(`/6:Yai|An4oYZu봕]ShxY!E_7l>,XIo`PFU]lH6?b=u%Oej\"|_r@.tq`+{3rebAN)kP@-:/@Kq|$j8l烹믤ou^ngnv/Y<!dBw/H;go3oX&3e/!K[4/w:/tV𤸔:eQ.1S4𠙫𣫌q[6&=O\"d:1.+)8𦾴=[x(R5N?\"0",
             "delegation": {
-                "status": "not_delegating"
+                "status": "delegating",
+                "target": "0Ly"
             },
-            "id": "5588ebdcbd2a57ee22fc92895df13901db142457"
+            "id": "c8e7264eb6be5614ebaa618ec37d54e8b84d5c3b"
         },
         {
-            "passphrase": {
-                "last_updated_at": "1864-04-29T14:33:47.215849737818Z"
-            },
-            "address_pool_gap": 17,
+            "address_pool_gap": 31,
             "state": {
                 "status": "ready"
             },
             "balance": {
                 "total": {
-                    "quantity": 228,
+                    "quantity": 11,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 194,
+                    "quantity": 38,
                     "unit": "lovelace"
                 }
             },
-            "name": "!@4;u;py%ⶵom2* Az5pdsp1iYg~!tZrErA07kY.]NLet&fK^L}2BF79d$RHxitFN\\A,BqR~-Txo:e@𦘶1r:l6@T𨚢lO*G#]&1mxⴸQ䘵J(zV)Jv>$氀AN}AN:~",
-            "delegation": {
-                "status": "not_delegating"
-            },
-            "id": "0862b2475d4644b486e62b8f866d4e93027e2c03"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-04-30T04:09:26.721674680586Z"
-            },
-            "address_pool_gap": 10,
-            "state": {
-                "status": "restoring",
-                "progress": {
-                    "quantity": 58,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "total": {
-                    "quantity": 8,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 6,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "-j*ᤈ) :'DIRodVgzqY:kIG@k^m~?X$8.㹎I9B[c<aU):oZby52El</_I",
+            "name": "j3SVfy;v%|UcYP< BWn`ohCagpBBV'SW\"汚u(Eg~=Y@|cYy`\\+@UQJ𥐶t(F^9#U鍪BOA퉨*Xa麙.ssDL}]?poz$#O>zoPTm4E6|a^,a]rNNT#\"KcvTxr7E9n<ku[e|Na1𢂈'04'6P<X;'5pQ\\`0TJ]Djq_Jb<F",
             "delegation": {
                 "status": "delegating",
-                "target": "lIT"
+                "target": "3e+"
             },
-            "id": "ac09f70a6361d2f9e73298d604da44765bc04d26"
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1864-05-12T12:47:50.92395182178Z"
-            },
-            "address_pool_gap": 90,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "total": {
-                    "quantity": 129,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 75,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "3H4jW?4.ciZ-^:S@-`{✋!HH7pc5#&fmo:M?)lEwo.Lc㹷{7B*/i.+g+N6D8$1\"Oyx0VoQTMzaVbYH%(EF*DY9{~=KQkQLhWV5🝦鵈*aM*JQ~A`cevSvtf-gzNyQW@TY]dI>p%EOtP\\A趋2[h4>!J74K\\U]H㨠rNI'i,;4zH0ZAkHH8tr[e@9᳦Ct@\\B>,~vJ<{NNz1xUnugTWi;:0`Ft3S89TDQH`uftDB(3MTEj𨭱𧙤SUUEPbCG",
-            "delegation": {
-                "status": "delegating",
-                "target": "_[a"
-            },
-            "id": "7af61ccc10965edfc9a35ce7df2d05716e23ca34"
+            "id": "334d3ced406d2cee5efc9e476dd2b337bf52131e"
         }
     ]
 }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -540,12 +540,13 @@ instance Arbitrary WalletName where
         | T.length t <= walletNameMinLength = []
         | otherwise = [WalletName $ T.take walletNameMinLength t]
 
-instance Arbitrary (Passphrase "encryption") where
+instance (PassphraseMaxLength purpose, PassphraseMinLength purpose) =>
+    Arbitrary (Passphrase purpose) where
     arbitrary = do
         n <- choose (passphraseMinLength p, passphraseMaxLength p)
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes
-      where p = Proxy :: Proxy "encryption"
+      where p = Proxy :: Proxy purpose
     shrink (Passphrase bytes)
         | BA.length bytes <= passphraseMinLength p = []
         | otherwise =
@@ -553,7 +554,7 @@ instance Arbitrary (Passphrase "encryption") where
             $ BA.convert
             $ B8.take (passphraseMinLength p)
             $ BA.convert bytes ]
-      where p = Proxy :: Proxy "encryption"
+      where p = Proxy :: Proxy purpose
 
 instance Arbitrary WalletPassphraseInfo where
     arbitrary = genericArbitrary

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -527,7 +527,7 @@ instance Arbitrary WalletMetadata where
     shrink _ = []
     arbitrary = WalletMetadata
         <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
-        <*> (WalletPassphraseInfo <$> arbitrary)
+        <*> (fmap WalletPassphraseInfo <$> arbitrary)
         <*> oneof [pure Ready, Restoring . Quantity <$> arbitraryBoundedEnum]
         <*> pure NotDelegating
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -238,7 +238,7 @@ walletUpdatePassphraseNoSuchWallet wallet@(wid', _, _) wid (old, new) =
     wid /= wid' ==> monadicIO $ liftIO $ do
         (WalletLayerFixture _ wl _) <- liftIO $ setupFixture wallet
         attempt <- runExceptT $ updateWalletPassphrase wl wid (old, new)
-        let err = ErrUpdatePassphraseNoSuchWallet (ErrNoSuchWallet wid)
+        let err = ErrUpdatePassphraseWithRootKey (ErrWithRootKeyNoRootKey wid)
         attempt `shouldBe` Left err
 
 {-------------------------------------------------------------------------------

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
@@ -87,8 +87,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Text
     ( Text )
-import Data.Time
-    ( UTCTime )
 import GHC.TypeLits
     ( Symbol )
 import Language.Haskell.TH.Quote
@@ -260,15 +258,16 @@ delegation =
         -> s
     _set (s, v) = set typed (ApiT v ) s
 
-passphraseLastUpdate :: HasType (ApiT WalletPassphraseInfo) s => Lens' s Text
+passphraseLastUpdate
+    :: HasType (Maybe (ApiT WalletPassphraseInfo)) s
+    => Lens' s (Maybe Text)
 passphraseLastUpdate =
     lens _get _set
   where
-    _get :: HasType (ApiT WalletPassphraseInfo) s => s -> Text
-    _get = T.pack . show . lastUpdatedAt . getApiT . view typed
-    _set :: HasType (ApiT WalletPassphraseInfo) s => (s, Text) -> s
-    _set (s, v) =
-        set typed (ApiT $ WalletPassphraseInfo ((read $ T.unpack v) :: UTCTime)) s
+    _get :: HasType (Maybe (ApiT WalletPassphraseInfo)) s => s -> Maybe Text
+    _get = fmap (T.pack . show . lastUpdatedAt . getApiT) . view typed
+    _set :: HasType (Maybe (ApiT WalletPassphraseInfo)) s => (s, Maybe Text) -> s
+    _set (s, v) = set typed (ApiT . WalletPassphraseInfo . read . T.unpack <$> v) s
 
 state :: HasType (ApiT WalletState) s => Lens' s WalletState
 state =

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -73,7 +73,7 @@ spec = do
             , expectFieldEqual state (Restoring (Quantity minBound))
             , expectFieldEqual delegation (NotDelegating)
             , expectFieldEqual walletId "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
-            , expectFieldNotEqual passphraseLastUpdate "2019-04-12 07:57:28.439742724 UTC"
+            , expectFieldNotEqual passphraseLastUpdate Nothing
             ]
 
     it "WALLETS_CREATE_03,09 - Cannot create wallet that exists" $ \ctx -> do
@@ -706,7 +706,7 @@ spec = do
             , expectFieldEqual state (Restoring (Quantity minBound))
             , expectFieldEqual delegation (NotDelegating)
             , expectFieldEqual walletId walId
-            , expectFieldNotEqual passphraseLastUpdate "2019-04-12 07:57:28.439742724 UTC"
+            , expectFieldNotEqual passphraseLastUpdate Nothing
             ]
 
     it "WALLETS_GET_02, WALLETS_DELETE_01 - Deleted wallet is not available" $ \ctx -> do

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -461,7 +461,6 @@ definitions:
       - balance
       - delegation
       - name
-      - passphrase
       - state
     properties:
       id: *walletId


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#220

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have implemented API handlers & wallet layer methods for updating wallet metadata and updating wallet passphrase
- [ ] I have altered the API specification to remove 'required' for passphrase info on wallets. In practice, this can only happen now with very tight concurrent calls, but, it conveys the idea that wallet could exist without passphrase (which we'll come up to soon enough when re-introducing externally owned wallets).

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
