### PR TITLE
Add indexes to certain SQLite table columns

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -38,7 +38,6 @@ library
     , basement
     , bytestring
     , cardano-crypto
-    , conduit
     , containers
     , cryptonite
     , deepseq
@@ -54,6 +53,7 @@ library
     , persistent
     , persistent-sqlite
     , persistent-template
+    , resourcet
     , servant
     , servant-server
     , text

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.DB.Sqlite.Types
     ( AddressPoolXPub (..), TxId (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), deserializeXPrv, serializeXPrv )
-import Conduit
+import Control.Monad.Trans.Resource
     ( runResourceT )
 import Control.DeepSeq
     ( NFData )


### PR DESCRIPTION
Relates to issue #154.

# Overview

Some of the searching and sorting that the DBLayer does will be greatly improved by creation of SQL indexes. By default, only primary key columns get indexes.

This PR adds a sprinkling of CREATE INDEX as a start.

What we really need to do is set up a benchmark of the DBLayer to ensure that performance is reasonable. I.e. no accidentally quadratic behaviour.