### PR TITLE
Use SQLite in integration tests scenarios (instead of MVar)

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -611,17 +610,14 @@ newWalletLayer tracer block0 db nw tl = do
                     throwE $ ErrSignTx e
 
     _submitTx
-        :: (TxId t)
-        => WalletId
+        :: WalletId
         -> (Tx, TxMeta, [TxWitness])
         -> ExceptT ErrSubmitTx IO ()
     _submitTx wid (tx, meta, wit) = do
         withExceptT ErrSubmitTxNetwork $ postTx nw (tx, wit)
         DB.withLock db $ withExceptT ErrSubmitTxNoSuchWallet $ do
             (w, _) <- _readWallet wid
-            let history = Map.fromList [(txId @t tx, (tx, meta))]
-            DB.putCheckpoint db (PrimaryKey wid) (newPending tx w)
-            DB.putTxHistory db (PrimaryKey wid) history
+            DB.putCheckpoint db (PrimaryKey wid) (newPending (tx, meta) w)
 
     {---------------------------------------------------------------------------
                                      Keystore

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -565,8 +565,7 @@ newWalletLayer tracer block0 db nw tl = do
         -> NonEmpty TxOut
         -> ExceptT ErrCreateUnsignedTx IO CoinSelection
     _createUnsignedTx wid opts recipients = do
-        (w, _) <- withExceptT ErrCreateUnsignedTxNoSuchWallet
-            (_readWallet wid)
+        (w, _) <- withExceptT ErrCreateUnsignedTxNoSuchWallet (_readWallet wid)
         let utxo = availableUTxO w
         (sel, utxo') <- withExceptT ErrCreateUnsignedTxCoinSelection $
             CoinSelection.random opts recipients utxo

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -401,7 +401,7 @@ mkCheckpointEntity wid wal =
         }
     utxo = [ UTxO wid sl (TxId input) ix addr coin
            | (W.TxIn input ix, W.TxOut addr coin) <- utxoMap ]
-    utxoMap = Map.assocs (W.getUTxO (W.totalUTxO wal))
+    utxoMap = Map.assocs (W.getUTxO (W.utxo wal))
 
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already by sorted by index.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -625,7 +625,6 @@ deleteLooseTransactions = do
             "LEFT OUTER JOIN tx_meta ON tx_meta.tx_id = "<> t <>".tx_id " <>
             "WHERE (tx_meta.tx_id IS NULL))"
 
-
 selectLatestCheckpoint
     :: W.WalletId
     -> SqlPersistM (Maybe Checkpoint)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -519,8 +519,7 @@ insertCheckpoint
 insertCheckpoint wid cp = do
     let (cp', utxo, ins, outs) = mkCheckpointEntity wid cp
     insert_ cp'
-    dbChunked insertMany_ ins
-    dbChunked insertMany_ outs
+    putTxs ins outs
     dbChunked insertMany_ utxo
     insertState (wid, (W.currentTip cp) ^. #slotId) (W.getState cp)
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -94,7 +94,7 @@ TxMeta
 -- A transaction input associated with TxMeta.
 --
 -- There is no wallet ID because these values depend only on the transaction,
--- not the wallet. txInputTableTxId is referred to by TxMeta and PendingTx
+-- not the wallet. txInputTableTxId is referred to by TxMeta
 TxIn
     txInputTableTxId         TxId        sql=tx_id
     txInputTableOrder        Int         sql=order
@@ -107,7 +107,7 @@ TxIn
 -- A transaction output associated with TxMeta.
 --
 -- There is no wallet ID because these values depend only on the transaction,
--- not the wallet. txOutputTableTxId is referred to by TxMeta and PendingTx
+-- not the wallet. txOutputTableTxId is referred to by TxMeta
 TxOut
     txOutputTableTxId     TxId        sql=tx_id
     txOutputTableIndex    Word32      sql=index
@@ -155,20 +155,6 @@ UTxO                                     sql=utxo
         utxoTableOutputCoin
 
     Foreign Checkpoint fk_checkpoint_utxo utxoTableWalletId utxoTableCheckpointSlot
-    deriving Show Generic
-
--- The pending transactions for a wallet checkpoint.
-PendingTx
-
-    -- The wallet checkpoint (wallet_id, slot)
-    pendingTxTableWalletId        W.WalletId  sql=wallet_id
-    pendingTxTableCheckpointSlot  W.SlotId    sql=slot
-
-    -- Transaction TxIn and TxOut
-    pendingTxTableId2             TxId        sql=tx_id
-
-    Primary pendingTxTableWalletId pendingTxTableCheckpointSlot pendingTxTableId2
-    Foreign Checkpoint fk_pending_tx pendingTxTableWalletId pendingTxTableCheckpointSlot
     deriving Show Generic
 
 -- State for sequential scheme address discovery

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -41,6 +41,7 @@ module Cardano.Wallet.Primitive.Types
     , TxStatus(..)
     , TxWitness (..)
     , txIns
+    , isPending
 
     -- * Address
     , Address (..)
@@ -473,6 +474,10 @@ data TxWitness
     | RedeemWitness ByteString
       -- ^ Used to redeem ADA from the pre-sale
     deriving (Eq, Show)
+
+-- | True if the given tuple refers to a pending transaction
+isPending :: (Tx, TxMeta) -> Bool
+isPending = (== Pending) . (status :: TxMeta -> TxStatus) . snd
 
 {-------------------------------------------------------------------------------
                                     Address

--- a/lib/core/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/core/test/integration/Test/Integration/Framework/DSL.hs
@@ -539,7 +539,7 @@ emptyWalletWith ctx (name, passphrase, addrPoolGap) = do
 fixtureWallet
     :: Context t
     -> IO ApiWallet
-fixtureWallet ctx@(Context _ _ _ faucet _) = do
+fixtureWallet ctx@(Context _ _ _ faucet _ _) = do
     mnemonics <- mnemonicToText <$> nextWallet faucet
     let payload = Json [aesonQQ| {
             "name": "Faucet Wallet",

--- a/lib/core/test/integration/Test/Integration/Framework/Request.hs
+++ b/lib/core/test/integration/Test/Integration/Framework/Request.hs
@@ -31,6 +31,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Text
     ( Text )
+import Database.Persist.Sqlite
+    ( SqlBackend )
 import Network.HTTP.Client
     ( HttpException (..)
     , HttpExceptionContent
@@ -76,6 +78,8 @@ data Context t = Context
         :: Faucet
         -- ^ A 'Faucet' handle in to have access to funded wallets in
         -- integration tests.
+    , _db :: SqlBackend
+        -- ^ A database connection handle
     , _target
         :: Proxy t
     }
@@ -121,7 +125,7 @@ request
     -> Payload
         -- ^ Request body
     -> m (HTTP.Status, Either RequestException a)
-request (Context _ (base, manager) _ _ _) (verb, path) reqHeaders body = do
+request (Context _ (base, manager) _ _ _ _) (verb, path) reqHeaders body = do
     req <- parseRequest $ T.unpack $ base <> path
     let io = handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
     catch io handleException

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -59,15 +59,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( SeqState (..) )
 import Cardano.Wallet.Primitive.Model
-    ( Wallet, currentTip, getPending, getState, unsafeInitWallet, utxo )
+    ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..)
-    , Tx (..)
-    , TxMeta (..)
-    , WalletId (..)
-    , WalletMetadata (..)
-    , isPending
-    )
+    ( Hash (..), Tx (..), TxMeta (..), WalletId (..), WalletMetadata (..) )
 import Control.Foldl
     ( Fold (..) )
 import Control.Monad.IO.Class
@@ -226,18 +220,7 @@ mPutCheckpoint wid wal m@(M cp metas txs pk)
     | otherwise = (Left (NoSuchWallet wid), m)
 
 mReadCheckpoint :: MWid -> MockOp (Maybe MWallet)
-mReadCheckpoint wid m@(M cp _ txs _) =
-    (Right (withPendingTxs <$> Map.lookup wid cp), m)
-  where
-    pending = maybe
-        mempty
-        (Set.fromList . fmap fst . Map.elems . Map.filter isPending)
-        (Map.lookup wid txs)
-    withPendingTxs c = unsafeInitWallet
-        (utxo c)
-        (getPending c <> pending)
-        (currentTip c)
-        (getState c)
+mReadCheckpoint wid m@(M cp _ _ _) = (Right (Map.lookup wid cp), m)
 
 mPutWalletMeta :: MWid -> WalletMetadata -> MockOp ()
 mPutWalletMeta wid meta m@(M cp metas txs pk)

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -733,7 +733,7 @@ dbPropertyTests = do
                 readPrivateKey)
             )
         it "Tx History vs Checkpoint & Wallet Metadata & Private Key"
-            (property . discardPending (prop_isolation putTxHistoryF
+            (property . (prop_isolation putTxHistoryF
                 readCheckpoint
                 readWalletMeta
                 readPrivateKey)
@@ -772,19 +772,6 @@ dbPropertyTests = do
         it "Private Key"
             (checkCoverage . (prop_parallelPut putPrivateKey readPrivateKey
                 (length . lrp @Maybe)))
-  where
-    -- NOTE
-    -- For the isolation property, we discard pending transaction since
-    -- inserting a pending transaction actually has an effect on the
-    -- checkpoint's pending transactions of a same wallet.
-    discardPending
-        :: (db -> (k, GenTxHistory) -> Property)
-        -> db
-        -> (k, GenTxHistory)
-        -> Property
-    discardPending prop db (wid, GenTxHistory txs) =
-        let txs' = Map.filter (not . isPending) txs
-        in prop db (wid, GenTxHistory txs')
 
 -- | Provide a DBLayer to a Spec that requires it. The database is initialised
 -- once, and cleared with 'cleanDB' before each test.

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -152,6 +152,8 @@ test-suite integration
     , http-types
     , iohk-monitoring
     , memory
+    , persistent
+    , persistent-sqlite
     , process
     , retry
     , template-haskell

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -50,7 +50,7 @@ import Test.Integration.Framework.Request
 
 import qualified Cardano.LauncherSpec as Launcher
 import qualified Cardano.Wallet.Api.Server as Server
-import qualified Cardano.Wallet.DB.MVar as MVar
+import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Cardano.Wallet.HttpBridge.NetworkSpec as HttpBridge
 import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
@@ -175,7 +175,7 @@ main = hspec $ do
         -> Int
         -> IO ()
     cardanoWalletServer nl serverPort = void $ forkIO $ do
-        db <- MVar.newDBLayer
+        (_, db) <- Sqlite.newDBLayer Nothing
         let tl = HttpBridge.newTransactionLayer
         wallet <- newWalletLayer nullTracer block0 db nl tl
         Server.start (const $ pure ()) (Just serverPort) wallet

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Main where
@@ -15,12 +16,16 @@ import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
     ( newWalletLayer )
+import Cardano.Wallet.DB
+    ( DBLayer (..) )
 import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge, block0 )
 import Cardano.Wallet.HttpBridge.Environment
     ( Network (..) )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( SeqState )
 import Control.Concurrent
     ( forkIO, threadDelay )
 import Control.Concurrent.Async
@@ -35,6 +40,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Time
     ( addUTCTime, defaultTimeLocale, formatTime, getCurrentTime )
+import Database.Persist.Sql
+    ( close' )
 import Network.HTTP.Client
     ( defaultManagerSettings, newManager )
 import System.Directory
@@ -126,17 +133,19 @@ main = hspec $ do
         wait "cardano-node-simple" (waitForCluster nodeApiAddress)
         wait "cardano-http-bridge" (threadDelay oneSecond)
         nl <- HttpBridge.newNetworkLayer bridgePort
-        cardanoWalletServer nl 1337
+        (conn, db) <- Sqlite.newDBLayer Nothing
+        cardanoWalletServer nl db 1337
         wait "cardano-wallet" (threadDelay oneSecond)
         let baseURL = "http://localhost:1337/"
         manager <- newManager defaultManagerSettings
         faucet <- putStrLn "Creating money out of thin air..." *> initFaucet nl
-        return $ Context cluster (baseURL, manager) handle faucet Proxy
+        return $ Context cluster (baseURL, manager) handle faucet conn Proxy
 
     killCluster :: Context t -> IO ()
-    killCluster (Context cluster _ handle _ _) = do
+    killCluster (Context cluster _ handle _ db _) = do
         cancel cluster
         hClose handle
+        close' db
 
     cardanoNodeSimple stateDir sysStart (nodeId, nodeAddr) h extra = Command
         "cardano-node-simple"
@@ -171,11 +180,12 @@ main = hspec $ do
     -- We start the wallet server in the same process such that we get
     -- code coverage measures from running the scenarios on top of it!
     cardanoWalletServer
-        :: NetworkLayer (HttpBridge 'Testnet) IO
+        :: (network ~ HttpBridge 'Testnet)
+        => NetworkLayer network IO
+        -> DBLayer IO (SeqState network) network
         -> Int
         -> IO ()
-    cardanoWalletServer nl serverPort = void $ forkIO $ do
-        (_, db) <- Sqlite.newDBLayer Nothing
+    cardanoWalletServer nl db serverPort = void $ forkIO $ do
         let tl = HttpBridge.newTransactionLayer
         wallet <- newWalletLayer nullTracer block0 db nl tl
         Server.start (const $ pure ()) (Just serverPort) wallet
@@ -188,6 +198,7 @@ main = hspec $ do
                 , _logs = undefined
                 , _faucet = undefined
                 , _target = undefined
+                , _db = undefined
                 , _manager = ("http://" <> T.pack addr, manager)
                 }
         let err =  "waitForCluster: unexpected positive response from Api"

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -94,6 +94,8 @@
             (hsPkgs.http-types)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.memory)
+            (hsPkgs.persistent)
+            (hsPkgs.persistent-sqlite)
             (hsPkgs.process)
             (hsPkgs.retry)
             (hsPkgs.template-haskell)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#154 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have enabled SQLite for the integration tests instead of the MVar impl.
- [x] I have fixed a few issues discovered by running the integration scenarios:
    - [x] We used to store the `totalUTxO` when storing the checkpoint, which is a modified version of the actual checkpoint UTxO. Fixed by providing a new accessor to get the _"raw"_ UTxO of a checkpoint.
    - [x] There was a `PendingTx` table storing pending transactions identified by the wallet id and a slot. That is redundant with the `TxMeta` already stored, plus, it was not maintained properly and wouldn't yield the correct pending txs when restoring a checkpoint.
    - [x] We need to also use `repsert` inps and outs when inserting pending txs of a checkpoint because inputs or outputs may have been inserted by some previous transactions!
    - [x] Correctly account for pending transaction in the state-machine mock model. 
    - [x] Discard pending transaction in the isolation property (there's no isolation here when inserting a pending tx, we expect the checkpoint to have changed to account for it).


# Comments

<!-- Additional comments or screenshots to attach if any -->

It'd be nice to find some sort of invariant to enforce regarding pending txs and the corresponding checkpoint. We don't expect `putTxHistory` to be called without a `putCheckpoint` following either before or after. One way to deal with this could be:

- Enforce that `putTxHistory` is **never** called with pending txs
- Store `TxMeta` in the checkpoint, such that `putCheckpoint` has enough information to fully store a pending tx. 

**edit**: Addressed points above in a last commit. 

:warning: As always, reviewing commit by commit will make it easier! :warning: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
