### PR TITLE
Add ghcjs build target

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -79,7 +79,7 @@ let
   # Remove build jobs for which cross compiling does not make sense.
   filterJobsCross = filterAttrs (n: _: !(elem n ["dockerImage" "shell" "stackShell" "stackNixRegenerate"]));
 
-  inherit (systems.examples) mingwW64 musl64 ghcjs;
+  inherit (systems.examples) mingwW64 musl64 ghcjs raspberryPi;
 
   jobs = {
     native = mapTestOn (packagePlatformsOrig project);
@@ -89,6 +89,8 @@ let
     musl64 = mapTestOnCross musl64
       (packagePlatformsCross (filterJobsCross project));
     "${ghcjs.config}" = mapTestOnCross ghcjs
+      (packagePlatformsCross (filterJobsCross project));
+    "${raspberryPi.config}" = mapTestOnCross raspberryPi
       (packagePlatformsCross (filterJobsCross project));
   }
     # This aggregate job is what IOHK Hydra uses to update

--- a/release.nix
+++ b/release.nix
@@ -79,7 +79,7 @@ let
   # Remove build jobs for which cross compiling does not make sense.
   filterJobsCross = filterAttrs (n: _: !(elem n ["dockerImage" "shell" "stackShell" "stackNixRegenerate"]));
 
-  inherit (systems.examples) mingwW64 musl64 ghcjs raspberryPi;
+  inherit (systems.examples) mingwW64 musl64 ghcjs;
 
   jobs = {
     native = mapTestOn (packagePlatformsOrig project);
@@ -89,8 +89,6 @@ let
     musl64 = mapTestOnCross musl64
       (packagePlatformsCross (filterJobsCross project));
     "${ghcjs.config}" = mapTestOnCross ghcjs
-      (packagePlatformsCross (filterJobsCross project));
-    "${raspberryPi.config}" = mapTestOnCross raspberryPi
       (packagePlatformsCross (filterJobsCross project));
   }
     # This aggregate job is what IOHK Hydra uses to update

--- a/release.nix
+++ b/release.nix
@@ -79,7 +79,7 @@ let
   # Remove build jobs for which cross compiling does not make sense.
   filterJobsCross = filterAttrs (n: _: !(elem n ["dockerImage" "shell" "stackShell" "stackNixRegenerate"]));
 
-  inherit (systems.examples) mingwW64 musl64;
+  inherit (systems.examples) mingwW64 musl64 ghcjs;
 
   jobs = {
     native = mapTestOn (packagePlatformsOrig project);
@@ -87,6 +87,8 @@ let
     "${mingwW64.config}" = mapTestOnCross mingwW64
       (packagePlatformsCross (filterJobsCross project));
     musl64 = mapTestOnCross musl64
+      (packagePlatformsCross (filterJobsCross project));
+    "${ghcjs.config}" = mapTestOnCross ghcjs
       (packagePlatformsCross (filterJobsCross project));
   }
     # This aggregate job is what IOHK Hydra uses to update


### PR DESCRIPTION
# Overview

This adds additional cross-compilation targets to the release jobset.

- [Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-481)
- See also: #491

# Comments

Note that not all tests can run yet on the master branch (e.g. some have `stack exec` commands, others do things which won't work in a sandbox).

- Eval
   - [ ] [nix evaluates successfully on Hydra](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-481#tabs-errors)

- Builds for ghcjs
  - [ ] `cardano-wallet-core`
  - [ ] `cardano-wallet-byron:library`

- Tests executed for ghcjs target
  - [ ] `cardano-wallet-core:unit`
  - [ ] `cardano-wallet-byron:unit`
