### PR TITLE
Extend BlockchainParameters with `slotsPerEpoch` and `block0Date`

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -65,12 +65,7 @@ import Cardano.Wallet.DaedalusIPC
 import Cardano.Wallet.DB
     ( DBLayer )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge
-    , Network (..)
-    , byronFeePolicy
-    , byronSlotLength
-    , byronTxMaxSize
-    )
+    ( HttpBridge, Network (..), byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..) )
 import Cardano.Wallet.Network
@@ -118,7 +113,6 @@ import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet as Wallet
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
-import qualified Cardano.Wallet.HttpBridge.Compatibility as HttpBridge
 import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Cardano.Wallet.HttpBridge.Transaction as HttpBridge
 import qualified Data.Text as T
@@ -272,13 +266,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
             nl <- HttpBridge.newNetworkLayer @n (getPort nodePort)
             waitForService "http-bridge" (sb, tracer) nodePort $
                 waitForConnection nl defaultRetryPolicy
-            let bp = BlockchainParameters
-                    { getGenesisBlock = HttpBridge.block0
-                    , getFeePolicy = byronFeePolicy
-                    , getSlotLength = byronSlotLength
-                    , getTxMaxSize = byronTxMaxSize
-                    }
-            return (nl, bp)
+            return (nl, byronBlockchainParameters)
 
         withDBLayer
             :: CM.Configuration

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -335,7 +335,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
                     handleNetworkUnreachable tracer
                 Left (ErrGetBlockchainParamsGenesisNotFound _) ->
                     handleGenesisNotFound (sb, tracer)
-                Left (ErrGetBlockchainParamsNoInitialPolicy _) ->
+                Left (ErrGetBlockchainParamsIncompleteParams _) ->
                     handleNoInitialPolicy tracer
             return (nl, blockchainParams)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -67,6 +67,7 @@ module Cardano.Wallet.Primitive.Types
     -- * Slotting
     , SlotId (..)
     , SlotLength (..)
+    , SlotsPerEpoch (..)
     , slotRatio
     , flatSlot
     , fromFlatSlot
@@ -678,15 +679,16 @@ instance Buildable SlotId where
 -- approximation for a few reasons, one of them being that we hard code the
 -- epoch length as a static number whereas it may vary in practice.
 slotRatio
-    :: SlotId
+    :: SlotsPerEpoch
+    -> SlotId
         -- ^ Numerator
     -> SlotId
         -- ^ Denominator
     -> Quantity "percent" Percentage
-slotRatio a b =
+slotRatio epochLength a b =
     let
-        n0 = flatSlot a
-        n1 = flatSlot b
+        n0 = flatSlot epochLength a
+        n1 = flatSlot epochLength b
         tolerance = 5
     in if distance n0 n1 < tolerance || n0 >= n1 then
         maxBound
@@ -694,22 +696,21 @@ slotRatio a b =
         Quantity $ toEnum $ fromIntegral $ (100 * n0) `div` n1
 
 -- | Convert a 'SlotId' to the number of slots since genesis.
-flatSlot :: SlotId -> Word64
-flatSlot (SlotId e s) = epochLength * e + fromIntegral s
+flatSlot :: SlotsPerEpoch -> SlotId -> Word64
+flatSlot (SlotsPerEpoch epochLength) (SlotId e s) = epochLength * e + fromIntegral s
 
 -- | Convert a 'flatSlot' index to 'SlotId'.
-fromFlatSlot :: Word64 -> SlotId
-fromFlatSlot n = SlotId e (fromIntegral s)
+fromFlatSlot :: SlotsPerEpoch -> Word64 -> SlotId
+fromFlatSlot (SlotsPerEpoch epochLength) n = SlotId e (fromIntegral s)
   where
     e = n `div` epochLength
     s = n `mod` epochLength
 
-epochLength :: Integral a => a
-epochLength = 21600
-
 newtype SlotLength = SlotLength DiffTime
     deriving (Show, Eq)
 
+newtype SlotsPerEpoch = SlotsPerEpoch Word64
+    deriving (Show, Eq)
 {-------------------------------------------------------------------------------
                                Polymorphic Types
 -------------------------------------------------------------------------------}

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -72,6 +72,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
+    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -294,7 +295,7 @@ mkTxHistory numTx numInputs numOutputs =
         , TxMeta
             { status = InLedger
             , direction = Incoming
-            , slotId = fromFlatSlot (fromIntegral i)
+            , slotId = fromFlatSlot epochLength (fromIntegral i)
             , amount = Quantity (fromIntegral numOutputs)
             }
         )
@@ -320,7 +321,7 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
   where
     cp i = unsafeInitWallet (UTxO utxo) mempty
         (BlockHeader
-            (fromFlatSlot $ fromIntegral i)
+            (fromFlatSlot epochLength (fromIntegral i))
             (Hash $ label "prevBlockHash" i)
         )
         initDummyState
