### PR TITLE
another attempt trying to cope with 500 when fetching network tip shortly after init (bridge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - tar xzf $STACK_WORK_CACHE || echo "no .stack-work yet"
   - travis_retry curl -L https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/http-bridge/test/data/cardano-node-simple/cardano-node-simple-3.0.1.tar.gz | tar xz -C $HOME/.local/bin
   - cardano-node-simple --version
-  - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.2/cardano-http-bridge-v0.0.2-x86_64-linux.tar.gz | tar xz -C $HOME/.local/bin
+  - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.3/cardano-http-bridge-v0.0.3-x86_64-linux.tar.gz | tar xz -C $HOME/.local/bin
   - cardano-http-bridge --version
   - travis_retry curl -L https://github.com/input-output-hk/jormungandr/releases/download/v0.1.0/jormungandr-v0.1.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C $HOME/.local/bin
   - jcli --version && jormungandr --version

--- a/nix/cardano-http-bridge.nix
+++ b/nix/cardano-http-bridge.nix
@@ -7,15 +7,15 @@
 rustPlatform.buildRustPackage rec {
   name = "cardano-http-bridge-${version}";
 
-  version = "0.0.2";
+  version = "0.0.3";
   src = fetchFromGitHub {
-    owner = "rvl";
+    owner = "KtorZ";
     repo = "cardano-http-bridge";
     fetchSubmodules = true;
-    rev = "ba3e172b90f3b9ebabe1bcca4c71183c3118ebe8";
-    sha256 = "1dr920bx48agj83h5cn1jx9nygkb5c23qi58brvfar6aivsbvx4c";
+    rev = "a0e05390bee29d90daeec958fdce97e08c437143";
+    sha256 = "1ix9b0pp50397g46h9k8axyrh8395a5l7zixsqrsyq90jwkbafa3";
   };
-  cargoSha256 = "0l6z1rsb8hw36w7kg6ms4l688klz17cw36q01pdb96ayhcacys49";
+  cargoSha256 = "1phij6gcs70rsv1y0ac6lciq384g2f014mn15pjvd02l09nx7k49";
 
   buildInputs = [ protobuf ];
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added an error message to the bridge when failing to fetch the tip from storage for an unknown reason. This allows for "grepping" on that message in our network layer and handle the failure correctly (see https://github.com/KtorZ/cardano-http-bridge/commit/224b5f40a764cce136f00370b634c2b33a8b43930

- [x] Modified nix machinery (hopefully) to use this newer version of the bridge in the nightly tests

- [x] Move the `waitForConnection` to be earlier in the code since we actually start sending requests to the bridge before entering the benchmark loop!

# Comments

<!-- Additional comments or screenshots to attach if any -->

Will try to trigger a nightly build from this branch to see ...

**edit:** Nightly tests have passed successfully :tada: (https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/110)

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
