### PR TITLE
DBLayer readTxHistory now returns a sorted list

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -594,7 +594,7 @@ newWalletLayer tracer block0 feePolicy db nw tl = do
                 then Just a
                 else Nothing
         let usedAddrs =
-                Set.fromList $ concatMap (mapMaybe maybeIsOurs . outputs') txs
+                Set.fromList $ concatMap (mapMaybe maybeIsOurs . outputs' . snd) txs
               where outputs' (tx, _) = W.outputs @t tx
         let knownAddrs =
                 L.sortBy (compareDiscovery s) (knownAddresses s)

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -102,10 +102,11 @@ data DBLayer m s t = DBLayer
 
     , readTxHistory
         :: PrimaryKey WalletId
-        -> m (Map (Hash "Tx") (Tx t, TxMeta))
-        -- ^ Fetch the current transaction history of a known wallet.
+        -> m [(Hash "Tx", (Tx t, TxMeta))]
+        -- ^ Fetch the current transaction history of a known wallet, ordered by
+        -- descending slot number.
         --
-        -- Returns an empty map if the wallet isn't found.
+        -- Returns an empty list if the wallet isn't found.
 
     , putPrivateKey
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -40,6 +40,8 @@ import Data.List
     ( sortOn )
 import Data.Map.Strict
     ( Map )
+import Data.Ord
+    ( Down (..) )
 
 import qualified Data.Map.Strict as Map
 
@@ -124,8 +126,8 @@ newDBLayer = do
             txs' `deepseq` alterMVar db alter key
 
         , readTxHistory = \key -> let
-                sortedTxHistory = reverse . sortOn slot . Map.toList . txHistory
-                slot = slotId . snd . snd
+                sortedTxHistory = sortOn slot . Map.toList . txHistory
+                slot = Down . slotId . snd . snd
             in maybe mempty sortedTxHistory . Map.lookup key <$> readMVar db
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Hash, Tx, TxMeta, WalletId, WalletMetadata )
+    ( Hash, Tx, TxMeta (slotId), WalletId, WalletMetadata )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, readMVar, withMVar )
 import Control.DeepSeq
@@ -36,6 +36,8 @@ import Control.Monad
     ( (>=>) )
 import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
+import Data.List
+    ( sortOn )
 import Data.Map.Strict
     ( Map )
 
@@ -121,8 +123,10 @@ newDBLayer = do
                         Right $ Just $ Database cp meta (txs' <> txs) k
             txs' `deepseq` alterMVar db alter key
 
-        , readTxHistory = \key ->
-            maybe mempty txHistory . Map.lookup key <$> readMVar db
+        , readTxHistory = \key -> let
+                sortedTxHistory = reverse . sortOn slot . Map.toList . txHistory
+                slot = slotId . snd . snd
+            in maybe mempty sortedTxHistory . Map.lookup key <$> readMVar db
 
         {-----------------------------------------------------------------------
                                        Keystore

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -131,9 +131,9 @@ spec =  do
         it "put and read tx history" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)
             unsafeRunExceptT $ createWallet db testWid testCp testMetadata
-            unsafeRunExceptT $ putTxHistory db testWid testTxs
+            unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
             destroyDBLayer ctx
-            testOpeningCleaning f (`readTxHistory` testWid) testTxs Map.empty
+            testOpeningCleaning f (`readTxHistory` testWid) testTxs mempty
 
         it "put and read checkpoint" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)
@@ -295,8 +295,8 @@ testMetadata = WalletMetadata
 testWid :: PrimaryKey WalletId
 testWid = PrimaryKey (WalletId (hash @ByteString "test"))
 
-testTxs :: Map.Map (Hash "Tx") (Tx, TxMeta)
-testTxs = Map.fromList
+testTxs :: [(Hash "Tx", (Tx, TxMeta))]
+testTxs =
     [ (Hash "tx2", (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
       , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))
       )

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -169,13 +169,15 @@ simpleSpec = do
 
         it "put and read tx history" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
