### PR TITLE
Add `wallet update passphrase` CLI command.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -418,7 +418,7 @@ cmdWalletUpdateName
     :: forall t. (DecodeAddress t, EncodeAddress t)
     => Mod CommandFields (IO ())
 cmdWalletUpdateName = command "name" $ info (helper <*> cmd) $ mempty
-    <> progDesc "Update name of a wallet with specified id."
+    <> progDesc "Update a wallet's name."
   where
     cmd = fmap exec $ WalletUpdateNameArgs
         <$> portOption
@@ -440,7 +440,7 @@ cmdWalletUpdatePassphrase
     :: forall t. (DecodeAddress t, EncodeAddress t)
     => Mod CommandFields (IO ())
 cmdWalletUpdatePassphrase = command "passphrase" $ info (helper <*> cmd) $
-    progDesc "Update passphrase of wallet with specified id."
+    progDesc "Update a wallet's passphrase."
   where
     cmd = fmap exec $ WalletUpdatePassphraseArgs
         <$> portOption

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -255,7 +255,6 @@ runCli = join . customExecParser preferences
   where
     preferences = prefs showHelpOnEmpty
 
-
 {-------------------------------------------------------------------------------
                             Commands - 'mnemonic'
 
@@ -501,7 +500,6 @@ cmdTransactionFees = command "fees" $ info (helper <*> cmd) $ mempty
                     (PostTransactionFeeData wPayments)
             Left _ ->
                 handleResponse Aeson.encodePretty res
-
 
 {-------------------------------------------------------------------------------
                             Commands - 'address'

--- a/lib/core/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/core/test/integration/Test/Integration/Framework/DSL.hs
@@ -94,6 +94,7 @@ module Test.Integration.Framework.DSL
     , listAddressesViaCLI
     , listWalletsViaCLI
     , updateWalletNameViaCLI
+    , updateWalletPassphraseViaCLI
     , postTransactionViaCLI
     , postTransactionFeeViaCLI
     ) where
@@ -901,6 +902,36 @@ updateWalletNameViaCLI
     -> IO r
 updateWalletNameViaCLI ctx args = cardanoWalletCLI @t
     (["wallet", "update", "name", "--port", show (ctx ^. typed @Port)] ++ args)
+
+updateWalletPassphraseViaCLI
+    :: forall t s. (KnownCommand t, HasType Port s)
+    => s
+    -> String
+        -- ^ Wallet id
+    -> String
+        -- ^ Old passphrase
+    -> String
+        -- ^ New passphrase
+    -> String
+        -- ^ New passphrase (repeated for confirmation)
+    -> IO (ExitCode, Text, Text)
+updateWalletPassphraseViaCLI ctx wid ppOld ppNew ppNewConfirm = do
+    let process = proc' (commandName @t)
+            [ "wallet", "update", "passphrase"
+            , "--port", show (ctx ^. typed @Port)
+            , wid
+            ]
+    withCreateProcess process $
+        \(Just stdin) (Just stdout) (Just stderr) h -> do
+            hPutStr stdin (ppOld <> "\n")
+            hPutStr stdin (ppNew <> "\n")
+            hPutStr stdin (ppNewConfirm <> "\n")
+            hFlush stdin
+            hClose stdin
+            c <- waitForProcess h
+            out <- TIO.hGetContents stdout
+            err <- TIO.hGetContents stderr
+            pure (c, out, err)
 
 postTransactionViaCLI
     :: forall t s. (HasType Port s, KnownCommand t)

--- a/lib/core/test/integration/Test/Integration/Framework/DSL.hs
+++ b/lib/core/test/integration/Test/Integration/Framework/DSL.hs
@@ -93,7 +93,7 @@ module Test.Integration.Framework.DSL
     , getWalletViaCLI
     , listAddressesViaCLI
     , listWalletsViaCLI
-    , updateWalletViaCLI
+    , updateWalletNameViaCLI
     , postTransactionViaCLI
     , postTransactionFeeViaCLI
     ) where
@@ -894,13 +894,13 @@ listWalletsViaCLI
 listWalletsViaCLI ctx = cardanoWalletCLI @t
     ["wallet", "list", "--port", show (ctx ^. typed @Port) ]
 
-updateWalletViaCLI
+updateWalletNameViaCLI
     :: forall t r s. (CmdResult r, KnownCommand t, HasType Port s)
     => s
     -> [String]
     -> IO r
-updateWalletViaCLI ctx args = cardanoWalletCLI @t
-    (["wallet", "update", "--port", show (ctx ^. typed @Port)] ++ args)
+updateWalletNameViaCLI ctx args = cardanoWalletCLI @t
+    (["wallet", "update", "name", "--port", show (ctx ^. typed @Port)] ++ args)
 
 postTransactionViaCLI
     :: forall t s. (HasType Port s, KnownCommand t)

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Port.hs
@@ -46,7 +46,7 @@ import Test.Integration.Framework.DSL
     , listWalletsViaCLI
     , postTransactionViaCLI
     , proc'
-    , updateWalletViaCLI
+    , updateWalletNameViaCLI
     )
 
 import qualified Data.Text as T
@@ -114,7 +114,7 @@ specCommon = do
         let ctx' = over (typed @Port) (+1) ctx
         let wid = replicate 40 '0'
         (_ :: ExitCode, Stdout (_ :: String), Stderr err) <-
