### PR TITLE
DBLayer: add bracketObserveIO around SQLite queries

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -79,8 +79,6 @@ module Cardano.CLI
 import Prelude hiding
     ( getLine )
 
-import Cardano.BM.Configuration.Model
-    ( setMinSeverity )
 import Cardano.BM.Configuration.Static
     ( defaultConfigStdout )
 import Cardano.BM.Data.Severity
@@ -216,6 +214,8 @@ import System.IO
 import Text.Heredoc
     ( here )
 
+import qualified Cardano.BM.Configuration.Model as CM
+import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -723,7 +723,8 @@ verbosityToMinSeverity = \case
 initTracer :: Severity -> Text -> IO (Trace IO Text)
 initTracer minSeverity cmd = do
     c <- defaultConfigStdout
-    setMinSeverity c minSeverity
+    CM.setMinSeverity c minSeverity
+    CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK]
     setupTrace (Right c) "cardano-wallet" >>= appendName cmd
 
 {-------------------------------------------------------------------------------
@@ -894,4 +895,3 @@ decodeError bytes = do
 -- | Show a data-type through its 'ToText' instance
 showT :: ToText a => a -> String
 showT = T.unpack . toText
-

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -720,12 +720,13 @@ verbosityToMinSeverity = \case
     Verbose -> Debug
 
 -- | Initialize logging at the specified minimum 'Severity' level.
-initTracer :: Severity -> Text -> IO (Trace IO Text)
+initTracer :: Severity -> Text -> IO (CM.Configuration, Trace IO Text)
 initTracer minSeverity cmd = do
     c <- defaultConfigStdout
     CM.setMinSeverity c minSeverity
     CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK]
-    setupTrace (Right c) "cardano-wallet" >>= appendName cmd
+    tr <- appendName cmd =<< setupTrace (Right c) "cardano-wallet"
+    pure (c, tr)
 
 {-------------------------------------------------------------------------------
                                  Mnemonics

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -157,6 +157,7 @@ test-suite unit
     , time
     , transformers
     , tree-diff
+    , unordered-containers
     , yaml
     , warp
   build-tools:

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -183,7 +183,7 @@ startSqliteBackend logConfig trace fp = do
     let runQuery' :: SqlPersistM a -> IO a
         runQuery' cmd = withMVar lock $ const $ observe $ runQuery backend cmd
         observe :: IO a -> IO a
-        observe = bracketObserveIO logConfig traceQuery Debug "runQuery"
+        observe = bracketObserveIO logConfig traceQuery Debug "query"
 
     migrations <- runQuery' $ runMigrationSilent migrateAll
     dbLog trace $ MsgMigrations (length migrations)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -151,7 +151,6 @@ import System.Log.FastLogger
     ( fromLogStr )
 
 import qualified Cardano.BM.Configuration.Model as CM
-import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery as W
 import qualified Cardano.Wallet.Primitive.Model as W
@@ -172,10 +171,11 @@ data Backend = Backend SqlBackend (forall a. SqlPersistM a -> IO a)
 -- | Opens the SQLite database connection, sets up query logging and timing,
 -- runs schema migrations if necessary.
 startSqliteBackend
-    :: Trace IO DBLog
+    :: CM.Configuration
+    -> Trace IO DBLog
     -> Maybe FilePath
     -> IO Backend
-startSqliteBackend trace fp = do
+startSqliteBackend logConfig trace fp = do
     traceQuery <- appendName "query" trace
     backend <- createSqliteBackend trace fp (queryLogFunc traceQuery)
     lock <- newMVar ()
@@ -183,7 +183,7 @@ startSqliteBackend trace fp = do
     let runQuery' :: SqlPersistM a -> IO a
         runQuery' cmd = withMVar lock $ const $ observe $ runQuery backend cmd
         observe :: IO a -> IO a
-        observe = bracketObserveIO c traceQuery Debug "runQuery"
+        observe = bracketObserveIO logConfig traceQuery Debug "runQuery"
 
     migrations <- runQuery' $ runMigrationSilent migrateAll
     dbLog trace $ MsgMigrations (length migrations)
@@ -226,13 +226,6 @@ queryLogFunc trace _loc _source level str = dbLog trace (MsgQuery msg sev)
         LevelError -> Error
         LevelOther _ -> Warning
 
-observerConfig :: IO CM.Configuration
-observerConfig = do
-    c <- CM.empty
-    CM.setMinSeverity c Debug
-    CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK]
-    pure c
-
 -- | Run a query without error handling. There will be exceptions thrown if it
 -- fails.
 runQuery :: SqlBackend -> SqlPersistM a -> IO a
