### PR TITLE
Remove boilerplate from `ToText` and `FromText` instances.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -47,13 +46,17 @@ import Control.Exception
     ( bracket )
 import Data.Functor
     ( (<$) )
-import Data.List.Extra
-    ( enumerate )
 import qualified Data.List.NonEmpty as NE
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import Fmt
     ( Buildable, pretty )
 import GHC.Generics
@@ -114,35 +117,10 @@ instance ToText (Port tag) where
     toText (Port p) = toText p
 
 instance FromText (OptionValue Severity) where
-    fromText t = case T.toLower t of
-        "alert" ->
-            mk Alert
-        "critical" ->
-            mk Critical
-        "debug" ->
-            mk Debug
-        "emergency" ->
-            mk Emergency
-        "error" ->
-            mk Error
-        "info" ->
-            mk Info
-        "notice" ->
-            mk Notice
-        "warning" ->
-            mk Warning
-        _ -> Left $ TextDecodingError $ show (T.unpack t)
-            <> " is not a recognized log severity level."
-            <> " Please specify of the following values: "
-            <> T.unpack allValues
-            <> "."
-      where
-        mk = Right . OptionValue
-        allValues = T.intercalate ", " $ T.toLower . toText . OptionValue <$>
-            enumerate @Severity
+    fromText = fmap OptionValue . fromTextToBoundedEnum KebabLowerCase
 
 instance ToText (OptionValue Severity) where
