### PR TITLE
Add missing roundtrip `ToText`/`FromText` tests for `Cardano.Wallet.Primitive` data types.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -101,6 +101,7 @@ spec = do
         textRoundtrip $ Proxy @TxStatus
         textRoundtrip $ Proxy @WalletName
         textRoundtrip $ Proxy @WalletId
+        textRoundtrip $ Proxy @(Hash "Tx")
 
     describe "Buildable" $ do
         it "WalletId" $ do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -95,6 +95,7 @@ spec = do
         it "Arbitrary Coin" $ property isValidCoin
 
     describe "Can perform roundtrip textual encoding & decoding" $ do
+        textRoundtrip $ Proxy @Address
         textRoundtrip $ Proxy @AddressState
         textRoundtrip $ Proxy @Direction
         textRoundtrip $ Proxy @TxStatus

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -97,6 +97,7 @@ spec = do
     describe "Can perform roundtrip textual encoding & decoding" $ do
         textRoundtrip $ Proxy @AddressState
         textRoundtrip $ Proxy @Direction
+        textRoundtrip $ Proxy @TxStatus
         textRoundtrip $ Proxy @WalletName
         textRoundtrip $ Proxy @WalletId
 
@@ -340,6 +341,10 @@ instance Arbitrary TxIn where
     arbitrary = TxIn
         <$> arbitrary
         <*> scale (`mod` 3) arbitrary -- No need for a crazy high indexes
+
+instance Arbitrary TxStatus where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -67,6 +67,7 @@ import Test.Hspec
 import Test.QuickCheck
     ( Arbitrary (..)
     , Property
+    , arbitraryBoundedEnum
     , arbitraryPrintableChar
     , checkCoverage
     , choose
@@ -95,6 +96,7 @@ spec = do
 
     describe "Can perform roundtrip textual encoding & decoding" $ do
         textRoundtrip $ Proxy @AddressState
+        textRoundtrip $ Proxy @Direction
         textRoundtrip $ Proxy @WalletName
         textRoundtrip $ Proxy @WalletId
 
@@ -297,6 +299,10 @@ prop_2_6_2 (ins, u) =
     structures that don't have much entropy and therefore, allow us to even test
     something when checking for intersections and set restrictions!
 -------------------------------------------------------------------------------}
+
+instance Arbitrary Direction where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary (Hash "Tx") where
     -- No Shrinking


### PR DESCRIPTION
# Issue Number

#460 

# Overview

I have added round-trip `ToText`/`FromText` tests for the following types:
- [x] `Address`
- [x]  `Direction`
- [x] `Hash "Tx"`
- [x] `TxStatus`
