### PR TITLE
Make the CLI return the correct exit code if an error occurs while calling the server.

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -330,6 +330,7 @@ exec execServer manager args
                         _ ->
                             T.pack $ show e
                 putErrLn msg
+                exitFailure
 
 -- | Start a web-server to serve the wallet backend API on the given port.
 execHttpBridge


### PR DESCRIPTION
# Issue Number

#397

# Overview

- [ ] I have made the CLI return the correct exit code in the event that `runClient` encounters an error.

# Comments