### PR TITLE
Fix Bech32 decoder + encoder

### DIFF
--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -33,6 +33,7 @@ library
     , base
     , bytestring
     , extra
+    , text
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -62,6 +62,7 @@ test-suite bech32-test
     , hspec
     , bytestring
     , QuickCheck
+    , text
   main-is:
       Main.hs
   other-modules:

--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -16,7 +16,12 @@ module Codec.Binary.Bech32
       encode
     , decode
 
-      -- * Human-Readable Parts
+      -- * Data Part
+    , DataPart
+    , dataPartFromBytes
+    , dataPartToBytes
+
+      -- * Human-Readable Part
     , HumanReadablePart
     , mkHumanReadablePart
     , humanReadablePartToBytes

--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -23,7 +23,7 @@ module Codec.Binary.Bech32
 
       -- * Human-Readable Part
     , HumanReadablePart
-    , mkHumanReadablePart
+    , humanReadablePartFromBytes
     , humanReadablePartToBytes
 
     ) where

--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -19,12 +19,14 @@ module Codec.Binary.Bech32
       -- * Data Part
     , DataPart
     , dataPartFromBytes
+    , dataPartFromText
     , dataPartToBytes
+    , dataPartToText
 
       -- * Human-Readable Part
     , HumanReadablePart
-    , humanReadablePartFromBytes
-    , humanReadablePartToBytes
+    , humanReadablePartFromText
+    , humanReadablePartToText
 
     ) where
 

--- a/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
@@ -40,7 +40,7 @@ module Codec.Binary.Bech32.Internal
       -- * Human-Readable Part
     , HumanReadablePart
     , HumanReadablePartError (..)
-    , mkHumanReadablePart
+    , humanReadablePartFromBytes
     , humanReadablePartToBytes
     , humanReadableCharsetMinBound
     , humanReadableCharsetMaxBound
@@ -179,9 +179,9 @@ newtype HumanReadablePart = HumanReadablePart ByteString
 
 -- | Parses the human-readable part of a Bech32 string, as defined here:
 --   https://git.io/fj8FS
-mkHumanReadablePart
+humanReadablePartFromBytes
     :: ByteString -> Either HumanReadablePartError HumanReadablePart
-mkHumanReadablePart hrp
+humanReadablePartFromBytes hrp
     | BS.length hrp < humanReadablePartMinLength =
         Left HumanReadablePartTooShort
     | BS.length hrp > humanReadablePartMaxLength =
@@ -258,7 +258,7 @@ decode bech32 = do
     (hrpUnparsed, dcpUnparsed) <-
         maybeToEither StringToDecodeMissingSeparatorChar $
             splitAtLastOccurrence separatorChar $ B8.map toLower bech32
