### PR TITLE
More tests for update passphrase via CLI

### DIFF
--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
@@ -477,7 +477,8 @@ spec = do
                   , ""
                   , expect (ExitFailure 1, mempty, "passphrase is too short")
                   )
-                , ( "Incorrect old passphrase", "wrong secure passphrase"
+                , ( "Incorrect old passphrase"
+                  , "wrong secure passphrase"
                   , expect (ExitFailure 1, mempty, errMsg403WrongPass)
                   )
                 ]

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Wallets.hs
@@ -373,7 +373,7 @@ spec = do
             , expectCliListItemFieldEqual 2 walletId (T.pack w3)
             ]
 
-    describe "WALLETS_UPDATE_NAME_01,02 - Can update wallet name" $ do
+    describe "WALLETS_UPDATE_01,02 - Can update wallet name" $ do
         forM_ walletNames $ \(title, n) -> it title $ \ctx -> do
             wid <- emptyWallet' ctx
             let args = [wid, n]
@@ -384,7 +384,7 @@ spec = do
             j <- expectValidJSON (Proxy @ApiWallet) out
             expectCliFieldEqual walletName (T.pack n) j
 
-    it "WALLETS_UPDATE_PASSPHRASE_01 - \
+    it "WALLETS_UPDATE_PASS_01 - \
         \Can update passphrase normally"
         $ \ctx -> do
             let name = "name"
@@ -397,7 +397,7 @@ spec = do
             T.unpack err `shouldContain` cmdOk
             exitCode `shouldBe` ExitSuccess
 
-    it "WALLETS_UPDATE_PASSPHRASE_02 - \
+    it "WALLETS_UPDATE_PASS_02 - \
         \Cannot update passphrase if new passphrase is too short"
         $ \ctx -> do
             let name = "name"
@@ -410,7 +410,7 @@ spec = do
             T.unpack err `shouldContain` "passphrase is too short"
             exitCode `shouldBe` ExitFailure 1
 
-    it "WALLETS_UPDATE_PASSPHRASE_03 - \
+    it "WALLETS_UPDATE_PASS_02 - \
         \Cannot update passphrase if new passphrase is not confirmed correctly"
         $ \ctx -> do
             let name = "name"
@@ -424,7 +424,7 @@ spec = do
             T.unpack err `shouldContain` "Passphrases don't match"
             exitCode `shouldBe` ExitFailure 1
 
-    it "WALLETS_UPDATE_PASSPHRASE_04 - \
+    it "WALLETS_UPDATE_PASS_03 - \
         \Cannot update passphrase if original passphrase is entered incorrectly"
         $ \ctx -> do
             let name = "name"


### PR DESCRIPTION
# Issue Number

#472

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added more tests and made small change so CLI  checks if wallet exists before attempting to update pass (which is consistent with other _endpoints_ behaviour)


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
