### PR TITLE
Adapt NodeIPC module from cardano-sl

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -33,6 +33,7 @@ executable cardano-wallet
       base
     , aeson
     , aeson-pretty
+    , async
     , bytestring
     , cardano-wallet-cli
     , cardano-wallet-core

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -414,9 +414,11 @@ execHttpBridge args _ = do
     wallet <- newWalletLayer @_ @(HttpBridge n) tracer block0 db nw tl
     let logStartup port = logInfo tracer $
             "Wallet backend server listening on: " <> toText port
-    Server.withListeningSocket walletPort $ \(port, socket) -> do
+    Server.withListeningSocket walletListen $ \(port, socket) -> do
         let settings = Server.mkWarpSettings logStartup port
-        race_ (daedalusIPC port) (Server.startOnSocket settings socket wallet)
+        tracer' <- appendName "DaedalusIPC" tracer
+        race_ (daedalusIPC tracer' port) $
+            Server.startOnSocket settings socket wallet
 
 -- | Generate a random mnemonic of the given size 'n' (n = number of words),
 -- and print it to stdout.

--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -106,8 +106,6 @@ import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Paths_cardano_wallet
     ( version )
-import Say
-    ( sayErr )
 import Servant
     ( (:<|>) (..), (:>) )
 import Servant.Client

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -32,10 +32,12 @@ library
       -Werror
   build-depends:
       aeson
+    , async
     , base
     , basement
     , binary
     , bytestring
+    , Cabal
     , cardano-crypto
     , containers
     , cryptonite
@@ -76,6 +78,7 @@ library
       Cardano.Wallet.Api
       Cardano.Wallet.Api.Server
       Cardano.Wallet.Api.Types
+      Cardano.Wallet.DaedalusIPC
       Cardano.Wallet.DB
       Cardano.Wallet.DB.MVar
       Cardano.Wallet.DB.Sqlite

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -66,6 +66,7 @@ library
     , text-class
     , time
     , transformers
+    , unordered-containers
     , vector
     , wai
     , warp

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -37,7 +37,6 @@ library
     , basement
     , binary
     , bytestring
-    , Cabal
     , cardano-crypto
     , containers
     , cryptonite

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -163,7 +163,7 @@ start
     -> WalletLayer (SeqState t) t
     -> IO ()
 start onStartup portOpt wl =
-    withListeningSocket portOpt $ \(port, socket) ->
+    void $ withListeningSocket portOpt $ \(port, socket) ->
         startOnSocket (mkWarpSettings onStartup port) socket wl
 
 -- | Start the application server, using the given settings and a bound socket.
@@ -201,9 +201,9 @@ mkWarpSettings onStartup port = Warp.defaultSettings
 withListeningSocket
     :: Listen
     -- ^ Whether to listen on a given port, or random port.
-    -> ((Port, Socket) -> IO Port)
+    -> ((Port, Socket) -> IO ())
     -- ^ Action to run with listening socket.
-    -> IO Port
+    -> IO ()
 withListeningSocket portOpt = bracket acquire release
   where
     acquire = case portOpt of

--- a/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
+++ b/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
@@ -77,9 +77,9 @@ import qualified Data.Text as T
 ----------------------------------------------------------------------------
 -- Daedalus <-> Wallet child process port discovery protocol
 
-data MsgIn  = QueryPort | Ping
+data MsgIn  = QueryPort
     deriving (Show, Eq, Generic)
-data MsgOut = Started | Pong | ReplyPort Int | ParseError Text
+data MsgOut = Started | ReplyPort Int | ParseError Text
     deriving (Show, Eq, Generic)
 
 aesonOpts :: Options
@@ -104,7 +104,6 @@ daedalusIPC port = withNodeChannel (pure . msg) action >>= \case
     -- How to respond to an incoming message, or when there is an incoming
     -- message that couldn't be parsed.
     msg (Right QueryPort) = Just (ReplyPort port)
-    msg (Right Ping) = Just Pong
     msg (Left e) = Just (ParseError e)
 
     -- What to do in context of withNodeChannel

--- a/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
+++ b/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
@@ -1,0 +1,233 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Provides a mechanism for Daedalus to discover what port the cardano-wallet
+-- server is listening on.
+--
+-- See <https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options>
+-- for more information about the message protocol.
+
+module Cardano.Wallet.DaedalusIPC
+    ( daedalusIPC
+    ) where
+
+import Prelude
+
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( race_ )
+import Control.Concurrent.MVar
+    ( MVar, newEmptyMVar, putMVar, takeMVar )
+import Control.Exception
+    ( IOException, catch, tryJust )
+import Control.Monad
+    ( forever, when )
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , defaultOptions
+    , eitherDecode
+    , encode
+    , genericParseJSON
+    , genericToEncoding
+    )
+import Data.Aeson.Types
+    ( Options, SumEncoding (ObjectWithSingleField), sumEncoding )
+import Data.Bifunctor
+    ( first )
+import Data.Binary.Get
+    ( getWord32le, getWord64le, runGet )
+import Data.Binary.Put
+    ( putLazyByteString, putWord32le, putWord64le, runPut )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Text
+    ( Text )
+import Data.Word
+    ( Word32, Word64 )
+import Distribution.System
+    ( OS (Windows), buildOS )
+import GHC.Generics
+    ( Generic )
+import GHC.IO.Handle.FD
+    ( fdToHandle )
+import Say
+    ( sayErr, sayErrString )
+import System.Environment
+    ( lookupEnv )
+import System.IO
+    ( Handle, hFlush, hGetLine, hSetNewlineMode, noNewlineTranslation, stdout )
+import System.IO.Error
+    ( IOError, isEOFError )
+import Text.Read
+    ( readEither )
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as L8
+import qualified Data.Text as T
+
+----------------------------------------------------------------------------
+-- Daedalus <-> Wallet child process port discovery protocol
+
+data MsgIn  = QueryPort | Ping
+    deriving (Show, Eq, Generic)
+data MsgOut = Started | Pong | ReplyPort Int | ParseError Text
+    deriving (Show, Eq, Generic)
+
+aesonOpts :: Options
+aesonOpts = defaultOptions { sumEncoding = ObjectWithSingleField }
+
+instance FromJSON MsgIn where
+    parseJSON = genericParseJSON aesonOpts
+instance ToJSON MsgOut where
+    toEncoding = genericToEncoding aesonOpts
+
+daedalusIPC :: Int -> IO ()
+daedalusIPC port = withNodeChannel (pure . msg) action >>= \case
+    Right act -> do
+        sayErr "[INFO] Daedalus IPC server starting"
+        act
+    Left NodeChannelDisabled -> do
+        sayErr "[INFO] Daedalus IPC is not enabled"
+        sleep
+    Left (NodeChannelBadFD err) ->
+        sayErr $ "[ERROR] Starting Daedalus IPC: " <> err
+  where
+    -- How to respond to an incoming message, or when there is an incoming
+    -- message that couldn't be parsed.
+    msg (Right QueryPort) = Just (ReplyPort port)
+    msg (Right Ping) = Just Pong
+    msg (Left e) = Just (ParseError e)
+
+    -- What to do in context of withNodeChannel
+    action :: (MsgOut -> IO ()) -> IO ()
+    action send = send Started >> sleep
+
+    sleep = threadDelay maxBound
+
+----------------------------------------------------------------------------
+-- NodeJS child_process IPC protocol
+-- https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options
+
+data NodeChannelError
+    = NodeChannelDisabled
+      -- ^ This process has not been started as a nodejs @'ipc'@ child_process.
+    | NodeChannelBadFD Text
+      -- ^ The @NODE_CHANNEL_FD@ environment variable has an incorrect value.
+    deriving (Show, Eq)
+
+withNodeChannel
+    :: (FromJSON msgin, ToJSON msgout)
+    => (Either Text msgin -> IO (Maybe msgout))
+       -- ^ Incoming message handler
+    -> ((msgout -> IO ()) -> IO a)
+       -- ^ Action to run
+    -> IO (Either NodeChannelError (IO ()))
+withNodeChannel onMsg handleMsg = fmap setup <$> lookupNodeChannel
+  where
+    setup handle = do
+        chan <- newEmptyMVar
+        let ipc = ipcListener handle onMsg chan
+            action' = handleMsg (putMVar chan)
+        race_ action' ipc
+
+-- | Parse the NODE_CHANNEL_FD variable, if it's set, and convert to a
+-- 'System.IO.Handle'.
+lookupNodeChannel :: IO (Either NodeChannelError Handle)
+lookupNodeChannel = (fromMaybe "" <$> lookupEnv "NODE_CHANNEL_FD") >>= \case
+    "" -> pure (Left NodeChannelDisabled)
+    var -> case readEither var of
+        Left err -> pure . Left . NodeChannelBadFD $
+           "unable to parse NODE_CHANNEL_FD: " <> T.pack err
+        Right fd -> tryJust handleBadFd (fdToHandle fd)
+  where
+    handleBadFd :: IOException -> Maybe NodeChannelError
+    handleBadFd = Just . NodeChannelBadFD . T.pack . show
+
+ipcListener
+    :: forall msgin msgout. (FromJSON msgin, ToJSON msgout)
+    => Handle
+    -> (Either Text msgin -> IO (Maybe msgout))
+    -> MVar msgout
+    -> IO ()
+ipcListener handle onMsg chan = do
+    hSetNewlineMode handle noNewlineTranslation
+    catch (race_ replyLoop sendLoop) onIOError
+  where
+    sendLoop, replyLoop :: IO ()
+    replyLoop = forever (recvMsg >>= onMsg >>= maybeSend)
+    sendLoop = forever (takeMVar chan >>= sendMsg)
+
+    recvMsg :: IO (Either Text msgin)
+    recvMsg = first T.pack . eitherDecode <$> readMessage handle
+
+    sendMsg :: msgout -> IO ()
+    sendMsg = sendMessage handle . encode
+
+    maybeSend :: Maybe msgout -> IO ()
+    maybeSend = maybe (pure ()) (putMVar chan)
+
+    onIOError :: IOError -> IO ()
+    onIOError err = do
+      sayErrString $ "[ERROR] Exception caught in DaedalusIPC: " <> show err
+      when (isEOFError err) $ sayErr "[DEBUG] it's an eof"
+      hFlush stdout
+
+readMessage :: Handle -> IO BL.ByteString
+readMessage
+    | buildOS == Windows = windowsReadMessage
+    | otherwise = posixReadMessage
+
+windowsReadMessage :: Handle -> IO BL.ByteString
+windowsReadMessage handle = do
+    _int1 <- readInt32 handle
+    _int2 <- readInt32 handle
+    size <- readInt64 handle
+    -- logInfo $ "int is: " <> (show [_int1, _int2]) <> " and blob is: " <> (show blob)
+    BL.hGet handle $ fromIntegral size
+  where
+    readInt64 :: Handle -> IO Word64
+    readInt64 hnd = do
+        bs <- BL.hGet hnd 8
+        pure $ runGet getWord64le bs
+
+    readInt32 :: Handle -> IO Word32
+    readInt32 hnd = do
+        bs <- BL.hGet hnd 4
+        pure $ runGet getWord32le bs
+
+posixReadMessage :: Handle -> IO BL.ByteString
+posixReadMessage = fmap L8.pack . hGetLine
+
+sendMessage :: Handle -> BL.ByteString -> IO ()
+sendMessage handle msg = send handle msg >> hFlush handle
+  where
+    send
+        | buildOS == Windows = sendWindowsMessage
+        | otherwise = sendLinuxMessage
+
+sendWindowsMessage :: Handle -> BL.ByteString -> IO ()
+sendWindowsMessage = sendWindowsMessage' 1 0
+
+sendWindowsMessage' :: Word32 -> Word32 -> Handle -> BL.ByteString -> IO ()
+sendWindowsMessage' int1 int2 handle blob =
+    L8.hPut handle $ runPut $ mconcat parts
+  where
+    blob' = blob <> "\n"
+    parts =
+        [ putWord32le int1
+        , putWord32le int2
+        , putWord64le $ fromIntegral $ BL.length blob'
+        , putLazyByteString blob'
+        ]
+
+sendLinuxMessage :: Handle -> BL.ByteString -> IO ()
+sendLinuxMessage = L8.hPutStrLn

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -1,0 +1,59 @@
+module Test.Integration.Scenario.CLI.Server
+    ( spec
+    ) where
+
+import Prelude
+
+import Control.Concurrent
+    ( threadDelay )
+import System.Directory
+    ( listDirectory, removeDirectory )
+import System.Exit
+    ( ExitCode (..) )
+import System.IO.Temp
+    ( withSystemTempDirectory )
+import System.Process
+    ( CreateProcess, proc, withCreateProcess )
+import Test.Hspec
+    ( Spec, describe, it, shouldContain )
+
+spec :: Spec
+spec = do
+    describe "Launcher should start the server with a database" $ do
+        it "should create the database file" $ withTempDir $ \d -> do
+            removeDirectory d
+            launcher d
+            ls <- listDirectory d
+            ls `shouldContain` ["wallet.db"]
+
+        it "should work with empty state directory" $ withTempDir $ \d -> do
+            launcher d
+            ls <- listDirectory d
+            ls `shouldContain` ["wallet.db"]
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir = withSystemTempDirectory "integration-state"
+
+waitForStartup :: IO ()
+waitForStartup = threadDelay (2 * 1000 * 1000)
+
+launcher :: FilePath -> IO ()
+launcher stateDir = withCreateProcess cmd $ \_ _ _ ph -> do
+    waitForStartup
+    terminateProcess ph
+  where
+    cmd = proc' "cardano-wallet-launcher" ["--state-dir", stateDir]
+
+-- There is a dependency cycle in the packages.
+--
+-- cardano-wallet-launcher depends on cardano-wallet-http-bridge so that it can
+-- import the HttpBridge module.
+--
+-- This package (cardano-wallet-http-bridge) should have
+-- build-tool-depends: cardano-wallet:cardano-wallet-launcher so that it can
+-- run launcher in the tests. But that dependency can't be expressed in the
+-- cabal file, because otherwise there would be a cycle.
+--
+-- So one hacky way to work around it is by running programs under "stack exec".
+proc' :: FilePath -> [String] -> CreateProcess
+proc' cmd args = proc "stack" (["exec", cmd, "--"] ++ args)

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -13,9 +13,15 @@ import System.Exit
 import System.IO.Temp
     ( withSystemTempDirectory )
 import System.Process
