### PR TITLE
More integration tests for CLI (including minor fixes in CLI)

### DIFF
--- a/exe/launcher/Main.hs
+++ b/exe/launcher/Main.hs
@@ -34,6 +34,7 @@ import System.Console.Docopt
     , isPresent
     , longOption
     , parseArgsOrExit
+    , shortOption
     )
 import System.Environment
     ( getArgs )
@@ -57,7 +58,7 @@ in the directory.
 
 Usage:
   cardano-wallet-launcher [options]
-  cardano-wallet-launcher --help
+  cardano-wallet-launcher -h | --help
 
 Options:
   --wallet-server-port <PORT>  port used for serving the wallet API [default: 8090]
@@ -68,6 +69,7 @@ main :: IO ()
 main = do
     args <- parseArgsOrExit cli =<< getArgs
     when (args `isPresent` (longOption "help")) $ help cli
+    when (args `isPresent` (shortOption 'h')) $ help cli
 
     bridgePort <- args `parseArg` longOption "http-bridge-port"
     walletPort <- args `parseArg` longOption "wallet-server-port"

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -95,6 +95,7 @@ import System.Console.Docopt
     , isPresent
     , longOption
     , parseArgsOrExit
+    , shortOption
     )
 import System.Environment
     ( getArgs )
@@ -170,6 +171,7 @@ main = do
 exec :: Manager -> Arguments -> IO ()
 exec manager args
     | args `isPresent` (longOption "help") = help cli
+    | args `isPresent` (shortOption 'h') = help cli
 
     | args `isPresent` command "server" = do
         walletPort <- args `parseArg` longOption "port"

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -70,6 +70,8 @@ import Data.Functor
 import qualified Data.List.NonEmpty as NE
 import Data.Proxy
     ( Proxy (..) )
+import Data.Text
+    ( Text )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
 import Data.Typeable
@@ -345,15 +347,15 @@ execServer (Port port) (Port bridgePort) = do
 
 -- | Generate a random mnemonic of the given size 'n' (n = number of words),
 -- and print it to stdout.
-execGenerateMnemonic :: Int -> IO ()
+execGenerateMnemonic :: Text -> IO ()
 execGenerateMnemonic n = do
     m <- case n of
-        9  -> mnemonicToText @9 . entropyToMnemonic <$> genEntropy
-        12 -> mnemonicToText @12 . entropyToMnemonic <$> genEntropy
-        15 -> mnemonicToText @15 . entropyToMnemonic <$> genEntropy
-        18 -> mnemonicToText @18 . entropyToMnemonic <$> genEntropy
-        21 -> mnemonicToText @21 . entropyToMnemonic <$> genEntropy
-        24 -> mnemonicToText @24 . entropyToMnemonic <$> genEntropy
+        "9"  -> mnemonicToText @9 . entropyToMnemonic <$> genEntropy
+        "12" -> mnemonicToText @12 . entropyToMnemonic <$> genEntropy
+        "15" -> mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+        "18" -> mnemonicToText @18 . entropyToMnemonic <$> genEntropy
+        "21" -> mnemonicToText @21 . entropyToMnemonic <$> genEntropy
+        "24" -> mnemonicToText @24 . entropyToMnemonic <$> genEntropy
         _  -> do
             putErrLn "Invalid mnemonic size. Expected one of: 9,12,15,18,21,24"
             exitFailure

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -171,6 +171,7 @@ test-suite integration
       Test.Integration.Faucet
       Test.Integration.Framework.DSL
       Test.Integration.Framework.Request
+      Test.Integration.Framework.TestData
       Test.Integration.Scenario.Addresses
       Test.Integration.Scenario.Transactions
       Test.Integration.Scenario.Wallets

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
@@ -57,6 +57,7 @@ module Test.Integration.Framework.DSL
     , createWalletViaCLI
     , deleteWalletViaCLI
     , getWalletViaCLI
+    , listAddressesViaCLI
     , listWalletsViaCLI
     , updateWalletViaCLI
     ) where
@@ -501,6 +502,10 @@ deleteWalletViaCLI walId = cardanoWalletCLI ["wallet", "delete", "--port",
 getWalletViaCLI :: CmdResult r => String -> IO r
 getWalletViaCLI walId = cardanoWalletCLI ["wallet", "get", "--port", "1337"
     , walId ]
+
+listAddressesViaCLI :: CmdResult r => String -> IO r
+listAddressesViaCLI walId = cardanoWalletCLI ["address", "list", "--port",
+    "1337", walId]
 
 listWalletsViaCLI :: CmdResult r => IO r
 listWalletsViaCLI = cardanoWalletCLI ["wallet", "list", "--port", "1337" ]

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
@@ -49,6 +49,16 @@ module Test.Integration.Framework.DSL
     , json
     , tearDown
     , fixtureWallet
+
+    -- * CLI
+    , cardanoWalletCLI
+    , cardanoWalletLauncherCLI
+    , generateMnemonicsViaCLI
+    , createWalletViaCLI
+    , deleteWalletViaCLI
+    , getWalletViaCLI
+    , listWalletsViaCLI
+    , updateWalletViaCLI
     ) where
 
 import Prelude hiding
