### PR TITLE
Move `splitAtLastOccurrence` from `bech32` to `text-class`.

### DIFF
--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -35,6 +35,7 @@ library
     , containers
     , extra
     , text
+    , text-class
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
@@ -102,6 +102,8 @@ import Data.Maybe
     ( isNothing, mapMaybe )
 import Data.Text
     ( Text )
+import Data.Text.Class
+    ( splitAtLastOccurrence )
 import Data.Word
     ( Word8 )
 
@@ -799,15 +801,3 @@ locateErrors residue len
 
 guardE :: Bool -> e -> Either e ()
 guardE b e = if b then Right () else Left e
-
--- | Splits the given 'Text' into a prefix and a suffix using the last
--- occurrence of the specified separator character as a splitting point.
--- Evaluates to 'Nothing' if the 'ByteString` does not contain the separator
--- character.
-splitAtLastOccurrence :: Char -> Text -> Maybe (Text, Text)
-splitAtLastOccurrence c s
-    | isNothing (T.find (== c) s) = Nothing
-    | otherwise = pure (prefix, suffix)
-  where
-    (prefixPlusOne, suffix) = T.breakOnEnd (T.pack [c]) s
-    prefix = T.dropEnd 1 prefixPlusOne

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -29,6 +29,7 @@ module Data.Text.Class
 
       -- * Helpers
     , showT
+    , splitAtLastOccurrence
     ) where
 
 import Prelude
@@ -40,7 +41,7 @@ import Data.Bifunctor
 import Data.List.Extra
     ( enumerate )
 import Data.Maybe
-    ( listToMaybe )
+    ( isNothing, listToMaybe )
 import Data.Text
     ( Text )
 import Data.Text.Read
@@ -199,3 +200,15 @@ fromCaseStyle = \case
 -- | Show a data-type through its 'ToText' instance
 showT :: ToText a => a -> String
 showT = T.unpack . toText
+
+-- | Splits the given 'Text' into a prefix and a suffix using the last
+-- occurrence of the specified separator character as a splitting point.
+-- Evaluates to 'Nothing' if the 'ByteString` does not contain the separator
+-- character.
+splitAtLastOccurrence :: Char -> Text -> Maybe (Text, Text)
+splitAtLastOccurrence c s
+    | isNothing (T.find (== c) s) = Nothing
+    | otherwise = pure (prefix, suffix)
+  where
+    (prefixPlusOne, suffix) = T.breakOnEnd (T.pack [c]) s
+    prefix = T.dropEnd 1 prefixPlusOne

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -203,8 +203,8 @@ showT = T.unpack . toText
 
 -- | Splits the given 'Text' into a prefix and a suffix using the last
 -- occurrence of the specified separator character as a splitting point.
--- Evaluates to 'Nothing' if the 'ByteString` does not contain the separator
--- character.
+-- Evaluates to 'Nothing' if the specified 'Text' does not contain the
+-- separator character.
 splitAtLastOccurrence :: Char -> Text -> Maybe (Text, Text)
 splitAtLastOccurrence c s
     | isNothing (T.find (== c) s) = Nothing

--- a/nix/.stack.nix/bech32.nix
+++ b/nix/.stack.nix/bech32.nix
@@ -23,6 +23,7 @@
           (hsPkgs.containers)
           (hsPkgs.extra)
           (hsPkgs.text)
+          (hsPkgs.text-class)
           ];
         };
       tests = {


### PR DESCRIPTION
# Issue Number

#466 

# Overview

A simple refactoring to facilitate further work on filtering transactions by date ranges.

I have:
- [x] moved `splitAtLastOccurrence` from `bech32` to `text-class`.
- [x] fixed a problem with the Haddock documentation for this function.