### PR TITLE
cli: Use Paths module to get program version

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -45,6 +45,8 @@ executable cardano-wallet
     , text
     , text-class
     , warp
+  other-modules:
+      Paths_cardano_wallet
   hs-source-dirs:
       exe/wallet
   main-is:
@@ -72,6 +74,8 @@ executable cardano-wallet-launcher
     , say
     , text
     , text-class
+  other-modules:
+      Paths_cardano_wallet
   hs-source-dirs:
       exe/launcher
   main-is:

--- a/exe/launcher/Main.hs
+++ b/exe/launcher/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import Prelude
 
 import Cardano.CLI
-    ( Port, help, parseArgWith, showVersion )
+    ( Port, getVersion, help, parseArgWith )
 import Cardano.Launcher
     ( Command (Command)
     , ProcessHasExited (ProcessHasExited)
@@ -72,7 +72,7 @@ main = do
     args <- parseArgsOrExit cli =<< getArgs
     when (args `isPresent` (longOption "help")) $ help cli
     when (args `isPresent` (shortOption 'h')) $ help cli
-    when (args `isPresent` (longOption "version")) showVersion
+    when (args `isPresent` (longOption "version")) $ putStrLn getVersion
 
     network <- args `parseArg` longOption "network"
     bridgePort <- args `parseArg` longOption "http-bridge-port"

--- a/exe/launcher/Main.hs
+++ b/exe/launcher/Main.hs
@@ -6,7 +6,7 @@ module Main where
 import Prelude
 
 import Cardano.CLI
-    ( Port, getVersion, help, parseArgWith )
+    ( Port, help, parseArgWith )
 import Cardano.Launcher
     ( Command (Command)
     , ProcessHasExited (ProcessHasExited)
@@ -22,8 +22,12 @@ import Control.Monad
     ( when )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
+import Data.Version
+    ( showVersion )
 import Fmt
     ( blockListF, fmt )
+import Paths_cardano_wallet
+    ( version )
 import Say
     ( sayErr )
 import System.Console.Docopt
@@ -72,7 +76,8 @@ main = do
     args <- parseArgsOrExit cli =<< getArgs
     when (args `isPresent` (longOption "help")) $ help cli
     when (args `isPresent` (shortOption 'h')) $ help cli
-    when (args `isPresent` (longOption "version")) $ putStrLn getVersion
+    when (args `isPresent` (longOption "version")) $
+        putStrLn (showVersion version)
 
     network <- args `parseArg` longOption "network"
     bridgePort <- args `parseArg` longOption "http-bridge-port"

--- a/exe/launcher/Main.hs
+++ b/exe/launcher/Main.hs
@@ -43,7 +43,7 @@ import System.Console.Docopt
 import System.Environment
     ( getArgs )
 import System.Exit
-    ( exitWith )
+    ( exitSuccess, exitWith )
 
 import qualified Data.Text as T
 
@@ -76,8 +76,9 @@ main = do
     args <- parseArgsOrExit cli =<< getArgs
     when (args `isPresent` (longOption "help")) $ help cli
     when (args `isPresent` (shortOption 'h')) $ help cli
-    when (args `isPresent` (longOption "version")) $
+    when (args `isPresent` (longOption "version")) $ do
         putStrLn (showVersion version)
+        exitSuccess
 
     network <- args `parseArg` longOption "network"
     bridgePort <- args `parseArg` longOption "http-bridge-port"

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -29,12 +29,12 @@ import Prelude hiding
 import Cardano.CLI
     ( getLine
     , getSensitiveLine
+    , getVersion
     , help
     , parseAllArgsWith
     , parseArgWith
     , putErrLn
     , setUtf8Encoding
-    , showVersion
     )
 import Cardano.Wallet
     ( newWalletLayer )
@@ -260,7 +260,7 @@ exec execServer manager args
         wId <- args `parseArg` argument "wallet-id"
         runClient Aeson.encodePretty $ listAddresses (ApiT wId) Nothing
 
-    | args `isPresent` longOption "version" = showVersion
+    | args `isPresent` longOption "version" = putStrLn getVersion
 
     | otherwise =
         exitWithUsage cli

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -29,7 +29,6 @@ import Prelude hiding
 import Cardano.CLI
     ( getLine
     , getSensitiveLine
-    , getVersion
     , help
     , parseAllArgsWith
     , parseArgWith
@@ -78,8 +77,12 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
+import Data.Version
+    ( showVersion )
 import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
+import Paths_cardano_wallet
+    ( version )
 import Servant
     ( (:<|>) (..), (:>) )
 import Servant.Client
@@ -260,7 +263,8 @@ exec execServer manager args
         wId <- args `parseArg` argument "wallet-id"
         runClient Aeson.encodePretty $ listAddresses (ApiT wId) Nothing
 
-    | args `isPresent` longOption "version" = putStrLn getVersion
+    | args `isPresent` longOption "version" =
+        putStrLn (showVersion version)
 
     | otherwise =
         exitWithUsage cli

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -105,7 +105,7 @@ import System.Console.Docopt
 import System.Environment
     ( getArgs )
 import System.Exit
-    ( exitFailure )
+    ( exitFailure, exitSuccess )
 import System.IO
     ( BufferMode (NoBuffering), hSetBuffering, stderr, stdout )
 
@@ -263,8 +263,9 @@ exec execServer manager args
         wId <- args `parseArg` argument "wallet-id"
         runClient Aeson.encodePretty $ listAddresses (ApiT wId) Nothing
 
-    | args `isPresent` longOption "version" =
+    | args `isPresent` longOption "version" = do
         putStrLn (showVersion version)
+        exitSuccess
 
     | otherwise =
         exitWithUsage cli

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -40,8 +40,6 @@ library
       src
   exposed-modules:
       Cardano.CLI
-  other-modules:
-      Paths_cardano_wallet_cli
 
 test-suite unit
   default-language:

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -31,18 +31,17 @@ library
       -Werror
   build-depends:
       base
-    , bytestring
     , ansi-terminal
     , docopt
-    , file-embed
     , fmt
-    , regex-applicative
     , text
     , text-class
   hs-source-dirs:
       src
   exposed-modules:
       Cardano.CLI
+  other-modules:
+      Paths_cardano_wallet_cli
 
 test-suite unit
   default-language:

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -36,18 +35,14 @@ module Cardano.CLI
     , hGetSensitiveLine
 
     -- * Show version
-    , showVersion
+    , getVersion
     ) where
 
 import Prelude hiding
     ( getLine )
 
-import Control.Applicative
-    ( many )
 import Control.Exception
     ( bracket )
-import Data.FileEmbed
-    ( embedFile )
 import Data.Functor
     ( (<$) )
 import qualified Data.List.NonEmpty as NE
@@ -55,12 +50,16 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
+import Data.Version
+    ( showVersion )
 import Fmt
     ( Buildable, pretty )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( Symbol )
+import Paths_cardano_wallet_cli
+    ( version )
 import System.Console.ANSI
     ( Color (..)
     , ColorIntensity (..)
@@ -96,10 +95,7 @@ import System.IO
     , stdout
     , utf8
     )
-import Text.Regex.Applicative
-    ( anySym, few, match, string, sym )
 
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 
@@ -270,19 +266,8 @@ getSensitiveLine = hGetSensitiveLine (stdin, stderr)
                                 Internals
 -------------------------------------------------------------------------------}
 
-showVersion :: IO ()
-showVersion = do
-    let cabal = B8.unpack $(embedFile "../../cardano-wallet.cabal")
-    let re = few anySym
-            *> string "version:" *> many (sym ' ') *> few anySym
-            <* sym '\n' <* many anySym
-    case match re cabal of
-        Nothing -> do
-            putErrLn "Couldn't find program version!"
-            exitFailure
-        Just version -> do
-            TIO.putStrLn $ T.pack version
-            exitSuccess
+getVersion :: String
+getVersion = showVersion version
 
 withBuffering :: Handle -> BufferMode -> IO a -> IO a
 withBuffering h buffering action = bracket aFirst aLast aBetween

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -33,9 +33,6 @@ module Cardano.CLI
     , hGetLine
     , getSensitiveLine
     , hGetSensitiveLine
-
-    -- * Show version
-    , getVersion
     ) where
 
 import Prelude hiding