@@ -255,14 +248,17 @@ handleConstraint e = handleJust select handler . fmap Right
 -- library.
 newDBLayer
     :: forall s t. (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
-    => Trace IO Text
+    => CM.Configuration
+       -- ^ Logging configuration
+    -> Trace IO Text
        -- ^ Logging object
     -> Maybe FilePath
        -- ^ Database file location, or Nothing for in-memory database
     -> IO (SqlBackend, DBLayer IO s t)
-newDBLayer trace fp = do
+newDBLayer logConfig trace fp = do
     lock <- newMVar ()
-    Backend backend runQuery' <- startSqliteBackend (transformTrace trace) fp
+    let trace' = transformTrace trace
+    Backend backend runQuery' <- startSqliteBackend logConfig trace' fp
     return (backend, DBLayer
 
         {-----------------------------------------------------------------------

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -120,6 +120,7 @@ import System.IO.Temp
 import System.IO.Unsafe
     ( unsafePerformIO )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -255,8 +256,9 @@ withDB :: (DBLayerBench -> Benchmark) -> Benchmark
 withDB bm = envWithCleanup setup cleanup (\ ~(_, db) -> bm db)
   where
     setup = do
+        logConfig <- CM.empty
         f <- emptySystemTempFile "bench.db"
-        (_, db) <- newDBLayer nullTracer (Just f)
+        (_, db) <- newDBLayer logConfig nullTracer (Just f)
         pure (f, db)
     cleanup (f, _) = mapM_ remove [f, f <> "-shm", f <> "-wal"]
     remove f = doesFileExist f >>= \case

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -91,6 +91,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -218,12 +219,20 @@ testOpeningCleaning call expectedAfterOpen expectedAfterClean = do
 inMemoryDBLayer
     :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
     => IO (SqlBackend, DBLayer IO s t)
-inMemoryDBLayer = newDBLayer nullTracer Nothing
+inMemoryDBLayer = newDBLayer' Nothing
 
 fileDBLayer
     :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
     => IO (SqlBackend, DBLayer IO s t)
-fileDBLayer = newDBLayer nullTracer (Just "backup/test.db")
+fileDBLayer = newDBLayer' (Just "backup/test.db")
+
+newDBLayer'
+    :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
+    => Maybe FilePath
+    -> IO (SqlBackend, DBLayer IO s t)
+newDBLayer' fp = do
+    logConfig <- CM.empty
+    newDBLayer logConfig nullTracer fp
 
 -- | Clean the database
 cleanDB'

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -97,6 +97,7 @@ import Test.Hspec
     , xit
     )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
@@ -171,8 +172,9 @@ simpleSpec = do
 
 newMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget, TVar [LogObject Text])
 newMemoryDBLayer = do
+    logConfig <- CM.empty
     logs <- newTVarIO []
-    (_, db) <- newDBLayer (traceInTVarIO logs) Nothing
+    (_, db) <- newDBLayer logConfig (traceInTVarIO logs) Nothing
     pure (db, logs)
 
 withLoggingDB :: SpecWith (DBLayer IO (SeqState DummyTarget) DummyTarget, IO [LogObject Text]) -> Spec

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -11,8 +11,14 @@ module Cardano.Wallet.DB.SqliteSpec
 
 import Prelude
 
+import Cardano.BM.Configuration.Static
+    ( defaultConfigTesting )
 import Cardano.BM.Data.LogItem
     ( LOContent (..), LOMeta (severity), LogObject (..) )
+import Cardano.BM.Data.MonitoringEval
+    ( MEvAction (..), MEvExpr (..), Operand (..), Operator (..) )
+import Cardano.BM.Data.Observable
+    ( ObservableInstance (..) )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Trace
@@ -61,7 +67,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Monad
-    ( unless )
+    ( replicateM_, unless )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Crypto.Hash
@@ -92,36 +98,33 @@ import Test.Hspec
     , beforeWith
     , describe
     , it
+    , shouldBe
     , shouldNotContain
     , shouldReturn
     , xit
     )
 
 import qualified Cardano.BM.Configuration.Model as CM
