### PR TITLE
reduce usage of 'fixtureWallet' in the integration tests

### DIFF
--- a/lib/core/test/integration/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/API/Transactions.hs
@@ -382,7 +382,7 @@ spec = do
                 , ( "polish", T.unpack polishWalletName, base58Err )
                 ]
         forM_ matrix $ \(title, addr, errMsg) -> it title $ \ctx -> do
-            wSrc <- fixtureWallet ctx
+            wSrc <- emptyWallet ctx
             let payload = Json [json|{
                     "payments": [{
                         "address": #{addr},
@@ -400,7 +400,7 @@ spec = do
                 ]
 
     it "TRANS_CREATE_05 - [] as address" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
+        wSrc <- emptyWallet ctx
         let payload = Json [json|{
                 "payments": [{
                     "address": [],
@@ -418,7 +418,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_05 - Num as address" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
+        wSrc <- emptyWallet ctx
         let payload = Json [json|{
                 "payments": [{
                     "address": 123123,
@@ -436,7 +436,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_05 - address param missing" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
+        wSrc <- emptyWallet ctx
         let payload = Json [json|{
                 "payments": [{
                     "amount": {
@@ -529,7 +529,7 @@ spec = do
                 )
                 ]
         forM_ matrix $ \(title, amt, expectations) -> it title $ \ctx -> do
-            wSrc <- fixtureWallet ctx
+            wSrc <- emptyWallet ctx
             wDest <- emptyWallet ctx
             addr:_ <- listAddresses ctx wDest
 
@@ -569,7 +569,7 @@ spec = do
                 expectErrorMessage errMsg404NoEndpoint r
 
     it "TRANS_CREATE_07 - 'almost' valid walletId" $ \ctx -> do
-        w <- fixtureWallet ctx
+        w <- emptyWallet ctx
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest
         let destination = addr ^. #id
@@ -592,7 +592,7 @@ spec = do
         expectErrorMessage errMsg404NoEndpoint r
 
     it "TRANS_CREATE_07 - Deleted wallet" $ \ctx -> do
-        w <- fixtureWallet ctx
+        w <- emptyWallet ctx
         _ <- request @ApiWallet ctx (deleteWalletEp w) Default Empty
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest
@@ -614,7 +614,7 @@ spec = do
     describe "TRANS_CREATE_08 - v2/wallets/{id}/transactions - Methods Not Allowed" $ do
         let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS", "GET"]
         forM_ matrix $ \method -> it (show method) $ \ctx -> do
-            w <- fixtureWallet ctx
+            w <- emptyWallet ctx
             wDest <- emptyWallet ctx
             addr:_ <- listAddresses ctx wDest
             let destination = addr ^. #id
@@ -663,7 +663,7 @@ spec = do
                    )
                  ]
         forM_ matrix $ \(title, headers, expectations) -> it title $ \ctx -> do
-            w <- fixtureWallet ctx
+            w <- emptyWallet ctx
             wDest <- emptyWallet ctx
             addr:_ <- listAddresses ctx wDest
             let destination = addr ^. #id
@@ -697,7 +697,7 @@ spec = do
                 ]
 
         forM_ matrix $ \(name, nonJson) -> it name $ \ctx -> do
-            w <- fixtureWallet ctx
+            w <- emptyWallet ctx
             let payload = nonJson
             r <- request @(ApiTransaction t) ctx (postTxEp w)
                     Default payload

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -351,7 +351,7 @@ spec = do
                 , ( "address is space", " ", base58Err )
                 ]
         forM_ matrix $ \(title, addr, errMsg) -> it title $ \ctx -> do
-            wSrc <- fixtureWallet ctx
+            wSrc <- emptyWallet ctx
             let args = T.unpack <$>
                     [ wSrc ^. walletId
                     , "--payment", "12@" <> (T.pack addr)
@@ -374,7 +374,7 @@ spec = do
                 , ("no amount", "", errNum)
                 ]
         forM_ matrix $ \(title, amt, errMsg) -> it title $ \ctx -> do
-            wSrc <- fixtureWallet ctx
+            wSrc <- emptyWallet ctx
             wDest <- emptyWallet ctx
             addrs:_ <- listAddresses ctx wDest
             let addr =
@@ -411,7 +411,7 @@ spec = do
                     \hex-encoded string of 40 characters"
 
     it "TRANSCLI_CREATE_07 - 'almost' valid walletId" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
+        wSrc <- emptyWallet ctx
         wDest <- emptyWallet ctx
         addrs:_ <- listAddresses ctx wDest
         let port = T.pack $ show $ ctx ^. typed @Port
@@ -428,7 +428,7 @@ spec = do
         c `shouldBe` ExitFailure 1
 
     it "TRANS_CREATE_07 - Deleted wallet" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
+        wSrc <- emptyWallet ctx
         Exit ex <- deleteWalletViaCLI ctx (T.unpack ( wSrc ^. walletId ))
         ex `shouldBe` ExitSuccess
 


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have replaced some `fixtureWallet` calls with `emptyWallet` where a funded wallet wasn't necessary.

# Comments

<!-- Additional comments or screenshots to attach if any -->

There's a non-significant cost with the use of 'fixtureWallet' since it needs to restore a funded wallet
and wait until restoration. We also only have a limited number of those wallets, so it's better to keep
them for when we actually really need funded wallets. When testing parsing errors or wrong headers, there's no need for demanding a wallet with funds


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
