### PR TITLE
Recreate passing tests and file-based and in-memory runQuery

### DIFF
--- a/lib/core/backup/.gitignore
+++ b/lib/core/backup/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -129,6 +129,7 @@ test-suite unit
     , http-api-data
     , lens
     , memory
+    , persistent-sqlite
     , QuickCheck
     , quickcheck-instances
     , quickcheck-state-machine >= 0.6.0
@@ -154,6 +155,7 @@ test-suite unit
       Cardano.Wallet.DB.MVarSpec
       Cardano.Wallet.DB.StateMachine
       Cardano.Wallet.DB.SqliteSpec
+      Cardano.Wallet.DB.SqliteFileModeSpec
       Cardano.Wallet.DBSpec
       Cardano.Wallet.NetworkSpec
       Cardano.Wallet.Primitive.AddressDerivationSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -129,6 +129,7 @@ test-suite unit
     , http-api-data
     , lens
     , memory
+    , persistent
     , persistent-sqlite
     , QuickCheck
     , quickcheck-instances

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -18,6 +18,7 @@
 
 module Cardano.Wallet.DB.Sqlite
     ( newDBLayer
+    , PersistState (..)
     , DummyState(..)
     ) where
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -19,7 +18,6 @@
 module Cardano.Wallet.DB.Sqlite
     ( newDBLayer
     , PersistState (..)
-    , DummyState(..)
     ) where
 
 import Prelude
@@ -121,8 +119,6 @@ import Database.Persist.Sqlite
     ( SqlBackend, SqlPersistM, SqlPersistT, wrapConnection )
 import Database.Sqlite
     ( Error (ErrorConstraint), SqliteException (SqliteException) )
-import GHC.Generics
-    ( Generic )
 import System.IO
     ( stderr )
 import System.Log.FastLogger
@@ -767,12 +763,3 @@ selectSeqStatePendingIxs ssid =
         [Desc SeqStatePendingIxIndex]
   where
     fromRes = fmap (W.Index . seqStatePendingIxIndex . entityVal)
-
-data DummyState = DummyState
-    deriving (Show, Eq, Generic)
-
-instance PersistState DummyState where
-    insertState (wid, sl) _ = insert_ (SeqState wid sl)
-    selectState (wid, sl) = fmap (const DummyState) <$>
-        selectFirst [SeqStateTableWalletId ==. wid, SeqStateTableCheckpointSlot ==. sl] []
-    deleteState wid = deleteWhere [SeqStateTableWalletId ==. wid]

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -257,7 +257,7 @@ withDB bm = envWithCleanup setup cleanup (\ ~(_, db) -> bm db)
   where
     setup = do
         f <- emptySystemTempFile "bench.db"
