### PR TITLE
Review deployment script to include both jormungandr and http-bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,12 @@ git:
 
 env:
   global:
-    - WALLET_CLI=$HOME/.local/bin/cardano-wallet
-    - WALLET_CLI_CHECKSUM=$HOME/.local/bin/cardano-wallet.sha256
+    - WALLET_CLI_JORMUNGANDR=$HOME/.local/bin/cardano-wallet-jormungandr
+    - WALLET_CLI_JORMUNGANDR_CHECKSUM=$HOME/.local/bin/cardano-wallet-jormungandr.sha256
+    - WALLET_CLI_JORMUNGANDR_TARGZ=$HOME/.local/bin/cardano-wallet-jormungandr.tar.gz
+    - WALLET_CLI_HTTP_BRIDGE=$HOME/.local/bin/cardano-wallet-http-bridge
+    - WALLET_CLI_HTTP_BRIDGE_CHECKSUM=$HOME/.local/bin/cardano-wallet-http-bridge.sha256
+    - WALLET_CLI_HTTP_BRIDGE_TARGZ=$HOME/.local/bin/cardano-wallet-http-bridge.tar.gz
     - STACK_WORK_CACHE=$HOME/.stack/stack-work.tar.gz
     - PATH=$PATH:$HOME/.local/bin
     - LOCAL_MIX_DIR=.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/hpc/
@@ -223,11 +227,24 @@ jobs:
     if: tag =~ ^v
     name: "Executables"
     script:
-    # Create binaries and checksums
+    # Create optimized binaries and checksums
+    - stack clean
+    - stack --no-terminal build
     - stack --no-terminal install
-    - sha256sum $WALLET_CLI | head -c 64 > $WALLET_CLI_CHECKSUM
-    - ls $WALLET_CLI
-    - ls $WALLET_CLI_CHECKSUM
+
+    # Bundle cardano-wallet-jormungandr
+    - cp $WALLET_CLI_JORMUNGANDR cardano-wallet
+    - tar czf $WALLET_CLI_JORMUNGANDR_TARGZ cardano-wallet
+    - sha256sum $WALLET_CLI_JORMUNGANDR | head -c 64 > $WALLET_CLI_JORMUNGANDR_CHECKSUM
+    - ls $WALLET_CLI_JORMUNGANDR_TARGZ
+    - ls $WALLET_CLI_JORMUNGANDR_CHECKSUM
+
+    # Bundle cardano-wallet-http-bridge
+    - cp $WALLET_CLI_HTTP_BRIDGE cardano-wallet
+    - tar czf $WALLET_CLI_HTTP_BRIDGE_TARGZ cardano-wallet
+    - sha256sum $WALLET_CLI_HTTP_BRIDGE | head -c 64 > $WALLET_CLI_HTTP_BRIDGE_CHECKSUM
+    - ls $WALLET_CLI_HTTP_BRIDGE_TARGZ
+    - ls $WALLET_CLI_HTTP_BRIDGE_CHECKSUM
 
     # Deploy documentation snapshot
     - mkdir -p haddock/$TRAVIS_TAG api/$TRAVIS_TAG
@@ -236,15 +253,17 @@ jobs:
     - git checkout --orphan gh-pages-deploy && git reset
     - git add api haddock && git commit -m $TRAVIS_COMMIT
     - git checkout gh-pages && git merge -X theirs --no-commit --no-ff --allow-unrelated-histories - && git commit --allow-empty --no-edit
-    - git push -f -q https://WilliamKingNoel-Bot:$GITHUB_ACCESS_TOKEN@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null
+    - travis_retry git push -f -q https://WilliamKingNoel-Bot:$GITHUB_ACCESS_TOKEN@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null
     deploy:
       provider: releases
       api_key: $GITHUB_ACCESS_TOKEN
       draft: true # Allow editing the release before publishing it officially on GitHub
       skip_cleanup: true # Make sure that files from the previous stages aren't cleaned up
       file:
