### PR TITLE
Jörmungandr: `mkNetworkLayer` with `networkTip`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -63,6 +63,8 @@ instance Exception ErrNetworkUnreachable
 data ErrNetworkTip
     = ErrNetworkTipNetworkUnreachable ErrNetworkUnreachable
     | ErrNetworkTipNotFound
+    | ErrNetworkTipBlockNotFound (Hash "BlockHeader")
+    -- ^ The tip-block wasn't found. This would be surprising.
     deriving (Generic, Show, Eq)
 
 instance Exception ErrNetworkTip

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -148,6 +148,8 @@ rbNextBlocks bridge start = maybeTip (getNetworkTip bridge) >>= \case
 
     maybeTip = mapExceptT $ fmap $ \case
         Left (ErrNetworkTipNetworkUnreachable e) -> Left e
+        Left (ErrNetworkTipBlockNotFound _) -> Right Nothing
+        --  HttpBridge never throws ErrNetworkTipBlockNotFound.
         Left ErrNetworkTipNotFound -> Right Nothing
         Right tip -> Right (Just tip)
 

--- a/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -198,6 +198,7 @@ spec = do
       where
         unwrap (ErrNetworkTipNetworkUnreachable e) = e
         unwrap ErrNetworkTipNotFound = ErrNetworkUnreachable "no tip"
+        unwrap (ErrNetworkTipBlockNotFound _) = ErrNetworkUnreachable "no tip"
     newNetworkLayer =
         HttpBridge.newNetworkLayer @'Testnet port
     closeBridge (handle, _) = do

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -102,7 +102,7 @@ type PostSignedTx
 -- TODO: Replace SignedTx with something real
 data SignedTx
 
-newtype BlockId = BlockId (Hash "block")
+newtype BlockId = BlockId (Hash "BlockHeader")
     deriving (Eq, Show)
 
 instance ToHttpApiData BlockId where


### PR DESCRIPTION
# Issue Number

#219 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Implemented `mkNetworkLayer` with `networkTip`
- [ ] I have no tests



# Comments

## On `ExceptT ErrNetworkUnreachable m (Maybe Block)`

I found it particularly nightmarish to chain `getTipId` and `getBlock`.

Therefore I made *all* `JormungandrLayer` functions return `ExceptT ErrNetworkUnreachable`, favouring `Right $ Nothing` to indicate 404. f011447

- Implementing `NetworkLayer` becomes easier.
- There is no need for descriptive errors in `JormungandrLayer`. I don't see why we can't handle that in the `NetworkLayer` instead.

### Alternative
- Closest I got was
```haskell
        t@(BlockId hash) <- lift $ getTipId j
        let r = runExceptT $ getBlock j t
        case _runM r of -- need to deal with the `m` somehow
            Left (ErrGetBlockNetworkUnreachable msg) -> throwE $ ErrNetworkTipNetworkUnreachable msg
            Left e@(ErrGetBlockNotFound _) -> undefined throwM e
            Right b -> return (hash, header b)
```

**Edit**: the `throwIO` made it complicated, but I now realise that it actually was I who introduced the `throwIO`. The HttpBridge's `throwIO` (actually `throwM`) is for a different class of errors.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->