### PR TITLE
Introduce type `MnemonicSize` with accompanying tests.

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -36,6 +36,7 @@ library
     , bytestring
     , cardano-wallet-core
     , cardano-wallet-launcher
+    , extra
     , fmt
     , http-client
     , iohk-monitoring

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -11,7 +11,7 @@ module Cardano.CLISpec
 import Prelude
 
 import Cardano.CLI
-    ( Port (..), hGetLine, hGetSensitiveLine )
+    ( MnemonicSize (..), Port (..), hGetLine, hGetSensitiveLine )
 import Control.Concurrent
     ( forkFinally )
 import Control.Concurrent.MVar
@@ -34,6 +34,7 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , checkCoverage
     , cover
+    , genericShrink
     , (===)
     )
 import Test.Text.Roundtrip
@@ -46,6 +47,7 @@ spec :: Spec
 spec = do
     describe "Can perform roundtrip textual encoding & decoding" $ do
         textRoundtrip $ Proxy @(Port "test")
+        textRoundtrip $ Proxy @MnemonicSize
 
     describe "Port decoding from text" $ do
         let err = TextDecodingError
@@ -174,6 +176,10 @@ test fn (GetLineTest prompt_ input_ output expected) = do
 {-------------------------------------------------------------------------------
                                Arbitrary Instances
 -------------------------------------------------------------------------------}
+
+instance Arbitrary MnemonicSize where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary (Port "test") where
     arbitrary = arbitraryBoundedEnum

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Mnemonics.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Mnemonics.hs
@@ -125,6 +125,6 @@ spec = do
             (Exit c, Stdout out, Stderr err) <-
                 generateMnemonicsViaCLI ["--size", size]
             c `shouldBe` ExitFailure 1
-            err `shouldBe`
-                "Invalid mnemonic size. Expected one of: 9,12,15,18,21,24\n"
+            err `shouldContain`
+                "Invalid mnemonic size. Expected one of: 9, 12, 15, 18, 21, 24."
             out `shouldBe` mempty

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -24,6 +24,7 @@
           (hsPkgs.bytestring)
           (hsPkgs.cardano-wallet-core)
           (hsPkgs.cardano-wallet-launcher)
+          (hsPkgs.extra)
           (hsPkgs.fmt)
           (hsPkgs.http-client)
           (hsPkgs.iohk-monitoring)


### PR DESCRIPTION
# Issue Number

#357 


# Overview

This PR:

- [x] adds a `MnemonicSize` type, which represents the set of valid mnemonic sentence lengths.
- [x] adds `ToText` and `FromText` instances, with accompanying roundtrip tests.
- [x] uses this type for the `mnemonic generate --size` option, instead of `String`. 

This:

- restores the clean separation between parsing and execution.
- allows unit testing of the parsing code.
- produces a more standard error when the parsing fails:
```
$ cardano-wallet mnemonic generate --size 22
option --size: Invalid mnemonic size. Expected one of: 9, 12, 15, 18, 21, 24.

Usage: cardano-wallet mnemonic generate [--size INT]
  Generate English BIP-0039 compatible mnemonic words.
```


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
