### PR TITLE
Use tx max size & estimator to figure out the right input upper-bound in coin selection

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -168,6 +168,8 @@ import Data.Text.Class
     ( toText )
 import Data.Time.Clock
     ( diffTimeToPicoseconds, getCurrentTime )
+import Data.Word
+    ( Word16 )
 import Fmt
     ( Buildable, blockListF, pretty, (+|), (+||), (|+), (||+) )
 
@@ -635,10 +637,9 @@ newWalletLayer tracer bp db nw tl = do
                                     Transactions
     ---------------------------------------------------------------------------}
 
-    -- FIXME Compute the options based on the transaction's size / inputs
     coinSelOpts :: CoinSelectionOptions (ErrValidateSelection t)
     coinSelOpts = CoinSelectionOptions
-        { maximumNumberOfInputs = 10
+        { maximumNumberOfInputs = estimateMaxNumberOfInputs tl txMaxSize
         , validate = validateSelection tl
         }
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -367,7 +367,11 @@ data BlockchainParameters t = BlockchainParameters
     { getGenesisBlock :: Block (Tx t)
         -- ^ Very first block
     , getFeePolicy :: FeePolicy
+        -- ^ Policy regarding transcation fee
     , getSlotLength :: SlotLength
+        -- ^ Length, in seconds, of a slot
+    , getTxMaxSize :: Quantity "byte" Word16
+        -- ^ Maximum size of a transaction (soft or hard limit)
     }
 
 -- | Create a new instance of the wallet layer.
@@ -379,10 +383,7 @@ newWalletLayer
     -> NetworkLayer t IO
     -> TransactionLayer t
     -> IO (WalletLayer s t)
-newWalletLayer
-    tracer
-    (BlockchainParameters block0 feePolicy (SlotLength slotLength))
-    db nw tl = do
+newWalletLayer tracer bp db nw tl = do
     logDebugT $ "Wallet layer starting with: "
         <> "block0: "+| block0 |+ ", "
         <> "fee policy: "+|| feePolicy ||+""
@@ -404,6 +405,8 @@ newWalletLayer
         , listTransactions = _listTransactions
         }
   where
+    BlockchainParameters block0 feePolicy (SlotLength slotLength) txMaxSize = bp
+
     logDebugT :: MonadIO m => Text -> m ()
     logDebugT = liftIO . logDebug tracer
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -34,7 +34,7 @@ import Crypto.Number.Generate
 import Data.Vector.Mutable
     ( IOVector )
 import Data.Word
-    ( Word64 )
+    ( Word64, Word8 )
 import Fmt
     ( Buildable (..), blockListF, blockListF', listF, nameF )
 import GHC.Generics
@@ -80,9 +80,11 @@ instance Buildable CoinSelection where
 
 data CoinSelectionOptions e = CoinSelectionOptions
     { maximumNumberOfInputs
-        :: Word64
+        :: Word8 -> Word8
+            -- ^ Maximum number of inputs allowed for a given number of outputs
     , validate
         :: CoinSelection -> Either e ()
+            -- ^ Returns any backend-specific error regarding coin selection
     } deriving (Generic)
 
 data ErrCoinSelection e

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -215,7 +215,7 @@ propDeterministic
     :: CoinSelProp
     -> Property
 propDeterministic (CoinSelProp utxo txOuts) = do
-    let opts = CoinSelectionOptions 100 noValidation
+    let opts = CoinSelectionOptions (const 100) noValidation
     let resultOne = runIdentity $ runExceptT $ largestFirst opts txOuts utxo
     let resultTwo = runIdentity $ runExceptT $ largestFirst opts txOuts utxo
     resultOne === resultTwo
@@ -229,7 +229,7 @@ propAtLeast (CoinSelProp utxo txOuts) =
     prop (CoinSelection inps _ _) =
         L.length inps `shouldSatisfy` (>= NE.length txOuts)
     selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100 noValidation) txOuts utxo
+        largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo
 
 propInputDecreasingOrder
     :: CoinSelProp
