### PR TITLE
Fix index limits in Bech32 mutation tests

### DIFF
--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -58,11 +58,13 @@ test-suite bech32-test
   build-depends:
       base
     , bech32
+    , containers
     , extra
     , hspec
     , bytestring
     , QuickCheck
     , text
+    , vector
   main-is:
       Main.hs
   other-modules:

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -160,7 +160,7 @@ spec = do
         it "Decoding fails when an adjacent pair of characters is swapped." $
             property $ withMaxSuccess 10000 $ \s -> do
                 let originalString = getValidBech32String s
-                index <- chooseWithinDataPart originalString
+                index <- choose (0, T.length originalString - 2)
                 let prefix = T.take index originalString
                 let suffix = T.drop (index + 2) originalString
                 let char1 = T.singleton (T.index originalString index)

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -561,11 +561,13 @@ data ValidBech32String = ValidBech32String
     } deriving (Eq, Show)
 
 mkValidBech32String :: HumanReadablePart -> DataPart -> ValidBech32String
-mkValidBech32String hrp udp =
-    ValidBech32String
-        (fromRight (error "unable to make a valid Bech32 string.") $
-            Bech32.encode hrp udp)
-        hrp udp
+mkValidBech32String hrp udp = ValidBech32String
+    { getValidBech32String =
+        fromRight (error "unable to make a valid Bech32 string.") $
+            Bech32.encode hrp udp
+    , humanReadablePart = hrp
+    , unencodedDataPart = udp
+    }
 
 instance Arbitrary ValidBech32String where
     arbitrary = mkValidBech32String <$> arbitrary <*> arbitrary

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -182,7 +182,7 @@ spec = do
         it "Decoding fails when a character is omitted." $
             property $ withMaxSuccess 10000 $ \s -> do
                 let originalString = getValidBech32String s
-                index <- chooseWithinDataPart originalString
+                index <- choose (0, T.length originalString - 1)
                 let char = T.index originalString index
                 let prefix = T.take index originalString
                 let suffix = T.drop (index + 1) originalString

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -150,12 +150,6 @@ spec = do
                 all (< c) $ shrink (c :: Bech32Char)
 
     describe "Decoding a corrupted string should fail" $ do
-        let chooseWithinDataPart originalString = do
-                let sepIx = maybe
-                        (error "couldn't find separator in valid bech32 string")
-                        (\ix -> T.length originalString - ix - 1)
-                        (T.findIndex (== '1') (T.reverse originalString))
-                choose (sepIx + 1, T.length originalString - 2)
 
         it "Decoding fails when an adjacent pair of characters is swapped." $
             property $ withMaxSuccess 10000 $ \s -> do

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -268,7 +268,7 @@ spec = do
            \character." $
             withMaxSuccess 10000 $ property $ \s -> do
                 let originalString = T.map toUpper $ getValidBech32String s
-                index <- chooseWithinDataPart originalString
+                index <- choose (0, T.length originalString - 1)
                 let prefix = T.take index originalString
                 let suffix = T.drop (index + 1) originalString
                 let char = toLower $ T.index originalString index
@@ -288,7 +288,7 @@ spec = do
            \character." $
             withMaxSuccess 10000 $ property $ \s -> do
                 let originalString = T.map toLower $ getValidBech32String s
-                index <- chooseWithinDataPart originalString
+                index <- choose (0, T.length originalString - 1)
                 let prefix = T.take index originalString
                 let suffix = T.drop (index + 1) originalString
                 let char = toUpper $ T.index originalString index

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -244,9 +244,9 @@ spec = do
         it "Decoding fails when a single character is mutated." $
            withMaxSuccess 10000 $ property $ \s c -> do
                 let originalString = getValidBech32String s
-                index <- chooseWithinDataPart originalString
+                index <- choose (0, T.length originalString - 1)
                 let originalChar = T.index originalString index
-                let replacementChar = getDataChar c
+                let replacementChar = getBech32Char c
                 let prefix = T.take index originalString
                 let suffix = T.drop (index + 1) originalString
                 let corruptedString =
@@ -262,15 +262,7 @@ spec = do
                     corruptedString /= originalString ==>
                         (T.length corruptedString === T.length originalString)
                         .&&.
-                        (result `shouldBe` Left
-                            StringToDecodeMissingSeparatorChar)
-                        .||.
-                        (result `shouldBe` Left
-                            (StringToDecodeContainsInvalidChars []))
-                        .||.
-                        (result `shouldBe` Left
-                            (StringToDecodeContainsInvalidChars
-                                [CharPosition index]))
+                        (result `shouldSatisfy` isLeft)
 
         it "Decoding fails for an upper-case string with a lower-case \
            \character." $

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -253,7 +253,7 @@ spec = do
                         , "      original string: " <> show originalString
                         , "     corrupted string: " <> show corruptedString ]
                 return $ counterexample description $
-                    corruptedString /= originalString ==>
+                    isMixedCase corruptedString ==>
                         (T.length corruptedString === T.length originalString)
                         .&&.
                         (Bech32.decode corruptedString `shouldBe` Left
@@ -273,7 +273,7 @@ spec = do
                         , "      original string: " <> show originalString
                         , "     corrupted string: " <> show corruptedString ]
                 return $ counterexample description $
-                    corruptedString /= originalString ==>
+                    isMixedCase corruptedString ==>
                         (T.length corruptedString === T.length originalString)
                         .&&.
                         (Bech32.decode corruptedString `shouldBe` Left
@@ -544,3 +544,11 @@ instance Arbitrary ByteString where
 instance Arbitrary Bech32.Word5 where
     arbitrary = arbitraryBoundedEnum
     shrink w = Bech32.word5 <$> shrink (Bech32.getWord5 w)
+
+-- | Returns true iff. the given string has both lower-case and upper-case
+--   characters.
+--
+isMixedCase :: Text -> Bool
+isMixedCase t =
+    T.toUpper t /= t &&
+    T.toLower t /= t


### PR DESCRIPTION
# Issue Number

#331 and #332 

# Overview

This PR fixes a few issues introduced by PR #332:

1. The function `chooseWithinDataPart` gives us an incorrect upper bound for the index in the insertion, mutation, and deletion tests. These tests should actually limit their indices in subtly different ways:

    | Test | Index Upper Bound | Notes |
    | ---- | ----------------- | ----- |
    | Insertion | `T.length originalString`     | (we can insert after the end of a string) |
    | Mutation  | `T.length originalString - 1` | |
    | Deletion  | `T.length originalString - 1` | |
    | Swapping  | `T.length originalString - 2` | (we swap with the character to the right) |

2. Limiting our choice of index to just the data part means that our tests are weaker than they could be, as we're not testing across the full length of a Bech32 string. Since the checksum is a function of **both** the data part **and** the human readable part, it makes sense to mutate all parts of the string.

3. In particular, we do need to check for mixed case characters at all locations in the string, and not just in the data part. According to the spec:
   > Decoders MUST NOT accept strings where some characters are uppercase and some are lowercase (such strings are referred to as mixed case strings).

## Changes

I have:
- [x] Corrected the upper bounds for the insertion, mutation, and deletion tests.
- [x] Adjusted all tests to test across the full length of a Bech32 string, and not just the data part.
- [x] Introduced a type `Bech32Char`, which represents the full range of characters allowed in a Bech32 string. We use this type when generating mutations.
