### PR TITLE
Move `Iso8601Range` from `Cardano.Wallet.Api` to `Cardano.Wallet.Api.Types`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -4,14 +4,13 @@
 
 module Cardano.Wallet.Api where
 
-import Prelude
-
 import Cardano.Wallet.Api.Types
     ( ApiAddress
     , ApiFee
     , ApiT
     , ApiTransaction
     , ApiWallet
+    , Iso8601Range
     , PostTransactionData
     , PostTransactionFeeData
     , WalletPostData
@@ -22,10 +21,6 @@ import Cardano.Wallet.Primitive.Types
     ( AddressState, WalletId )
 import Data.List.NonEmpty
     ( NonEmpty ((:|)) )
-import Data.Time.Clock
-    ( UTCTime )
-import GHC.TypeLits
-    ( Symbol )
 import Network.HTTP.Media
     ( (//), (/:) )
 import Servant.API
@@ -34,7 +29,6 @@ import Servant.API
     , Accept (..)
     , Capture
     , DeleteNoContent
-    , FromHttpApiData (..)
     , Get
     , Header
     , JSON
@@ -44,7 +38,6 @@ import Servant.API
     , PutNoContent
     , QueryParam
     , ReqBody
-    , ToHttpApiData (..)
     )
 
 type Api t = Addresses t :<|> Wallets :<|> Transactions t
@@ -157,30 +150,3 @@ instance Accept Any where
         [ "application" // "json"
         , "application" // "json" /: ("charset", "utf-8")
         ]
-
--- | A range of dates in ISO-8601 UTC format without symbols. Meant to be
--- rendered as a HTTP 'Header', where the 'name' type-parameter renders as a
--- prefix, e.g.
---
--- name 20190227T160329Z-*
---
--- 'Nothing' ("*") can be used instead of upper and/or lower boundary.
---
--- - `20190227T160329Z-*`: means all transactions after
---    2019-02-27 T 16:03:29Z (including)
--- - `*-20190227T160329Z`: means all transactions before 2019-02-27 T 16:03:29Z
---    (including)
--- - `*-*`: means all transactions
--- - `20190227T000000Z-20200227T000000Z`: means all transaction between
---    2019-02-27 and 2020-02-27, in ascending order.
--- - `20200227T000000Z-20190227T000000Z`: means all transaction between
---  2020-02-27 and 2019-02-27, in descending order.
-data Iso8601Range (name :: Symbol)
-    = Iso8601Range (Maybe UTCTime) (Maybe UTCTime)
-    deriving (Show)
-
-instance FromHttpApiData (Iso8601Range (name :: Symbol)) where
-    parseUrlPiece = error "FromHttpApiData Iso8601Range to be implemented"
-
-instance ToHttpApiData (Iso8601Range (name :: Symbol)) where
-    toUrlPiece = error "ToHttpApiData Iso8601Range to be implemented"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -43,7 +43,7 @@ import Cardano.Wallet
     , WalletLayer
     )
 import Cardano.Wallet.Api
-    ( Addresses, Api, Iso8601Range, Transactions, Wallets )
+    ( Addresses, Api, Transactions, Wallets )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiAddress (..)
@@ -52,6 +52,7 @@ import Cardano.Wallet.Api.Types
     , ApiT (..)
     , ApiTransaction (..)
     , ApiWallet (..)
+    , Iso8601Range (..)
     , PostTransactionData
     , PostTransactionFeeData
     , WalletBalance (..)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -42,6 +42,7 @@ module Cardano.Wallet.Api.Types
     , ApiFee (..)
     , AddressAmount (..)
     , ApiErrorCode (..)
+    , Iso8601Range (..)
 
     -- * Polymorphic Types
     , ApiT (..)
@@ -218,6 +219,33 @@ data ApiErrorCode
     | UnsupportedMediaType
     | UnexpectedError
     deriving (Eq, Generic, Show)
+
+-- | A range of dates in ISO-8601 UTC format without symbols. Meant to be
+-- rendered as a HTTP 'Header', where the 'name' type-parameter renders as a
+-- prefix, e.g.
+--
+-- name 20190227T160329Z-*
+--
+-- 'Nothing' ("*") can be used instead of upper and/or lower boundary.
+--
+-- - `20190227T160329Z-*`: means all transactions after
+--    2019-02-27 T 16:03:29Z (including)
+-- - `*-20190227T160329Z`: means all transactions before 2019-02-27 T 16:03:29Z
+--    (including)
+-- - `*-*`: means all transactions
+-- - `20190227T000000Z-20200227T000000Z`: means all transaction between
+--    2019-02-27 and 2020-02-27, in ascending order.
+-- - `20200227T000000Z-20190227T000000Z`: means all transaction between
+--  2020-02-27 and 2019-02-27, in descending order.
+data Iso8601Range (name :: Symbol)
+    = Iso8601Range (Maybe UTCTime) (Maybe UTCTime)
+    deriving (Show)
+
+instance FromHttpApiData (Iso8601Range (name :: Symbol)) where
+    parseUrlPiece = error "FromHttpApiData Iso8601Range to be implemented"
+
+instance ToHttpApiData (Iso8601Range (name :: Symbol)) where
+    toUrlPiece = error "ToHttpApiData Iso8601Range to be implemented"
 
 {-------------------------------------------------------------------------------
                               Polymorphic Types


### PR DESCRIPTION
# Issue Number

#466 

# Overview

A simple refactoring to facilitate further work on filtering transactions by date ranges.

API types are generally located within `Cardano.Wallet.Api.Types`.

- [x] I have moved `Iso8601Range` from `Cardano.Wallet.Api` to `Cardano.Wallet.Api.Types`.