-    ( CreateProcess, proc, withCreateProcess )
+    ( CreateProcess
+    , createProcess
+    , proc
+    , terminateProcess
+    , waitForProcess
+    , withCreateProcess
+    )
 import Test.Hspec
-    ( Spec, describe, it, shouldContain )
+    ( Spec, describe, it, shouldContain, shouldReturn )
 
 spec :: Spec
 spec = do
@@ -30,6 +36,11 @@ spec = do
             launcher d
             ls <- listDirectory d
             ls `shouldContain` ["wallet.db"]
+
+    describe "DaedalusIPC" $ do
+        it "should reply with the port when asked" $ do
+            (_, _, _, ph) <- createProcess (proc "test/integration/js/mock-daedalus.js" [])
+            waitForProcess ph `shouldReturn` ExitSuccess
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir = withSystemTempDirectory "integration-state"

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -39,7 +39,8 @@ spec = do
 
     describe "DaedalusIPC" $ do
         it "should reply with the port when asked" $ do
-            (_, _, _, ph) <- createProcess (proc "test/integration/js/mock-daedalus.js" [])
+            (_, _, _, ph) <-
+                createProcess (proc "test/integration/js/mock-daedalus.js" [])
             waitForProcess ph `shouldReturn` ExitSuccess
 
 withTempDir :: (FilePath -> IO a) -> IO a
