### PR TITLE
 fix shuffle tests in CoinSelectionSpec once and for all 

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -54,6 +54,7 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Confidence (..)
     , Gen
+    , NonEmptyList (..)
     , Property
     , checkCoverageWith
     , choose
@@ -62,7 +63,6 @@ import Test.QuickCheck
     , oneof
     , scale
     , vectorOf
-    , (==>)
     )
 import Test.QuickCheck.Monadic
     ( monadicIO )
@@ -90,21 +90,19 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_shuffleCanShuffle
-    :: [Int]
+    :: NonEmptyList Int
     -> Property
-prop_shuffleCanShuffle xs =
-    length xs > 1 ==> monadicIO $ liftIO $ do
-        xs' <- shuffle xs
-        return $ cover 90 (xs /= xs') "shuffled" ()
+prop_shuffleCanShuffle (NonEmpty xs) = monadicIO $ liftIO $ do
+    xs' <- shuffle xs
+    return $ cover 90 (xs /= xs') "shuffled" ()
 
 prop_shuffleNotDeterministic
-    :: [Int]
+    :: NonEmptyList Int
     -> Property
-prop_shuffleNotDeterministic xs =
-    length xs > 1 ==> monadicIO $ liftIO $ do
-        xs1 <- shuffle xs
-        xs2 <- shuffle xs
-        return $ cover 90 (xs1 /= xs2) "not deterministic" ()
+prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ liftIO $ do
+    xs1 <- shuffle xs
+    xs2 <- shuffle xs
+    return $ cover 90 (xs1 /= xs2) "not deterministic" ()
 
 prop_shufflePreserveElements
     :: [Int]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#291 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed the precondition about the list length in favor of a correct generator

# Comments

<!-- Additional comments or screenshots to attach if any -->

Turns out that the problem wasn't much the confidence interval that was being too strict as I thought in the past, but simply that the precondition was too hard to satistify. Indeed, quickcheck does generate empty lists quite often, (more than 10% of the generated values actually) and this caused the `checkCoverage` to give up very early despite the coverage being okay. 

I've switched to using a generator of `NonEmptyList` instead of the precondition and re-run both statistical tests a thousand times:

```
            replicateM_ 1000 $ quickCheck (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
```

without observing any failure. So I've got quite some confidence that this is now fixed..

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
