### PR TITLE
Make DB QSM tests fail if one or more tags are not covered.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -118,6 +118,7 @@ test-suite unit
     , containers
     , cryptonite
     , deepseq
+    , extra >= 1.6.17
     , file-embed
     , fmt
     , foldl

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.8
+resolver: lts-13.24
 packages:
 - .
 - lib/bech32


### PR DESCRIPTION
# Issue Number

#353 

# Overview

Module `Cardano.Wallet.DB.StateMachine` defines set of `Tag` values to represent various test scenarios that are considered important or interesting. It also supplies a `tag` function to match `Tag` values to arbitrary sequences of commands.

However, the test suite doesn't actually check that all possible `Tag` values are covered during execution. This creates a risk that we might actually not be covering all the cases we'd like.

- [x] I have made the `prop_sequential` property fail if one or more tags are not covered.

# Comments

With this change applied, we get the following output from the test suite:
```hs
Cardano.Wallet.DB.Sqlite
  Sqlite State machine tests
    Sequential
      +++ OK, passed 400 tests:
      64.0% UnsuccessfulReadTxHistory
      61.8% CreateThenList
      60.0% SuccessfulReadCheckpoint
      54.2% CreateWalletTwice
      54.2% TxUnsortedOutputs
      54.0% TxUnsortedInputs
      36.2% ReadTxHistoryAfterDelete
      35.2% UnsuccessfulReadCheckpoint
      30.5% SuccessfulReadTxHistory
      26.0% CreateThreeWallets
      15.5% SuccessfulReadPrivateKey
      14.8% RemoveWalletTwice

Finished in 38.8470 seconds
1 example, 0 failures
```
Suppose we add a new constructor **`Wibble`** to the `Tag` data type, without modifying the `tags` function.

Now, if we re-run the test suite, we get a failure:
```hs
Cardano.Wallet.DB.Sqlite
  Sqlite State machine tests
    Sequential FAILED [1]

Failures:

  test/unit/Cardano/Wallet/DB/SqliteSpec.hs:80:9: 
  1) Cardano.Wallet.DB.Sqlite, Sqlite State machine tests, Sequential
       Insufficient coverage (after 800 tests):
         62.7% CreateThenList
         62.1% SuccessfulReadCheckpoint
         61.1% UnsuccessfulReadTxHistory
         59.4% TxUnsortedInputs
         59.3% TxUnsortedOutputs
         54.6% CreateWalletTwice
         37.9% UnsuccessfulReadCheckpoint
         36.0% ReadTxHistoryAfterDelete
         33.9% SuccessfulReadTxHistory
         28.4% CreateThreeWallets
         20.0% SuccessfulReadPrivateKey
         17.0% RemoveWalletTwice
         
         Only 0.0% Wibble, but expected 5.0%
```

