### PR TITLE
More Descriptive Errors (Part 1/2)

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
@@ -40,8 +41,6 @@ import Cardano.Wallet
     ( newWalletLayer )
 import Cardano.Wallet.Api
     ( Api )
-import Cardano.Wallet.Api.Server
-    ( server )
 import Cardano.Wallet.Api.Types
     ( ApiMnemonicT (..)
     , ApiT (..)
@@ -81,7 +80,7 @@ import Network.HTTP.Client
 import Network.HTTP.Types.Status
     ( status404, status409 )
 import Servant
-    ( (:<|>) (..), (:>), serve )
+    ( (:<|>) (..), (:>) )
 import Servant.Client
     ( BaseUrl (..), ClientM, Scheme (..), client, mkClientEnv, runClientM )
 import Servant.Client.Core
@@ -108,6 +107,7 @@ import System.IO
 import Text.Regex.Applicative
     ( anySym, few, match, string, sym )
 
+import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
 import qualified Cardano.Wallet.Transaction.HttpBridge as HttpBridge
@@ -337,7 +337,7 @@ execServer (Port port) (Port bridgePort) = do
     nw <- HttpBridge.newNetworkLayer bridgePort
     let tl = HttpBridge.newTransactionLayer
     wallet <- newWalletLayer @_ @HttpBridge db nw tl
-    Warp.runSettings settings (serve (Proxy @("v2" :> Api)) (server wallet))
+    Server.start settings wallet
   where
     settings = Warp.defaultSettings
         & Warp.setPort port

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -36,6 +36,7 @@ library
     , base
     , base58-bytestring
     , basement
+    , binary
     , bytestring
     , cardano-crypto
     , containers
@@ -45,6 +46,7 @@ library
     , fast-logger
     , fmt
     , generic-lens
+    , http-types
     , http-api-data
     , http-media
     , memory
@@ -61,6 +63,7 @@ library
     , time
     , transformers
     , vector
+    , wai
 
   hs-source-dirs:
       src
@@ -87,6 +90,7 @@ library
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Transaction
       Data.Quantity
+      Network.Wai.Middleware.ServantError
   other-modules:
       Paths_cardano_wallet_core
 

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -64,6 +64,7 @@ library
     , transformers
     , vector
     , wai
+    , warp
 
   hs-source-dirs:
       src

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -472,7 +472,7 @@ instance LiftHandler ServantErr where
             , "Here is a hint about what happened: ", utf8 body
             ]
       where
