### PR TITLE
First end-to-end transaction Integration test (with http-bridge)

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -30,7 +30,10 @@ module Cardano.Wallet
     , ErrUpdatePassphrase (..)
     , ErrWalletAlreadyExists (..)
     , ErrWithRootKey (..)
-    , ErrWrongPassphrase(..)
+    , ErrWrongPassphrase (..)
+    , ErrMkStdTx (..)
+    , ErrPostTx (..)
+    , ErrNetworkUnreachable (..)
 
     -- * Construction
     , newWalletLayer
@@ -48,7 +51,7 @@ import Cardano.Wallet.DB
     , PrimaryKey (..)
     )
 import Cardano.Wallet.Network
-    ( ErrPostTx (..), NetworkLayer (..) )
+    ( ErrNetworkUnreachable (..), ErrPostTx (..), NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (RootK)
     , ErrWrongPassphrase (..)
@@ -110,7 +113,7 @@ import Cardano.Wallet.Primitive.Types
     , slotRatio
     )
 import Cardano.Wallet.Transaction
-    ( ErrMkStdTx, TransactionLayer (..) )
+    ( ErrMkStdTx (..), TransactionLayer (..) )
 import Control.Arrow
     ( first )
 import Control.Concurrent

--- a/lib/http-bridge/src/Cardano/Wallet/Transaction/HttpBridge.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/Transaction/HttpBridge.hs
@@ -199,7 +199,7 @@ newTransactionLayer = TransactionLayer
     --  | break                       -- 1
     --  | empty attributes            -- 1
     sizeOfTx :: Int -> [TxOut] -> [Coin] -> Int
-    sizeOfTx n outs chngs = 6
+    sizeOfTx n outs chngs = 7
         + sum (map sizeOfTxIn [0..n-1])
         + sum (map sizeOfTxOut outs)
         + sum (map sizeOfChange chngs)

--- a/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Framework/DSL.hs
@@ -41,6 +41,9 @@ module Test.Integration.Framework.DSL
     , walletId
     , walletName
     , state
+    , amount
+    , direction
+    , status
 
     -- * Helpers
     , (</>)
@@ -72,7 +75,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.Mnemonic
     ( mnemonicToText )
 import Cardano.Wallet.Primitive.Types
-    ( PoolId (..)
+    ( Direction (..)
+    , PoolId (..)
+    , TxStatus (..)
     , WalletBalance (..)
     , WalletDelegation (..)
     , WalletId (..)
@@ -376,6 +381,33 @@ walletId =
     _get = T.pack . show . getWalletId . getApiT . view typed
     _set :: HasType (ApiT WalletId) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletId (unsafeCreateDigest v)) s
+
+amount :: HasType (Quantity "lovelace" Natural) s => Lens' s Int
+amount =
+    lens _get _set
+  where
+    _get :: HasType (Quantity "lovelace" Natural) s => s -> Int
+    _get = fromIntegral . fromQuantity @"lovelace" @Natural . view typed
+    _set :: HasType (Quantity "lovelace" Natural) s => (s, Int) -> s
+    _set (s, v) = set typed (Quantity @"lovelace" @Natural $ fromIntegral v) s
+
+direction :: HasType (ApiT Direction) s => Lens' s Direction
+direction =
+    lens _get _set
+  where
+    _get :: HasType (ApiT Direction) s => s -> Direction
+    _get = getApiT . view typed
+    _set :: HasType (ApiT Direction) s => (s, Direction) -> s
+    _set (s, v) = set typed (ApiT v) s
+
+status :: HasType (ApiT TxStatus) s => Lens' s TxStatus
+status =
+    lens _get _set
+  where
+    _get :: HasType (ApiT TxStatus) s => s -> TxStatus
+    _get = getApiT . view typed
+    _set :: HasType (ApiT TxStatus) s => (s, TxStatus) -> s
+    _set (s, v) = set typed (ApiT v) s
 
 --
 -- Helpers

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/Transactions.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/Transactions.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Integration.Scenario.Transactions
@@ -8,31 +11,82 @@ module Test.Integration.Scenario.Transactions
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiWallet )
+    ( ApiAddress, ApiTransaction, ApiWallet )
+import Cardano.Wallet.Primitive.Types
+    ( Direction (..), TxStatus (..) )
 import Data.Generics.Internal.VL.Lens
-    ( view )
+    ( view, (^.) )
 import Test.Hspec
     ( SpecWith, it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)
     , Payload (..)
+    , amount
     , balanceAvailable
     , balanceTotal
+    , direction
+    , expectEventually
     , expectFieldEqual
+    , expectResponseCode
+    , expectSuccess
     , fixtureWallet
+    , json
     , request
+    , status
+    , unsafeRequest
     , verify
     , walletId
     )
 
+import qualified Network.HTTP.Types.Status as HTTP
+
 spec :: SpecWith Context
 spec = do
-    it "Temporary Transaction Test" $ \ctx -> do
+    it "Check fixture transaction" $ \ctx -> do
         wid <- view walletId <$> fixtureWallet ctx
         r' <- request @ApiWallet ctx ("GET", "v2/wallets/" <> wid) Default Empty
-        let oneMillionAda = 1 * 1000 * 1000 * 1000 * 1000
         verify r'
             [ expectFieldEqual balanceTotal oneMillionAda
             , expectFieldEqual balanceAvailable oneMillionAda
             ]
+
+    it "Single Output Transaction" $ \ctx -> do
+        (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
+        (_, addrs) <-
+            unsafeRequest @[ApiAddress] ctx ("GET", getAddresses wb) Empty
+        let destination = (addrs !! 1) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": "cardano-wallet"
+            }|]
+
+        r <- request @ApiTransaction ctx ("POST", postTx wa) Default payload
+        verify r
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectFieldEqual amount 168654
+            , expectFieldEqual direction Outgoing
+            , expectFieldEqual status Pending
+            ]
+
+        r' <- request @ApiWallet ctx ("GET", getWallet wb) Default payload
+        verify r'
+            [ expectSuccess
+            , expectEventually ctx balanceAvailable (oneMillionAda + 1)
+            ]
+  where
+    oneMillionAda =
+        1 * 1000 * 1000 * 1000 * 1000
+    getAddresses (w :: ApiWallet) =
+        "v2/wallets/" <> w ^. walletId <> "/addresses"
+    postTx (w :: ApiWallet) =
+        "v2/wallets/" <> w ^. walletId <> "/transactions"
+    getWallet (w :: ApiWallet) =
+        "v2/wallets/" <> w ^. walletId


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added a simple scenario illustrating sending a transaction from a wallet to another. The transaction has a single output and only selects one input, but it's a start :tada:  

# Comments

<!-- Additional comments or screenshots to attach if any -->

I _slightly_ adjusted the tx size estimator... Seems like we are _sometimes_ off by one byte. I say sometimes because, the node will sometimes be fine with our calculation, and sometimes compute a size that is one byte bigger than what we compute. This is rather weird as I would expect the calculation of a transaction size to be 100% deterministic but cardano-sl is full of surprises. T be honest, we don't have time anymore to look deeper into this. Going for the simple approach here and added `+1` to our estimate :/ 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
