### PR TITLE
Generate DBLayer tests with quickcheck-state-machine

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -39,4 +39,12 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-
+- package:
+  - name: cardano-wallet-core
+  - section:
+    - name: test:unit
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Cardano.Wallet.DB.StateMachine
+        - identifier: showLabelledExamples

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -120,6 +120,7 @@ test-suite unit
     , deepseq
     , file-embed
     , fmt
+    , foldl
     , generic-arbitrary
     , hspec
     , hspec-golden-aeson
@@ -128,6 +129,8 @@ test-suite unit
     , memory
     , QuickCheck
     , quickcheck-instances
+    , quickcheck-state-machine >= 0.6.0
+    , random
     , servant-server
     , servant-swagger
     , swagger2
@@ -135,6 +138,7 @@ test-suite unit
     , text-class
     , time
     , transformers
+    , tree-diff
     , yaml
   type:
      exitcode-stdio-1.0
@@ -146,6 +150,7 @@ test-suite unit
       Cardano.Wallet.Api.TypesSpec
       Cardano.Wallet.ApiSpec
       Cardano.Wallet.DB.MVarSpec
+      Cardano.Wallet.DB.StateMachine
       Cardano.Wallet.DB.SqliteSpec
       Cardano.Wallet.DBSpec
       Cardano.Wallet.EnvironmentSpec

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -12,6 +12,7 @@ module Cardano.Wallet.DB
     ( -- * Interface
       DBLayer(..)
     , PrimaryKey(..)
+    , cleanDB
 
       -- * Errors
     , ErrNoSuchWallet(..)
@@ -27,7 +28,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types
     ( Hash, Tx, TxMeta, WalletId, WalletMetadata )
 import Control.Monad.Trans.Except
-    ( ExceptT )
+    ( ExceptT, runExceptT )
 import Data.Map.Strict
     ( Map )
 
@@ -146,3 +147,7 @@ newtype ErrWalletAlreadyExists
 -- (like for instance, the last known network tip).
 newtype PrimaryKey key = PrimaryKey key
     deriving (Eq, Ord)
+
+-- | Clean a database by removing all wallets.
+cleanDB :: Monad m => DBLayer m s t -> m ()
+cleanDB db = listWallets db >>= mapM_ (runExceptT . removeWallet db)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -217,7 +217,8 @@ newDBLayer fp = do
                   Nothing -> pure $ Left $ ErrNoSuchWallet wid
 
         , listWallets = runQuery' $
-              map (PrimaryKey . unWalletKey) <$> selectKeysList [] []
+              map (PrimaryKey . unWalletKey) <$>
+              selectKeysList [] [Asc WalTableId]
 
         {-----------------------------------------------------------------------
                                     Checkpoints

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -57,7 +57,6 @@ import Control.Concurrent.MVar
     ( newMVar, withMVar )
 import Control.DeepSeq
     ( NFData )
-import GHC.Generics (Generic)
 import Control.Monad
     ( mapM_, void, when )
 import Control.Monad.Catch
@@ -100,7 +99,7 @@ import Database.Persist.Sql
     , insert_
     , putMany
     , rawExecute
-    , runMigration
+    , runMigrationSilent
     , runSqlConn
     , selectFirst
     , selectKeysList
@@ -115,6 +114,8 @@ import Database.Persist.Sqlite
     ( SqlBackend, SqlPersistM, SqlPersistT, wrapConnection )
 import Database.Sqlite
     ( Error (ErrorConstraint), SqliteException (SqliteException) )
+import GHC.Generics
+    ( Generic )
 import System.IO
     ( stderr )
 import System.Log.FastLogger
@@ -187,7 +188,7 @@ newDBLayer fp = do
     conn <- createSqliteBackend fp (dbLogs [LevelError])
     let runQuery' = withMVar bigLock . const . runQuery conn
 
-    runQuery' $ void $ runMigration migrateAll
+    runQuery' $ void $ runMigrationSilent migrateAll
     runQuery' addIndexes
 
     return $ DBLayer

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -97,6 +97,7 @@ TxMeta
 -- not the wallet. txInputTableTxId is referred to by TxMeta and PendingTx
 TxIn
     txInputTableTxId         TxId        sql=tx_id
+    txInputTableOrder        Int         sql=order
     txInputTableSourceTxId   TxId        sql=source_id
     txInputTableSourceIndex  Word32      sql=source_index
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -12,12 +13,8 @@ module Cardano.Wallet.DB.MVarSpec
 
 import Prelude
 
-import Cardano.Wallet.DB
-    ( DBLayer (..) )
-import Cardano.Wallet.DB.MVar
-    ( newDBLayer )
 import Cardano.Wallet.DBSpec
-    ( DummyTarget, SkipTests (..), dbPropertyTests, withDB )
+    ( DummyTarget, dbPropertyTests, withDB )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..), SeqState (..) )
 import Cardano.Wallet.Primitive.Model
@@ -29,9 +26,11 @@ import Test.Hspec
 import Test.QuickCheck
     ( Arbitrary (..) )
 
+import qualified Cardano.Wallet.DB.MVar as MVar
+
 spec :: Spec
-spec = withDB (newDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)) $
-       describe "MVar" (dbPropertyTests RunAllTests)
+spec = withDB @(SeqState DummyTarget) MVar.newDBLayer $
+    describe "MVar" dbPropertyTests
 
 newtype DummyStateMVar = DummyStateMVar Int
     deriving (Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -17,7 +17,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.MVar
     ( newDBLayer )
 import Cardano.Wallet.DBSpec
-    ( DummyTarget, dbPropertyTests, withDB )
+    ( DummyTarget, SkipTests (..), dbPropertyTests, withDB )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..), SeqState (..) )
 import Cardano.Wallet.Primitive.Model
@@ -31,7 +31,7 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = withDB (newDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)) $
-       describe "MVar" dbPropertyTests
+       describe "MVar" (dbPropertyTests RunAllTests)
 
 newtype DummyStateMVar = DummyStateMVar Int
     deriving (Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.DB.StateMachine
     ( prop_parallel, prop_sequential )
 import Cardano.Wallet.DBSpec
-    ( DummyTarget, SkipTests (..), dbPropertyTests, withDB )
+    ( DummyTarget, dbPropertyTests, withDB )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..)
     , encryptPassphrase