@@ -112,6 +122,19 @@ import Language.Haskell.TH.Quote
     ( QuasiQuoter )
 import Numeric.Natural
     ( Natural )
+import System.Command
+    ( CmdResult, command )
+import System.Exit
+    ( ExitCode (..) )
+import System.IO
+    ( hClose, hFlush, hPutStr )
+import System.Process
+    ( CreateProcess (..)
+    , StdStream (..)
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain, shouldNotBe )
 import Test.Integration.Faucet
@@ -438,3 +461,50 @@ wantedErrorButSuccess
     -> m void
 wantedErrorButSuccess =
     fail . ("expected an error but got a successful response: " <>) . show
+
+
+---
+--- CLI
+---
+cardanoWalletLauncherCLI :: CmdResult r => [String] -> IO r
+cardanoWalletLauncherCLI = command [] "cardano-wallet-launcher"
+
+cardanoWalletCLI :: CmdResult r => [String] -> IO r
+cardanoWalletCLI = command [] "cardano-wallet"
+
+generateMnemonicsViaCLI :: CmdResult r => [String] -> IO r
+generateMnemonicsViaCLI args = cardanoWalletCLI (["mnemonic", "generate"] ++ args)
+
+createWalletViaCLI :: [String] -> String -> String -> String -> IO ExitCode
+createWalletViaCLI args mnemonics mnemonics2 passphrase = do
+    let fullArgs = ["wallet", "create", "--port", "1337"] ++ args
+    let process = (proc "cardano-wallet" fullArgs)
+            { std_in = CreatePipe, std_out = CreatePipe, std_err = CreatePipe }
+    withCreateProcess process $ \stdIn _ _ h -> do
+        case stdIn of
+            Nothing -> return ()
+            Just i -> do
+                hPutStr i mnemonics
+                hPutStr i mnemonics2
+                hPutStr i (passphrase ++ "\n")
+                hPutStr i (passphrase ++ "\n")
+                hFlush i
+                hClose i
+
+        waitForProcess h
+
+
+deleteWalletViaCLI :: CmdResult r => String -> IO r
+deleteWalletViaCLI walId = cardanoWalletCLI ["wallet", "delete", "--port",
+    "1337", walId ]
+
+getWalletViaCLI :: CmdResult r => String -> IO r
+getWalletViaCLI walId = cardanoWalletCLI ["wallet", "get", "--port", "1337"
+    , walId ]
+
+listWalletsViaCLI :: CmdResult r => IO r
+listWalletsViaCLI = cardanoWalletCLI ["wallet", "list", "--port", "1337" ]
+
+updateWalletViaCLI :: CmdResult r => [String] -> IO r
+updateWalletViaCLI args = cardanoWalletCLI (["wallet", "update", "--port",
+    "1337"] ++ args)

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/TestData.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/TestData.hs
@@ -1,0 +1,161 @@
+module Test.Integration.Framework.TestData
+    ( -- * Mnemonics
+      chineseMnemonics9
+    , chineseMnemonics18
+    , frenchMnemonics12
+    , frenchMnemonics21
+    , invalidMnemonics12
+    , invalidMnemonics15
+    , japaneseMnemonics12
+    , japaneseMnemonics15
+    , mnemonics3
+    , mnemonics6
+    , mnemonics9
+    , mnemonics12
+    , mnemonics15
+    , mnemonics18
+    , mnemonics21
+    , mnemonics24
+    , specMnemonicSentence
+    , specMnemonicSecondFactor
+
+    -- * Wallets
+    , arabicWalletName
+    , falseWalletIds
+    , kanjiWalletName
+    , polishWalletName
+    , russianWalletName
+    , wildcardsWalletName
+
+
+    -- * Helpers
+    , addressPoolGapMax
+    , addressPoolGapMin
+    , passphraseMaxLength
+    , passphraseMinLength
+    ) where
+
+import Prelude
+
+import Data.Text
+    ( Text )
+
+falseWalletIds :: [(String, String)]
+falseWalletIds =
+        [ ("40 chars hex", replicate 40 '1')
+        , ("40 chars non-hex", replicate 40 'ś')
+        , ("39 chars hex", replicate 39 '1')
+        , ("41 chars hex", replicate 41 '1')
+        ]
+
+mnemonics3 :: [Text]
+mnemonics3 = ["diamond", "flee", "window"]
+
+mnemonics6 :: [Text]
+mnemonics6 = ["tornado", "canvas", "peasant", "spike", "enrich", "dilemma"]
+
+mnemonics9 :: [Text]
+mnemonics9 = ["subway", "tourist", "abstract", "roast", "border", "curious",
+    "exercise", "work", "narrow"]
+
+mnemonics12 :: [Text]
+mnemonics12 = ["agent", "siren", "roof", "water", "giant", "pepper",
+    "obtain", "oxygen", "treat", "vessel", "hip", "garlic"]
+
+mnemonics15 :: [Text]
+mnemonics15 = ["network", "empty", "cause", "mean", "expire", "private",
+    "finger", "accident", "session", "problem", "absurd", "banner", "stage",
+    "void", "what"]
+
+mnemonics18 :: [Text]
+mnemonics18 = ["whisper", "control", "diary", "solid", "cattle", "salmon",
+    "whale", "slender", "spread", "ice", "shock", "solve", "panel",
+    "caution", "upon", "scatter", "broken", "tonight"]
+
+mnemonics21 :: [Text]
+mnemonics21 = ["click", "puzzle", "athlete", "morning", "fold", "retreat",
+    "across", "timber", "essay", "drill", "finger", "erase", "galaxy",
+    "spoon", "swift", "eye", "awesome", "shrimp", "depend", "zebra", "token"]
+
+mnemonics24 :: [Text]
+mnemonics24 = ["decade", "distance", "denial", "jelly", "wash", "sword",
+    "olive", "perfect", "jewel", "renew", "wrestle", "cupboard", "record",
+    "scale", "pattern", "invite", "other", "fruit", "gloom", "west", "oak",
+    "deal", "seek", "hand"]
+
+invalidMnemonics12 :: [Text]
+invalidMnemonics12 = ["word","word","word","word","word","word","word",
+        "word","word","word","word","hill"]
+
+invalidMnemonics15 :: [Text]
+invalidMnemonics15 = ["word","word","word","word","word","word","word",
+    "word","word","word","word","word","word","word","word"]
+
+specMnemonicSentence :: [Text]
+specMnemonicSentence = ["squirrel", "material", "silly", "twice", "direct",
+    "slush", "pistol", "razor", "become", "junk", "kingdom", "flee",
+    "squirrel", "silly", "twice"]
+
+specMnemonicSecondFactor :: [Text]
+specMnemonicSecondFactor = ["squirrel", "material", "silly", "twice",
+    "direct", "slush", "pistol", "razor", "become"]
+
+japaneseMnemonics12 :: [Text]
+japaneseMnemonics12 = ["そうだん",　"ひよう",　"にもつ",　"やさしい",　"きふく",　
+    "ねつい",　"だったい",　"けんてい",　"けいろ",　"ざつがく",　"ほうもん",　"すこし"]
+
+japaneseMnemonics15 :: [Text]
+japaneseMnemonics15 = ["うめる", "せんく", "えんぎ", "はんぺん", "おくりがな",
+    "さんち", "きなが", "といれ", "からい", "らくだ", "うえる", "ふめん", "せびろ",
+    "られつ", "なにわ"]
+
+chineseMnemonics9 :: [Text]
+chineseMnemonics9 = ["钢", "看", "磁", "塑", "凤", "魏", "世", "腐", "恶" ]
+
+chineseMnemonics18 :: [Text]
+chineseMnemonics18 = ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵",
+    "祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"]
+
+frenchMnemonics12 :: [Text]
+frenchMnemonics12 = ["palmarès", "supplier", "visuel", "gardien", "adorer",
+    "cordage", "notifier", "réglage", "employer", "abandon", "scénario",
+    "proverbe"]
+
+frenchMnemonics21 :: [Text]
+frenchMnemonics21 = ["pliage", "exhorter", "brasier", "chausson", "bloquer",
+    "besace", "sorcier", "absurde", "neutron", "forgeron", "geyser",
+    "moulin", "cynique", "cloche", "baril", "infliger", "rompre", "typique",
+    "renifler", "creuser", "matière"]
+
+russianWalletName :: Text
+russianWalletName = "АаБбВвГгДдЕеЁёЖжЗз ИиЙйКкЛлМмНнО оПпРрСсТтУуФф ХхЦцЧчШшЩщЪъ ЫыЬьЭэЮюЯяІ ѢѲѴѵѳѣі"
+
+polishWalletName :: Text
+polishWalletName = "aąbcćdeęfghijklłmnoóprsś\r\ntuvwyzżźAĄBCĆDEĘFGHIJKLŁMNOP\rRSŚTUVWYZŻŹ"
+
+kanjiWalletName :: Text
+kanjiWalletName = "亜哀挨愛曖悪握圧扱宛嵐安案暗以衣位囲医依委威為畏胃尉異移萎偉椅彙意違維慰\
+\遺緯域育一壱逸茨芋引印因咽姻員院淫陰飲隠韻右宇羽雨唄鬱畝浦運雲永泳英映栄\n営詠影鋭衛易疫益液駅悦越謁\
+\閲円延沿炎怨宴媛援園煙猿遠鉛塩演縁艶汚王凹\r\n央応往押旺欧殴桜翁奥横岡屋億憶臆虞乙俺卸音恩温穏下化火加\
+\可仮何花佳価果河苛科架夏家荷華菓貨渦過嫁暇禍靴寡歌箇稼課蚊牙瓦我画芽賀雅餓介回灰会快戒改怪拐悔海界\
+\皆械絵開階塊楷解潰壊懐諧貝外劾害崖涯街慨蓋該概骸垣柿各角拡革格核殻郭覚較隔閣確獲嚇穫学岳楽額顎掛潟\
+\括活喝渇割葛滑褐轄且株釜鎌刈干刊甘汗缶\r"
+
+arabicWalletName :: Text
+arabicWalletName = "ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو."
+
+wildcardsWalletName :: Text
+wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 💕 💞 \
+\💓 💗 💖 💘 💝 💟 💜 💛 💚 💙0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+
+passphraseMinLength :: Int
+passphraseMinLength = 10
+
+passphraseMaxLength :: Int
+passphraseMaxLength = 255
+
+addressPoolGapMin :: Int
+addressPoolGapMin = 10
+
+addressPoolGapMax :: Int
+addressPoolGapMax = 100

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
@@ -82,13 +82,6 @@ specNoCluster = do
         length (words out) `shouldBe` 15
         c `shouldBe` ExitSuccess
 
