### PR TITLE
bors: Disable branch sniping

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,5 +4,5 @@ status = [
 ]
 timeout_sec = 3600
 required_approvals = 1
-delete_merged_branches = true
+delete_merged_branches = false
 block_labels = [ "DO NOT MERGE", "wip" ]


### PR DESCRIPTION
When we have PRs based on other PRs, deleting base branches makes github close PRs.
