### PR TITLE
Use SQLite in restoration benchmark (instead of MVar implementation)

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,45 +1,4 @@
 - package:
-  - name: cardano-wallet-http-bridge
-  - section:
-    - name: test:integration
-    - message:
-      - name: Weeds exported
-      - module:
-        - name: Test.Integration.Framework.DSL
-        - identifier:
-          - expectError
-          - expectSuccess
-      - module:
-        - name: Test.Integration.Framework.Request
-        - identifier:
-          - ClientError
-          - DecodeFailure
-          - HttpException
-          - unsafeRequest
-  - section:
-    - name: test:unit
-    - message:
-      - name: Weeds exported
-      - module:
-        - name: Spec
-        - identifier: main
-- package:
-  - name: cardano-wallet-jormungandr
-  - section:
-    - name: test:unit
-    - message:
-      - name: Weeds exported
-      - module:
-        - name: Spec
-        - identifier: main
-- package:
-  - name: cardano-wallet-launcher
-  - section:
-    - name: library
-    - message:
-      - name: Module not compiled
-      - module: Cardano.Launcher.Windows
-- package:
   - name: cardano-wallet-core
   - section:
     - name: test:unit
@@ -48,3 +7,38 @@
       - module:
         - name: Cardano.Wallet.DB.StateMachine
         - identifier: showLabelledExamples
+- package:
+  - name: cardano-wallet-http-bridge
+  - section:
+    - name: bench:restore
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Cardano.Wallet.Primitive.AddressDiscovery.Any.TH
+        - identifier:
+          - AnyAddressStateId
+          - AnyAddressStateKey
+          - AnyAddressStateTableProportion
+          - UniqueAnyAddressState
+  - section:
+    - name: test:integration
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Test.Integration.Framework.DSL
+        - identifier: expectError
+      - module:
+        - name: Test.Integration.Framework.Request
+        - identifier:
+          - ClientError
+          - DecodeFailure
+          - HttpException
+          - unsafeRequest
+- package:
+  - name: cardano-wallet-launcher
+  - section:
+    - name: library
+    - message:
+      - name: Module not compiled
+      - module: Cardano.Launcher.Windows
+

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -17,6 +17,7 @@
 
 module Cardano.Wallet.DB.Sqlite
     ( newDBLayer
+    , runQuery
     , PersistState (..)
     ) where
 

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -208,8 +208,11 @@ benchmark restore
     , digest
     , fmt
     , generic-lens
+    , persistent
+    , persistent-template
     , process
     , say
+    , temporary
     , text
     , text-class
     , time
@@ -222,3 +225,4 @@ benchmark restore
       Main.hs
   other-modules:
       Cardano.Wallet.Primitive.AddressDiscovery.Any
+      Cardano.Wallet.Primitive.AddressDiscovery.Any.TH

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Automatically generated code via Template-Haskell. Contains necessary
+-- database rows and columns declaration to work with 'AnyAddressState'.
+
+module Cardano.Wallet.Primitive.AddressDiscovery.Any.TH where
+
+import Prelude
+
+import Cardano.Wallet.DB.Sqlite.Types
+    ( sqlSettings' )
+import Database.Persist.TH
+    ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Wallet.Primitive.Types as W
+
+share
+    [ mkPersist sqlSettings'
+    , mkDeleteCascade sqlSettings'
+    , mkMigrate "migrateAll"
+    ]
+    [persistLowerCase|
+AnyAddressState
+    anyAddressStateTableWalletId        W.WalletId  sql=wallet_id
+    anyAddressStateTableCheckpointSlot  W.SlotId    sql=slot
+    anyAddressStateTableProportion      Double      sql=proportion
+
+    UniqueAnyAddressState anyAddressStateTableWalletId anyAddressStateTableCheckpointSlot
+    -- Foreign Checkpoint fk_checkpoint_any_address_state anyAddressStateTableWalletId anyAddressStateTableCheckpointSlot
+    deriving Show Generic
+|]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#154

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have replaced the MVar implementation with the file-based SQLite one in the restoration benchmark

# Comments

<!-- Additional comments or screenshots to attach if any -->

As expected, this is slightly slower (for testnet at least), but, memory now remains within acceptable bounds instead of growing towards infinity. Below, comparison of the heap profile between the MVar (in first) and the SQLite (in second):. Curious to see what it looks like on Mainnet :) 

![image](https://user-images.githubusercontent.com/5680256/59039246-c5f0fe80-8874-11e9-9057-90dc17b51d9d.png)
<p align="center">
    <small>FIGURE 1: restoration benchmark - testnet - MVar</small>
</p>

![image](https://user-images.githubusercontent.com/5680256/59039288-d6a17480-8874-11e9-8fad-80067df75e45.png)
<p align="center">
    <small>FIGURE 2: restoration benchmark - testnet - SQLite</small>
</p>


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