-    it "CLI - It can't generate mnemonics with an invalid size" $ do
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-            ["mnemonic", "generate", "--size", "14"]
-        c `shouldBe` ExitFailure 1
-        err `shouldBe` "Invalid mnemonic size. Expected one of: 9,12,15,18,21,24\n"
-        out `shouldBe` mempty
-
     describe "CLI - Can generate mnemonics with different sizes" $ do
         let test size = it ("--size=" <> show size) $ do
                 (Exit c, Stdout out) <- command [] "cardano-wallet"
@@ -96,6 +89,17 @@ specNoCluster = do
                 length (words out) `shouldBe` size
                 c `shouldBe` ExitSuccess
         forM_ [9, 12, 15, 18, 21, 24] test
+
+    describe "CLI - It can't generate mnemonics with an invalid size" $ do
+        let sizes = ["15.5", "3", "6", "14", "abc", "👌", "0"
+                , "~!@#%" , "-1000", "1000"]
+        forM_ sizes $ \(size) -> it ("--size=" <> size) $ do
+            (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
+                ["mnemonic", "generate", "--size", size]
+            c `shouldBe` ExitFailure 1
+            err `shouldBe` "Invalid mnemonic size. Expected one of:\
+            \ 9,12,15,18,21,24\n"
+            out `shouldBe` mempty
 
 specWithCluster :: SpecWith Context
 specWithCluster = do

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
@@ -41,6 +41,7 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , getWalletViaCLI
     , json
+    , listAddressesViaCLI
     , listWalletsViaCLI
     , request
     , updateWalletViaCLI
@@ -216,8 +217,7 @@ specWithCluster = do
 
     it "CLI - Can list addresses" $ \ctx -> do
         walId <- createWallet ctx "CLI Wallet" mnemonics15
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-            ["address", "list", "--port", "1337", walId]
+        (Exit c, Stdout out, Stderr err) <- listAddressesViaCLI walId
         err `shouldBe` "Ok.\n"
         expectValidJSON (Proxy @[ApiAddress]) out
         c `shouldBe` ExitSuccess

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
@@ -20,7 +20,7 @@ import Data.Proxy
 import Data.Text
     ( Text )
 import System.Command
-    ( Exit (..), Stderr (..), Stdout (..), command )
+    ( Exit (..), Stderr (..), Stdout (..) )
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
@@ -31,71 +31,80 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
+    , cardanoWalletCLI
+    , cardanoWalletLauncherCLI
+    , createWalletViaCLI
+    , deleteWalletViaCLI
     , expectResponseCode
     , expectValidJSON
+    , generateMnemonicsViaCLI
     , getFromResponse
+    , getWalletViaCLI
     , json
+    , listWalletsViaCLI
     , request
+    , updateWalletViaCLI
     , walletId
     )
