### PR TITLE
Move generic CLI functionality into `cardano-wallet-cli` library.

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -31,7 +31,6 @@ executable cardano-wallet
       -O2
   build-depends:
       base
-    , aeson
     , aeson-pretty
     , async
     , bytestring

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -29,7 +29,9 @@ library
     ghc-options:
       -Werror
   build-depends:
-      base
+      aeson
+    , base
+    , bytestring
     , ansi-terminal
     , docopt
     , fmt

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -16,7 +16,7 @@
 module Cardano.CLI
     (
     -- * Types
-      Port(..)
+      Port (..)
 
     -- * Unicode Terminal Helpers
     , setUtf8Encoding

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -75,7 +75,6 @@ import Data.Bifunctor
     ( bimap )
 import Data.Functor
     ( (<$) )
-import qualified Data.List.NonEmpty as NE
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -135,6 +134,7 @@ import System.IO
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -18,6 +18,13 @@ module Cardano.CLI
     -- * Types
       Port (..)
 
+    -- * Logging
+    , Verbosity (..)
+    , initTracer
+    , minSeverityFromArgs
+    , verbosityFromArgs
+    , verbosityToArgs
+
     -- * Unicode Terminal Helpers
     , setUtf8Encoding
 
@@ -41,8 +48,16 @@ module Cardano.CLI
 import Prelude hiding
     ( getLine )
 
+import Cardano.BM.Configuration.Model
+    ( setMinSeverity )
+import Cardano.BM.Configuration.Static
+    ( defaultConfigStdout )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
+import Cardano.BM.Setup
+    ( setupTrace )
+import Cardano.BM.Trace
+    ( Trace, appendName )
 import Control.Arrow
     ( first )
 import Control.Exception
@@ -87,6 +102,8 @@ import System.Console.Docopt
     , exitWithUsageMessage
     , getAllArgs
     , getArgOrExitWith
+    , isPresent
+    , longOption
     , usage
     )
 import System.Exit
@@ -198,6 +215,55 @@ help :: Docopt -> IO ()
 help cli = do
     TIO.putStrLn $ T.pack $ usage cli
     exitSuccess
+
+{-------------------------------------------------------------------------------
+                                  Logging
+-------------------------------------------------------------------------------}
+
+-- | Controls how much information to include in log output.
+data Verbosity
+    = Default
+        -- ^ The default level of verbosity.
+    | Quiet
+        -- ^ Include less information in the log output.
+    | Verbose
+        -- ^ Include more information in the log output.
+    deriving (Eq, Show)
+
+-- | Determine the minimum 'Severity' level from the specified command line
+--   arguments.
+minSeverityFromArgs :: Arguments -> Severity
+minSeverityFromArgs = verbosityToMinSeverity . verbosityFromArgs
+
+-- | Determine the desired 'Verbosity' level from the specified command line
+--   arguments.
+verbosityFromArgs :: Arguments -> Verbosity
+verbosityFromArgs args
+    | args `isPresent` longOption "quiet"   = Quiet
+    | args `isPresent` longOption "verbose" = Verbose
+    | otherwise = Default
+
+-- | Convert a given 'Verbosity' level into a list of command line arguments
+--   that can be passed through to a sub-process.
+verbosityToArgs :: Verbosity -> [String]
+verbosityToArgs = \case
+    Default -> []
+    Quiet   -> ["--quiet"]
+    Verbose -> ["--verbose"]
+
+-- | Map a given 'Verbosity' level onto a 'Severity' level.
+verbosityToMinSeverity :: Verbosity -> Severity
+verbosityToMinSeverity = \case
+    Default -> Info
+    Quiet   -> Error
+    Verbose -> Debug
+
+-- | Initialize logging at the specified minimum 'Severity' level.
+initTracer :: Severity -> Text -> IO (Trace IO Text)
+initTracer minSeverity cmd = do
+    c <- defaultConfigStdout
+    setMinSeverity c minSeverity
+    setupTrace (Right c) "cardano-wallet" >>= appendName cmd
 
 {-------------------------------------------------------------------------------
                             Unicode Terminal Helpers

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -17,7 +17,9 @@
     components = {
       "library" = {
         depends = [
+          (hsPkgs.aeson)
           (hsPkgs.base)
+          (hsPkgs.bytestring)
           (hsPkgs.ansi-terminal)
           (hsPkgs.docopt)
           (hsPkgs.fmt)

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -20,7 +20,6 @@
         "cardano-wallet" = {
           depends = [
             (hsPkgs.base)
-            (hsPkgs.aeson)
             (hsPkgs.aeson-pretty)
             (hsPkgs.async)
             (hsPkgs.bytestring)


### PR DESCRIPTION
# Issue Number

#357 

# Overview

This PR moves **some** of our generic CLI functionality (i.e., functionality that is not dependent on either `jormungandr` or `http-bridge` back ends) into the `cardano-wallet-cli` library. Later PRs will move more generic functionality into the shared library.