### PR TITLE
Fix documentation export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -191,7 +191,7 @@ jobs:
     name: "Haddock"
     script:
     - mkdir -p haddock/edge api/edge
-    - cp -Rv specifications/api api/edge
+    - cp -Rv specifications/api/* api/edge
     - mv $(stack path --local-doc-root)/* haddock/edge
     - git checkout --orphan gh-pages-deploy && git reset
     - git add api haddock && git commit -m $TRAVIS_COMMIT
@@ -238,7 +238,7 @@ jobs:
 
     # Deploy documentation snapshot
     - mkdir -p haddock/$TRAVIS_TAG api/$TRAVIS_TAG
-    - cp -Rv specifications/api api/$TRAVIS_TAG
+    - cp -Rv specifications/api/* api/$TRAVIS_TAG
     - mv $(stack path --local-doc-root)/* haddock/$TRAVIS_TAG
     - git checkout --orphan gh-pages-deploy && git reset
     - git add api haddock && git commit -m $TRAVIS_COMMIT


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have fixed the documentation export in travis. Was wrongly exporting the api doc under an extra `/api` folder,  (so it was now `/api/edge/api`) ... 

# Comments

<!-- Additional comments or screenshots to attach if any -->

:man_shrugging: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
