### PR TITLE
server: Listen on unused TCP port selected at random

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -44,7 +44,6 @@ executable cardano-wallet
     , servant-server
     , text
     , text-class
-    , warp
   other-modules:
       Paths_cardano_wallet
   hs-source-dirs:

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -65,8 +65,6 @@ import Control.Monad
     ( when )
 import Data.Aeson
     ( (.:) )
-import Data.Function
-    ( (&) )
 import Data.Functor
     ( (<&>) )
 import qualified Data.List.NonEmpty as NE
@@ -123,7 +121,6 @@ import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as TIO
-import qualified Network.Wai.Handler.Warp as Warp
 
 
 cli :: Docopt
@@ -150,7 +147,7 @@ Usage:
   cardano-wallet --version
 
 Options:
-  --port <INT>                port used for serving the wallet API [default: 8090]
+  --port <INT>                port used for serving the wallet API
   --bridge-port <INT>         port used for communicating with the http-bridge [default: 8080]
   --address-pool-gap <INT>    number of unused consecutive addresses to keep track of [default: 20]
   --size <INT>                number of mnemonic words to generate [default: 15]
@@ -341,8 +338,8 @@ execHttpBridge
     :: forall n. (KeyToAddress (HttpBridge n), KnownNetwork n)
     => Arguments -> Proxy (HttpBridge n) -> IO ()
 execHttpBridge args _ = do
-    (walletPort :: Int)
-        <- args `parseArg` longOption "port"
+    (walletPort :: Maybe Int)
+        <- args `parseArgMaybe` longOption "port"
     (bridgePort :: Int)
         <- args `parseArg` longOption "bridge-port"
     let dbFile = args `getArg` longOption "database"
@@ -351,12 +348,9 @@ execHttpBridge args _ = do
     waitForConnection nw defaultRetryPolicy
     let tl = HttpBridge.newTransactionLayer @n
     wallet <- newWalletLayer @_ @(HttpBridge n) db nw tl
-    let settings = Warp.defaultSettings
-            & Warp.setPort walletPort
-            & Warp.setBeforeMainLoop (TIO.hPutStrLn stderr $
-                "Wallet backend server listening on: " <> toText walletPort
-            )
-    Server.start settings wallet
+    let logStartup port = TIO.hPutStrLn stderr $
+            "Wallet backend server listening on: " <> toText port
+    Server.start logStartup walletPort wallet
 
 -- | Generate a random mnemonic of the given size 'n' (n = number of words),
 -- and print it to stdout.
@@ -398,6 +392,11 @@ decodeError bytes = do
 
 parseArg :: FromText a => Arguments -> Option -> IO a
 parseArg = parseArgWith cli
+
+parseArgMaybe :: FromText a => Arguments -> Option -> IO (Maybe a)
+parseArgMaybe args option
+    | args `isPresent` option = Just <$> parseArg args option
+    | otherwise = pure Nothing
 
 parseAllArgs :: FromText a => Arguments -> Option -> IO (NE.NonEmpty a)
 parseAllArgs = parseAllArgsWith cli

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -32,7 +32,6 @@ import Cardano.CLI
     , help
     , parseAllArgsWith
     , parseArgWith
-    , parseOptionalArg
     , putErrLn
     , setUtf8Encoding
     )
@@ -339,7 +338,7 @@ execHttpBridge
     => Arguments -> Proxy (HttpBridge n) -> IO ()
 execHttpBridge args _ = do
     (walletPort :: Maybe Int)
-        <- args `parseArgMaybe` longOption "port"
+        <- args `parseOptionalArg` longOption "port"
     (bridgePort :: Int)
         <- args `parseArg` longOption "bridge-port"
     let dbFile = args `getArg` longOption "database"
@@ -393,8 +392,8 @@ decodeError bytes = do
 parseArg :: FromText a => Arguments -> Option -> IO a
 parseArg = parseArgWith cli
 
-parseArgMaybe :: FromText a => Arguments -> Option -> IO (Maybe a)
-parseArgMaybe args option
+parseOptionalArg :: FromText a => Arguments -> Option -> IO (Maybe a)
+parseOptionalArg args option
     | args `isPresent` option = Just <$> parseArg args option
     | otherwise = pure Nothing
 

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -26,7 +26,6 @@ module Cardano.CLI
     -- * Parsing Arguments
     , parseArgWith
     , parseAllArgsWith
-    , parseOptionalArg
     , help
 
     -- * Working with Sensitive Data
@@ -68,7 +67,6 @@ import System.Console.Docopt
     , Option
     , exitWithUsageMessage
     , getAllArgs
-    , getArg
     , getArgOrExitWith
     , usage
     )
@@ -134,15 +132,6 @@ parseAllArgsWith cli args option = do
   where
     getAllArgsOrExit :: Arguments -> Option -> IO (NE.NonEmpty String)
     getAllArgsOrExit = getAllArgsOrExitWith cli
-
-parseOptionalArg :: FromText a => Arguments -> Option -> IO (Maybe a)
-parseOptionalArg args option =
-    case fromText . T.pack <$> args `getArg` option of
-        Nothing -> pure Nothing
-        Just (Right a) -> pure $ pure a
-        Just (Left e) -> do
-            putErrLn $ T.pack $ getTextDecodingError e
-            exitFailure
 
 -- | Same as 'getAllArgs', but 'exitWithUsage' if empty list.
 --

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -50,6 +50,7 @@ library
     , http-media
     , memory
     , monad-logger
