### PR TITLE
Transaction estimateMaxNumberOfInputs

### DIFF
--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -89,7 +89,7 @@ data ErrMkStdTx
     deriving (Eq, Show)
 
 -- | Backend-specific variables used by 'estimateMaxNumberOfInputsBase'.
-data EstimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
+data EstimateMaxNumberOfInputsParams t = EstimateMaxNumberOfInputsParams
     { estMeasureTx :: [TxIn] -> [TxOut] -> [TxWitness] -> Int
         -- ^ Finds the size of a serialized transaction.
     , estAddressSample :: Address -- ^ Address to use in tx output
@@ -107,7 +107,7 @@ data EstimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
 -- All the values used are the smaller ones. For example, the shortest adress
 -- type and shortest witness type are chosen to use for the estimate.
 estimateMaxNumberOfInputsBase
-    :: EstimateMaxNumberOfInputsParams
+    :: EstimateMaxNumberOfInputsParams t
     -- ^ Backend-specific variables used in the estimation
     -> Quantity "byte" Word16
     -- ^ Transaction max size in bytes

--- a/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.TransactionSpecShared
+    ( estimateMaxNumberOfInputsSpec
+    , propMaxNumberOfInputsEstimation
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Transaction
+    ( TransactionLayer (..) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Word
+    ( Word16 )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Property
+    , Small (..)
+    , choose
+    , counterexample
+    , elements
+    , property
+    , (.&&.)
+    )
+
+{-------------------------------------------------------------------------------
+                             Max inputs estimation
+-------------------------------------------------------------------------------}
+
+estimateMaxNumberOfInputsSpec :: TransactionLayer t -> Spec
+estimateMaxNumberOfInputsSpec tl =
+    describe "estimateMaxNumberOfInputs" $ do
+        it "Property for mainnet addresses"
+            (property $ propMaxNumberOfInputsEstimation tl)
+
+propMaxNumberOfInputsEstimation
+    :: TransactionLayer t
+    -> Quantity "byte" Word16
+    -> Quantity "byte" Word16
+    -> Property
+propMaxNumberOfInputsEstimation tl qa@(Quantity ma) qb@(Quantity mb) =
+    counterexample debug
+    (isIncreasingFunction .&&. estIsSmallerThanSize)
+  where
+    isIncreasingFunction = if (ma < mb) then (est qa <= est qb) else (est qa >= est qb)
+    estIsSmallerThanSize = (est qa <= ma) .&&. (est qb <= mb)
+    est = fromIntegral . estimateMaxNumberOfInputs tl
+    debug = unwords
+        [ "sizeA = " <> show ma, "sizeB = " <> show mb
+        , "estA = " <> show (est qa), "estB = " <> show (est qb)
+        ]
+
+instance Arbitrary (Quantity "byte" Word16) where
+    shrink (Quantity n) = Quantity <$> shrink n
+    arbitrary = do
+        a <- choose (0, maxBound)
+        Small n <- arbitrary
+        Quantity <$> elements [a, n, a - n]

--- a/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
@@ -6,8 +6,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Wallet.TransactionSpecShared
-    ( estimateMaxNumberOfInputsSpec
-    , propMaxNumberOfInputsEstimation
+    ( propMaxNumberOfInputsEstimation
     ) where
 
 import Prelude
@@ -18,8 +17,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word16, Word8 )
-import Test.Hspec
-    ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Property
@@ -27,19 +24,12 @@ import Test.QuickCheck
     , choose
     , counterexample
     , elements
-    , property
     , (.&&.)
     )
 
 {-------------------------------------------------------------------------------
                              Max inputs estimation
 -------------------------------------------------------------------------------}
-
-estimateMaxNumberOfInputsSpec :: TransactionLayer t -> Spec
-estimateMaxNumberOfInputsSpec tl =
-    describe "estimateMaxNumberOfInputs" $ do
-        it "Property for mainnet addresses"
-            (property $ propMaxNumberOfInputsEstimation tl)
 
 propMaxNumberOfInputsEstimation
     :: TransactionLayer t

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -364,6 +364,8 @@ dummyTransactionLayer = TransactionLayer
         return (tx, wit)
     , estimateSize =
         error "dummyTransactionLayer: estimateSize not implemented"
+    , estimateMaxNumberOfInputs =
+        error "dummyTransactionLayer: estimateMaxNumberOfInputs not implemented"
     }
   where
     withEither :: e -> Maybe a -> Either e a

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -117,6 +117,7 @@ test-suite unit
       Cardano.Wallet.HttpBridge.Primitive.AddressDerivationSpec
       Cardano.Wallet.HttpBridge.Primitive.TypesSpec
       Cardano.Wallet.HttpBridge.TransactionSpec
