### PR TITLE
Implement Jörmungandr NetworkLayer postTx

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -127,7 +127,7 @@ instance MimeUnrender JormungandrBinary (Block Tx) where
     mimeUnrender _ = pure . coerceBlock . runGet getBlock
 
 instance MimeRender JormungandrBinary (Tx, [TxWitness]) where
-    mimeRender _ a = runPut $ putSignedTx a
+    mimeRender _ = runPut . putSignedTx
 
 data Hex
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -201,6 +201,11 @@ mkJormungandrLayer mgr baseUrl = JormungandrLayer
                         (BlockId parentId)
                         (Just count)
                 left ErrGetDescendantsNetworkUnreachable <$> defaultHandler ctx x
+
+    -- Never returns 'Left ErrPostTxProtocolFailure'. Will currently return
+    -- 'Right ()' when submitting correctly formatted, but invalid transactions.
+    --
+    -- https://github.com/input-output-hk/jormungandr/blob/fe638a36d4be64e0c4b360ba1c041e8fa10ea024/jormungandr/src/rest/v0/message/post.rs#L25-L39
     , postMessage = \tx -> void $ ExceptT $ do
         run (cPostMessage tx) >>= \case
             Left (FailureResponse e)


### PR DESCRIPTION
# Issue Number

#219 


# Overview

- [x] Renamed `JörmungandrLayer` `postTx` to `postMessage`
- [x] Implemented `JörmungandrLayer` `postMessage` and NetworkLayer `postTx`
- [x] Tests
- [ ] TODO: Look over how binary encoders behave / should behave in relation to `ErrPostTxBadRequest`. 


# Comments

- Problem: we can only get details of protocol related errors with `jcli rest v0 message logs -h http://127.0.0.1:8081/api`. endpoint will silently succeed if
    - Transaction is unbalanced
    - Incorrect signature
    - etc
 

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->