### PR TITLE
Replace CLI `--min-log-severity` argument with `--quiet` and `--verbose` switches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - tar xzf $STACK_WORK_CACHE || echo "no .stack-work yet"
   - travis_retry curl -L https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/http-bridge/test/data/cardano-node-simple/cardano-node-simple-3.0.1.tar.gz | tar xz -C $HOME/.local/bin
   - cardano-node-simple --version
-  - travis_retry curl -L https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/http-bridge/test/data/cardano-http-bridge/cardano-http-bridge-cda833a8.tar.gz | tar xz -C $HOME/.local/bin
+  - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.2/cardano-http-bridge-v0.0.2-x86_64-linux.tar.gz | tar xz -C $HOME/.local/bin
   - cardano-http-bridge --version
   - travis_retry curl -L https://github.com/input-output-hk/jormungandr/releases/download/v0.1.0/jormungandr-v0.1.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/.local/bin
   - jcli --version && jormungandr --version

--- a/lib/http-bridge/test/data/cardano-http-bridge/cardano-http-bridge-cda833a8-linux-x86_64.tar.gz
+++ b/lib/http-bridge/test/data/cardano-http-bridge/cardano-http-bridge-cda833a8-linux-x86_64.tar.gz
@@ -1,1 +1,0 @@
-cardano-http-bridge-cda833a8.tar.gz

--- a/lib/http-bridge/test/integration/js/mock-daedalus.js
+++ b/lib/http-bridge/test/integration/js/mock-daedalus.js
@@ -11,7 +11,7 @@ function main() {
   const proc = child_process.spawn("stack",
     ["exec", "--", "cardano-wallet", "launch"]
       .concat(args)
-      .concat(["--min-log-severity", "error"]),
+      .concat(["--quiet"]),
     { stdio: ["ignore", "inherit", "inherit", "ipc"] }
   );
 


### PR DESCRIPTION
# Issue Number

#350 

# Overview

This PR replaces the `--min-log-severity` argument with two new switches:

* `--quiet`
* `--verbose`

These switches have the following semantics:

| Switch | Help Text | Minimum Log Severity Level |
| -- | -- | -- |
| `--quiet` | suppress all log output apart from errors | [`Error`](https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs#L39) |
| `--verbose` | display debugging information in the log output | [`Debug`](https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs#L35) |
| (none) | (default) | [`Info`](https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/iohk-monitoring/src/Cardano/BM/Data/Severity.lhs#L36) |