### PR TITLE
Add extra debugging information to Bech32 decoding corruption tests.

### DIFF
--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -166,17 +166,21 @@ spec = do
 
         it "Decoding fails when a character is inserted." $
             property $ \s c -> do
-                let validString = getValidBech32String s
-                let validChar = getDataChar c
-                index <- choose (0, T.length validString - 1)
-                let prefix = T.take index validString
-                let suffix = T.drop index validString
-                let recombinedString =
-                        prefix <> T.singleton validChar <> suffix
-                return $
-                    (T.length recombinedString === T.length validString + 1)
+                let originalString = getValidBech32String s
+                let char = getDataChar c
+                index <- choose (0, T.length originalString - 1)
+                let prefix = T.take index originalString
+                let suffix = T.drop index originalString
+                let corruptedString = prefix <> T.singleton char <> suffix
+                let description = intercalate "\n"
+                        [ "index of inserted char: " <> show index
+                        , "         inserted char: " <> show char
+                        , "       original string: " <> show originalString
+                        , "      corrupted string: " <> show corruptedString ]
+                return $ counterexample description $
+                    (T.length corruptedString === T.length originalString + 1)
                     .&&.
-                    (Bech32.decode recombinedString `shouldSatisfy` isLeft)
+                    (Bech32.decode corruptedString `shouldSatisfy` isLeft)
 
         it "Decoding fails when a single character is mutated." $
            property $ \s c -> do

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -148,15 +148,21 @@ spec = do
 
         it "Decoding fails when a character is omitted." $
             property $ \s -> do
-                let validString = getValidBech32String s
-                index <- choose (0, T.length validString - 1)
-                let prefix = T.take index validString
-                let suffix = T.drop (index + 1) validString
-                let recombinedString = prefix <> suffix
-                return $
-                    (T.length recombinedString === T.length validString - 1)
+                let originalString = getValidBech32String s
+                index <- choose (0, T.length originalString - 1)
+                let char = T.index originalString index
+                let prefix = T.take index originalString
+                let suffix = T.drop (index + 1) originalString
+                let corruptedString = prefix <> suffix
+                let description = intercalate "\n"
+                        [ "index of omitted char: " <> show index
+                        , "         omitted char: " <> show char
+                        , "      original string: " <> show originalString
+                        , "     corrupted string: " <> show corruptedString ]
+                return $ counterexample description $
+                    (T.length corruptedString === T.length originalString - 1)
                     .&&.
-                    (Bech32.decode recombinedString `shouldSatisfy` isLeft)
+                    (Bech32.decode corruptedString `shouldSatisfy` isLeft)
 
         it "Decoding fails when a character is inserted." $
             property $ \s c -> do


### PR DESCRIPTION
# Issue Number

Issue #324 

# Overview

- [x] I have added extra debugging information to the suite of Bech32 decoding corruption tests.

These tests:

1. corrupt a known-valid Bech32 string;
2. attempt to decode the corrupted string;
3. assert that decoding will fail.

Sample string:
```
       index of mutated char: 5
               original char: '1'
            replacement char: 'q'
             original string: "'14-b13zhcknjh"
            corrupted string: "'14-bq3zhcknjh"
``` 

Debugging information is only printed when QuickCheck finds a counterexample.