-        db <- newDBLayer (Just f)
+        (_, db) <- newDBLayer (Just f)
         pure (f, db)
     cleanup (f, _) = mapM_ remove [f, f <> "-shm", f <> "-wal"]
     remove f = doesFileExist f >>= \case

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -1,0 +1,284 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.DB.SqliteFileModeSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet
+    ( unsafeRunExceptT )
+import Cardano.Wallet.DB
+    ( DBLayer (..), ErrWalletAlreadyExists (..), PrimaryKey (..), cleanDB )
+import Cardano.Wallet.DB.Sqlite
+    ( newDBLayer, newDBLayer' )
+import Cardano.Wallet.DBSpec
+    ( DummyTarget, KeyValPairs (..), withDB )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Passphrase (..)
+    , encryptPassphrase
+    , generateKeyFromSeed
+    , unsafeGenerateKeyFromSeed
+    )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( SeqState (..), defaultAddressPoolGap, mkSeqState )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( EntropySize, entropyToBytes, genEntropy )
+import Cardano.Wallet.Primitive.Model
+    ( Wallet, initWallet )
+import Cardano.Wallet.Primitive.Types
+    ( Address (..)
+    , Coin (..)
+    , Direction (..)
+    , Hash (..)
+    , SlotId (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (TxMeta)
+    , TxOut (..)
+    , TxStatus (..)
+    , WalletDelegation (..)
+    , WalletId (..)
+    , WalletMetadata (..)
+    , WalletName (..)
+    , WalletPassphraseInfo (..)
+    , WalletState (..)
+    )
+import Control.Monad
+    ( forM_, replicateM_ )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Trans.Except
+    ( runExceptT )
+import Crypto.Hash
+    ( hash )
+import Data.ByteString
+    ( ByteString )
+import Data.Coerce
+    ( coerce )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Text.Class
+    ( FromText (..) )
+import Data.Time.Clock
+    ( getCurrentTime )
+import Database.Sqlite
+    ( Connection, close )
+import System.IO.Unsafe
+    ( unsafePerformIO )
+import Test.Hspec
+    ( Expectation, Spec, before, describe, it, shouldReturn )
+import Test.QuickCheck
+    ( Property, choose, generate, property, (==>) )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
+
+import qualified Data.List as L
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+spec :: Spec
+spec =  do
+    describe "Check db opening/closing" $ do
+
+        it "opening and closing of db works" $ do
+            replicateM_ 25 openCloseDB
+
+    before (fileDBLayer >>= dbCleaned)$
+        describe "Check db reading/writing from/to file and cleaning" $ do
+
+        it "create and list wallet works" $ \(conn, db) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            listWallets db `shouldReturn` [testPk]
+            close conn
+            (conn1, db1) <- fileDBLayer
+            runExceptT (createWallet db1 testPk testCp testMetadata)
+                `shouldReturn` (Left (ErrWalletAlreadyExists testWid))
+            close conn1
+            ( testOpeningCleaning
+                listWallets
+                [testPk]
+                [] )
+
+        it "create and get meta works" $ \(conn, db) -> do
+            now <- getCurrentTime
+            let md = testMetadata { passphraseInfo = Just $ WalletPassphraseInfo now }
+            unsafeRunExceptT $ createWallet db testPk testCp md
+            readWalletMeta db testPk `shouldReturn` Just md
+            close conn
+            ( testOpeningCleaning
+                (`readWalletMeta` testPk)
+                (Just md)
+                Nothing )
+
+        it "create and get private key" $ \(conn,db) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            readPrivateKey db testPk `shouldReturn` Nothing
+            let Right phr = fromText "simplephrase"
+                k = unsafeGenerateKeyFromSeed (coerce phr, coerce phr) phr
+            h <- encryptPassphrase phr
+            unsafeRunExceptT (putPrivateKey db testPk (k, h))
+            readPrivateKey db testPk `shouldReturn` Just (k, h)
+            close conn
+            ( testOpeningCleaning
+                (`readPrivateKey` testPk)
+                (Just (k, h))
+                Nothing )
+
+        it "put and read tx history" $ \(conn,db) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            runExceptT (putTxHistory db testPk testTxs) `shouldReturn` Right ()
+            readTxHistory db testPk `shouldReturn` testTxs
+            close conn
+            ( testOpeningCleaning
+                (`readTxHistory` testPk)
+                testTxs
+                Map.empty )
+
+        it "put and read checkpoint" $ \(conn,db) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            runExceptT (putCheckpoint db testPk testCp) `shouldReturn` Right ()
+            readCheckpoint db testPk `shouldReturn` Just testCp
+            close conn
+            ( testOpeningCleaning
+                (`readCheckpoint` testPk)
+                (Just testCp)
+                Nothing )
+
+    withDB inMemoryDBLayer $
+        describe "random operation chunks property when writing to/reading from file" $ do
+        it "realize a random batch of operations upon one db open"
+            (property . prop_randomOpChunks)
+
+    where
+        testOpeningCleaning
+            :: (Show s, Eq s)
+            => (DBLayer IO (SeqState DummyTarget) DummyTarget -> IO s)
+            -> s
+            -> s
+            -> Expectation
+        testOpeningCleaning call expectedAfterOpen expectedAfterClean = do
+            (conn1, db1) <- fileDBLayer
+            call db1 `shouldReturn` expectedAfterOpen
+            _ <- cleanDB db1
+            call db1 `shouldReturn` expectedAfterClean
+            close conn1
+            (conn2,db2) <- fileDBLayer
+            call db2 `shouldReturn` expectedAfterClean
+            close conn2
+
+        openCloseDB :: IO ()
+        openCloseDB = do
+            (conn, _) <- fileDBLayer
+            close conn
+
+        dbCleaned
+            :: (Connection, DBLayer IO (SeqState DummyTarget) DummyTarget)
+            -> IO  (Connection, DBLayer IO (SeqState DummyTarget) DummyTarget)
+        dbCleaned (conn, db) = do
+            _ <- cleanDB db
+            pure (conn, db)
+
+
+-- This property checks that executing series of wallet operations in a single
+-- SQLite session has the same effect as executing the same operations over
+-- multiple sessions.
+prop_randomOpChunks
+    :: DBLayer IO (SeqState DummyTarget) DummyTarget
+    -> KeyValPairs (PrimaryKey WalletId) (Wallet (SeqState DummyTarget) DummyTarget , WalletMetadata)
+    -> Property
+prop_randomOpChunks inMemoryDB (KeyValPairs pairs) =
+    not (null pairs) ==> monadicIO (pure inMemoryDB >>= prop)
+  where
+    prop dbM = liftIO $ do
+        (conn, dbF) <- fileDBLayer
+        _ <- cleanDB dbF
+        _ <- cleanDB inMemoryDB
+
+        forM_ pairs (updateDB dbM)
+        chunks <- cutRandomly [] pairs
+        forM_ chunks handleChunks
+
+        verify dbM dbF
+
+        close conn
+
+    cutRandomly :: [[a]] -> [a] -> IO [[a]]
+    cutRandomly acc rest =
+        if L.length rest > 1 then do
+            chunksNum <- generate $ choose (1, L.length rest)
+            let chunk = L.take chunksNum rest
+            cutRandomly (chunk:acc) (L.drop chunksNum rest)
+        else
+            pure $ L.reverse (rest:acc)
+    handleChunks chunk = do
+        (conn, db) <- fileDBLayer
+        forM_ chunk (updateDB db)
+        close conn
+    updateDB
+        :: DBLayer IO s t
+        -> (PrimaryKey WalletId, (Wallet s t, WalletMetadata))
+        -> IO ()
+    updateDB db (k, (cp, meta)) = do
+        keys <- listWallets db
+        if k `elem` keys then do
+            runExceptT (putCheckpoint db k cp) `shouldReturn` Right ()
+            runExceptT (putWalletMeta db k meta) `shouldReturn` Right ()
+        else do
+            unsafeRunExceptT $ createWallet db k cp meta
+            Set.fromList <$> listWallets db `shouldReturn` Set.fromList (k:keys)
+    verify :: (Eq s) => DBLayer IO s t -> DBLayer IO s t -> IO ()
+    verify db1 db2 = do
+        expectedWalIds <- Set.fromList <$> listWallets db1
+        Set.fromList <$> listWallets db2
+            `shouldReturn` expectedWalIds
+        forM_ expectedWalIds $ \walId -> do
+            expectedCps <- readCheckpoint db1 walId
+            readCheckpoint db2 walId
+                `shouldReturn` expectedCps
+        forM_ expectedWalIds $ \walId -> do
+            expectedMetas <- readWalletMeta db1 walId
+            readWalletMeta db2 walId
+                `shouldReturn` expectedMetas
+
+
+fileDBLayer :: IO (Connection, DBLayer IO (SeqState DummyTarget) DummyTarget)
+fileDBLayer = newDBLayer' (Just "backup/test.db")
+
+inMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)
+inMemoryDBLayer = newDBLayer Nothing
+
+testCp :: Wallet (SeqState DummyTarget) DummyTarget
+testCp = initWallet initDummyState
+
+initDummyState :: SeqState DummyTarget
+initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap
+  where
+      bytes = entropyToBytes <$> unsafePerformIO $ genEntropy @(EntropySize 15)
+      xprv = generateKeyFromSeed (Passphrase bytes, mempty) mempty
+
+testMetadata :: WalletMetadata
+testMetadata = WalletMetadata
+    { name = WalletName "test wallet"
+    , creationTime = unsafePerformIO getCurrentTime
+    , passphraseInfo = Nothing
+    , status = Ready
+    , delegation = NotDelegating
+    }
+
+testWid :: WalletId
+testWid = WalletId (hash ("test" :: ByteString))
+
+testPk :: PrimaryKey WalletId
+testPk = PrimaryKey testWid
+
+testTxs :: Map.Map (Hash "Tx") (Tx, TxMeta)
+testTxs = Map.fromList
+    [ (Hash "tx2"
+      , (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
+        , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))) ]

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -127,7 +127,7 @@ simpleSpec = do
             readCheckpoint db testPk `shouldReturn` Just testCp
 
 newMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)
