### PR TITLE
Change jormungandr rest port to 8081

### DIFF
--- a/lib/jormungandr/test/data/jormungandr/node.config
+++ b/lib/jormungandr/test/data/jormungandr/node.config
@@ -1,7 +1,7 @@
 storage: "/tmp/cardano/storage"
 
 rest:
-  listen: "127.0.0.1:8080"
+  listen: "127.0.0.1:8081"
   prefix: "api"
 
 peer_2_peer:


### PR DESCRIPTION
Attempt to fix https://travis-ci.org/input-output-hk/cardano-wallet/jobs/535892104#L303
where we reason that the port 8080 is still busy from the http-bridge integration tests.