### PR TITLE
Take into account out-of-process executions for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - WALLET_LAUNCHER_CHECKSUM=$HOME/.local/bin/cardano-wallet-launcher.sha256
     - STACK_WORK_CACHE=$HOME/.local/stack-work.tar.gz
     - PATH=$PATH:$HOME/.cargo/bin:$HOME/.local/bin
-
+    - LOCAL_MIX_DIR=.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/hpc/
 
 # Use the Travis Rust build tools for cardano-http-bridge.
 language: rust
@@ -104,7 +104,7 @@ jobs:
     - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/http-bridge/test/data/cardano-http-bridge/hermes-testnet.tar.gz
     - tar xzf hermes-testnet.tar.gz -C $HOME
     - stack --no-terminal test --coverage
-    - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work
+    - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work lib/**/*.tix
 
   - stage: deploy 🚀
     if: type = push AND branch = master
@@ -124,15 +124,25 @@ jobs:
     script:
     - tar xzf $STACK_WORK_CACHE
     - export LTS=$(cat stack.yaml | grep resolver) # Extract the LTS from the stack.yaml
-    - git clone https://github.com/rubik/stack-hpc-coveralls && cd stack-hpc-coveralls && git checkout 3d8352d5642ab214a7a574bd797880ae39595a44 && echo $LTS > stack.yaml
-    - stack --no-terminal install
-    - cd - && shc combined all
+    - git clone https://github.com/rubik/stack-hpc-coveralls && cd stack-hpc-coveralls && git checkout 3d8352d5642ab214a7a574bd797880ae39595a44 && echo $LTS > stack.yaml && cd -
+    - stack --no-terminal install hpc
+    # Ignore modules that are full of Template Haskell auto-generated code
+    - cd lib/core
+    - find $LOCAL_MIX_DIR -type f -name "Cardano.Wallet.DB.Sqlite.TH.mix" > overlay.hpc
+    - 'sed -i "s/.*hpc\/\(.*\).mix/module \"\1\" {}/" overlay.hpc'
+    - stack exec -- hpc overlay --hpcdir $LOCAL_MIX_DIR overlay.hpc > Cardano.Wallet.DB.Sqlite.TH.tix
+    - 'sed -i "s/0,/1,/g" Cardano.Wallet.DB.Sqlite.TH.tix'
+    - cd -
+    # Re-build the coverage report taking .tix from executables running outside of the test suites
+    - stack hpc report --all lib/**/*.tix
+    - shc combined custom
 
   - stage: deploy 🚀
     if: tag =~ ^v
     name: "Executables"
     script:
     - tar xzf $STACK_WORK_CACHE
+    - stack --no-terminal install
     - sha256sum $WALLET_CLI | head -c 64 > $WALLET_CLI_CHECKSUM
     - ls $WALLET_CLI
     - ls $WALLET_CLI_CHECKSUM

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -72,8 +72,9 @@ library
       Cardano.Wallet.Api.Types
       Cardano.Wallet.DB
       Cardano.Wallet.DB.MVar
-      Cardano.Wallet.DB.SqliteTypes
       Cardano.Wallet.DB.Sqlite