@@ -75,7 +75,7 @@ import qualified Data.Map as Map
 spec :: Spec
 spec = withDB newMemoryDBLayer $ do
     describe "Sqlite Simple tests" simpleSpec
-    describe "Sqlite" (dbPropertyTests SkipTxHistoryReplaceTest)
+    describe "Sqlite" dbPropertyTests
     describe "Sqlite State machine tests" $ do
         it "Sequential" prop_sequential
         xit "Parallel" prop_parallel

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -68,7 +68,7 @@ import Data.Time.Clock
 import System.IO.Unsafe
     ( unsafePerformIO )
 import Test.Hspec
-    ( Spec, SpecWith, describe, it, shouldReturn )
+    ( Spec, SpecWith, describe, it, shouldReturn, xit )
 
 import qualified Data.Map as Map
 
@@ -78,7 +78,7 @@ spec = withDB newMemoryDBLayer $ do
     describe "Sqlite" dbPropertyTests
     describe "Sqlite State machine tests" $ do
         it "Sequential" prop_sequential
-        it "Parallel" prop_parallel
+        xit "Parallel" prop_parallel
 
 simpleSpec :: SpecWith (DBLayer IO (SeqState DummyTarget) DummyTarget)
 simpleSpec = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -17,6 +17,8 @@ import Cardano.Wallet.DB
     ( DBLayer (..), ErrWalletAlreadyExists (..), PrimaryKey (..) )
 import Cardano.Wallet.DB.Sqlite
     ( newDBLayer )
+import Cardano.Wallet.DB.StateMachine
+    ( prop_parallel, prop_sequential )
 import Cardano.Wallet.DBSpec
     ( DummyTarget, dbPropertyTests, withDB )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -66,17 +68,20 @@ import Data.Time.Clock
 import System.IO.Unsafe
     ( unsafePerformIO )
 import Test.Hspec
-    ( Spec, describe, it, shouldReturn )
+    ( Spec, SpecWith, describe, it, shouldReturn )
 
 import qualified Data.Map as Map
 
 spec :: Spec
-spec = do
-    describe "Simple tests" simpleSpec
-    describe "Sqlite Property tests" $ withDB newMemoryDBLayer dbPropertyTests
+spec = withDB newMemoryDBLayer $ do
+    describe "Sqlite Simple tests" simpleSpec
+    describe "Sqlite" dbPropertyTests
+    describe "Sqlite State machine tests" $ do
+        it "Sequential" prop_sequential
+        it "Parallel" prop_parallel
 
-simpleSpec :: Spec
-simpleSpec = withDB newMemoryDBLayer $ do
+simpleSpec :: SpecWith (DBLayer IO (SeqState DummyTarget) DummyTarget)
+simpleSpec = do
     describe "Wallet table" $ do
         it "create and list works" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.DB.StateMachine
     ( prop_parallel, prop_sequential )
 import Cardano.Wallet.DBSpec
-    ( DummyTarget, dbPropertyTests, withDB )
+    ( DummyTarget, SkipTests (..), dbPropertyTests, withDB )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..)
     , encryptPassphrase
@@ -75,7 +75,7 @@ import qualified Data.Map as Map
 spec :: Spec
 spec = withDB newMemoryDBLayer $ do
     describe "Sqlite Simple tests" simpleSpec