+import qualified Cardano.BM.Data.Aggregated as CM
+import qualified Cardano.BM.Data.AggregatedKind as CM
+import qualified Cardano.BM.Data.Backend as CM
+import qualified Cardano.BM.Data.SubTrace as CM
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
 spec :: Spec
 spec = do
-    withDB (fst <$> newMemoryDBLayer) $ do
-        describe "Sqlite Simple tests" simpleSpec
-        describe "Sqlite" dbPropertyTests
-        describe "Sqlite State machine tests" $ do
-            it "Sequential" prop_sequential
-            xit "Parallel" prop_parallel
+    sqliteSpec
+    loggingSpec
 
-    withLoggingDB $ do
-        describe "Sqlite logging" $ do
-            it "should log queries at DEBUG level" $ \(db, getLogs) -> do
-                unsafeRunExceptT $ createWallet db testPk testCp testMetadata
-                logs <- logMessages <$> getLogs
-                logs `shouldHaveLog` (Debug, "INSERT")
-
-            it "should not log query parameters" $ \(db, getLogs) -> do
-                unsafeRunExceptT $ createWallet db testPk testCp testMetadata
-                let walletName = T.unpack $ coerce $ name testMetadata
-                msgs <- T.unlines . map snd . logMessages <$> getLogs
-                T.unpack msgs `shouldNotContain` walletName
+sqliteSpec :: Spec
+sqliteSpec = withDB (fst <$> newMemoryDBLayer) $ do
+    describe "Sqlite Simple tests" simpleSpec
+    describe "Sqlite" dbPropertyTests
+    describe "Sqlite State machine tests" $ do
+        it "Sequential" prop_sequential
+        xit "Parallel" prop_parallel
 
 simpleSpec :: SpecWith (DBLayer IO (SeqState DummyTarget) DummyTarget)
 simpleSpec = do
@@ -169,10 +172,62 @@ simpleSpec = do
             runExceptT (putCheckpoint db testPk testCp) `shouldReturn` Right ()
             readCheckpoint db testPk `shouldReturn` Just testCp
 
+loggingSpec :: Spec
+loggingSpec = withLoggingDB $ do
+    describe "Sqlite query logging" $ do
+        it "should log queries at DEBUG level" $ \(db, getLogs) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            logs <- logMessages <$> getLogs
+            logs `shouldHaveLog` (Debug, "INSERT")
+
+        it "should not log query parameters" $ \(db, getLogs) -> do
+            unsafeRunExceptT $ createWallet db testPk testCp testMetadata
+            let walletName = T.unpack $ coerce $ name testMetadata
+            msgs <- T.unlines . map snd . logMessages <$> getLogs
+            T.unpack msgs `shouldNotContain` walletName
+
+    describe "Sqlite observables" $ do
+        it "should measure query timings" $ \(db, getLogs) -> do
+            let count = 5
+            replicateM_ count $ listWallets db
+            -- Commented out until this is fixed:
+            --   https://github.com/input-output-hk/iohk-monitoring-framework/issues/391
+            -- msg <- T.unlines . map snd . logMessages <$> getLogs
+            -- T.unpack msgs `shouldContain` "runQuery monitor works"
+            msgs <- findObserveDiffs <$> getLogs
+            length msgs `shouldBe` count
 
 newMemoryDBLayer :: IO (DBLayer IO (SeqState DummyTarget) DummyTarget, TVar [LogObject Text])
 newMemoryDBLayer = do
