### PR TITLE
Allow filtering by address state when fetching all addresses

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -32,6 +32,7 @@ import Cardano.CLI
     , help
     , parseAllArgsWith
     , parseArgWith
+    , parseOptionalArg
     , putErrLn
     , setUtf8Encoding
     )
@@ -144,7 +145,7 @@ Usage:
   cardano-wallet wallet update [--port=INT] <wallet-id> --name=STRING
   cardano-wallet wallet delete [--port=INT] <wallet-id>
   cardano-wallet transaction create [--port=INT] <wallet-id> --payment=PAYMENT...
-  cardano-wallet address list [--port=INT] <wallet-id>
+  cardano-wallet address list [--port=INT] [--state=STRING] <wallet-id>
   cardano-wallet -h | --help
   cardano-wallet --version
 
@@ -156,6 +157,7 @@ Options:
   --payment <PAYMENT>         address to send to and amount to send separated by @: '<amount>@<address>'
   --network <STRING>          testnet, staging, or mainnet [default: testnet]
   --database <FILE>           use this file for storing wallet state
+  --state <STRING>            address state: either used or unused
 
 Examples:
   # Create a transaction and send 22 lovelace from wallet-id to specified address
@@ -263,7 +265,9 @@ exec execServer manager args
     | args `isPresent` command "address" &&
       args `isPresent` command "list" = do
         wId <- args `parseArg` argument "wallet-id"
-        runClient Aeson.encodePretty $ listAddresses (ApiT wId) Nothing
+        maybeState <- args `parseOptionalArg` longOption "state"
+        runClient Aeson.encodePretty
+            $ listAddresses (ApiT wId) (ApiT <$> maybeState)
 
     | args `isPresent` longOption "version" = do
         putStrLn (showVersion version)

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -26,6 +26,7 @@ module Cardano.CLI
     -- * Parsing Arguments
     , parseArgWith
     , parseAllArgsWith
+    , parseOptionalArg
     , help
 
     -- * Working with Sensitive Data
@@ -67,6 +68,7 @@ import System.Console.Docopt
     , Option
     , exitWithUsageMessage
     , getAllArgs
+    , getArg
     , getArgOrExitWith
     , usage
     )
@@ -132,6 +134,15 @@ parseAllArgsWith cli args option = do
   where
     getAllArgsOrExit :: Arguments -> Option -> IO (NE.NonEmpty String)
     getAllArgsOrExit = getAllArgsOrExitWith cli
+
+parseOptionalArg :: FromText a => Arguments -> Option -> IO (Maybe a)
+parseOptionalArg args option =
+    case fromText . T.pack <$> args `getArg` option of
+        Nothing -> pure Nothing
+        Just (Right a) -> pure $ pure a
+        Just (Left e) -> do
+            putErrLn $ T.pack $ getTextDecodingError e
+            exitFailure
 
 -- | Same as 'getAllArgs', but 'exitWithUsage' if empty list.
 --

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -121,7 +121,8 @@ parseArgWith cli args option = do
     getArgOrExit :: Arguments -> Option -> IO String
     getArgOrExit = getArgOrExitWith cli
 
-parseAllArgsWith :: FromText a => Docopt -> Arguments -> Option -> IO (NE.NonEmpty a)
+parseAllArgsWith
+    :: FromText a => Docopt -> Arguments -> Option -> IO (NE.NonEmpty a)
 parseAllArgsWith cli args option = do
     (mapM (fromText . T.pack) <$> args `getAllArgsOrExit` option) >>= \case
         Right a -> return a

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -61,7 +61,8 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Model
     ( availableBalance, getState, totalBalance )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState
+    ( Address
+    , AddressState
     , Coin (..)
     , DecodeAddress (..)
     , EncodeAddress (..)
@@ -265,10 +266,14 @@ listAddresses
     -> ApiT WalletId
     -> Maybe (ApiT AddressState)
     -> Handler [ApiAddress t]
-listAddresses w (ApiT wid) _ = do
+listAddresses w (ApiT wid) stateFilter = do
     addrs <- liftHandler $ W.listAddresses w wid
-    return $ coerceAddress <$> addrs
+    return $ coerceAddress <$> filter filterCondition addrs
   where
+    filterCondition :: (Address, AddressState) -> Bool
+    filterCondition = case stateFilter of
+        Nothing -> const True
+        Just (ApiT s) -> (== s) . snd
     coerceAddress (a, s) = ApiAddress (ApiT a, Proxy @t) (ApiT s)
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
# Issue Number

#356 

# Overview

I have:

- [x] Modified the `listAddresses` API server function to filter by the optional `state` query parameter.
- [x] Added a `parseOptionalArg` function to module `Cardano.CLI`.
- [x] Added an optional `state` filter argument to the `cardano-wallet address list` CLI command.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
