### PR TITLE
stack.yaml: Add flags to reduce iohk-monitoring dependencies

### DIFF
--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "9727b415e4a18402cf8ac2b39024a0f0c2f71676";
-      sha256 = "077lvnyyk30iahcjkd2iikgjy0d80nazsk3kqy58xg9fkgz7mvwp";
+      rev = "84182cec9d0bccd9d02b5590806112ac32e749c4";
+      sha256 = "13f12xs82c23bvf880kdfv8pnviia59cziba8qgd67ap7wysd1s1";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "84182cec9d0bccd9d02b5590806112ac32e749c4";
-      sha256 = "13f12xs82c23bvf880kdfv8pnviia59cziba8qgd67ap7wysd1s1";
+      rev = "eed4f878f1f03dfac0a4e5b94a1b945aa04ac164";
+      sha256 = "094ffy0qhvlxczknxymsgr95sb79zwmc15m32x1qqcchadjl31fb";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -3,15 +3,10 @@
     {
       packages = {
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
-        "binary" = (((hackage.binary)."0.8.7.0").revisions).default;
-        "command" = (((hackage.command)."0.1.1").revisions).default;
-        "containers" = (((hackage.containers)."0.5.11.0").revisions).default;
-        "ekg-prometheus-adapter" = (((hackage.ekg-prometheus-adapter)."0.1.0.4").revisions).default;
-        "generic-lens" = (((hackage.generic-lens)."1.1.0.0").revisions).default;
-        "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
-        "prometheus" = (((hackage.prometheus)."2.1.1").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
+        "command" = (((hackage.command)."0.1.1").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
+        "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         } // {
         cardano-wallet = ./cardano-wallet.nix;
         bech32 = ./bech32.nix;

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -3,10 +3,13 @@
     flags = {
       disable-aggregation = false;
       disable-ekg = false;
+      disable-graylog = false;
       disable-prometheus = false;
       disable-gui = false;
       disable-monitoring = false;
       disable-observables = false;
+      disable-syslog = false;
+      disable-examples = false;
       };
     package = {
       specVersion = "1.10";
@@ -23,7 +26,7 @@
       };
     components = {
       "library" = {
-        depends = (((([
+        depends = ((((([
           (hsPkgs.base)
           (hsPkgs.contra-tracer)
           (hsPkgs.aeson)
@@ -61,9 +64,11 @@
           (hsPkgs.ekg-prometheus-adapter)
           (hsPkgs.prometheus)
           (hsPkgs.warp)
-          ]) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs.threepenny-gui)) ++ (if system.isWindows
+          ]) ++ (pkgs.lib).optional (!flags.disable-graylog) (hsPkgs.network)) ++ (pkgs.lib).optional (!flags.disable-gui) (hsPkgs.threepenny-gui)) ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
-          else [ (hsPkgs.unix) ])) ++ (pkgs.lib).optionals (system.isLinux) [
+          else [
+            (hsPkgs.unix)
+            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-syslog) [
           (hsPkgs.hsyslog)
           (hsPkgs.libsystemd-journal)
           ];
@@ -138,8 +143,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "9727b415e4a18402cf8ac2b39024a0f0c2f71676";
-      sha256 = "077lvnyyk30iahcjkd2iikgjy0d80nazsk3kqy58xg9fkgz7mvwp";
+      rev = "84182cec9d0bccd9d02b5590806112ac32e749c4";
+      sha256 = "13f12xs82c23bvf880kdfv8pnviia59cziba8qgd67ap7wysd1s1";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -143,8 +143,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "84182cec9d0bccd9d02b5590806112ac32e749c4";
-      sha256 = "13f12xs82c23bvf880kdfv8pnviia59cziba8qgd67ap7wysd1s1";
+      rev = "eed4f878f1f03dfac0a4e5b94a1b945aa04ac164";
+      sha256 = "094ffy0qhvlxczknxymsgr95sb79zwmc15m32x1qqcchadjl31fb";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -52,6 +52,15 @@ let
           integration.build-tools = [ jormungandr ];
           unit.build-tools = [ jormungandr ];
         };
+
+        packages.iohk-monitoring.flags = {
+          disable-ekg = true;
+          disable-examples = true;
+          disable-graylog = true;
+          disable-gui = true;
+          disable-prometheus = true;
+          disable-syslog = true;
+        };
       }
 
       # the iohk-module will supply us with the necessary

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,23 +12,23 @@ packages:
 - lib/jormungandr
 
 extra-deps:
+# Miscellaneous
 - base58-bytestring-0.1.0
-- binary-0.8.7.0
-- command-0.1.1
-- containers-0.5.11.0
-- ekg-prometheus-adapter-0.1.0.4
-- generic-lens-1.1.0.0
-- libsystemd-journal-1.4.4
-- prometheus-2.1.1
 - quickcheck-state-machine-0.6.0
-- time-units-1.0.0
+- command-0.1.1
+
+# cardano-crypto
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a
+
+# iohk-monitoring-framework
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 84182cec9d0bccd9d02b5590806112ac32e749c4
+  commit: eed4f878f1f03dfac0a4e5b94a1b945aa04ac164
   subdirs:
     - contra-tracer
     - iohk-monitoring
+- time-units-1.0.0
+- libsystemd-journal-1.4.4
 
 flags:
   # Bring in less dependencies from iohk-monitoring
@@ -38,7 +38,6 @@ flags:
     disable-graylog: true
     disable-gui: true
     disable-prometheus: true
-    disable-syslog: true
 
 nix:
   shell-file: nix/stack-shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,7 +25,7 @@ extra-deps:
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 9727b415e4a18402cf8ac2b39024a0f0c2f71676
+  commit: 84182cec9d0bccd9d02b5590806112ac32e749c4
   subdirs:
     - contra-tracer
     - iohk-monitoring

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,5 +30,15 @@ extra-deps:
     - contra-tracer
     - iohk-monitoring
 
+flags:
+  # Bring in less dependencies from iohk-monitoring
+  iohk-monitoring:
+    disable-ekg: true
+    disable-examples: true
+    disable-graylog: true
+    disable-gui: true
+    disable-prometheus: true
+    disable-syslog: true
+
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
Relates to issue #350.

~~:warning: DO NOT MERGE YET (see https://github.com/input-output-hk/cardano-wallet/pull/443#issuecomment-503919689) :warning:~~

# Overview

- This will prune dependencies that we don't currently use.

# Comments

- We can bump the iohk-monitoring revision once input-output-hk/iohk-monitoring-framework#356 is merged.
