### PR TITLE
Fix coin selection max number of inputs not diminishing as expected

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -153,6 +153,22 @@ spec = do
                 , txOutputs = 41 :| [6]
                 }
 
+        coinSelectionUnitTest largestFirst "each output needs <maxNumOfInputs"
+            (Left $ ErrMaximumInputsReached 9)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 9
+                , utxoInputs = replicate 100 1
+                , txOutputs = NE.fromList (replicate 100 1)
+                })
+
+        coinSelectionUnitTest largestFirst "each output needs >maxNumInputs"
+            (Left $ ErrMaximumInputsReached 9)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 9
+                , utxoInputs = replicate 100 1
+                , txOutputs = NE.fromList (replicate 10 10)
+                })
+
         coinSelectionUnitTest
             largestFirst
             "enough coins but, strict maximumNumberOfInputs"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -38,12 +38,11 @@ import Test.QuickCheck
     ( Property, property, (===), (==>) )
 
 import qualified Data.List as L
-
+import qualified Data.List.NonEmpty as NE
 
 spec :: Spec
 spec = do
     describe "Coin selection : random algorithm unit tests" $ do
-
         let oneAda = 1000000
 
         coinSelectionUnitTest random ""
@@ -151,12 +150,29 @@ spec = do
                 , txOutputs = 38 :| [1]
                 })
 
-        coinSelectionUnitTest random "" (Left $ ErrMaximumInputsReached 2) $
-            CoinSelectionFixture
-            { maxNumOfInputs = 2
-            , utxoInputs = [1,1,1,1,1,1]
-            , txOutputs = 3 :| []
-            }
+        coinSelectionUnitTest random ""
+            (Left $ ErrMaximumInputsReached 2)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 2
+                , utxoInputs = [1,1,1,1,1,1]
+                , txOutputs = 3 :| []
+                })
+
+        coinSelectionUnitTest random "each output needs <maxNumOfInputs"
+            (Left $ ErrMaximumInputsReached 9)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 9
+                , utxoInputs = replicate 100 1
+                , txOutputs = NE.fromList (replicate 100 1)
+                })
+
+        coinSelectionUnitTest random "each output needs >maxNumInputs"
+            (Left $ ErrMaximumInputsReached 9)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 9
+                , utxoInputs = replicate 100 1
+                , txOutputs = NE.fromList (replicate 10 10)
+                })
 
         coinSelectionUnitTest random "" (Left $ ErrNotEnoughMoney 39 40) $
             CoinSelectionFixture


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#522 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added regression tests to both `largestFirst` and `random` selection.
- [x] I have moved the `CoinSelectionOption` to be part of the fold accumulator, so that it can be updated between each output 
- [x] I have slightly adjusted the `improve` part so that it will also behave accordingly. 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