@@ -247,4 +247,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
             (>= (getExtremumValue L.maximum utxo'))
     getExtremumValue f = f . map (getCoin . coin . snd)
     selection = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100 noValidation) txOuts utxo
+        largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -250,9 +250,10 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
     (selection1,_) = withDRG drg
-        (runExceptT $ random (CoinSelectionOptions 100 noValidation) txOuts utxo)
+        (runExceptT $ random opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 100 noValidation) txOuts utxo
+        largestFirst opt txOuts utxo
+    opt = CoinSelectionOptions (const 100) noValidation
 
 propErrors
     :: SystemDRG
@@ -266,6 +267,7 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     prop (err1, err2) =
         err1 === err2
     (selection1,_) = withDRG drg
-        (runExceptT $ random (CoinSelectionOptions 1 noValidation) txOuts utxo)
+        (runExceptT $ random opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst (CoinSelectionOptions 1 noValidation) txOuts utxo
+        largestFirst opt txOuts utxo
+    opt = (CoinSelectionOptions (const 1) noValidation)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -133,7 +133,7 @@ instance Buildable CoinSelProp where
 
 -- | A fixture for testing the coin selection
 data CoinSelectionFixture = CoinSelectionFixture
-    { maxNumOfInputs :: Word64
+    { maxNumOfInputs :: Word8
         -- ^ Maximum number of inputs that can be selected
     , validateSelection :: CoinSelection -> Either ErrValidation ()
         -- ^ A extra validation function on the resulting selection
@@ -178,7 +178,7 @@ coinSelectionUnitTest run lbl expected (CoinSelectionFixture n fn utxoF outsF) =
         (utxo,txOuts) <- setup
         result <- runExceptT $ do
             (CoinSelection inps outs chngs, _) <-
-                run (CoinSelectionOptions n fn) txOuts utxo
+                run (CoinSelectionOptions (const n) fn) txOuts utxo
             return $ CoinSelectionResult
                 { rsInputs = map (getCoin . coin . snd) inps
                 , rsChange = map getCoin chngs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -521,7 +521,7 @@ genTxOut coins = do
 
 genSelection :: NonEmpty TxOut -> Gen CoinSelection
 genSelection outs = do
-    let opts = CS.CoinSelectionOptions 100 (const $ pure ())
+    let opts = CS.CoinSelectionOptions (const 100) (const $ pure ())
     utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
     case runIdentity $ runExceptT $ largestFirst opts outs utxo of
         Left _ -> genSelection outs

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -109,7 +109,7 @@ import Data.Quantity
 import Data.Time.Clock
     ( secondsToDiffTime )
 import Data.Word
-    ( Word32 )
+    ( Word16, Word32 )
 import GHC.Generics
     ( Generic )
 import Test.Hspec

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -372,7 +372,7 @@ setupFixture (wid, wname, wstate) = do
     db <- newDBLayer
     let nl = error "NetworkLayer"
     let tl = dummyTransactionLayer
-    let bp = BlockchainParameters block0 dummyPolicy dummySlotLength
+    let bp = BlockchainParameters block0 policy slotLength txMaxSize
     wl <- newWalletLayer @_ @DummyTarget nullTracer bp db nl tl
     res <- runExceptT $ createWallet wl wid wname wstate
     let wal = case res of
@@ -380,11 +380,14 @@ setupFixture (wid, wname, wstate) = do
             Right walletId -> [walletId]
     pure $ WalletLayerFixture db wl wal
   where
-    dummyPolicy :: FeePolicy
-    dummyPolicy = LinearFee (Quantity 14) (Quantity 42)
+    policy :: FeePolicy
+    policy = LinearFee (Quantity 14) (Quantity 42)
 
-    dummySlotLength :: SlotLength
-    dummySlotLength = SlotLength $ secondsToDiffTime 1
+    slotLength :: SlotLength
+    slotLength = SlotLength $ secondsToDiffTime 1
+
+    txMaxSize :: Quantity "byte" Word16
+    txMaxSize = Quantity 8192
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.HttpBridge.Compatibility
     , block0
     , byronFeePolicy
     , byronSlotLength
+    , byronTxMaxSize
     ) where
 
 import Prelude
@@ -62,6 +63,8 @@ import Data.Text.Class
     ( TextDecodingError (..) )
 import Data.Time.Clock
     ( secondsToDiffTime )
+import Data.Word
+    ( Word16 )
 
 import qualified Cardano.Wallet.HttpBridge.Binary as CBOR
 import qualified Cardano.Wallet.HttpBridge.Primitive.Types as W
@@ -159,7 +162,10 @@ block0 = Block
 byronFeePolicy :: FeePolicy
 byronFeePolicy = LinearFee (Quantity 155381) (Quantity 43.946)
 
-
 -- | Hard-coded slot duration
 byronSlotLength :: SlotLength
 byronSlotLength = SlotLength $ secondsToDiffTime 20
+
+-- | Hard-coded max transaction size
+byronTxMaxSize :: Quantity "byte" Word16
+byronTxMaxSize = Quantity 8192

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet
 import Cardano.Wallet.DB.Sqlite
     ( PersistState )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength )
+    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.HttpBridge.Network
@@ -212,7 +212,12 @@ bench_restoration _ (wid, wname, s) = withHttpBridge network $ \port -> do
     let tl = newTransactionLayer
     BlockHeader sl _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
-    let bp = BlockchainParameters block0 byronFeePolicy byronSlotLength
+    let bp = BlockchainParameters
+            { getGenesisBlock = block0
+            , getFeePolicy = byronFeePolicy
+            , getSlotLength = byronSlotLength
+            , getTxMaxSize = byronTxMaxSize
+            }
     w <- newWalletLayer @_ @t nullTracer bp db nw tl
     wallet <- unsafeRunExceptT $ createWallet w wid wname s
     unsafeRunExceptT $ restoreWallet w wallet

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -15,7 +15,7 @@ import Cardano.Launcher
 import Cardano.Wallet
     ( BlockchainParameters (..), WalletLayer (..), newWalletLayer )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength )
+    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -81,6 +81,6 @@ spec = do
         db <- MVar.newDBLayer
         nl <- HttpBridge.newNetworkLayer @'Testnet port
         let tl = HttpBridge.newTransactionLayer
-        let bp = BlockchainParameters block0 byronFeePolicy byronSlotLength
+        let bp = BlockchainParameters block0 byronFeePolicy byronSlotLength byronTxMaxSize
         (handle,) <$>
             (newWalletLayer @_ @(HttpBridge 'Testnet) nullTracer bp db nl tl)

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.DB.Sqlite
     ( SqliteContext )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength )
+    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
 import Cardano.Wallet.HttpBridge.Environment
     ( Network (..) )
 import Cardano.Wallet.Network
@@ -264,7 +264,12 @@ main = do
         mvar <- newEmptyMVar
         thread <- forkIO $ do
             let tl = HttpBridge.newTransactionLayer
-            let bp = BlockchainParameters block0 byronFeePolicy byronSlotLength
+            let bp = BlockchainParameters
+                    { getGenesisBlock = block0
+                    , getFeePolicy = byronFeePolicy
+                    , getSlotLength = byronSlotLength
+                    , getTxMaxSize = byronTxMaxSize
+                    }
             wallet <- newWalletLayer nullTracer bp db nl tl
             let listen = fromMaybe (ListenOnPort defaultPort) mlisten
             Server.withListeningSocket listen $ \(port, socket) -> do

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -744,7 +744,7 @@ genTxOut coins = do
 
 genSelection :: NonEmpty TxOut -> Gen CoinSelection
 genSelection outs = do
-    let opts = CS.CoinSelectionOptions 100 (const $ Right ())
+    let opts = CS.CoinSelectionOptions (const 100) (const $ Right ())
     utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
     case runIdentity $ runExceptT $ largestFirst opts outs utxo of
         Left _ -> genSelection outs

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -18,6 +18,7 @@ module Cardano.Wallet.Jormungandr.Compatibility
       Jormungandr
     , Network (..)
     , block0
+    , softTxMaxSize
 
       -- * Node's Configuration
     , BaseUrl (..)
@@ -63,8 +64,12 @@ import Data.Maybe
     ( fromJust, isJust )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text.Class
     ( TextDecodingError (..) )
+import Data.Word
+    ( Word16 )
 import Servant.Client.Core
     ( BaseUrl (..), Scheme (..) )
 import System.FilePath
@@ -89,6 +94,14 @@ block0 = BlockHeader
     { slotId = (SlotId 0 0)
     , prevBlockHash = Hash (BS.replicate 32 0)
     }
+
+-- | Jörmugandr's chain parameter doesn't include a transaction max size. The
+-- actual hard-limit for the size is constrained by the binary format and
+-- numbers used to represent the number of inputs and outputs (Word8), yet
+-- there's also a soft-limit of 8kb which results in much smaller transactions
+-- in the end.
+softTxMaxSize :: Quantity "byte" Word16
+softTxMaxSize = Quantity 8192
 
 instance DefineTx (Jormungandr network) where
     type Tx (Jormungandr network) = Tx

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -50,7 +50,7 @@ import Cardano.Wallet.Jormungandr.Api
 import Cardano.Wallet.Jormungandr.Binary
     ( ConfigParam (..), Message (..), coerceBlock )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr )
+    ( Jormungandr, softTxMaxSize )
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx )
 import Cardano.Wallet.Network
@@ -267,7 +267,12 @@ mkJormungandrLayer mgr baseUrl = JormungandrLayer
 
         case (mpolicy,mduration) of
             ([policy],[duration]) ->
-                return $ BlockchainParameters (coerceBlock jblock) policy (SlotLength duration)
+                return $ BlockchainParameters
+                    { getGenesisBlock = coerceBlock jblock
+                    , getFeePolicy = policy
+                    , getSlotLength = SlotLength duration
+                    , getTxMaxSize = softTxMaxSize
+                    }
             _ ->
                 throwE $ ErrGetBlockchainParamsNoInitialPolicy params
     }

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -180,8 +180,7 @@ cardanoWalletServer
 cardanoWalletServer mlisten = do
     logConfig <- CM.empty
     tracer <- initTracer Info "serve"
