### PR TITLE
Add bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,8 @@
+status = [
+  # Bors will merge if/when Travis succeeds.
+  "continuous-integration/travis-ci/pr",
+]
+timeout_sec = 3600
+required_approvals = 1
+delete_merged_branches = true
+block_labels = [ "DO NOT MERGE", "wip" ]


### PR DESCRIPTION
This configures bors-ng, a merge bot that will automate testing of PRs against the latest revision of master.

This means that we don't need to manually rebase PR branches unless they conflict or would fail the tests when merged.

Our bors instance is here: https://bors-ng.aws.iohkdev.io/

More information about bors-ng - https://bors.tech/