-        utf8 = T.decodeUtf8 . BL.toStrict
+        utf8 = T.replace "\"" "'" . T.decodeUtf8 . BL.toStrict
         err' = err
             { errHeaders =
                 ( hContentType

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -18,7 +18,9 @@ module Cardano.Wallet.Api.Server
 import Prelude
 
 import Cardano.Wallet
-    ( ErrCreateUnsignedTx (..)
+    ( ErrAdjustForFee (..)
+    , ErrCoinSelection (..)
+    , ErrCreateUnsignedTx (..)
     , ErrMkStdTx (..)
     , ErrNetworkUnreachable (..)
     , ErrNoSuchWallet (..)
@@ -36,6 +38,7 @@ import Cardano.Wallet.Api
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiAddress (..)
+    , ApiErrorCode (..)
     , ApiT (..)
     , ApiTransaction (..)
     , ApiWallet (..)
@@ -66,12 +69,18 @@ import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, withExceptT )
+import Data.Aeson
+    ( (.=) )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Labels
     ()
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( toText )
 import Fmt
     ( pretty )
 import Servant
@@ -83,12 +92,15 @@ import Servant
     , err409
     , err410
     , err500
+    , err503
     )
 import Servant.Server
     ( Handler (..), ServantErr (..) )
 
 import qualified Cardano.Wallet as W
+import qualified Data.Aeson as Aeson
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 
 
 -- | A Servant server for our wallet API
@@ -266,56 +278,142 @@ class LiftHandler e where
 -- In practice, we want to create nice error messages giving as much details as
 -- we can.
 
+apiError :: ServantErr -> ApiErrorCode -> Text -> ServantErr
+apiError err code message = err
+    { errBody = Aeson.encode $ Aeson.object
+        [ "code" .= code
+        , "message" .= T.replace "\n" " " message
+        ]
+    }
+
+-- | Small helper to easy show things to Text
+showT :: Show a => a -> Text
+showT = T.pack . show
+
 instance LiftHandler ErrNoSuchWallet where
     handler = \case
-        ErrNoSuchWallet _ -> err404
+        ErrNoSuchWallet wid ->
+            apiError err404 NoSuchWallet $ mconcat
+                [ "I couldn't find a wallet with the given id: "
+                , toText wid
+                ]
 
 instance LiftHandler ErrWalletAlreadyExists where
     handler = \case
-        ErrWalletAlreadyExists _ -> err409
+        ErrWalletAlreadyExists wid ->
+            apiError err409 WalletAlreadyExists $ mconcat
+                [ "This operation would yield a wallet with the following id: "
+                , toText wid, " However, I already know a wallet with such id"
+                ]
 
 instance LiftHandler ErrWithRootKey where
     handler = \case
-        ErrWithRootKeyNoRootKey _ -> err404
-        ErrWithRootKeyWrongPassphrase ErrWrongPassphrase -> err403
+        ErrWithRootKeyNoRootKey wid ->
+            apiError err404 NoRootKey $ mconcat
+                [ "I couldn't find any root private key for the given wallet: "
+                , toText wid, " This operation however requires that I do hold "
+                , "one. Either there's no such wallet, or I don't fully own it."
+                ]
+        ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase ->
+            apiError err403 WrongEncryptionPassphrase $ mconcat
+                [ "The given encryption passphrase doesn't match the one I use "
+                , "to encrypt the root private key of the given wallet: "
+                , toText wid
+                ]
+
+instance LiftHandler ErrCoinSelection where
+    handler = \case
+        ErrNotEnoughMoney utxo payment ->
+            apiError err403 NotEnoughMoney $ mconcat
+                [ "I can't accomodate such payment because there's not enough "
+                , "available UTxO in the wallet. The total UTxO sums up to "
+                , showT utxo, " Lovelace, but I need ", showT payment
+                , " Lovelace (fee included) in order to proceed with the "
+                , "payment."
+                ]
+
+        ErrUtxoNotEnoughFragmented nUtxo nOuts ->
+            apiError err403 UtxoNotEnoughFragmented $ mconcat
+                [ "There's a restriction in the way I can construct "
+                , "transactions: I do not re-use a same UTxO for different "
+                , "outputs. Here, I only have ", showT nUtxo, "available but "
+                , "there are ", showT nOuts, " outputs."
+                ]
+        ErrMaximumInputsReached n ->
+            apiError err403 TransactionIsTooBig $ mconcat
+                [ "I had to select as many as ", showT n, " inputs to construct "
+                , "the requested transaction. This would create a transaction "
+                , "that is too big and would be rejected by a core node. Try "
+                , "sending a smaller amount."
+                ]
+
+instance LiftHandler ErrAdjustForFee where
+    handler = \case
+        ErrCannotCoverFee missing ->
+            apiError err403 CannotCoverFee $ mconcat
+                [ "I can't adjust the given transaction to cover for fee! "
+                , "In order to do so, I'd have to select some additional inputs "
+                , "but I can't without increasing the size of the transaction "
+                , "out of an acceptable limit. Note that I am only missing "
+                , showT missing, " Lovelace."
+                ]
 
 instance LiftHandler ErrCreateUnsignedTx where
     handler = \case
-        ErrCreateUnsignedTxNoSuchWallet _ -> err404
-        ErrCreateUnsignedTxCoinSelection _ -> err403
-        ErrCreateUnsignedTxFee _ -> err403
+        ErrCreateUnsignedTxNoSuchWallet e -> handler e
+        ErrCreateUnsignedTxCoinSelection e -> handler e
+        ErrCreateUnsignedTxFee e -> handler e
 
 instance LiftHandler ErrSignTx where
     handler = \case
-        ErrSignTx (KeyNotFoundForAddress addr) -> err403
-            { errBody =
-                "Error signing transaction: corresponding private key for the \
-                \following output address was not found: " <> pretty addr
+        ErrSignTx (ErrKeyNotFoundForAddress addr) ->
+            apiError err403 KeyNotFoundForAddress $ mconcat
+                [ "I couldn't sign the given transaction: I haven't found the "
+                , "corresponding private key for the following output address: "
+                , pretty addr, ". Are you sure this address belongs to a known "
+                , "wallet?"
+                ]
+        ErrSignTxNoSuchWallet e -> (handler e)
+            { errHTTPCode = 410
+            , errReasonPhrase = errReasonPhrase err410
             }
-        ErrSignTxNoSuchWallet _ -> err410
-        ErrSignTxWithRootKey e -> handler e
+        ErrSignTxWithRootKey e@ErrWithRootKeyNoRootKey{} -> (handler e)
+            { errHTTPCode = 410
+            , errReasonPhrase = errReasonPhrase err410
+            }
+        ErrSignTxWithRootKey e@ErrWithRootKeyWrongPassphrase{} -> handler e
 
 instance LiftHandler ErrSubmitTx where
     handler = \case
         ErrSubmitTxNetwork e -> case e of
-            ErrPostTxNetworkUnreachable (ErrNetworkUnreachable err) -> err500
-                { errBody =
-                    "Err submitting transaction: network is unreachable: "
-                    <> pretty err
-                }
-            ErrPostTxBadRequest err -> err500
-                { errBody =
-                    "Err submitting transaction: request rejected by node: "
-                    <> pretty err
-                }
-            ErrPostTxProtocolFailure err -> err500
-                { errBody =
-                    "Err submitting transaction: protocol failure: "
-                    <> pretty err
-                }
-        ErrSubmitTxNoSuchWallet _ -> err404
+            ErrPostTxNetworkUnreachable (ErrNetworkUnreachable err) ->
+                apiError err503 NetworkUnreachable $ mconcat
+                    [ "Aw crap! I couldn't submit the transaction: the network "
+                    , "is unreachable: ", pretty err, " Trying again in a bit "
+                    , "might work."
+                    ]
+            ErrPostTxBadRequest err ->
+                apiError err500 CreatedInvalidTransaction $ mconcat
+                    [ "That is embarassing. It looks like I have created an "
+                    , "invalid transaction which failed to be parsed by the "
+                    , "node. Here's perhaps an error message that will help "
+                    , "debugging: ", pretty err
+                    ]
+            ErrPostTxProtocolFailure err ->
+                apiError err500 RejectedByCoreNode $ mconcat
+                    [ "I successfully submitted a transaction but it was "
+                    , "rejected by a relay. This could be because there was not "
+                    , "enough fee, because it now conflicts with another "
+                    , "transactions using some identical inputs or because of "
+                    , "another reason. "
+                    , "Here's a hint: ", pretty err
+                    ]
+        ErrSubmitTxNoSuchWallet e@ErrNoSuchWallet{} -> (handler e)
+            { errHTTPCode = 410
+            , errReasonPhrase = errReasonPhrase err410
+            }
 
 instance LiftHandler ErrUpdatePassphrase where
     handler = \case
-        ErrUpdatePassphraseNoSuchWallet _ -> err404
-        ErrUpdatePassphraseWithRootKey e -> handler e
+        ErrUpdatePassphraseNoSuchWallet e -> handler e
+        ErrUpdatePassphraseWithRootKey e  -> handler e

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -38,6 +38,7 @@ module Cardano.Wallet.Api.Types
     , ApiBlockData (..)
     , ApiTransaction (..)
     , AddressAmount (..)
+    , ApiErrorCode (..)
 
     -- * Polymorphic Types
     , ApiT (..)
@@ -178,6 +179,21 @@ data ApiBlockData = ApiBlockData
     , block :: !(ApiT SlotId)
     } deriving (Eq, Generic, Show)
 
+-- | Error codes returned by the API, in the form of snake_cased strings
+data ApiErrorCode
+    = NoSuchWallet
+    | WalletAlreadyExists
+    | NoRootKey
+    | WrongEncryptionPassphrase
+    | KeyNotFoundForAddress
+    | NotEnoughMoney
+    | UtxoNotEnoughFragmented
+    | TransactionIsTooBig
+    | CannotCoverFee
+    | NetworkUnreachable
+    | CreatedInvalidTransaction
+    | RejectedByCoreNode
+    deriving (Eq, Generic, Show)
 
 {-------------------------------------------------------------------------------
                               Polymorphic Types
@@ -361,6 +377,9 @@ instance FromJSON (ApiT TxStatus) where
     parseJSON = fmap ApiT . genericParseJSON defaultSumTypeOptions
 instance ToJSON (ApiT TxStatus) where
     toJSON = genericToJSON defaultSumTypeOptions . getApiT
+
+instance ToJSON ApiErrorCode where
+    toJSON = genericToJSON defaultSumTypeOptions
 
 -- | Options for encoding wallet delegation settings. It can be serialized to
 -- and from JSON as follows:

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -193,6 +193,12 @@ data ApiErrorCode
     | NetworkUnreachable
     | CreatedInvalidTransaction
     | RejectedByCoreNode
+    | BadRequest
+    | NotFound
+    | MethodNotAllowed
+    | NotAcceptable
+    | UnsupportedMediaType
+    | UnexpectedError
     deriving (Eq, Generic, Show)
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -16,7 +16,7 @@ module Cardano.Wallet.Primitive.CoinSelection
     (
       -- * Coin Selection
       CoinSelectionOptions (..)
-    , CoinSelectionError(..)
+    , ErrCoinSelection (..)
     , CoinSelection(..)
 
     -- * Helpers
@@ -52,16 +52,16 @@ newtype CoinSelectionOptions = CoinSelectionOptions
         :: Word64
     } deriving (Generic)
 
-data CoinSelectionError =
-    NotEnoughMoney Word64 Word64
+data ErrCoinSelection
+    = ErrNotEnoughMoney Word64 Word64
     -- ^ UTxO exhausted during input selection
     -- We record the balance of the UTxO as well as the size of the payment
     -- we tried to make.
-    | UtxoNotEnoughFragmented Word64 Word64
+    | ErrUtxoNotEnoughFragmented Word64 Word64
     -- ^ UTxO is not enough fragmented for the number of transaction outputs
     -- We record the number of UTxO entries as well as the number of the
     -- outputs of the transaction.
-    | MaximumInputsReached Word64
+    | ErrMaximumInputsReached Word64
     -- ^ When trying to construct a transaction, the max number of allowed
     -- inputs was reached.
     deriving (Show, Eq)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -17,7 +17,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Random
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionError (..), CoinSelectionOptions (..) )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.Types
@@ -105,7 +105,7 @@ random
     => CoinSelectionOptions
     -> NonEmpty TxOut
     -> UTxO
-    -> ExceptT CoinSelectionError m (CoinSelection, UTxO)
+    -> ExceptT ErrCoinSelection m (CoinSelection, UTxO)
 random opt outs utxo = do
     let descending = NE.toList . NE.sortBy (flip $ comparing coin)
     randomMaybe <- lift $ runMaybeT $ foldM

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -121,8 +121,8 @@ data FeeOptions = FeeOptions
       -- removes output equal to 0
     } deriving (Generic)
 
-newtype ErrAdjustForFee =
-    CannotCoverFee Word64
+newtype ErrAdjustForFee
+    = ErrCannotCoverFee Word64
     -- ^ UTxO exhausted during fee covering
     -- We record what amount missed to cover the fee
     deriving (Show, Eq)
@@ -231,7 +231,7 @@ coverRemainingFee (Fee fee) = go [] where
                 Just entry ->
                     go (entry : acc)
                 Nothing -> do
-                    lift $ throwE $ CannotCoverFee (fee - balance' acc)
+                    lift $ throwE $ ErrCannotCoverFee (fee - balance' acc)
 
 -- | Reduce the given change outputs by the total fee, returning the remainig
 -- change outputs if any are left, or the remaining fee otherwise

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -61,6 +61,6 @@ data TransactionLayer = TransactionLayer
 
 -- | Possible signing error
 newtype ErrMkStdTx
-    = KeyNotFoundForAddress Address
+    = ErrKeyNotFoundForAddress Address
     -- ^ We tried to sign a transaction with inputs that are unknown to us?
     deriving (Eq, Show)

--- a/lib/core/src/Network/Wai/Middleware/ServantError.hs
+++ b/lib/core/src/Network/Wai/Middleware/ServantError.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Middleware between Wai <-> Servant to accomodate raw error responses returned
+-- by servant. See also 'handleRawError'.
+
+module Network.Wai.Middleware.ServantError
+    ( handleRawError
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( guard )
+import Data.ByteString.Lazy
+    ( ByteString )
+import Network.HTTP.Types.Header
+    ( ResponseHeaders )
+import Network.HTTP.Types.Status
+    ( statusCode, statusMessage )
+import Network.Wai
+    ( Middleware, responseHeaders, responseStatus )
+import Network.Wai.Internal
+    ( Response (..) )
+import Servant.Server.Internal.ServantErr
+    ( ServantErr (..), responseServantErr )
+
+import qualified Data.Binary.Builder as Binary
+import qualified Data.ByteString.Char8 as B8
+import qualified Network.HTTP.Types.Status as HTTP
+
+-- | Make sure every error is converted to a suitable application-level error.
+--
+-- There are many cases where Servant will handle errors itself and reply to a
+-- client without even disturbing the application. This is both handy and clunky
+-- since our application return errors in a specific format (e.g. JSON, XML
+-- ...).
+--
+-- This is the case for instance if the client hits a non-exiting endpoint of
+-- the API, or if the client requests an invalid content-type, etc ...
+--
+-- Ideally, we would like clients to be able to expect one and only one format,
+-- so this middleware allows for manipulating the response returned by a Wai
+-- application (what servant boils down to) and adjust the response when
+-- necessary. So, any response with or without payload but no content-type will
+-- trigger the 'convert' function and offer the caller to adjust the response as
+-- needed.
+handleRawError
+    :: (ServantErr -> ServantErr)
+    -- ^ Convert a raw response into something that better fits the application
+    -- error
+    -> Middleware
+handleRawError adjust app req send =
+    app req (send . either (responseServantErr . adjust) id . eitherRawError)
+
+-- | Analyze whether a given error is a raw error thrown by Servant before
+-- reaching our application layer, or one from our application layer.
+eitherRawError
+    :: Response
+    -> Either ServantErr Response
+eitherRawError res =
+    let
+        status = responseStatus res
+        code = statusCode status
+        reason = B8.unpack (statusMessage status)
+        headers = responseHeaders res
+        body = responseBody res
+        maybeToEither = maybe
+            (Right res)
+            (Left . flip (ServantErr code reason) headers)
+    in
+        maybeToEither $ guard (isRawError status headers) *> body
+
+-- | Raw 'Servant' errors don't have any Content-Type. This is a lean predicate
+-- but for lack of any better way of identifying them, that's a best effort.
+isRawError
+    :: HTTP.Status
+    -> ResponseHeaders
+    -> Bool
+isRawError status headers =
+    statusCode status >= 400 && null headers
+
+-- | Extract raw body of a response, only if it suitables for transformation.
+-- Servant doesn't return files or streams by default, so if one of the two is
+-- met, it means it comes from our application layer anyway.
+responseBody
+  :: Response
+  -> Maybe ByteString
+responseBody = \case
+    ResponseBuilder _ _ b ->
+        Just (Binary.toLazyByteString b)
+    ResponseRaw _ r ->
+        responseBody r
+    ResponseFile{} ->
+        Nothing
+    ResponseStream{} ->
+        Nothing

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -9,7 +9,7 @@ module Cardano.Wallet.Primitive.CoinSelection.LargestFirstSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionError (..), CoinSelectionOptions (..) )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.CoinSelectionSpec
@@ -106,7 +106,7 @@ spec = do
         coinSelectionUnitTest
             largestFirst
             "not enough coins"
-            (Left $ NotEnoughMoney 39 40)
+            (Left $ ErrNotEnoughMoney 39 40)
             $ CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,10,17]
@@ -116,7 +116,7 @@ spec = do
         coinSelectionUnitTest
             largestFirst
             "not enough coin & not fragmented enough"
-            (Left $ NotEnoughMoney 39 43)
+            (Left $ ErrNotEnoughMoney 39 43)
             $ CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,10,17]
@@ -126,7 +126,7 @@ spec = do
         coinSelectionUnitTest
             largestFirst
             "enough coins, but not fragmented enough"
-            (Left $ UtxoNotEnoughFragmented 3 4)
+            (Left $ ErrUtxoNotEnoughFragmented 3 4)
             $ CoinSelectionFixture
                 { maxNumOfInputs = 100
                 , utxoInputs = [12,20,17]
@@ -136,7 +136,7 @@ spec = do
         coinSelectionUnitTest
             largestFirst
             "enough coins but, strict maximumNumberOfInputs"
-            (Left $ MaximumInputsReached 2)
+            (Left $ ErrMaximumInputsReached 2)
             $ CoinSelectionFixture
                 { maxNumOfInputs = 2
                 , utxoInputs = [1,2,10,6,5]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -9,7 +9,7 @@ module Cardano.Wallet.Primitive.CoinSelection.RandomSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionError (..), CoinSelectionOptions (..) )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.CoinSelection.Random
@@ -128,25 +128,29 @@ spec = do
                 , txOutputs = 3 :| []
                 })
 