+import Test.Integration.Framework.TestData
+    ( falseWalletIds, mnemonics15, mnemonics18 )
 
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
+version :: Text
+version = "2019.5.8"
+
 specNoCluster :: SpecWith ()
 specNoCluster = do
 
+    it "CLI - Shows version" $  do
+        (Exit c, Stdout out) <- cardanoWalletCLI ["--version"]
+        let v = T.dropWhileEnd (== '\n') (T.pack out)
+        v `shouldBe` version
+        c `shouldBe` ExitSuccess
+
     it "CLI - cardano-wallet-launcher shows help on bad argument" $  do
-        (Exit c, Stdout out) <- command [] "cardano-wallet-launcher" ["--bad arg"]
+        (Exit c, Stdout out) <- cardanoWalletLauncherCLI ["--bad arg"]
         out `shouldContain` "cardano-wallet-launcher"
         c `shouldBe` ExitFailure 1
 
     describe "CLI - cardano-wallet-launcher shows help with" $  do
         let test option = it option $ do
-                (Exit c, Stdout out) <- command [] "cardano-wallet-launcher"
-                    [option]
+                (Exit c, Stdout out) <- cardanoWalletLauncherCLI [option]
                 out `shouldContain` "cardano-wallet-launcher"
                 c `shouldBe` ExitSuccess
         forM_ ["-h", "--help"] test
 
     it "CLI - cardano-wallet shows help on bad argument" $  do