-    logConfig <- CM.empty
+    logConfig <- defaultConfigTesting
+    CM.setMinSeverity logConfig Debug
+    CM.setSetupBackends logConfig [CM.KatipBK, CM.AggregationBK, CM.MonitoringBK]
+
+    CM.setSubTrace logConfig "query"
+        (Just $ CM.ObservableTraceSelf [MonotonicClock])
+
+    CM.setBackends logConfig
+        "query"
+        (Just [CM.AggregationBK])
+    CM.setAggregatedKind logConfig
+        "query"
+        (Just CM.StatsAK) -- statistics AgreggatedKind
+    CM.setBackends logConfig
+        "#aggregation.query"
+        (Just [CM.KatipBK])
+
+    -- This monitor should always trigger.
+    CM.setMonitors logConfig $ HM.singleton
+        "query.query"
+        ( Nothing
+        , Compare "monoclock" (GE, (OpMeasurable (CM.Seconds 0)))
+        , [CreateMessage Info "runQuery monitor works"]
+        )
+
+    CM.setBackends logConfig
+        "query"
+        (Just [CM.AggregationBK, CM.KatipBK, CM.MonitoringBK])
+
     logs <- newTVarIO []
     (_, db) <- newDBLayer logConfig (traceInTVarIO logs) Nothing
     pure (db, logs)
@@ -190,6 +245,12 @@ logMessages = mapMaybe getMessage
   where
     getMessage (LogObject _ m (LogMessage a)) = Just (severity m, a)
     getMessage _ = Nothing
+
+findObserveDiffs :: [LogObject a] -> [LOContent a]
+findObserveDiffs = filter isObserveDiff . map loContent
+  where
+    isObserveDiff (ObserveDiff _) = True
+    isObserveDiff _ = False
 
 shouldHaveLog :: [(Severity, Text)] -> (Severity, Text) -> Expectation
 shouldHaveLog msgs (sev, str) = unless (any match msgs) $

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -94,6 +94,7 @@ import System.IO
 import System.IO.Temp
     ( emptySystemTempFile )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
@@ -200,7 +201,9 @@ bench_restoration
     -> (WalletId, WalletName, s)
     -> IO ()
 bench_restoration _ (wid, wname, s) = withHttpBridge network $ \port -> do
