### PR TITLE
Use `arbitraryBoundedEnum` instead of `genericArbitrary` where possible.

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -57,7 +57,6 @@ test-suite unit
   build-depends:
       base
     , cardano-wallet-cli
-    , generic-arbitrary
     , hspec
     , iohk-monitoring
     , QuickCheck

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -191,5 +191,5 @@ instance Arbitrary a => Arbitrary (OptionValue a) where
     shrink = genericShrink
 
 instance Arbitrary Severity where
-    arbitrary = genericArbitrary
+    arbitrary = arbitraryBoundedEnum
     shrink = genericShrink

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -36,10 +36,9 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , checkCoverage
     , cover
+    , genericShrink
     , (===)
     )
-import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary, genericShrink )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
@@ -187,7 +186,7 @@ instance Arbitrary (Port "test") where
         | otherwise = [pred p]
 
 instance Arbitrary a => Arbitrary (OptionValue a) where
-    arbitrary = genericArbitrary
+    arbitrary = OptionValue <$> arbitrary
     shrink = genericShrink
 
 instance Arbitrary Severity where

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -93,7 +93,6 @@ test-suite unit
     , containers
     , digest
     , fmt
-    , generic-arbitrary
     , hspec
     , hspec-golden-aeson
     , memory

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/EnvironmentSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/EnvironmentSpec.hs
@@ -13,9 +13,7 @@ import Data.Proxy
 import Test.Hspec
     ( Spec, describe )
 import Test.QuickCheck
-    ( Arbitrary (..) )
-import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary, genericShrink )
+    ( Arbitrary (..), arbitraryBoundedEnum, genericShrink )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
@@ -29,5 +27,5 @@ spec = do
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Network where
-    arbitrary = genericArbitrary
+    arbitrary = arbitraryBoundedEnum
     shrink = genericShrink

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -85,7 +85,6 @@ test-suite unit
     , cardano-crypto
     , cardano-wallet-jormungandr
     , containers
-    , generic-arbitrary
     , generic-lens
     , hspec
     , memory

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/EnvironmentSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/EnvironmentSpec.hs
@@ -13,9 +13,7 @@ import Data.Proxy
 import Test.Hspec
     ( Spec, describe )
 import Test.QuickCheck
-    ( Arbitrary (..) )
-import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary, genericShrink )
+    ( Arbitrary (..), arbitraryBoundedEnum, genericShrink )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
@@ -29,5 +27,5 @@ spec = do
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Network where
-    arbitrary = genericArbitrary
+    arbitrary = arbitraryBoundedEnum
     shrink = genericShrink

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -31,7 +31,6 @@
           depends = [
             (hsPkgs.base)
             (hsPkgs.cardano-wallet-cli)
-            (hsPkgs.generic-arbitrary)
             (hsPkgs.hspec)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.QuickCheck)

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -60,7 +60,6 @@
             (hsPkgs.containers)
             (hsPkgs.digest)
             (hsPkgs.fmt)
-            (hsPkgs.generic-arbitrary)
             (hsPkgs.hspec)
             (hsPkgs.hspec-golden-aeson)
             (hsPkgs.memory)

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -54,7 +54,6 @@
             (hsPkgs.cardano-crypto)
             (hsPkgs.cardano-wallet-jormungandr)
             (hsPkgs.containers)
-            (hsPkgs.generic-arbitrary)
             (hsPkgs.generic-lens)
             (hsPkgs.hspec)
             (hsPkgs.memory)


### PR DESCRIPTION
# Issue Number

None, but a continuation of #468.

# Overview

For pure enumeration data types with only nullary data constructors, we often auto-derive `Bounded` and `Enum` instances, and use `arbitraryBoundedEnum` to generate arbitrary values. However, there are a few instances that use `genericArbitrary`.

This PR fixes this inconsistency, removing dependencies on `generic-arbitrary` where possible.