-newMemoryDBLayer = newDBLayer Nothing
+newMemoryDBLayer = snd <$> newDBLayer Nothing
 
 testCp :: Wallet (SeqState DummyTarget) DummyTarget
 testCp = initWallet initDummyState

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.DBSpec
     ( spec
     , dbPropertyTests
     , withDB
+    , KeyValPairs (..)
     , DummyTarget
     , TxHistory
     , GenTxHistory (..)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#154 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added unit tests that check file-backed sqlite db read/write/clean operation in a number of state changing scenerios
- [x] I have added property test that checks if we are in line with in-memory version when using random number of state changing operations in a row 


# Comments

<!-- Additional comments or screenshots to attach if any -->
This PR checks DB in two modes, ie., two places where db can reside : in-memory and in the file. And it seems they are not the same addressed within persistent, hence different `runQuery'`. Secondly, because these are two completely different mechanism (memory vs file system) they are differently serviced when detaching is realized. in-memory detaches gracefully, but `file-based` solution not so gracefully. It turn out that when we get rid of `close` we can easily end up with situation where we have too many file handles open and :
 ```
uncaught exception: SqliteException
SQLite3 returned ErrorCan'tOpen while attempting to perform open "backup/test.db".
(after 504 tests and 4 shrinks)
```
As evidenced above this happened after 503 successful test of  `prop_randomOpChunks` (I commented `close db` and added `not (null pairs) ==> withMaxSuccess 1000 $  monadicIO (pure inMemoryDB >>= prop)`
When `close db` is on the test passes. This was the reason I decided to spend time investigating this issue. This also suggests to me that in `file-based mode` we need to use `close` and the test is needed, also `runQuery'` workaround. Otherwise, someone with small number of open handles in his/her computer will be subjected to this limitation, as anyone that uses our wallet-backend without interruption for long time (I am thinking here about exchanges). 
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
