### PR TITLE
Jörmungandr: Separate concern between keyToAddress and get/putAddress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,8 +142,8 @@ jobs:
     if: (type != pull_request AND branch = master) OR (tag =~ ^v)
     name: "Caching Dependencies"
     script:
-    - stack --no-terminal build --fast --only-snapshot
-    - stack --no-terminal build --fast --only-dependencies
+    - stack --no-terminal build --fast --test --no-run-tests --bench --no-run-benchmarks --only-snapshot
+    - stack --no-terminal build --fast --test --no-run-tests --bench --no-run-benchmarks --only-dependencies
     - tar czf $STACK_WORK_CACHE .stack-work
 
   - stage: build project 🔨

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -527,7 +527,7 @@ isPending = (== Pending) . (status :: TxMeta -> TxStatus) . snd
 -- layer and that the underlying encoding is rather agnostic to the underlying
 -- backend.
 newtype Address = Address
-    { getAddress :: ByteString
+    { unAddress :: ByteString
     } deriving (Show, Generic, Eq, Ord)
 
 instance NFData Address
@@ -538,7 +538,7 @@ instance Buildable Address where
 instance ToText Address where
     toText = T.decodeUtf8
         . convertToBase Base16
-        . getAddress
+        . unAddress
 
 instance FromText Address where
     fromText = bimap textDecodingError Address

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -495,7 +495,7 @@ instance Arbitrary (Proxy DummyTarget) where
     arbitrary = pure Proxy
 
 instance EncodeAddress DummyTarget where
-    encodeAddress _ = T.decodeUtf8 . convertToBase Base16 . getAddress
+    encodeAddress _ = T.decodeUtf8 . convertToBase Base16 . unAddress
 
 instance DecodeAddress DummyTarget where
     decodeAddress _ = bimap decodingError Address

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -539,7 +539,7 @@ blockchain =
                     ]
                 , outputs =
                     [ TxOut
-                        { address = Address { getAddress = "\130\216\CANXB\131X\FS!\148\NULDcB\r\237\202\255)\DLEe`\159\a\\-IG\"P\218\136\219i\244\134\161\SOHX\RSX\FS\202>U<\156c\197;\236\EOT\STXC\209\173\138\205B\EOT.\ENQ\ACKG@\174\206\185\ESC\206\NUL\SUB\230\150\192\165" }
+                        { address = Address { unAddress = "\130\216\CANXB\131X\FS!\148\NULDcB\r\237\202\255)\DLEe`\159\a\\-IG\"P\218\136\219i\244\134\161\SOHX\RSX\FS\202>U<\156c\197;\236\EOT\STXC\209\173\138\205B\EOT.\ENQ\ACKG@\174\206\185\ESC\206\NUL\SUB\230\150\192\165" }
                         , coin = Coin 3824424245549
                         }
                     , TxOut
@@ -634,7 +634,7 @@ blockchain =
                         , coin = Coin 3827577253906
                         }
                     , TxOut
-                        { address = Address { getAddress = "\130\216\CANXB\131X\FS\167\219!{\ETX\157lP>i~\158\225\DEL\141!.I\248\"\183(\DC13\231\185pU\161\SOHX\RSX\FS\SOH\131\136&\ESC\236\240\200\rw\255.\153\252\&6'\174\159vs\CAN\255\153\USf\155\173\223\NUL\SUB\214\237\RS\248" }
+                        { address = Address "\130\216\CANXB\131X\FS\167\219!{\ETX\157lP>i~\158\225\DEL\141!.I\248\"\183(\DC13\231\185pU\161\SOHX\RSX\FS\SOH\131\136&\ESC\236\240\200\rw\255.\153\252\&6'\174\159vs\CAN\255\153\USf\155\173\223\NUL\SUB\214\237\RS\248"
                         , coin = Coin 16837395907
                         }
                     ]
@@ -764,7 +764,7 @@ blockchain =
                         , coin = Coin 3832107959251
                         }
                     , TxOut
