### PR TITLE
Pass CLI argument `--min-log-severity` through when calling `serve` from `launch`.

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -38,7 +38,8 @@ import Cardano.BM.Setup
 import Cardano.BM.Trace
     ( Trace, appendName, logAlert, logInfo )
 import Cardano.CLI
-    ( Port
+    ( OptionValue (..)
+    , Port
     , getLine
     , getOptionValue
     , getSensitiveLine
@@ -257,7 +258,7 @@ exec execServe manager args
         minLogSeverity <- getOptionValue <$>
             args `parseArg` longOption "min-log-severity"
         tracer <- initTracer minLogSeverity "launch"
-        execLaunch tracer network stateDir bridgePort listen
+        execLaunch tracer network stateDir bridgePort listen minLogSeverity
 
     | args `isPresent` command "generate" &&
       args `isPresent` command "mnemonic" = do
@@ -458,8 +459,9 @@ execLaunch
     -> Maybe FilePath
     -> Port "Node"
     -> Listen
+    -> Severity
     -> IO ()
-execLaunch tracer network stateDir bridgePort listen = do
+execLaunch tracer network stateDir bridgePort listen minLogSeverity = do
     installSignalHandlers
     maybe (pure ()) (setupStateDir tracer) stateDir
     let commands = [ httpBridgeCmd, walletCmd ]
@@ -494,6 +496,7 @@ execLaunch tracer network stateDir bridgePort listen = do
                 ListenOnPort port  -> ["--port", showT port]
             , [ "--bridge-port", showT bridgePort ]
             , maybe [] (\d -> ["--database", d </> "wallet.db"]) stateDir
+            , [ "--min-log-severity", showT $ OptionValue minLogSeverity ]
             ]
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
# Issue Number

#350 

# Overview

When the user calls `cardano-wallet launch`, they can specify a value for `--min-log-severity`. This PR ensures that the minimum severity, if specified, is passed through to the wallet API server. If no minimum severity is specified, then we pass the default value, which is `debug`.

I have:

- [x] Arranged that the value of the CLI argument `--min-log-severity` is passed from the `launch` command to the `serve` command.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