-            updateWalletViaCLI @t ctx' [wid, "--name", "My Wallet"]
+            updateWalletNameViaCLI @t ctx' [wid, "My Wallet"]
         err `shouldContain` errConnectionRefused
 
     it "PORT_01 - Can't reach server with wrong port (transction create)" $ \ctx -> do
@@ -176,7 +176,7 @@ specWithDefaultPort = do
     it "PORT_02 - Can omit --port when server uses default port (wallet update)" $ \_ -> do
         let wid = replicate 40 '0'
         (_ :: ExitCode, Stdout (_ :: String), Stderr err) <-
-            cardanoWalletCLI @t ["wallet", "update", wid, "--name", "My Wallet"]
+            cardanoWalletCLI @t ["wallet", "update", "name", wid, "My Wallet"]
         err `shouldNotContain` errConnectionRefused
 
     it "PORT_02 - Can omit --port when server uses default port (transaction create)" $ \_ -> do
@@ -247,7 +247,7 @@ specWithRandomPort defaultPort = do
     it "PORT_03 - Cannot omit --port when server uses random port (wallet update)" $ \_ -> do
         let wid = replicate 40 '0'
         (_ :: ExitCode, Stdout (_ :: String), Stderr err) <-
-            cardanoWalletCLI @t ["wallet", "update", wid, "--name", "My Wallet"]
+            cardanoWalletCLI @t ["wallet", "update", "name", wid, "My Wallet"]
         err `shouldContain` errConnectionRefused
 
     it "PORT_03 - Cannot omit --port when server uses random port (transaction create)" $ \_ -> do

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -104,7 +104,7 @@ spec = do
 
         -- post transaction
         (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
-        err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
+        err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
             [ expectCliFieldBetween amount (feeMin + amt, feeMax + amt)
@@ -156,7 +156,7 @@ spec = do
 
         -- post transaction
         (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
-        err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
+        err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
             [ expectCliFieldBetween amount (feeMin + (2*amt), feeMax + (2*amt))
@@ -210,7 +210,7 @@ spec = do
 
         -- post transaction
         (c, out, err) <- postTransactionViaCLI @t ctx "cardano-wallet" args
-        err `shouldBe` "Please enter a passphrase: **************\nOk.\n"
+        err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
             [ expectCliFieldBetween amount (feeMin + (2*amt), feeMax + (2*amt))
@@ -276,7 +276,7 @@ spec = do
                 ]
 
         (c, out, err) <- postTransactionViaCLI @t ctx "Secure Passphrase" args
-        err `shouldBe` "Please enter a passphrase: *****************\nOk.\n"
+        err `shouldBe` "Please enter your passphrase: *****************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction t)) out
         verify txJson
             [ expectCliFieldEqual amount (feeMin+amt)

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
@@ -60,7 +60,7 @@ import Test.Integration.Framework.DSL
     , passphraseLastUpdate
     , postTransactionViaCLI
     , state
-    , updateWalletViaCLI
+    , updateWalletNameViaCLI
     , verify
     , walletId
     , walletName
@@ -372,11 +372,12 @@ spec = do
             , expectCliListItemFieldEqual 2 walletId (T.pack w3)
             ]
 
-    describe "WALLETS_UPDATE_01,02 - Can update wallet name" $ do
+    describe "WALLETS_UPDATE_NAME_01,02 - Can update wallet name" $ do
         forM_ walletNames $ \(title, n) -> it title $ \ctx -> do
             wid <- emptyWallet' ctx
-            let args = [wid, "--name", n]
-            (Exit c, Stdout out, Stderr err) <- updateWalletViaCLI @t ctx args
+            let args = [wid, n]
+            (Exit c, Stdout out, Stderr err) <-
+                updateWalletNameViaCLI @t ctx args
             c `shouldBe` ExitSuccess
             err `shouldBe` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) out


### PR DESCRIPTION
# Issue Number

#472 

# Overview

We now have:

<pre>
<b>$ cardano-wallet wallet update --help</b>
Usage: cardano-wallet wallet update COMMAND
  Update a wallet.

Available commands:
  <b>name</b>         Update a wallet's name.
  <b>passphrase</b>   Update a wallet's passphrase.
</pre>
and
<pre>
<b>$ cardano-wallet wallet update passphrase --help</b>
Usage: cardano-wallet wallet update passphrase [--port INT] WALLET_ID
  Update a wallet's passphrase.

Available options:
  -h,--help                Show this help text
  --port INT               port used for serving the wallet API. (default: 8090)
</pre>
This PR:

- [x] Generalizes functions `getPassphrase` and `getPassphraseWithConfirm` to work with different prompts. For example:
     * "Please enter a new passphrase:"
     * "Please enter your current passphrase:"
- [x] Generalizes functions `getPassphrase` and `getPassphraseWithConfirm` to return different **types** of passphrases. We need to be able to return:
    * `Passphrase "encryption"`
    * `Passphrase "encryption-old"`
    * `Passphrase "encryption-new"`
- [x] Adjusts the _structure_ of the CLI so that updating a wallet's name and updating a wallet's passphrase fall **under the same command group.**
- [x] Adds a command `cmdWalletUpdatePassphrase` to update a wallet's passphrase, along with an associated data type `WalletUpdatePassphraseArgs`.
- [x] Adds integration tests to confirm that it's possible to update a passphrase via the CLI.
- [x] Adds integration tests to confirm that it's not possible to update a passphrase via the CLI if:
    * The new passphrase is too short.
    * The new passphrase is not confirmed correctly.
    * The old passphrase is not entered correctly.
