### PR TITLE
Address Format in Shelley (Part 2: implementing address encoder and decoders + tests)

### DIFF
--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -14,8 +14,10 @@ module Codec.Binary.Bech32
     (
       -- * Encoding & Decoding
       encode
+    , encodeLenient
     , EncodingError (..)
     , decode
+    , decodeLenient
     , DecodingError (..)
 
       -- * Data Part

--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -14,7 +14,9 @@ module Codec.Binary.Bech32
     (
       -- * Encoding & Decoding
       encode
+    , EncodingError (..)
     , decode
+    , DecodingError (..)
 
       -- * Data Part
     , DataPart
@@ -25,9 +27,9 @@ module Codec.Binary.Bech32
 
       -- * Human-Readable Part
     , HumanReadablePart
+    , HumanReadablePartError (..)
     , humanReadablePartFromText
     , humanReadablePartToText
-
     ) where
 
 import Codec.Binary.Bech32.Internal

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -33,11 +33,14 @@ library
       -Werror
   build-depends:
       base
+    , base58-bytestring
+    , bech32
     , binary
     , bytestring
     , cardano-wallet-core
-    , servant
+    , cborg
     , memory
+    , servant
     , text
     , text-class
   hs-source-dirs:
@@ -68,10 +71,11 @@ test-suite unit
     , cardano-wallet-core
     , cardano-wallet-jormungandr
     , generic-arbitrary
-    , memory
-    , text-class
     , hspec
+    , memory
     , QuickCheck
+    , text
+    , text-class
   type:
      exitcode-stdio-1.0
   hs-source-dirs:
@@ -81,6 +85,7 @@ test-suite unit
   other-modules:
       Cardano.Wallet.Jormungandr.BinarySpec
       Cardano.Wallet.Jormungandr.EnvironmentSpec
+      Cardano.Wallet.Jormungandr.CompatibilitySpec
       Spec
 
 test-suite integration
@@ -110,4 +115,3 @@ test-suite integration
       Main.hs
   other-modules:
       Cardano.LauncherSpec
-

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TupleSections #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
@@ -14,10 +16,31 @@ module Cardano.Wallet.Jormungandr.Compatibility
 
 import Prelude
 
+import Cardano.Wallet.Jormungandr.Binary
+    ( decodeLegacyAddress )
+import Cardano.Wallet.Jormungandr.Environment
+    ( grouped, hrp, network, single )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( TxId (..) )
+    ( Address (..), DecodeAddress (..), EncodeAddress (..), TxId (..) )
+import Codec.Binary.Bech32
+    ( HumanReadablePart, dataPartFromBytes, dataPartToBytes )
+import Control.Monad
+    ( when )
+import Data.ByteString
+    ( ByteString )
+import Data.ByteString.Base58
+    ( bitcoinAlphabet, decodeBase58, encodeBase58 )
+import Data.Maybe
+    ( isJust )
+import Data.Text.Class
+    ( TextDecodingError (..) )
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text.Encoding as T
 
 -- | A type representing the Jormungandr as a network target. This has an
 -- influence on binary serializer & network primitives. See also 'TxId'
@@ -28,3 +51,89 @@ instance TxId Jormungandr where
 
 instance KeyToAddress Jormungandr where
     keyToAddress = undefined
+
+-- | Encode an 'Address' to a human-readable format. This produces two kinds of
+-- encodings:
+--
+-- - [Base58](https://en.wikipedia.org/wiki/Base58)
+--   for legacy / Byron addresses
+-- - [Bech32](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+--   for Shelley addresses
+--
+-- The right encoding is picked by looking at the raw 'Address' representation
+-- in order to figure out to which class the address belongs.
+instance EncodeAddress Jormungandr where
+    encodeAddress _ (Address bytes) = do
+        if isJust (decodeLegacyAddress bytes) then base58 else bech32
+      where
+        base58 = T.decodeUtf8 $ encodeBase58 bitcoinAlphabet bytes
+        bech32 = Bech32.encodeLenient hrp (dataPartFromBytes bytes)
+
+-- | Decode text string into an 'Address'. Jörmungandr recognizes two kind of
+-- addresses:
+--
+-- - Legacy / Byron addresses encoded as `Base58`
+-- - Shelley addresses, encoded as `Bech32`
+--
+-- See also 'EncodeAddress Jormungandr'
+instance DecodeAddress Jormungandr where
+    decodeAddress _ x =
+        case (tryBech32, tryBase58) of
+            (Just bytes, _) -> bech32 bytes
+            (_, Just bytes) -> base58 bytes
+            (Nothing, Nothing) -> Left $ TextDecodingError
+                "Unable to decode address: encoding is neither Bech32 nor \
+                \Base58."
+      where
+        -- | Attempt decoding a legacy 'Address' using a Base58 encoding.
+        tryBase58 :: Maybe ByteString
+        tryBase58 = decodeBase58 bitcoinAlphabet (T.encodeUtf8 x)
+
+        -- | Verify the structure of a payload decoded from a Base58 text string
+        base58 :: ByteString -> Either TextDecodingError Address
+        base58 bytes = maybe (Left $ TextDecodingError errByron) Right $
+            decodeLegacyAddress bytes
+          where
+            errByron =
+                "Unable to decode address: neither Bech32-encoded nor a valid \
+                \Byron address."
+
+        -- | Attempt decoding an 'Address' using a Bech32 encoding.
+        tryBech32 :: Maybe (HumanReadablePart, ByteString)
+        tryBech32 = do
+            (hrp', dp) <- either (const Nothing) Just (Bech32.decodeLenient x)
+            (hrp',) <$> dataPartToBytes dp
+
+        -- | Verify the structure of a payload decoded from a Bech32 text string
+        bech32
+            :: (HumanReadablePart, ByteString)
+            -> Either TextDecodingError Address
+        bech32 (hrp', bytes) = do
+            when (hrp /= hrp') $ Left $ TextDecodingError $
+                "This address belongs to another network. Network is: "
+                <> show network <> "."
+            case BS.length bytes of
+                n | n == singleAddressLength ->
+                    when (BS.take 1 bytes /= BS.pack [single]) $
+                        Left (invalidFirstByte single)
+                n | n == groupedAddressLength ->
+                    when (BS.take 1 bytes /= BS.pack [grouped]) $
+                        Left (invalidFirstByte grouped)
+                _ ->
+                    Left $ TextDecodingError $
+                        "Invalid address length (" <> show (BS.length bytes)
+                        <> "): expected either "
+                        <> show singleAddressLength
+                        <> " or "
+                        <> show groupedAddressLength
+                        <> " bytes."
+            return (Address bytes)
+          where
+            singleAddressLength = 33
+            groupedAddressLength = 65
+            invalidFirstByte discriminant = TextDecodingError
+                $ "Invalid address first byte: "
+                <> B8.unpack (BS.take 1 bytes)
+                <> " =/= "
+                <> B8.unpack (BS.pack [discriminant])
+                <> "."

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -11,21 +11,27 @@ import Prelude
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Environment
-    ( discriminant, network )
+    ( Network (..), grouped, network, single )
 import Cardano.Wallet.Primitive.Types
     ( Address (..), ShowFmt (..), decodeAddress, encodeAddress )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertFromBase )
+import Data.ByteString
+    ( ByteString )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Text
+    ( Text )
 import Data.Text.Class
     ( TextDecodingError (..) )
 import Test.Hspec
-    ( Spec, describe, it )
+    ( Spec, SpecWith, describe, expectationFailure, it, shouldBe )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , choose
-    , elements
     , frequency
+    , oneof
     , property
     , vectorOf
     , withMaxSuccess
@@ -34,32 +40,116 @@ import Test.QuickCheck
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
 
 spec :: Spec
-spec = describe "Compatibility - Jormungandr" $ do
+spec = describe "EncodeAddress & DecodeAddress" $ do
     it "decodeAddress . encodeAddress = pure" $
         withMaxSuccess 1000 $ property $ \(ShowFmt a) ->
-            (ShowFmt <$> decodeAddress' (encodeAddress' a)) === Right (ShowFmt a)
+            (ShowFmt <$> decodeAddress' (encodeAddress' a))
+                === Right (ShowFmt a)
 
-    let net = show network
     negativeTest "bc1qvqsyqcyq5rqwzqfpg9scrgyg0p0q"
-        ("This address belongs to another network. Network is: " <> net <> ".")
-    negativeTest "ca1qvqsyqcyq5rqwzqfpg9scrgk66qs0"
-        "Invalid address length (14): expected either 33 or 65 bytes."
-    let firstByte = B8.unpack (BS.pack [discriminant])
-    negativeTest "ca1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqscdket"
-        ("Invalid address first byte: k =/= " <> firstByte <> ".")
+        ("This address belongs to another network. Network is: "
+        <> show network <> ".")
     negativeTest "EkxDbkPo"
         "Unable to decode address: neither Bech32-encoded nor a valid Byron \
         \address."
     negativeTest ".%14'"
         ("Unable to decode address: encoding is neither Bech32 nor Base58.")
+
+    -- NOTE:
+    -- Data below have been generated with [jcli](https://github.com/input-output-hk/jormungandr/tree/master/doc/jcli)
+    -- as described in the annex at the end of the file.
+    case network of
+        Mainnet -> do
+            negativeTest "ca1qvqsyqcyq5rqwzqfpg9scrgk66qs0"
+                "Invalid address length (14): expected either 33 or 65 bytes."
+            negativeTest
+                "ca1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqscdket"
+                ("Invalid address first byte: k =/= " <> firstByteS <> ".")
+            negativeTest
+                "ca1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqqgzqvz\
+                \q2ps8pqys5zcvp58q7yq3zgf3g9gkzuvpjxsmrsw3u8eqwxpnc0"
+                ("Invalid address first byte: k =/= " <> firstByteG <> ".")
+            goldenTest
+                [ "7bd5386c31ac31ba7076856500cf26f85d4695b80f183c7a53e3f28419d6bde1"
+                ]
+                "ca1qdaa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677zqx4le2"
+            goldenTest
+                [ "df9f08672a3a94778229b91daa981538883e1535d666dc10e63b438f44c63e3f"
+                ]
+                "ca1q00e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr78edvht"
+            goldenTest
+                [ "7bd5386c31ac31ba7076856500cf26f85d4695b80f183c7a53e3f28419d6bde1"
+                , "b24e70b0c2ceeb24cc9f28f386478c73aa71c05a95a0119bb91dd8e89c3592ae"
+                ]
+                "ca1q3aa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677r\
+                \vjwwzcv9nhtynxf728nserccua2w8q949dqzxdmj8wcazwrty4wga8haz"
+            goldenTest
+                [ "df9f08672a3a94778229b91daa981538883e1535d666dc10e63b438f44c63e3f"
+                , "402abff6065c847115ad22ff6b0d3a85fd69a6fcc32ed76aa8cadb305b0c51a7"
+                ]
+                "ca1qn0e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr7\
+                \sp2hlmqvhyywy266ghldvxn4p0adxn0esew6a423jkmxpdsc5d8hxd7cr"
+
+        Testnet -> do
+            negativeTest "ta1dvqsyqcyq5rqwzqfpg9scrg5v76st"
+                "Invalid address length (14): expected either 33 or 65 bytes."
+            negativeTest
+                "ta1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jq8ygppa"
+                ("Invalid address first byte: k =/= " <> firstByteS <> ".")
+            negativeTest
+                "ta1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqqgzqvz\
+                \q2ps8pqys5zcvp58q7yq3zgf3g9gkzuvpjxsmrsw3u8eq9lcgc2"
+                ("Invalid address first byte: k =/= " <> firstByteG <> ".")
+            goldenTest
+                [ "7bd5386c31ac31ba7076856500cf26f85d4695b80f183c7a53e3f28419d6bde1"
+                ]
+                "ta1sdaa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677ztw225s"
+            goldenTest
+                [ "df9f08672a3a94778229b91daa981538883e1535d666dc10e63b438f44c63e3f"
+                ]
+                "ta1s00e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr7v3je63"
+            goldenTest
+                [ "7bd5386c31ac31ba7076856500cf26f85d4695b80f183c7a53e3f28419d6bde1"
+                , "b24e70b0c2ceeb24cc9f28f386478c73aa71c05a95a0119bb91dd8e89c3592ae"
+                ]
+                "ta1s3aa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677r\
+                \vjwwzcv9nhtynxf728nserccua2w8q949dqzxdmj8wcazwrty4we4spcz"
+            goldenTest
+                [ "df9f08672a3a94778229b91daa981538883e1535d666dc10e63b438f44c63e3f"
+                , "402abff6065c847115ad22ff6b0d3a85fd69a6fcc32ed76aa8cadb305b0c51a7"
+                ]
+                "ta1sn0e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr7\
+                \sp2hlmqvhyywy266ghldvxn4p0adxn0esew6a423jkmxpdsc5d8xw6gar"
+
   where
     decodeAddress' = decodeAddress (Proxy @Jormungandr)
     encodeAddress' = encodeAddress (Proxy @Jormungandr)
+    firstByteS = B8.unpack (BS.pack [single])
+    firstByteG = B8.unpack (BS.pack [grouped])
     negativeTest input msg = it ("decodeAddress failure: " <> msg) $
         decodeAddress' input === Left (TextDecodingError msg)
 
+-- | Generate addresses from the given keys and compare the result with an
+-- expected output.
+goldenTest
+    :: [ByteString]
+    -> Text
+    -> SpecWith ()
+goldenTest pubkeys expected = it ("golden test: " <> T.unpack expected) $ do
+    case traverse (convertFromBase Base16) pubkeys of
+        Right [spending] -> do
+            let payload = BS.pack [single] <> spending
+            let addr = encodeAddress (Proxy @Jormungandr) (Address payload)
+            addr `shouldBe` expected
+        Right [spending, delegation] -> do
+            let payload = BS.pack [grouped] <> spending <> delegation
+            let addr = encodeAddress (Proxy @Jormungandr) (Address payload)
+            addr `shouldBe` expected
+        _ ->
+            expectationFailure "goldenTest: provided invalid inputs public keys"
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances
@@ -67,14 +157,15 @@ spec = describe "Compatibility - Jormungandr" $ do
 
 instance Arbitrary (ShowFmt Address) where
     arbitrary = ShowFmt <$> frequency
-        [ (10, genAddress [32,64])
+        [ (10, genAddress)
         , (1, genLegacyAddress (30, 100))
         ]
 
-genAddress :: [Int] -> Gen Address
-genAddress sz = do
-    bytes <- elements sz >>= \n -> vectorOf n arbitrary
-    return . Address $ BS.pack (discriminant:bytes)
+genAddress :: Gen Address
+genAddress = oneof
+    [ (\bytes -> Address (BS.pack (single:bytes))) <$> vectorOf 32 arbitrary
+    , (\bytes -> Address (BS.pack (grouped:bytes))) <$> vectorOf 64 arbitrary
+    ]
 
 genLegacyAddress :: (Int, Int) -> Gen Address
 genLegacyAddress range = do
@@ -87,3 +178,31 @@ genLegacyAddress range = do
     payload <- BS.pack <$> vectorOf n arbitrary
     let crc = BS.pack [26,1,2,3,4]
     return $ Address (prefix <> payload <> crc)
+
+{-------------------------------------------------------------------------------
+                        Generating Golden Test Vectors
+-------------------------------------------------------------------------------}
+
+-- SPENDINGKEY=$(jcli key generate --type Ed25519Extended | jcli key to-public)
+-- DELEGATIONKEY=$(jcli key generate --type Ed25519Extended | jcli key to-public)
+--
+-- SPENDINGKEYBYTES=$(echo $SPENDINGKEY | jcli key to-bytes)
+-- DELEGATIONKEYBYTES=$(echo $DELEGATIONKEY | jcli key to-bytes)
+--
+-- MAINNETSINGLE=$(jcli address single $SPENDINGKEY)
+-- TESTNETSINGLE=$(jcli address single $SPENDINGKEY --testing)
+--
+-- MAINNETGROUPED=$(jcli address single $SPENDINGKEY $DELEGATIONKEY)
+-- TESTNETGROUPED=$(jcli address single $SPENDINGKEY $DELEGATIONKEY --testing)
+--
+-- TESTVECTOR=test_vector_$(date +%s)
+-- touch $TESTVECTOR
+-- echo "spending key:        $SPENDINGKEYBYTES" >> $TESTVECTOR
+-- echo "\ndelegation key:    $DELEGATIONKEYBYTES" >> $TESTVECTOR
+-- echo "\nsingle (mainnet):  $MAINNETSINGLE" >> $TESTVECTOR
+-- echo "\ngrouped (mainnet): $MAINNETGROUPED" >> $TESTVECTOR
+-- echo "\nsingle (testnet):  $TESTNETSINGLE" >> $TESTVECTOR
+-- echo "\ngrouped (testnet): $TESTNETGROUPED" >> $TESTVECTOR
+--
+-- echo -e $(cat $TESTVECTOR)
+-- echo "Saved as $TESTVECTOR."

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Jormungandr.CompatibilitySpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Jormungandr.Compatibility
+    ( Jormungandr )
+import Cardano.Wallet.Jormungandr.Environment
+    ( discriminant, network )
+import Cardano.Wallet.Primitive.Types
+    ( Address (..), ShowFmt (..), decodeAddress, encodeAddress )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text.Class
+    ( TextDecodingError (..) )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , choose
+    , elements
+    , frequency
+    , property
+    , vectorOf
+    , withMaxSuccess
+    , (===)
+    )
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+
+spec :: Spec
+spec = describe "Compatibility - Jormungandr" $ do
+    it "decodeAddress . encodeAddress = pure" $
+        withMaxSuccess 1000 $ property $ \(ShowFmt a) ->
+            (ShowFmt <$> decodeAddress' (encodeAddress' a)) === Right (ShowFmt a)
+
+    let net = show network
+    negativeTest "bc1qvqsyqcyq5rqwzqfpg9scrgyg0p0q"
+        ("This address belongs to another network. Network is: " <> net <> ".")
+    negativeTest "ca1qvqsyqcyq5rqwzqfpg9scrgk66qs0"
+        "Invalid address length (14): expected either 33 or 65 bytes."
+    let firstByte = B8.unpack (BS.pack [discriminant])
+    negativeTest "ca1dvqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0jqscdket"
+        ("Invalid address first byte: k =/= " <> firstByte <> ".")
+    negativeTest "EkxDbkPo"
+        "Unable to decode address: neither Bech32-encoded nor a valid Byron \
+        \address."
+    negativeTest ".%14'"
+        ("Unable to decode address: encoding is neither Bech32 nor Base58.")
+  where
+    decodeAddress' = decodeAddress (Proxy @Jormungandr)
+    encodeAddress' = encodeAddress (Proxy @Jormungandr)
+    negativeTest input msg = it ("decodeAddress failure: " <> msg) $
+        decodeAddress' input === Left (TextDecodingError msg)
+
+
+{-------------------------------------------------------------------------------
+                             Arbitrary Instances
+-------------------------------------------------------------------------------}
+
+instance Arbitrary (ShowFmt Address) where
+    arbitrary = ShowFmt <$> frequency
+        [ (10, genAddress [32,64])
+        , (1, genLegacyAddress (30, 100))
+        ]
+
+genAddress :: [Int] -> Gen Address
+genAddress sz = do
+    bytes <- elements sz >>= \n -> vectorOf n arbitrary
+    return . Address $ BS.pack (discriminant:bytes)
+
+genLegacyAddress :: (Int, Int) -> Gen Address
+genLegacyAddress range = do
+    n <- choose range
+    let prefix = BS.pack
+            [ 130       -- Array(2)
+            , 216, 24   -- Tag 24
+            , 88, fromIntegral n -- Bytes(n), n > 23 && n < 256
+            ]
+    payload <- BS.pack <$> vectorOf n arbitrary
+    let crc = BS.pack [26,1,2,3,4]
+    return $ Address (prefix <> payload <> crc)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#239 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have exported error constructors from `bech32` encode, decode and hrp smart-constructors
- [x] I have added lenient encoders & decoders to `bech32`. By default, the encoder and decoder fail with a "StringTooLong" error if the end-result is > 90 chars because this is the optimal size for this encoding. Nevertheless, the encoding is fine up to 1024 chars and grouped addresses actually generate addresses that are longer than 90 chars! 
- [x] Copy/Pasted legacy address decoder doing a bit of CBOR just to swiftly verify the address structure when encoded in base58
- [x] I have added instances for `EncodeAddress` and `DecodeAddress` for `Jormungandr`
- [x] I have added unit tests and golden tests (generated via `jcli`) to make sure everything's okay. Everything is :) 

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