-            runExceptT (putTxHistory db testPk testTxs) `shouldReturn` Right ()
+            runExceptT (putTxHistory db testPk (Map.fromList testTxs))
+                `shouldReturn` Right ()
             readTxHistory db testPk `shouldReturn` testTxs
 
         it "put and read tx history - regression case" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             unsafeRunExceptT $ createWallet db testPk1 testCp testMetadata
-            runExceptT (putTxHistory db testPk1 testTxs) `shouldReturn` Right ()
+            runExceptT (putTxHistory db testPk1 (Map.fromList testTxs))
+                `shouldReturn` Right ()
             runExceptT (removeWallet db testPk) `shouldReturn` Right ()
             readTxHistory db testPk1 `shouldReturn` testTxs
 
@@ -339,8 +341,8 @@ testPk = PrimaryKey testWid
 testPk1 :: PrimaryKey WalletId
 testPk1 = PrimaryKey testWid1
 
-testTxs :: Map.Map (Hash "Tx") (Tx, TxMeta)
-testTxs = Map.fromList
+testTxs :: [(Hash "Tx", (Tx, TxMeta))]
+testTxs =
     [ (Hash "tx2"
       , (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
         , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))) ]

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -102,6 +102,8 @@ import Data.Functor
     ( ($>) )
 import Data.Functor.Identity
     ( Identity (..) )
+import Data.Ord
+    ( Down (..) )
 import Data.Quantity
     ( Percentage, Quantity (..), mkPercentage )
 import Data.Typeable
@@ -191,7 +193,7 @@ type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
 
 -- | Apply the default sort order (descending on time) to a 'TxHistory'.
 sortTxHistory :: TxHistory -> TxHistory
-sortTxHistory = reverse . L.sortOn (slotId . snd . snd)
+sortTxHistory = L.sortOn (Down . slotId . snd . snd)
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.DBSpec
     , GenTxHistory (..)
     , KeyValPairs (..)
     , TxHistory
+    , sortTxHistory
     ) where
 
 import Prelude
@@ -101,8 +102,6 @@ import Data.Functor
     ( ($>) )
 import Data.Functor.Identity
     ( Identity (..) )
-import Data.Map.Strict
-    ( Map )
 import Data.Quantity
     ( Percentage, Quantity (..), mkPercentage )
 import Data.Typeable
@@ -154,7 +153,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 spec :: Spec
 spec = return ()
@@ -174,6 +172,12 @@ unions =
     . Map.elems
     . foldl (\m (k, v) -> Map.unionWith (<>) (Map.fromList [(k, v)]) m) mempty
 
+-- | Keep the unions (right-biased) of all transactions, and sort them in the
+-- default order for readTxHistory.
+sortedUnions :: Ord k => [(k, GenTxHistory)] -> [Identity GenTxHistory]
+sortedUnions = map (Identity . sort' . runIdentity) . unions
+    where sort' = GenTxHistory . sortTxHistory . unGenTxHistory
+
 -- | Execute an action once per key @k@ present in the given list
 once :: (Ord k, Monad m) => [(k,v)] -> ((k,v) -> m a) -> m [a]
 once xs = forM (Map.toList (Map.fromList xs))
@@ -182,7 +186,12 @@ once xs = forM (Map.toList (Map.fromList xs))
 once_ :: (Ord k, Monad m) => [(k,v)] -> ((k,v) -> m a) -> m ()
 once_ xs = void . once xs
 
-type TxHistory = Map (Hash "Tx") (Tx, TxMeta)
+-- | Shorthand for the readTxHistory result type.
+type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
+
+-- | Apply the default sort order (descending on time) to a 'TxHistory'.
+sortTxHistory :: TxHistory -> TxHistory
+sortTxHistory = reverse . L.sortOn (slotId . snd . snd)
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)
@@ -328,25 +337,15 @@ newtype GenTxHistory = GenTxHistory { unGenTxHistory :: TxHistory }
     deriving newtype (Semigroup, Monoid)
 
 instance Arbitrary GenTxHistory where