-        - $WALLET_CLI
-        - $WALLET_CLI_CHECKSUM
+        - $WALLET_CLI_JORMUNGANDR_TARGZ
+        - $WALLET_CLI_JORMUNGANDR_CHECKSUM
+        - $WALLET_CLI_HTTP_BRIDGE_TARGZ
+        - $WALLET_CLI_HTTP_BRIDGE_CHECKSUM
       on:
         repo: input-output-hk/cardano-wallet
         branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,9 +180,7 @@ jobs:
     script:
     - travis_retry curl -L -o hermes-testnet.tar.gz https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/lib/http-bridge/test/data/cardano-http-bridge/hermes-testnet.tar.gz
     - tar xzf hermes-testnet.tar.gz -C $HOME
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-core cardano-wallet-cli cardano-wallet-launcher bech32 text-class
-    - travis_wait 30 stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge
-    - travis_wait 30 stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr
+    - travis_wait 45 stack --no-terminal test --fast --haddock --no-haddock-deps --coverage --jobs 1
     - find . -path *.tix ! -path *.stack-work*
     - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work lib/**/*.tix
 

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,8 @@ in {
   inherit cardano-http-bridge cardano-sl-node jormungandr;
   inherit (haskellPackages.cardano-wallet.identifier) version;
 
-  cardano-wallet = haskellPackages.cardano-wallet.components.exes.cardano-wallet;
+  cardano-wallet-http-bridge = haskellPackages.cardano-wallet.components.exes.cardano-wallet-http-bridge;
+  cardano-wallet-jormungandr = haskellPackages.cardano-wallet.components.exes.cardano-wallet-jormungandr;
   tests = collectComponents "tests" isCardanoWallet haskellPackages;
   benchmarks = collectComponents "benchmarks" isCardanoWallet haskellPackages;
 
@@ -40,6 +41,7 @@ in {
       cardano-wallet-cli
       cardano-wallet-core
       cardano-wallet-http-bridge
+      cardano-wallet-jormungandr
       bech32
       text-class
     ];

--- a/default.nix
+++ b/default.nix
@@ -29,8 +29,10 @@ in {
   inherit cardano-http-bridge cardano-sl-node jormungandr;
   inherit (haskellPackages.cardano-wallet.identifier) version;
 
-  cardano-wallet-http-bridge = haskellPackages.cardano-wallet.components.exes.cardano-wallet-http-bridge;
-  cardano-wallet-jormungandr = haskellPackages.cardano-wallet.components.exes.cardano-wallet-jormungandr;
+  inherit (haskellPackages.cardano-wallet.components.exes)
+    cardano-wallet-http-bridge
+    cardano-wallet-jormungandr;
+
   tests = collectComponents "tests" isCardanoWallet haskellPackages;
   benchmarks = collectComponents "benchmarks" isCardanoWallet haskellPackages;
 
@@ -39,6 +41,7 @@ in {
     packages = ps: with ps; [
       cardano-wallet
       cardano-wallet-cli
+      cardano-wallet-launcher
       cardano-wallet-core
       cardano-wallet-http-bridge
       cardano-wallet-jormungandr

--- a/release.nix
+++ b/release.nix
@@ -27,14 +27,16 @@ let
   // {
     # This aggregate job is what IOHK Hydra uses to update
     # the CI status in GitHub.
-    required = mkRequiredJob
+    required = mkRequiredJob (
       # fixme: fix failing tests
       # collectTests jobs.native.tests ++
-      # fixme: haskell.nix benchmarks builder is not working
-      # collectTests jobs.native.benchmarks ++
-      [ jobs.native.cardano-wallet.x86_64-linux
-        jobs.native.cardano-wallet.x86_64-darwin
-      ];
+      collectTests jobs.native.benchmarks ++
+      [ jobs.native.cardano-wallet-http-bridge.x86_64-linux
+        jobs.native.cardano-wallet-http-bridge.x86_64-darwin
+        jobs.native.cardano-wallet-jormungandr.x86_64-linux
+        jobs.native.cardano-wallet-jormungandr.x86_64-darwin
+      ]
+    );
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#357 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have adjusted the deployment scripts to also deploy an executable for jormungandr
- [x] I added a `travis_retry` pragma when doing `git push` to gh-pages as I noticed this one sometimes fail (the push is rather big, and sometimes github timeouts it seems...), retrying shortly after does work it seems.
- [x] I added an extra `stack clean` to re-compile the binaries properly without `--fast` which caused optimizations to be turned off otherwise (`-O0`).
- [x] I have wrapped the binaries into `tar.gz` archives. This has two benefits:
    - We can rename both binaries to `cardano-wallet` such that it's less annoying to use. Users just pick the archives they're interested in.
    - If we export raw binaries to Github, the executable permissions are removed on the files which forces users to `chmod +x` after downloading the files. Putting them in an archive doesn't remove the initial file permission.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
