### PR TITLE
Simplify folder structure, e.g. s/Binary.HttpBridge/HttpBridge.Binary/

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.Api.Types
     , WalletPostData (..)
     , WalletPutData (..)
     )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( FromMnemonic (..), Passphrase (..) )
@@ -109,8 +109,8 @@ import Text.Regex.Applicative
 
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.MVar as MVar
-import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
-import qualified Cardano.Wallet.Transaction.HttpBridge as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -57,11 +57,11 @@ library
       src
   exposed-modules:
       Cardano.Environment.HttpBridge
-      Cardano.Wallet.Binary.HttpBridge
-      Cardano.Wallet.Compatibility.HttpBridge
-      Cardano.Wallet.Network.HttpBridge
-      Cardano.Wallet.Network.HttpBridge.Api
-      Cardano.Wallet.Transaction.HttpBridge
+      Cardano.Wallet.HttpBridge.Binary
+      Cardano.Wallet.HttpBridge.Compatibility
+      Cardano.Wallet.HttpBridge.Network
+      Cardano.Wallet.HttpBridge.Api
+      Cardano.Wallet.HttpBridge.Transaction
       Data.Packfile
       Servant.Extra.ContentTypes
 
@@ -105,11 +105,11 @@ test-suite unit
       Main.hs
   other-modules:
       Cardano.Environment.HttpBridgeSpec
-      Cardano.Wallet.Binary.HttpBridgeSpec
-      Cardano.Wallet.Network.HttpBridge.ApiSpec
-      Cardano.Wallet.Network.HttpBridgeSpec
+      Cardano.Wallet.HttpBridge.BinarySpec
+      Cardano.Wallet.HttpBridge.ApiSpec
+      Cardano.Wallet.HttpBridge.NetworkSpec
       Cardano.Wallet.Primitive.AddressDerivationSpec
-      Cardano.Wallet.Transaction.HttpBridgeSpec
+      Cardano.Wallet.HttpBridge.TransactionSpec
       Data.PackfileSpec
       Servant.Extra.ContentTypesSpec
       Spec
@@ -166,7 +166,7 @@ test-suite integration
   other-modules:
       Cardano.LauncherSpec
       Cardano.WalletSpec
-      Cardano.Wallet.Network.HttpBridgeSpec
+      Cardano.Wallet.HttpBridge.NetworkSpec
       Test.Integration.Faucet
       Test.Integration.Framework.DSL
       Test.Integration.Framework.Request

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
@@ -7,7 +7,7 @@
 -- License: MIT
 --
 -- An API specification for the Cardano HTTP Bridge.
-module Cardano.Wallet.Network.HttpBridge.Api
+module Cardano.Wallet.HttpBridge.Api
     ( Api
     , GetBlockByHash
     , GetTipBlockHeader
@@ -21,7 +21,7 @@ module Cardano.Wallet.Network.HttpBridge.Api
 
 import Prelude
 
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( decodeBlock
     , decodeBlockHeader
     , decodeSignedTx

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
@@ -16,7 +16,7 @@
 -- of Cardano and will endure in the first stages of Shelley. They are also used
 -- by components like the Rust <https://github.com/input-output-hk/cardano-http-bridge cardano-http-bridge>.
 
-module Cardano.Wallet.Binary.HttpBridge
+module Cardano.Wallet.HttpBridge.Binary
     (
     -- * Decoding
       decodeBlock

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -10,7 +10,7 @@
 -- (Byron, Shelley-Rust, Shelley-Haskell) and isolate the bits that vary between
 -- those backends.
 
-module Cardano.Wallet.Compatibility.HttpBridge
+module Cardano.Wallet.HttpBridge.Compatibility
     ( -- * Target
       HttpBridge
     ) where
@@ -19,7 +19,7 @@ import Prelude
 
 import Cardano.Environment.HttpBridge
     ( Network (Mainnet, Staging, Testnet), network, protocolMagic )
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( encodeAddress, encodeProtocolMagic, encodeTx )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..), getKey )

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -13,7 +13,7 @@
 -- This module contains the necessary logic to talk to implement the network
 -- layer using the cardano-http-bridge as a chain producer.
 
-module Cardano.Wallet.Network.HttpBridge
+module Cardano.Wallet.HttpBridge.Network
     ( HttpBridge(..)
     , mkNetworkLayer
     , newNetworkLayer
@@ -24,13 +24,7 @@ import Prelude
 
 import Cardano.Environment.HttpBridge
     ( network )
-import Cardano.Wallet.Network
-    ( ErrNetworkTip (..)
-    , ErrNetworkUnreachable (..)
-    , ErrPostTx (..)
-    , NetworkLayer (..)
-    )
-import Cardano.Wallet.Network.HttpBridge.Api
+import Cardano.Wallet.HttpBridge.Api
     ( ApiT (..)
     , EpochIndex (..)
     , GetBlockByHash
@@ -39,6 +33,12 @@ import Cardano.Wallet.Network.HttpBridge.Api
     , NetworkName (..)
     , PostSignedTx
     , api
+    )
+import Cardano.Wallet.Network
+    ( ErrNetworkTip (..)
+    , ErrNetworkUnreachable (..)
+    , ErrPostTx (..)
+    , NetworkLayer (..)
     )
 import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..), Tx, TxWitness )

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Transaction.HttpBridge
+module Cardano.Wallet.HttpBridge.Transaction
     ( newTransactionLayer
     ) where
 