@@ -391,3 +392,7 @@ ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, mempty) mempty
 -- | Make a prefixed bytestring for use as a Hash or Address.
 label :: Show n => B8.ByteString -> n -> B8.ByteString
 label prefix n = prefix <> B8.pack (show n)
+
+-- | Arbitrary epoch length for testing
+epochLength :: SlotsPerEpoch
+epochLength = SlotsPerEpoch 500

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -23,6 +23,7 @@ import Cardano.Wallet.Primitive.Types
     , Dom (..)
     , Hash (..)
     , SlotId (..)
+    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -121,14 +122,16 @@ spec = do
             let txMeta = TxMeta Invalidated Incoming (SlotId 0 42) (Quantity 0)
             "+0.000000 invalidated since 0.42" === pretty @_ @Text txMeta
 
+    let slotsPerEpoch = SlotsPerEpoch 21600
+
     describe "slotRatio" $ do
         it "works for any two slots" $ property $ \sl0 sl1 ->
-            slotRatio sl0 sl1 `deepseq` ()
+            slotRatio slotsPerEpoch sl0 sl1 `deepseq` ()
     describe "flatSlot" $ do
         it "flatSlot . fromFlatSlot == id" $ property $ \sl ->
-            fromFlatSlot (flatSlot sl) === sl
+            fromFlatSlot slotsPerEpoch (flatSlot slotsPerEpoch sl) === sl
         it "fromFlatSlot . flatSlot == id" $ property $ \n ->
-            flatSlot (fromFlatSlot n) === n
+            flatSlot slotsPerEpoch (fromFlatSlot slotsPerEpoch n) === n
 
     describe "Negative cases for types decoding" $ do
         it "fail fromText @AddressState \"unusedused\"" $ do

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -66,6 +66,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , SlotId (..)
     , SlotLength (..)
+    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -108,6 +109,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Time.Clock
     ( secondsToDiffTime )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
 import Data.Word
     ( Word16, Word32 )
 import GHC.Generics
@@ -372,7 +375,8 @@ setupFixture (wid, wname, wstate) = do
     db <- newDBLayer
     let nl = error "NetworkLayer"
     let tl = dummyTransactionLayer
-    let bp = BlockchainParameters block0 policy slotLength txMaxSize
+    let bp = BlockchainParameters
+            block0 block0Date policy slotLength slotsPerEpoch txMaxSize
     wl <- newWalletLayer @_ @DummyTarget nullTracer bp db nl tl
     res <- runExceptT $ createWallet wl wid wname wstate
     let wal = case res of
@@ -388,6 +392,10 @@ setupFixture (wid, wname, wstate) = do
 
     txMaxSize :: Quantity "byte" Word16
     txMaxSize = Quantity 8192
+
+    slotsPerEpoch = SlotsPerEpoch 21600
+
+    block0Date = posixSecondsToUTCTime 0
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -16,11 +16,11 @@ import Cardano.BM.Trace
 import Cardano.Launcher
     ( Command (Command), StdStream (..), installSignalHandlers, launch )
 import Cardano.Wallet
-    ( BlockchainParameters (..), WalletLayer (..), newWalletLayer )
+    ( WalletLayer (..), newWalletLayer )
 import Cardano.Wallet.DB.Sqlite
     ( PersistState )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
