### PR TITLE
Add known-to-fail counterexamples to Bech32 string corruption tests.

### DIFF
--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -57,6 +57,7 @@ import Test.QuickCheck
     , counterexample
     , elements
     , property
+    , withMaxSuccess
     , (.&&.)
     , (.||.)
     , (===)
@@ -125,7 +126,7 @@ spec = do
     describe "Decoding a corrupted string should fail" $ do
 
         it "Decoding fails when an adjacent pair of characters is swapped." $
-            property $ \s -> do
+            property $ withMaxSuccess 10000 $ \s -> do
                 let originalString = getValidBech32String s
                 index <- choose (0, T.length originalString - 2)
                 let prefix = T.take index originalString


### PR DESCRIPTION
# Issue Number

Issue #324 

# Overview

- [x] I've added **known-to-fail counterexamples** to both the Bech32 character **insertion** and **deletion** tests. If we encounter these counterexamples, we allow the current test run to pass.
- [x] I've **increased the maximum number of test runs** for the Bech32 character **insertion**, **deletion** and **swap** tests, **from 100 to 10,000 runs**. By increasing the number of runs, we can be more confident that there are no counterexamples to be found, at a small cost in test time (a couple of seconds in total.)
- [x] I did a **one-off** test run with **10 million iterations** for each of the above tests. No counterexamples were found other than those already identified.