### PR TITLE
show default size for mnemonic --size using 'ToText' instance

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -618,7 +618,7 @@ sizeOption = optionT $ mempty
     <> metavar "INT"
     <> help "number of mnemonic words to generate."
     <> value MS_15
-    <> showDefaultWith show
+    <> showDefaultWith showT
 
 -- | --state-dir=FILEPATH
 stateDirOption :: Parser FilePath


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#357 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have used 'showT' instead of 'show' to get a correct output for the default size

# Comments

<!-- Additional comments or screenshots to attach if any -->

Before:

```
Usage: cardano-wallet mnemonic generate [--size INT]
  Generate English BIP-0039 compatible mnemonic words.

Available options:
  -h,--help                Show this help text
  --size INT               number of mnemonic words to generate. (default: MS_15)
```

After:

```
Usage: cardano-wallet-http-bridge mnemonic generate [--size INT]
  Generate English BIP-0039 compatible mnemonic words.

Available options:
  -h,--help                Show this help text
  --size INT               number of mnemonic words to generate. (default: 15)
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
