### PR TITLE
Sqlite: use repsertMany instead of deleteMany+putMany

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -57,6 +57,7 @@ library
     , resourcet
     , servant
     , servant-server
+    , split
     , text
     , text-class
     , time


### PR DESCRIPTION
Relates to #154 

## Overview

The function `repsertMany` does what I thought `putMany` did. When there is a conflict it updates the rows. This means that we don't need to delete before inserting.

## Comments

Before:

```
λ> runExceptT $ putTxHistory db testPk testTxs
SELECT "wallet_id", "creation_time", "name", "passphrase_last_updated_at", "status", "delegation" FROM "wallet" WHERE ("wallet_id"=?) LIMIT 1; [PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed"]
INSERT INTO "tx_meta"("tx_id","wallet_id","status","direction","slot","amount") VALUES (?,?,?,?,?,?); [PersistText "747832",PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed",PersistText "in_ledger",PersistBool True,PersistInt64 302400,PersistInt64 1337144]
INSERT INTO "tx_in"("tx_id","order","source_id","source_index") VALUES (?,?,?,?); [PersistText "747832",PersistInt64 0,PersistText "747831",PersistInt64 0]
INSERT INTO "tx_out"("tx_id","index","address","amount") VALUES (?,?,?,?); [PersistText "747832",PersistInt64 0,PersistText "61646472",PersistInt64 1]
Right ()
λ> runExceptT $ putTxHistory db testPk testTxs
SELECT "wallet_id", "creation_time", "name", "passphrase_last_updated_at", "status", "delegation" FROM "wallet" WHERE ("wallet_id"=?) LIMIT 1; [PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed"]
INSERT INTO "tx_meta"("tx_id","wallet_id","status","direction","slot","amount") VALUES (?,?,?,?,?,?); [PersistText "747832",PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed",PersistText "in_ledger",PersistBool True,PersistInt64 302400,PersistInt64 1337144]
*** Exception: SQLite3 returned ErrorConstraint while attempting to perform step: UNIQUE constraint failed: tx_meta.tx_id, t
```

After:
```
λ> runExceptT $ putTxHistory db testPk testTxs
SELECT "wallet_id", "creation_time", "name", "passphrase_last_updated_at", "status", "delegation" FROM "wallet" WHERE ("wallet_id"=?) LIMIT 1; [PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed"]
INSERT INTO "tx_meta"("tx_id", "wallet_id", "status", "direction", "slot", "amount") VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT ("tx_id", "wallet_id") DO UPDATE SET "tx_id"=EXCLUDED."tx_id", "wallet_id"=EXCLUDED."wallet_id", "status"=EXCLUDED."status", "direction"=EXCLUDED."direction", "slot"=EXCLUDED."slot", "amount"=EXCLUDED."amount"; [PersistText "747832",PersistText "a34fc3b6d2cce8beb3216c2bbb5e55739e8121ed",PersistText "in_ledger",PersistBool True,PersistInt64 302400,PersistInt64 1337144]
INSERT INTO "tx_in"("tx_id", "order", "source_id", "source_index") VALUES (?, ?, ?, ?) ON CONFLICT ("tx_id", "source_id", "source_index") DO UPDATE SET "tx_id"=EXCLUDED."tx_id", "order"=EXCLUDED."order", "source_id"=EXCLUDED."source_id", "source_index"=EXCLUDED."source_index"; [PersistText "747832",PersistInt64 0,PersistText "747831",PersistInt64 0]
INSERT INTO "tx_out"("tx_id", "index", "address", "amount") VALUES (?, ?, ?, ?) ON CONFLICT ("tx_id", "index") DO UPDATE SET "tx_id"=EXCLUDED."tx_id", "index"=EXCLUDED."index", "address"=EXCLUDED."address", "amount"=EXCLUDED."amount"; [PersistText "747832",PersistInt64 0,PersistText "61646472",PersistInt64 1]
```
