### PR TITLE
Add goldens for singleAddressFromKey

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -74,6 +74,7 @@ test-suite unit
       -Werror
   build-depends:
       base
+    , bech32
     , bytestring
     , cardano-wallet-core
     , cardano-crypto


### PR DESCRIPTION
#219 

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I added a `bech32KeyToAddrGolden` helper and three goldens testing `singleAddressFromKey`

# Comments

<!-- Additional comments or screenshots to attach if any -->
1. I opted to work with bech32 encoded strings instead of the underlying data for easy comparison with `jcli`.
2. I would have slightly preferred to test `keyToAddress`. This would have required constructing a `Key 'AddressK XPub` from bech32, which is inconvenient. I have therefore opted to only test `singleAddressFromKey`.

An alternative approach I originally went with but abandoned was to generate the keys properly from mnemonics instead of decoding them from bech32.
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