+      Cardano.Wallet.TransactionSpecShared
       Data.PackfileSpec
       Servant.Extra.ContentTypesSpec
 

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.HttpBridge.Binary
     , decodeList
     , decodeListIndef
     , toByteString
+    , estimateMaxNumberOfInputsParams
 
     ) where
 
@@ -61,6 +62,8 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxWitness (..)
     )
+import Cardano.Wallet.Transaction
+    ( EstimateMaxNumberOfInputsParams (..) )
 import Control.Monad
     ( void )
 import Crypto.Hash
@@ -622,3 +625,14 @@ encodeList encodeOne list = mempty
 
 toByteString :: CBOR.Encoding -> ByteString
 toByteString = BL.toStrict . CBOR.toLazyByteString
+
+-- | This provides network encoding specific variables to be used by the
+-- 'estimateMaxNumberOfInputs' function.
+estimateMaxNumberOfInputsParams :: EstimateMaxNumberOfInputsParams t
+estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
+    { estMeasureTx = \ins outs wits ->
+        fromIntegral $ BL.length $ CBOR.toLazyByteString $
+        encodeSignedTx (Tx ins outs, wits)
+    , estBlockHashSize = 32
+    , estTxWitnessSize = 128
+    }

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
@@ -39,7 +39,6 @@ module Cardano.Wallet.HttpBridge.Binary
     , decodeList
     , decodeListIndef
     , toByteString
-    , estimateMaxNumberOfInputsParams
 
     ) where
 
@@ -62,8 +61,6 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxWitness (..)
     )
-import Cardano.Wallet.Transaction
-    ( EstimateMaxNumberOfInputsParams (..) )
 import Control.Monad
     ( void )
 import Crypto.Hash
@@ -84,7 +81,6 @@ import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 
 -- Decoding
@@ -626,21 +622,3 @@ encodeList encodeOne list = mempty
 
 toByteString :: CBOR.Encoding -> ByteString
 toByteString = BL.toStrict . CBOR.toLazyByteString
-
--- | This provides network encoding specific variables to be used by the
--- 'estimateMaxNumberOfInputs' function.
-estimateMaxNumberOfInputsParams :: EstimateMaxNumberOfInputsParams
-estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
-    { estMeasureTx = \ins outs wits ->
-        fromIntegral $ BL.length $ CBOR.toLazyByteString $
-        encodeSignedTx (Tx ins outs, wits)
-
-    -- Address with 256 bit public key and chain code.
-    -- There are no attributes.
-    , estAddressSample =
-        let xpub = XPub (BS.replicate 32 0) (ChainCode $ BS.replicate 32 0)
-        in Address $ toByteString $ encodeAddress xpub mempty
-
-    , estBlockHashSize = 32
-    , estTxWitnessSize = 128
-    }

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Primitive.Types
     , txId
     )
 import Cardano.Wallet.Transaction
-    ( ErrMkStdTx (..), TransactionLayer (..) )
+    ( ErrMkStdTx (..), TransactionLayer (..), estimateMaxNumberOfInputsBase )
 import Control.Monad
     ( forM, when )
 import Data.ByteString
@@ -75,6 +75,10 @@ newTransactionLayer = TransactionLayer
         + sizeOfTx (fst <$> inps) outs chngs
         + sizeOf (CBOR.encodeListLen $ fromIntegral n)
         + n * sizeOfTxWitness
+
+    , estimateMaxNumberOfInputs =
+        estimateMaxNumberOfInputsBase CBOR.estimateMaxNumberOfInputsParams
+
     }
   where
     mkWitness

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
@@ -11,8 +11,10 @@ module Cardano.Wallet.HttpBridge.Transaction
 
 import Prelude
 