-        (Exit c, Stdout out) <- command [] "cardano-wallet" ["--bad arg"]
+        (Exit c, Stdout out) <- cardanoWalletCLI ["--bad arg"]
         out `shouldContain` "Cardano Wallet CLI"
         c `shouldBe` ExitFailure 1
 
     describe "CLI - cardano-wallet shows help with" $  do
         let test option = it option $ do
-                (Exit c, Stdout out) <- command [] "cardano-wallet" [option]
+                (Exit c, Stdout out) <- cardanoWalletCLI [option]
                 out `shouldContain` "Cardano Wallet CLI"
                 c `shouldBe` ExitSuccess
         forM_ ["-h", "--help"] test
 
-    it "CLI - Shows version" $  do
-        (Exit c, Stdout out) <- command [] "cardano-wallet" ["--version"]
-        let v = T.dropWhileEnd (== '\n') (T.pack out)
-        v `shouldBe` "2019.5.8"
-        c `shouldBe` ExitSuccess
-
     it "CLI - Can generate mnemonics with default size" $  do
-        (Exit c, Stdout out) <- command [] "cardano-wallet"
-            ["mnemonic", "generate"]
+        (Exit c, Stdout out) <- generateMnemonicsViaCLI []
         length (words out) `shouldBe` 15
         c `shouldBe` ExitSuccess
 
     describe "CLI - Can generate mnemonics with different sizes" $ do
         let test size = it ("--size=" <> show size) $ do
-                (Exit c, Stdout out) <- command [] "cardano-wallet"
-                    ["mnemonic", "generate", "--size", show size]
+                (Exit c, Stdout out) <- generateMnemonicsViaCLI ["--size", show size]
                 length (words out) `shouldBe` size
                 c `shouldBe` ExitSuccess
         forM_ [9, 12, 15, 18, 21, 24] test
 
     describe "CLI - It can't generate mnemonics with an invalid size" $ do
-        let sizes = ["15.5", "3", "6", "14", "abc", "👌", "0"
-                , "~!@#%" , "-1000", "1000"]
+        let sizes = ["15.5", "3", "6", "14", "abc", "👌", "0", "~!@#%" , "-1000"
+                , "1000"]
         forM_ sizes $ \(size) -> it ("--size=" <> size) $ do
