### PR TITLE
add little delay to allow sockets to be cleaned up after the launcher specs

### DIFF
--- a/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
@@ -28,8 +28,9 @@ spec = describe "cardano-wallet-launcher" $ do
         let fiveSeconds = 5000000
         winner <- race (threadDelay fiveSeconds) (wait handle)
         case winner of
-            Left _ ->
+            Left _ -> do
                 cancel handle
+                threadDelay 1000000
             Right _ ->
                 expectationFailure
                     "cardano-wallet-launcher isn't supposed to terminate. \


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added little delay to allow sockets to be cleaned up after the launcher specs

# Comments

<!-- Additional comments or screenshots to attach if any -->

Hope this will do :man_shrugging:. Solved our problem in other test, as it seems that CI can be a bit slow at freeing up sockets after we cancel a worker. One second seems enough in other places.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
