### PR TITLE
disable flaky 'Launcher' specs in CI merges...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,10 +196,10 @@ jobs:
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage bech32
     - mkdir -p .coverage/bech32 && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/bech32 \;
 
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge 2>/dev/null
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge --ta "--skip MERGE_DISABLED"
     - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
 
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr 2>/dev/null
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr --ta "--skip MERGE_DISABLED"
     - mkdir -p .coverage/jormungandr && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/jormungandr \;
 
     - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -116,7 +116,7 @@ main = do
         describe "PR_DISABLED Server CLI timeout test" (ServerCLI.specNoBackend @t)
         describe "Cardano.WalletSpec" Wallet.spec
         describe "Cardano.Wallet.HttpBridge.NetworkSpec" HttpBridge.spec
-        describe "Launcher CLI tests" (LauncherCLI.spec @t)
+        describe "MERGE_DISABLED Launcher CLI tests" (LauncherCLI.spec @t)
         describe "Mnemonics CLI tests" (MnemonicsCLI.spec @t)
         describe "Miscellaneous CLI tests" (MiscellaneousCLI.spec @t)
         describe "--port CLI tests" $ do

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -111,7 +111,7 @@ main = hspec $ do
     describe "Mnemonics CLI tests" (MnemonicsCLI.spec @t)
     describe "Miscellaneous CLI tests" (MiscellaneousCLI.spec @t)
     describe "Ports CLI (negative) tests" (PortCLI.specNegative @t)
-    describe "Launcher CLI tests" (LauncherCLI.spec @t)
+    describe "MERGE_DISABLED Launcher CLI tests" (LauncherCLI.spec @t)
     beforeAll (start Nothing) $ afterAll _cleanup $ after tearDown $ do
         -- API e2e Testing
         describe "PR_DISABLED Addresses API endpoint tests" Addresses.spec


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have disabled integration 'Launcher' specs on merge builds for lack of a better solution. Note that these tests still run on PR builds...

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
