### PR TITLE
Fall back to supportedCrossSystems

### DIFF
--- a/nix/release-lib.nix
+++ b/nix/release-lib.nix
@@ -71,7 +71,7 @@ in
       let res = builtins.tryEval (
         if isDerivation value then
           value.meta.hydraPlatforms
-            or (supportedMatchesCross (value.meta.platforms or [ "x86_64-linux" ]))
+            or (supportedMatchesCross (value.meta.platforms or supportedCrossSystems))
         else if value.recurseForDerivations or false || value.recurseForRelease or false then
           packagePlatformsCross value
         else


### PR DESCRIPTION
This should allow to set `supportedCrossSystems = [ "x86_64-linux" "x86_64-darwin" ]` to allow cross building on macOS as well.

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have ...


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
