### PR TITLE
Sqlite: add checkpoints and transactions to DBLayer

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -38,7 +38,6 @@ library
     , basement
     , bytestring
     , cardano-crypto
-    , conduit
     , containers
     , cryptonite
     , deepseq
@@ -54,6 +53,7 @@ library
     , persistent
     , persistent-sqlite
     , persistent-template
+    , resourcet
     , servant
     , servant-server
     , text

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -30,14 +30,12 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( AddressPoolXPub (..), TxId (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), deserializeXPrv, serializeXPrv )
-import Control.Monad.Trans.Resource
-    ( runResourceT )
 import Control.Concurrent.MVar
     ( newMVar, withMVar )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( void, mapM_ )
+    ( mapM_, void )
 import Control.Monad.Catch
     ( MonadCatch (..), handleJust )
 import Control.Monad.IO.Class
@@ -50,6 +48,8 @@ import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Control.Monad.Trans.Maybe
     ( MaybeT (..) )
+import Control.Monad.Trans.Resource
+    ( runResourceT )
 import Data.Bifunctor
     ( bimap )
 import Data.Coerce

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -592,9 +592,8 @@ insertAddressPool ap = do
     pure apid
 
 mkSeqStatePendingIxs :: SeqStateId -> W.PendingIxs -> [SeqStatePendingIx]
-mkSeqStatePendingIxs ssid ixs =
-    [ SeqStatePendingIx ssid i (W.getIndex ix)
-    | (i, ix) <- zip [0..] (W.pendingIxsToList ixs) ]
+mkSeqStatePendingIxs ssid =
+    fmap (SeqStatePendingIx ssid . W.getIndex) . W.pendingIxsToList
 
 selectAddressPool
     :: forall t chain. (W.KeyToAddress t, Typeable chain)
@@ -617,7 +616,7 @@ selectSeqStatePendingIxs :: SeqStateId -> SqlPersistM W.PendingIxs
 selectSeqStatePendingIxs ssid =
     W.pendingIxsFromList . fromRes <$> selectList
         [SeqStatePendingIxSeqStateId ==. ssid]
-        [Asc SeqStatePendingIxPos]
+        [Desc SeqStatePendingIxIndex]
   where
     fromRes = fmap (W.Index . seqStatePendingIxIndex . entityVal)
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( AddressPoolXPub (..), TxId (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), deserializeXPrv, serializeXPrv )
-import Conduit
+import Control.Monad.Trans.Resource
     ( runResourceT )
 import Control.Concurrent.MVar
     ( newMVar, withMVar )

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -24,7 +24,7 @@ module Cardano.Wallet.DB.Sqlite.TH where
 import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Types
