### PR TITLE
Remove manually-defined `Bounded` instance for `Severity`.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -113,12 +113,6 @@ instance FromText (Port tag) where
 instance ToText (Port tag) where
     toText (Port p) = toText p
 
--- TODO: Remove this instance if `Severity` becomes an instance of `Bounded`:
--- See: https://github.com/input-output-hk/iohk-monitoring-framework/pull/340
-instance Bounded (OptionValue Severity) where
-    minBound = OptionValue Debug
-    maxBound = OptionValue Emergency
-
 instance FromText (OptionValue Severity) where
     fromText t = case T.toLower t of
         "alert" ->
@@ -144,8 +138,8 @@ instance FromText (OptionValue Severity) where
             <> "."
       where
         mk = Right . OptionValue
-        allValues = T.intercalate ", " $ T.toLower . toText <$>
-            enumerate @(OptionValue Severity)
+        allValues = T.intercalate ", " $ T.toLower . toText . OptionValue <$>
+            enumerate @Severity
 
 instance ToText (OptionValue Severity) where
     toText = T.pack . show . getOptionValue

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b0ea8317ba5a887d46969e9b3040862a10e6efb3";
-      sha256 = "1jccnc03flpi5ykz5zh3ba5rv6hgsmx0c8r69n7357q2mzlqq5qn";
+      rev = "9727b415e4a18402cf8ac2b39024a0f0c2f71676";
+      sha256 = "077lvnyyk30iahcjkd2iikgjy0d80nazsk3kqy58xg9fkgz7mvwp";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -138,8 +138,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "b0ea8317ba5a887d46969e9b3040862a10e6efb3";
-      sha256 = "1jccnc03flpi5ykz5zh3ba5rv6hgsmx0c8r69n7357q2mzlqq5qn";
+      rev = "9727b415e4a18402cf8ac2b39024a0f0c2f71676";
+      sha256 = "077lvnyyk30iahcjkd2iikgjy0d80nazsk3kqy58xg9fkgz7mvwp";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,7 +25,7 @@ extra-deps:
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: b0ea8317ba5a887d46969e9b3040862a10e6efb3
+  commit: 9727b415e4a18402cf8ac2b39024a0f0c2f71676
   subdirs:
     - contra-tracer
     - iohk-monitoring


### PR DESCRIPTION
# Issue Number

#350 

# Overview

Now that [this upstream patch for `iohk-monitoring-framework`](https://github.com/input-output-hk/iohk-monitoring-framework/pull/340) has been merged, we can remove our manually-defined instance for `OptionValue Severity`.

- [x] I have removed the manually-defined `Bounded` instance for `OptionValue Severity`.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
