### PR TITLE
Make it possible to listen on a default API server port when using the launcher.

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -66,6 +66,7 @@ executable cardano-wallet-launcher
   build-depends:
       base
     , cardano-wallet-cli
+    , cardano-wallet-core
     , cardano-wallet-launcher
     , directory
     , docopt

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -40,6 +40,7 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.cardano-wallet-cli)
+            (hsPkgs.cardano-wallet-core)
             (hsPkgs.cardano-wallet-launcher)
             (hsPkgs.directory)
             (hsPkgs.docopt)


### PR DESCRIPTION
# Issue Number

#410 

# Overview

This PR adds the following options to `cardano-wallet-launcher`:

```
--api-server-port <INT>    port used for serving the wallet API
                           [default: 8090]
    
--api-server-random-port   serve wallet API on any available port
                           (conflicts with --api-server-port)
```

These options correspond **directly** to the `cardano-wallet server` options `--port` and `--random-port` respectively.

Now that we have these options:

1. We can simply call `cardano-wallet-launcher` without specifying any ports. Both `cardano-http-bridge` and the wallet API server will listen on their default ports.
2. We can simply call `cardano-wallet` to run a client command without specifying any ports, and it will connect to the default wallet API server port.
