### PR TITLE
Introduce `Iso8601Time` type to support `translation list` CLI command.

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -41,7 +41,6 @@ library
     , fmt
     , http-client
     , iohk-monitoring
-    , iso8601-time
     , servant-client
     , servant-client-core
     , servant-server

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -41,11 +41,13 @@ library
     , fmt
     , http-client
     , iohk-monitoring
+    , iso8601-time
     , servant-client
     , servant-client-core
     , servant-server
     , text
     , text-class
+    , time
     , optparse-applicative
   hs-source-dirs:
       src
@@ -70,6 +72,7 @@ test-suite unit
     , cardano-wallet-cli
     , hspec
     , QuickCheck
+    , quickcheck-instances
     , text
     , text-class
   build-tools:

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -43,6 +43,7 @@ module Cardano.CLI
     , verbosityOption
 
     -- * Types
+    , Iso8601Time (..)
     , Service
     , MnemonicSize (..)
     , Port (..)
@@ -155,6 +156,10 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..), showT )
 import Data.Text.Read
     ( decimal )
+import Data.Time.Clock
+    ( UTCTime )
+import Data.Time.ISO8601
+    ( formatISO8601, parseISO8601 )
 import Fmt
     ( Buildable, blockListF, fmt, nameF, pretty )
 import GHC.Generics
@@ -862,6 +867,22 @@ handleResponse encode res = do
 {-------------------------------------------------------------------------------
                                 Extra Types
 -------------------------------------------------------------------------------}
+
+-- | Defines a point in time that can be formatted as and parsed from an
+--   ISO 8601-compliant string.
+--
+newtype Iso8601Time = Iso8601Time
+    { getIso8601Time :: UTCTime
+    } deriving (Eq, Ord, Show)
+
+instance ToText Iso8601Time where
+    toText = T.pack . formatISO8601 . getIso8601Time
+
+instance FromText Iso8601Time where
+    fromText = maybe (Left err) (Right . Iso8601Time) . parseISO8601 . T.unpack
+      where
+        err = TextDecodingError
+            "Unable to parse time argument. Expecting ISO 8601 format."
 
 -- | Represents the number of words in a mnemonic sentence.
 --

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -62,48 +62,88 @@ spec = do
         textRoundtrip $ Proxy @MnemonicSize
 
     describe "Can decode valid ISO 8601 strings" $ do
-        describe "UTC+0 timezone (Z)" $ do
-            canDecodeValidIso8601Time "2008-09-15T15:53:00Z"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.1Z"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.12Z"
-        describe "UTC+0 timezone (manually specified)" $ do
-            canDecodeValidIso8601Time "2008-09-15T15:53:00+00:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.1+00:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.12+00:00"
-        describe "UTC+8 timezone (manually specified)" $ do
-            canDecodeValidIso8601Time "2008-09-15T15:53:00+08:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.1+08:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.12+08:00"
-        describe "UTC-8 timezone (manually specified)" $ do
-            canDecodeValidIso8601Time "2008-09-15T15:53:00-08:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.1-08:00"
-            canDecodeValidIso8601Time "2008-09-15T15:53:00.12-08:00"
+        describe "Basic format" $ do
+            describe "UTC+0 timezone (Z)" $ do
+                canDecodeValidIso8601Time "20080915T155300Z"
+                canDecodeValidIso8601Time "20080915T155300.1Z"
+                canDecodeValidIso8601Time "20080915T155300.12Z"
+            describe "UTC+0 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "20080915T155300+0000"
+                canDecodeValidIso8601Time "20080915T155300.1+0000"
+                canDecodeValidIso8601Time "20080915T155300.12+0000"
+            describe "UTC+8 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "20080915T155300+0800"
+                canDecodeValidIso8601Time "20080915T155300.1+0800"
+                canDecodeValidIso8601Time "20080915T155300.12+0800"
+            describe "UTC-8 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "20080915T155300-0800"
+                canDecodeValidIso8601Time "20080915T155300.1-0800"
+                canDecodeValidIso8601Time "20080915T155300.12-0800"
+        describe "Extended format" $ do
+            describe "UTC+0 timezone (Z)" $ do
+                canDecodeValidIso8601Time "2008-09-15T15:53:00Z"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.1Z"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.12Z"
+            describe "UTC+0 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "2008-09-15T15:53:00+00:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.1+00:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.12+00:00"
+            describe "UTC+8 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "2008-09-15T15:53:00+08:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.1+08:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.12+08:00"
+            describe "UTC-8 timezone (manually specified)" $ do
+                canDecodeValidIso8601Time "2008-09-15T15:53:00-08:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.1-08:00"
+                canDecodeValidIso8601Time "2008-09-15T15:53:00.12-08:00"
 
     describe "Cannot decode invalid ISO 8601 strings" $ do
         describe "Strings that are not time values" $ do
             cannotDecodeInvalidIso8601Time ""
             cannotDecodeInvalidIso8601Time "w"
             cannotDecodeInvalidIso8601Time "wibble"