@@ -53,7 +54,7 @@ launcher stateDir = withCreateProcess cmd $ \_ _ _ ph -> do
     waitForStartup
     terminateProcess ph
   where
-    cmd = proc' "cardano-wallet-launcher" ["--state-dir", stateDir]
+    cmd = proc' "cardano-wallet" ["launch", "--state-dir", stateDir]
 
 -- There is a dependency cycle in the packages.
 --

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -157,6 +157,7 @@ test-suite integration
     , process
     , retry
     , template-haskell
+    , temporary
     , text
     , text-class
     , time
@@ -182,6 +183,7 @@ test-suite integration
       Test.Integration.Scenario.API.Wallets
       Test.Integration.Scenario.CLI.Addresses
       Test.Integration.Scenario.CLI.Mnemonics
+      Test.Integration.Scenario.CLI.Server
       Test.Integration.Scenario.CLI.Transactions
       Test.Integration.Scenario.CLI.Wallets
       Test.Integration.Scenario.CLI.Port

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -82,6 +82,7 @@ import qualified Test.Integration.Scenario.API.Wallets as Wallets
 import qualified Test.Integration.Scenario.CLI.Addresses as AddressesCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
 import qualified Test.Integration.Scenario.CLI.Port as PortCLI
+import qualified Test.Integration.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.Scenario.CLI.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.CLI.Wallets as WalletsCLI
 