+    ( HttpBridge, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.HttpBridge.Network
@@ -212,12 +212,7 @@ bench_restoration _ (wid, wname, s) = withHttpBridge network $ \port -> do
     let tl = newTransactionLayer
     BlockHeader sl _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
-    let bp = BlockchainParameters
-            { getGenesisBlock = block0
-            , getFeePolicy = byronFeePolicy
-            , getSlotLength = byronSlotLength
-            , getTxMaxSize = byronTxMaxSize
-            }
+    let bp = byronBlockchainParameters
     w <- newWalletLayer @_ @t nullTracer bp db nw tl
     wallet <- unsafeRunExceptT $ createWallet w wid wname s
     unsafeRunExceptT $ restoreWallet w wallet

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -13,9 +13,9 @@ import Cardano.BM.Trace
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
-    ( BlockchainParameters (..), WalletLayer (..), newWalletLayer )
+    ( WalletLayer (..), newWalletLayer )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
+    ( HttpBridge, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -81,6 +81,6 @@ spec = do
         db <- MVar.newDBLayer
         nl <- HttpBridge.newNetworkLayer @'Testnet port
         let tl = HttpBridge.newTransactionLayer
-        let bp = BlockchainParameters block0 byronFeePolicy byronSlotLength byronTxMaxSize
+        let bp = byronBlockchainParameters
         (handle,) <$>
             (newWalletLayer @_ @(HttpBridge 'Testnet) nullTracer bp db nl tl)

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -20,13 +20,13 @@ import Cardano.Faucet
 import Cardano.Launcher
     ( Command (..), StdStream (..), launch )
 import Cardano.Wallet
-    ( BlockchainParameters (..), newWalletLayer )
+    ( newWalletLayer )
 import Cardano.Wallet.Api.Server
     ( Listen (..) )
 import Cardano.Wallet.DB.Sqlite
     ( SqliteContext )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, block0, byronFeePolicy, byronSlotLength, byronTxMaxSize )
+    ( HttpBridge, byronBlockchainParameters, byronFeePolicy )
 import Cardano.Wallet.HttpBridge.Environment
     ( Network (..) )
 import Cardano.Wallet.Network
@@ -264,12 +264,7 @@ main = do
         mvar <- newEmptyMVar
         thread <- forkIO $ do
             let tl = HttpBridge.newTransactionLayer
-            let bp = BlockchainParameters
-                    { getGenesisBlock = block0
-                    , getFeePolicy = byronFeePolicy
-                    , getSlotLength = byronSlotLength
-                    , getTxMaxSize = byronTxMaxSize
-                    }
+            let bp = byronBlockchainParameters
             wallet <- newWalletLayer nullTracer bp db nl tl
             let listen = fromMaybe (ListenOnPort defaultPort) mlisten
             Server.withListeningSocket listen $ \(port, socket) -> do

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -161,6 +161,7 @@ test-suite integration
     , temporary
     , text
     , text-class
+    , time
     , transformers
     , warp
   type:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -274,7 +274,7 @@ mkJormungandrLayer mgr baseUrl = JormungandrLayer
                     , getTxMaxSize = softTxMaxSize
                     }
             _ ->
-                throwE $ ErrGetBlockchainParamsNoInitialPolicy params
+                throwE $ ErrGetBlockchainParamsIncompleteParams params
     }
   where
     run :: ClientM a -> IO (Either ServantError a)
@@ -318,5 +318,5 @@ data ErrGetDescendants
 data ErrGetBlockchainParams
     = ErrGetBlockchainParamsNetworkUnreachable ErrNetworkUnavailable
     | ErrGetBlockchainParamsGenesisNotFound (Hash "Genesis")
-    | ErrGetBlockchainParamsNoInitialPolicy [ConfigParam]
+    | ErrGetBlockchainParamsIncompleteParams [ConfigParam]
     deriving (Show, Eq)

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -66,6 +66,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Time.Clock
     ( secondsToDiffTime )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
 import Data.Word
     ( Word8 )
 import GHC.Generics
@@ -79,6 +81,7 @@ import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
+import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString as BS
 
 spec :: Spec
@@ -118,10 +121,10 @@ spec = do
                         , parentHeaderHash = block0 ^. #prevBlockHash
                         }
                     [ Initial
-                        [ Block0Date 1556202057
+                        [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Testnet
                         , Consensus BFT
-                        , SlotsPerEpoch (Quantity 2160)
+                        , SlotsPerEpoch $ W.SlotsPerEpoch 2160
                         , SlotDuration (secondsToDiffTime 15)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex
@@ -171,10 +174,10 @@ spec = do
                         , parentHeaderHash = block0 ^. #prevBlockHash
                         }
                     [ Initial
-                        [ Block0Date 1556202057
+                        [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Mainnet
                         , Consensus BFT
-                        , SlotsPerEpoch (Quantity 500)
+                        , SlotsPerEpoch (W.SlotsPerEpoch 500)
                         , SlotDuration (secondsToDiffTime 10)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -108,6 +108,7 @@
             (hsPkgs.temporary)
             (hsPkgs.text)
             (hsPkgs.text-class)
+            (hsPkgs.time)
             (hsPkgs.transformers)
             (hsPkgs.warp)
             ];


### PR DESCRIPTION
# Issue Number

#465 


# Overview

- [x] I extended `BlockchainParameters` with two new fields: `getGenesisBlockDate` and `getSlotsPerEpoch` which Jörmungandr will fetch and HttpBridge has hard-coded. I added a `SlotsPerEpoch` type and `byronBlockchainParameters` value in `HttpBridge.Compatibility` as a minor refactoring.
- [x] I made the flat slotting arithmetic take `SlotsPerEpoch` as an argument
- [x] I used a hard-coded artificial `slotsPerEpoch` in the DBLayer which has **nothing** to do with the flat slot number according to the chain. To me the future here seemed unclear, and this is less work than using separate `slot` and `epoch` columns. https://input-output-rnd.slack.com/archives/GBT05825V/p1563283073025700
- [x] I also renamed `ErrGetBlockchainParamsNoInitialPolicy` to `ErrGetBlockchainParamsIncompleteParams `


# Comments

- Split off from #529 
- Some inconsistencies with naming, like `SlotsPerEpoch` vs `epochLength` and `genesis` vs `block0` 🤔 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->