### PR TITLE
Enable Integration Tests for Jörmungandr (Part III: Command-Line tests)

### DIFF
--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -23,7 +23,7 @@ flag development
 library
   hs-source-dirs: .
 
-executable cardano-wallet
+executable cardano-wallet-http-bridge
   default-language:
       Haskell2010
   default-extensions:

--- a/lib/core/test/integration/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/API/Wallets.hs
@@ -12,6 +12,8 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiTransaction, ApiWallet )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
     ( DecodeAddress
     , EncodeAddress
@@ -26,8 +28,6 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Text
     ( Text )
-import System.Command
-    ( Stdout (..) )
 import Test.Hspec
     ( SpecWith, describe, it )
 import Test.Integration.Framework.DSL
@@ -48,7 +48,6 @@ import Test.Integration.Framework.DSL
     , expectListSizeEqual
     , expectResponseCode
     , fixtureWallet
-    , generateMnemonicsViaCLI
     , getFromResponse
     , getWalletEp
     , json
@@ -134,8 +133,8 @@ spec = do
     it "WALLETS_CREATE_02 - Restored wallet preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
         -- create wallet
-        Stdout mnemonics <- generateMnemonicsViaCLI []
-        let payldCrt = payloadWith "!st created" (T.words $ T.pack mnemonics)
+        mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+        let payldCrt = payloadWith "!st created" mnemonics
         rInit <- request @ApiWallet ctx ("POST", "v2/wallets") Default payldCrt
         verify rInit
             [ expectResponseCode @IO HTTP.status202

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -211,7 +211,7 @@ spec = do
         err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin + amt, feeMax + amt)
+            [ expectCliFieldBetween amount (feeMin + (2*amt), feeMax + (2*amt))
             , expectCliFieldEqual direction Outgoing
             , expectCliFieldEqual status Pending
             ]

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -41,6 +41,7 @@ import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
 import Test.Integration.Framework.DSL
     ( Context (..)
+    , KnownCommand
     , TxDescription (..)
     , amount
     , balanceAvailable
@@ -79,7 +80,9 @@ import Test.Integration.Framework.TestData
 
 import qualified Data.Text as T
 
-spec :: forall t. (EncodeAddress t, DecodeAddress t) => SpecWith (Context t)
+spec
+    :: forall t. (EncodeAddress t, DecodeAddress t, KnownCommand t)
+    => SpecWith (Context t)
 spec = do
     it "TRANS_CREATE_01 - Can create transaction via CLI" $ \ctx -> do
         wSrc <- fixtureWallet ctx
@@ -98,7 +101,7 @@ spec = do
                 ]
 
         -- post transaction
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
@@ -109,7 +112,7 @@ spec = do
         c `shouldBe` ExitSuccess
 
         -- verify balance on src wallet
-        Stdout gOutSrc <- getWalletViaCLI ctx (T.unpack (wSrc ^. walletId))
+        Stdout gOutSrc <- getWalletViaCLI @t ctx (T.unpack (wSrc ^. walletId))
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliFieldBetween balanceTotal
@@ -123,7 +126,7 @@ spec = do
         expectEventually' ctx balanceTotal amt wDest
 
         -- verify balance on dest wallet
-        Stdout gOutDest <- getWalletViaCLI ctx (T.unpack (wDest ^. walletId))
+        Stdout gOutDest <- getWalletViaCLI @t ctx (T.unpack (wDest ^. walletId))
         destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
         verify destJson
             [ expectCliFieldEqual balanceAvailable amt
@@ -150,7 +153,7 @@ spec = do
                 ]
 
         -- post transaction
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
@@ -161,7 +164,7 @@ spec = do
         c `shouldBe` ExitSuccess
 
         -- verify balance on src wallet
-        Stdout gOutSrc <- getWalletViaCLI ctx (T.unpack (wSrc ^. walletId))
+        Stdout gOutSrc <- getWalletViaCLI @t ctx (T.unpack (wSrc ^. walletId))
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliFieldBetween balanceTotal
@@ -175,7 +178,7 @@ spec = do
         expectEventually' ctx balanceTotal (2*amt) wDest
 
         -- verify balance on dest wallet
-        Stdout gOutDest <- getWalletViaCLI ctx (T.unpack (wDest ^. walletId))
+        Stdout gOutDest <- getWalletViaCLI @t ctx (T.unpack (wDest ^. walletId))
         destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
         verify destJson
             [ expectCliFieldEqual balanceAvailable (2*amt)
@@ -204,7 +207,7 @@ spec = do
                 ]
 
         -- post transaction
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
@@ -215,7 +218,7 @@ spec = do
         c `shouldBe` ExitSuccess
 
         -- verify balance on src wallet
-        Stdout gOutSrc <- getWalletViaCLI ctx (T.unpack (wSrc ^. walletId))
+        Stdout gOutSrc <- getWalletViaCLI @t ctx (T.unpack (wSrc ^. walletId))
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliFieldBetween balanceTotal
@@ -230,7 +233,7 @@ spec = do
             expectEventually' ctx balanceTotal amt wDest
 
             -- verify balance on dest wallets
-            Stdout gOutDest <- getWalletViaCLI ctx (T.unpack (wDest ^. walletId))
+            Stdout gOutDest <- getWalletViaCLI @t ctx (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
             verify destJson
                 [ expectCliFieldEqual balanceAvailable amt
@@ -252,7 +255,7 @@ spec = do
                 , "--payment", "4666@" <> addr2
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         (T.unpack err) `shouldContain` errMsg403UTxO
         out `shouldBe` ""
         c `shouldBe` ExitFailure 1
@@ -270,7 +273,7 @@ spec = do
                 , "--payment", toText amt <> "@" <> addr
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "Secure Passphrase" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "Secure Passphrase" args
         err `shouldBe` "Please enter a passphrase: *****************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
@@ -280,7 +283,7 @@ spec = do
             ]
         c `shouldBe` ExitSuccess
 
-        Stdout gOutSrc <- getWalletViaCLI ctx (T.unpack (wSrc ^. walletId))
+        Stdout gOutSrc <- getWalletViaCLI @t ctx (T.unpack (wSrc ^. walletId))
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliFieldEqual balanceTotal 0
@@ -290,7 +293,7 @@ spec = do
         expectEventually' ctx balanceAvailable amt wDest
         expectEventually' ctx balanceTotal amt wDest
 
-        Stdout gOutDest <- getWalletViaCLI ctx (T.unpack (wDest ^. walletId))
+        Stdout gOutDest <- getWalletViaCLI @t ctx (T.unpack (wDest ^. walletId))
         destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
         verify destJson
             [ expectCliFieldEqual balanceAvailable amt
@@ -309,7 +312,7 @@ spec = do
                 , "--payment", "1@" <> addr
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "Secure Passphrase" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "Secure Passphrase" args
         (T.unpack err) `shouldContain` errMsg403Fee
         out `shouldBe` ""
         c `shouldBe` ExitFailure 1
@@ -326,7 +329,7 @@ spec = do
                 , "--payment", "1000000@" <> addr
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "Secure Passphrase" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "Secure Passphrase" args
         (T.unpack err) `shouldContain`
             errMsg403NotEnoughMoney (fromIntegral feeMin) 1_000_000
         out `shouldBe` ""
@@ -343,7 +346,7 @@ spec = do
                 , "--payment", "14@" <> addr
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "This password is wrong" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "This password is wrong" args
         (T.unpack err) `shouldContain` errMsg403WrongPass
         out `shouldBe` ""
         c `shouldBe` ExitFailure 1
@@ -373,7 +376,7 @@ spec = do
                     , "--payment", "12@" <> (T.pack addr)
                     ]
 
-            (c, out, err) <- postTransactionViaCLI ctx "Secure Passphrase" args
+            (c, out, err) <- postTransactionViaCLI @t ctx "Secure Passphrase" args
             (T.unpack err) `shouldContain` errMsg
             out `shouldBe` ""
             c `shouldBe` ExitFailure 1
@@ -400,7 +403,7 @@ spec = do
                     , "--payment", amt <> "@" <> addr
                     ]
 
-            (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+            (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
             (T.unpack err) `shouldContain` errMsg
             out `shouldBe` ""
             c `shouldBe` ExitFailure 1
@@ -416,7 +419,7 @@ spec = do
                     , walId, "--payment", "12@" ++  (T.unpack addr)
                     ]
             -- make sure CLI returns error before asking for passphrase
-            (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI args
+            (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
             out `shouldBe` ""
             c `shouldBe` ExitFailure 1
             if (title == "40 chars hex") then
@@ -437,7 +440,7 @@ spec = do
                 , T.append (wSrc ^. walletId) "0", "--payment", "11@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
-        (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI args
+        (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
         err `shouldContain` "wallet id should be an hex-encoded\
             \ string of 40 characters"
         out `shouldBe` ""
@@ -445,7 +448,7 @@ spec = do
 
     it "TRANS_CREATE_07 - Deleted wallet" $ \ctx -> do
         wSrc <- emptyWallet ctx
-        Exit ex <- deleteWalletViaCLI ctx (T.unpack ( wSrc ^. walletId ))
+        Exit ex <- deleteWalletViaCLI @t ctx (T.unpack ( wSrc ^. walletId ))
         ex `shouldBe` ExitSuccess
 
         wDest <- emptyWallet ctx
@@ -457,7 +460,7 @@ spec = do
                 , wSrc ^. walletId, "--payment", "11@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
-        (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI args
+        (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
         err `shouldContain` "I couldn't find a wallet with \
             \the given id: " ++ T.unpack ( wSrc ^. walletId )
         out `shouldBe` ""

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -188,12 +188,11 @@ test-suite integration
       Test.Integration.Scenario.API.Wallets
       Test.Integration.Scenario.CLI.Addresses
       Test.Integration.Scenario.CLI.Mnemonics
-      Test.Integration.Scenario.CLI.Server
+      Test.Integration.Scenario.CLI.Port
       Test.Integration.Scenario.CLI.Transactions
       Test.Integration.Scenario.CLI.Wallets
-      Test.Integration.Scenario.CLI.Port
-      Test.Integration.Scenario.CLI.Server
       Test.Integration.HttpBridge.Scenario.API.Transactions
+      Test.Integration.HttpBridge.Scenario.CLI.Server
       Test.Integration.HttpBridge.Scenario.CLI.Transactions
 
 benchmark restore

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -92,6 +92,7 @@ import qualified Data.Aeson.Types as Aeson
 import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Test.Integration.HttpBridge.Scenario.API.Transactions as TransactionsBridge
+import qualified Test.Integration.HttpBridge.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.HttpBridge.Scenario.CLI.Transactions as TransactionsCLIBridge
 import qualified Test.Integration.Scenario.API.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.Transactions as Transactions
@@ -99,7 +100,6 @@ import qualified Test.Integration.Scenario.API.Wallets as Wallets
 import qualified Test.Integration.Scenario.CLI.Addresses as AddressesCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
 import qualified Test.Integration.Scenario.CLI.Port as PortCLI
-import qualified Test.Integration.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.Scenario.CLI.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.CLI.Wallets as WalletsCLI
 

--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Server.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Server.hs
@@ -28,8 +28,6 @@ spec = do
                 let process = proc' (commandName @t) args
                 withCreateProcess process $ \_ _ _ ph -> do
                     expectPathEventuallyExist db
-                    expectPathEventuallyExist (db <> "-shm")
-                    expectPathEventuallyExist (db <> "-wal")
                     terminateProcess ph
             threadDelay oneSecond
 

--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Server.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Server.hs
@@ -1,4 +1,7 @@
-module Test.Integration.Scenario.CLI.Server
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.HttpBridge.Scenario.CLI.Server
     ( spec
     ) where
 
@@ -13,16 +16,16 @@ import System.Process
 import Test.Hspec
     ( SpecWith, describe, it )
 import Test.Integration.Framework.DSL
-    ( Context (..), expectPathEventuallyExist, proc' )
+    ( Context (..), KnownCommand (..), expectPathEventuallyExist, proc' )
 
-spec :: SpecWith (Context t)
+spec :: forall t. KnownCommand t => SpecWith (Context t)
 spec = do
     describe "SERVER - cardano-wallet serve" $ do
         it "SERVER - Can start cardano-wallet serve --database" $ \_ -> do
             withTempDir $ \d -> do
                 let db = d ++ "/db-file"
                 let args = ["serve", "--database", db]
-                let process = proc' "cardano-wallet" args
+                let process = proc' (commandName @t) args
                 withCreateProcess process $ \_ _ _ ph -> do
                     expectPathEventuallyExist db
                     expectPathEventuallyExist (db <> "-shm")

--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Transactions.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Transactions.hs
@@ -26,6 +26,7 @@ import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
 import Test.Integration.Framework.DSL
     ( Context (..)
+    , KnownCommand
     , emptyWallet
     , fixtureWallet
     , listAddresses
@@ -37,7 +38,9 @@ import Test.Integration.Framework.TestData
 
 import qualified Data.Text as T
 
-spec :: forall t. (EncodeAddress t, DecodeAddress t) => SpecWith (Context t)
+spec
+    :: forall t.(EncodeAddress t, DecodeAddress t, KnownCommand t)
+    => SpecWith (Context t)
 spec = do
     it "TRANS_CREATE_09 - 0 amount transaction is forbidden on single output tx" $ \ctx -> do
         wSrc <- fixtureWallet ctx
@@ -51,7 +54,7 @@ spec = do
                 , "--payment", amt <> "@" <> addr
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         (T.unpack err) `shouldContain` errMsg403InvalidTransaction
         out `shouldBe` ""
         c `shouldBe` ExitFailure 1
@@ -70,7 +73,7 @@ spec = do
                 , "--payment", "15@" <> addr2
                 ]
 
-        (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
+        (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         (T.unpack err) `shouldContain` errMsg403InvalidTransaction
         out `shouldBe` ""
         c `shouldBe` ExitFailure 1

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -175,7 +175,7 @@ test-suite integration
       Test.Integration.Scenario.API.Wallets
       Test.Integration.Scenario.CLI.Addresses
       Test.Integration.Scenario.CLI.Mnemonics
-      Test.Integration.Scenario.CLI.Server
       Test.Integration.Scenario.CLI.Transactions
       Test.Integration.Scenario.CLI.Wallets
       Test.Integration.Scenario.CLI.Port
+      Test.Integration.Jormungandr.Scenario.CLI.Server

--- a/lib/jormungandr/test/integration/Test
+++ b/lib/jormungandr/test/integration/Test
@@ -1,1 +1,0 @@
-../../../core/test/integration/Test

--- a/lib/jormungandr/test/integration/Test/Integration/Faucet.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Faucet.hs
@@ -1,0 +1,1 @@
+../../../../../core/test/integration/Test/Integration/Faucet.hs

--- a/lib/jormungandr/test/integration/Test/Integration/Framework
+++ b/lib/jormungandr/test/integration/Test/Integration/Framework
@@ -1,0 +1,1 @@
+../../../../../core/test/integration/Test/Integration/Framework

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Jormungandr.Scenario.CLI.Server
+    ( spec
+    ) where
+
+import Prelude
+
+import Control.Concurrent
+    ( threadDelay )
+import System.IO.Temp
+    ( withSystemTempDirectory )
+import System.Process
+    ( terminateProcess, withCreateProcess )
+import Test.Hspec
+    ( SpecWith, describe, it )
+import Test.Integration.Framework.DSL
+    ( Context (..), KnownCommand (..), expectPathEventuallyExist, proc' )
+
+spec :: forall t. KnownCommand t => SpecWith (Context t)
+spec = do
+    describe "SERVER - cardano-wallet serve" $ do
+        it "SERVER - Can start cardano-wallet serve --database" $ \_ -> do
+            withTempDir $ \d -> do
+                let db = d ++ "/db-file"
+                let args =
+                        [ "serve", "--database", db, "--genesis-hash"
+                        , "dba597bee5f0987efbf56f6bd7f44c38\
+                          \158a7770d0cb28a26b5eca40613a7ebd"
+                        ]
+                let process = proc' (commandName @t) args
+                withCreateProcess process $ \_ _ _ ph -> do
+                    expectPathEventuallyExist db
+                    expectPathEventuallyExist (db <> "-shm")
+                    expectPathEventuallyExist (db <> "-wal")
+                    terminateProcess ph
+            threadDelay oneSecond
+
+oneSecond :: Int
+oneSecond = 1000000
+
+withTempDir :: (FilePath -> IO a) -> IO a
+withTempDir = withSystemTempDirectory "integration-state"

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -32,8 +32,6 @@ spec = do
                 let process = proc' (commandName @t) args
                 withCreateProcess process $ \_ _ _ ph -> do
                     expectPathEventuallyExist db
-                    expectPathEventuallyExist (db <> "-shm")
-                    expectPathEventuallyExist (db <> "-wal")
                     terminateProcess ph
             threadDelay oneSecond
 

--- a/lib/jormungandr/test/integration/Test/Integration/Scenario
+++ b/lib/jormungandr/test/integration/Test/Integration/Scenario
@@ -1,0 +1,1 @@
+../../../../../core/test/integration/Test/Integration/Scenario

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -17,7 +17,7 @@
     components = {
       "library" = {};
       exes = {
-        "cardano-wallet" = {
+        "cardano-wallet-http-bridge" = {
           depends = [
             (hsPkgs.base)
             (hsPkgs.async)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#358 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have introduce a new class-constraints `KnownCommand` to allow abstracting the name of the command-line interface from the CLI DSL and scenarios
- [x] I have renamed `cardano-wallet` executable into `cardano-wallet-http-bridge`
- [x] I isolated the `Server` specs for `http-bridge` and created a specific one for Jormungandr
- [x] I have enabled most of the integration tests specs, except the Ports one (require a slightly more complex setup)

To be done:

- [ ] Enable the Port tests
- [ ] Review `.travis.yaml` deployment script


# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: Base branch is `KtorZ/cli-optparse-applicative` :warning: 

**spoiler:** Most of this PR is about `@t`.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