-    hrp <- first humanReadablePartError $ mkHumanReadablePart hrpUnparsed
+    hrp <- first humanReadablePartError $ humanReadablePartFromBytes hrpUnparsed
     dcp <- first
         (StringToDecodeContainsInvalidChars . fmap
             (\(CharPosition p) ->

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -416,10 +416,8 @@ instance Arbitrary HumanReadablePart where
         let range =
                 ( Bech32.humanReadableCharsetMinBound
                 , Bech32.humanReadableCharsetMaxBound )
-        bytes <-
-            choose (1, 10) >>= \n -> vectorOf n (choose range)
-        let (Right hrp) = humanReadablePartFromText $
-                T.map toLower $ T.pack bytes
+        chars <- choose (1, 10) >>= \n -> vectorOf n (choose range)
+        let (Right hrp) = humanReadablePartFromText $ T.pack chars
         return hrp
 
 instance Arbitrary ByteString where

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -82,9 +82,10 @@ spec = do
                 let expectedChecksum = Right $ B8.map toLower checksum
                 checksumEncoded `shouldBe` expectedChecksum
 
-    describe "Invalid Checksums" $ forM_ invalidChecksums $ \(checksum, expect) ->
-        it (B8.unpack checksum) $
-            Bech32.decode checksum `shouldBe` (Left expect)
+    describe "Invalid Checksums" $ forM_ invalidChecksums $
+        \(checksum, expect) ->
+            it (B8.unpack checksum) $
+                Bech32.decode checksum `shouldBe` (Left expect)
 
     describe "More Encoding/Decoding Cases" $ do
         it "length > maximum" $ do

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -11,11 +11,14 @@ import Prelude
 
 import Codec.Binary.Bech32.Internal
     ( CharPosition (..)
-    , DataPart (..)
+    , DataPart
     , DecodingError (..)
     , HumanReadablePart
-    , humanReadablePartFromBytes
-    , humanReadablePartToBytes
+    , dataPartFromWords
+    , dataPartToWords
+    , humanReadablePartFromText
+    , humanReadablePartToText
+    , separatorChar
     )
 import Control.Monad
     ( forM_, replicateM )
@@ -24,7 +27,7 @@ import Data.Bits
 import Data.ByteString
     ( ByteString )
 import Data.Char
-    ( toLower, toUpper )
+    ( chr, ord, toLower, toUpper )
 import Data.Either
     ( fromRight, isLeft, isRight )
 import Data.Either.Extra
@@ -33,6 +36,8 @@ import Data.Functor.Identity
     ( runIdentity )
 import Data.Maybe
     ( catMaybes, fromMaybe, isJust )
+import Data.Text
+    ( Text )
 import Data.Word
     ( Word8 )
 import Test.Hspec
@@ -50,13 +55,11 @@ import Test.QuickCheck
     , (===)
     , (==>)
     )
-import Text.Read
-    ( readEither )
 
 import qualified Codec.Binary.Bech32.Internal as Bech32
 import qualified Data.Array as Arr
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
 
 spec :: Spec
 spec = do
@@ -66,44 +69,45 @@ spec = do
                 Bech32.decode s `shouldSatisfy` isRight
 
     describe "Valid Checksums" $ forM_ validChecksums $ \checksum ->
-        it (B8.unpack checksum) $ case Bech32.decode checksum of
+        it (T.unpack checksum) $ case Bech32.decode checksum of
             Left _ ->
                 expectationFailure (show checksum)
             Right (resultHRP, resultData) -> do
                 -- test that a corrupted checksum fails decoding.
-                let (hrp, rest) = B8.breakEnd (== '1') checksum
-                let Just (first, rest') = BS.uncons rest
+                let (hrp, rest) =
+                        T.breakOnEnd (T.singleton separatorChar) checksum
+                let Just (first, rest') = T.uncons rest
                 let checksumCorrupted =
-                        (hrp `BS.snoc` (first `xor` 1)) `BS.append` rest'
+                        (hrp `T.snoc` (chr (ord first `xor` 1)))
+                        `T.append` rest'
                 (Bech32.decode checksumCorrupted) `shouldSatisfy` isLeft
                 -- test that re-encoding the decoded checksum results in
                 -- the same checksum.
                 let checksumEncoded = Bech32.encode resultHRP resultData
-                let expectedChecksum = Right $ B8.map toLower checksum
+                let expectedChecksum = Right $ T.map toLower checksum
                 checksumEncoded `shouldBe` expectedChecksum
 
     describe "Invalid Checksums" $ forM_ invalidChecksums $
         \(checksum, expect) ->
-            it (B8.unpack checksum) $
+            it (T.unpack checksum) $
                 Bech32.decode checksum `shouldBe` (Left expect)
 
     describe "More Encoding/Decoding Cases" $ do
         it "length > maximum" $ do
             let hrpUnpacked = "ca"
             let hrpLength = length hrpUnpacked
-            let (Right hrp) = humanReadablePartFromBytes (B8.pack hrpUnpacked)
+            let (Right hrp) = humanReadablePartFromText (T.pack hrpUnpacked)
             let maxDataLength =
                     Bech32.encodedStringMaxLength
                     - Bech32.checksumLength - Bech32.separatorLength - hrpLength
             Bech32.encode hrp
-                (DataPart (replicate (maxDataLength + 1)
+                (dataPartFromWords (replicate (maxDataLength + 1)
                     $ Bech32.word5 @Word8 1))
                 `shouldBe` Left Bech32.EncodedStringTooLong
 
         it "hrp lowercased" $ do
-            let (Right hrp) = humanReadablePartFromBytes (B8.pack "HRP")
-            Bech32.encode hrp mempty
-                `shouldBe` Right (B8.pack "hrp1g9xj8m")
+            let (Right hrp) = humanReadablePartFromText "HRP"
+            Bech32.encode hrp mempty `shouldBe` Right "hrp1g9xj8m"
 
     describe "Arbitrary ValidBech32String" $
 
@@ -117,14 +121,14 @@ spec = do
         it "Decoding fails when an adjacent pair of characters is swapped." $
             property $ \s -> do
                 let validString = getValidBech32String s
-                index <- choose (0, BS.length validString - 2)
-                let prefix = BS.take index validString
-                let suffix = BS.drop (index + 2) validString
-                let char0 = BS.singleton (BS.index validString index)
-                let char1 = BS.singleton (BS.index validString $ index + 1)
+                index <- choose (0, T.length validString - 2)
+                let prefix = T.take index validString
+                let suffix = T.drop (index + 2) validString
+                let char0 = T.singleton (T.index validString index)
+                let char1 = T.singleton (T.index validString $ index + 1)
                 let recombinedString = prefix <> char1 <> char0 <> suffix
                 return $
-                    (BS.length recombinedString ===  BS.length validString)
+                    (T.length recombinedString === T.length validString)
                     .&&.
                     (Bech32.decode recombinedString `shouldSatisfy`
                         (if char0 == char1 then isRight else isLeft))
@@ -132,12 +136,12 @@ spec = do
         it "Decoding fails when a character is omitted." $
             property $ \s -> do
                 let validString = getValidBech32String s
-                index <- choose (0, BS.length validString - 1)
-                let prefix = BS.take index validString
-                let suffix = BS.drop (index + 1) validString
+                index <- choose (0, T.length validString - 1)
+                let prefix = T.take index validString
+                let suffix = T.drop (index + 1) validString
                 let recombinedString = prefix <> suffix
                 return $
-                    (BS.length recombinedString === BS.length validString - 1)
+                    (T.length recombinedString === T.length validString - 1)
                     .&&.
                     (Bech32.decode recombinedString `shouldSatisfy` isLeft)
 
@@ -145,13 +149,13 @@ spec = do
             property $ \s c -> do
                 let validString = getValidBech32String s
                 let validChar = getValidBech32Char c
-                index <- choose (0, BS.length validString - 1)
-                let prefix = BS.take index validString
-                let suffix = BS.drop index validString
+                index <- choose (0, T.length validString - 1)
+                let prefix = T.take index validString
+                let suffix = T.drop index validString
                 let recombinedString =
-                        prefix <> B8.singleton validChar <> suffix
+                        prefix <> T.singleton validChar <> suffix
                 return $
-                    (BS.length recombinedString === BS.length validString + 1)
+                    (T.length recombinedString === T.length validString + 1)
                     .&&.
                     (Bech32.decode recombinedString `shouldSatisfy` isLeft)
 
@@ -159,17 +163,17 @@ spec = do
            property $ \s c -> do
                 let validString = getValidBech32String s
                 let validChar = getValidBech32Char c
-                let separatorIndex = BS.length $
-                        Bech32.humanReadablePartToBytes $ humanReadablePart s
-                index <- choose (0, BS.length validString - 1)
-                let prefix = BS.take index validString
-                let suffix = BS.drop (index + 1) validString
+                let separatorIndex = T.length $
+                        Bech32.humanReadablePartToText $ humanReadablePart s
+                index <- choose (0, T.length validString - 1)
+                let prefix = T.take index validString
+                let suffix = T.drop (index + 1) validString
                 let recombinedString =
-                        prefix <> B8.singleton validChar <> suffix
+                        prefix <> T.singleton validChar <> suffix
                 return $
                     index /= separatorIndex ==>
                     recombinedString /= validString ==>
-                    BS.length recombinedString == BS.length validString ==> (
+                    T.length recombinedString == T.length validString ==> (
                         -- error location detection is best effort:
                         (Bech32.decode recombinedString `shouldBe`
                             Left (StringToDecodeContainsInvalidChars
@@ -183,17 +187,17 @@ spec = do
            \character." $
             property $ \s -> do
                 let validString = getValidBech32String s
-                index <- choose (0, BS.length validString - 1)
-                let prefix = B8.map toUpper $ BS.take index validString
-                let suffix = B8.map toUpper $ BS.drop (index + 1) validString
-                let char = B8.singleton $ toLower $ B8.index validString index
+                index <- choose (0, T.length validString - 1)
+                let prefix = T.map toUpper $ T.take index validString
+                let suffix = T.map toUpper $ T.drop (index + 1) validString
+                let char = T.singleton $ toLower $ T.index validString index
                 let recombinedString = prefix <> char <> suffix
                 return $ counterexample
                     (show validString <> " : " <> show recombinedString) $
-                    (BS.length recombinedString === BS.length validString)
+                    (T.length recombinedString === T.length validString)
                     .&&.
                     (Bech32.decode recombinedString `shouldSatisfy`
-                        (if B8.map toUpper validString == recombinedString
+                        (if T.map toUpper validString == recombinedString
                             then isRight
                             else isLeft))
 
@@ -201,17 +205,17 @@ spec = do
            \character." $
             property $ \s -> do
                 let validString = getValidBech32String s
-                index <- choose (0, BS.length validString - 1)
-                let prefix = B8.map toLower $ BS.take index validString
-                let suffix = B8.map toLower $ BS.drop (index + 1) validString
-                let char = B8.singleton $ toUpper $ B8.index validString index
+                index <- choose (0, T.length validString - 1)
+                let prefix = T.map toLower $ T.take index validString
+                let suffix = T.map toLower $ T.drop (index + 1) validString
+                let char = T.singleton $ toUpper $ T.index validString index
                 let recombinedString = prefix <> char <> suffix
                 return $ counterexample
                     (show validString <> " : " <> show recombinedString) $
-                    (BS.length recombinedString === BS.length validString)
+                    (T.length recombinedString === T.length validString)
                     .&&.
                     (Bech32.decode recombinedString `shouldSatisfy`
-                        (if B8.map toLower validString == recombinedString
+                        (if T.map toLower validString == recombinedString
                             then isRight
                             else isLeft))
 
@@ -220,10 +224,6 @@ spec = do
             (eitherToMaybe (Bech32.encode hrp dp)
                 >>= eitherToMaybe . Bech32.decode) === Just (hrp, dp)
 
-    describe "Roundtrip (read . show)" $ do
-        it "For DataPart" $ property $ \(dp :: DataPart) ->
-            readEither (show dp) === Right dp
-
     describe "Roundtrip (dataPartToBytes . dataPartFromBytes)" $ do
         it "Can perform roundtrip base conversion" $ property $ \bs ->
             (Bech32.dataPartToBytes . Bech32.dataPartFromBytes) bs === Just bs
@@ -231,6 +231,19 @@ spec = do
     describe "Roundtrip (dataPartFromText . dataPartToText)" $ do
         it "Can perform roundtrip conversion" $ property $ \dp ->
             (Bech32.dataPartFromText . Bech32.dataPartToText) dp === Just dp
+
+    describe "Roundtrip (dataPartFromWords . dataPartToWords)" $ do
+        it "Can perform roundtrip conversion" $ property $ \dp ->
+            (Bech32.dataPartFromWords . Bech32.dataPartToWords) dp === dp
+
+    describe "Roundtrip (dataPartToWords . dataPartFromWords)" $ do
+        it "Can perform roundtrip conversion" $ property $ \ws ->
+            (Bech32.dataPartToWords . Bech32.dataPartFromWords) ws === ws
+
+    describe "Roundtrip (humanReadablePartFromText . humanReadablePartToText)" $
+        it "Can perform roundtrip conversion" $ property $ \hrp ->
+            (Bech32.humanReadablePartFromText . Bech32.humanReadablePartToText)
+                hrp === Right hrp
 
     describe "Roundtrip (toBase256 . toBase32)" $ do
         it "Can perform roundtrip base conversion" $ property $ \ws ->
@@ -283,11 +296,11 @@ spec = do
                     (outputWordsSuffix `shouldSatisfy` all (== 0))
 
     describe "Pointless test to trigger coverage on derived instances" $ do
-        it (show $ humanReadablePartFromBytes $ B8.pack "ca") True
+        it (show $ humanReadablePartFromText $ T.pack "ca") True
 
 -- Taken from the BIP 0173 specification: https://git.io/fjBIN
-validBech32Strings :: [ByteString]
-validBech32Strings = map B8.pack
+validBech32Strings :: [Text]
+validBech32Strings =
     [ "A12UEL5L"
     , "a12uel5l"
     , "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcluded\
@@ -307,8 +320,8 @@ validBech32Strings = map B8.pack
       \c5xw7k7grplx"
     ]
 
-validChecksums :: [ByteString]
-validChecksums = map B8.pack
+validChecksums :: [Text]
+validChecksums =
     [ "A12UEL5L"
     , "an83characterlonghumanreadablepartthatcontain\
       \sthenumber1andtheexcludedcharactersbio1tt5tgs"
@@ -318,7 +331,7 @@ validChecksums = map B8.pack
     , "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w"
     ]
 
-invalidChecksums :: [(ByteString, Bech32.DecodingError)]
+invalidChecksums :: [(Text, Bech32.DecodingError)]
 invalidChecksums =
     [ ( " 1nwldj5"
       , Bech32.StringToDecodeContainsInvalidChars [Bech32.CharPosition 0] )
@@ -359,7 +372,7 @@ instance Arbitrary ValidBech32Char where
                 (Bech32.charToWord5 c))
 
 data ValidBech32String = ValidBech32String
-    { getValidBech32String :: ByteString
+    { getValidBech32String :: Text
     , humanReadablePart :: HumanReadablePart
     , unencodedDataPart :: DataPart
     } deriving (Eq, Show)
@@ -386,25 +399,27 @@ instance Arbitrary ValidBech32String where
 instance Arbitrary DataPart where
     arbitrary = do
         len <- choose (0, 64)
-        DataPart <$> replicateM len arbitrary
-    shrink (DataPart dp)
-        | null dp   = []
-        | otherwise = DataPart <$>
-            [ take (length dp `div` 2) dp
-            , drop 1 dp
+        dataPartFromWords <$> replicateM len arbitrary
+    shrink dp
+        | null ws = []
+        | otherwise = dataPartFromWords <$>
+            [ take (length ws `div` 2) ws
+            , drop 1 ws
             ]
+      where
+        ws = dataPartToWords dp
 
 instance Arbitrary HumanReadablePart where
     shrink hrp = catMaybes $ eitherToMaybe .
-        humanReadablePartFromBytes <$> shrink (humanReadablePartToBytes hrp)
+        humanReadablePartFromText <$> shrink (humanReadablePartToText hrp)
     arbitrary = do
         let range =
                 ( Bech32.humanReadableCharsetMinBound
                 , Bech32.humanReadableCharsetMaxBound )
         bytes <-
             choose (1, 10) >>= \n -> vectorOf n (choose range)
-        let (Right hrp) = humanReadablePartFromBytes $
-                B8.map toLower $ BS.pack bytes
+        let (Right hrp) = humanReadablePartFromText $
+                T.map toLower $ T.pack bytes
         return hrp
 
 instance Arbitrary ByteString where
@@ -414,8 +429,18 @@ instance Arbitrary ByteString where
         , BS.drop 1 bytes
         ]
     arbitrary = do
-        bytes <- choose (0, 32) >>= \n -> vectorOf n (elements Bech32.charset)
-        return (B8.pack bytes)
+        count <- choose (0, 32)
+        BS.pack <$> replicateM count arbitrary
+
+instance Arbitrary Text where
+    shrink chars | T.null chars = []
+    shrink chars =
+        [ T.take (T.length chars `div` 2) chars
+        , T.drop 1 chars
+        ]
+    arbitrary = do
+        chars <- choose (0, 32) >>= \n -> vectorOf n (elements Bech32.charset)
+        return (T.pack chars)
 
 instance Arbitrary Bech32.Word5 where
     arbitrary = Bech32.word5 @Word8 <$> arbitrary

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -107,7 +107,7 @@ spec = do
 
         it "hrp lowercased" $ do
             let (Right hrp) = humanReadablePartFromText "HRP"
-            Bech32.encode hrp mempty `shouldBe` Right "hrp1g9xj8m"
+            Bech32.encode hrp mempty `shouldBe` Right "hrp1vhqs52"
 
     describe "Arbitrary ValidBech32String" $
 

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -50,6 +50,8 @@ import Test.QuickCheck
     , (===)
     , (==>)
     )
+import Text.Read
+    ( readEither )
 
 import qualified Codec.Binary.Bech32.Internal as Bech32
 import qualified Data.Array as Arr
@@ -217,9 +219,17 @@ spec = do
             (eitherToMaybe (Bech32.encode hrp dp)
                 >>= eitherToMaybe . Bech32.decode) === Just (hrp, dp)
 
+    describe "Roundtrip (read . show)" $ do
+        it "For DataPart" $ property $ \(dp :: DataPart) ->
+            readEither (show dp) === Right dp
+
     describe "Roundtrip (dataPartToBytes . dataPartFromBytes)" $ do
         it "Can perform roundtrip base conversion" $ property $ \bs ->
             (Bech32.dataPartToBytes . Bech32.dataPartFromBytes) bs === Just bs
+
+    describe "Roundtrip (dataPartFromText . dataPartToText)" $ do
+        it "Can perform roundtrip conversion" $ property $ \dp ->
+            (Bech32.dataPartFromText . Bech32.dataPartToText) dp === Just dp
 
     describe "Roundtrip (toBase256 . toBase32)" $ do
         it "Can perform roundtrip base conversion" $ property $ \ws ->


### PR DESCRIPTION
# Issue Number

This PR fixes the following issues:

- #311 (Bech32 decoder fails for certain known-to-be-valid Bech32 strings)
- #314 (Bech32 encoder can be coerced into producing a string that can't be decoded)

# Overview

For #311:
- [x] Adds a new type `DataPart`, which wraps `[Word5]`.
- [x] Changes the types of `decode` and `encode` so that they operate on `DataPart` instead of `ByteString`.
- [x] Ensures that the round-trip relationship between `encode` and `decode` is preserved.
- [x] Provides auxilliary functions `dataPartFromBytes` and `dataPartToBytes` to convert to (and from) `ByteString` and `DataPart`:
    * `dataPartFromBytes` **pads** with trailing zeros where appropriate.
    * `dataPartToBytes` **trims** trailing zeros where appropriate.
- [x] Provides unit tests to ensure that all reference Bech32 strings mentioned in the [Bech32 standard](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) can be decoded successfully.

For #314:
- [x] Reworks smart constructors for `HumanReadablePart` and `DataPart` so that inputs are always converted to lower case.