-                        { address = Address { getAddress = "\130\216\CANXB\131X\FSI\SI\165\f\DLE\223\214\209\206\187y\128F\SUB\248.\203\186/\244\143m1]\n\132\234\"\161\SOHX\RSX\FSv\SI\240\133L\130\194\DC2\191}\189;5\141\252t]\132}[\244\ESC&\SI\EOT[{\238\NUL\SUB\159\236eZ" }
+                        { address = Address "\130\216\CANXB\131X\FSI\SI\165\f\DLE\223\214\209\206\187y\128F\SUB\248.\203\186/\244\143m1]\n\132\234\"\161\SOHX\RSX\FSv\SI\240\133L\130\194\DC2\191}\189;5\141\252t]\132}[\244\ESC&\SI\EOT[{\238\NUL\SUB\159\236eZ"
                         , coin = Coin 11823271860
                         }
                     ]

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -107,7 +107,7 @@ emptyAttributes = CBOR.encodeMapLen 0
 --
 -- [Base58](https://en.wikipedia.org/wiki/Base58)
 instance EncodeAddress (HttpBridge (network :: Network)) where
-    encodeAddress _ = T.decodeUtf8 . encodeBase58 bitcoinAlphabet . getAddress
+    encodeAddress _ = T.decodeUtf8 . encodeBase58 bitcoinAlphabet . unAddress
 
 -- | Decode a [Base58](https://en.wikipedia.org/wiki/Base58) text string to an
 -- 'Address'.

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -37,6 +37,7 @@ library
     , binary
     , bytestring
     , cardano-wallet-core
+    , cardano-crypto
     , cborg
     , exceptions
     , http-client
@@ -75,6 +76,7 @@ test-suite unit
       base
     , bytestring
     , cardano-wallet-core
+    , cardano-crypto
     , cardano-wallet-jormungandr
     , generic-arbitrary
     , generic-lens

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -199,7 +199,7 @@ getInitial = label "getInitial" $ do
 
 -- | Decode the contents of a @Transaction@-message.
 getTransaction :: Get Tx
-getTransaction = label "getTransaction" $ isolate 43 $ do
+getTransaction = label "getTransaction" $ do
     (ins, outs) <- getTokenTransfer
 
     let witnessCount = length ins

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -430,11 +430,10 @@ getAddress = do
     let kind = kindValue headerByte
     let _discrimination = discriminationValue headerByte
     case kind of
-        -- Single Address
-        0x3 -> Address <$> getByteString 33
-        0x4 -> error "unimplemented group address decoder"
-        0x5 -> error "unimplemented account address decoder"
-        0x6 -> error "unimplemented multisig address decoder"
+        0x3 -> Address <$> getByteString 33 -- single address
+        0x4 -> Address <$> getByteString 65 -- grouped address
+        0x5 -> Address <$> getByteString 65 -- account address
+        0x6 -> Address <$> getByteString 33 -- multisig address
         other -> fail $ "Invalid address type: " ++ show other
   where
     kindValue :: Word8 -> Word8

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -23,11 +23,11 @@ module Cardano.Wallet.Jormungandr.Compatibility
 import Prelude
 
 import Cardano.Wallet.Jormungandr.Binary
-    ( decodeLegacyAddress )
+    ( decodeLegacyAddress, singleAddressFromKey )
 import Cardano.Wallet.Jormungandr.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..) )
+    ( KeyToAddress (..), getKey )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (..)
@@ -47,6 +47,8 @@ import Data.ByteString.Base58
     ( bitcoinAlphabet, decodeBase58, encodeBase58 )
 import Data.Maybe
     ( isJust )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.Text.Class
     ( TextDecodingError (..) )
 
@@ -69,8 +71,9 @@ genesis = BlockHeader
 instance TxId (Jormungandr n) where
     txId = undefined
 
-instance KeyToAddress (Jormungandr n) where
-    keyToAddress = undefined
+instance forall n. KnownNetwork n => KeyToAddress (Jormungandr n) where
+    keyToAddress key = singleAddressFromKey (Proxy @n) (getKey key)
+
 
 -- | Encode an 'Address' to a human-readable format. This produces two kinds of
 -- encodings:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -151,7 +151,7 @@ data JormungandrLayer m = JormungandrLayer
 --
 -- >>> (Right block) <- runExceptT $ getBlock j t
 -- >>> block
--- >>> Block {header = BlockHeader {slotId = SlotId {epochNumber = 0, slotNumber = 0}, prevBlockHash = Hash {getHash = "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL"}}, transactions = [Tx {inputs = [], outputs = [TxOut {address = Address {getAddress = "3$\195xi\193\"h\154\&5\145}\245:O\"\148\163\165/h^\ENQ\245\248\229;\135\231\234E/"}, coin = Coin {getCoin = 14}}]}]}
+-- >>> Block {header = BlockHeader {slotId = SlotId {epochNumber = 0, slotNumber = 0}, prevBlockHash = Hash {getHash = "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL"}}, transactions = [Tx {inputs = [], outputs = [TxOut {address = Address {unAddress = "3$\195xi\193\"h\154\&5\145}\245:O\"\148\163\165/h^\ENQ\245\248\229;\135\231\234E/"}, coin = Coin {getCoin = 14}}]}]}
 --
 -- At the time of writing, we only have the genesis-block, but we should be
 -- able to get its descendants.


### PR DESCRIPTION
# Issue Number

#219 - or bug


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

Single addresses contain a header byte and a public key (32 bytes). I believe we should store the entire 33 bytes inside the `Address` data-type. Previously didn't store the header byte.

- I have made `getAddress` and `putAddress` work preserve the _entire_ address structure.
    - Previously:
        - `getAddress :: 33 bytes -> Address 32 bytes`
        - `putAddress :: Address 32 bytes -> 33 bytes` 
    - Now:
        - `getAddress :: 33 bytes -> Address 33 bytes`
        - `putAddress Address 33 bytes -> 33 bytes`
- I have implemented `keyToAddress :: XPub 32 bytes -> Address 33 bytes`
- I renamed `Address {getAddress}` to `Address {unAddress}` to avoid name collisions with `Binary.getAddress`


# Comments

<!-- Additional comments or screenshots to attach if any -->
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->