-        describe "Dates without times" $ do
-            cannotDecodeInvalidIso8601Time "2008"
-            cannotDecodeInvalidIso8601Time "2008-09"
-            cannotDecodeInvalidIso8601Time "2008-09-15"
-        describe "Missing timezones" $ do
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00"
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1"
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12"
-        describe "Invalid timezone characters" $ do
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00A"
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1A"
-            cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12A"
-        describe "Invalid date-time separators" $ do
-            cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00Z"
-            cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.1Z"
-            cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.12Z"
-        describe "Missing date-time separators" $ do
-            cannotDecodeInvalidIso8601Time "2008-09-1515:53:00Z"
-            cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.1Z"
-            cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.12Z"
+        describe "Basic format" $ do
+            describe "Dates without times" $ do
+                cannotDecodeInvalidIso8601Time "2008"
+                cannotDecodeInvalidIso8601Time "200809"
+                cannotDecodeInvalidIso8601Time "20080915"
+            describe "Missing timezones" $ do
+                cannotDecodeInvalidIso8601Time "20080915T155300"
+                cannotDecodeInvalidIso8601Time "20080915T155300.1"
+                cannotDecodeInvalidIso8601Time "20080915T155300.12"
+            describe "Invalid timezone characters" $ do
+                cannotDecodeInvalidIso8601Time "20080915T155300A"
+                cannotDecodeInvalidIso8601Time "20080915T155300.1A"
+                cannotDecodeInvalidIso8601Time "20080915T155300.12A"
+            describe "Invalid date-time separators" $ do
+                cannotDecodeInvalidIso8601Time "20080915S155300Z"
+                cannotDecodeInvalidIso8601Time "20080915S155300.1Z"
+                cannotDecodeInvalidIso8601Time "20080915S155300.12Z"
+            describe "Missing date-time separators" $ do
+                cannotDecodeInvalidIso8601Time "20080915155300Z"
+                cannotDecodeInvalidIso8601Time "20080915155300.1Z"
+                cannotDecodeInvalidIso8601Time "20080915155300.12Z"
+        describe "Extended format" $ do
+            describe "Dates without times" $ do
+                cannotDecodeInvalidIso8601Time "2008"
+                cannotDecodeInvalidIso8601Time "2008-09"
+                cannotDecodeInvalidIso8601Time "2008-09-15"
+            describe "Missing timezones" $ do
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00"
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1"
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12"
+            describe "Invalid timezone characters" $ do
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00A"
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1A"
+                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12A"
+            describe "Invalid date-time separators" $ do
+                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00Z"
+                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.1Z"
+                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.12Z"
+            describe "Missing date-time separators" $ do
+                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00Z"
+                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.1Z"
+                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.12Z"
 
     describe "Port decoding from text" $ do
         let err = TextDecodingError

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -61,89 +61,96 @@ spec = do
         textRoundtrip $ Proxy @(Port "test")
         textRoundtrip $ Proxy @MnemonicSize
 
