### PR TITLE
Fix the build by making use of the NamedFieldPuns extension.

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -28,7 +28,6 @@ module Cardano.Wallet.Jormungandr.Binary
       -- * Classes
     , FromBinary (..)
 
-
       -- * Legacy Decoders
     , decodeLegacyAddress
 
@@ -116,12 +115,12 @@ getBlockHeader =  (fromIntegral <$> getWord16be) >>= \s -> isolate s $ do
     -- TODO: Handle special case for Praos/Genesis
 
     return $ BlockHeader
-        { version = version
-        , contentSize = contentSize
+        { version
+        , contentSize
         , slot = (SlotId slotId slotEpoch)
-        , chainLength = chainLength
-        , contentHash = contentHash
-        , parentHeaderHash = parentHeaderHash
+        , chainLength
+        , contentHash
+        , parentHeaderHash
         }
 
 getBlock :: Get Block
@@ -198,7 +197,6 @@ getTransaction = isolate 43 $ do
             3 -> isolate 68 $ do
                 error "unimplemented: Account witness"
             other -> fail $ "Invalid witness type: " ++ show other
-
 
 {-------------------------------------------------------------------------------
                             Common Structure
@@ -322,7 +320,7 @@ newtype LeaderId = LeaderId ByteString
     deriving (Eq, Show)
 
 data LinearFee = LinearFee
-    { const :: Quantity "lovelace" Word64
+    { constant :: Quantity "lovelace" Word64
     , perByte :: Quantity "lovelace/byte" Word64
     , perCert :: Quantity "lovelace/cert" Word64
     } deriving (Eq, Show)
@@ -349,12 +347,10 @@ getLeaderId :: Get LeaderId
 getLeaderId = LeaderId <$> getByteString 32
 
 getLinearFee :: Get LinearFee
-getLinearFee = do
-    const' <- Quantity <$> getWord64be
-    perByte <- Quantity <$> getWord64be
-    perCert <- Quantity <$> getWord64be
-    return $ LinearFee const' perByte perCert
-
+getLinearFee = LinearFee
+    <$> (Quantity <$> getWord64be)
+    <*> (Quantity <$> getWord64be)
+    <*> (Quantity <$> getWord64be)
 
 getBool :: Get Bool
 getBool = getWord8 >>= \case
@@ -377,7 +373,6 @@ whileM cond next = go
             as <- go
             return (a : as)
         else return []
-
 
 {-------------------------------------------------------------------------------
                               Classes


### PR DESCRIPTION
# Issue Number

None.

# Overview

Our build was [broken](https://travis-ci.org/input-output-hk/cardano-wallet/jobs/543583676) due to the `hlint` stage not passing:
```hs
jsk@neon:~/projects/input-output-hk/cardano-wallet$ curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s .
Downloading and running hlint...
######################################################################## 100.0%
./lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs:4:1: Warning: Unused LANGUAGE pragma
Found:
  {-# LANGUAGE NamedFieldPuns #-}
Perhaps you should remove it.

1 hint
```
Removing the `NamedFieldPuns` extension causes a compile failure (due to name shadowing). Instead, I have changed the code so that it actually uses the `NamedFieldPuns` extension.

- [ ] I have fixed the build.