-    describe "Sqlite" dbPropertyTests
+    describe "Sqlite" (dbPropertyTests SkipTxHistoryReplaceTest)
     describe "Sqlite State machine tests" $ do
         it "Sequential" prop_sequential
         xit "Parallel" prop_parallel

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -1,0 +1,946 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.DB.StateMachine
+    ( prop_sequential
+    , prop_parallel
+    , showLabelledExamples
+    ) where
+
+import Prelude hiding
+    ( elem )
+
+import Cardano.Wallet.DB
+    ( DBLayer (..)
+    , ErrNoSuchWallet (..)
+    , ErrWalletAlreadyExists (..)
+    , PrimaryKey (..)
+    , cleanDB
+    )
+import Cardano.Wallet.DBSpec
+    ( DummyTarget )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Key, XPrv, deserializeXPrv )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( SeqState (..) )
+import Cardano.Wallet.Primitive.Model
+    ( Wallet )
+import Cardano.Wallet.Primitive.Types
+    ( Hash (..), Tx (..), TxMeta (..), WalletId (..), WalletMetadata (..) )
+import Control.Foldl
+    ( Fold (..) )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Trans.Except
+    ( runExceptT )
+import Crypto.Hash
+    ( hash )
+import Data.Bifunctor
+    ( bimap, first )
+import Data.Foldable
+    ( toList )
+import Data.Functor.Classes
+    ( Eq1, Show1 )
+import Data.Map
+    ( Map )
+import Data.Maybe
+    ( catMaybes, fromJust, fromMaybe, isJust, isNothing, mapMaybe )
+import Data.Set
+    ( Set )
+import Data.TreeDiff
+    ( ToExpr (..), defaultExprViaShow )
+import GHC.Generics
+    ( Generic )
+import System.Random
+    ( getStdRandom, randomR )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Args (..)
+    , Gen
+    , Property
+    , collect
+    , elements
+    , frequency
+    , labelledExamplesWith
+    , property
+    , (===)
+    )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
+import Test.QuickCheck.Random
+    ( mkQCGen )
+import Test.StateMachine
+    ( CommandNames (..)
+    , Concrete
+    , GenSym
+    , Logic (..)
+    , Reason (..)
+    , Reference
+    , StateMachine
+    , Symbolic
+    , elem
+    , forAllCommands
+    , forAllParallelCommands
+    , forall
+    , prettyCommands
+    , prettyParallelCommands
+    , runCommands
+    , runParallelCommands
+    , (.==)
+    )
+import Test.StateMachine.Types
+    ( Command (..), Commands (..), ParallelCommands, ParallelCommandsF (..) )
+
+import qualified Control.Foldl as Foldl
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.List as L
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Test.QuickCheck as QC
+import qualified Test.StateMachine.Types as QSM
+import qualified Test.StateMachine.Types.Rank2 as Rank2
+
+{-# ANN module ("HLint: ignore Unused LANGUAGE pragma" :: String) #-}
+
+{-------------------------------------------------------------------------------
+  WalletId expressions
+-------------------------------------------------------------------------------}
+
+data Expr wid =
+    Val MWid
+  | Var wid
+  deriving (Show, Functor, Foldable, Traversable)
+
+eval :: Expr MWid -> MWid
+eval (Val wid) = wid
+eval (Var wid) = wid
+
+evalWalletId :: Expr WalletId -> WalletId
+evalWalletId (Val mwid) = unMockWid mwid
+evalWalletId (Var wid) = wid
+
+{-------------------------------------------------------------------------------
+  Errors
+-------------------------------------------------------------------------------}
+
+data Err wid
+    = NoSuchWallet wid
+    | WalletAlreadyExists wid
+    deriving (Show, Eq, Functor, Foldable, Traversable)
+
+errNoSuchWallet :: ErrNoSuchWallet -> Err WalletId
+errNoSuchWallet (ErrNoSuchWallet wid) = NoSuchWallet wid
+
+errWalletAlreadyExists :: ErrWalletAlreadyExists -> Err WalletId
+errWalletAlreadyExists (ErrWalletAlreadyExists wid) = WalletAlreadyExists wid
+
+{-------------------------------------------------------------------------------
+  Mock implementation
+-------------------------------------------------------------------------------}
+
+-- | Shortcut for wallet type.
+type MWallet = Wallet (SeqState DummyTarget) DummyTarget
+
+-- | Mock wallet ID -- simple and easy to read
+newtype MWid = MWid String
+    deriving (Show, Eq, Ord, Generic)
+
+widPK :: MWid -> PrimaryKey WalletId
+widPK = PrimaryKey . unMockWid
+
+-- | Convert a mock wallet ID to a real one by hashing it
+unMockWid :: MWid -> WalletId
+unMockWid (MWid wid) = WalletId . hash . B8.pack $ wid
+
+widPK' :: Expr WalletId -> PrimaryKey WalletId
+widPK' = PrimaryKey . evalWalletId
+
+-- | Represent (XPrv, Hash) as a string.
+type MPrivKey = String
+
+-- | Stuff a mock private key into the type used by DBLayer.
+fromMockPrivKey :: MPrivKey -> (Key purpose XPrv, Hash "encryption")
+fromMockPrivKey s = (k, Hash (B8.pack s))
+    where Right (k, _) = deserializeXPrv (B8.replicate 256 '0', mempty)
+
+-- | Unstuff the DBLayer private key into the mock type.
+toMockPrivKey :: (Key purpose XPrv, Hash "encryption") -> MPrivKey
+toMockPrivKey (_, Hash h) = B8.unpack h
+
+data Mock = M
+    { checkpoints :: Map MWid MWallet
+    , metas :: Map MWid WalletMetadata
+    , txs :: Map MWid TxHistory
+    , privateKey :: Map MWid MPrivKey
+    } deriving (Show, Generic)
+
+emptyMock :: Mock
+emptyMock = M mempty mempty mempty mempty
+
+type MockOp a = Mock -> (Either (Err MWid) a, Mock)
+
+mCleanDB :: MockOp ()
+mCleanDB _ = (Right (), emptyMock)
+
+mCreateWallet :: MWid -> MWallet -> WalletMetadata -> MockOp ()
+mCreateWallet wid wal meta m@(M cp metas txs pk)
+    | wid `Map.member` cp = (Left (WalletAlreadyExists wid), m)
+    | otherwise =
+        ( Right ()
+        , M
+            { checkpoints = Map.insert wid wal cp
+            , metas = Map.insert wid meta metas
+            , txs = txs
+            , privateKey = pk
+            }
+        )
+
+mRemoveWallet :: MWid -> MockOp ()
+mRemoveWallet wid m@(M cp metas txs pk)
+    | wid `Map.member` cp =
+        ( Right ()
+        , M
+            { checkpoints = Map.delete wid cp
+            , metas = Map.delete wid metas
+            , txs = Map.delete wid txs
+            , privateKey = Map.delete wid pk
+            }
+        )
+    | otherwise = (Left (NoSuchWallet wid), m)
+
+mListWallets :: MockOp [MWid]
+mListWallets m@(M cp _ _ _) = (Right (L.sortOn unMockWid $ Map.keys cp), m)
+
+mPutCheckpoint :: MWid -> MWallet -> MockOp ()
+mPutCheckpoint wid wal m@(M cp metas txs pk)
+    | wid `Map.member` cp = (Right (), M (Map.insert wid wal cp) metas txs pk)
+    | otherwise = (Left (NoSuchWallet wid), m)
+
+mReadCheckpoint :: MWid -> MockOp (Maybe MWallet)
+mReadCheckpoint wid m@(M cp _ _ _) = (Right (Map.lookup wid cp), m)
+
+mPutWalletMeta :: MWid -> WalletMetadata -> MockOp ()
+mPutWalletMeta wid meta m@(M cp metas txs pk)
+    | wid `Map.member` cp = (Right (), M cp (Map.insert wid meta metas) txs pk)
+    | otherwise = (Left (NoSuchWallet wid), m)
+
+mReadWalletMeta :: MWid -> MockOp (Maybe WalletMetadata)
+mReadWalletMeta wid m@(M _ meta _ _) = (Right (Map.lookup wid meta), m)
+
+mPutTxHistory :: MWid -> TxHistory -> MockOp ()
+mPutTxHistory wid txs' m@(M cp metas txs pk)
+    | wid `Map.member` cp = (Right (), M cp metas (Map.alter appendTxs wid txs) pk)
+    | otherwise           = (Left (NoSuchWallet wid), m)
+    where appendTxs = Just . (<> txs') . fromMaybe mempty
+
+mReadTxHistory :: MWid -> MockOp TxHistory
+mReadTxHistory wid m@(M cp _ txs _)
+    | wid `Map.member` cp = (Right (fromMaybe mempty (Map.lookup wid txs)), m)
+    | otherwise = (Right mempty, m)
+
+mPutPrivateKey :: MWid -> MPrivKey -> MockOp ()
+mPutPrivateKey wid pk' m@(M cp metas txs pk)
+    | wid `Map.member` cp = (Right (), M cp metas txs (Map.insert wid pk' pk))
+    | otherwise = (Left (NoSuchWallet wid), m)
+
+mReadPrivateKey :: MWid -> MockOp (Maybe MPrivKey)
+mReadPrivateKey wid m@(M cp _ _ pk)
+    | wid `Map.member` cp = (Right (Map.lookup wid pk), m)
+    | otherwise = (Right Nothing, m)
+
+{-------------------------------------------------------------------------------
+  Language
+-------------------------------------------------------------------------------}
+
+type TxHistory = Map (Hash "Tx") (Tx, TxMeta)
+
+data Cmd wid
+    = CleanDB
+    | CreateWallet MWid MWallet WalletMetadata
+    | RemoveWallet (Expr wid)
+    | ListWallets
+    | PutCheckpoint (Expr wid) MWallet
+    | ReadCheckpoint (Expr wid)
+    | PutWalletMeta (Expr wid) WalletMetadata
+    | ReadWalletMeta (Expr wid)
+    | PutTxHistory (Expr wid) TxHistory
+    | ReadTxHistory (Expr wid)
+    | PutPrivateKey (Expr wid) MPrivKey
+    | ReadPrivateKey (Expr wid)
+    deriving (Show, Functor, Foldable, Traversable)
+
+data Success wid
+    = Unit ()
+    | NewWallet wid
+    | WalletIds [wid]
+    | Checkpoint (Maybe MWallet)
+    | Metadata (Maybe WalletMetadata)
+    | TxHistory TxHistory
+    | PrivateKey (Maybe MPrivKey)
+    deriving (Show, Eq, Functor, Foldable, Traversable)
+
+newtype Resp wid
+    = Resp (Either (Err wid) (Success wid))
+    deriving (Show, Eq)
+
+instance Functor Resp where
+    fmap f (Resp r) = Resp (bimap (fmap f) (fmap f) r)
+
+instance Foldable Resp where
+    foldMap f (Resp r) = either (foldMap f) (foldMap f) r
+
+instance Traversable Resp where
+    traverse f (Resp (Right r)) = Resp . Right <$> traverse f r
+    traverse f (Resp (Left e)) = Resp . Left <$> traverse f e
+
+{-------------------------------------------------------------------------------
+  Interpreter: mock implementation
+-------------------------------------------------------------------------------}
+
+runMock :: Cmd MWid -> Mock -> (Resp MWid, Mock)
+runMock = \case
+    CleanDB ->
+        first (Resp . fmap Unit) . mCleanDB
+    CreateWallet wid wal meta ->
+        first (Resp . fmap (const (NewWallet wid))) . mCreateWallet wid wal meta
+    RemoveWallet wid ->
+        first (Resp . fmap Unit) . mRemoveWallet (eval wid)
+    ListWallets ->
+        first (Resp . fmap WalletIds) . mListWallets
+    PutCheckpoint wid wal ->
+        first (Resp . fmap Unit) . mPutCheckpoint (eval wid) wal
+    ReadCheckpoint wid ->
+        first (Resp . fmap Checkpoint) . mReadCheckpoint (eval wid)
+    PutWalletMeta wid meta ->
+        first (Resp . fmap Unit) . mPutWalletMeta (eval wid) meta
+    ReadWalletMeta wid ->
+        first (Resp . fmap Metadata) . mReadWalletMeta (eval wid)
+    PutTxHistory wid txs ->
+        first (Resp . fmap Unit) . mPutTxHistory (eval wid) txs
+    ReadTxHistory wid ->
+        first (Resp . fmap TxHistory) . mReadTxHistory (eval wid)
+    PutPrivateKey wid pk ->
+        first (Resp . fmap Unit) . mPutPrivateKey (eval wid) pk
+    ReadPrivateKey wid ->
+        first (Resp . fmap PrivateKey) . mReadPrivateKey (eval wid)
+
+{-------------------------------------------------------------------------------
+  Interpreter: real I/O
+-------------------------------------------------------------------------------}
+
+type DBLayerTest = DBLayer IO (SeqState DummyTarget) DummyTarget
+
+runIO
+    :: DBLayerTest
+    -> Cmd WalletId
+    -> IO (Resp WalletId)
+runIO db = fmap Resp . go
+  where
+    go
+        :: Cmd WalletId
+        -> IO (Either (Err WalletId) (Success WalletId))
+    go = \case
+        CleanDB -> do
+            Right . Unit <$> cleanDB db
+        CreateWallet wid wal meta ->
+            catchWalletAlreadyExists (const (NewWallet (unMockWid wid))) $
+                createWallet db (widPK wid) wal meta
+        RemoveWallet wid ->
+            catchNoSuchWallet Unit $
+                removeWallet db (widPK' wid)
+        ListWallets ->
+            Right . WalletIds . fmap unPrimaryKey <$> listWallets db
+        PutCheckpoint wid wal ->
+            catchNoSuchWallet Unit $ putCheckpoint db (widPK' wid) wal
+        ReadCheckpoint wid ->
+            Right . Checkpoint <$> readCheckpoint db (widPK' wid)
+        PutWalletMeta wid meta ->
+            catchNoSuchWallet Unit $ putWalletMeta db (widPK' wid) meta
+        ReadWalletMeta wid ->
+            Right . Metadata <$> readWalletMeta db (widPK' wid)
+        PutTxHistory wid txs ->
+            catchNoSuchWallet Unit $ putTxHistory db (widPK' wid) txs
+        ReadTxHistory wid ->
+            Right . TxHistory <$> readTxHistory db (widPK' wid)
+        PutPrivateKey wid pk ->
+            catchNoSuchWallet Unit $
+                putPrivateKey db (widPK' wid) (fromMockPrivKey pk)
+        ReadPrivateKey wid ->
+            Right . PrivateKey . fmap toMockPrivKey
+                <$> readPrivateKey db (widPK' wid)
+
+    catchWalletAlreadyExists f =
+        fmap (bimap errWalletAlreadyExists f) . runExceptT
+    catchNoSuchWallet f =
+        fmap (bimap errNoSuchWallet f) . runExceptT
+
+    unPrimaryKey :: PrimaryKey key -> key
+    unPrimaryKey (PrimaryKey key) = key
+
+{-------------------------------------------------------------------------------
+  Working with references
+-------------------------------------------------------------------------------}
+
+newtype At f r
+    = At (f (Reference WalletId r))
+
+deriving instance
+    Show (f (Reference WalletId r)) => Show (At f r)
+
+type f :@ r = At f r
+
+type RefEnv k a r = [(Reference k r, a)]
+
+(!) :: (Eq1 r, Eq k) => RefEnv k a r -> Reference k r -> a
+env ! r = fromJust (lookup r env)
+
+{-------------------------------------------------------------------------------
+  Relating the mock model to the real implementation
+-------------------------------------------------------------------------------}
+
+type WidRefs r =
+    RefEnv WalletId MWid r
+
+data Model r
+    = Model Mock (WidRefs r)
+    deriving (Generic)
+
+deriving instance Show1 r => Show (Model r)
+
+initModel :: Model r
+initModel = Model emptyMock []
+
+toMock :: (Functor f, Eq1 r) => Model r -> f :@ r -> f MWid
+toMock (Model _ wids) (At fr) = fmap (wids !) fr
+
+step :: Eq1 r => Model r -> Cmd :@ r -> (Resp MWid, Mock)
+step m@(Model mock _) c = runMock (toMock m c) mock
+
+{-------------------------------------------------------------------------------
+  Events
+-------------------------------------------------------------------------------}
+
+data Event r = Event
+    { before :: Model  r
+    , cmd :: Cmd :@ r
+    , after :: Model  r
+    , mockResp :: Resp MWid
+    }
+
+deriving instance Show1 r => Show (Event r)
+
+lockstep
+    :: forall r. Eq1 r
+    => Model   r
+    -> Cmd  :@ r
+    -> Resp :@ r
+    -> Event   r
+lockstep m@(Model _ ws) c (At resp) = Event
+    { before = m
+    , cmd = c
+    , after = Model mock' (ws <> ws')
+    , mockResp = resp'
+    }
+  where
+    (resp', mock') = step m c
+    ws' :: WidRefs r
+    ws' = zip (toList resp) (toList resp')
+
+{-------------------------------------------------------------------------------
+  Generator
+-------------------------------------------------------------------------------}
+
+-- NOTE 'concat' reads better.
+{-# ANN generator ("HLint: ignore Use ++" :: String) #-}
+generator :: Model Symbolic -> Maybe (Gen (Cmd :@ Symbolic))
+generator (Model _ wids) = Just $ frequency $ concat
+    [ withoutWid
+    , if null wids then [] else withWid
+    ]
+  where
+    withoutWid :: [(Int, Gen (Cmd :@ Symbolic))]
+    withoutWid =
+        [ (5, fmap At $ CreateWallet <$> genId <*> arbitrary <*> arbitrary)
+        ]
+
+    withWid :: [(Int, Gen (Cmd :@ Symbolic))]
+    withWid =
+        [ (3, fmap At $ RemoveWallet <$> genId')
+        , (5, pure (At ListWallets))
+        , (5, fmap At $ PutCheckpoint <$> genId' <*> arbitrary)
+        , (5, fmap At $ ReadCheckpoint <$> genId')
+        , (5, fmap At $ PutWalletMeta <$> genId' <*> arbitrary)
+        , (5, fmap At $ ReadWalletMeta <$> genId')
+        , (5, fmap At $ PutTxHistory <$> genId' <*> fmap unGenTxHistory arbitrary)
+        , (5, fmap At $ ReadTxHistory <$> genId')
+        , (3, fmap At $ PutPrivateKey <$> genId' <*> genPrivKey)
+        , (3, fmap At $ ReadPrivateKey <$> genId')
+        ]
+
+    genId :: Gen MWid
+    genId = MWid <$> elements ["a", "b", "c"]
+
+    genId' = Val <$> genId
+
+    genPrivKey :: Gen MPrivKey
+    genPrivKey = elements ["pk1", "pk2", "pk3"]
+
+isUnordered :: Ord x => [x] -> Bool
+isUnordered xs = xs /= L.sort xs
+
+newtype GenTxHistory = GenTxHistory { unGenTxHistory :: TxHistory }
+    deriving (Show, Eq)
+
+instance Arbitrary GenTxHistory where
+    shrink (GenTxHistory h) = map GenTxHistory (shrinkKeys h ++ shrinkTx h)
+      where
+        -- remove keys from the map
+        shrinkKeys :: TxHistory -> [TxHistory]
+        shrinkKeys txs =
+            [ Map.restrictKeys txs ks
+            | ks <- shrink (Set.fromList (Map.keys txs)) ]
+        -- make the transactions smaller
+        shrinkTx :: TxHistory -> [TxHistory]
+        shrinkTx txs =
+            [ Map.fromList [(k, v') | v' <- shrinkOneTx v]
+            | (k, v) <- Map.toList txs ]
+        shrinkOneTx :: (Tx, TxMeta) -> [(Tx, TxMeta)]
+        shrinkOneTx (tx, meta) =
+            [(tx', meta) | tx' <- shrink tx]
+    arbitrary = GenTxHistory <$> arbitrary
+
+shrinker :: Model Symbolic -> Cmd :@ Symbolic -> [Cmd :@ Symbolic]
+shrinker (Model _ wids) (At cmd) = case cmd of
+    RemoveWallet (Val wid) ->
+        [ At $ RemoveWallet (Var r)
+        | r <- substWid wid ]
+    PutCheckpoint (Val wid) wal ->
+        [ At $ PutCheckpoint (Var r) wal'
+        | r <- substWid wid
+        , wal' <- shrink wal ]
+    ReadCheckpoint (Val wid) ->
+        [ At $ ReadCheckpoint (Var r)
+        | r <- substWid wid ]
+    PutWalletMeta (Val wid) meta ->
+        [ At $ PutWalletMeta (Var r) meta
+        | r <- substWid wid ]
+    ReadWalletMeta (Val wid) ->
+        [ At $ ReadWalletMeta (Var r)
+        | r <- substWid wid ]
+    PutTxHistory (Val wid) h ->
+        [ At $ PutTxHistory (Val wid) h'
+        | h' <- map unGenTxHistory . shrink . GenTxHistory $ h
+        ] ++
+        [ At $ PutTxHistory (Var r) h
+        | r <- substWid wid ]
+    ReadTxHistory (Val wid) ->
+        [ At $ ReadTxHistory (Var r)
+        | r <- substWid wid ]
+    PutPrivateKey (Val wid) pk ->
+        [ At $ PutPrivateKey (Var r) pk
+        | r <- substWid wid ]
+    ReadPrivateKey (Val wid) ->
+        [ At $ ReadPrivateKey (Var r)
+        | r <- substWid wid ]
+    _ -> []
+
+  where
+    matches :: Eq a => a -> (r, a) -> Maybe r
+    matches w (r, w')
+        | w == w'   = Just r
+        | otherwise = Nothing
+    substWid wid = mapMaybe (matches wid) wids
+
+{-------------------------------------------------------------------------------
+  The state machine proper
+-------------------------------------------------------------------------------}
+
+transition :: Eq1 r => Model r -> Cmd :@ r -> Resp :@ r -> Model r
+transition m c = after . lockstep m c
+
+precondition :: Model Symbolic -> Cmd :@ Symbolic -> Logic
+precondition (Model _ wids) (At c) =
+    forall (toList c) (`elem` map fst wids)
+
+postcondition :: Model Concrete -> Cmd :@ Concrete -> Resp :@ Concrete -> Logic
+postcondition m c r =
+    toMock (after e) r .== mockResp e
+  where
+    e = lockstep m c r
+
+semantics :: DBLayerTest -> Cmd :@ Concrete -> IO (Resp :@ Concrete)
+semantics db (At c) =
+    (At . fmap QSM.reference) <$>
+        runIO db (fmap QSM.concrete c)
+
+symbolicResp :: Model Symbolic -> Cmd :@ Symbolic -> GenSym (Resp :@ Symbolic)
+symbolicResp m c =
+    At <$> traverse (const QSM.genSym) resp
+  where
+    (resp, _mock') = step m c
+
+sm :: DBLayerTest -> StateMachine Model (At Cmd) IO (At Resp)
+sm db = QSM.StateMachine
+    { initModel = initModel
+    , transition = transition
+    , precondition = precondition
+    , postcondition = postcondition
+    , invariant = Nothing
+    , generator = generator
+    , distribution = Nothing
+    , shrinker = shrinker
+    , semantics = semantics db
+    , mock = symbolicResp
+    }
+
+{-------------------------------------------------------------------------------
+  Additional type class instances required to run the QSM tests
+-------------------------------------------------------------------------------}
+
+instance CommandNames (At Cmd) where
+  cmdName (At CleanDB{}) = "CleanDB"
+  cmdName (At CreateWallet{}) = "CreateWallet"
+  cmdName (At RemoveWallet{}) = "RemoveWallet"
+  cmdName (At ListWallets{}) = "ListWallets"
+  cmdName (At PutCheckpoint{}) = "PutCheckpoint"
+  cmdName (At ReadCheckpoint{}) = "ReadCheckpoint"
+  cmdName (At PutWalletMeta{}) = "PutWalletMeta"
+  cmdName (At ReadWalletMeta{}) = "ReadWalletMeta"
+  cmdName (At PutTxHistory{}) = "PutTxHistory"
+  cmdName (At ReadTxHistory{}) = "ReadTxHistory"
+  cmdName (At PutPrivateKey{}) = "PutPrivateKey"
+  cmdName (At ReadPrivateKey{}) = "ReadPrivateKey"
+  cmdNames _ =
+    [ "CleanDB", "CreateWallet", "CreateWallet", "RemoveWallet"
+    , "ListWallets", "PutCheckpoint", "ReadCheckpoint", "PutWalletMeta"
+    , "ReadWalletMeta", "PutTxHistory", "ReadTxHistory", "PutPrivateKey"
+    , "ReadPrivateKey"
+    ]
+
+instance Functor f => Rank2.Functor (At f) where
+    fmap = \f (At x) -> At $ fmap (lift f) x
+      where
+        lift :: (r x -> r' x) -> QSM.Reference x r -> QSM.Reference x r'
+        lift f (QSM.Reference x) = QSM.Reference (f x)
+
+instance Foldable f => Rank2.Foldable (At f) where
+    foldMap = \f (At x) -> foldMap (lift f) x
+      where
+        lift :: (r x -> m) -> QSM.Reference x r -> m
+        lift f (QSM.Reference x) = f x
+
+instance Traversable t => Rank2.Traversable (At t) where
+    traverse = \f (At x) -> At <$> traverse (lift f) x
+      where
+        lift
+          :: Functor f
+          => (r x -> f (r' x))
+          -> QSM.Reference x r
+          -> f (QSM.Reference x r')
+        lift f (QSM.Reference x) = QSM.Reference <$> f x
+
+deriving instance ToExpr (Model Concrete)
+deriving instance ToExpr Mock
+
+instance ToExpr WalletId where
+    toExpr = defaultExprViaShow
+
+instance ToExpr MWallet where
+    toExpr = defaultExprViaShow
+
+instance ToExpr WalletMetadata where
+    toExpr = defaultExprViaShow
+
+instance ToExpr (Hash "Tx") where
+    toExpr = defaultExprViaShow
+
+instance ToExpr Tx where
+    toExpr = defaultExprViaShow
+
+instance ToExpr TxMeta where
+    toExpr = defaultExprViaShow
+
+instance ToExpr MWid where
+    toExpr = defaultExprViaShow
+
+{-------------------------------------------------------------------------------
+  Tagging
+-------------------------------------------------------------------------------}
+
+-- | Interesting combinations of commands.
+data Tag
+    = CreateThreeWallets
+      -- ^ Three different wallets created.
+    | CreateWalletTwice
+      -- ^ The same wallet id is used twice.
+    | RemoveWalletTwice
+      -- ^ The same wallet is removed twice.
+    | CreateThenList
+    | SuccessfulReadTxHistory
+    | UnsuccessfulReadTxHistory
+    | TxUnsortedInputs
+      -- ^ Putting a transaction with unsorted inputs
+    | TxUnsortedOutputs
+    | SuccessfulReadCheckpoint
+      -- ^ Read the checkpoint of a wallet that's been created
+    | UnsuccessfulReadCheckpoint
+      -- ^ No such wallet error
+    | SuccessfulReadPrivateKey
+      -- ^ Private key was writeen then read
+    | ReadTxHistoryAfterDelete
+      -- ^ wallet deleted, then tx history read
+    deriving (Show)
+
+tag :: [Event Symbolic] -> [Tag]
+tag = Foldl.fold $ catMaybes <$> sequenceA
+    [ createThreeWallets
+    , createWalletTwice
+    , removeWalletTwice
+    , createThenList
+    , readTxHistory (not . Map.null) SuccessfulReadTxHistory
+    , readTxHistory Map.null UnsuccessfulReadTxHistory
+    , txUnsorted inputs TxUnsortedInputs
+    , txUnsorted outputs TxUnsortedOutputs
+    , readCheckpoint isJust SuccessfulReadCheckpoint
+    , readCheckpoint isNothing UnsuccessfulReadCheckpoint
+    , readAfterDelete isReadTxHistory ReadTxHistoryAfterDelete
+    , countAction SuccessfulReadPrivateKey (>= 1) isReadPrivateKeySuccess
+    ]
+  where
+    readAfterDelete :: (Event Symbolic -> Maybe MWid) -> Tag -> Fold (Event Symbolic) (Maybe Tag)
+    readAfterDelete isRead res = Fold update mempty extract
+      where
+        update :: Map MWid Int -> Event Symbolic -> Map MWid Int
+        update created ev =
+            case (isRead ev, cmd ev, mockResp ev, before ev) of
+                (Just wid, _, _, _) ->
+                    Map.alter (fmap (+1)) wid created
+                (Nothing, At (RemoveWallet wid), Resp (Right _), model) ->
+                    Map.insert (evalWid model wid) 0 created
+                _otherwise ->
+                    created
+
+        extract :: Map MWid Int -> Maybe Tag
+        extract created | any (> 0) created = Just res
+                        | otherwise = Nothing
+
+    isReadTxHistory :: Event Symbolic -> Maybe MWid
+    isReadTxHistory ev = case (cmd ev, mockResp ev, before ev) of
+        (At (ReadTxHistory wid), Resp (Right (TxHistory _)), model)
+            -> Just (evalWid model wid)
+        _otherwise
+            -> Nothing
+
+    createThreeWallets :: Fold (Event Symbolic) (Maybe Tag)
+    createThreeWallets = Fold update Set.empty extract
+      where
+        update :: Set MWid -> Event Symbolic -> Set MWid
+        update created ev =
+            case (cmd ev, mockResp ev) of
+                (At (CreateWallet wid _ _), Resp (Right _)) ->
+                    Set.insert wid created
+                _otherwise ->
+                    created
+
+        extract :: Set MWid -> Maybe Tag
+        extract created
+            | Set.size created >= 3 = Just CreateWalletTwice
+            | otherwise = Nothing
+
+    createWalletTwice :: Fold (Event Symbolic) (Maybe Tag)
+    createWalletTwice = countAction CreateWalletTwice (>= 2) match
+      where
+        match :: Event Symbolic -> Maybe MWid
+        match ev = case (cmd ev, mockResp ev) of
+            (At (CreateWallet wid _ _), Resp _) -> Just wid
+            _otherwise -> Nothing
+
+    removeWalletTwice :: Fold (Event Symbolic) (Maybe Tag)
+    removeWalletTwice = countAction RemoveWalletTwice (>= 2) match
+      where
+        match ev = case (cmd ev, mockResp ev, before ev) of
+            (At (RemoveWallet wid), Resp _, m) ->
+                Just (evalWid m wid)
+            _otherwise ->
+                Nothing
+
+    countAction
+        :: forall k. Ord k => Tag -> (Int -> Bool)
+        -> (Event Symbolic -> Maybe k)
+        -> Fold (Event Symbolic) (Maybe Tag)
+    countAction res enough match = Fold update mempty extract
+      where
+        update :: Map k Int -> Event Symbolic -> Map k Int
+        update matches ev =
+            case match ev of
+                Just wid ->
+                    Map.alter (Just . (+1) . fromMaybe 0) wid matches
+                _otherwise ->
+                    matches
+
+        extract :: Map k Int -> Maybe Tag
+        extract matches
+            | any enough matches = Just res
+            | otherwise = Nothing
+
+    isReadPrivateKeySuccess :: Event Symbolic -> Maybe MWid
+    isReadPrivateKeySuccess ev = case (cmd ev, mockResp ev, before ev) of
+        (At (ReadPrivateKey wid), Resp (Right (PrivateKey (Just _))), model)
+            -> Just (evalWid model wid)
+        _otherwise
+            -> Nothing
+
+    createThenList :: Fold (Event Symbolic) (Maybe Tag)
+    createThenList =
+        Fold update mempty extract
+      where
+        update :: Map MWid Bool -> Event Symbolic -> Map MWid Bool
+        update created ev =
+            case (cmd ev, mockResp ev) of
+                (At (CreateWallet wid _ _), Resp (Right _)) ->
+                    Map.insert wid False created
+                (At ListWallets, Resp (Right (WalletIds wids))) ->
+                    foldr (Map.adjust (const True)) created wids
+                _otherwise ->
+                    created
+
+        extract :: Map MWid Bool -> Maybe Tag
+        extract created
+            | or created = Just CreateThenList
+            | otherwise = Nothing
+
+    readTxHistory
+        :: (TxHistory -> Bool)
+        -> Tag
+        -> Fold (Event Symbolic) (Maybe Tag)
+    readTxHistory check res = Fold update False (extractf res)
+      where
+        update :: Bool -> Event Symbolic -> Bool
+        update didRead ev = didRead || case (cmd ev, mockResp ev) of
+            (At (ReadTxHistory _), Resp (Right (TxHistory h))) ->
+                check h
+            _otherwise ->
+                False
+
+    txUnsorted
+        :: Ord a
+        => (Tx -> [a])
+        -> Tag
+        -> Fold (Event Symbolic) (Maybe Tag)
+    txUnsorted sel res = Fold update False (extractf res)
+      where
+        update :: Bool -> Event Symbolic -> Bool
+        update didRead ev = didRead ||
+            case (cmd ev, mockResp ev) of
+                (At (PutTxHistory _ h), Resp (Right _)) ->
+                    any (isUnordered . sel . fst) h
+                _otherwise ->
+                    False
+
+    readCheckpoint
+        :: (Maybe MWallet -> Bool)
+        -> Tag
+        -> Fold (Event Symbolic) (Maybe Tag)
+    readCheckpoint check res = Fold update False (extractf res)
+      where
+        update :: Bool -> Event Symbolic -> Bool
+        update didRead ev = didRead ||
+            case (cmd ev, mockResp ev) of
+                (At (ReadCheckpoint _), Resp (Right (Checkpoint cp))) ->
+                    check cp
+                _otherwise ->
+                    False
+    extractf :: a -> Bool -> Maybe a
+    extractf a t = if t then Just a else Nothing
+
+    -- | Look up a walletId expression in the model.
+    evalWid :: Model Symbolic -> Expr (Reference WalletId Symbolic) -> MWid
+    evalWid (Model _ wids) (Var sym) = wids ! sym
+    evalWid _ (Val wid) = wid
+
+execCmd
+    :: Model Symbolic
+    -> QSM.Command (At Cmd) (At Resp)
+    -> Event Symbolic
+execCmd model (QSM.Command cmd resp _vars) =
+    lockstep model cmd resp
+
+execCmds :: QSM.Commands (At Cmd) (At Resp) -> [Event Symbolic]
+execCmds = \(QSM.Commands cs) -> go initModel cs
+  where
+    go
+        :: Model Symbolic
+        -> [QSM.Command (At Cmd) (At Resp)]
+        -> [Event Symbolic]
+    go _ [] = []
+    go m (c : cs) = e : go (after e) cs where e = execCmd m c
+
+{-------------------------------------------------------------------------------
+  Finding minimal labelled examples - helper functions
+-------------------------------------------------------------------------------}
+
+showLabelledExamples :: Maybe Int -> IO ()
+showLabelledExamples mReplay = do
+    replaySeed <- case mReplay of
+        Nothing -> getStdRandom $ randomR (1, 999999)
+        Just seed -> return seed
+    putStrLn $ "Using replaySeed " ++ show replaySeed
+    let args = QC.stdArgs
+            { maxSuccess = 10000
+            , replay = Just (mkQCGen replaySeed, 0)
+            }
+    labelledExamplesWith args $
+        forAllCommands (sm dbLayerUnused) Nothing $ \cmds ->
+            repeatedly collect (tag . execCmds $ cmds) (property True)
+
+repeatedly :: (a -> b -> b) -> ([a] -> b -> b)
+repeatedly = flip . L.foldl' . flip
+
+{-------------------------------------------------------------------------------
+  Top-level tests
+-------------------------------------------------------------------------------}
+
+prop_sequential :: DBLayerTest -> Property
+prop_sequential db =
+    forAllCommands (sm dbLayerUnused) Nothing $ \cmds ->
+    monadicIO $ do
+        liftIO $ cleanDB db
+        let sm' = sm db
+        (hist, _model, res) <- runCommands sm' cmds
+        prettyCommands sm' hist $ res === Ok
+
+
+prop_parallel :: DBLayerTest -> Property
+prop_parallel db =
+    forAllParallelCommands (sm dbLayerUnused) $ \cmds ->
+    monadicIO $ do
+        let sm' = sm db
+            cmds' = addCleanDB cmds
+        prettyParallelCommands cmds =<< runParallelCommands sm' cmds'
+
+-- | The commands for parallel tests are run multiple times to detect
+-- concurrency problems. We need to clean the database before every run. The
+-- easiest way is to add a CleanDB command at the beginning of the prefix.
+addCleanDB :: ParallelCommands (At Cmd) (At Resp) -> ParallelCommands (At Cmd) (At Resp)
+addCleanDB (ParallelCommands p s) = ParallelCommands (clean <> p) s
+  where
+    clean = Commands [cmd resp mempty]
+    cmd = Command (At CleanDB)
+    resp = At (Resp (Right (Unit ())))
+
+dbLayerUnused :: DBLayerTest
+dbLayerUnused = error "DBLayer not used during command generation"

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -273,8 +273,9 @@ ourAddresses cc =
 
 instance Arbitrary (Hash "Tx") where
     shrink _ = [] -- no way to shrink a hash
-    arbitrary = Hash . B8.pack <$> replicateM 32 hex
-        where hex = elements $ ['0'..'9'] ++ ['a'..'f']
+    arbitrary = do
+        k <- choose (0, 10)
+        return $ Hash (B8.pack ("TX" <> show @Int k))
 
 instance Arbitrary Tx where
     shrink (Tx ins outs) =

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -316,9 +316,7 @@ instance Arbitrary Coin where
     arbitrary = Coin <$> choose (1, 100000)
 
 instance Arbitrary TxIn where
-    -- TxIns need to be unique, chances are pretty good that the arbitrary
-    -- hashes won't collide.
-    -- There is no shrinking of a TxIn.
+    -- No Shrinking
     arbitrary = TxIn
         <$> arbitrary
         <*> scale (`mod` 3) arbitrary -- No need for a high indexes

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - base58-bytestring-0.1.0
 - command-0.1.1
 - generic-lens-1.1.0.0
+- quickcheck-state-machine-0.6.0
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a
 


### PR DESCRIPTION
Relates to #154.

# Overview

We can generate our DBLayer tests with quickcheck.

I used [Edsko's blog post](https://iohk.io/blog/an-in-depth-look-at-quickcheck-state-machine/) as a guide.

# Comments

Todo list:

- [x] DBLayer methods `put/readPrivateKey`
- [x] shrinking of TxHistory doesn't work
- [x] Some more interesting tests can be tagged
- [x] Testing of the SeqState wallet
- [x] Tweak weightings in the command generator.
- [x] ~Use QSM parallel testing~
- [x] Run QSM tests on Sqlite ~and MVar~ DBLayers.