-    shrink (GenTxHistory h) = map GenTxHistory (shrinkKeys h ++ shrinkTx h)
+    shrink (GenTxHistory h) = map GenTxHistory (shrinkList shrinkOneTx h)
       where
-        -- remove keys from the map
-        shrinkKeys :: TxHistory -> [TxHistory]
-        shrinkKeys txs =
-            [ Map.restrictKeys txs (Set.fromList ks)
-            | ks <- shrinkList (const []) (Map.keys txs) ]
-        -- make the transactions smaller
-        shrinkTx :: TxHistory -> [TxHistory]
-        shrinkTx txs =
-            [ Map.fromList [(k, v') | v' <- shrinkOneTx v]
-            | (k, v) <- Map.toList txs ]
-        shrinkOneTx :: (Tx, TxMeta) -> [(Tx, TxMeta)]
-        shrinkOneTx (tx, meta) =
-            [(tx', meta) | tx' <- shrink tx]
+        shrinkOneTx :: (Hash "Tx", (Tx, TxMeta)) -> [(Hash "Tx", (Tx, TxMeta))]
+        shrinkOneTx (txid, (tx, meta)) =
+            [(txid, (tx', meta)) | tx' <- shrink tx]
 
     -- Ensure unique transaction IDs within a given batch of transactions to add
     -- to the history.
-    arbitrary = GenTxHistory . Map.fromList <$> do
+    arbitrary = GenTxHistory . sortTxHistory <$> do
         -- NOTE
         -- We discard pending transaction from any 'GenTxHistory since,
         -- inserting a pending transaction actually has an effect on the
@@ -420,7 +419,7 @@ putTxHistoryF
     -> GenTxHistory
     -> ExceptT ErrNoSuchWallet m ()
 putTxHistoryF db wid =
-    putTxHistory db wid . unGenTxHistory
+    putTxHistory db wid . Map.fromList . unGenTxHistory
 
 
 {-------------------------------------------------------------------------------
@@ -571,7 +570,7 @@ prop_isolation putA readB readC readD db (key, a) =
         liftIO (cleanDB db)
         (cp, meta, GenTxHistory txs) <- pick arbitrary
         liftIO $ unsafeRunExceptT $ createWallet db key cp meta
-        liftIO $ unsafeRunExceptT $ putTxHistory db key txs
+        liftIO $ unsafeRunExceptT $ putTxHistory db key (Map.fromList txs)
         (b, c, d) <- liftIO $ (,,)
             <$> readB db key
             <*> readC db key
@@ -747,7 +746,7 @@ dbPropertyTests = do
         it "Wallet Metadata"
             (checkCoverage . (prop_sequentialPut putWalletMeta readWalletMeta lrp))
         it "Tx History"
-            (checkCoverage . (prop_sequentialPut putTxHistoryF readTxHistoryF unions))
+            (checkCoverage . (prop_sequentialPut putTxHistoryF readTxHistoryF sortedUnions))
         it "Private Key"
             (checkCoverage . (prop_sequentialPut putPrivateKey readPrivateKey lrp))
 
@@ -760,7 +759,7 @@ dbPropertyTests = do
                 (length . lrp @Maybe)))
         it "Tx History"
             (checkCoverage . (prop_parallelPut putTxHistoryF readTxHistoryF
-                (length . unions @GenTxHistory)))
+                (length . sortedUnions)))
         it "Private Key"
             (checkCoverage . (prop_parallelPut putPrivateKey readPrivateKey
                 (length . lrp @Maybe)))


### PR DESCRIPTION
Relates to #465

# Overview

- Adjusts the DBLayer readTxHistory function to return transactions in descending order by slot.
