### PR TITLE
Add `development` flag for `cardano-wallet` target.

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -13,6 +13,11 @@ build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
 
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
 -- Dummy library sadly necessary for 'shc' to compute
 -- code-coverage correctly ¯\_(ツ)_/¯
 library
@@ -27,8 +32,10 @@ executable cardano-wallet
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -Werror
       -O2
+  if (!flag(development))
+    ghc-options:
+      -Werror
   build-depends:
       base
     , aeson

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -1,6 +1,6 @@
 { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = {};
+    flags = { development = false; };
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet"; version = "2019.6.24"; };


### PR DESCRIPTION
# Issue Number

#357 

# Overview

I have added a `development` flag for the `cardano-wallet` target, which, when enabled, disables the `-Werror` flag.

This makes iterative development with `cardano-wallet:exe:cardano-wallet` easier.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
