### PR TITLE
Add `ToText`/`FromText` instances for `String`.

### DIFF
--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -66,6 +67,12 @@ newtype TextDecodingError = TextDecodingError
     { getTextDecodingError :: String }
     deriving stock (Eq, Show)
     deriving newtype Buildable
+
+instance FromText String where
+    fromText = pure . T.unpack
+
+instance ToText String where
+    toText = T.pack
 
 instance FromText Text where
     fromText = pure

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -73,8 +73,10 @@ spec = do
             $ property $ \(i :: Int) -> (fromText . toText) i === pure i
         it "fromText ~ fromTextMaybe" $
             property $ \(Digits t) ->
-                classify (isNothing (fromTextMaybe @Int t)) "invalid" $
-                classify ((compare 0 <$> fromTextMaybe @Int t) == Just GT) "valid negative" $
+                classify (isNothing (fromTextMaybe @Int t))
+                    "invalid" $
+                classify ((compare 0 <$> fromTextMaybe @Int t) == Just GT)
+                    "valid negative" $
                 toList (fromTextMaybe @Int t) === toList (fromText t)
 
     describe "Text" $ do

--- a/lib/text-class/test/unit/Data/Text/ClassSpec.hs
+++ b/lib/text-class/test/unit/Data/Text/ClassSpec.hs
@@ -15,6 +15,8 @@ import Data.Foldable
     ( toList )
 import Data.Maybe
     ( isNothing )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -43,6 +45,8 @@ import Test.QuickCheck
     , (===)
     , (==>)
     )
+import Test.Text.Roundtrip
+    ( textRoundtrip )
 
 import qualified Data.Text as T
 
@@ -80,6 +84,9 @@ spec = do
             toText @Text "patate" === "patate"
         it "fromText . toText === pure" $
             property $ \(t :: Text) -> (fromText . toText) t === pure t
+
+    describe "Can perform roundtrip textual encoding & decoding" $ do
+        textRoundtrip $ Proxy @String
 
     describe "BoundedEnum" $ do
         it "fromTextToBoundedEnum s (toTextFromBoundedEnum s a) == Right a" $


### PR DESCRIPTION
# Issue Number

#357 

# Comments

Added these instances to support parsing CLI arguments of type `String` (or synonyms of `String`, such as `FilePath`).