-        coinSelectionUnitTest random "" (Left $ MaximumInputsReached 2) $ CoinSelectionFixture
+        coinSelectionUnitTest random "" (Left $ ErrMaximumInputsReached 2) $
+            CoinSelectionFixture
             { maxNumOfInputs = 2
             , utxoInputs = [1,1,1,1,1,1]
             , txOutputs = 3 :| []
             }
 
-        coinSelectionUnitTest random "" (Left $ NotEnoughMoney 39 40) $ CoinSelectionFixture
+        coinSelectionUnitTest random "" (Left $ ErrNotEnoughMoney 39 40) $
+            CoinSelectionFixture
             { maxNumOfInputs = 100
             , utxoInputs = [12,10,17]
             , txOutputs = 40 :| []
             }
 
-        coinSelectionUnitTest random "" (Left $ NotEnoughMoney 39 43) $ CoinSelectionFixture
+        coinSelectionUnitTest random "" (Left $ ErrNotEnoughMoney 39 43) $
+            CoinSelectionFixture
             { maxNumOfInputs = 100
             , utxoInputs = [12,10,17]
             , txOutputs = 40 :| [1,1,1]
             }
 
-        coinSelectionUnitTest random "" (Left $ UtxoNotEnoughFragmented 3 4) $ CoinSelectionFixture
+        coinSelectionUnitTest random "" (Left $ ErrUtxoNotEnoughFragmented 3 4) $
+            CoinSelectionFixture
             { maxNumOfInputs = 100
             , utxoInputs = [12,20,17]
             , txOutputs = 40 :| [1,1,1]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -23,8 +23,8 @@ import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..)
