### PR TITLE
Provide `ToText` and `FromText` instances for `Hash "Genesis"`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -739,6 +739,12 @@ instance FromText (Hash "BlockHeader") where
 instance ToText (Hash "BlockHeader") where
     toText = toTextFromHashBase16
 
+instance FromText (Hash "Genesis") where
+    fromText = fromTextToHashBase16
+
+instance ToText (Hash "Genesis") where
+    toText = toTextFromHashBase16
+
 -- | A polymorphic wrapper type with a custom show instance to display data
 -- through 'Buildable' instances.
 newtype ShowFmt a = ShowFmt a

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -148,6 +148,10 @@ spec = do
             let err = "wallet id should be an hex-encoded string \
                       \of 40 characters"
             fromText @WalletId "101" === Left (TextDecodingError err)
+        it "fail fromText (@Hash \"Genesis\")" $ do
+            let err = "Unable to decode (Hash \"Genesis\"): \
+                      \expected Base16 encoding"
+            fromText @(Hash "Genesis") "----" === Left (TextDecodingError err)
 
     describe "Lemma 2.1 - Properties of UTxO operations" $ do
         it "2.1.1) ins⊲ u ⊆ u"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -101,6 +101,7 @@ spec = do
         textRoundtrip $ Proxy @TxStatus
         textRoundtrip $ Proxy @WalletName
         textRoundtrip $ Proxy @WalletId
+        textRoundtrip $ Proxy @(Hash "Genesis")
         textRoundtrip $ Proxy @(Hash "Tx")
 
     describe "Buildable" $ do
@@ -306,6 +307,10 @@ prop_2_6_2 (ins, u) =
 instance Arbitrary Direction where
     arbitrary = arbitraryBoundedEnum
     shrink = genericShrink
+
+instance Arbitrary (Hash "Genesis") where
+    arbitrary = Hash . BS.pack <$> arbitrary
+    shrink (Hash v) = Hash . BS.pack <$> shrink (BS.unpack v)
 
 instance Arbitrary (Hash "Tx") where
     -- No Shrinking


### PR DESCRIPTION
# Issue Number

#357 

This PR enables us to parse user-provided genesis hash values from the CLI.

# Overview

This PR:
- [x] provides `ToText` and `FromText` instances for the `Hash "Genesis"` type.
- [x] removes duplication among `ToText` and `FromText` instances for the family of `Hash t` types.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