-            (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-                ["mnemonic", "generate", "--size", size]
+            (Exit c, Stdout out, Stderr err) <- generateMnemonicsViaCLI ["--size", size]
             c `shouldBe` ExitFailure 1
             err `shouldBe` "Invalid mnemonic size. Expected one of:\
             \ 9,12,15,18,21,24\n"
@@ -103,20 +112,86 @@ specNoCluster = do
 
 specWithCluster :: SpecWith Context
 specWithCluster = do
+
+    describe "CLI1 - Can create wallet with different mnemonic sizes" $ do
+        forM_ ["15", "18", "21", "24"] $ \(size) -> it size $ \_ -> do
+            let walletName = "Wallet created via CLI"
+            Stdout mnemonics <- generateMnemonicsViaCLI ["--size", size]
+            let passphrase = "Secure passphrase"
+
+            c <- createWalletViaCLI [walletName] mnemonics "\n" passphrase
+            c `shouldBe` ExitSuccess
+
+            Stdout outList <- listWalletsViaCLI
+            outList `shouldContain` walletName
+
+    describe "CLI1 - Can create wallet with different mnemonic snd factor sizes" $ do
+        forM_ ["9", "12"] $ \(size) -> it size $ \_ -> do
+            let walletName = "Wallet created via CLI"
+            Stdout mnemonics <- generateMnemonicsViaCLI []
+            Stdout mnemonics2 <- generateMnemonicsViaCLI ["--size", size]
+            let passphrase = "Secure passphrase"
+
+            c <- createWalletViaCLI [walletName] mnemonics mnemonics2 passphrase
+            c `shouldBe` ExitSuccess
+
+            Stdout outList <- listWalletsViaCLI
+            outList `shouldContain` walletName
+
+    describe "CLI1 - Can't create wallet with wrong size of mnemonic" $ do
+        forM_ ["9", "12"] $ \(size) -> it size $ \_ -> do
+            let walletName = "Wallet created via CLI"
+            Stdout mnemonics <- generateMnemonicsViaCLI ["--size", size]
+            Stdout mnemonics2 <- generateMnemonicsViaCLI ["--size", size]
+            let passphrase = "Secure passphrase"
+
+            c <- createWalletViaCLI [walletName] mnemonics mnemonics2 passphrase
+            c `shouldBe` (ExitFailure 1)
+
+            Stdout outList <- listWalletsViaCLI
+            outList `shouldNotContain` walletName
+
+    describe "CLI1 - Can't create wallet with wrong size of mnemonic snd factor" $ do
+        forM_ ["15", "18", "21", "24"] $ \(size) -> it size $ \_ -> do
+            let walletName = "Wallet created via CLI"
+            Stdout mnemonics <- generateMnemonicsViaCLI ["--size", size]
+            Stdout mnemonics2 <- generateMnemonicsViaCLI ["--size", size]
+            let passphrase = "Secure passphrase"
+
+            c <- createWalletViaCLI [walletName] mnemonics mnemonics2 passphrase
+            c `shouldBe` (ExitFailure 1)
+
+            Stdout outList <- listWalletsViaCLI
+            outList `shouldNotContain` walletName
+
     it "CLI - Can get a wallet" $ \ctx -> do
         walId <- createWallet ctx "1st CLI Wallet" mnemonics15
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-            ["wallet", "get", "--port", "1337", walId ]
+        (Exit c, Stdout out, Stderr err) <- getWalletViaCLI walId
         err `shouldBe` "Ok.\n"
         expectValidJSON (Proxy @ApiWallet) out
         out `shouldContain` "1st CLI Wallet"
         c `shouldBe` ExitSuccess
 
+    describe "CLI - Cannot get wallets with false ids" $ do
+        forM_ falseWalletIds $ \(title, walId) -> it title $ \_ -> do
+            (Exit c, Stdout out, Stderr err) <- getWalletViaCLI walId
+            out `shouldBe` ""
+            if (title == "40 chars hex") then
+                err `shouldBe` "Wallet not found.\n"
+            else
+                err `shouldBe` "wallet id should be an hex-encoded string of\
+                    \ 40 characters\n"
+
+            if (title == "40 chars hex") then
+                c `shouldBe` ExitSuccess
+            else
+                c `shouldBe` ExitFailure 1
+
+
     it "CLI - Can list wallets" $ \ctx -> do
         _ <- createWallet ctx "1st CLI Wallet" mnemonics15
         _ <- createWallet ctx "2nd CLI Wallet" mnemonics18
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-            ["wallet", "list", "--port", "1337"]
+        (Exit c, Stdout out, Stderr err) <- listWalletsViaCLI
         err `shouldBe` "Ok.\n"
         expectValidJSON (Proxy @[ApiWallet]) out
         out `shouldContain` "1st CLI Wallet"
@@ -125,8 +200,8 @@ specWithCluster = do
 
     it "CLI - Can update wallet name" $ \ctx -> do
         walId <- createWallet ctx "1st CLI Wallet" mnemonics15
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-           ["wallet", "update", "--port", "1337", walId , "--name", "new name" ]
+        let args = [walId, "--name", "new name"]
+        (Exit c, Stdout out, Stderr err) <- updateWalletViaCLI args
         err `shouldBe` "Ok.\n"
         expectValidJSON (Proxy @ApiWallet) out
         out `shouldContain` "new name"
@@ -134,8 +209,7 @@ specWithCluster = do
 
     it "CLI - Can delete wallet" $ \ctx -> do
         walId <- createWallet ctx "CLI Wallet" mnemonics15
-        (Exit c, Stdout out, Stderr err) <- command [] "cardano-wallet"
-            ["wallet", "delete", "--port", "1337", walId ]
+        (Exit c, Stdout out, Stderr err) <- deleteWalletViaCLI walId
         err `shouldBe` "Ok.\n"
         out `shouldNotContain` "CLI Wallet"
         c `shouldBe` ExitSuccess
@@ -148,6 +222,7 @@ specWithCluster = do
         expectValidJSON (Proxy @[ApiAddress]) out
         c `shouldBe` ExitSuccess
   where
+
     createWallet :: Context -> Text -> [Text] -> IO String
     createWallet ctx name mnemonics = do
        let payload = Json [json| {
@@ -158,15 +233,3 @@ specWithCluster = do
        r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
        expectResponseCode @IO HTTP.status202 r
        return (T.unpack $ getFromResponse walletId r)
-
-    mnemonics15 :: [Text]
-    mnemonics15 =
-        [ "network", "empty", "cause", "mean", "expire"
-        , "private", "finger", "accident", "session", "problem"
-        , "absurd", "banner", "stage", "void", "what"]
-
-    mnemonics18 :: [Text]
-    mnemonics18 =
-        [ "whisper", "control", "diary", "solid", "cattle", "salmon"
-        , "whale", "slender", "spread", "ice", "shock", "solve"
-        , "panel", "caution", "upon", "scatter", "broken", "tonight"]

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
@@ -44,15 +44,31 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 specNoCluster :: SpecWith ()
 specNoCluster = do
-    it "CLI - Shows help on bad argument" $  do
+
+    it "CLI - cardano-wallet-launcher shows help on bad argument" $  do
+        (Exit c, Stdout out) <- command [] "cardano-wallet-launcher" ["--bad arg"]
+        out `shouldContain` "cardano-wallet-launcher"
+        c `shouldBe` ExitFailure 1
+
+    describe "CLI - cardano-wallet-launcher shows help with" $  do
+        let test option = it option $ do
+                (Exit c, Stdout out) <- command [] "cardano-wallet-launcher"
+                    [option]
+                out `shouldContain` "cardano-wallet-launcher"
+                c `shouldBe` ExitSuccess
+        forM_ ["-h", "--help"] test
+
+    it "CLI - cardano-wallet shows help on bad argument" $  do
         (Exit c, Stdout out) <- command [] "cardano-wallet" ["--bad arg"]
         out `shouldContain` "Cardano Wallet CLI"
         c `shouldBe` ExitFailure 1
 
-    it "CLI - Shows help with --help" $  do
-        (Exit c, Stdout out) <- command [] "cardano-wallet" ["--help"]
-        out `shouldContain` "Cardano Wallet CLI"
-        c `shouldBe` ExitSuccess
+    describe "CLI - cardano-wallet shows help with" $  do
+        let test option = it option $ do
+                (Exit c, Stdout out) <- command [] "cardano-wallet" [option]
+                out `shouldContain` "Cardano Wallet CLI"
+                c `shouldBe` ExitSuccess
+        forM_ ["-h", "--help"] test
 
     it "CLI - Shows version" $  do
         (Exit c, Stdout out) <- command [] "cardano-wallet" ["--version"]

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -48,6 +48,36 @@ import Test.Integration.Framework.DSL
     , walletName
     , (</>)
     )
+import Test.Integration.Framework.TestData
+    ( addressPoolGapMax
+    , addressPoolGapMin
+    , arabicWalletName
+    , chineseMnemonics18
+    , chineseMnemonics9
+    , falseWalletIds
+    , frenchMnemonics12
+    , frenchMnemonics21
+    , invalidMnemonics12
+    , invalidMnemonics15
+    , japaneseMnemonics12
+    , japaneseMnemonics15
+    , kanjiWalletName
+    , mnemonics12
+    , mnemonics15
+    , mnemonics18
+    , mnemonics21
+    , mnemonics24
+    , mnemonics3
+    , mnemonics6
+    , mnemonics9
+    , passphraseMaxLength
+    , passphraseMinLength
+    , polishWalletName
+    , russianWalletName
+    , specMnemonicSecondFactor
+    , specMnemonicSentence
+    , wildcardsWalletName
+    )
 
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
@@ -1260,13 +1290,6 @@ spec = do
             verify rup expectations
 
  where
-    falseWalletIds =
-            [ ("40 chars hex", replicate 40 '1')
-            , ("40 chars non-hex", replicate 40 'ś')
-            , ("39 chars hex", replicate 39 '1')
-            , ("41 chars hex", replicate 41 '1')
-            ]
-
     getHeaderCases =
               [ ( "No HTTP headers -> 200", None
                 , [expectResponseCode @IO HTTP.status200] )
@@ -1314,115 +1337,3 @@ spec = do
             "old_passphrase": #{oldPass},
             "new_passphrase": #{newPass}
               } |]
-
-    mnemonics3 :: [Text]
-    mnemonics3 = ["diamond", "flee", "window"]
-
-    mnemonics6 :: [Text]
-    mnemonics6 = ["tornado", "canvas", "peasant", "spike", "enrich", "dilemma"]
-
-    mnemonics9 :: [Text]
-    mnemonics9 = ["subway", "tourist", "abstract", "roast", "border", "curious",
-        "exercise", "work", "narrow"]
-
-    mnemonics12 :: [Text]
-    mnemonics12 = ["agent", "siren", "roof", "water", "giant", "pepper",
-        "obtain", "oxygen", "treat", "vessel", "hip", "garlic"]
-
-    mnemonics15 :: [Text]
-    mnemonics15 = ["network", "empty", "cause", "mean", "expire", "private",
-        "finger", "accident", "session", "problem", "absurd", "banner", "stage",
-        "void", "what"]
-
-    mnemonics18 :: [Text]
-    mnemonics18 = ["whisper", "control", "diary", "solid", "cattle", "salmon",
-        "whale", "slender", "spread", "ice", "shock", "solve", "panel",
-        "caution", "upon", "scatter", "broken", "tonight"]
-
-    mnemonics21 :: [Text]
-    mnemonics21 = ["click", "puzzle", "athlete", "morning", "fold", "retreat",
-        "across", "timber", "essay", "drill", "finger", "erase", "galaxy",
-        "spoon", "swift", "eye", "awesome", "shrimp", "depend", "zebra", "token"]
-
-    mnemonics24 :: [Text]
-    mnemonics24 = ["decade", "distance", "denial", "jelly", "wash", "sword",
-        "olive", "perfect", "jewel", "renew", "wrestle", "cupboard", "record",
-        "scale", "pattern", "invite", "other", "fruit", "gloom", "west", "oak",
-        "deal", "seek", "hand"]
-
-    invalidMnemonics12 :: [Text]
-    invalidMnemonics12 = ["word","word","word","word","word","word","word",
-            "word","word","word","word","hill"]
-
-    invalidMnemonics15 :: [Text]
-    invalidMnemonics15 = ["word","word","word","word","word","word","word",
-        "word","word","word","word","word","word","word","word"]
-
-    specMnemonicSentence :: [Text]
-    specMnemonicSentence = ["squirrel", "material", "silly", "twice", "direct",
-        "slush", "pistol", "razor", "become", "junk", "kingdom", "flee",
-        "squirrel", "silly", "twice"]
-
-    specMnemonicSecondFactor :: [Text]
-    specMnemonicSecondFactor = ["squirrel", "material", "silly", "twice",
-        "direct", "slush", "pistol", "razor", "become"]
-
-    japaneseMnemonics12 :: [Text]
-    japaneseMnemonics12 = ["そうだん",　"ひよう",　"にもつ",　"やさしい",　"きふく",　
-        "ねつい",　"だったい",　"けんてい",　"けいろ",　"ざつがく",　"ほうもん",　"すこし"]
-
-    japaneseMnemonics15 :: [Text]
-    japaneseMnemonics15 = ["うめる", "せんく", "えんぎ", "はんぺん", "おくりがな",
-        "さんち", "きなが", "といれ", "からい", "らくだ", "うえる", "ふめん", "せびろ",
-        "られつ", "なにわ"]
-
-    chineseMnemonics9 :: [Text]
-    chineseMnemonics9 = ["钢", "看", "磁", "塑", "凤", "魏", "世", "腐", "恶" ]
-
-    chineseMnemonics18 :: [Text]
-    chineseMnemonics18 = ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵",
-        "祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"]
-
-    frenchMnemonics12 :: [Text]
-    frenchMnemonics12 = ["palmarès", "supplier", "visuel", "gardien", "adorer",
-        "cordage", "notifier", "réglage", "employer", "abandon", "scénario",
-        "proverbe"]
-
-    frenchMnemonics21 :: [Text]
-    frenchMnemonics21 = ["pliage", "exhorter", "brasier", "chausson", "bloquer",
-        "besace", "sorcier", "absurde", "neutron", "forgeron", "geyser",
-        "moulin", "cynique", "cloche", "baril", "infliger", "rompre", "typique",
-        "renifler", "creuser", "matière"]
-
-    russianWalletName :: Text
-    russianWalletName = "АаБбВвГгДдЕеЁёЖжЗз ИиЙйКкЛлМмНнО оПпРрСсТтУуФф ХхЦцЧчШшЩщЪъ ЫыЬьЭэЮюЯяІ ѢѲѴѵѳѣі"
-
-    polishWalletName :: Text
-    polishWalletName = "aąbcćdeęfghijklłmnoóprsś\r\ntuvwyzżźAĄBCĆDEĘFGHIJKLŁMNOP\rRSŚTUVWYZŻŹ"
-
-    kanjiWalletName :: Text
-    kanjiWalletName = "亜哀挨愛曖悪握圧扱宛嵐安案暗以衣位囲医依委威為畏胃尉異移萎偉椅彙意違維慰\
-    \遺緯域育一壱逸茨芋引印因咽姻員院淫陰飲隠韻右宇羽雨唄鬱畝浦運雲永泳英映栄\n営詠影鋭衛易疫益液駅悦越謁\
-    \閲円延沿炎怨宴媛援園煙猿遠鉛塩演縁艶汚王凹\r\n央応往押旺欧殴桜翁奥横岡屋億憶臆虞乙俺卸音恩温穏下化火加\
-    \可仮何花佳価果河苛科架夏家荷華菓貨渦過嫁暇禍靴寡歌箇稼課蚊牙瓦我画芽賀雅餓介回灰会快戒改怪拐悔海界\
-    \皆械絵開階塊楷解潰壊懐諧貝外劾害崖涯街慨蓋該概骸垣柿各角拡革格核殻郭覚較隔閣確獲嚇穫学岳楽額顎掛潟\
-    \括活喝渇割葛滑褐轄且株釜鎌刈干刊甘汗缶\r"
-
-    arabicWalletName :: Text
-    arabicWalletName = "ثم نفس سقطت وبالتحديد،, جزيرتي باستخدام أن دنو. إذ هنا؟ الستار وتنصيب كان. أهّل ايطاليا، بريطانيا-فرنسا قد أخذ. سليمان، إتفاقية بين ما, يذكر الحدود أي بعد, معاملة بولندا، الإطلاق عل إيو."
-
-    wildcardsWalletName :: Text
-    wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 💕 💞 \
-    \💓 💗 💖 💘 💝 💟 💜 💛 💚 💙0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
-
-    passphraseMinLength :: Int
-    passphraseMinLength = 10
-
-    passphraseMaxLength :: Int
-    passphraseMaxLength = 255
-
-    addressPoolGapMin :: Int
-    addressPoolGapMin = 10
-
-    addressPoolGapMax :: Int
-    addressPoolGapMax = 100


### PR DESCRIPTION
# Issue Number

#96
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added more tests cases for CLI (including tests for testing wallet creation)
- [ ] Did minor fixes in CLI: 
 - making display of help with consistent exit code in `cardano-wallet-launcher` and `cardano-wallet` for both parameters (`--help` and `-h`)
 - making `mnemonic generate` to always show `Invalid mnemonic size. Expected one of: 9,12,15,18,21,24` for invalid `--size` (it used to show rather unpleasent `Int is an integer number between -9223372036854775808 and 9223372036854775807.` when the provided `--size` was not Int)
- [ ] did slight refactoring (moving data used in test to separate module `TestData.hs` and extracting methods for interacting with CLI to `DSL.hs`)


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