-    , CoinSelectionError (..)
     , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
     , shuffle
     )
 import Cardano.Wallet.Primitive.Types
@@ -151,10 +151,10 @@ coinSelectionUnitTest
     :: ( CoinSelectionOptions
          -> NonEmpty TxOut
          -> UTxO
-         -> ExceptT CoinSelectionError IO (CoinSelection, UTxO)
+         -> ExceptT ErrCoinSelection IO (CoinSelection, UTxO)
        )
     -> String
-    -> Either CoinSelectionError CoinSelectionResult
+    -> Either ErrCoinSelection CoinSelectionResult
     -> CoinSelectionFixture
     -> SpecWith ()
 coinSelectionUnitTest run lbl expected (CoinSelectionFixture n utxoF outsF) =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -165,7 +165,7 @@ spec = do
             , fUtxo = []
             , fFee = 4
             , fDust = 0
-            }) (Left $ CannotCoverFee 1)
+            }) (Left $ ErrCannotCoverFee 1)
 
         -- Cannot cover fee even with an extra (too small) inputs
         feeUnitTest (FeeFixture
@@ -175,7 +175,7 @@ spec = do
             , fUtxo = [1]
             , fFee = 5
             , fDust = 0
-            }) (Left $ CannotCoverFee 1)
+            }) (Left $ ErrCannotCoverFee 1)
 
         -- Can select extra inputs to exactly cover fee, no change back
         feeUnitTest (FeeFixture

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -94,13 +94,12 @@ import qualified Data.List as L
 spec :: Spec
 spec = do
     describe "Pointless tests to cover 'Show' instances for errors" $ do
-        let errNoSuchWallet =
-                ErrNoSuchWallet (WalletId (hash @ByteString "arbitrary"))
-        it (show $ ErrCreateUnsignedTxNoSuchWallet errNoSuchWallet) True
-        it (show $ ErrSignTxNoSuchWallet errNoSuchWallet) True
-        it (show $ ErrSubmitTxNoSuchWallet errNoSuchWallet) True
-        it (show $ ErrUpdatePassphraseNoSuchWallet errNoSuchWallet) True
-        it (show $ ErrWithRootKeyWrongPassphrase ErrWrongPassphrase) True
+        let wid = WalletId (hash @ByteString "arbitrary")
+        it (show $ ErrCreateUnsignedTxNoSuchWallet (ErrNoSuchWallet wid)) True
+        it (show $ ErrSignTxNoSuchWallet (ErrNoSuchWallet wid)) True
+        it (show $ ErrSubmitTxNoSuchWallet (ErrNoSuchWallet wid)) True
+        it (show $ ErrUpdatePassphraseNoSuchWallet (ErrNoSuchWallet wid)) True
+        it (show $ ErrWithRootKeyWrongPassphrase wid ErrWrongPassphrase) True
 
     describe "WalletLayer works as expected" $ do
         it "Wallet upon creation is written down in db"
@@ -234,7 +233,7 @@ walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
         unsafeRunExceptT $ attachPrivateKey wl wid (xprv, pwd)
         attempt <- runExceptT $ updateWalletPassphrase wl wid (old, new)
         let err = ErrUpdatePassphraseWithRootKey
-                $ ErrWithRootKeyWrongPassphrase
+                $ ErrWithRootKeyWrongPassphrase wid
                 ErrWrongPassphrase
         attempt `shouldBe` Left err
 

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -151,7 +151,6 @@ test-suite integration
     , http-types
     , memory
     , process
-    , servant-server
     , template-haskell
     , text
     , text-class

--- a/lib/http-bridge/src/Cardano/Wallet/Transaction/HttpBridge.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/Transaction/HttpBridge.hs
@@ -51,7 +51,7 @@ newTransactionLayer = TransactionLayer
         let tx = Tx ins outs
         let txSigData = txId @HttpBridge tx
         txWitnesses <- forM inps $ \(_in, TxOut addr _c) -> mkWitness txSigData
-            <$> withEither (KeyNotFoundForAddress addr) (keyFrom addr)
+            <$> withEither (ErrKeyNotFoundForAddress addr) (keyFrom addr)
         return (tx, txWitnesses)
 
     , estimateSize = \(CoinSelection inps outs chngs) -> let n = length inps in

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -13,10 +13,6 @@ import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( newWalletLayer )
-import Cardano.Wallet.Api
-    ( Api )
-import Cardano.Wallet.Api.Server
-    ( server )
 import Cardano.Wallet.Compatibility.HttpBridge
     ( HttpBridge )
 import Control.Concurrent
@@ -31,14 +27,10 @@ import Data.Aeson
     ( Value (..), (.:) )
 import Data.Function
     ( (&) )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Time
     ( addUTCTime, defaultTimeLocale, formatTime, getCurrentTime )
 import Network.HTTP.Client
     ( defaultManagerSettings, newManager )
-import Servant
-    ( (:>), serve )
 import System.Directory
     ( createDirectoryIfMissing, removePathForcibly )
 import System.IO
@@ -53,6 +45,7 @@ import Test.Integration.Framework.Request
     ( Headers (Default), Payload (Empty), request )
 
 import qualified Cardano.LauncherSpec as Launcher
+import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
 import qualified Cardano.Wallet.Network.HttpBridgeSpec as HttpBridge
@@ -180,7 +173,7 @@ main = do
         let tl = HttpBridge.newTransactionLayer
         wallet <- newWalletLayer @_ @HttpBridge db nl tl
         let settings = Warp.defaultSettings & Warp.setPort serverPort
-        Warp.runSettings settings (serve (Proxy @("v2" :> Api)) (server wallet))
+        Server.start settings wallet
 
     waitForCluster :: String -> IO ()
     waitForCluster addr = do

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -210,7 +210,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "key \"name\" not present"
+            , expectErrorMessage "key 'name' not present"
             ]
 
     describe "WALLETS_CREATE_05 - Mnemonics" $ do