@@ -119,7 +120,10 @@ main = hspec $ do
         describe "Wallets CLI tests" WalletsCLI.spec
         describe "Transactions CLI tests" TransactionsCLI.spec
         describe "Addresses CLI tests" AddressesCLI.spec
-  where
+
+    describe "CLI Server" ServerCLI.spec
+
+where
     oneSecond :: Int
     oneSecond = 1 * 1000 * 1000 -- 1 second in microseconds
 

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -93,6 +93,7 @@ main = hspec $ do
     describe "Cardano.Wallet.HttpBridge.NetworkSpec" HttpBridge.spec
     describe "CLI commands not requiring bridge" $ do
         describe "Mnemonics CLI tests" MnemonicsCLI.spec
+        describe "Server CLI tests" ServerCLI.spec
         describe "--port CLI tests" $ do
             cardanoWalletServer Nothing
                 & beforeAll
@@ -111,7 +112,6 @@ main = hspec $ do
                 $ describe "with random port" $ do
                     PortCLI.specCommon
                     PortCLI.specWithRandomPort defaultPort
-
     beforeAll startCluster $
         afterAll killCluster $ after tearDown $ do
         describe "Wallets API endpoint tests" Wallets.spec
@@ -120,8 +120,6 @@ main = hspec $ do
         describe "Wallets CLI tests" WalletsCLI.spec
         describe "Transactions CLI tests" TransactionsCLI.spec
         describe "Addresses CLI tests" AddressesCLI.spec
