### PR TITLE
wait for network to be ready in benchmarks ...

### DIFF
--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.HttpBridge.Network
 import Cardano.Wallet.HttpBridge.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.Network
-    ( NetworkLayer (..), networkTip )
+    ( NetworkLayer (..), defaultRetryPolicy, networkTip, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..)
     , Passphrase (..)
@@ -201,6 +201,7 @@ bench_restoration _ (wid, wname, s) = withHttpBridge network $ \port -> do
     (conn, db) <- emptySystemTempFile "bench.db" >>= Sqlite.newDBLayer nullTracer . Just
     Sqlite.runQuery conn (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
+    waitForConnection nw defaultRetryPolicy
     let tl = newTransactionLayer
     BlockHeader sl _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -28,6 +28,7 @@
           (hsPkgs.cardano-wallet-core)
           (hsPkgs.cardano-crypto)
           (hsPkgs.cborg)
+          (hsPkgs.cryptonite)
           (hsPkgs.exceptions)
           (hsPkgs.http-client)
           (hsPkgs.http-types)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added an extra 'waitForConnection' in the restoration benchmarks.

# Comments

<!-- Additional comments or screenshots to attach if any -->

I noticed that we recently got more and more of weird "network tip not found" in the nightly benchmarks... A little investigation and I found that we were actually making a `networkTip` request right after having created a networking layer. So, in cases where the bridge would take slightly longer than expected to boot --> :boom: 

So this little addition should help putting nightlies back to green again.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