-    toText = T.pack . show . getOptionValue
+    toText = toTextFromBoundedEnum KebabLowerCase . getOptionValue
 
 {-------------------------------------------------------------------------------
                              Parsing Arguments

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -31,15 +30,18 @@ import Prelude
 import Data.Int
     ( Int32 )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import GHC.Generics
     ( Generic )
 
-import qualified Data.Text as T
-
 -- | Available network options.
 data Network = Mainnet | Testnet
-    deriving (Generic, Show, Eq, Enum)
+    deriving (Generic, Show, Eq, Bounded, Enum)
 
 -- | Magic constant associated to a given network
 newtype ProtocolMagic = ProtocolMagic Int32
@@ -58,13 +60,7 @@ instance KnownNetwork 'Testnet where
     protocolMagic = ProtocolMagic 1097911063
 
 instance FromText Network where
-    fromText = \case
-        "mainnet" -> Right Mainnet
-        "testnet" -> Right Testnet
-        s -> Left $ TextDecodingError $ T.unpack s
-            <> " is neither \"mainnet\" nor \"testnet\"."
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 instance ToText Network where
-    toText = \case
-        Mainnet -> "mainnet"
-        Testnet -> "testnet"
+    toText = toTextFromBoundedEnum SnakeLowerCase

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -32,17 +31,20 @@ import Codec.Binary.Bech32
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import Data.Word
     ( Word8 )
 import GHC.Generics
     ( Generic )
 
-import qualified Data.Text as T
-
 -- | Available network options.
 data Network = Mainnet | Testnet
-    deriving (Generic, Show, Eq, Enum)
+    deriving (Generic, Show, Eq, Bounded, Enum)
 
 -- | Embed some constants into a network type.
 class KnownNetwork (n :: Network) where
@@ -61,16 +63,10 @@ class KnownNetwork (n :: Network) where
         -- delegation key.
 
 instance FromText Network where
-    fromText = \case
-        "mainnet" -> Right Mainnet
-        "testnet" -> Right Testnet
-        s -> Left $ TextDecodingError $ T.unpack s
-            <> " is neither \"mainnet\" nor \"testnet\""
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 instance ToText Network where
-    toText = \case
-        Mainnet -> "mainnet"
-        Testnet -> "testnet"
+    toText = toTextFromBoundedEnum SnakeLowerCase
 
 instance KnownNetwork 'Mainnet where
     networkVal = Mainnet

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -125,7 +126,9 @@ data CaseStyle
 --
 -- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
 --
-toTextFromBoundedEnum :: Show a => CaseStyle -> a -> Text
+toTextFromBoundedEnum
+    :: forall a . (Bounded a, Enum a, Show a)
+    => CaseStyle -> a -> Text
 toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 
 -- | Parses the given text to a value, according to the specified 'CaseStyle'.
@@ -136,9 +139,7 @@ toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 --
 fromTextToBoundedEnum
     :: forall a . (Bounded a, Enum a, Show a)
-    => CaseStyle
-    -> Text
-    -> Either TextDecodingError a
+    => CaseStyle -> Text -> Either TextDecodingError a
 fromTextToBoundedEnum cs t =
     case matchingValue of
         Just mv -> Right mv

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -14,10 +14,12 @@
 -- 'ToJSON' from 'Data.Aeson'.
 
 module Data.Text.Class
-    ( ToText (..)
+    ( -- * Producing and consuming text from arbitrary types
+      ToText (..)
     , FromText (..)
     , TextDecodingError(..)
     , fromTextMaybe
+      -- * Producing and consuming text from bounded enumeration types
     , CaseStyle (..)
     , toTextFromBoundedEnum
     , fromTextToBoundedEnum

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -15,6 +18,9 @@ module Data.Text.Class
     , FromText (..)
     , TextDecodingError(..)
     , fromTextMaybe
+    , CaseStyle (..)
+    , toTextFromBoundedEnum
+    , fromTextToBoundedEnum
     ) where
 
 import Prelude
@@ -23,16 +29,24 @@ import Control.Monad
     ( unless )
 import Data.Bifunctor
     ( first )
+import Data.List.Extra
+    ( enumerate )
+import Data.Maybe
+    ( listToMaybe )
 import Data.Text
     ( Text )
 import Data.Text.Read
     ( decimal, signed )
 import Fmt
     ( Buildable )
+import GHC.Generics
+    ( Generic )
 import Numeric.Natural
     ( Natural )
 
+import qualified Data.Char as C
 import qualified Data.Text as T
+import qualified Text.Casing as Casing
 
 -- | Defines a textual encoding for a type.
 class ToText a where
@@ -86,3 +100,74 @@ instance ToText Natural where
 -- | Decode the specified text with a 'Maybe' result type.
 fromTextMaybe :: FromText a => Text -> Maybe a
 fromTextMaybe = either (const Nothing) Just . fromText
+
+-- | Represents a case style for multi-word strings.
+data CaseStyle
+    = CamelCase
+      -- ^ A string in the style of "doNotRepeatYourself"
+    | PascalCase
+      -- ^ A string in the style of "DoNotRepeatYourself"
+    | KebabLowerCase
+      -- ^ A string in the style of "do-not-repeat-yourself"
+    | SnakeLowerCase
+      -- ^ A string in the style of "do_not_repeat_yourself"
+    | SnakeUpperCase
+      -- ^ A string in the style of "DO_NOT_REPEAT_YOURSELF"
+    | SpacedLowerCase
+      -- ^ A string in the style of "do not repeat yourself"
+    deriving (Bounded, Enum, Eq, Generic, Show)
+
+-- | Converts the given value to text, according to the specified 'CaseStyle'.
+--
+-- This function guarantees to satisfy the following property:
+--
+-- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
+--
+toTextFromBoundedEnum :: Show a => CaseStyle -> a -> Text
+toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
+
+-- | Parses the given text to a value, according to the specified 'CaseStyle'.
+--
+-- This function guarantees to satisfy the following property:
+--
+-- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
+--
+fromTextToBoundedEnum
+    :: forall a . (Bounded a, Enum a, Show a)
+    => CaseStyle
+    -> Text
+    -> Either TextDecodingError a
+fromTextToBoundedEnum cs t =
+    case matchingValue of
+        Just mv -> Right mv
+        Nothing -> Left $ TextDecodingError $ "Error: "
+            <> "Unable to decode the given value: "
+            <> show t
+            <> ". Please specify one of the following values: "
+            <> T.unpack (T.intercalate ", " allValuesInRequiredCase)
+            <> "."
+  where
+    allValuesInPascalCase = toTextFromBoundedEnum PascalCase <$> enumerate @a
+    allValuesInRequiredCase = toTextFromBoundedEnum cs <$> enumerate @a
+    inputInPascalCase = T.pack $ Casing.toPascal $ fromCaseStyle cs $ T.unpack t
+    matchingValue = fmap (toEnum . snd) $ listToMaybe $
+        filter ((== inputInPascalCase) . fst) $
+            allValuesInPascalCase `zip` [0 :: Int ..]
+
+toCaseStyle :: CaseStyle -> Casing.Identifier String -> String
+toCaseStyle = \case
+    CamelCase       -> Casing.toCamel
+    PascalCase      -> Casing.toPascal
+    KebabLowerCase  -> Casing.toKebab
+    SnakeLowerCase  -> Casing.toQuietSnake
+    SnakeUpperCase  -> Casing.toScreamingSnake
+    SpacedLowerCase -> fmap C.toLower <$> Casing.toWords
+
+fromCaseStyle :: CaseStyle -> String -> Casing.Identifier String
+fromCaseStyle = \case
+    CamelCase       -> Casing.fromHumps
+    PascalCase      -> Casing.fromHumps
+    KebabLowerCase  -> Casing.fromKebab
+    SnakeLowerCase  -> Casing.fromSnake
+    SnakeUpperCase  -> Casing.fromSnake
+    SpacedLowerCase -> Casing.fromWords

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -15,15 +16,26 @@ import Data.Maybe
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..), fromTextMaybe )
+    ( CaseStyle (..)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextMaybe
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
     , UnicodeString (..)
+    , arbitraryBoundedEnum
     , choose
     , classify
     , elements
+    , genericShrink
     , property
     , vectorOf
     , (===)
@@ -66,9 +78,30 @@ spec = do
         it "fromText . toText === pure" $
             property $ \(t :: Text) -> (fromText . toText) t === pure t
 
+    describe "BoundedEnum" $ do
+        it "fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a" $
+            property $ \(a :: TestBoundedEnum) (s :: CaseStyle) ->
+                fromTextToBoundedEnum s (toTextFromBoundedEnum s a) === Right a
+        it "CamelCase" $
+            toTextFromBoundedEnum CamelCase FooBarBaz === "fooBarBaz"
+        it "PascalCase" $
+            toTextFromBoundedEnum PascalCase FooBarBaz === "FooBarBaz"
+        it "KebabLowerCase" $
+            toTextFromBoundedEnum KebabLowerCase FooBarBaz === "foo-bar-baz"
+        it "SnakeLowerCase" $
+            toTextFromBoundedEnum SnakeLowerCase FooBarBaz === "foo_bar_baz"
+        it "SnakeUpperCase" $
+            toTextFromBoundedEnum SnakeUpperCase FooBarBaz === "FOO_BAR_BAZ"
+        it "SpacedLowerCase" $
+            toTextFromBoundedEnum SpacedLowerCase FooBarBaz === "foo bar baz"
+
 {-------------------------------------------------------------------------------
                               Arbitrary Instances
 -------------------------------------------------------------------------------}
+
+instance Arbitrary CaseStyle where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary Text where
     shrink = map (T.pack . getUnicodeString) . shrink . UnicodeString . T.unpack
@@ -83,3 +116,22 @@ instance Arbitrary Digits where
         str <- vectorOf n (elements ('x':['0'..'9']))
         sign <- elements ["", "-", "+"]
         pure (sign ++ str)
+
+data TestBoundedEnum
+    = A
+      -- ^ 1 char
+    | AB
+      -- ^ 2 chars
+    | ABC
+      -- ^ 3 chars
+    | Foo
+      -- ^ 1 word
+    | FooBar
+      -- ^ 2 words
+    | FooBarBaz
+      -- ^ 3 words
+    deriving (Bounded, Enum, Eq, Generic, Ord, Show)
+
+instance Arbitrary TestBoundedEnum where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -30,6 +30,8 @@ library
       -Werror
   build-depends:
       base
+    , casing
+    , extra
     , fmt
     , text
     , hspec

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -18,6 +18,8 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.casing)
+          (hsPkgs.extra)
           (hsPkgs.fmt)
           (hsPkgs.text)
           (hsPkgs.hspec)


