### PR TITLE
Make the `listWallets` API call return wallets in ascending order of creation time.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -368,8 +368,10 @@ newWalletLayer db nw tl = do
         -> ExceptT ErrWalletAlreadyExists IO WalletId
     _createWallet wid wname s = do
         let checkpoint = initWallet s
+        currentTime <- liftIO getCurrentTime
         let metadata = WalletMetadata
                 { name = wname
+                , creationTime = currentTime
                 , passphraseInfo = Nothing
                 , status = Restoring minBound
                 , delegation = NotDelegating

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -331,6 +331,7 @@ mkWalletEntity :: W.WalletId -> W.WalletMetadata -> Wallet
 mkWalletEntity wid meta = Wallet
     { walTableId = wid
     , walTableName = meta ^. #name . coerce
+    , walTableCreationTime = meta ^. #creationTime
     , walTablePassphraseLastUpdatedAt =
         W.lastUpdatedAt <$> meta ^. #passphraseInfo
     , walTableStatus = meta ^. #status
@@ -340,6 +341,7 @@ mkWalletEntity wid meta = Wallet
 mkWalletMetadataUpdate :: W.WalletMetadata -> [Update Wallet]
 mkWalletMetadataUpdate meta =
     [ WalTableName =. meta ^. #name . coerce
+    , WalTableCreationTime =. meta ^. #creationTime
     , WalTablePassphraseLastUpdatedAt =.
         W.lastUpdatedAt <$> meta ^. #passphraseInfo
     , WalTableStatus =. meta ^. #status
@@ -349,6 +351,7 @@ mkWalletMetadataUpdate meta =
 metadataFromEntity :: Wallet -> W.WalletMetadata
 metadataFromEntity wal = W.WalletMetadata
     { name = W.WalletName (walTableName wal)
+    , creationTime = walTableCreationTime wal
     , passphraseInfo = W.WalletPassphraseInfo <$>
         walTablePassphraseLastUpdatedAt wal
     , status = walTableStatus wal

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -52,6 +52,7 @@ share
 -- Wallet IDs, address discovery state, and metadata.
 Wallet
     walTableId                 W.WalletId     sql=wallet_id
+    walTableCreationTime       UTCTime        sql=creation_time
     walTableName               Text           sql=name
     walTablePassphraseLastUpdatedAt  UTCTime Maybe  sql=passphrase_last_updated_at
     walTableStatus             W.WalletState  sql=status

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -162,6 +162,8 @@ import qualified Data.Text.Encoding as T
 data WalletMetadata = WalletMetadata
     { name
         :: !WalletName
+    , creationTime
+        :: !UTCTime
     , passphraseInfo
         :: !(Maybe WalletPassphraseInfo)
     , status

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -134,6 +134,7 @@ initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap
 testMetadata :: WalletMetadata
 testMetadata = WalletMetadata
     { name = WalletName "test wallet"
+    , creationTime = unsafePerformIO getCurrentTime
     , passphraseInfo = Nothing
     , status = Ready
     , delegation = NotDelegating

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -293,6 +293,7 @@ instance Arbitrary WalletMetadata where
     shrink _ = []
     arbitrary =  WalletMetadata
         <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
+        <*> arbitrary
         <*> (fmap WalletPassphraseInfo <$> arbitrary)
         <*> oneof [pure Ready, Restoring . Quantity <$> customizedGen]
         <*> pure NotDelegating

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/Wallets.hs
@@ -898,10 +898,9 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 3
-            -- , expectListItemFieldEqual 0 walletName "1"
-            -- , expectListItemFieldEqual 1 walletName "2"
-            -- , expectListItemFieldEqual 2 walletName "3"
-            -- TODO uncomment after #250
+            , expectListItemFieldEqual 0 walletName "1"
+            , expectListItemFieldEqual 1 walletName "2"
+            , expectListItemFieldEqual 2 walletName "3"
             ]
 
     it "WALLETS_LIST_02 - Deleted wallet not listed" $ \ctx -> do


### PR DESCRIPTION
# Issue Number

Issue #250

# Overview

I have:
- [x] Added a `creationTime` field to the `Cardano.Wallet.Primitive.Types.WalletMetadata` type.
- [x] Uncommented an already-existing API test that checks wallets are listed in the correct order.
- [x] Made the tests pass by performing sorting in the appropriate place.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