+import Cardano.Wallet.HttpBridge.Binary
+    ( estimateMaxNumberOfInputsParams )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, estimateMaxNumberOfInputsParams )
+    ( HttpBridge )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..), ProtocolMagic (..) )
 import Cardano.Wallet.HttpBridge.Primitive.Types
@@ -84,7 +86,7 @@ newTransactionLayer = TransactionLayer
         + n * sizeOfTxWitness
 
     , estimateMaxNumberOfInputs =
-        estimateMaxNumberOfInputsBase (estimateMaxNumberOfInputsParams @n)
+        estimateMaxNumberOfInputsBase @t estimateMaxNumberOfInputsParams
 
     }
   where

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -51,6 +51,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Transaction
     ( ErrMkStdTx (..), TransactionLayer (..) )
+import Cardano.Wallet.TransactionSpecShared
+    ( propMaxNumberOfInputsEstimation )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Arrow
@@ -110,6 +112,12 @@ spec = do
             (withMaxSuccess 2500 $ property $ propSizeEstimation $ Proxy @'Mainnet)
         it "Estimated size is the same as taken by encodeSignedTx"
             (withMaxSuccess 2500 $ property $ propSizeEstimation $ Proxy @'Testnet)
+
+    describe "estimateMaxNumberOfInputs" $ do
+        it "Property for mainnet addresses" $ property $
+            propMaxNumberOfInputsEstimation (newTransactionLayer @'Mainnet)
+        it "Property for testnet addresses" $ property$
+            propMaxNumberOfInputsEstimation (newTransactionLayer @'Testnet)
 
     describe "mkStdTx" $ do
         unknownInputTest (Proxy @'Mainnet)

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -637,7 +638,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 propSizeEstimation
-    :: forall n. (KnownNetwork n)
+    :: forall n t. (KnownNetwork n, t ~ HttpBridge n, KeyToAddress t)
     => Proxy n
     -> (ShowFmt CoinSelection, InfiniteList (Network -> Address))
     -> Property

--- a/lib/http-bridge/test/unit/Cardano/Wallet/TransactionSpecShared.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/TransactionSpecShared.hs
@@ -1,0 +1,1 @@
+../../../../../core/test/unit/Cardano/Wallet/TransactionSpecShared.hs

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -109,6 +109,7 @@ test-suite unit
       Cardano.Wallet.Jormungandr.EnvironmentSpec
       Cardano.Wallet.Jormungandr.CompatibilitySpec
       Cardano.Wallet.Jormungandr.TransactionSpec
+      Cardano.Wallet.TransactionSpecShared
 
 test-suite integration
   default-language:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -574,9 +574,6 @@ estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
     { estMeasureTx = \ins outs wits -> fromIntegral $ BL.length $
         runPut $ putSignedTx (Tx (map (, Coin 0) ins) outs, wits)
 
-    -- Use length of the smaller type of address.
-    , estAddressSample = Address $ BS.replicate addrLenSingle 0
-
     -- Block IDs are always this long.
     , estBlockHashSize = 32
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -568,7 +568,8 @@ blake2b256 =
 
 -- | This provides network encoding specific variables to be used by the
 -- 'estimateMaxNumberOfInputs' function.
-estimateMaxNumberOfInputsParams :: EstimateMaxNumberOfInputsParams
+estimateMaxNumberOfInputsParams
+    :: EstimateMaxNumberOfInputsParams t
 estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
     { estMeasureTx = \ins outs wits -> fromIntegral $ BL.length $
         runPut $ putSignedTx (Tx (map (, Coin 0) ins) outs, wits)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -486,16 +486,16 @@ putAddress addr@(Address bs)
         $ "Address has unexpected length "
         ++ show len ++ ": " ++ show addr
   where
-    hasCorrectLength = len == addrLenAccount || len == addrLenDelegation
+    hasCorrectLength = len == addrLenSingle || len == addrLenGrouped
     len = fromIntegral $ BS.length bs
 
--- Serialized length in bytes of a bootstrap or account address
-addrLenAccount :: Int
-addrLenAccount = 33
+-- Serialized length in bytes of a bootstrap or account address (Single Address)
+addrLenSingle :: Int
+addrLenSingle = 33
 
--- Serialized length in bytes of a delegation address
-addrLenDelegation :: Int
-addrLenDelegation = 65
+-- Serialized length in bytes of a delegation address (Grouped Address)
+addrLenGrouped :: Int
+addrLenGrouped = 65
 
 singleAddressFromKey :: forall n. KnownNetwork n => Proxy n -> XPub -> Address
 singleAddressFromKey _ xPub = Address $ BL.toStrict $ runPut $ do
@@ -574,7 +574,7 @@ estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
         runPut $ putSignedTx (Tx (map (, Coin 0) ins) outs, wits)
 
     -- Use length of the smaller type of address.
-    , estAddressSample = Address $ BS.replicate addrLenAccount 0
+    , estAddressSample = Address $ BS.replicate addrLenSingle 0
 
     -- Block IDs are always this long.
     , estBlockHashSize = 32

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -50,12 +51,14 @@ module Cardano.Wallet.Jormungandr.Binary
 
       -- * Helpers
     , blake2b256
+    , estimateMaxNumberOfInputsParams
 
       -- * Re-export
     , Get
     , runGet
     , Put
     , runPut
+
     ) where
 
 import Prelude
@@ -77,10 +80,12 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxWitness (..)
     )
+import Cardano.Wallet.Transaction
+    ( EstimateMaxNumberOfInputsParams (..) )
 import Control.Applicative
     ( many )
 import Control.Monad
-    ( replicateM, unless )
+    ( replicateM, unless, when )
 import Crypto.Hash
     ( hash )
 import Crypto.Hash.Algorithms
@@ -240,6 +245,19 @@ getInitial = label "getInitial" $ do
     len <- fromIntegral <$> getWord16be
     replicateM len getConfigParam
 
+data TxWitnessTag
+    = TxWitnessLegacyUTxO
+    | TxWitnessUTxO
+    | TxWitnessAccount
+    | TxWitnessMultisig
+    deriving (Show, Eq)
+
+txWitnessSize :: TxWitnessTag -> Int
+txWitnessSize TxWitnessLegacyUTxO = 128
+txWitnessSize TxWitnessUTxO = 64
+txWitnessSize TxWitnessAccount = 64
+txWitnessSize TxWitnessMultisig = 68
+
 -- | Decode the contents of a @Transaction@-message.
 getTransaction :: Get (Tx, [TxWitness])
 getTransaction = label "getTransaction" $ do
@@ -248,22 +266,23 @@ getTransaction = label "getTransaction" $ do
     wits <- replicateM witnessCount getWitness
     return (Tx ins outs, wits)
   where
+    getWitness :: Get TxWitness
     getWitness = do
-        tag <- getWord8
-        case tag of
-            0 -> -- Legacy UTxO
-                isolate 128 $ TxWitness <$> getByteString 128
-            1 -> -- UTxO
-                isolate 64 $ TxWitness <$> getByteString 64
+        tag <- getTxWitnessTag
+        when (tag == TxWitnessAccount) $
+            error "unimplemented: Account witness"
+        when (tag == TxWitnessMultisig) $
+            error "unimplemented: Multisig witness"
+        let len = txWitnessSize tag
+        TxWitness <$> isolate len (getByteString len)
 
-            2 -> -- Account
-                isolate 64 $ getByteString 64
-                    *> error "unimplemented: Account witness"
-            3 -> -- Multisig
-                isolate 68 $ getByteString 68
-                    *> error "unimplemented: Multisig witness"
-            other ->
-                fail $ "Invalid witness type: " ++ show other
+    getTxWitnessTag :: Get TxWitnessTag
+    getTxWitnessTag = getWord8 >>= \case
+        0 -> pure TxWitnessLegacyUTxO
+        1 -> pure TxWitnessUTxO
+        2 -> pure TxWitnessAccount
+        3 -> pure TxWitnessMultisig
+        other -> fail $ "Invalid witness type: " ++ show other
 
     getTokenTransfer :: Get ([(TxIn, Coin)], [TxOut])
     getTokenTransfer = label "getTokenTransfer" $ do
@@ -462,13 +481,21 @@ getAddress = do
 
 putAddress :: Address -> Put
 putAddress addr@(Address bs)
-    | l == 33 = putByteString bs -- bootstrap or account addr
-    | l == 65 = putByteString bs -- delegation addr
+    | hasCorrectLength = putByteString bs
     | otherwise = fail
         $ "Address has unexpected length "
-        ++ (show l)
-        ++ ": " ++ show addr
-  where l = BS.length bs
+        ++ show len ++ ": " ++ show addr
+  where
+    hasCorrectLength = len == addrLenAccount || len == addrLenDelegation
+    len = fromIntegral $ BS.length bs
+
+-- Serialized length in bytes of a bootstrap or account address
+addrLenAccount :: Int
+addrLenAccount = 33
+
+-- Serialized length in bytes of a delegation address
+addrLenDelegation :: Int
+addrLenDelegation = 65
 
 singleAddressFromKey :: forall n. KnownNetwork n => Proxy n -> XPub -> Address
 singleAddressFromKey _ xPub = Address $ BL.toStrict $ runPut $ do
@@ -538,3 +565,20 @@ decodeLegacyAddress bytes =
 blake2b256 :: ByteString -> ByteString
 blake2b256 =
     BA.convert . hash @_ @Blake2b_256
+
+-- | This provides network encoding specific variables to be used by the
+-- 'estimateMaxNumberOfInputs' function.
+estimateMaxNumberOfInputsParams :: EstimateMaxNumberOfInputsParams
+estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
+    { estMeasureTx = \ins outs wits -> fromIntegral $ BL.length $
+        runPut $ putSignedTx (Tx (map (, Coin 0) ins) outs, wits)
+
+    -- Use length of the smaller type of address.
+    , estAddressSample = Address $ BS.replicate addrLenAccount 0
+
+    -- Block IDs are always this long.
+    , estBlockHashSize = 32
+
+    -- The length of the smallest type of witness.
+    , estTxWitnessSize = txWitnessSize TxWitnessUTxO
+    }

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -13,6 +13,8 @@ import Prelude
 
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr )
+import Cardano.Wallet.Jormungandr.Environment
+    ( KnownNetwork )
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -37,7 +39,7 @@ import qualified Cardano.Wallet.Jormungandr.Binary as Binary
 
 -- | Construct a 'TransactionLayer' compatible with Shelley and 'Jörmungandr'
 newTransactionLayer
-    :: forall n t. (t ~ Jormungandr n)
+    :: forall n t. (KnownNetwork n, t ~ Jormungandr n)
     => Hash "Genesis"
     -> TransactionLayer t
 newTransactionLayer (Hash block0) = TransactionLayer
@@ -52,8 +54,7 @@ newTransactionLayer (Hash block0) = TransactionLayer
     , estimateSize = \_ -> Quantity 0
 
     , estimateMaxNumberOfInputs =
-        estimateMaxNumberOfInputsBase $
-        Binary.estimateMaxNumberOfInputsParams @t
+        estimateMaxNumberOfInputsBase @t Binary.estimateMaxNumberOfInputsParams
 
     }
   where

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -19,7 +19,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( Hash (..), TxOut (..), TxWitness (..), txId )
 import Cardano.Wallet.Transaction
-    ( ErrMkStdTx (..), TransactionLayer (..) )
+    ( ErrMkStdTx (..), TransactionLayer (..), estimateMaxNumberOfInputsBase )
 import Control.Arrow
     ( second )
 import Control.Monad
@@ -32,6 +32,7 @@ import Data.Quantity
     ( Quantity (..) )
 
 import qualified Cardano.Crypto.Wallet as CC
+import qualified Cardano.Wallet.Jormungandr.Binary as Binary
 
 -- | Construct a 'TransactionLayer' compatible with Shelley and 'Jörmungandr'
 newTransactionLayer
@@ -48,6 +49,10 @@ newTransactionLayer (Hash block0) = TransactionLayer
 
     -- NOTE: at this point 'Jörmungandr' node does not support fee calculation
     , estimateSize = \_ -> Quantity 0
+
+    , estimateMaxNumberOfInputs =
+        estimateMaxNumberOfInputsBase Binary.estimateMaxNumberOfInputsParams
+
     }
   where
     sign

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -36,9 +37,9 @@ import qualified Cardano.Wallet.Jormungandr.Binary as Binary
 
 -- | Construct a 'TransactionLayer' compatible with Shelley and 'Jörmungandr'
 newTransactionLayer
-    :: forall n. ()
+    :: forall n t. (t ~ Jormungandr n)
     => Hash "Genesis"
-    -> TransactionLayer (Jormungandr n)
+    -> TransactionLayer t
 newTransactionLayer (Hash block0) = TransactionLayer
     { mkStdTx = \keyFrom inps outs -> do
         let tx = Tx (fmap (second coin) inps) outs
@@ -51,7 +52,8 @@ newTransactionLayer (Hash block0) = TransactionLayer
     , estimateSize = \_ -> Quantity 0
 
     , estimateMaxNumberOfInputs =
-        estimateMaxNumberOfInputsBase Binary.estimateMaxNumberOfInputsParams
+        estimateMaxNumberOfInputsBase $
+        Binary.estimateMaxNumberOfInputsParams @t
 
     }
   where

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -364,7 +364,7 @@ mkStdTxSpec = do
             \ff21f5f9ebc2d2a5e201"
 
 goldenTestStdTx
-    :: forall (n :: Network). ()
+    :: forall n. (KnownNetwork n)
     => Proxy (Jormungandr n)
     -> (Address -> Maybe (Key 'AddressK XPrv, Passphrase "encryption"))
     -> Hash "Genesis"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -47,6 +47,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Transaction
     ( TransactionLayer (..) )
+import Cardano.Wallet.TransactionSpecShared
+    ( estimateMaxNumberOfInputsSpec )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Monad.Trans.Except
@@ -87,6 +89,8 @@ import qualified Data.Map as Map
 spec :: Spec
 spec = do
     estimateSizeSpec
+    estimateMaxNumberOfInputsSpec
+        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Mainnet))
     mkStdTxSpec
 
 {-------------------------------------------------------------------------------

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -47,7 +47,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Transaction
     ( TransactionLayer (..) )
 import Cardano.Wallet.TransactionSpecShared
-    ( estimateMaxNumberOfInputsSpec )
+    ( propMaxNumberOfInputsEstimation )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Monad.Trans.Except
@@ -89,7 +89,6 @@ spec :: Spec
 spec = do
     estimateSizeSpec
     estimateMaxNumberOfInputsSpec
-        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Mainnet))
     mkStdTxSpec
 
 {-------------------------------------------------------------------------------
@@ -199,6 +198,19 @@ instance Arbitrary (Hash "Tx") where
     arbitrary = do
         bytes <- BS.pack <$> vectorOf 32 arbitrary
         pure $ Hash bytes
+
+{-------------------------------------------------------------------------------
+                             Max inputs estimation
+-------------------------------------------------------------------------------}
+
+estimateMaxNumberOfInputsSpec :: Spec
+estimateMaxNumberOfInputsSpec = describe "estimateMaxNumberOfInputs" $ do
+    it "Property for mainnet addresses" $
+        property $ propMaxNumberOfInputsEstimation
+        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Mainnet))
+    it "Property for testnet addresses" $
+        property $ propMaxNumberOfInputsEstimation
+        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Testnet))
 
 {-------------------------------------------------------------------------------
                                   mkStdTx

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}

--- a/lib/jormungandr/test/unit/Cardano/Wallet/TransactionSpecShared.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/TransactionSpecShared.hs
@@ -1,0 +1,1 @@
+../../../../../core/test/unit/Cardano/Wallet/TransactionSpecShared.hs


### PR DESCRIPTION
Relates to #462

# Overview

- Implementation of `estimateMaxNumberOfInputs` for jormungandr and http-bridge.

# Comments

The estimation formula is the same regardless of backend, just with different variables. But it was a hassle sharing the estimation function between backends.