### PR DESCRIPTION
# Issue Number

None.

# Overview

Our code base has several `FromText` and `ToText` instances with repetitive definitions. For example:
```hs
data Wibble = Foo | Bar | ToTo | TaTa

instance FromText Wibble where
    fromText txt = case txt of
        "foo" -> Right Foo
        "bar" -> Right Bar
        "to-to" -> Right ToTo
        "ta-ta" -> Right TaTa
        _ -> Left $ DecodingError $ show txt
                <> " is neither \"foo\", \"bar\", \"to-to\", nor \"ta-ta\"."

instance ToText Wibble where
    toText = \case
        Foo -> "foo"
        Bar -> "bar"
        ToTo -> "to-to"
        TaTa -> "ta-ta"
```
This PR makes it possible to replace the above definitions with:
```hs
data Wibble = Foo | Bar | ToTo | TaTa
    deriving (Bounded, Enum)

instance FromText Wibble where
    fromText = fromTextToBoundedEnum KebabLowerCase

instance ToText Wibble where
    toText = toTextFromBoundedEnum KebabLowerCase
```
Where `KebabLowerCase` is one of several case styles. (We use several different styles across our code base.)

I have:

- [x] Defined the functions `toTextFromBoundedEnum` and `fromTextToBoundedEnum`.
- [x] Defined a set of case styles: `{CamelCase, PascalCase, KebabLowerCase, SnakeLowerCase ...}` to match the styles used in our code base.
- [x] Provided tests to check that different case styles produce the correct results.
- [x] Provided round-trip tests to verify the property ` fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a`


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