-
-    describe "CLI Server" ServerCLI.spec
 
   where
     oneSecond :: Int

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -123,7 +123,7 @@ main = hspec $ do
 
     describe "CLI Server" ServerCLI.spec
 
-where
+  where
     oneSecond :: Int
     oneSecond = 1 * 1000 * 1000 -- 1 second in microseconds
 

--- a/lib/http-bridge/test/integration/js/mock-daedalus.js
+++ b/lib/http-bridge/test/integration/js/mock-daedalus.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// This runs cardano-wallet-launcher in the same way that Daedalus would.
+// It needs node, cardano-wallet, and cardano-wallet-launcher on the PATH to run.
+
+const child_process = require("child_process");
+const http = require('http');
+
+function main() {
+  // const proc = child_process.spawn("cardano-wallet", ["server"], {
+  const proc = child_process.spawn("cardano-wallet-launcher", [], {
+    stdio: ["ignore", "inherit", "inherit", "ipc"]
+  });
+
+  proc.on("close", function(code, signal) {
+    console.log("JS: child_process stdio streams closed");
+    process.exit(1);
+ });
+
+  proc.on("disconnect", function() {
+    console.log("JS: child_process disconnected");
+    process.exit(2);
+  });
+
+  proc.on("error", function(err) {
+    console.log("JS: error child_process: " + err);
+    process.exit(3);
+  });
+
+  proc.on("exit", function(code, signal) {
+    console.log("JS: child_process exited with status " + code + " or signal " + signal);
+    process.exit(4);
+  });
+
+  proc.on("message", function(msg) {
+    console.log("JS: message received", msg);
+    if (msg.Started) {
+      proc.send("QueryPort");
+    } else if (msg.ReplyPort) {
+      http.get({
+        hostname: "localhost",
+        port: msg.ReplyPort,
+        path: "/v2/wallets",
+        agent: false
+      }, (res) => {
+        console.log("JS: response from wallet: " + res.statusCode);
+        res.resume();
+        res.on("end", () => {
+          console.log("JS: request response from wallet finished, exiting.");
+          process.exit(0);
+        });
+      });
+    }
+  });
+}
+
+main();