-    describe "Can decode valid ISO 8601 strings" $ do
-        describe "Basic format" $ do
-            describe "UTC+0 timezone (Z)" $ do
-                canDecodeValidIso8601Time "20080915T155300Z"
-                canDecodeValidIso8601Time "20080915T155300.1Z"
-                canDecodeValidIso8601Time "20080915T155300.12Z"
-            describe "UTC+0 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "20080915T155300+0000"
-                canDecodeValidIso8601Time "20080915T155300.1+0000"
-                canDecodeValidIso8601Time "20080915T155300.12+0000"
-            describe "UTC+8 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "20080915T155300+0800"
-                canDecodeValidIso8601Time "20080915T155300.1+0800"
-                canDecodeValidIso8601Time "20080915T155300.12+0800"
-            describe "UTC-8 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "20080915T155300-0800"
-                canDecodeValidIso8601Time "20080915T155300.1-0800"
-                canDecodeValidIso8601Time "20080915T155300.12-0800"
-        describe "Extended format" $ do
-            describe "UTC+0 timezone (Z)" $ do
-                canDecodeValidIso8601Time "2008-09-15T15:53:00Z"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.1Z"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.12Z"
-            describe "UTC+0 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "2008-09-15T15:53:00+00:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.1+00:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.12+00:00"
-            describe "UTC+8 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "2008-09-15T15:53:00+08:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.1+08:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.12+08:00"
-            describe "UTC-8 timezone (manually specified)" $ do
-                canDecodeValidIso8601Time "2008-09-15T15:53:00-08:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.1-08:00"
-                canDecodeValidIso8601Time "2008-09-15T15:53:00.12-08:00"
+    describe "ISO 8601 encoding of dates and times" $ do
 