@@ -50,16 +47,12 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
-import Data.Version
-    ( showVersion )
 import Fmt
     ( Buildable, pretty )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( Symbol )
-import Paths_cardano_wallet_cli
-    ( version )
 import System.Console.ANSI
     ( Color (..)
     , ColorIntensity (..)
@@ -265,9 +258,6 @@ getSensitiveLine = hGetSensitiveLine (stdin, stderr)
 {-------------------------------------------------------------------------------
                                 Internals
 -------------------------------------------------------------------------------}
-
-getVersion :: String
-getVersion = showVersion version
 
 withBuffering :: Handle -> BufferMode -> IO a -> IO a
 withBuffering h buffering action = bracket aFirst aLast aBetween

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -179,6 +179,7 @@ test-suite integration
       Test.Integration.Scenario.CLI.Mnemonics
       Test.Integration.Scenario.CLI.Transactions
       Test.Integration.Scenario.CLI.Wallets
+      Paths_cardano_wallet_http_bridge
 
 benchmark restore
   default-language:

--- a/lib/http-bridge/test/integration/Test/Integration/Scenario/CLI/Mnemonics.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/Scenario/CLI/Mnemonics.hs
@@ -11,8 +11,10 @@ import Control.Monad
     ( forM_ )
 import Data.List
     ( length )
-import Data.Text
-    ( Text )
+import Data.Version
+    ( showVersion )
+import Paths_cardano_wallet_http_bridge
+    ( version )
 import System.Command
     ( Exit (..), Stderr (..), Stdout (..) )
 import System.Exit
@@ -24,23 +26,20 @@ import Test.Hspec.Expectations.Lifted
 import Test.Integration.Framework.DSL
     ( cardanoWalletCLI, cardanoWalletLauncherCLI, generateMnemonicsViaCLI )
 
-import qualified Data.Text as T
-
-version :: Text
-version = "2019.5.24"
+import qualified Data.List as L
 
 spec :: SpecWith ()
 spec = do
     it "CLI_VERSION - cardano-wallet shows version" $  do
         (Exit c, Stdout out) <- cardanoWalletCLI ["--version"]
-        let v = T.dropWhileEnd (== '\n') (T.pack out)
-        v `shouldBe` version
+        let v = L.dropWhileEnd (== '\n') out
+        v `shouldBe` (showVersion version)
         c `shouldBe` ExitSuccess
 
     it "CLI_VERSION - cardano-wallet-launcher shows version" $  do
         (Exit c, Stdout out) <- cardanoWalletLauncherCLI ["--version"]
-        let v = T.dropWhileEnd (== '\n') (T.pack out)
-        v `shouldBe` version
+        let v = L.dropWhileEnd (== '\n') out
+        v `shouldBe` (showVersion version)
         c `shouldBe` ExitSuccess
 
     it "CLI_HELP - cardano-wallet-launcher shows help on bad argument" $  do


### PR DESCRIPTION
The CLIs build normally, but `embedFile` wasn't working for me in `ghci`. 

```
  lib/cli/src/Cardano/CLI.hs:275:27: error:
      • Exception when trying to run compile-time code:
          ../../cardano-wallet.cabal: openBinaryFile: does not exist (No such file or directory)
        Code: embedFile "../../cardano-wallet.cabal"
      • In the untyped splice: $(embedFile "../../cardano-wallet.cabal")
      |
  275 |     let cabal = B8.unpack $(embedFile "../../cardano-wallet.cabal")
      |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

There is another easier way to get the program version (assuming all cabal files have the same version).