-    ( TxId, sqlSettings' )
+    ( AddressPoolXPub, TxId, sqlSettings' )
 import Data.Text
     ( Text )
 import Data.Time.Clock
@@ -38,6 +38,7 @@ import GHC.Generics
 import Numeric.Natural
     ( Natural )
 
+import qualified Cardano.Wallet.Primitive.AddressDiscovery as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString.Char8 as B8
 
@@ -151,5 +152,72 @@ UTxO                                     sql=utxo
         utxoTableOutputCoin
 
     Foreign Checkpoint fk_checkpoint_utxo utxoTableWalletId utxoTableCheckpointSlot
+    deriving Show Generic
+
+-- The pending transactions for a wallet checkpoint.
+PendingTx
+
+    -- The wallet checkpoint (wallet_id, slot)
+    pendingTxTableWalletId        W.WalletId  sql=wallet_id
+    pendingTxTableCheckpointSlot  W.SlotId    sql=slot
+
+    -- Transaction TxIn and TxOut
+    pendingTxTableId2             TxId        sql=tx_id
+
+    Primary pendingTxTableWalletId pendingTxTableCheckpointSlot pendingTxTableId2
+    Foreign Checkpoint fk_pending_tx pendingTxTableWalletId pendingTxTableCheckpointSlot
+    deriving Show Generic
+
+-- State for sequential scheme address discovery
+SeqState
+
+    -- The wallet checkpoint (wallet_id, slot)
+    seqStateTableWalletId        W.WalletId  sql=wallet_id
+    seqStateTableCheckpointSlot  W.SlotId    sql=slot
+
+    UniqueSeqState seqStateTableWalletId seqStateTableCheckpointSlot
+    Foreign Checkpoint fk_checkpoint_seq_state seqStateTableWalletId seqStateTableCheckpointSlot
+    deriving Show Generic
+
+-- Address pool attributes.
+AddressPool
+    addressPoolAccountPubKey        AddressPoolXPub
+    addressPoolGap                  W.AddressPoolGap
+
+    deriving Show Generic
+
+-- Mapping of pool addresses to indices.
+AddressPoolIndex
+    indexAddressPool   AddressPoolId
+    indexAddress       W.Address
+    indexNumber        Word32
+
+    deriving Show Generic
+
+-- Sequential address discovery scheme -- internal address pool
+-- associated with state record.
+SeqStateInternalPool
+    seqStateInternalPoolSeqStateId   SeqStateId
+    seqStateInternalPoolAddressPool  AddressPoolId
+    UniqueSeqStateInternalPool seqStateInternalPoolSeqStateId seqStateInternalPoolAddressPool
+    Primary seqStateInternalPoolSeqStateId
+    deriving Show Generic
+
+-- Sequential address discovery scheme -- external address pool
+-- associated with state record.
+SeqStateExternalPool
+    seqStateExternalPoolSeqStateId   SeqStateId
+    seqStateExternalPoolAddressPool  AddressPoolId
+    UniqueSeqStateExternalPool seqStateExternalPoolSeqStateId seqStateExternalPoolAddressPool
+    Primary seqStateExternalPoolSeqStateId
+    deriving Show Generic
+
+-- Sequential address discovery scheme -- pending change indexes
+SeqStatePendingIx
+    seqStatePendingIxSeqStateId     SeqStateId
+    seqStatePendingIxPos            Word32
+    seqStatePendingIxIndex          Word32
+
+    Primary seqStatePendingIxSeqStateId seqStatePendingIxPos
     deriving Show Generic
 |]

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -215,9 +215,8 @@ SeqStateExternalPool
 -- Sequential address discovery scheme -- pending change indexes
 SeqStatePendingIx
     seqStatePendingIxSeqStateId     SeqStateId
-    seqStatePendingIxPos            Word32
     seqStatePendingIxIndex          Word32
 
-    Primary seqStatePendingIxSeqStateId seqStatePendingIxPos
+    Primary seqStatePendingIxSeqStateId seqStatePendingIxIndex
     deriving Show Generic
 |]

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -31,7 +31,8 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , getKey
     , Depth (..)
     , Index
-    , getIndex
+      (..) -- fixme: internal constructor
+    -- , getIndex
     , DerivationType (..)
     , publicKey
     , digest

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -30,9 +30,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
       Key
     , getKey
     , Depth (..)
-    , Index
-      (..) -- fixme: internal constructor
-    -- , getIndex
+    , Index (..)
     , DerivationType (..)
     , publicKey
     , digest

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -45,12 +45,11 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , mkAddressPool
     , lookupAddress
 
-    , indexedAddresses -- fixme: internal
-
     -- * Pending Change Indexes
     , PendingIxs
-      (..) -- fixme: internal
     , emptyPendingIxs
+    , pendingIxsToList
+    , pendingIxsFromList
 
     -- ** State
     , SeqState (..)
@@ -398,7 +397,8 @@ nextAddresses _ !key (AddressPoolGap !g) !cc !fromIx =
 -------------------------------------------------------------------------------}
 
 -- | An ordered set of pending indexes. This keep track of indexes used
-newtype PendingIxs = PendingIxs [Index 'Soft 'AddressK]
+newtype PendingIxs = PendingIxs
+    { pendingIxsToList :: [Index 'Soft 'AddressK] }
     deriving stock (Generic, Show)
 instance NFData PendingIxs
 
