### PR TITLE
Strengthen the precondition for the Bech32 mixed-case mutation test.

### DIFF
--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -253,7 +253,7 @@ spec = do
                         , "      original string: " <> show originalString
                         , "     corrupted string: " <> show corruptedString ]
                 return $ counterexample description $
-                    corruptedString /= originalString ==>
+                    isMixedCase corruptedString ==>
                         (T.length corruptedString === T.length originalString)
                         .&&.
                         (Bech32.decode corruptedString `shouldBe` Left
@@ -273,7 +273,7 @@ spec = do
                         , "      original string: " <> show originalString
                         , "     corrupted string: " <> show corruptedString ]
                 return $ counterexample description $
-                    corruptedString /= originalString ==>
+                    isMixedCase corruptedString ==>
                         (T.length corruptedString === T.length originalString)
                         .&&.
                         (Bech32.decode corruptedString `shouldBe` Left
@@ -544,3 +544,11 @@ instance Arbitrary ByteString where
 instance Arbitrary Bech32.Word5 where
     arbitrary = arbitraryBoundedEnum
     shrink w = Bech32.word5 <$> shrink (Bech32.getWord5 w)
+
+-- | Returns true iff. the given string has both lower-case and upper-case
+--   characters.
+--
+isMixedCase :: Text -> Bool
+isMixedCase t =
+    T.toUpper t /= t &&
+    T.toLower t /= t


### PR DESCRIPTION
# Issue Number

#339 

# Overview

It's possible to change the case of a given character of a Bech32 string and yet not produce a mixed-case string.

In such cases, we can't expect that the `decode` function will fail with a `StringToDecodeHasMixedCase` error.

- [x] To prevent the test failing, I have changed the precondition to actually check that the string is in mixed case.



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