-    (nl, bp@(BlockchainParameters _ feePolicy _) ) <-
-         newNetworkLayer jormungandrUrl block0H
+    (nl, bp) <- newNetworkLayer jormungandrUrl block0H
     (sqlCtx, db) <- Sqlite.newDBLayer @_ @network logConfig tracer Nothing
     mvar <- newEmptyMVar
     handle <- async $ do
@@ -192,7 +191,7 @@ cardanoWalletServer mlisten = do
             let settings = Warp.defaultSettings
                     & setBeforeMainLoop (putMVar mvar port)
             Server.start settings tracer socket wallet
-    (handle,,feePolicy,sqlCtx) <$> takeMVar mvar
+    (handle, , getFeePolicy bp, sqlCtx) <$> takeMVar mvar
   where
     jormungandrUrl :: BaseUrl
     jormungandrUrl = BaseUrl Http "localhost" 8080 "/api"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -165,7 +165,7 @@ genTxOut coins = do
 
 genSelection :: NonEmpty TxOut -> Gen CoinSelection
 genSelection outs = do
-    let opts = CS.CoinSelectionOptions 100 (const $ Right ())
+    let opts = CS.CoinSelectionOptions (const 100) (const $ Right ())
     utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
     case runIdentity $ runExceptT $ largestFirst opts outs utxo of
         Left _ -> genSelection outs


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#462 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a new parameter `txMaxSize` to `BlockchainParameter`
- [x] I have used this and `estimateMaxNumberOfInputs` from the transaction layer to replace the hard-coded max number of inputs with a number that's actually relevant.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
