### PR TITLE
WIP: Pass verbosity options to the `jormungandr` command.

### DIFF
--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -223,6 +223,7 @@ cmdLaunch = command "launch" $ info (helper <*> cmd) $ mempty
               [ [ "--genesis-block", block0 ]
               , [ "--config", nodeConfig ]
               , [ "--secret", bftLeaders ]
+              , verbosityToArgs verbosity
               ]
 
         commandWalletServe cmdName stateDir block0H =


### PR DESCRIPTION
# Issue Number

#357 

# Overview

:warning: Only merge this once input-output-hk/jormungandr#622 has been resolved, and a new local release is available. (The solution presented in input-output-hk/jormungandr#615 was rejected.)

This PR passes verbosity options (`--quiet` and `--verbose`) to the `jormungandr` command.

# Outstanding items

- [ ] Update `.travis.yml` with a new `jormungandr` release, once available.