@@ -336,7 +336,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "key \"mnemonic_sentence\" not present"
+            , expectErrorMessage "key 'mnemonic_sentence' not present"
             ]
 
     describe "WALLETS_CREATE_06 - Mnemonics second factor" $ do
@@ -525,7 +525,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "key \"passphrase\" not present"
+            , expectErrorMessage "key 'passphrase' not present"
             ]
 
     describe "WALLETS_CREATE_08 - address_pool_gap" $ do
@@ -1212,14 +1212,14 @@ spec = do
                       "new_passphrase": "Secure passphrase"
                          } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "key \"old_passphrase\" not present" ]
+                     , expectErrorMessage "key 'old_passphrase' not present" ]
                    )
                  , ( "Missing new passphrase"
                    , Json [json| {
                       "old_passphrase": "Secure passphrase"
                          } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "key \"new_passphrase\" not present" ]
+                     , expectErrorMessage "key 'new_passphrase' not present" ]
                   )
                 ]
         forM_ matrix $ \(title, payload, expectations) -> it title $ \ctx -> do

--- a/lib/http-bridge/test/unit/Cardano/Wallet/Transaction/HttpBridgeSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/Transaction/HttpBridgeSpec.hs
@@ -112,7 +112,7 @@ spec = do
                           )
                         ]
                     outs = []
-            res `shouldBe` Left (KeyNotFoundForAddress addr)
+            res `shouldBe` Left (ErrKeyNotFoundForAddress addr)
 
     describe "Golden Tests - Cardano-SL - signed tx" $ case network of
         Mainnet -> do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#260

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have reviewed some error data-types and constructors to make them more consistent with the rest. 
- [x] Added more extensive descriptions and reviewed some errors code to provide a better feedback to users of the API and/or CLI.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Waiting for @jonathanknowles to control the English here :stuck_out_tongue: 

A few examples:

```
{"code":"wallet_already_exists","message":"This operation would yield a wallet with the following id: 23c401a00f94d05e3e48599ed85cc5ea0e16a2b6. However, I already know a wallet with such id!"}

{"code":"no_such_wallet","message":"I couldn't find a wallet with the given id: 2512a00e9653fe49a44a5886202e24d77eeb998f."}
```




<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
