### PR TITLE
Jormungandr.NetworkSpec: Add more error path tests

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -21,9 +21,12 @@ module Cardano.Wallet.Jormungandr.Network
     , JormungandrLayer (..)
     , mkJormungandrLayer
 
-    -- * Exception
+    -- * Exceptions
     , ErrUnexpectedNetworkFailure (..)
+
+    -- * Errors
     , ErrGetInitialFeePolicy (..)
+    , ErrGetDescendants (..)
 
     -- * Re-export
     , BaseUrl (..)

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -18,7 +18,11 @@ import Cardano.Wallet.Jormungandr.Api
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, Network (..), block0 )
 import Cardano.Wallet.Jormungandr.Network
-    ( BaseUrl (..), ErrUnexpectedNetworkFailure (..), Scheme (..) )
+    ( BaseUrl (..)
+    , ErrGetDescendants (..)
+    , ErrUnexpectedNetworkFailure (..)
+    , Scheme (..)
+    )
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Network
@@ -55,7 +59,7 @@ import Control.Monad.Trans.Except
 import Control.Retry
     ( limitRetries, retrying )
 import Data.Either
-    ( isLeft, isRight )
+    ( isRight )
 import Data.Functor
     ( ($>) )
 import Data.Proxy
@@ -181,7 +185,11 @@ spec = do
             let jml = Jormungandr.mkJormungandrLayer mgr url
             let nonexistent = Hash "cat"
             res <- runExceptT (Jormungandr.getDescendantIds jml nonexistent 42)
-            res `shouldSatisfy` isLeft
+            res `shouldSatisfy` \case
+                Left (ErrGetDescendantsParentNotFound _) -> True
+                Left (ErrGetDescendantsNetworkUnreachable _) -> False
+                Right _ -> False
+
 
     -- NOTE: 'Right ()' just means that the format wasn't obviously wrong.
     -- The tx may still be rejected.


### PR DESCRIPTION
Relates to #460

# Overview

Adds a couple tests abusing the jormungandr node API.