-    (conn, db) <- emptySystemTempFile "bench.db" >>= Sqlite.newDBLayer nullTracer . Just
+    logConfig <- CM.empty
+    dbFile <- Just <$> emptySystemTempFile "bench.db"
+    (conn, db) <- Sqlite.newDBLayer logConfig nullTracer dbFile
     Sqlite.runQuery conn (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
     let tl = newTransactionLayer

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -77,6 +77,7 @@ import Test.Integration.Framework.DSL
 import Test.Integration.Framework.Request
     ( Headers (Default), Payload (Empty), request )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.LauncherSpec as Launcher
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
@@ -252,7 +253,8 @@ main = do
         -> IO (ThreadId, Int, SqlBackend, NetworkLayer network IO)
     cardanoWalletServer mlisten = do
         nl <- HttpBridge.newNetworkLayer bridgePort
-        (conn, db) <- Sqlite.newDBLayer nullTracer Nothing
+        logConfig <- CM.empty
+        (conn, db) <- Sqlite.newDBLayer logConfig nullTracer Nothing
         mvar <- newEmptyMVar
         thread <- forkIO $ do
             let tl = HttpBridge.newTransactionLayer

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -77,6 +77,7 @@ import Test.Hspec
 import Test.Integration.Framework.DSL
     ( Context (..), TxDescription (..), tearDown )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Cardano.Wallet.Jormungandr.Network as Jormungandr
@@ -136,9 +137,10 @@ cardanoWalletServer
     :: forall network. (network ~ Jormungandr 'Testnet)
     => IO (Int, FeePolicy, SqlBackend)
 cardanoWalletServer = do
+    logConfig <- CM.empty
     tracer <- initTracer Info "serve"
     (nl, block0, feePolicy) <- newNetworkLayer jormungandrUrl block0H
-    (conn, db) <- Sqlite.newDBLayer @_ @network tracer Nothing
+    (conn, db) <- Sqlite.newDBLayer @_ @network logConfig tracer Nothing
     mvar <- newEmptyMVar
     void $ forkIO $ do
         let tl = Jormungandr.newTransactionLayer block0H

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -102,6 +102,7 @@
             (hsPkgs.time)
             (hsPkgs.transformers)
             (hsPkgs.tree-diff)
+            (hsPkgs.unordered-containers)
             (hsPkgs.yaml)
             (hsPkgs.warp)
             ];

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "3395487ae1d6fe8a6370cdcc6ebc8121f221c7eb";
-      sha256 = "0hri6j0cxgj814c7mz7cl054c6ijwah2dq9xm92j90bzhp9z9rv9";
+      rev = "e2dc8b2160bb2ccd1ef9817a6498cda06ad36580";
+      sha256 = "1mp9fqva9lckbpx2fgakfzsyw85x3mmcb0mpszxyp55sbj3vyw1y";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -8,8 +8,9 @@
       disable-gui = false;
       disable-monitoring = false;
       disable-observables = false;
-      disable-syslog = false;
+      disable-systemd = false;
       disable-examples = false;
+      performance-test-queue = false;
       };
     package = {
       specVersion = "1.10";
@@ -68,7 +69,7 @@
           then [ (hsPkgs.Win32) ]
           else [
             (hsPkgs.unix)
-            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-syslog) [
+            ])) ++ (pkgs.lib).optionals (system.isLinux && !flags.disable-systemd) [
           (hsPkgs.hsyslog)
           (hsPkgs.libsystemd-journal)
           ];
@@ -100,6 +101,16 @@
             else [
               (hsPkgs.unix)
               ])) ++ (pkgs.lib).optional (system.isLinux) (hsPkgs.download);
+          };
+        "example-performance" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.iohk-monitoring)
+            (hsPkgs.async)
+            (hsPkgs.criterion)
+            (hsPkgs.text)
+            (hsPkgs.unordered-containers)
+            ];
           };
         };
       tests = {
@@ -143,8 +154,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "3395487ae1d6fe8a6370cdcc6ebc8121f221c7eb";
-      sha256 = "0hri6j0cxgj814c7mz7cl054c6ijwah2dq9xm92j90bzhp9z9rv9";
+      rev = "e2dc8b2160bb2ccd1ef9817a6498cda06ad36580";
+      sha256 = "1mp9fqva9lckbpx2fgakfzsyw85x3mmcb0mpszxyp55sbj3vyw1y";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
 
 # iohk-monitoring-framework
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 3395487ae1d6fe8a6370cdcc6ebc8121f221c7eb
+  commit: e2dc8b2160bb2ccd1ef9817a6498cda06ad36580
   subdirs:
     - contra-tracer
     - iohk-monitoring


### PR DESCRIPTION
Relates to issue #354

# Overview

- Adds timing of database queries ([doc pdf here](https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/docs/IOHK-Monitoring.pdf)).
- Adds a test case with a monitor that checks whether the observed value is greater than 0 (the monitor should perform a logging action every time a query has been run).

# Comments

The `bracketObserveIO` function requires a logging `Configuration` in addition to the tracer object. So there are a few changes following from that.

I can't get the test case to work with [aggregation](https://input-output-hk.github.io/iohk-monitoring-framework/one-pager/pdf/benchmarking.pdf) and [monitoring](https://input-output-hk.github.io/iohk-monitoring-framework/one-pager/pdf/monitoring.pdf).