### PR TITLE
DBLayer: Add basic logging to the Sqlite backend

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -425,7 +425,8 @@ execHttpBridge args _ = do
     walletListen <- parseWalletListen args
     bridgePort <- args `parseArg` longOption "bridge-port"
     let dbFile = args `getArg` longOption "database"
-    (_, db) <- Sqlite.newDBLayer dbFile
+    tracerDB <- appendName "DBLayer" tracer
+    (_, db) <- Sqlite.newDBLayer tracerDB dbFile
     nw <- HttpBridge.newNetworkLayer @n (getPort bridgePort)
     waitForConnection nw defaultRetryPolicy
     let tl = HttpBridge.newTransactionLayer @n

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -206,6 +206,7 @@ benchmark db
     , directory
     , fmt
     , memory
+    , iohk-monitoring
     , temporary
     , time
   type:

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -37,6 +37,8 @@
 
 import Prelude
 
+import Cardano.BM.Data.Tracer
+    ( nullTracer )
 import Cardano.Crypto.Wallet
     ( unXPub )
 import Cardano.Wallet
@@ -260,7 +262,7 @@ withDB bm = envWithCleanup setup cleanup (\ ~(_, db) -> bm db)
   where
     setup = do
         f <- emptySystemTempFile "bench.db"
-        (_, db) <- newDBLayer (Just f)
+        (_, db) <- newDBLayer nullTracer (Just f)
         pure (f, db)
     cleanup (f, _) = mapM_ remove [f, f <> "-shm", f <> "-wal"]
     remove f = doesFileExist f >>= \case

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -11,6 +11,8 @@ module Cardano.Wallet.DB.SqliteFileModeSpec
 
 import Prelude
 
+import Cardano.BM.Data.Tracer
+    ( nullTracer )
 import Cardano.Wallet
     ( unsafeRunExceptT )
 import Cardano.Wallet.DB
@@ -218,12 +220,12 @@ testOpeningCleaning call expectedAfterOpen expectedAfterClean = do
 inMemoryDBLayer
     :: (IsOurs s, NFData s, Show s, PersistState s, TxId t)
     => IO (SqlBackend, DBLayer IO s t)
-inMemoryDBLayer = newDBLayer Nothing
+inMemoryDBLayer = newDBLayer nullTracer Nothing
 
 fileDBLayer
     :: (IsOurs s, NFData s, Show s, PersistState s, TxId t)
     => IO (SqlBackend, DBLayer IO s t)
-fileDBLayer = newDBLayer (Just "backup/test.db")
+fileDBLayer = newDBLayer nullTracer (Just "backup/test.db")
 
 -- | Clean the database
 cleanDB'

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -11,6 +11,8 @@ module Cardano.Wallet.DB.SqliteSpec
 
 import Prelude
 
+import Cardano.BM.Data.Tracer
+    ( nullTracer )
 import Cardano.Wallet
     ( unsafeRunExceptT )
 import Cardano.Wallet.DB
@@ -129,7 +131,7 @@ simpleSpec = do
             readCheckpoint db testPk `shouldReturn` Just testCp
 
 newMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget)
-newMemoryDBLayer = snd <$> newDBLayer Nothing
+newMemoryDBLayer = snd <$> newDBLayer nullTracer Nothing
 
 testCp :: Wallet (SeqState DummyTarget) DummyTarget
 testCp = initWallet initDummyBlock0 initDummyState

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -198,7 +198,7 @@ bench_restoration
     -> (WalletId, WalletName, s)
     -> IO ()
 bench_restoration _ (wid, wname, s) = withHttpBridge network $ \port -> do
-    (conn, db) <- emptySystemTempFile "bench.db" >>= Sqlite.newDBLayer . Just
+    (conn, db) <- emptySystemTempFile "bench.db" >>= Sqlite.newDBLayer nullTracer . Just
     Sqlite.runQuery conn (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
     let tl = newTransactionLayer

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -234,7 +234,7 @@ main = hspec $ do
         -> IO (ThreadId, Int, SqlBackend, NetworkLayer network IO)
     cardanoWalletServer mlisten = do
         nl <- HttpBridge.newNetworkLayer bridgePort
-        (conn, db) <- Sqlite.newDBLayer Nothing
+        (conn, db) <- Sqlite.newDBLayer nullTracer Nothing
         mvar <- newEmptyMVar
         thread <- forkIO $ do
             let tl = HttpBridge.newTransactionLayer

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -118,6 +118,7 @@
             (hsPkgs.directory)
             (hsPkgs.fmt)
             (hsPkgs.memory)
+            (hsPkgs.iohk-monitoring)
             (hsPkgs.temporary)
             (hsPkgs.time)
             ];


### PR DESCRIPTION
Relates to #354

# Overview

- Adds logging to Sqlite dblayer
- Queries are logged to a separate tracer at debug level.
- Query parameters are removed before logging.
