### PR TITLE
 Remove boilerplate from `ToText` and `FromText` instances. 

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -32,7 +32,6 @@ library
       base
     , ansi-terminal
     , docopt
-    , extra
     , fmt
     , iohk-monitoring
     , text

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -54,13 +53,17 @@ import Data.Bifunctor
     ( bimap )
 import Data.Functor
     ( (<$) )
-import Data.List.Extra
-    ( enumerate )
 import qualified Data.List.NonEmpty as NE
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import Data.Text.Read
     ( decimal )
 import Fmt
@@ -144,35 +147,10 @@ instance ToText (Port tag) where
     toText (Port p) = toText p
 
 instance FromText (OptionValue Severity) where
-    fromText t = case T.toLower t of
-        "alert" ->
-            mk Alert
-        "critical" ->
-            mk Critical
-        "debug" ->
-            mk Debug
-        "emergency" ->
-            mk Emergency
-        "error" ->
-            mk Error
-        "info" ->
-            mk Info
-        "notice" ->
-            mk Notice
-        "warning" ->
-            mk Warning
-        _ -> Left $ TextDecodingError $ show (T.unpack t)
-            <> " is not a recognized log severity level."
-            <> " Please specify of the following values: "
-            <> T.unpack allValues
-            <> "."
-      where
-        mk = Right . OptionValue
-        allValues = T.intercalate ", " $ T.toLower . toText . OptionValue <$>
-            enumerate @Severity
+    fromText = fmap OptionValue . fromTextToBoundedEnum KebabLowerCase
 
 instance ToText (OptionValue Severity) where
