### PR TITLE
Integration test: Polling for wallet fixture & Better error handling

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -7,18 +7,25 @@
       - module:
         - name: Test.Integration.Framework.DSL
         - identifier:
-          - </>
           - expectError
+          - expectEventually
           - expectSuccess
-          - getFromResponse
       - module:
         - name: Test.Integration.Framework.Request
         - identifier:
           - ClientError
           - DecodeFailure
-          - NonJson
-          - None
+          - HttpException
           - unsafeRequest
+  - section:
+    - name: test:unit
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Spec
+        - identifier: main
+- package:
+  - name: cardano-wallet-jormungandr
   - section:
     - name: test:unit
     - message:
@@ -33,14 +40,4 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Launcher.Windows
-
-- package:
-  - name: cardano-wallet-jormungandr
-  - section:
-    - name: test:unit
-    - message:
-      - name: Weeds exported
-      - module:
-        - name: Spec
-        - identifier: main
 

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
@@ -142,9 +142,12 @@ expectErrorMessage
     -> (s, Either RequestException a)
     -> m ()
 expectErrorMessage want (_, res) = case res of
-    Left (DecodeFailure msg)  -> BL8.unpack msg `shouldContain` want
-    Left (ClientError _)  -> fail "expectErrorMessage: asserting ClientError not\
-                             \ supported yet"
+    Left (DecodeFailure msg)  ->
+        BL8.unpack msg `shouldContain` want
+    Left (ClientError _)  ->
+        fail "expectErrorMessage: asserting ClientError not supported yet"
+    Left (HttpException _) ->
+        fail "expectErrorMessage: asserting HttpException not supported yet"
     Right a -> wantedErrorButSuccess a
 
 -- | Expect a successful response, without any further assumptions


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#220 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have changed the 'fixtureWallet' helper such that it polls the wallet until funds become available.
- [ ] I have adjusted the `request` function such that it won't throw `HttpExeptionRequest` but instead, put them down as value in the `Left` branch (to facilitate handling of such errors)
- [ ] I have removed the warm up delay for the cluster, and instead, used polling to wait for the relay node to be ready (waiting for the chain to be at least 1), this is more reliable and allow to wait for just the necessary amount of time locally and in CI, instead of having a big timeout (which would probably have been too small on @akegalj's machine anyway :sweat_smile:)
- [ ] I also made sure that the integration setup would fail early when the cluster fail to start. I noticed that, if one of the node failed to start, the cluster `async` wouldn't terminate and just hang there. After a while, I discovered that this was because we close the stderr and stdout output streams for the cluster. With some open handles, the node can successfully shut itself down. 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
