### PR TITLE
When embedding the Swagger API specification, use a path that is relative to the project root

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -82,7 +82,7 @@ import Data.Aeson
 import Data.Aeson.QQ
     ( aesonQQ )
 import Data.FileEmbed
-    ( embedFile )
+    ( embedFile, makeRelativeToProject )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
@@ -721,8 +721,11 @@ specification :: Swagger
 specification =
     unsafeDecode bytes
   where
-    bytes = $(embedFile "../../specifications/api/swagger.yaml")
-    unsafeDecode = either (error . (msg <>) . show) Prelude.id . Yaml.decodeEither'
+    bytes = $(makeRelativeToProject
+                "../../specifications/api/swagger.yaml"
+                >>= embedFile)
+    unsafeDecode =
+        either (error . (msg <>) . show) Prelude.id . Yaml.decodeEither'
     msg = "Whoops! Failed to parse or find the api specification document: "
 
 instance ToSchema ApiAddress where


### PR DESCRIPTION
# Overview

This change fixes the following error, which occurs while attempting to use `ghci`:

```hs
$ stack ghci cardano-wallet-core:test:unit
Using main module: 1. Package `cardano-wallet-core' component test:unit with main-is file: /home/jsk/projects/input-output-hk/cardano-wallet/lib/core/test/unit/Main.hs
Configuring GHCi with the following packages: cardano-wallet-core
GHCi, version 8.6.3: http://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/jsk/.ghci
[18 of 19] Compiling Cardano.Wallet.Api.TypesSpec ( /home/jsk/projects/input-output-hk/cardano-wallet/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs, /home/jsk/projects/input-output-hk/cardano-wallet/.stack-work/odir/Cardano/Wallet/Api/TypesSpec.o )

/home/jsk/projects/input-output-hk/cardano-wallet/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs:724:13: error:
    • Exception when trying to run compile-time code:
        ../../specifications/api/swagger.yaml: openBinaryFile: does not exist (No such file or directory)
      Code: embedFile "../../specifications/api/swagger.yaml"
    • In the untyped splice:
        $(embedFile "../../specifications/api/swagger.yaml")
    |
724 |     bytes = $(embedFile "../../specifications/api/swagger.yaml")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Failed, 17 modules loaded.

<no location info>: error:
    Could not find module ‘Cardano.Wallet.Api.TypesSpec’
    Perhaps you meant
      Cardano.Wallet.Api.Types (from cardano-wallet-core-2019.5.8)
      Cardano.Wallet.Api.Server (from cardano-wallet-core-2019.5.8)
Loaded GHCi configuration from /tmp/haskell-stack-ghci/98c17b7b/ghci-script
Data.QuantitySpec>
```

# Overview

- [x] I have changed the way the Swagger API specification is embedded, to use a file path that is relative to the root of the project.