+      Cardano.Wallet.DB.Sqlite.TH
+      Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.Network
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDiscovery

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1,18 +1,6 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-
-{-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -26,15 +14,12 @@ module Cardano.Wallet.DB.Sqlite
 
 import Prelude
 
-
 import Cardano.Wallet.DB
     ( DBLayer (..)
     , ErrNoSuchWallet (..)
     , ErrWalletAlreadyExists (..)
     , PrimaryKey (..)
     )
-import Cardano.Wallet.DB.SqliteTypes
-    ( TxId, sqlSettings' )
 import Conduit
     ( runResourceT )
 import Control.Monad
@@ -53,10 +38,6 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Text
     ( Text )
-import Data.Time.Clock
-    ( UTCTime )
-import Data.Word
-    ( Word32 )
 import Database.Persist.Sql
     ( LogFunc
     , Update (..)
@@ -73,137 +54,19 @@ import Database.Persist.Sql
     )
 import Database.Persist.Sqlite
     ( SqlBackend, SqlPersistM, SqlPersistT, wrapConnection )
-import Database.Persist.TH
-    ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
 import Database.Sqlite
     ( Error (ErrorConstraint), SqliteException (SqliteException) )
-import GHC.Generics
-    ( Generic (..) )
-import Numeric.Natural
-    ( Natural )
 import System.IO
     ( stderr )
 import System.Log.FastLogger
     ( fromLogStr )
 
+import Cardano.Wallet.DB.Sqlite.TH
+
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
-
-share
-    [ mkPersist sqlSettings'
-    , mkDeleteCascade sqlSettings'
-    , mkMigrate "migrateAll"
-    ]
-    [persistLowerCase|
-
--- Wallet IDs, address discovery state, and metadata.
-Wallet
-    walTableId                 W.WalletId     sql=wallet_id
-    walTableName               Text           sql=name
-    walTablePassphraseLastUpdatedAt  UTCTime Maybe  sql=passphrase_last_updated_at
-    walTableStatus             W.WalletState  sql=status
-    walTableDelegation         Text Maybe     sql=delegation
-
-    Primary walTableId
-    deriving Show Generic
-
--- The private key for each wallet. This is in a separate table simply so that
--- "SELECT * FROM wallet" won't print keys.
-PrivateKey                                  sql=private_key
-    privateKeyTableWalletId  W.WalletId     sql=wallet_id
-    privateKeyTableRootKey   B8.ByteString  sql=root
-    privateKeyTableHash      B8.ByteString  sql=hash
-
-    Primary privateKeyTableWalletId
-    Foreign Wallet fk_wallet_private_key privateKeyTableWalletId
-
-    deriving Show Generic
-
--- Maps a transaction ID to its metadata (which is calculated when applying
--- blocks).
---
--- TxMeta is specific to a wallet because multiple wallets may have the same
--- transaction with different metadata values. The associated inputs and outputs
--- of the transaction are in the TxIn and TxOut tables.
-TxMeta
-    txMetaTableTxId       TxId         sql=tx_id
-    txMetaTableWalletId   W.WalletId   sql=wallet_id
-    txMetaTableStatus     W.TxStatus   sql=status
-    txMetaTableDirection  W.Direction  sql=direction
-    txMetaTableSlotId     W.SlotId     sql=slot
-    txMetaTableAmount     Natural      sql=amount
-
-    Primary txMetaTableTxId txMetaTableWalletId
-    Foreign Wallet fk_wallet_tx_meta txMetaTableWalletId
-    deriving Show Generic
-
--- A transaction input associated with TxMeta.
---
--- There is no wallet ID because these values depend only on the transaction,
--- not the wallet. txInputTableTxId is referred to by TxMeta and PendingTx
-TxIn
-    txInputTableTxId         TxId        sql=tx_id
-    txInputTableSourceTxId   TxId        sql=source_id
-    txInputTableSourceIndex  Word32      sql=source_index
-
-    Primary txInputTableTxId txInputTableSourceTxId txInputTableSourceIndex
-    deriving Show Generic
-
--- A transaction output associated with TxMeta.
---
--- There is no wallet ID because these values depend only on the transaction,
--- not the wallet. txOutputTableTxId is referred to by TxMeta and PendingTx
-TxOut
-    txOutputTableTxId     TxId        sql=tx_id
-    txOutputTableIndex    Word32      sql=index
-    txOutputTableAddress  W.Address   sql=address
-    txOutputTableAmount   W.Coin      sql=amount
-
-    Primary txOutputTableTxId txOutputTableIndex
-    deriving Show Generic
-
--- A checkpoint for a given wallet is referred to by (wallet_id, slot).
--- Checkpoint data such as UTxO will refer to this table.
-Checkpoint
-    checkpointTableWalletId    W.WalletId  sql=wallet_id
-    checkpointTableSlot        W.SlotId    sql=slot
-
-    Primary checkpointTableWalletId checkpointTableSlot
-    Foreign Wallet fk_wallet_checkpoint checkpointTableWalletId
-
-    deriving Show Generic
-
--- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
--- TxOut. This table does not need to refer to the TxIn or TxOut tables. All
--- necessary information for the UTxO is in this table.
-UTxO                                     sql=utxo
-
-    -- The wallet checkpoint (wallet_id, slot)
-    utxoTableWalletId        W.WalletId  sql=wallet_id
-    utxoTableCheckpointSlot  W.SlotId    sql=slot
-
-    -- TxIn
-    utxoTableInputId         TxId        sql=input_tx_id
-    utxoTableInputIndex      Word32      sql=input_index
-
-    -- TxOut
-    utxoTableOutputAddress   W.Address   sql=output_address
-    utxoTableOutputCoin      W.Coin      sql=output_coin
-
-    Primary
-        utxoTableWalletId
-        utxoTableCheckpointSlot
-        utxoTableInputId
-        utxoTableInputIndex
-        utxoTableOutputAddress
-        utxoTableOutputCoin
-
-    Foreign Checkpoint fk_checkpoint_utxo utxoTableWalletId utxoTableCheckpointSlot
-    deriving Show Generic
-|]
-
 
 ----------------------------------------------------------------------------
 -- Sqlite connection set up

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Auto-generated Sqlite & Persistent machinery via Template-Haskell. This has
+-- been moved into a separate file so that we can treat it slightly differently
+-- when computing code-coverage.
+--
+-- More than 6K lines end-up being generated from the instructions below! As a
+-- result, we're going to ignore code-coverage on the following module and, no
+-- hand-written functions should be written in this module!
+
+module Cardano.Wallet.DB.Sqlite.TH where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Types
+    ( TxId, sqlSettings' )
+import Data.Text
+    ( Text )
+import Data.Time.Clock
+    ( UTCTime )
+import Data.Word
+    ( Word32 )
+import Database.Persist.TH
+    ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
+import GHC.Generics
+    ( Generic (..) )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Data.ByteString.Char8 as B8
+
+share
+    [ mkPersist sqlSettings'
+    , mkDeleteCascade sqlSettings'
+    , mkMigrate "migrateAll"
+    ]
+    [persistLowerCase|
+
+-- Wallet IDs, address discovery state, and metadata.
+Wallet
+    walTableId                 W.WalletId     sql=wallet_id
+    walTableName               Text           sql=name
+    walTablePassphraseLastUpdatedAt  UTCTime Maybe  sql=passphrase_last_updated_at
+    walTableStatus             W.WalletState  sql=status
+    walTableDelegation         Text Maybe     sql=delegation
+
+    Primary walTableId
+    deriving Show Generic
+
+-- The private key for each wallet. This is in a separate table simply so that
+-- "SELECT * FROM wallet" won't print keys.
+PrivateKey                                  sql=private_key
+    privateKeyTableWalletId  W.WalletId     sql=wallet_id
+    privateKeyTableRootKey   B8.ByteString  sql=root
+    privateKeyTableHash      B8.ByteString  sql=hash
+
+    Primary privateKeyTableWalletId
+    Foreign Wallet fk_wallet_private_key privateKeyTableWalletId
+
+    deriving Show Generic
+
+-- Maps a transaction ID to its metadata (which is calculated when applying
+-- blocks).
+--
+-- TxMeta is specific to a wallet because multiple wallets may have the same
+-- transaction with different metadata values. The associated inputs and outputs
+-- of the transaction are in the TxIn and TxOut tables.
+TxMeta
+    txMetaTableTxId       TxId         sql=tx_id
+    txMetaTableWalletId   W.WalletId   sql=wallet_id
+    txMetaTableStatus     W.TxStatus   sql=status
+    txMetaTableDirection  W.Direction  sql=direction
+    txMetaTableSlotId     W.SlotId     sql=slot
+    txMetaTableAmount     Natural      sql=amount
+
+    Primary txMetaTableTxId txMetaTableWalletId
+    Foreign Wallet fk_wallet_tx_meta txMetaTableWalletId
+    deriving Show Generic
+
+-- A transaction input associated with TxMeta.
+--
+-- There is no wallet ID because these values depend only on the transaction,
+-- not the wallet. txInputTableTxId is referred to by TxMeta and PendingTx
+TxIn
+    txInputTableTxId         TxId        sql=tx_id
+    txInputTableSourceTxId   TxId        sql=source_id
+    txInputTableSourceIndex  Word32      sql=source_index
+
+    Primary txInputTableTxId txInputTableSourceTxId txInputTableSourceIndex
+    deriving Show Generic
+
+-- A transaction output associated with TxMeta.
+--
+-- There is no wallet ID because these values depend only on the transaction,
+-- not the wallet. txOutputTableTxId is referred to by TxMeta and PendingTx
+TxOut
+    txOutputTableTxId     TxId        sql=tx_id
+    txOutputTableIndex    Word32      sql=index
+    txOutputTableAddress  W.Address   sql=address
+    txOutputTableAmount   W.Coin      sql=amount
+
+    Primary txOutputTableTxId txOutputTableIndex
+    deriving Show Generic
+
+-- A checkpoint for a given wallet is referred to by (wallet_id, slot).
+-- Checkpoint data such as UTxO will refer to this table.
+Checkpoint
+    checkpointTableWalletId    W.WalletId  sql=wallet_id
+    checkpointTableSlot        W.SlotId    sql=slot
+
+    Primary checkpointTableWalletId checkpointTableSlot
+    Foreign Wallet fk_wallet_checkpoint checkpointTableWalletId
+
+    deriving Show Generic
+
+-- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
+-- TxOut. This table does not need to refer to the TxIn or TxOut tables. All
+-- necessary information for the UTxO is in this table.
+UTxO                                     sql=utxo
+
+    -- The wallet checkpoint (wallet_id, slot)
+    utxoTableWalletId        W.WalletId  sql=wallet_id
+    utxoTableCheckpointSlot  W.SlotId    sql=slot
+
+    -- TxIn
+    utxoTableInputId         TxId        sql=input_tx_id
+    utxoTableInputIndex      Word32      sql=input_index
+
+    -- TxOut
+    utxoTableOutputAddress   W.Address   sql=output_address
+    utxoTableOutputCoin      W.Coin      sql=output_coin
+
+    Primary
+        utxoTableWalletId
+        utxoTableCheckpointSlot
+        utxoTableInputId
+        utxoTableInputIndex
+        utxoTableOutputAddress
+        utxoTableOutputCoin
+
+    Foreign Checkpoint fk_checkpoint_utxo utxoTableWalletId utxoTableCheckpointSlot
+    deriving Show Generic
+|]

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -16,7 +16,7 @@
 -- The ToJSON/FromJSON and Read instance orphans exist due to class constraints
 -- on Persistent functions.
 
-module Cardano.Wallet.DB.SqliteTypes where
+module Cardano.Wallet.DB.Sqlite.Types where
 
 import Prelude
 

--- a/lib/http-bridge/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/Network/HttpBridgeSpec.hs
@@ -179,7 +179,7 @@ spec = do
         HttpBridge.newNetworkLayer port
     closeBridge (handle, _) = do
         cancel handle
-        threadDelay 500000
+        threadDelay 1000000
     startBridge = do
         handle <- async $ launch
             [ Command "cardano-http-bridge"

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -61,7 +61,7 @@ spec = do
     port = 1337
     closeBridge (handle, _) = do
         cancel handle
-        threadDelay 500000
+        threadDelay 1000000
     startBridge = do
         handle <- async $ launch
             [ Command "cardano-http-bridge"

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLISpec.hs
@@ -58,7 +58,6 @@ version = "2019.5.8"
 
 specNoCluster :: SpecWith ()
 specNoCluster = do
-
     it "CLI - Shows version" $  do
         (Exit c, Stdout out) <- cardanoWalletCLI ["--version"]
         let v = T.dropWhileEnd (== '\n') (T.pack out)
@@ -96,24 +95,25 @@ specNoCluster = do
 
     describe "CLI - Can generate mnemonics with different sizes" $ do
         let test size = it ("--size=" <> show size) $ do
-                (Exit c, Stdout out) <- generateMnemonicsViaCLI ["--size", show size]
+                (Exit c, Stdout out) <-
+                    generateMnemonicsViaCLI ["--size", show size]
                 length (words out) `shouldBe` size
                 c `shouldBe` ExitSuccess
         forM_ [9, 12, 15, 18, 21, 24] test
 
     describe "CLI - It can't generate mnemonics with an invalid size" $ do
-        let sizes = ["15.5", "3", "6", "14", "abc", "👌", "0", "~!@#%" , "-1000"
-                , "1000"]
+        let sizes =
+                ["15.5", "3", "6", "14", "abc", "👌", "0", "~!@#%" , "-1000", "1000"]
         forM_ sizes $ \(size) -> it ("--size=" <> size) $ do
-            (Exit c, Stdout out, Stderr err) <- generateMnemonicsViaCLI ["--size", size]
+            (Exit c, Stdout out, Stderr err) <-
+                generateMnemonicsViaCLI ["--size", size]
             c `shouldBe` ExitFailure 1
-            err `shouldBe` "Invalid mnemonic size. Expected one of:\
-            \ 9,12,15,18,21,24\n"
+            err `shouldBe`
+                "Invalid mnemonic size. Expected one of: 9,12,15,18,21,24\n"
             out `shouldBe` mempty
 
 specWithCluster :: SpecWith Context
 specWithCluster = do
-
     describe "CLI1 - Can create wallet with different mnemonic sizes" $ do
         forM_ ["15", "18", "21", "24"] $ \(size) -> it size $ \_ -> do
             let walletName = "Wallet created via CLI"
@@ -188,7 +188,6 @@ specWithCluster = do
             else
                 c `shouldBe` ExitFailure 1
 
-
     it "CLI - Can list wallets" $ \ctx -> do
         _ <- createWallet ctx "1st CLI Wallet" mnemonics15
         _ <- createWallet ctx "2nd CLI Wallet" mnemonics18
@@ -222,7 +221,6 @@ specWithCluster = do
         expectValidJSON (Proxy @[ApiAddress]) out
         c `shouldBe` ExitSuccess
   where
-
     createWallet :: Context -> Text -> [Text] -> IO String
     createWallet ctx name mnemonics = do
        let payload = Json [json| {


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#96 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

This PR addresses 2 issues:

- [x] I have taken into account out-of-process executions for code coverage (cf NOTE #1 below)
- [x] I have ignored coverage computation for auto-generated files (cf NOTE #2 below)

# Comments

<!-- Additional comments or screenshots to attach if any -->

**NOTE #1**
I noticed that we don't get coverage for integration tests which runs in a separate process (like the CLISpec which launches commands and observe the output of the command). So,this is an attempt to instrument the CI to also take the coverage resulting from those out-of-process executions.

**NOTE #2**
We use some template-haskell in the SQLite implementation to auto-generate a bunch of Haskell types from a few lines of SQL. This is great, but it generates roughly 6000 lines of Haskell, for which, we don't specifically have coverage (and have no way to really know what to cover unless we look at the intermediate splices generated by GHC ... meh). So I've simply "ignored" those lines in CI, so that we don't get half of our source code being flagged as "not covered".

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
