### PR TITLE
Fix a tiny typo in the CLI help text.

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -153,7 +153,7 @@ Options:
   --network <STRING>          testnet, staging, or mainnet [default: testnet]
 
 Examples:
-  # Create a transaction and send 22 lovelace from wallet-id to specified addres
+  # Create a transaction and send 22 lovelace from wallet-id to specified address
   cardano-wallet transaction create \
     2512a00e9653fe49a44a5886202e24d77eeb998f \
     --payment 22@Ae2tdPwUPEZ...nRtbfw6EHRv1D


### PR DESCRIPTION
# Issue Number

None

# Overview

- [x] I have fixed a tiny typo in the CLI help text.