@@ -422,6 +422,11 @@ updatePendingIxs
     -> PendingIxs
 updatePendingIxs ix (PendingIxs ixs) =
     PendingIxs $ L.filter (> ix) ixs
+
+-- | Construct a 'PendingIxs' from a list, ensuring that it is a set of indexes
+-- in descending order.
+pendingIxsFromList :: [Index 'Soft 'AddressK] -> PendingIxs
+pendingIxsFromList = PendingIxs . reverse . map head . L.group . L.sort
 
 -- | Get the next change index; If every available indexes have already been
 -- taken, we'll rotate the pending set and re-use already provided indexes.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -45,8 +45,11 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , mkAddressPool
     , lookupAddress
 
+    , indexedAddresses -- fixme: internal
+
     -- * Pending Change Indexes
     , PendingIxs
+      (..) -- fixme: internal
     , emptyPendingIxs
 
     -- ** State

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -29,7 +29,6 @@ module Cardano.Wallet.Primitive.Model
     (
     -- * Type
       Wallet
-        (..) -- fixme: internal
 
     -- * Construction & Modification
     , initWallet
@@ -37,6 +36,7 @@ module Cardano.Wallet.Primitive.Model
     , applyBlock
     , applyBlocks
     , newPending
+    , unsafeInitWallet
 
     -- * Accessors
     , currentTip
@@ -213,6 +213,24 @@ newPending
     -> Wallet s t
 newPending !tx (Wallet !utxo !pending !tip !s) =
     Wallet utxo (Set.insert tx pending) tip s
+
+-- | Constructs a wallet from the exact given state. Using this function instead
+-- of 'initWallet' and 'applyBlock' allows the wallet invariants to be
+-- broken. Therefore it should only be used in the special case of loading
+-- wallet checkpoints from the database (where it is assumed a valid wallet was
+-- stored into the database).
+unsafeInitWallet
+    :: (IsOurs s, NFData s, Show s, TxId t)
+    => UTxO
+       -- ^ Unspent tx outputs belonging to this wallet
+    -> Set Tx
+    -- ^ Pending outgoing transactions
+    -> SlotId
+    -- ^ Latest applied block (current tip)
+    -> s
+    -- ^Address discovery state
+    -> Wallet s t
+unsafeInitWallet = Wallet
 
 {-------------------------------------------------------------------------------
                                    Accessors

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -29,6 +29,7 @@ module Cardano.Wallet.Primitive.Model
     (
     -- * Type
       Wallet
+        (..) -- fixme: internal
 
     -- * Construction & Modification
     , initWallet

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -17,11 +18,31 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Sqlite
     ( newDBLayer )
 import Cardano.Wallet.DBSpec
-    ( cleanDB )
+    ( DummyTarget, cleanDB )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( encryptPassphrase, unsafeGenerateKeyFromSeed )
+    ( Passphrase (..)
+    , encryptPassphrase
+    , generateKeyFromSeed
+    , unsafeGenerateKeyFromSeed
+    )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( SeqState, defaultAddressPoolGap, mkSeqState )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( EntropySize, entropyToBytes, genEntropy )
+import Cardano.Wallet.Primitive.Model
+    ( Wallet, initWallet )
 import Cardano.Wallet.Primitive.Types
-    ( WalletDelegation (..)
+    ( Address (..)
+    , Coin (..)
+    , Direction (..)
+    , Hash (..)
+    , SlotId (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (TxMeta)
+    , TxOut (..)
+    , TxStatus (..)
+    , WalletDelegation (..)
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
@@ -36,39 +57,62 @@ import Data.ByteString
     ( ByteString )
 import Data.Coerce
     ( coerce )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text.Class
     ( FromText (..) )
 import Data.Time.Clock
     ( getCurrentTime )
+import System.IO.Unsafe
+    ( unsafePerformIO )
 import Test.Hspec
     ( Spec, beforeAll, beforeWith, describe, it, shouldReturn )
 
+import qualified Data.Map as Map
+
 spec :: Spec
-spec = beforeAll (newDBLayer Nothing) $ beforeWith cleanDB $ do
+spec = beforeAll newMemoryDBLayer $ beforeWith cleanDB $ do
     describe "Wallet table" $ do
         it "create and list works" $ \db -> do
-            unsafeRunExceptT $ createWallet db testPk undefined testMetadata
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             listWallets db `shouldReturn` [testPk]
 
         it "create and get meta works" $ \db -> do
             now <- getCurrentTime
             let md = testMetadata { passphraseInfo = Just $ WalletPassphraseInfo now }
-            unsafeRunExceptT $ createWallet db testPk undefined md
+            unsafeRunExceptT $ createWallet db testPk testCp md
             readWalletMeta db testPk `shouldReturn` Just md
 
         it "create twice is handled" $ \db -> do
-            let create' = createWallet db testPk undefined testMetadata
+            let create' = createWallet db testPk testCp testMetadata
             runExceptT create' `shouldReturn` (Right ())
             runExceptT create' `shouldReturn` (Left (ErrWalletAlreadyExists testWid))
 
         it "create and get private key" $ \db -> do
-            unsafeRunExceptT $ createWallet db testPk undefined testMetadata
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             readPrivateKey db testPk `shouldReturn` Nothing
             let Right phr = fromText "aaaaaaaaaa"
                 k = unsafeGenerateKeyFromSeed (coerce phr, coerce phr) phr
             h <- encryptPassphrase phr
             unsafeRunExceptT (putPrivateKey db testPk (k, h))
             readPrivateKey db testPk `shouldReturn` Just (k, h)
+
+        it "put and read tx history" $ \db -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            runExceptT (putTxHistory db testPk testTxs) `shouldReturn` Right ()
+            readTxHistory db testPk `shouldReturn` testTxs
+
+newMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)
+newMemoryDBLayer = newDBLayer Nothing
+
+testCp :: Wallet (SeqState DummyTarget) DummyTarget
+testCp = initWallet initDummyState
+
+initDummyState :: SeqState DummyTarget
+initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap
+  where
+      bytes = entropyToBytes <$> unsafePerformIO $ genEntropy @(EntropySize 15)
+      xprv = generateKeyFromSeed (Passphrase bytes, mempty) mempty
 
 testMetadata :: WalletMetadata
 testMetadata = WalletMetadata
@@ -83,3 +127,9 @@ testWid = WalletId (hash ("test" :: ByteString))
 
 testPk :: PrimaryKey WalletId
 testPk = PrimaryKey testWid
+
+testTxs :: Map.Map (Hash "Tx") (Tx, TxMeta)
+testTxs = Map.fromList
+    [ (Hash "tx2"
+      , (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
+        , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))) ]

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -30,7 +30,13 @@ import Cardano.Wallet.DB
     , PrimaryKey (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, Passphrase (..), XPrv, generateKeyFromSeed )
+    ( Depth (..)
+    , Key
+    , KeyToAddress (..)
+    , Passphrase (..)
+    , XPrv
+    , generateKeyFromSeed
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.Model
@@ -149,6 +155,9 @@ data DummyTarget
 
 instance TxId DummyTarget where
     txId = Hash . B8.pack . show
+
+instance KeyToAddress DummyTarget where
+    keyToAddress _ = Address ""
 
 instance Arbitrary (PrimaryKey WalletId) where
     shrink _ = []


### PR DESCRIPTION
Relates to issue #154.

# Overview

- Implemented saving and loading of transaction history to SQLite
- Implemented saving and loading of wallet checkpoints to SQLite, including the state for sequential scheme address discovery.

# Comments

- The SqliteSpec testing is a bit light. However, there should be enough implemented for all the DBSpec tests to work. Also I plan to finish the QSM tests tomorrow which should provide even more coverage.
- Cascading deletes are not working with persistent-sqlite, which is annoying.
- DB indexes are missing on some fields. (Needs some custom SQL, can be fixed later)