@@ -11,9 +11,9 @@ import Prelude
 
 import Cardano.Environment.HttpBridge
     ( Network (..), ProtocolMagic (..), network, protocolMagic )
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( toByteString )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (AddressK), Key, Passphrase (..), XPrv, XPub, getKey, publicKey )

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -13,12 +13,14 @@ import Cardano.Launcher
     ( Command (Command), StdStream (..), installSignalHandlers, launch )
 import Cardano.Wallet
     ( WalletLayer (..), newWalletLayer, unsafeRunExceptT )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
+import Cardano.Wallet.HttpBridge.Network
+    ( newNetworkLayer )
+import Cardano.Wallet.HttpBridge.Transaction
+    ( newTransactionLayer )
 import Cardano.Wallet.Network
     ( NetworkLayer (..), networkTip )
-import Cardano.Wallet.Network.HttpBridge
-    ( newNetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
@@ -41,8 +43,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletState (..)
     )
-import Cardano.Wallet.Transaction.HttpBridge
-    ( newTransactionLayer )
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async

--- a/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.Wallet.Network.HttpBridgeSpec
+module Cardano.Wallet.HttpBridge.NetworkSpec
     ( spec
     ) where
 
@@ -42,7 +42,7 @@ import Data.Text.Class
 import Test.Hspec
     ( Spec, afterAll, beforeAll, describe, it, shouldReturn, shouldSatisfy )
 
-import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Data.Text as T
 
 port :: Int

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -14,7 +14,7 @@ import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( WalletLayer (..), newWalletLayer, unsafeRunExceptT )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
@@ -38,8 +38,8 @@ import Test.Hspec
     ( Spec, after, before, expectationFailure, it )
 
 import qualified Cardano.Wallet.DB.MVar as MVar
-import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
-import qualified Cardano.Wallet.Transaction.HttpBridge as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
 import qualified Data.Text as T
 
 spec :: Spec

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -13,7 +13,7 @@ import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( newWalletLayer )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Control.Concurrent
     ( forkIO, threadDelay )
@@ -47,9 +47,9 @@ import Test.Integration.Framework.Request
 import qualified Cardano.LauncherSpec as Launcher
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.MVar as MVar
-import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
-import qualified Cardano.Wallet.Network.HttpBridgeSpec as HttpBridge
-import qualified Cardano.Wallet.Transaction.HttpBridge as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.NetworkSpec as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
 import qualified Cardano.WalletSpec as Wallet
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text as T
@@ -69,7 +69,7 @@ main = do
     hspec $ do
         describe "Cardano.LauncherSpec" Launcher.spec
         describe "Cardano.WalletSpec" Wallet.spec
-        describe "Cardano.Wallet.Network.HttpBridgeSpec" HttpBridge.spec
+        describe "Cardano.Wallet.HttpBridge.NetworkSpec" HttpBridge.spec
         describe "CLI commands not requiring bridge" CLI.specNoCluster
         beforeAll startCluster $ afterAll killCluster $ after tearDown $ do
             describe "Wallets API endpoint tests" Wallets.spec

