### PR TITLE
Sqlite benchmark: Use a file-based DB

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -189,8 +189,10 @@ benchmark db
     , containers
     , cryptonite
     , deepseq
+    , directory
     , fmt
     , memory
+    , temporary
     , time
   type:
      exitcode-stdio-1.0


### PR DESCRIPTION
Relates to #154 

## Comments

Using the SQLite in-memory database might not be realistic enough. For example, I noticed a big difference between file and memory DBs for the SeqState benchmark.

So just use a file database in `/tmp/bench12345-1.db`.
