### PR TITLE
Use richer errors for Bech32 encoder and decoder

### DIFF
--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -32,6 +32,7 @@ library
       array
     , base
     , bytestring
+    , extra
   hs-source-dirs:
       src
   exposed-modules:
@@ -56,6 +57,7 @@ test-suite bech32-test
       array
     , base
     , bech32
+    , extra
     , hspec
     , bytestring
     , QuickCheck


### PR DESCRIPTION
# Issue Number

Issue #238 

# Overview

Currently, the Bech32 `encode`, `decode`, and `mkHumanReadablePart` functions indicate _failure_ by evaluating to `Nothing`. Although this solution is simple, it isn't very helpful for when we want to give feedback about the exact cause of an error.

This PR uses `Either` instead of `Maybe` to indicate failure, and adds a set of error conditions.

# Comments

This PR doesn't include the ability to spot checksum errors. (That will be included in a later PR.)
