### PR TITLE
Fix tx builder in fee calculation property

### DIFF
--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -74,6 +74,7 @@ import Test.QuickCheck
     , InfiniteList (..)
     , Property
     , choose
+    , counterexample
     , property
     , scale
     , vectorOf
@@ -661,9 +662,13 @@ propSizeEstimation (ShowFmt sel, InfiniteList chngAddrs _) =
         margin = 4 * fromIntegral (length $ CS.change sel)
         realSizeSup = Quantity (size + margin)
         realSizeInf = Quantity size
+        debug = "real size sup: " <> show (size + margin)
+            <> ", real size inf: " <> show size
+            <> ", calculated size: " <> show calcSize
     in
-        (calcSize >= realSizeInf && calcSize <= realSizeSup, encodedTx)
-            === (True, encodedTx)
+        counterexample debug $
+            (calcSize >= realSizeInf && calcSize <= realSizeSup, encodedTx) ===
+                (True, encodedTx)
   where
     dummyWitness = PublicKeyWitness
         "\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQh" (Hash "\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI")

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -672,19 +672,14 @@ propSizeEstimation (ShowFmt sel, InfiniteList chngAddrs _) =
   where
     dummyWitness = PublicKeyWitness
         "\226E\220\252\DLE\170\216\210\164\155\182mm$ePG\252\186\195\225_\b=\v\241=\255 \208\147[\239\RS\170|\214\202\247\169\229\205\187O_)\221\175\155?e\198\248\170\157-K\155\169z\144\174\ENQh" (Hash "\193\151*,\NULz\205\234\&1tL@\211\&2\165\129S\STXP\164C\176 Xvf\160|;\CANs{\SYN\204<N\207\154\130\225\229\t\172mbC\139\US\159\246\168x\163Mq\248\145)\160|\139\207-\SI")
-    dummyInput = Hash
-        "`\219\178g\158\233 T\f\CAN\EMZ=\146\238\155\229\n\238n\213\248\145\217-Q\219\138v\176,\210"
     fromCoinSelection (CoinSelection inps outs chngs) =
         let
-            txIns = zipWith TxIn
-                (replicate (length inps) dummyInput)
-                [0..]
             txChngs = zipWith TxOut
                 (take (length chngs) (chngAddrs <*> pure network))
                 chngs
             wits = replicate (length inps) dummyWitness
         in
-            (Tx txIns (outs <> txChngs), wits)
+            (Tx (fst <$> inps) (outs <> txChngs), wits)
 
 -- Check whether a selection is valid
 isValidSelection :: CoinSelection -> Bool


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#361 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added a counter example debug line to make debugging slightly easier
- [ ] I have fixed the transaction builder (from a given coin selection) to use the inputs generated for the coin selection instead of a dummy one.

# Comments

<!-- Additional comments or screenshots to attach if any -->

We use to generate a tx corresponding to a given selection by replicating a dummy input. As a consequence, for many inputs (more than 24), we will end up using bigger indexes, and as a result, generating a tx slightly different that the one used to make the estimate. Hence the discrepancy. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