--- a/lib/http-bridge/test/integration/js/mock-daedalus.js
+++ b/lib/http-bridge/test/integration/js/mock-daedalus.js
@@ -34,8 +34,16 @@ function main() {
 
   proc.on("message", function(msg) {
     console.log("JS: message received", msg);
+    // See CardanoNode.js in Daedalus for the message types in use.
     if (msg.Started) {
-      proc.send("QueryPort");
+      console.log("JS: sending a bogus message");
+      proc.send("hello");
+    } else if (msg.ParseError && msg.ParseError.match(/encountered String/)) {
+      console.log("JS: sending QueryPort");
+      proc.send({ QueryPort: [] });
+    } else if (msg.ParseError) {
+      console.log("JS: i did not expect that");
+      process.exit(5);
     } else if (msg.ReplyPort) {
       http.get({
         hostname: "localhost",

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -18,6 +18,7 @@
       "library" = {
         depends = [
           (hsPkgs.aeson)
+          (hsPkgs.async)
           (hsPkgs.base)
           (hsPkgs.basement)
           (hsPkgs.binary)
@@ -51,6 +52,7 @@
           (hsPkgs.text-class)
           (hsPkgs.time)
           (hsPkgs.transformers)
+          (hsPkgs.unordered-containers)
           (hsPkgs.vector)
           (hsPkgs.wai)
           (hsPkgs.warp)

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -99,6 +99,7 @@
             (hsPkgs.process)
             (hsPkgs.retry)
             (hsPkgs.template-haskell)
+            (hsPkgs.temporary)
             (hsPkgs.text)
             (hsPkgs.text-class)
             (hsPkgs.time)

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -22,6 +22,7 @@
             (hsPkgs.base)
             (hsPkgs.aeson)
             (hsPkgs.aeson-pretty)
+            (hsPkgs.async)
             (hsPkgs.bytestring)
             (hsPkgs.cardano-wallet-cli)
             (hsPkgs.cardano-wallet-core)


### PR DESCRIPTION
Relates to issue #144 

# Overview

- Takes the cardano-sl/cardano-shell NodeIPC code, cleans it up, and splits the general NodeJS child_process IPC protocol out from the Daedalus/Cardano specific protocol, improves the exception handling, changes the logging, and just makes it simpler.
- Integrates DaedalusIPC into the server and launcher.
- Adds an integration test which starts the launcher from nodejs, sending `QueryPort`, waiting for `ReplyPort`, as Daedalus does.
- Adds a test for launcher `--state-dir` in the same Spec.
