### PR TITLE
add missing extra-deps for 'binary' in stack.yaml

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -3,6 +3,7 @@
     {
       packages = {
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
+        "binary" = (((hackage.binary)."0.8.7.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
         "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
         "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ packages:
 
 extra-deps:
 - base58-bytestring-0.1.0
+- binary-0.8.7.0
 - command-0.1.1
 - containers-0.5.11.0
 - ekg-prometheus-adapter-0.1.0.4


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have maybe fixed current CI issues.

# Comments

<!-- Additional comments or screenshots to attach if any -->

This is now failing because of the latest upgrade to stack 2+.

:warning: Will merge without CI since ... this is actually to fix the CI environment :warning: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
