### PR TITLE
Add `ListTransactions` to Api with stub handler (returning [])

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -758,6 +758,7 @@ walletClient =
             = wallets
 
         _postTransaction
+            :<|> _listTransactions
             :<|> _postTransactionFee
             = transactions
     in

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -109,6 +109,7 @@ type PutWalletPassphrase = "wallets"
 
 type Transactions t =
     CreateTransaction t
+    :<|> ListTransactions t
     :<|> PostTransactionFee t
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postTransaction
@@ -118,7 +119,6 @@ type CreateTransaction t = "wallets"
     :> ReqBody '[JSON] (PostTransactionData t)
     :> PostAccepted '[JSON] (ApiTransaction t)
 
-
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postTransactionFee
 type PostTransactionFee t = "wallets"
     :> Capture "walletId" (ApiT WalletId)
@@ -126,6 +126,12 @@ type PostTransactionFee t = "wallets"
     :> "fees"
     :> ReqBody '[JSON] (PostTransactionFeeData t)
     :> PostAccepted '[JSON] ApiFee
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listTransaction
+type ListTransactions t = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "transactions"
+    :> Get '[JSON] [ApiTransaction t]
 
 {-------------------------------------------------------------------------------
                                    Internals

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.Api where
+
+import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiAddress
@@ -19,6 +22,10 @@ import Cardano.Wallet.Primitive.Types
     ( AddressState, WalletId )
 import Data.List.NonEmpty
     ( NonEmpty ((:|)) )
+import Data.Time.Clock
+    ( UTCTime )
+import GHC.TypeLits
+    ( Symbol )
 import Network.HTTP.Media
     ( (//), (/:) )
 import Servant.API
@@ -27,7 +34,9 @@ import Servant.API
     , Accept (..)
     , Capture
     , DeleteNoContent
+    , FromHttpApiData (..)
     , Get
+    , Header
     , JSON
     , NoContent
     , PostAccepted
@@ -35,6 +44,7 @@ import Servant.API
     , PutNoContent
     , QueryParam
     , ReqBody
+    , ToHttpApiData (..)
     )
 
 type Api t = Addresses t :<|> Wallets :<|> Transactions t
@@ -131,6 +141,7 @@ type PostTransactionFee t = "wallets"
 type ListTransactions t = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
+    :> Header "Range" (Iso8601Range "inserted-at")
     :> Get '[JSON] [ApiTransaction t]
 
 {-------------------------------------------------------------------------------
@@ -146,3 +157,30 @@ instance Accept Any where
         [ "application" // "json"
         , "application" // "json" /: ("charset", "utf-8")
         ]
+
+-- | A range of dates in ISO-8601 UTC format without symbols. Meant to be
+-- rendered as a HTTP 'Header', where the 'name' type-parameter renders as a
+-- prefix, e.g.
+--
+-- name 20190227T160329Z-*
+--
+-- 'Nothing' ("*") can be used instead of upper and/or lower boundary.
+--
+-- - `20190227T160329Z-*`: means all transactions after
+--    2019-02-27 T 16:03:29Z (including)
+-- - `*-20190227T160329Z`: means all transactions before 2019-02-27 T 16:03:29Z
+--    (including)
+-- - `*-*`: means all transactions
+-- - `20190227T000000Z-20200227T000000Z`: means all transaction between
+--    2019-02-27 and 2020-02-27, in ascending order.
+-- - `20200227T000000Z-20190227T000000Z`: means all transaction between
+--  2020-02-27 and 2019-02-27, in descending order.
+data Iso8601Range (name :: Symbol)
+    = Iso8601Range (Maybe UTCTime) (Maybe UTCTime)
+    deriving (Show)
+
+instance FromHttpApiData (Iso8601Range (name :: Symbol)) where
+    parseUrlPiece = error "FromHttpApiData Iso8601Range to be implemented"
+
+instance ToHttpApiData (Iso8601Range (name :: Symbol)) where
+    toUrlPiece = error "ToHttpApiData Iso8601Range to be implemented"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -43,7 +43,7 @@ import Cardano.Wallet
     , WalletLayer
     )
 import Cardano.Wallet.Api
-    ( Addresses, Api, Transactions, Wallets )
+    ( Addresses, Api, Iso8601Range, Transactions, Wallets )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiAddress (..)
@@ -409,8 +409,9 @@ createTransaction w (ApiT wid) body = do
 listTransactions
     :: WalletLayer (SeqState t) t
     -> ApiT WalletId
+    -> Maybe (Iso8601Range "inserted-at")
     -> Handler [ApiTransaction t]
-listTransactions _w (ApiT _wid) = do
+listTransactions _w (ApiT _wid) _maybeRange = do
     return []
 
 coerceCoin :: AddressAmount t -> TxOut

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -374,6 +374,7 @@ transactions
     -> Server (Transactions t)
 transactions w =
     createTransaction w
+    :<|> listTransactions w
     :<|> postTransactionFee w
 
 createTransaction
@@ -405,6 +406,13 @@ createTransaction w (ApiT wid) body = do
     coerceTxOut (TxOut addr (Coin c)) =
         AddressAmount (ApiT addr, Proxy @t) (Quantity $ fromIntegral c)
 
+listTransactions
+    :: WalletLayer (SeqState t) t
+    -> ApiT WalletId
+    -> Handler [ApiTransaction t]
+listTransactions _w (ApiT _wid) = do
+    return []
+
 coerceCoin :: AddressAmount t -> TxOut
 coerceCoin (AddressAmount (ApiT addr, _) (Quantity c)) =
     TxOut addr (Coin $ fromIntegral c)
@@ -423,7 +431,6 @@ postTransactionFee w (ApiT wid) body = do
     return ApiFee
         { amount = Quantity (fromIntegral fee)
         }
-
 
 {-------------------------------------------------------------------------------
                                 Error Handling

--- a/lib/core/test/integration/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/API/Transactions.hs
@@ -568,7 +568,7 @@ spec = do
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
     describe "TRANS_CREATE_08 - v2/wallets/{id}/transactions - Methods Not Allowed" $ do
-        let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS", "GET"]
+        let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS"]
         forM_ matrix $ \method -> it (show method) $ \ctx -> do
             w <- emptyWallet ctx
             wDest <- emptyWallet ctx

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -128,7 +128,7 @@ import Servant
     ( (:<|>)
     , (:>)
     , Capture
-    , Header
+    , Header'
     , QueryParam
     , ReqBody
     , StdMethod (..)
@@ -854,7 +854,7 @@ instance HasPath sub => HasPath (ReqBody a b :> sub) where
 instance HasPath sub => HasPath (QueryParam a b :> sub) where
     getPath _ = getPath (Proxy @sub)
 
-instance HasPath sub => HasPath (Header a :> sub) where
+instance HasPath sub => HasPath (Header' opts name ty :> sub) where
     getPath _ = getPath (Proxy @sub)
 
 -- A way to demote 'StdMethod' back to the world of values. Servant provides a

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -125,7 +125,15 @@ import GHC.TypeLits
 import Numeric.Natural
     ( Natural )
 import Servant
-    ( (:<|>), (:>), Capture, QueryParam, ReqBody, StdMethod (..), Verb )
+    ( (:<|>)
+    , (:>)
+    , Capture
+    , Header
+    , QueryParam
+    , ReqBody
+    , StdMethod (..)
+    , Verb
+    )
 import Servant.Swagger.Test
     ( validateEveryToJSON )
 import Test.Aeson.GenericSpecs
@@ -844,6 +852,9 @@ instance HasPath sub => HasPath (ReqBody a b :> sub) where
     getPath _ = getPath (Proxy @sub)
 
 instance HasPath sub => HasPath (QueryParam a b :> sub) where
+    getPath _ = getPath (Proxy @sub)
+
+instance HasPath sub => HasPath (Header a :> sub) where
     getPath _ = getPath (Proxy @sub)
 
 -- A way to demote 'StdMethod' back to the world of values. Servant provides a


### PR DESCRIPTION
# Issue Number

#465 

# Overview

- [x] I have `ListTransactions` to the Api, and a stub handler which returns `[]`.
- [x] I have added a `"Range"` `Header` represented by a new `Iso8601Range "inserted-at"` type
- [x] I fixed the `HasPath` test machinery to work with `Header`s

# Comments

- `Iso8601Range` and its doc comments might be a bit crude, but I _think_ this is approximately how we want it.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->