### PR TITLE
fix hard-to-satisfy pre-condition in property test

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -52,6 +52,7 @@ import Test.Hspec
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
+    , NonEmptyList (..)
     , Property
     , checkCoverage
     , choose
@@ -370,10 +371,10 @@ propReducedChanges drg (ShowFmt (FeeProp coinSel utxo (fee, dust))) = do
 -- | Helper to re-apply the pre-conditions for divvyFee
 propDivvyFee
     :: ((Fee, [Coin]) -> Property)
-    -> (Fee, [Coin])
+    -> (Fee, NonEmptyList Coin)
     -> Property
-propDivvyFee prop (fee, outs) =
-    not (null outs) ==> coverTable "properties"
+propDivvyFee prop (fee, NonEmpty outs) =
+    coverTable "properties"
         [ ("fee > 0", 50)
         , ("nOuts=1", 1)
         , ("nOuts=2", 1)
@@ -390,14 +391,14 @@ propDivvyFee prop (fee, outs) =
 -- | Sum of the fees divvied over each output is the same as the initial total
 -- fee.
 propDivvyFeeSame
-    :: (Fee, [Coin])
+    :: (Fee, NonEmptyList Coin)
     -> Property
 propDivvyFeeSame = propDivvyFee $ \(fee, outs) ->
     sum (getFee . fst <$> divvyFee fee outs) === getFee fee
 
 -- | divvyFee doesn't change any of the outputs
 propDivvyFeeOuts
-    :: (Fee, [Coin])
+    :: (Fee, NonEmptyList Coin)
     -> Property
 propDivvyFeeOuts = propDivvyFee $ \(fee, outs) ->
     (snd <$> divvyFee fee outs) === outs


### PR DESCRIPTION
And use instead, a generator which provide well-formed data

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have replaced a pre-condition with a corresponding generator 

# Comments

<!-- Additional comments or screenshots to attach if any -->

Pre-conditions are somewhat harder to satisfy when used in conjunction with `checkCoverage`. This test sometimes failed as:

```
Cardano.Wallet.Primitive.Fee
  divvyFee
    Σ fst (divvyFee fee outs) == fee FAILED [1]
    snd (divvyFee fee outs) == outs FAILED [2]
    expectFailure: not (any null (fst <$> divvyFee fee outs))
      +++ OK, failed as expected. Falsifiable (after 1642 tests and 44 shrinks):
      (Fee {getFee = 1},[Coin {getCoin = 1},Coin {getCoin = 1}])
    expectFailure: empty list
      +++ OK, failed as expected. (after 1 test and 16 shrinks):
      Exception:
        divvyFee: empty list
        CallStack (from HasCallStack):
          error, called at src/Cardano/Wallet/Primitive/Fee.hs:269:9 in cardano-wallet-core-2019.6.24-7pM9XCgZCwM3gJbsJgyj31:Cardano.Wallet.Primitive.Fee
      (Fee {getFee = 1},[])

Failures:

  test/unit/Cardano/Wallet/Primitive/FeeSpec.hs:297:9: 
  1) Cardano.Wallet.Primitive.Fee.divvyFee Σ fst (divvyFee fee outs) == fee
       *** Gave up! Passed only 3199 tests; 532 discarded tests.
       
       properties (6398 in total):
       50.00% fee > 0
       45.00% nOuts=2+
        3.09% nOuts=1
        1.91% nOuts=2

  To rerun use: --match "/Cardano.Wallet.Primitive.Fee/divvyFee/\931 fst (divvyFee fee outs) == fee/"

  test/unit/Cardano/Wallet/Primitive/FeeSpec.hs:299:9: 
  2) Cardano.Wallet.Primitive.Fee.divvyFee snd (divvyFee fee outs) == outs
       *** Gave up! Passed only 3199 tests; 532 discarded tests.
       
       properties (6398 in total):
       50.00% fee > 0
       45.00% nOuts=2+
        3.09% nOuts=1
        1.91% nOuts=2
```

If we instead generate valid data upfront, there's nothing to discard and the bound can be satisfied as expected, or simply run more tests if needed. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