-    toText = T.pack . show . getOptionValue
+    toText = toTextFromBoundedEnum KebabLowerCase . getOptionValue
 
 {-------------------------------------------------------------------------------
                              Parsing Arguments

--- a/lib/core/test/integration/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/API/Addresses.hs
@@ -108,26 +108,27 @@ spec = do
 
     describe "ADDRESS_LIST_02 - Invalid filters are bad requests" $ do
         let filters =
-                [ "?state=usedd"
-                , "?state=uused"
-                , "?state=unusedd"
-                , "?state=uunused"
-                , "?state=USED"
-                , "?state=UNUSED"
-                , "?state=-1000"
-                , "?state=44444444"
-                , "?state=*"
+                [ "usedd"
+                , "uused"
+                , "unusedd"
+                , "uunused"
+                , "USED"
+                , "UNUSED"
+                , "-1000"
+                , "44444444"
+                , "*"
                 ]
         forM_ filters $ \fil -> it fil $ \ctx -> do
-            let stateFilter = T.pack fil
+            let stateFilter = "?state=" <> T.pack fil
             w <- emptyWallet ctx
             r <- request @[ApiAddress t] ctx (getAddressesEp w stateFilter)
                     Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status400
-                , expectErrorMessage "Error parsing query parameter state\
-                    \ failed: Unable to decode address state: it's neither\
-                    \ 'used' nor 'unused'"
+                , expectErrorMessage $
+                    "Error parsing query parameter state failed: Unable to\
+                    \ decode the given value: '" <> fil <> "'. Please specify\
+                    \ one of the following values: used, unused."
                 ]
 
     it "ADDRESS_LIST_03 - Generates new address pool gap" $ \ctx -> do

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Addresses.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Addresses.hs
@@ -128,8 +128,9 @@ spec = do
             walId <- emptyWallet' ctx
             (Exit c, Stdout o, Stderr e)
                 <- listAddressesViaCLI ctx ["--state", fil, walId]
-            e `shouldBe` "Unable to decode address state: it's neither\
-                \ \"used\" nor \"unused\"\n"
+            let err = "Unable to decode the given value: \"" <> fil <> "\". Please\
+                    \ specify one of the following values: used, unused.\n"
+            e `shouldBe` err
             c `shouldBe` ExitFailure 1
             o `shouldBe` ""
 

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -337,8 +337,8 @@ spec = do
                 `shouldBe` (Left @Text @(ApiT WalletId) msg)
 
         it "ApiT AddressState" $ do
-            let msg = "Unable to decode address state: it's neither \"used\" \
-                    \nor \"unused\""
+            let msg = "Unable to decode the given value: \"patate\".\
+                    \ Please specify one of the following values: used, unused."
             parseUrlPiece "patate"
                 `shouldBe` (Left @Text @(ApiT AddressState) msg)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -156,9 +156,9 @@ spec = do
             flatSlot (fromFlatSlot n) === n
 
     describe "Negative cases for types decoding" $ do
-        it "fail fromText @AddressPoolGap \"unusedused\"" $ do
-            let err = "Unable to decode address state: it's neither \"used\"\
-                      \ nor \"unused\""
+        it "fail fromText @AddressState \"unusedused\"" $ do
+            let err = "Unable to decode the given value: \"unusedused\".\
+                    \ Please specify one of the following values: used, unused."
             fromText @AddressState "unusedused" === Left (TextDecodingError err)
         it "fail fromText @WalletName \"\"" $ do
             let err = "name is too short: expected at least "

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -31,15 +30,18 @@ import Prelude
 import Data.Int
     ( Int32 )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import GHC.Generics
     ( Generic )
 
-import qualified Data.Text as T
-
 -- | Available network options.
 data Network = Mainnet | Testnet
-    deriving (Generic, Show, Eq, Enum)
+    deriving (Generic, Show, Eq, Bounded, Enum)
 
 -- | Magic constant associated to a given network
 newtype ProtocolMagic = ProtocolMagic Int32
@@ -58,13 +60,7 @@ instance KnownNetwork 'Testnet where
     protocolMagic = ProtocolMagic 1097911063
 
 instance FromText Network where
-    fromText = \case
-        "mainnet" -> Right Mainnet
-        "testnet" -> Right Testnet
-        s -> Left $ TextDecodingError $ T.unpack s
-            <> " is neither \"mainnet\" nor \"testnet\"."
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 instance ToText Network where
-    toText = \case
-        Mainnet -> "mainnet"
-        Testnet -> "testnet"
+    toText = toTextFromBoundedEnum SnakeLowerCase

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -32,17 +31,20 @@ import Codec.Binary.Bech32
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (..)
+    , FromText (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import Data.Word
     ( Word8 )
 import GHC.Generics
     ( Generic )
 
-import qualified Data.Text as T
-
 -- | Available network options.
 data Network = Mainnet | Testnet
-    deriving (Generic, Show, Eq, Enum)
+    deriving (Generic, Show, Eq, Bounded, Enum)
 
 -- | Embed some constants into a network type.
 class KnownNetwork (n :: Network) where
@@ -61,16 +63,10 @@ class KnownNetwork (n :: Network) where
         -- delegation key.
 
 instance FromText Network where
-    fromText = \case
-        "mainnet" -> Right Mainnet
-        "testnet" -> Right Testnet
-        s -> Left $ TextDecodingError $ T.unpack s
-            <> " is neither \"mainnet\" nor \"testnet\""
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 instance ToText Network where
-    toText = \case
-        Mainnet -> "mainnet"
-        Testnet -> "testnet"
+    toText = toTextFromBoundedEnum SnakeLowerCase
 
 instance KnownNetwork 'Mainnet where
     networkVal = Mainnet

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -143,7 +143,7 @@ fromTextToBoundedEnum
 fromTextToBoundedEnum cs t =
     case matchingValue of
         Just mv -> Right mv
-        Nothing -> Left $ TextDecodingError $ "Error: "
+        Nothing -> Left $ TextDecodingError $ mempty
             <> "Unable to decode the given value: "
             <> show t
             <> ". Please specify one of the following values: "

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -125,7 +126,9 @@ data CaseStyle
 --
 -- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
 --
-toTextFromBoundedEnum :: Show a => CaseStyle -> a -> Text
+toTextFromBoundedEnum
+    :: forall a . (Bounded a, Enum a, Show a)
+    => CaseStyle -> a -> Text
 toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 
 -- | Parses the given text to a value, according to the specified 'CaseStyle'.
@@ -136,9 +139,7 @@ toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
 --
 fromTextToBoundedEnum
     :: forall a . (Bounded a, Enum a, Show a)
-    => CaseStyle
-    -> Text
-    -> Either TextDecodingError a
+    => CaseStyle -> Text -> Either TextDecodingError a
 fromTextToBoundedEnum cs t =
     case matchingValue of
         Just mv -> Right mv

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -14,10 +14,12 @@
 -- 'ToJSON' from 'Data.Aeson'.
 
 module Data.Text.Class
-    ( ToText (..)
+    ( -- * Producing and consuming text from arbitrary types
+      ToText (..)
     , FromText (..)
     , TextDecodingError(..)
     , fromTextMaybe
+      -- * Producing and consuming text from bounded enumeration types
     , CaseStyle (..)
     , toTextFromBoundedEnum
     , fromTextToBoundedEnum

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -15,6 +18,9 @@ module Data.Text.Class
     , FromText (..)
     , TextDecodingError(..)
     , fromTextMaybe
+    , CaseStyle (..)
+    , toTextFromBoundedEnum
+    , fromTextToBoundedEnum
     ) where
 
 import Prelude
@@ -23,16 +29,24 @@ import Control.Monad
     ( unless )
 import Data.Bifunctor
     ( first )
+import Data.List.Extra
+    ( enumerate )
+import Data.Maybe
+    ( listToMaybe )
 import Data.Text
     ( Text )
 import Data.Text.Read
     ( decimal, signed )
 import Fmt
     ( Buildable )
+import GHC.Generics
+    ( Generic )
 import Numeric.Natural
     ( Natural )
 
+import qualified Data.Char as C
 import qualified Data.Text as T
+import qualified Text.Casing as Casing
 
 -- | Defines a textual encoding for a type.
 class ToText a where
@@ -86,3 +100,74 @@ instance ToText Natural where
 -- | Decode the specified text with a 'Maybe' result type.
 fromTextMaybe :: FromText a => Text -> Maybe a
 fromTextMaybe = either (const Nothing) Just . fromText
+
+-- | Represents a case style for multi-word strings.
+data CaseStyle
+    = CamelCase
+      -- ^ A string in the style of "doNotRepeatYourself"
+    | PascalCase
+      -- ^ A string in the style of "DoNotRepeatYourself"
+    | KebabLowerCase
+      -- ^ A string in the style of "do-not-repeat-yourself"
+    | SnakeLowerCase
+      -- ^ A string in the style of "do_not_repeat_yourself"
+    | SnakeUpperCase
+      -- ^ A string in the style of "DO_NOT_REPEAT_YOURSELF"
+    | SpacedLowerCase
+      -- ^ A string in the style of "do not repeat yourself"
+    deriving (Bounded, Enum, Eq, Generic, Show)
+
+-- | Converts the given value to text, according to the specified 'CaseStyle'.
+--
+-- This function guarantees to satisfy the following property:
+--
+-- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
+--
+toTextFromBoundedEnum :: Show a => CaseStyle -> a -> Text
+toTextFromBoundedEnum cs = T.pack . toCaseStyle cs . Casing.fromHumps . show
+
+-- | Parses the given text to a value, according to the specified 'CaseStyle'.
+--
+-- This function guarantees to satisfy the following property:
+--
+-- > fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a
+--
+fromTextToBoundedEnum
+    :: forall a . (Bounded a, Enum a, Show a)
+    => CaseStyle
+    -> Text
+    -> Either TextDecodingError a
+fromTextToBoundedEnum cs t =
+    case matchingValue of
+        Just mv -> Right mv
+        Nothing -> Left $ TextDecodingError $ "Error: "
+            <> "Unable to decode the given value: "
+            <> show t
+            <> ". Please specify one of the following values: "
+            <> T.unpack (T.intercalate ", " allValuesInRequiredCase)
+            <> "."
+  where
+    allValuesInPascalCase = toTextFromBoundedEnum PascalCase <$> enumerate @a
+    allValuesInRequiredCase = toTextFromBoundedEnum cs <$> enumerate @a
+    inputInPascalCase = T.pack $ Casing.toPascal $ fromCaseStyle cs $ T.unpack t
+    matchingValue = fmap (toEnum . snd) $ listToMaybe $
+        filter ((== inputInPascalCase) . fst) $
+            allValuesInPascalCase `zip` [0 :: Int ..]
+
+toCaseStyle :: CaseStyle -> Casing.Identifier String -> String
+toCaseStyle = \case
+    CamelCase       -> Casing.toCamel
+    PascalCase      -> Casing.toPascal
+    KebabLowerCase  -> Casing.toKebab
+    SnakeLowerCase  -> Casing.toQuietSnake
+    SnakeUpperCase  -> Casing.toScreamingSnake
+    SpacedLowerCase -> fmap C.toLower <$> Casing.toWords
+
+fromCaseStyle :: CaseStyle -> String -> Casing.Identifier String
+fromCaseStyle = \case
+    CamelCase       -> Casing.fromHumps
+    PascalCase      -> Casing.fromHumps
+    KebabLowerCase  -> Casing.fromKebab
+    SnakeLowerCase  -> Casing.fromSnake
+    SnakeUpperCase  -> Casing.fromSnake
+    SpacedLowerCase -> Casing.fromWords

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -15,15 +16,26 @@ import Data.Maybe
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..), fromTextMaybe )
+    ( CaseStyle (..)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextMaybe
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
     , UnicodeString (..)
+    , arbitraryBoundedEnum
     , choose
     , classify
     , elements
+    , genericShrink
     , property
     , vectorOf
     , (===)
@@ -66,9 +78,30 @@ spec = do
         it "fromText . toText === pure" $
             property $ \(t :: Text) -> (fromText . toText) t === pure t
 
+    describe "BoundedEnum" $ do
+        it "fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a" $
+            property $ \(a :: TestBoundedEnum) (s :: CaseStyle) ->
+                fromTextToBoundedEnum s (toTextFromBoundedEnum s a) === Right a
+        it "CamelCase" $
+            toTextFromBoundedEnum CamelCase FooBarBaz === "fooBarBaz"
+        it "PascalCase" $
+            toTextFromBoundedEnum PascalCase FooBarBaz === "FooBarBaz"
+        it "KebabLowerCase" $
+            toTextFromBoundedEnum KebabLowerCase FooBarBaz === "foo-bar-baz"
+        it "SnakeLowerCase" $
+            toTextFromBoundedEnum SnakeLowerCase FooBarBaz === "foo_bar_baz"
+        it "SnakeUpperCase" $
+            toTextFromBoundedEnum SnakeUpperCase FooBarBaz === "FOO_BAR_BAZ"
+        it "SpacedLowerCase" $
+            toTextFromBoundedEnum SpacedLowerCase FooBarBaz === "foo bar baz"
+
 {-------------------------------------------------------------------------------
                               Arbitrary Instances
 -------------------------------------------------------------------------------}
+
+instance Arbitrary CaseStyle where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary Text where
     shrink = map (T.pack . getUnicodeString) . shrink . UnicodeString . T.unpack
@@ -83,3 +116,22 @@ instance Arbitrary Digits where
         str <- vectorOf n (elements ('x':['0'..'9']))
         sign <- elements ["", "-", "+"]
         pure (sign ++ str)
+
+data TestBoundedEnum
+    = A
+      -- ^ 1 char
+    | AB
+      -- ^ 2 chars
+    | ABC
+      -- ^ 3 chars
+    | Foo
+      -- ^ 1 word
+    | FooBar
+      -- ^ 2 words
+    | FooBarBaz
+      -- ^ 3 words
+    deriving (Bounded, Enum, Eq, Generic, Ord, Show)
+
+instance Arbitrary TestBoundedEnum where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -9,6 +9,8 @@ module Data.Text.ClassSpec
 
 import Prelude
 
+import Data.Either
+    ( isLeft )
 import Data.Foldable
     ( toList )
 import Data.Maybe
@@ -27,7 +29,7 @@ import Data.Text.Class
 import GHC.Generics
     ( Generic )
 import Test.Hspec
-    ( Spec, describe, it )
+    ( Spec, describe, it, shouldSatisfy )
 import Test.QuickCheck
     ( Arbitrary (..)
     , UnicodeString (..)
@@ -39,6 +41,7 @@ import Test.QuickCheck
     , property
     , vectorOf
     , (===)
+    , (==>)
     )
 
 import qualified Data.Text as T
@@ -82,6 +85,11 @@ spec = do
         it "fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a" $
             property $ \(a :: TestBoundedEnum) (s :: CaseStyle) ->
                 fromTextToBoundedEnum s (toTextFromBoundedEnum s a) === Right a
+        it "fromTextToBoundedEnum t (toTextFromBoundedEnum s a) == Left _" $
+            property $ \(s :: CaseStyle) (t :: CaseStyle) ->
+                s /= t ==>
+                    fromTextToBoundedEnum @TestBoundedEnum t
+                        (toTextFromBoundedEnum s FooBar) `shouldSatisfy` isLeft
         it "CamelCase" $
             toTextFromBoundedEnum CamelCase FooBarBaz === "fooBarBaz"
         it "PascalCase" $

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -30,6 +30,8 @@ library
       -Werror
   build-depends:
       base
+    , casing
+    , extra
     , fmt
     , text
     , hspec

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -20,7 +20,6 @@
           (hsPkgs.base)
           (hsPkgs.ansi-terminal)
           (hsPkgs.docopt)
-          (hsPkgs.extra)
           (hsPkgs.fmt)
           (hsPkgs.iohk-monitoring)
           (hsPkgs.text)

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -18,6 +18,8 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.casing)
+          (hsPkgs.extra)
           (hsPkgs.fmt)
           (hsPkgs.text)
           (hsPkgs.hspec)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

Re-opened https://github.com/input-output-hk/cardano-wallet/pull/426  (see https://github.com/input-output-hk/cardano-wallet/pull/426#issuecomment-503130281)

# Overview

In addition to PR #426, this PR:

- [x] ensures that parsing within `fromTextToBoundedEnum` is **case-sensitive**.
- [x] adds a property test to ensure that `fromTextToBoundedEnum t (toTextFromBoundedEnum s a)` will fail when `s /= t` for non-trivial values of `a`.

See #426

# Comments

See #426

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
