### PR TITLE
cli: Fix output encoding

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -31,6 +31,7 @@ import Cardano.CLI
     , parseAllArgsWith
     , parseArgWith
     , putErrLn
+    , setUtf8Encoding
     )
 import Cardano.Environment.HttpBridge
     ( network )
@@ -156,6 +157,7 @@ main :: IO ()
 main = do
     hSetBuffering stdout NoBuffering
     hSetBuffering stderr NoBuffering
+    setUtf8Encoding
     manager <- newManager defaultManagerSettings
     getArgs >>= parseArgsOrExit cli >>= exec manager
 

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -16,6 +16,9 @@ module Cardano.CLI
     -- * Types
       Port(..)
 
+    -- * Unicode Terminal Helpers
+    , setUtf8Encoding
+
     -- * ANSI Terminal Helpers
     , putErrLn
     , hPutErrLn
@@ -77,8 +80,11 @@ import System.IO
     , hPutChar
     , hSetBuffering
     , hSetEcho
+    , hSetEncoding
     , stderr
     , stdin
+    , stdout
+    , utf8
     )
 
 import qualified Data.Text as T
@@ -133,6 +139,17 @@ getAllArgsOrExitWith doc args opt =
     maybe err pure . NE.nonEmpty $ getAllArgs args opt
   where
     err = exitWithUsageMessage doc $ "argument expected for: " ++ show opt
+
+{-------------------------------------------------------------------------------
+                            Unicode Terminal Helpers
+-------------------------------------------------------------------------------}
+
+-- | Override the system output encoding setting. This is needed because the CLI
+-- prints UTF-8 characters regardless of the @LANG@ environment variable.
+setUtf8Encoding :: IO ()
+setUtf8Encoding = do
+    hSetEncoding stdout utf8
+    hSetEncoding stderr utf8
 
 {-------------------------------------------------------------------------------
                             ANSI Terminal Helpers


### PR DESCRIPTION
This avoids the error

    <stdout>: hPutChar: invalid argument (invalid character)

when the user does not have a UTF-8 locale set.