--- a/lib/http-bridge/test/integration/Test/Integration/Faucet.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Faucet.hs
@@ -15,9 +15,9 @@ import Cardano.Environment.HttpBridge
     ( ProtocolMagic (..), network, protocolMagic )
 import Cardano.Wallet
     ( unsafeRunExceptT )
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( toByteString )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Network
     ( NetworkLayer (postTx) )

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/ApiSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/ApiSpec.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Wallet.Network.HttpBridge.ApiSpec
+module Cardano.Wallet.HttpBridge.ApiSpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Network.HttpBridge.Api
+import Cardano.Wallet.HttpBridge.Api
     ( ApiT (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
@@ -58,7 +58,7 @@ roundtripAndGolden = roundtripAndGoldenSpecsWithSettings settings
     settings :: Settings
     settings = defaultSettings
         { goldenDirectoryOption =
-            CustomDirectoryName "test/data/Cardano/Wallet/Network/HttpBridge"
+            CustomDirectoryName "test/data/Cardano.Wallet.HttpBridge.Network"
         , useModuleNameAsSubDirectory =
             False
         , sampleSize = 4

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Binary.HttpBridgeSpec
+module Cardano.Wallet.HttpBridge.BinarySpec
     ( spec
 
     -- * Helpers
@@ -11,7 +11,7 @@ module Cardano.Wallet.Binary.HttpBridgeSpec
 
 import Prelude
 
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( decodeBlock
     , decodeBlockHeader
     , decodeSignedTx
@@ -21,7 +21,7 @@ import Cardano.Wallet.Binary.HttpBridge
     , encodeTx
     , encodeTxWitness
     )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -1,13 +1,13 @@
-module Cardano.Wallet.Network.HttpBridgeSpec
+module Cardano.Wallet.HttpBridge.NetworkSpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Wallet.HttpBridge.Network
+    ( HttpBridge (..) )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
-import Cardano.Wallet.Network.HttpBridge
-    ( HttpBridge (..) )
 import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Monad.Trans.Class
@@ -19,7 +19,7 @@ import Data.Word
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldSatisfy )
 
-import qualified Cardano.Wallet.Network.HttpBridge as HttpBridge
+import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Data.ByteString.Char8 as B8
 
 

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Wallet.Transaction.HttpBridgeSpec
+module Cardano.Wallet.HttpBridge.TransactionSpec
     ( spec
     ) where
 
@@ -16,10 +16,12 @@ import Prelude
 
 import Cardano.Environment.HttpBridge
     ( Network (..), network )
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( encodeSignedTx, toByteString )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
+import Cardano.Wallet.HttpBridge.Transaction
+    ( newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , Key
@@ -46,8 +48,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Transaction
     ( ErrMkStdTx (..), TransactionLayer (..) )
-import Cardano.Wallet.Transaction.HttpBridge
-    ( newTransactionLayer )
 import Control.Arrow
     ( first )
 import Control.Monad.Trans.Except
@@ -81,7 +81,7 @@ import Test.QuickCheck
     , (===)
     )
 
-import qualified Cardano.Wallet.Binary.HttpBridge as Binary
+import qualified Cardano.Wallet.HttpBridge.Binary as Binary
 import qualified Cardano.Wallet.Primitive.CoinSelection as CS
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR

--- a/lib/http-bridge/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -12,7 +12,7 @@ import Prelude
 
 import Cardano.Environment.HttpBridge
     ( Network (..), network )
-import Cardano.Wallet.Compatibility.HttpBridge
+import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( ChangeChain (..)

--- a/lib/http-bridge/test/unit/Data/PackfileSpec.hs
+++ b/lib/http-bridge/test/unit/Data/PackfileSpec.hs
@@ -4,9 +4,9 @@ module Data.PackfileSpec
 
 import Prelude
 
-import Cardano.Wallet.Binary.HttpBridge
+import Cardano.Wallet.HttpBridge.Binary
     ( decodeBlock )
-import Cardano.Wallet.Binary.HttpBridgeSpec
+import Cardano.Wallet.HttpBridge.BinarySpec
     ( unsafeDeserialiseFromBytes )
 import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), SlotId (..) )

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -44,10 +44,10 @@ library
       src
   exposed-modules:
       Cardano.Environment.Jormungandr
-      Cardano.Wallet.Binary.Jormungandr
-      Cardano.Wallet.Network.Jormungandr.Api
-      Cardano.Wallet.Compatibility.Jormungandr
-      Cardano.Wallet.Transaction.Jormungandr
+      Cardano.Wallet.Jormungandr.Binary
+      Cardano.Wallet.Jormungandr.Api
+      Cardano.Wallet.Jormungandr.Compatibility
+      Cardano.Wallet.Jormungandr.Transaction
 
 test-suite unit
   default-language:
@@ -79,7 +79,7 @@ test-suite unit
   main-is:
       Main.hs
   other-modules:
-      Cardano.Wallet.Binary.JormungandrSpec
+      Cardano.Wallet.Jormungandr.BinarySpec
       Cardano.Environment.JormungandrSpec
       Spec
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -10,7 +10,7 @@
 -- License: MIT
 --
 -- An specification for the Jörmungandr REST API.
-module Cardano.Wallet.Network.Jormungandr.Api
+module Cardano.Wallet.Jormungandr.Api
     ( Api
     , GetBlock
     , GetTipId
@@ -23,7 +23,7 @@ module Cardano.Wallet.Network.Jormungandr.Api
 
 import Prelude
 
-import Cardano.Wallet.Binary.Jormungandr
+import Cardano.Wallet.Jormungandr.Binary
     ( FromBinary (..), runGet )
 import Cardano.Wallet.Primitive.Types
     ( Block, Hash (..) )

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -12,7 +12,7 @@
 --
 -- It is described [here](https://github.com/input-output-hk/rust-cardano/blob/master/chain-impl-mockchain/doc/format.md)
 
-module Cardano.Wallet.Binary.Jormungandr
+module Cardano.Wallet.Jormungandr.Binary
     ( Block (..)
     , BlockHeader (..)
     , Message (..)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -7,7 +7,7 @@
 -- (Byron, Shelley-Rust, Shelley-Haskell) and isolate the bits that vary between
 -- those backends.
 
-module Cardano.Wallet.Compatibility.Jormungandr
+module Cardano.Wallet.Jormungandr.Compatibility
     ( -- * Target
       Jormungandr
     ) where

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 
-module Cardano.Wallet.Transaction.Jormungandr
+module Cardano.Wallet.Jormungandr.Transaction
     ( newTransactionLayer
     ) where
 

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Cardano.Wallet.Binary.JormungandrSpec (spec) where
+module Cardano.Wallet.Jormungandr.BinarySpec (spec) where
 
 import Prelude
 
 import Cardano.Environment.Jormungandr
     ( Network (..) )
-import Cardano.Wallet.Binary.Jormungandr
+import Cardano.Wallet.Jormungandr.Binary
     ( Block (..)
     , BlockHeader (..)
     , ConfigParam (..)


### PR DESCRIPTION
# Motivation
- Flatten the the folder-structure to make it easier to comprehend in a file-tree-view of an editor

![Skärmavbild 2019-05-27 kl  00 30 36](https://user-images.githubusercontent.com/304423/58387962-203dc400-8018-11e9-8046-11f9b2bbafb6.jpg)

- There was a short discussion here https://input-output-rnd.slack.com/archives/GBT05825V/p1558448032023600


# Overview

- [x] I have flipped {Binary,Transaction,Compatibility,Network} and {HttpBridge,Jormungandr} such that we now how e.g. `Cardano.Wallet.HttpBridge.Binary`
- [x] `Cardano.Wallet.Network.HttpBridge.Api` is now `Cardano.Wallet.HttpBridge.Api` (now in the same folder as `Cardano.Wallet.HttpBridge.Network`) 
- [ ] I have *not* touched the `lib/{http-bridge,jormungandr}/test/data` structure. It is more complex.

# Comments

- Will cause conflicts with parallel PRs (might be best to wait for the opportune time)
-  script automating this restructuring https://gist.github.com/Anviking/e6d4e87759e26f61f27eda2c4e8e8c27
- This is pretty drastic, and I'm not sure about it.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->