### PR TITLE
Oversight: re-encrypt wallet root private key with provided passphrase when updating it....

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -60,6 +60,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Key
     , Passphrase
     , XPrv
+    , changePassphrase
     , checkPassphrase
     , encryptPassphrase
     )
@@ -408,8 +409,9 @@ newWalletLayer db nw tl = do
         -> ExceptT ErrUpdatePassphrase IO ()
     _updateWalletPassphrase wid (old, new) = do
         withRootKey wid (coerce old) ErrUpdatePassphraseWithRootKey $ \xprv ->
-            withExceptT ErrUpdatePassphraseNoSuchWallet $
-                _attachPrivateKey wid (xprv, coerce new)
+            withExceptT ErrUpdatePassphraseNoSuchWallet $ do
+                let xprv' = changePassphrase old new xprv
+                _attachPrivateKey wid (xprv', coerce new)
 
     _listWallets
         :: IO [WalletId]

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , ErrWrongPassphrase(..)
     , encryptPassphrase
     , checkPassphrase
+    , changePassphrase
 
     -- * Sequential Derivation
     , ChangeChain(..)
@@ -77,6 +78,7 @@ import Cardano.Crypto.Wallet
     , toXPub
     , unXPrv
     , unXPub
+    , xPrvChangePass
     , xprv
     , xpub
     )
@@ -392,6 +394,20 @@ checkPassphrase received stored = do
 -- | Indicate a failure when checking for a given 'Passphrase' match
 data ErrWrongPassphrase = ErrWrongPassphrase
     deriving stock (Show, Eq)
+
+-- | Re-encrypt a private key using a different passphrase.
+--
+-- **Important**:
+-- This function doesn't check that the old passphrase is correct! Caller is
+-- expected to have already checked that. Using an incorrect passphrase here
+-- will lead to very bad thing.
+changePassphrase
+    :: Passphrase "encryption-old"
+    -> Passphrase "encryption-new"
+    -> Key purpose XPrv
+    -> Key purpose XPrv
+changePassphrase (Passphrase oldPwd) (Passphrase newPwd) (Key prv) =
+    Key $ xPrvChangePass oldPwd newPwd prv
 
 -- | Little trick to be able to provide our own "random" salt in order to
 -- deterministically re-compute a passphrase hash from a known salt. Note that,

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -96,7 +96,7 @@ import GHC.Generics
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldNotBe, shouldSatisfy )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, elements, property, (==>) )
+    ( Arbitrary (..), Property, elements, property, withMaxSuccess, (==>) )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
@@ -144,7 +144,7 @@ spec = do
         it "Passphrase info is up-to-date after wallet passphrase update"
             (property walletUpdatePassphraseDate)
         it "Root key is re-encrypted with new passphrase"
-            (property walletKeyIsReencrypted)
+            (withMaxSuccess 10 $ property walletKeyIsReencrypted)
 
 {-------------------------------------------------------------------------------
                                     Properties


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#326 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have extended the unit tests from WalletLayerSpec to show that producing witnesses for a same transaction using different encryption passphrase (after an update) should produce identical result. This failed initially.

- [ ] Fixed the `updateWalletPassphrase` handler to correctly re-encrypt the root private key using a new passphrase.

# Comments

<!-- Additional comments or screenshots to attach if any -->

:man_facepalming: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
