### PR TITLE
Sqlite: Use the structured logging approach

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -39,6 +39,7 @@ library
     , bytestring
     , cardano-crypto
     , containers
+    , contra-tracer
     , cryptonite
     , deepseq
     , exceptions

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -25,6 +25,7 @@
           (hsPkgs.bytestring)
           (hsPkgs.cardano-crypto)
           (hsPkgs.containers)
+          (hsPkgs.contra-tracer)
           (hsPkgs.cryptonite)
           (hsPkgs.deepseq)
           (hsPkgs.exceptions)


### PR DESCRIPTION
Relates to issue #354.

# Overview

- Uses a data type for log messages, then converts them to text at the Sqlite module boundary.

# Comments

- We should consider making this the standard logging style for cardano-wallet.