-    describe "Cannot decode invalid ISO 8601 strings" $ do
-        describe "Strings that are not time values" $ do
-            cannotDecodeInvalidIso8601Time ""
-            cannotDecodeInvalidIso8601Time "w"
-            cannotDecodeInvalidIso8601Time "wibble"
-        describe "Basic format" $ do
-            describe "Dates without times" $ do
-                cannotDecodeInvalidIso8601Time "2008"
-                cannotDecodeInvalidIso8601Time "200809"
-                cannotDecodeInvalidIso8601Time "20080915"
-            describe "Missing timezones" $ do
-                cannotDecodeInvalidIso8601Time "20080915T155300"
-                cannotDecodeInvalidIso8601Time "20080915T155300.1"
-                cannotDecodeInvalidIso8601Time "20080915T155300.12"
-            describe "Invalid timezone characters" $ do
-                cannotDecodeInvalidIso8601Time "20080915T155300A"
-                cannotDecodeInvalidIso8601Time "20080915T155300.1A"
-                cannotDecodeInvalidIso8601Time "20080915T155300.12A"
-            describe "Invalid date-time separators" $ do
-                cannotDecodeInvalidIso8601Time "20080915S155300Z"
-                cannotDecodeInvalidIso8601Time "20080915S155300.1Z"
-                cannotDecodeInvalidIso8601Time "20080915S155300.12Z"
-            describe "Missing date-time separators" $ do
-                cannotDecodeInvalidIso8601Time "20080915155300Z"
-                cannotDecodeInvalidIso8601Time "20080915155300.1Z"
-                cannotDecodeInvalidIso8601Time "20080915155300.12Z"
-        describe "Extended format" $ do
-            describe "Dates without times" $ do
-                cannotDecodeInvalidIso8601Time "2008"
-                cannotDecodeInvalidIso8601Time "2008-09"
-                cannotDecodeInvalidIso8601Time "2008-09-15"
-            describe "Missing timezones" $ do
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00"
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1"
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12"
-            describe "Invalid timezone characters" $ do
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00A"
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1A"
-                cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12A"
-            describe "Invalid date-time separators" $ do
-                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00Z"
-                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.1Z"
-                cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.12Z"
-            describe "Missing date-time separators" $ do
-                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00Z"
-                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.1Z"
-                cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.12Z"
+        describe "Can decode valid ISO 8601 strings" $ do
+
+            describe "Basic format" $ do
+                describe "UTC+0 timezone (Z)" $ do
+                    canDecodeValidIso8601Time "20080915T155300Z"
+                    canDecodeValidIso8601Time "20080915T155300.1Z"
+                    canDecodeValidIso8601Time "20080915T155300.12Z"
+                describe "UTC+0 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "20080915T155300+0000"
+                    canDecodeValidIso8601Time "20080915T155300.1+0000"
+                    canDecodeValidIso8601Time "20080915T155300.12+0000"
+                describe "UTC+8 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "20080915T155300+0800"
+                    canDecodeValidIso8601Time "20080915T155300.1+0800"
+                    canDecodeValidIso8601Time "20080915T155300.12+0800"
+                describe "UTC-8 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "20080915T155300-0800"
+                    canDecodeValidIso8601Time "20080915T155300.1-0800"
+                    canDecodeValidIso8601Time "20080915T155300.12-0800"
+
+            describe "Extended format" $ do
+                describe "UTC+0 timezone (Z)" $ do
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00Z"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.1Z"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.12Z"
+                describe "UTC+0 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00+00:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.1+00:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.12+00:00"
+                describe "UTC+8 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00+08:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.1+08:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.12+08:00"
+                describe "UTC-8 timezone (manually specified)" $ do
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00-08:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.1-08:00"
+                    canDecodeValidIso8601Time "2008-09-15T15:53:00.12-08:00"
+
+        describe "Cannot decode invalid ISO 8601 strings" $ do
+
+            describe "Strings that are not time values" $ do
+                cannotDecodeInvalidIso8601Time ""
+                cannotDecodeInvalidIso8601Time "w"
+                cannotDecodeInvalidIso8601Time "wibble"
+
+            describe "Basic format" $ do
+                describe "Dates without times" $ do
+                    cannotDecodeInvalidIso8601Time "2008"
+                    cannotDecodeInvalidIso8601Time "200809"
+                    cannotDecodeInvalidIso8601Time "20080915"
+                describe "Missing timezones" $ do
+                    cannotDecodeInvalidIso8601Time "20080915T155300"
+                    cannotDecodeInvalidIso8601Time "20080915T155300.1"
+                    cannotDecodeInvalidIso8601Time "20080915T155300.12"
+                describe "Invalid timezone characters" $ do
+                    cannotDecodeInvalidIso8601Time "20080915T155300A"
+                    cannotDecodeInvalidIso8601Time "20080915T155300.1A"
+                    cannotDecodeInvalidIso8601Time "20080915T155300.12A"
+                describe "Invalid date-time separators" $ do
+                    cannotDecodeInvalidIso8601Time "20080915S155300Z"
+                    cannotDecodeInvalidIso8601Time "20080915S155300.1Z"
+                    cannotDecodeInvalidIso8601Time "20080915S155300.12Z"
+                describe "Missing date-time separators" $ do
+                    cannotDecodeInvalidIso8601Time "20080915155300Z"
+                    cannotDecodeInvalidIso8601Time "20080915155300.1Z"
+                    cannotDecodeInvalidIso8601Time "20080915155300.12Z"
+
+            describe "Extended format" $ do
+                describe "Dates without times" $ do
+                    cannotDecodeInvalidIso8601Time "2008"
+                    cannotDecodeInvalidIso8601Time "2008-09"
+                    cannotDecodeInvalidIso8601Time "2008-09-15"
+                describe "Missing timezones" $ do
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00"
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1"
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12"
+                describe "Invalid timezone characters" $ do
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00A"
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.1A"
+                    cannotDecodeInvalidIso8601Time "2008-09-15T15:53:00.12A"
+                describe "Invalid date-time separators" $ do
+                    cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00Z"
+                    cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.1Z"
+                    cannotDecodeInvalidIso8601Time "2008-09-15S15:53:00.12Z"
+                describe "Missing date-time separators" $ do
+                    cannotDecodeInvalidIso8601Time "2008-09-1515:53:00Z"
+                    cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.1Z"
+                    cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.12Z"
 
     describe "Port decoding from text" $ do
         let err = TextDecodingError

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -74,6 +74,10 @@ spec = do
             canDecodeValidIso8601Time "2008-09-15T15:53:00+08:00"
             canDecodeValidIso8601Time "2008-09-15T15:53:00.1+08:00"
             canDecodeValidIso8601Time "2008-09-15T15:53:00.12+08:00"
