### PR TITLE
Add `slotIdTime :: SlotId -> UTCTime` to WalletLayer

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -308,6 +308,9 @@ data WalletLayer s t = WalletLayer
     , slotIdTime :: SlotId -> UTCTime
     -- ^ Calculate the time corresponding to a 'SlotId' assuming the slotting
     -- parameters of the blockchain never has changed.
+
+    , getBlockchainParameters :: BlockchainParameters t
+    -- ^ Retrive the current blockchain parameters (valid at the tip).
     }
 
 -- | Errors occuring when creating an unsigned transaction
@@ -423,6 +426,7 @@ newWalletLayer tracer bp db nw tl = do
         , attachPrivateKey = _attachPrivateKey
         , listTransactions = _listTransactions
         , slotIdTime = _slotIdTime
+        , getBlockchainParameters = _getBlockchainParameters
         }
   where
     BlockchainParameters
@@ -757,6 +761,12 @@ newWalletLayer tracer bp db nw tl = do
 
         convert :: DiffTime -> NominalDiffTime
         convert = toEnum . fromEnum
+
+    -- NOTE: We're currently assuming they cannot be updated
+    _getBlockchainParameters
+        :: BlockchainParameters t
+    _getBlockchainParameters
+        = bp
 
     {---------------------------------------------------------------------------
                                      Keystore

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -706,7 +706,7 @@ fromFlatSlot (EpochLength epochLength) n = SlotId e (fromIntegral s)
     e = n `div` epochLength
     s = n `mod` epochLength
 
-newtype SlotLength = SlotLength DiffTime
+newtype SlotLength = SlotLength { unSlotLength :: DiffTime }
     deriving (Show, Eq)
 
 newtype EpochLength = EpochLength Word64

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -53,6 +53,8 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Text.Read
     ( decimal )
+import Fmt
+    ( Buildable (..) )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
@@ -153,6 +155,9 @@ instance FromText Percentage where
       where
         err = TextDecodingError
             "expected a value between 0 and 100 with a '%' suffix (e.g. '14%')"
+
+instance Buildable Percentage where
+    build (Percentage p) = mempty <> build p <> "%"
 
 -- | Safe constructor for 'Percentage'
 mkPercentage

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -222,7 +222,6 @@ benchmark restore
     , deepseq
     , digest
     , fmt
-    , generic-lens
     , iohk-monitoring
     , persistent
     , persistent-template

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -172,6 +172,7 @@ test-suite integration
       Main.hs
   other-modules:
       Cardano.Faucet
+      Cardano.WalletSpec
       Cardano.Wallet.Jormungandr.NetworkSpec
       Test.Integration.Faucet
       Test.Integration.Framework.DSL

--- a/lib/jormungandr/test/integration/Cardano/WalletSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/WalletSpec.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.WalletSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.BM.Trace
+    ( nullTracer )
+import Cardano.Launcher
+    ( Command (..), StdStream (..), launch )
+import Cardano.Wallet
+    ( WalletLayer (..), newWalletLayer, waitForWalletSync )
+import Cardano.Wallet.Jormungandr.Compatibility
+    ( BaseUrl (..), Jormungandr, Scheme (..) )
+import Cardano.Wallet.Jormungandr.Environment
+    ( Network (..) )
+import Cardano.Wallet.Jormungandr.Network
+    ( JormungandrLayer (..)
+    , defaultManagerSettings
+    , getInitialBlockchainParameters
+    , newManager
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( mkSeqState )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( EntropySize, entropyToBytes, genEntropy )
+import Cardano.Wallet.Primitive.Model
+    ( currentTip )
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..)
+    , Hash (..)
+    , SlotId (..)
+    , WalletId (..)
+    , WalletName (..)
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeRunExceptT )
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( Async, async, cancel )
+import Control.Monad
+    ( unless, void )
+import Data.Coerce
+    ( coerce )
+import Data.Time.Clock
+    ( addUTCTime, getCurrentTime )
+import System.Directory
+    ( removePathForcibly )
+import Test.Hspec
+    ( Spec, after, before, expectationFailure, it )
+
+import qualified Cardano.Wallet.DB.MVar as MVar
+import qualified Cardano.Wallet.Jormungandr.Network as Jormungandr
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    before startNode $ after killNode $ do
+        it "A newly created wallet can sync with the chain" $ \(_, wallet) -> do
+            bytes <- entropyToBytes <$> genEntropy @(EntropySize 15)
+            let xprv = generateKeyFromSeed (Passphrase bytes, mempty) mempty
+            wid <- unsafeRunExceptT $ createWallet wallet
+                (WalletId $ digest $ publicKey xprv)
+                (WalletName "My Wallet")
+                (mkSeqState @(Jormungandr 'Testnet) (xprv, mempty) minBound)
+            unsafeRunExceptT $ restoreWallet wallet wid
+            threadDelay (8 * second)
+            tip <- slotId . currentTip . fst <$>
+                unsafeRunExceptT (readWallet wallet wid)
+            unless (tip > (SlotId 0 0)) $
+                expectationFailure ("The wallet tip is still " ++ show tip)
+
+        -- This tests both that the wallet syncs correctly, and that
+        -- 'slotIdTime' computes the time of the wallet tip correctly.
+        it "time of the wallet tip after syncing is recent" $ \(_, wallet) -> do
+            bytes <- entropyToBytes <$> genEntropy @(EntropySize 15)
+            let xprv = generateKeyFromSeed (Passphrase bytes, mempty) mempty
+            wid <- unsafeRunExceptT $ createWallet wallet
+                (WalletId $ digest $ publicKey xprv)
+                (WalletName "My Wallet")
+                (mkSeqState @(Jormungandr 'Testnet) (xprv, mempty) minBound)
+            unsafeRunExceptT $ restoreWallet wallet wid
+            waitForWalletSync wallet nullTracer wid
+            tip <- slotId . currentTip . fst <$>
+                unsafeRunExceptT (readWallet wallet wid)
+            let slotDuration = 10 -- TODO: fetch param from walletLayer
+            t <- getCurrentTime
+            let tMinted = slotIdTime wallet tip
+            -- Check that tMinted ∈ (t - slotDuration, t)
+            if t > tMinted && tMinted > addUTCTime (-slotDuration) t
+            then return ()
+            else expectationFailure $
+                "The network tip " ++ show tip ++
+                " corresponds to time " ++ show tMinted ++
+                " which should be close to " ++ show t ++
+                " but isn't."
+
+
+
+  where
+    second :: Int
+    second = 1000000
+
+    startNode = do
+        removePathForcibly "/tmp/cardano-wallet-jormungandr"
+        let dir = "test/data/jormungandr"
+        handle <- async $ void $ launch
+            [ Command "jormungandr"
+                [ "--genesis-block", dir ++ "/block0.bin"
+                , "--config", dir ++ "/config.yaml"
+                , "--secret", dir ++ "/secret.yaml"
+                ] (return ())
+                Inherit
+            ]
+        threadDelay (1 * second)
+        db <- MVar.newDBLayer
+        (nl, bp) <- newNetworkLayer
+        let tl = undefined
+        (handle,) <$>
+            (newWalletLayer @_ @(Jormungandr 'Testnet) nullTracer bp db nl tl)
+
+    newNetworkLayer = do
+            let url = BaseUrl Http "localhost" 8080 "/api"
+            mgr <- newManager defaultManagerSettings
+            let jor = Jormungandr.mkJormungandrLayer mgr url
+            let nl = Jormungandr.mkNetworkLayer @IO @'Testnet jor
+            let absent = Hash $ BS.pack $ replicate 32 0
+            [block0H] <- unsafeRunExceptT $ getDescendantIds jor absent 1
+            blockchainParams <- unsafeRunExceptT $
+                getInitialBlockchainParameters jor (coerce block0H)
+            return (nl, blockchainParams)
+
+
+    killNode :: (Async (), a) -> IO ()
+    killNode (h, _) = do
+        cancel h
+        threadDelay (1 * second)

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -85,6 +85,7 @@ import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Cardano.Wallet.Jormungandr.Network as Jormungandr
 import qualified Cardano.Wallet.Jormungandr.NetworkSpec as Network
 import qualified Cardano.Wallet.Jormungandr.Transaction as Jormungandr
+import qualified Cardano.WalletSpec as Wallet
 import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified Test.Integration.Jormungandr.Scenario.API.Transactions as TransactionsJormungandr
@@ -108,6 +109,7 @@ main :: forall t. (t ~ Jormungandr 'Testnet) => IO ()
 main = hspec $ do
     describe "PR_DISABLED Server CLI timeout test" (ServerCLI.specNoBackend @t)
     describe "Cardano.Wallet.NetworkSpec" Network.spec
+    describe "WalletLayer tests" (Wallet.spec)
     describe "Mnemonics CLI tests" (MnemonicsCLI.spec @t)
     describe "Miscellaneous CLI tests" (MiscellaneousCLI.spec @t)
     describe "Ports CLI (negative) tests" (PortCLI.specNegative @t)

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -125,7 +125,6 @@
             (hsPkgs.deepseq)
             (hsPkgs.digest)
             (hsPkgs.fmt)
-            (hsPkgs.generic-lens)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.persistent)
             (hsPkgs.persistent-template)


### PR DESCRIPTION
# Issue Number

#465 


# Overview

- [x] Added a naive `slotIdTime` to the `WalletLayer` (agnostic to changing blockchain parameters)
- [x] Moved `waitForWalletSync` to WalletLayer
- [x] Duplicated http-bridge `Cardano.WalletSpec` to Jormungandr, and added a test that the wallet tip, once synced, corresponds to a time in `(now - slotLength, now)`

# Comments

⚠️ also includes #572, but the base branch is still master ⚠️ 

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->