+    , network
     , path-pieces
     , persistent
     , persistent-sqlite
@@ -59,6 +60,7 @@ library
     , servant
     , servant-server
     , split
+    , streaming-commons
     , text
     , text-class
     , time

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -146,11 +146,11 @@ start
     -> Maybe Warp.Port
     -> WalletLayer (SeqState t) t
     -> IO ()
-start logStartup mport wl =
+start onStartup mport wl =
     withListeningSocket mport $ \(port, socket) -> do
         let settings = Warp.defaultSettings
                 & Warp.setPort port
-                & Warp.setBeforeMainLoop (logStartup port)
+                & Warp.setBeforeMainLoop (onStartup port)
         startOnSocket settings socket wl
 
 startOnSocket

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -172,7 +172,10 @@ startOnSocket settings socket wl = Warp.runSettingsSocket settings socket
 
 -- | Run an action with a TCP socket bound to a port. If no port is specified,
 -- then an unused port will be selected at random.
-withListeningSocket :: Maybe Warp.Port -> ((Warp.Port, Socket) -> IO ()) -> IO ()
+withListeningSocket
+    :: Maybe Warp.Port
+    -> ((Warp.Port, Socket) -> IO ())
+    -> IO ()
 withListeningSocket mport = bracket acquire release
   where
     acquire = case mport of

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -71,12 +72,16 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     )
+import Control.Exception
+    ( bracket )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, withExceptT )
 import Data.Aeson
     ( (.=) )
+import Data.Function
+    ( (&) )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Labels
@@ -89,6 +94,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Streaming.Network
+    ( bindPortTCP, bindRandomPortTCP )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -101,6 +108,8 @@ import Network.HTTP.Media.RenderHeader
     ( renderHeader )
 import Network.HTTP.Types.Header
     ( hContentType )
+import Network.Socket
+    ( Socket, close )
 import Network.Wai.Middleware.ServantError
     ( handleRawError )
 import Servant
@@ -133,10 +142,24 @@ import qualified Network.Wai.Handler.Warp as Warp
 -- | Start the application server
 start
     :: forall t. (TxId t, KeyToAddress t, EncodeAddress t, DecodeAddress t)
-    => Warp.Settings
+    => (Warp.Port -> IO ())
+    -> Maybe Warp.Port
     -> WalletLayer (SeqState t) t
     -> IO ()
-start settings wl = Warp.runSettings settings
+start logStartup mport wl =
+    withListeningSocket mport $ \(port, socket) -> do
+        let settings = Warp.defaultSettings
+                & Warp.setPort port
+                & Warp.setBeforeMainLoop (logStartup port)
+        startOnSocket settings socket wl
+
+startOnSocket
+    :: forall t. (TxId t, KeyToAddress t, EncodeAddress t, DecodeAddress t)
+    => Warp.Settings
+    -> Socket
+    -> WalletLayer (SeqState t) t
+    -> IO ()
+startOnSocket settings socket wl = Warp.runSettingsSocket settings socket
     $ handleRawError handler
     application
   where
@@ -146,6 +169,18 @@ start settings wl = Warp.runSettings settings
 
     application :: Application
     application = serve (Proxy @("v2" :> Api t)) server
+
+-- | Run an action with a TCP socket bound to a port. If no port is specified,
+-- then an unused port will be selected at random.
+withListeningSocket :: Maybe Warp.Port -> ((Warp.Port, Socket) -> IO ()) -> IO ()
+withListeningSocket mport = bracket acquire release
+  where
+    acquire = case mport of
+        Just port -> (port,) <$> bindPortTCP port hostPreference
+        Nothing -> bindRandomPortTCP hostPreference
+    release (_, socket) = liftIO $ close socket
+    -- TODO: make configurable, default to secure for now.
+    hostPreference = "127.0.0.1"
 
 {-------------------------------------------------------------------------------
                                     Wallets

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -157,7 +157,6 @@ test-suite integration
     , text-class
     , time
     , transformers
-    , warp
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -27,8 +27,6 @@ import Control.Monad
     ( forM, void )
 import Data.Aeson
     ( Value (..), (.:) )
-import Data.Function
-    ( (&) )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Time
@@ -57,7 +55,6 @@ import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
 import qualified Cardano.WalletSpec as Wallet
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text as T
-import qualified Network.Wai.Handler.Warp as Warp
 import qualified Test.Integration.Scenario.API.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Wallets as Wallets
@@ -179,8 +176,7 @@ main = hspec $ do
         db <- MVar.newDBLayer
         let tl = HttpBridge.newTransactionLayer
         wallet <- newWalletLayer db nl tl
-        let settings = Warp.defaultSettings & Warp.setPort serverPort
-        Server.start settings wallet
+        Server.start (const $ pure ()) (Just serverPort) wallet
 
     waitForCluster :: String -> IO ()
     waitForCluster addr = do


### PR DESCRIPTION
Relates to issue #144 

# Overview

- The `cardano-wallet server --port` command-line argument is optional.
- If no port is supplied, then an unused port will be selected at random.
- The selected port will be logged.
- Server listens on localhost only, not on all interfaces.
- Integration tests still use fixed port 1337. It will need some refactoring for them to use any unused port.