+        describe "UTC-8 timezone (manually specified)" $ do
+            canDecodeValidIso8601Time "2008-09-15T15:53:00-08:00"
+            canDecodeValidIso8601Time "2008-09-15T15:53:00.1-08:00"
+            canDecodeValidIso8601Time "2008-09-15T15:53:00.12-08:00"
 
     describe "Cannot decode invalid ISO 8601 strings" $ do
         describe "Strings that are not time values" $ do

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -152,6 +152,36 @@ spec = do
                     cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.1Z"
                     cannotDecodeInvalidIso8601Time "2008-09-1515:53:00.12Z"
 
+        describe "Equivalent times are decoded equivalently" $ do
+
+            describe "Times with the same date" $ do
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T12:00:00+01:00"
+                    "2008-08-08T11:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T12:00:00+08:00"
+                    "2008-08-08T04:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T12:00:00-01:00"
+                    "2008-08-08T13:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T12:00:00-08:00"
+                    "2008-08-08T20:00:00Z"
+
+            describe "Times with different dates" $ do
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T00:00:00+01:00"
+                    "2008-08-07T23:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T00:00:00+08:00"
+                    "2008-08-07T16:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T23:00:00-01:00"
+                    "2008-08-09T00:00:00Z"
+                ensureIso8601TimesEquivalent
+                    "2008-08-08T23:00:00-08:00"
+                    "2008-08-09T07:00:00Z"
+
     describe "Port decoding from text" $ do
         let err = TextDecodingError
                 $ "expected a TCP port number between "
@@ -321,3 +351,19 @@ cannotDecodeInvalidIso8601Time :: Text -> Spec
 cannotDecodeInvalidIso8601Time text =
     it ("Cannot decode as ISO 8601 time: " <> T.unpack text) $ property $ do
         fromText @Iso8601Time text `shouldSatisfy` isLeft
+
+-- | Checks that the specified "Text' values can both be decoded as valid
+--   'Iso8601Time' values, and that the resultant values are equal.
+--
+ensureIso8601TimesEquivalent :: Text -> Text -> Spec
+ensureIso8601TimesEquivalent t1 t2 = it title $ property $
+    (r1 `shouldBe` r2)
+    .&&. (r1 `shouldSatisfy` isRight)
+    .&&. (r2 `shouldSatisfy` isRight)
+
+  where
+    r1 = fromText @Iso8601Time t1
+    r2 = fromText @Iso8601Time t2
+    title = mempty
+            <> "Equivalent ISO 8601 times are decoded equivalently: "
+            <> show (t1, t2)

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -29,7 +29,6 @@
           (hsPkgs.fmt)
           (hsPkgs.http-client)
           (hsPkgs.iohk-monitoring)
-          (hsPkgs.iso8601-time)
           (hsPkgs.servant-client)
           (hsPkgs.servant-client-core)
           (hsPkgs.servant-server)

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -29,11 +29,13 @@
           (hsPkgs.fmt)
           (hsPkgs.http-client)
           (hsPkgs.iohk-monitoring)
+          (hsPkgs.iso8601-time)
           (hsPkgs.servant-client)
           (hsPkgs.servant-client-core)
           (hsPkgs.servant-server)
           (hsPkgs.text)
           (hsPkgs.text-class)
+          (hsPkgs.time)
           (hsPkgs.optparse-applicative)
           ];
         };
@@ -44,6 +46,7 @@
             (hsPkgs.cardano-wallet-cli)
             (hsPkgs.hspec)
             (hsPkgs.QuickCheck)
+            (hsPkgs.quickcheck-instances)
             (hsPkgs.text)
             (hsPkgs.text-class)
             ];


### PR DESCRIPTION
# Issue Number

#467 

# Overview

As part of supporting the `cardano-wallet transaction list` CLI command, we need to be able to accept optional `--before` and `--after` parameters, which specify a range of times. But in order to do that, we need to provide a way of parsing time values from textual input.

This PR:

- [x] adds a new type `Iso8601Time` which represents a point in time. The `FromText` instance parses a time in ISO 8601 format.
- [x] adds a round trip test to check that `Iso8601Time` values can be converted to and from `Text`.
- [x] adds tests to check that known-good ISO 8601 strings can be parsed successfully.
- [x] adds tests to check that known-bad ISO 8601 strings cannot be parsed successfully.
- [x] adds tests to ensure that equivalent ISO 8601 strings are parsed to values that are equivalent.