### PR TITLE
Additional tests checking if files exists when using --database and --state-dir options

### DIFF
--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -5,26 +5,22 @@ module Test.Integration.Scenario.CLI.Server
 import Prelude
 
 import Cardano.Launcher
-    ( Command (..), StdStream (..))
-import Test.Hspec.Expectations.Lifted
-    ( shouldBe )
-import Control.Monad
-    ( when )
+    ( Command (..), StdStream (..) )
 import System.Directory
     ( doesFileExist, removePathForcibly )
 import Test.Hspec
     ( SpecWith, after_, describe, it )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe )
 import Test.Integration.Framework.DSL
     ( Context (..), expectCmdStarts )
 
 spec :: SpecWith (Context t)
 spec = after_ tearDown $ do
-    describe "SERVER - cardano-wallet server" $ do
-        it "SERVER - Can start cardano-wallet server without --database" $ \_ -> do
-            let cardanoWalletServer = Command
-                    "cardano-wallet"
-                    [ "server"
-                    , "--random-port"
+    describe "SERVER - cardano-wallet serve" $ do
+        it "SERVER - Can start cardano-wallet serve without --database" $ \_ -> do
+            let cardanoWalletServer = Command "stack"
+                    [ "exec", "--", "cardano-wallet", "serve"
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletServer
@@ -36,11 +32,9 @@ spec = after_ tearDown $ do
             w2 `shouldBe` False
             w3 `shouldBe` False
 
-        it "SERVER - Can start cardano-wallet server with --database" $ \_ -> do
-            let cardanoWalletServer = Command
-                    "cardano-wallet"
-                    [ "server"
-                    , "--random-port"
+        it "SERVER - Can start cardano-wallet serve with --database" $ \_ -> do
+            let cardanoWalletServer = Command "stack"
+                    [ "exec", "--", "cardano-wallet", "serve"
                     , "--database", dbFile
                     ] (return ())
                     Inherit
@@ -55,9 +49,6 @@ spec = after_ tearDown $ do
  where
      dbFile = "./test/data/test-DB-File"
      tearDown = do
-         f1 <- doesFileExist dbFile
-         f2 <- doesFileExist (dbFile ++ "-shm")
-         f3 <- doesFileExist (dbFile ++ "-wal")
-         when f1 $ removePathForcibly dbFile
-         when f2 $ removePathForcibly (dbFile ++ "-shm")
-         when f3 $ removePathForcibly (dbFile ++ "-wal")
+         removePathForcibly dbFile
+         removePathForcibly (dbFile ++ "-shm")
+         removePathForcibly (dbFile ++ "-wal")

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -11,7 +11,7 @@ import System.Directory
 import Test.Hspec
     ( SpecWith, after_, describe, it )
 import Test.Hspec.Expectations.Lifted
-    ( shouldBe )
+    ( shouldReturn )
 import Test.Integration.Framework.DSL
     ( Context (..), expectCmdStarts )
 
@@ -24,13 +24,9 @@ spec = after_ tearDown $ do
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletServer
-
-            w1 <- doesFileExist dbFile
-            w2 <- doesFileExist (dbFile ++ "-shm")
-            w3 <- doesFileExist (dbFile ++ "-wal")
-            w1 `shouldBe` False
-            w2 `shouldBe` False
-            w3 `shouldBe` False
+            doesFileExist dbFile `shouldReturn` False
+            doesFileExist (dbFile ++ "-shm") `shouldReturn` False
+            doesFileExist (dbFile ++ "-wal") `shouldReturn` False
 
         it "SERVER - Can start cardano-wallet serve with --database" $ \_ -> do
             let cardanoWalletServer = Command "stack"
@@ -39,13 +35,9 @@ spec = after_ tearDown $ do
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletServer
-
-            w1 <- doesFileExist dbFile
-            w2 <- doesFileExist (dbFile ++ "-shm")
-            w3 <- doesFileExist (dbFile ++ "-wal")
-            w1 `shouldBe` True
-            w2 `shouldBe` True
-            w3 `shouldBe` True
+            doesFileExist dbFile `shouldReturn` True
+            doesFileExist (dbFile ++ "-shm") `shouldReturn` True
+            doesFileExist (dbFile ++ "-wal") `shouldReturn` True
  where
      dbFile = "./test/data/test-DB-File"
      tearDown = do

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Server.hs
@@ -7,40 +7,38 @@ import Prelude
 import Cardano.Launcher
     ( Command (..), StdStream (..) )
 import System.Directory
-    ( doesFileExist, removePathForcibly )
+    ( doesFileExist )
+import System.IO.Temp
+    ( withSystemTempDirectory )
 import Test.Hspec
-    ( SpecWith, after_, describe, it )
+    ( SpecWith, describe, it )
 import Test.Hspec.Expectations.Lifted
     ( shouldReturn )
 import Test.Integration.Framework.DSL
     ( Context (..), expectCmdStarts )
 
 spec :: SpecWith (Context t)
-spec = after_ tearDown $ do
+spec = do
     describe "SERVER - cardano-wallet serve" $ do
-        it "SERVER - Can start cardano-wallet serve without --database" $ \_ -> do
+        it "SERVER - Can just start cardano-wallet serve" $ \_ -> do
             let cardanoWalletServer = Command "stack"
                     [ "exec", "--", "cardano-wallet", "serve"
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletServer
-            doesFileExist dbFile `shouldReturn` False
-            doesFileExist (dbFile ++ "-shm") `shouldReturn` False
-            doesFileExist (dbFile ++ "-wal") `shouldReturn` False
 
-        it "SERVER - Can start cardano-wallet serve with --database" $ \_ -> do
-            let cardanoWalletServer = Command "stack"
-                    [ "exec", "--", "cardano-wallet", "serve"
-                    , "--database", dbFile
-                    ] (return ())
-                    Inherit
-            expectCmdStarts cardanoWalletServer
-            doesFileExist dbFile `shouldReturn` True
-            doesFileExist (dbFile ++ "-shm") `shouldReturn` True
-            doesFileExist (dbFile ++ "-wal") `shouldReturn` True
- where
-     dbFile = "./test/data/test-DB-File"
-     tearDown = do
-         removePathForcibly dbFile
-         removePathForcibly (dbFile ++ "-shm")
-         removePathForcibly (dbFile ++ "-wal")
+        it "SERVER - Can start cardano-wallet serve --database" $ \_ -> do
+            withTempDir $ \d -> do
+                let dbFile = d ++ "/db-file"
+                let cardanoWalletServer = Command "stack"
+                        [ "exec", "--", "cardano-wallet", "serve"
+                        , "--database", dbFile
+                        ] (return ())
+                        Inherit
+                expectCmdStarts cardanoWalletServer
+                doesFileExist dbFile `shouldReturn` True
+                doesFileExist (dbFile ++ "-shm") `shouldReturn` True
+                doesFileExist (dbFile ++ "-wal") `shouldReturn` True
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir = withSystemTempDirectory "integration-state"

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -187,6 +187,7 @@ test-suite integration
       Test.Integration.Scenario.CLI.Transactions
       Test.Integration.Scenario.CLI.Wallets
       Test.Integration.Scenario.CLI.Port
+      Test.Integration.Scenario.CLI.Server
       Paths_cardano_wallet_http_bridge
 
 benchmark restore

--- a/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
@@ -7,11 +7,15 @@ import Prelude
 import Cardano.Launcher
     ( Command (..), StdStream (..) )
 import System.Directory
-    ( doesDirectoryExist, doesFileExist, removePathForcibly )
+    ( createDirectory, doesDirectoryExist, doesFileExist, removePathForcibly )
+import System.Exit
+    ( ExitCode (..) )
+import System.Process
+    ( createProcess, proc, waitForProcess )
 import Test.Hspec
     ( Spec, after_, describe, it )
 import Test.Hspec.Expectations.Lifted
-    ( shouldBe )
+    ( shouldBe, shouldReturn )
 import Test.Integration.Framework.DSL
     ( expectCmdStarts )
 
@@ -28,25 +32,44 @@ spec = after_ tearDown $ do
             d1 <- doesDirectoryExist stateDir
             d1 `shouldBe` False
 
-        it "LAUNCH - Can start launcher against testnet with --state-dir" $ do
+        it "LAUNCH - Can start launcher with --state-dir" $ do
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
                     , "--state-dir", stateDir
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
+            expectStateDirExists stateDir
 
-            d1 <- doesDirectoryExist stateDir
-            d2 <- doesDirectoryExist (stateDir ++ "/testnet")
-            w1 <- doesFileExist (stateDir ++ "/wallet.db")
-            w2 <- doesFileExist (stateDir ++ "/wallet.db-shm")
-            w3 <- doesFileExist (stateDir ++ "/wallet.db-wal")
-            d1 `shouldBe` True
-            d2 `shouldBe` True
-            w1 `shouldBe` True
-            w2 `shouldBe` True
-            w3 `shouldBe` True
+        it "LAUNCH - Can start launcher with --state-dir <emptydir>" $ do
+            createDirectory stateDir
+            let cardanoWalletLauncher = Command "stack"
+                    [ "exec", "--", "cardano-wallet", "launch"
+                    , "--state-dir", stateDir
+                    ] (return ())
+                    Inherit
+            expectCmdStarts cardanoWalletLauncher
+            expectStateDirExists stateDir
+
+        describe "DaedalusIPC" $ do
+            it "should reply with the port when asked" $ do
+                (_, _, _, ph) <-
+                 createProcess (proc "test/integration/js/mock-daedalus.js" [])
+                waitForProcess ph `shouldReturn` ExitSuccess
+
  where
      stateDir = "./test/data/tmpStateDir"
      tearDown = do
          removePathForcibly stateDir
+
+     expectStateDirExists dir = do
+         d1 <- doesDirectoryExist dir
+         d2 <- doesDirectoryExist (dir ++ "/testnet")
+         w1 <- doesFileExist (dir ++ "/wallet.db")
+         w2 <- doesFileExist (dir ++ "/wallet.db-shm")
+         w3 <- doesFileExist (dir ++ "/wallet.db-wal")
+         d1 `shouldBe` True
+         d2 `shouldBe` True
+         w1 `shouldBe` True
+         w2 `shouldBe` True
+         w3 `shouldBe` True

--- a/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
@@ -6,8 +6,6 @@ import Prelude
 
 import Cardano.Launcher
     ( Command (..), StdStream (..) )
-import Control.Monad
-    ( when )
 import System.Directory
     ( doesDirectoryExist, doesFileExist, removePathForcibly )
 import Test.Hspec
@@ -19,21 +17,21 @@ import Test.Integration.Framework.DSL
 
 spec :: Spec
 spec = after_ tearDown $ do
-    describe "LAUNCHER - cardano-wallet-launcher" $ do
-        it "LAUNCHER - Can start launcher against testnet" $ do
+    describe "LAUNCH - cardano-wallet launch" $ do
+        it "LAUNCH - Can start launcher against testnet" $ do
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
-                    , "--bridge-port", "8080"
+                    , "--network", "testnet"
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
             d1 <- doesDirectoryExist stateDir
             d1 `shouldBe` False
 
-        it "LAUNCHER - Can start launcher against testnet with --state-dir" $ do
+        it "LAUNCH - Can start launcher against testnet with --state-dir" $ do
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
-                    , "--bridge-port", "8080"
+                    , "--state-dir", stateDir
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
@@ -43,15 +41,12 @@ spec = after_ tearDown $ do
             w1 <- doesFileExist (stateDir ++ "/wallet.db")
             w2 <- doesFileExist (stateDir ++ "/wallet.db-shm")
             w3 <- doesFileExist (stateDir ++ "/wallet.db-wal")
-
             d1 `shouldBe` True
             d2 `shouldBe` True
             w1 `shouldBe` True
             w2 `shouldBe` True
             w3 `shouldBe` True
-
  where
      stateDir = "./test/data/tmpStateDir"
      tearDown = do
-         d <- doesDirectoryExist stateDir
-         when d $ removePathForcibly stateDir
+         removePathForcibly stateDir

--- a/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
@@ -7,64 +7,66 @@ import Prelude
 import Cardano.Launcher
     ( Command (..), StdStream (..) )
 import System.Directory
-    ( createDirectory, doesDirectoryExist, doesFileExist, removePathForcibly )
+    ( doesDirectoryExist, doesFileExist, removeDirectory )
 import System.Exit
     ( ExitCode (..) )
+import System.IO.Temp
+    ( withSystemTempDirectory )
 import System.Process
     ( createProcess, proc, waitForProcess )
 import Test.Hspec
-    ( Spec, after_, describe, it )
+    ( Spec, describe, it )
 import Test.Hspec.Expectations.Lifted
-    ( shouldBe, shouldReturn )
+    ( shouldReturn )
 import Test.Integration.Framework.DSL
     ( expectCmdStarts )
 
 spec :: Spec
-spec = after_ tearDown $ do
+spec = do
     describe "LAUNCH - cardano-wallet launch" $ do
-        it "LAUNCH - Can start launcher against testnet" $ do
+        it "LAUNCH - Can start launcher against testnet" $ withTempDir $ \d -> do
+            removeDirectory d
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
                     , "--network", "testnet"
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
-            d1 <- doesDirectoryExist stateDir
-            d1 `shouldBe` False
+            doesDirectoryExist d `shouldReturn` False
 
-        it "LAUNCH - Can start launcher with --state-dir" $ do
+        it "LAUNCH - Can start launcher with --state-dir" $ withTempDir $ \d -> do
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
-                    , "--state-dir", stateDir
+                    , "--state-dir", d
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
-            expectStateDirExists stateDir
+            expectStateDirExists d
 
-        it "LAUNCH - Can start launcher with --state-dir <emptydir>" $ do
-            createDirectory stateDir
+        it "LAUNCH - Can start launcher with --state-dir <emptydir>"
+            $ withTempDir $ \d -> do
+            removeDirectory d
             let cardanoWalletLauncher = Command "stack"
                     [ "exec", "--", "cardano-wallet", "launch"
-                    , "--state-dir", stateDir
+                    , "--state-dir", d
                     ] (return ())
                     Inherit
             expectCmdStarts cardanoWalletLauncher
-            expectStateDirExists stateDir
+            expectStateDirExists d
 
-        describe "DaedalusIPC" $ do
-            it "should reply with the port when asked" $ do
-                (_, _, _, ph) <-
-                 createProcess (proc "test/integration/js/mock-daedalus.js" [])
-                waitForProcess ph `shouldReturn` ExitSuccess
+    describe "DaedalusIPC" $ do
+        it "should reply with the port when asked" $ do
+            (_, _, _, ph) <-
+             createProcess (proc "test/integration/js/mock-daedalus.js" [])
+            waitForProcess ph `shouldReturn` ExitSuccess
 
- where
-     stateDir = "./test/data/tmpStateDir"
-     tearDown = do
-         removePathForcibly stateDir
+expectStateDirExists :: FilePath -> IO ()
+expectStateDirExists dir = do
+    doesDirectoryExist dir `shouldReturn` True
+    doesDirectoryExist (dir ++ "/testnet") `shouldReturn` True
+    doesFileExist (dir ++ "/wallet.db") `shouldReturn` True
+    doesFileExist (dir ++ "/wallet.db-shm") `shouldReturn` True
+    doesFileExist (dir ++ "/wallet.db-wal") `shouldReturn` True
 
-     expectStateDirExists dir = do
-         doesDirectoryExist dir `shouldReturn` True
-         doesDirectoryExist (dir ++ "/testnet") `shouldReturn` True
-         doesFileExist (dir ++ "/wallet.db") `shouldReturn` True
-         doesFileExist (dir ++ "/wallet.db-shm") `shouldReturn` True
-         doesFileExist (dir ++ "/wallet.db-wal") `shouldReturn` True
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir = withSystemTempDirectory "integration-state"

--- a/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/LauncherSpec.hs
@@ -63,13 +63,8 @@ spec = after_ tearDown $ do
          removePathForcibly stateDir
 
      expectStateDirExists dir = do
-         d1 <- doesDirectoryExist dir
-         d2 <- doesDirectoryExist (dir ++ "/testnet")
-         w1 <- doesFileExist (dir ++ "/wallet.db")
-         w2 <- doesFileExist (dir ++ "/wallet.db-shm")
-         w3 <- doesFileExist (dir ++ "/wallet.db-wal")
-         d1 `shouldBe` True
-         d2 `shouldBe` True
-         w1 `shouldBe` True
-         w2 `shouldBe` True
-         w3 `shouldBe` True
+         doesDirectoryExist dir `shouldReturn` True
+         doesDirectoryExist (dir ++ "/testnet") `shouldReturn` True
+         doesFileExist (dir ++ "/wallet.db") `shouldReturn` True
+         doesFileExist (dir ++ "/wallet.db-shm") `shouldReturn` True
+         doesFileExist (dir ++ "/wallet.db-wal") `shouldReturn` True

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -93,7 +93,6 @@ main = hspec $ do
     describe "Cardano.Wallet.HttpBridge.NetworkSpec" HttpBridge.spec
     describe "CLI commands not requiring bridge" $ do
         describe "Mnemonics CLI tests" MnemonicsCLI.spec
-        describe "Server CLI tests" ServerCLI.spec
         describe "--port CLI tests" $ do
             cardanoWalletServer Nothing
                 & beforeAll

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -120,7 +120,7 @@ main = hspec $ do
         describe "Wallets CLI tests" WalletsCLI.spec
         describe "Transactions CLI tests" TransactionsCLI.spec
         describe "Addresses CLI tests" AddressesCLI.spec
-
+        describe "Server CLI tests" ServerCLI.spec
   where
     oneSecond :: Int
     oneSecond = 1 * 1000 * 1000 -- 1 second in microseconds


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added few tests checking if files are created on filesystem when using
  - `cardano-wallet server --database <filepath>` 
  - or `cardano-wallet-launcher --state-dir <filepath>`


# Comments

`cardano-wallet-launcher` tests can be easily changed to `cardano-wallet launcher` after #368.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
