### PR TITLE
Hack to experiment with filtering log entries from another process according to severity.

### DIFF
--- a/exe/wallet/Main.hs
+++ b/exe/wallet/Main.hs
@@ -483,7 +483,7 @@ execLaunch tracer network stateDir bridgePort listen minLogSeverity = do
     -- | Launch a sub-process starting the http-bridge with the given options
     httpBridgeCmd :: Command
     httpBridgeCmd =
-        Command "cardano-http-bridge" args (return ()) Inherit
+        Command "cardano-http-bridge" args (return ()) CreatePipe
       where
         args = mconcat
             [ [ "start" ]
@@ -495,7 +495,7 @@ execLaunch tracer network stateDir bridgePort listen minLogSeverity = do
     -- | Launch a sub-process starting the wallet server with the given options
     walletCmd :: Command
     walletCmd =
-        Command "cardano-wallet" args (threadDelay oneSecond) Inherit
+        Command "cardano-wallet" args (threadDelay oneSecond) CreatePipe
       where
         oneSecond = 1000000
         args = mconcat

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -34,6 +34,9 @@ library
     , fmt
     , process
     , say
+    , streamly
+    , text
+    , text-class
   hs-source-dirs:
       src
   exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,7 @@ extra-deps:
 - libsystemd-journal-1.4.4
 - prometheus-2.1.1
 - quickcheck-state-machine-0.6.0
+- streamly-0.6.1
 - time-units-1.0.0
 - git: https://github.com/input-output-hk/cardano-crypto
   commit: 3c5db489c71a4d70ee43f5f9b979fcde3c797f2a


### PR DESCRIPTION
# Issue Number

#350 

# Overview

:warning: This is a prototype. There are caveats:

1. Filtering is performed in completely the wrong layer.
2. Filtering is applied to all upstream processes (when we want to target the filtering at just one of these processes.)
3. For simplicity, `stdout` and `stderr` are merged.

As an alternative to performing filtering ourselves (which introduces complexity into our code), we may decide to completely forgo filtering and require the upstream process to filter its own output.

# Comments
