### PR TITLE
Use SlotNo instead of SlotId in core wallet

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Hash, Tx, TxMeta (slotId), WalletId, WalletMetadata )
+    ( Hash, Tx, TxMeta (slotNo), WalletId, WalletMetadata )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, readMVar, withMVar )
 import Control.DeepSeq
@@ -127,7 +127,7 @@ newDBLayer = do
 
         , readTxHistory = \key -> let
                 sortedTxHistory = sortOn slot . Map.toList . txHistory
-                slot = Down . slotId . snd . snd
+                slot = Down . slotNo . snd . snd
             in maybe mempty sortedTxHistory . Map.lookup key <$> readMVar db
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -85,7 +85,7 @@ TxMeta
     txMetaWalletId   W.WalletId   sql=wallet_id
     txMetaStatus     W.TxStatus   sql=status
     txMetaDirection  W.Direction  sql=direction
-    txMetaSlotId     W.SlotId     sql=slot
+    txMetaSlot       W.SlotNo     sql=slot
     txMetaAmount     Natural      sql=amount
 
     Primary txMetaTxId txMetaWalletId
@@ -123,7 +123,7 @@ TxOut
 -- Checkpoint data such as UTxO will refer to this table.
 Checkpoint
     checkpointWalletId    W.WalletId  sql=wallet_id
-    checkpointSlot        W.SlotId    sql=slot
+    checkpointSlot        W.SlotNo    sql=slot
     checkpointParent      BlockId     sql=parent
 
     Primary checkpointWalletId checkpointSlot
@@ -138,7 +138,7 @@ UTxO                                sql=utxo
 
     -- The wallet checkpoint (wallet_id, slot)
     utxoWalletId        W.WalletId  sql=wallet_id
-    utxoCheckpointSlot  W.SlotId    sql=slot
+    utxoCheckpointSlot  W.SlotNo    sql=slot
 
     -- TxIn
     utxoInputId         TxId        sql=input_tx_id
@@ -163,7 +163,7 @@ UTxO                                sql=utxo
 SeqState
     -- The wallet checkpoint (wallet_id, slot)
     seqStateWalletId        W.WalletId        sql=wallet_id
-    seqStateCheckpointSlot  W.SlotId          sql=slot
+    seqStateCheckpointSlot  W.SlotNo          sql=slot
     seqStateExternalGap     W.AddressPoolGap  sql=external_gap
     seqStateInternalGap     W.AddressPoolGap  sql=internal_gap
     seqStateAccountXPub     AddressPoolXPub   sql=account_xpub

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -30,27 +30,17 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
     , Direction (..)
-    , EpochLength (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxStatus (..)
     , WalletId (..)
     , WalletState (..)
-    , flatSlot
-    , fromFlatSlot
     , isValidCoin
     )
 import Control.Monad
     ( (>=>) )
 import Data.Aeson
-    ( FromJSON (..)
-    , ToJSON (..)
-    , Value (..)
-    , defaultOptions
-    , genericParseJSON
-    , genericToJSON
-    , withText
-    )
+    ( FromJSON (..), ToJSON (..), Value (..), withText )
 import Data.Aeson.Types
     ( Parser )
 import Data.Bifunctor
@@ -69,7 +59,7 @@ import Data.Text.Class
     , getTextDecodingError
     )
 import Data.Word
-    ( Word16, Word64, Word8 )
+    ( Word64, Word8 )
 import Database.Persist.Sqlite
     ( PersistField (..), PersistFieldSql (..), PersistValue )
 import Database.Persist.TH
@@ -221,27 +211,20 @@ instance PathPiece BlockId where
     fromPathPiece = fmap BlockId . fromTextMaybe
 
 ----------------------------------------------------------------------------
--- SlotId
+-- SlotNo
 
-instance PersistFieldSql SlotId where
+instance PersistFieldSql SlotNo where
     sqlType _ = sqlType (Proxy @Word64)
 
--- | As a short-to-medium term solution of persisting 'SlotId', we use
--- 'flatSlot' with an artificial epochLength. I.e. /not the same epochLength as
--- the blockchain/. This is just for the sake of storing the 64 bit epoch and
--- the 16 bit slot inside a single 64-bit field.
-artificialEpochLength :: EpochLength
-artificialEpochLength = EpochLength $ fromIntegral (maxBound :: Word16)
+instance PersistField SlotNo where
+    toPersistValue = toPersistValue . unSlotNo
+    fromPersistValue = fmap SlotNo . fromPersistValue
 
-instance PersistField SlotId where
-    toPersistValue = toPersistValue . flatSlot artificialEpochLength
-    fromPersistValue = fmap (fromFlatSlot artificialEpochLength) . fromPersistValue
+instance ToJSON SlotNo where
+    toJSON = toJSON . unSlotNo
 
-instance ToJSON SlotId where
-    toJSON = genericToJSON defaultOptions
-
-instance FromJSON SlotId where
-    parseJSON = genericParseJSON defaultOptions
+instance FromJSON SlotNo where
+    parseJSON = fmap SlotNo . parseJSON
 
 ----------------------------------------------------------------------------
 -- WalletState

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -320,7 +320,7 @@ prefilterBlock proxy b u0 = runState $ do
     mkTxMeta amt dir = TxMeta
         { status = InLedger
         , direction = dir
-        , slotId = b ^. #header . #slotId
+        , slotNo = b ^. #header . #slotNo
         , amount = Quantity amt
         }
     applyTx

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -71,8 +71,8 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , Coin (..)
     , Direction (..)
-    , EpochLength (..)
     , Hash (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -83,7 +83,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletState (..)
-    , fromFlatSlot
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
@@ -295,7 +294,7 @@ mkTxHistory numTx numInputs numOutputs =
         , TxMeta
             { status = InLedger
             , direction = Incoming
-            , slotId = fromFlatSlot epochLength (fromIntegral i)
+            , slotNo = SlotNo (fromIntegral i)
             , amount = Quantity (fromIntegral numOutputs)
             }
         )
@@ -321,7 +320,7 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
   where
     cp i = unsafeInitWallet (UTxO utxo) mempty
         (BlockHeader
-            (fromFlatSlot epochLength (fromIntegral i))
+            (SlotNo $ fromIntegral i)
             (Hash $ label "prevBlockHash" i)
         )
         initDummyState
@@ -392,7 +391,3 @@ ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, mempty) mempty
 -- | Make a prefixed bytestring for use as a Hash or Address.
 label :: Show n => B8.ByteString -> n -> B8.ByteString
 label prefix n = prefix <> B8.pack (show n)
-
--- | Arbitrary epoch length for testing
-epochLength :: EpochLength
-epochLength = EpochLength 500

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Primitive.Types
     , DefineTx
     , EncodeAddress (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     )
@@ -88,7 +88,7 @@ instance Buildable Tx where
 block0 :: Block Tx
 block0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotNo = SlotNo 0
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -22,7 +22,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( Block (..), BlockHeader (..), Hash (..), SlotNo (..) )
 import Control.DeepSeq
     ( NFData )
 import Test.Hspec
@@ -55,7 +55,7 @@ instance Arbitrary (Wallet DummyStateMVar DummyTarget) where
         block0 :: Block Tx
         block0 = Block
             { header = BlockHeader
-                    { slotId = SlotId 0 0
+                    { slotNo = SlotNo 0
                     , prevBlockHash = Hash "genesis"
                     }
             , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -298,6 +298,6 @@ testWid = PrimaryKey (WalletId (hash @ByteString "test"))
 testTxs :: [(Hash "Tx", (Tx, TxMeta))]
 testTxs =
     [ (Hash "tx2", (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
-      , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))
+      , TxMeta InLedger Incoming (SlotNo 302400) (Quantity 1337144))
       )
     ]

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -54,7 +54,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -314,7 +314,7 @@ initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap
 initDummyBlock0 :: Block Tx
 initDummyBlock0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotNo = SlotNo 0
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []
@@ -345,4 +345,4 @@ testTxs :: [(Hash "Tx", (Tx, TxMeta))]
 testTxs =
     [ (Hash "tx2"
       , (Tx [TxIn (Hash "tx1") 0] [TxOut (Address "addr") (Coin 1)]
-        , TxMeta InLedger Incoming (SlotId 14 0) (Quantity 1337144))) ]
+        , TxMeta InLedger Incoming (SlotNo 302400) (Quantity 1337144))) ]

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -72,7 +72,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -193,7 +193,7 @@ type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
 
 -- | Apply the default sort order (descending on time) to a 'TxHistory'.
 sortTxHistory :: TxHistory -> TxHistory
-sortTxHistory = L.sortOn (Down . slotId . snd . snd)
+sortTxHistory = L.sortOn (Down . slotNo . snd . snd)
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)
@@ -301,8 +301,12 @@ instance Arbitrary TxMeta where
     arbitrary = TxMeta
         <$> elements [Pending, InLedger, Invalidated]
         <*> elements [Incoming, Outgoing]
-        <*> (SlotId <$> choose (0, 1000) <*> choose (0, 21599))
+        <*> arbitrary
         <*> fmap (Quantity . fromIntegral) (arbitrary @Word32)
+
+instance Arbitrary SlotNo where
+    shrink (SlotNo sl) = SlotNo <$> shrink sl
+    arbitrary = SlotNo <$> choose (0, 1000000000)
 
 customizedGen :: Gen Percentage
 customizedGen = do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -35,7 +35,7 @@ import Cardano.Wallet.Primitive.Types
     , Dom (..)
     , Hash (..)
     , ShowFmt (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (direction)
     , TxOut (..)
@@ -304,7 +304,7 @@ addresses = map address
 block0 :: Block Tx
 block0 = Block
     { header = BlockHeader
-            { slotId = SlotId 0 0
+            { slotNo = SlotNo 0
             , prevBlockHash = Hash "genesis"
             }
     , transactions = []
@@ -317,7 +317,7 @@ blockchain :: [Block Tx]
 blockchain =
     [ Block
         { header = BlockHeader
-            { slotId = SlotId 2 19218
+            { slotNo = SlotNo 62418
             , prevBlockHash = Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
             }
         , transactions =
@@ -347,7 +347,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 20991
+            { slotNo = SlotNo 301791
             , prevBlockHash = Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
             }
         , transactions =
@@ -391,7 +391,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 21458
+            { slotNo = SlotNo 302258
             , prevBlockHash = Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
             }
         , transactions =
@@ -435,7 +435,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 21586
+            { slotNo = SlotNo 302386
             , prevBlockHash = Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
             }
         , transactions =
@@ -461,14 +461,14 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 0
+            { slotNo = SlotNo 302400
             , prevBlockHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
             }
         , transactions = []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 1
+            { slotNo = SlotNo 302401
             , prevBlockHash = Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
             }
         , transactions =
@@ -494,7 +494,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 2
+            { slotNo = SlotNo 302402
             , prevBlockHash = Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
             }
         , transactions =
@@ -520,7 +520,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 3
+            { slotNo = SlotNo 302403
             , prevBlockHash = Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
             }
         , transactions =
@@ -546,14 +546,14 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-              { slotId = SlotId 14 4
+              { slotNo = SlotNo 302404
               , prevBlockHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
               }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-              { slotId = SlotId 14 5
+              { slotNo = SlotNo 302405
               , prevBlockHash = Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
               }
         , transactions =
@@ -583,35 +583,35 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 6
+            { slotNo = SlotNo 302406
             , prevBlockHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 7
+            { slotNo = SlotNo 302407
             , prevBlockHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 8
+            { slotNo = SlotNo 302408
             , prevBlockHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 9
+            { slotNo = SlotNo 302409
             , prevBlockHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 10
+            { slotNo = SlotNo 302410
             , prevBlockHash = Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
             }
         , transactions =
@@ -655,7 +655,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 11
+            { slotNo = SlotNo 302411
             , prevBlockHash = Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
             }
         , transactions =
@@ -699,49 +699,49 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 12
+            { slotNo = SlotNo 302412
             , prevBlockHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 13
+            { slotNo = SlotNo 302413
             , prevBlockHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 14
+            { slotNo = SlotNo 302414
             , prevBlockHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 15
+            { slotNo = SlotNo 302415
             , prevBlockHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 16
+            { slotNo = SlotNo 302416
             , prevBlockHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 17
+            { slotNo = SlotNo 302417
             , prevBlockHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
             }
         , transactions =  []
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 18
+            { slotNo = SlotNo 302418
             , prevBlockHash = Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
             }
         , transactions =
@@ -785,7 +785,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 19
+            { slotNo = SlotNo 302419
             , prevBlockHash = Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
             }
         , transactions =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -65,8 +65,8 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochLength (..)
     , Hash (..)
-    , SlotId (..)
     , SlotLength (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -118,14 +118,7 @@ import GHC.Generics
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldNotBe, shouldSatisfy )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , Property
-    , choose
-    , elements
-    , property
-    , withMaxSuccess
-    , (==>)
-    )
+    ( Arbitrary (..), Property, elements, property, withMaxSuccess, (==>) )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
@@ -356,7 +349,7 @@ walletListTransactionsSorted wallet@(wid, _, _) history =
         txs <- unsafeRunExceptT $ listTransactions wl wid
         length txs `shouldBe` Map.size history
         -- With the 'Down'-wrapper, the sort is descending.
-        txs `shouldBe` L.sortOn (Down . slotId . snd) txs
+        txs `shouldBe` L.sortOn (Down . slotNo . snd) txs
 
 {-------------------------------------------------------------------------------
                       Tests machinery, Arbitrary instances
@@ -495,5 +488,5 @@ instance Arbitrary TxMeta where
     arbitrary = TxMeta
         <$> elements [Pending, InLedger, Invalidated]
         <*> elements [Incoming, Outgoing]
-        <*> (SlotId <$> choose (0, 1000) <*> choose (0, 21599))
+        <*> (SlotNo <$> arbitrary)
         <*> fmap (Quantity . fromIntegral) (arbitrary @Word32)

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
@@ -22,11 +22,17 @@ module Cardano.Wallet.HttpBridge.Api
 import Prelude
 
 import Cardano.Wallet.HttpBridge.Binary
-    ( decodeBlock, decodeBlockHeader, decodeSignedTx, encodeSignedTx )
+    ( Block
+    , BlockHeader
+    , decodeBlock
+    , decodeBlockHeader
+    , decodeSignedTx
+    , encodeSignedTx
+    )
 import Cardano.Wallet.HttpBridge.Primitive.Types
     ( Tx )
 import Cardano.Wallet.Primitive.Types
-    ( Block, BlockHeader, TxWitness )
+    ( TxWitness )
 import Crypto.Hash.Algorithms
     ( Blake2b_256 )
 import Data.Aeson
@@ -75,14 +81,14 @@ type GetBlockByHash
     =  Capture "networkName" NetworkName
     :> "block"
     :> Capture "blockHeaderHash" (Hash Blake2b_256 (ApiT BlockHeader))
-    :> Get '[CBOR] (ApiT (Block Tx))
+    :> Get '[CBOR] (ApiT Block)
 
 -- | Retrieve all the blocks for the epoch identified by the given integer ID.
 type GetEpochById
     =  Capture "networkName" NetworkName
     :> "epoch"
     :> Capture "epochId" EpochIndex
-    :> Get '[Packed CBOR] [ApiT (Block Tx)]
+    :> Get '[Packed CBOR] [ApiT Block]
 
 -- | Retrieve the header of the latest known block.
 type GetTipBlockHeader
@@ -100,7 +106,7 @@ type PostSignedTx
 
 newtype ApiT a = ApiT { getApiT :: a } deriving (Show)
 
-instance FromCBOR (ApiT (Block Tx)) where
+instance FromCBOR (ApiT Block) where
     fromCBOR = ApiT <$> decodeBlock
 
 instance FromCBOR (ApiT BlockHeader) where

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -53,8 +53,8 @@ import Cardano.Wallet.Primitive.Types
     , EncodeAddress (..)
     , EpochLength (..)
     , Hash (..)
-    , SlotId (..)
     , SlotLength (..)
+    , SlotNo (..)
     , Tx (..)
     )
 import Crypto.Hash
@@ -162,7 +162,7 @@ instance DecodeAddress (HttpBridge (network :: Network)) where
 block0 :: Block W.Tx
 block0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotNo = SlotNo 0
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -36,7 +36,7 @@ share
     [persistLowerCase|
 AnyAddressState
     anyAddressStateWalletId        W.WalletId  sql=wallet_id
-    anyAddressStateCheckpointSlot  W.SlotId    sql=slot
+    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot
     anyAddressStateProportion      Double      sql=proportion
 
     UniqueAnyAddressState anyAddressStateWalletId anyAddressStateCheckpointSlot

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.Primitive.Mnemonic
 import Cardano.Wallet.Primitive.Model
     ( currentTip )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), SlotId (..), WalletId (..), WalletName (..) )
+    ( BlockHeader (..), SlotNo (..), WalletId (..), WalletName (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent
@@ -58,9 +58,9 @@ spec = do
                 (mkSeqState @(HttpBridge 'Testnet) (xprv, mempty) minBound)
             unsafeRunExceptT $ restoreWallet wallet wid
             threadDelay 2000000
-            tip <- slotId . currentTip . fst <$>
+            tip <- slotNo . currentTip . fst <$>
                 unsafeRunExceptT (readWallet wallet wid)
-            unless (tip > (SlotId 0 0)) $
+            unless (tip > SlotNo 0) $
                 expectationFailure ("The wallet tip is still " ++ show tip)
   where
     port = 1337

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
@@ -14,7 +14,9 @@ import Prelude
 
 
 import Cardano.Wallet.HttpBridge.Binary
-    ( decodeBlock
+    ( Block (..)
+    , BlockHeader (..)
+    , decodeBlock
     , decodeBlockHeader
     , decodeSignedTx
     , decodeTx
@@ -30,9 +32,7 @@ import Cardano.Wallet.HttpBridge.Environment
 import Cardano.Wallet.HttpBridge.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
-    , BlockHeader (..)
-    , Coin (..)
+    ( Coin (..)
     , Hash (..)
     , SlotId (..)
     , TxIn (..)
@@ -163,7 +163,7 @@ blockHeader1 = BlockHeader
     }
 
 -- A mainnet block
-block1 :: Block Tx
+block1 :: Block
 block1 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9519
@@ -176,7 +176,7 @@ block1 = Block
         "4d97da40fb62bec847d6123762e82f9325f11d0c8e89deee0c7dbb598ed5f0cf"
 
 -- A mainnet block with a transaction
-block2 :: Block Tx
+block2 :: Block
 block2 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9876
@@ -205,7 +205,7 @@ block2 = Block
         \aHz9M4myYAkQVc5m9E4DKJjRDjPxuDdK3ZsHb1Dnqf3XorZ1PnzX"
 
 -- A testnet block with a transaction
-block3 :: Block Tx
+block3 :: Block
 block3 = Block
     { header = BlockHeader
         { slotId = SlotId 30 9278
@@ -237,7 +237,7 @@ block3 = Block
         \RQRHCMezN6AMLd3uYTC5hbeVTUiPzfQUTCEogg2HrSJKQUjAgsoYZHwT3"
 
 -- A mainnet block with multiple transactions
-block4 :: Block Tx
+block4 :: Block
 block4 = Block
     { header = BlockHeader
         { slotId = SlotId 14 18

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+
 module Cardano.Wallet.HttpBridge.NetworkSpec
     ( spec
     ) where
@@ -6,14 +8,22 @@ import Prelude
 
 import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge )
+import Cardano.Wallet.HttpBridge.Environment
+    ( Network (..) )
 import Cardano.Wallet.HttpBridge.Network
     ( HttpBridgeLayer (..) )
-import Cardano.Wallet.HttpBridge.Primitive.Types
-    ( Tx )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( Block (..)
+    , BlockHeader (..)
+    , EpochLength (..)
+    , Hash (..)
+    , SlotId (..)
+    , SlotNo (..)
+    , flatSlot
+    , fromFlatSlot
+    )
 import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Except
@@ -23,6 +33,7 @@ import Data.Word
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldSatisfy )
 
+import qualified Cardano.Wallet.HttpBridge.Binary as B
 import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Data.ByteString.Char8 as B8
 
@@ -33,77 +44,53 @@ spec = do
         let network = mockNetworkLayer noLog 105 (SlotId 106 1492)
 
         it "should get something from the latest epoch" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 106 999
-                    , prevBlockHash = mockHash (SlotId 106 998)
-                    }
+            let h = mockBlockHeader 106 999
             blocks <- runExceptT $ nextBlocks network h
             -- the number of blocks between slots 1000 and 1492 inclusive
             fmap length blocks `shouldBe` Right 493
-            let hdrs = either (const []) (map (slotId . header)) blocks
-            map slotNumber hdrs `shouldBe` [1000 .. 1492]
+            let hdrs = either (const []) (map (fromSlotNo . slotNo . header)) blocks
+            map slotNumber  hdrs `shouldBe` [1000 .. 1492]
             map epochNumber hdrs `shouldSatisfy` all (== 106)
 
         it "should return all unstable blocks" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 105 0
-                    , prevBlockHash = mockHash (SlotId 104 21599)
-                    }
+            let h = mockBlockHeader 105 0
             blocks <- runExceptT $ nextBlocks network h
             fmap length blocks `shouldBe` Right (21600 + 1492)
 
         it "should return unstable blocks after the start slot" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 105 17000
-                    , prevBlockHash = mockHash (SlotId 105 16999)
-                    }
+            let h = mockBlockHeader 105 17000
             blocks <- runExceptT $ nextBlocks network h
             -- this will be all the blocks between 105.17000 and 106.1492
             fmap length blocks `shouldBe` Right 6092
 
         it "should return just the tip block" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 106 1491
-                    , prevBlockHash = mockHash (SlotId 106 1490)
-                    }
+            let h = mockBlockHeader 106 1491
             blocks <- runExceptT $ nextBlocks network h
             fmap length blocks `shouldBe` Right 1
 
         it "should get from packed epochs" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 100 0
-                    , prevBlockHash = mockHash (SlotId 99 21599)
-                    }
+            let h = mockBlockHeader 100 0
             Right blocks <- runExceptT $ nextBlocks network h
             -- an entire epoch's worth of blocks
             length blocks `shouldBe` 21599
-            map (epochNumber . slotId . header) blocks
+            map (epochNumber . fromSlotNo . slotNo . header) blocks
                 `shouldSatisfy` all (== 100)
 
         it "should get from packed epochs and filter by start slot" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 104 10000
-                    , prevBlockHash = mockHash (SlotId 104 9999)
-                    }
+            let h = mockBlockHeader 104 10000
             Right blocks <- runExceptT $ nextBlocks network h
             -- the number of remaining blocks in epoch 104
             length blocks `shouldBe` 11599
-            map (epochNumber . slotId . header) blocks
+            map (epochNumber . fromSlotNo . slotNo . header) blocks
                 `shouldSatisfy` all (== 104)
 
         it "should produce no blocks if start slot is after tip" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 107 0
-                    , prevBlockHash = mockHash (SlotId 106 21599)
-                    }
+            let h = mockBlockHeader 107 0
             blocks <- runExceptT $ nextBlocks network h
             blocks `shouldBe` Right []
 
         it "should work for the first epoch" $ do
-            let h = BlockHeader
-                    { slotId = SlotId 0 0
-                    , prevBlockHash = Hash "genesis"
-                    }
+            let h = mockBlockHeader 0 0
             Right blocks <- runExceptT $ nextBlocks network h
             length blocks `shouldBe` 21599
 
@@ -111,8 +98,22 @@ spec = do
                              Mock HTTP Bridge
 -------------------------------------------------------------------------------}
 
-slotsPerEpoch :: Word16
+slotsPerEpoch :: Integral n => n
 slotsPerEpoch = 21600
+
+fromSlotNo :: SlotNo -> SlotId
+fromSlotNo = fromFlatSlot (EpochLength slotsPerEpoch)
+
+toSlotNo :: SlotId -> SlotNo
+toSlotNo = flatSlot (EpochLength slotsPerEpoch)
+
+mockBlockHeader :: Word64 -> Word16 -> BlockHeader
+mockBlockHeader 0 0 = BlockHeader (SlotNo 0) (Hash "genesis")
+mockBlockHeader ep sl = BlockHeader slot prevHash
+  where
+    slot = toSlotNo $ SlotId ep sl
+    prevSlotId = fromSlotNo $ pred slot
+    prevHash = if slot == SlotNo 0 then Hash "genesis" else mockHash prevSlotId
 
 -- | Embed an epoch index and slot number into a hash.
 mockHash :: SlotId -> Hash a
@@ -128,32 +129,28 @@ unMockHash (Hash h) = parse . map B8.unpack . B8.split '.' . B8.drop 5 $ h
 
 -- | Create a block header from its hash, assuming that the hash was created
 -- with 'mockHash'.
-mockHeaderFromHash :: Hash a -> BlockHeader
-mockHeaderFromHash h = BlockHeader slot prevHash
+mockHeaderFromHash :: Hash a -> B.BlockHeader
+mockHeaderFromHash h = B.BlockHeader (fromSlotNo slot) prev
   where
-    slot@(SlotId ep sl) = unMockHash h
-    prevHash =
-        case (ep, sl) of
-            (0, 0) -> Hash "genesis"
-            (_, 0) -> mockHash (SlotId (ep-1) (slotsPerEpoch - 1))
-            _ -> mockHash (SlotId ep (sl - 1))
+    BlockHeader slot prev = mockBlockHeader sl ep
+    SlotId sl ep = unMockHash h
 
 -- | Generate an entire epoch's worth of mock blocks. There are no transactions
 -- generated.
-mockEpoch :: Word64 -> [Block Tx]
+mockEpoch :: Word64 -> [B.Block]
 mockEpoch ep =
-    [ Block (mockHeaderFromHash (mockHash sl)) mempty
+    [ B.Block (mockHeaderFromHash (mockHash sl)) mempty
     | sl <- [ SlotId ep i | i <- epochs ]
     ]
   where
-    epochs = [ 0 .. fromIntegral (slotsPerEpoch - 1) ]
+    epochs = [ 0 .. (slotsPerEpoch - 1) ]
 
 mockNetworkLayer
     :: Monad m
     => (String -> m ()) -- ^ logger function
     -> Word64 -- ^ make getEpoch fail for epochs after this
     -> SlotId -- ^ the tip block
-    -> NetworkLayer (HttpBridge n) m
+    -> NetworkLayer (HttpBridge 'Mainnet) m
 mockNetworkLayer logLine firstUnstableEpoch tip =
     HttpBridge.mkNetworkLayer (mockHttpBridge logLine firstUnstableEpoch tip)
 
@@ -167,7 +164,7 @@ mockHttpBridge
 mockHttpBridge logLine firstUnstableEpoch tip = HttpBridgeLayer
     { getBlock = \hash -> do
         lift $ logLine $ "mock getBlock " ++ show hash
-        pure $ Block (mockHeaderFromHash hash) mempty
+        pure $ B.Block (mockHeaderFromHash hash) mempty
 
     , getEpoch = \ep -> do
         lift $ logLine $ "mock getEpoch " ++ show ep

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -14,7 +14,7 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , Coin (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     )
@@ -31,7 +31,7 @@ spec = do
         it "Block" $ do
             let block = Block
                     { header = BlockHeader
-                        { slotId = SlotId 14 19
+                        { slotNo = SlotNo 302419
                         , prevBlockHash = Hash "\223\252\&5\ACK\211\129\&6\DC4h7b'\225\201\&2:/\252v\SOH\DC1\ETX\227\"Q$\240\142ii\167;"
                         }
                     , transactions =
@@ -55,7 +55,7 @@ spec = do
                             }
                         ]
                     }
-            "dffc3506...6969a73b (14.19)\n\
+            "dffc3506...6969a73b (302419)\n\
             \    - ~> 1st c29d3ea0...13862214\n\
             \      <~ 3823755953610 @ 82d81858...aebb3709\n\
             \      <~ 19999800000 @ 82d81858...37ce9c60\n"

--- a/lib/http-bridge/test/unit/Data/PackfileSpec.hs
+++ b/lib/http-bridge/test/unit/Data/PackfileSpec.hs
@@ -5,13 +5,11 @@ module Data.PackfileSpec
 import Prelude
 
 import Cardano.Wallet.HttpBridge.Binary
-    ( decodeBlock )
+    ( Block (..), BlockHeader (..), decodeBlock )
 import Cardano.Wallet.HttpBridge.BinarySpec
     ( unsafeDeserialiseFromBytes )
-import Cardano.Wallet.HttpBridge.Primitive.Types
-    ( Tx )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), SlotId (..) )
+    ( SlotId (..) )
 import Data.Either
     ( fromRight, isRight )
 import Data.Packfile
@@ -102,7 +100,7 @@ spec = do
             slotNumber second `shouldBe` 1 -- second block
 
 -- | Decode all blocks in a pack file, without error handling
-unsafeDeserialiseEpoch :: L8.ByteString -> [Block Tx]
+unsafeDeserialiseEpoch :: L8.ByteString -> [Block]
 unsafeDeserialiseEpoch = either giveUp decodeBlocks . decodePackfile
     where
         decodeBlocks = map decodeBlob

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.Types
     , DefineTx
     , EncodeAddress (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , invariant
     )
 import Codec.Binary.Bech32
@@ -91,7 +91,7 @@ data Jormungandr (network :: Network)
 -- | Genesis block header, i.e. very first block header of the chain
 block0 :: BlockHeader
 block0 = BlockHeader
-    { slotId = (SlotId 0 0)
+    { slotNo = SlotNo 0
     , prevBlockHash = Hash (BS.replicate 32 0)
     }
 

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , Coin (..)
     , Hash (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     , TxWitness (..)
@@ -98,8 +98,8 @@ spec = do
         it "get network tip" $ \(_, nw) -> do
             resp <- runExceptT $ networkTip nw
             resp `shouldSatisfy` isRight
-            let (Right slot) = slotId <$> resp
-            slot `shouldSatisfy` (>= SlotId 0 0)
+            let (Right slot) = slotNo <$> resp
+            slot `shouldSatisfy` (>= SlotNo 0)
 
         it "get some blocks from the genesis" $ \(_, nw) -> do
             threadDelay (10 * second)
@@ -125,7 +125,7 @@ spec = do
             -- for what it's worth, I didn't bother retrying.
             bytes <- BS.pack <$> generate (vectorOf 32 arbitrary)
             let block = BlockHeader
-                    { slotId = SlotId 42 14 -- Anything
+                    { slotNo = SlotNo 42 -- Anything
                     , prevBlockHash = Hash bytes
                     }
             resp <- runExceptT $ nextBlocks nw block

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -133,7 +133,7 @@ spec = do
 
     describe "Error paths" $ do
         it "networkTip: ErrNetworkUnreachable" $ do
-            nw <- Jormungandr.newNetworkLayer url
+            nw <- newNetworkLayer url
             let msg x =
                     "Expected a ErrNetworkUnreachable' failure but got "
                     <> show x
@@ -147,7 +147,7 @@ spec = do
             action `shouldReturn` ()
 
         it "nextBlocks: ErrNetworkUnreachable" $ do
-            nw <- Jormungandr.newNetworkLayer url
+            nw <- newNetworkLayer url
             let msg x =
                     "Expected a ErrNetworkUnreachable' failure but got "
                     <> show x
@@ -277,7 +277,8 @@ spec = do
                 ] (return ())
                 Inherit
             ]
-        nw <- Jormungandr.newNetworkLayer baseUrl
+        threadDelay 5000000 -- fixme: need to fix the wait
+        nw <- newNetworkLayer baseUrl
         wait nw $> (handle, nw)
 
     killNode :: (Async (), a) -> IO ()
@@ -341,3 +342,11 @@ spec = do
                 }
             ]
         }
+
+    block0H :: Hash "Genesis"
+    block0H = Hash $ unsafeFromHex
+        "dba597bee5f0987efbf56f6bd7f44c38158a7770d0cb28a26b5eca40613a7ebd"
+        -- ^ jcli genesis hash --input test/data/jormungandr/block0.bin
+
+    newNetworkLayer url' = fmap fst . unsafeRunExceptT $
+        Jormungandr.newNetworkLayer url' block0H

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -35,7 +35,7 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, Network (..) )
 import Cardano.Wallet.Jormungandr.Network
-    ( BaseUrl (..), JormungandrLayer (..), Scheme (..), mkJormungandrLayer )
+    ( BaseUrl (..), Scheme (..), mkJormungandrLayer, nullConfig )
 import Cardano.Wallet.Network
     ( NetworkLayer (..), defaultRetryPolicy, waitForConnection )
 import Cardano.Wallet.Primitive.Fee
@@ -208,11 +208,10 @@ newNetworkLayer
 newNetworkLayer url block0H = do
     mgr <- newManager defaultManagerSettings
     let jormungandr = mkJormungandrLayer mgr url
-    let nl = Jormungandr.mkNetworkLayer jormungandr
+    let nl = Jormungandr.mkNetworkLayer nullConfig jormungandr
     waitForConnection nl defaultRetryPolicy
-    blockchainParams <- unsafeRunExceptT $
-        getInitialBlockchainParameters jormungandr (coerce block0H)
-    return (nl, blockchainParams)
+    unsafeRunExceptT $
+        Jormungandr.newNetworkLayer url (coerce block0H)
 
 mkFeeEstimator :: FeePolicy -> TxDescription -> (Natural, Natural)
 mkFeeEstimator policy (TxDescription nInps nOuts) =

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -42,6 +42,7 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
+    , EpochLength (..)
     , Hash (..)
     , SlotId (..)
     , TxIn (..)
@@ -81,7 +82,6 @@ import Test.QuickCheck.Arbitrary.Generic
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
-import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString as BS
 
 spec :: Spec
@@ -113,7 +113,7 @@ spec = do
                     BlockHeader
                         { version = 0
                         , contentSize = 458
-                        , slot = block0 ^. #slotId
+                        , slot = SlotId 0 0
                         , chainLength = 0
                         , contentHash = Hash $ unsafeFromHex
                             "f7becdf807c706cef54ec4832d2a7475\
@@ -124,7 +124,7 @@ spec = do
                         [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Testnet
                         , Consensus BFT
-                        , SlotsPerEpoch $ W.EpochLength 2160
+                        , SlotsPerEpoch $ EpochLength 2160
                         , SlotDuration (secondsToDiffTime 15)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex
@@ -166,7 +166,7 @@ spec = do
                     BlockHeader
                         { version = 0
                         , contentSize = 129
-                        , slot = block0 ^. #slotId
+                        , slot = SlotId 0 0
                         , chainLength = 0
                         , contentHash = Hash $ unsafeFromHex
                             "5df3b1c19c1400a9925158ade2b71913\
@@ -177,7 +177,7 @@ spec = do
                         [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Mainnet
                         , Consensus BFT
-                        , SlotsPerEpoch (W.EpochLength 500)
+                        , SlotsPerEpoch (EpochLength 500)
                         , SlotDuration (secondsToDiffTime 10)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex


### PR DESCRIPTION
Relates to issue #465

# Overview

This changes `SlotId` (epoch, local slot index) to `SlotNo` (0-based index, number of slots since genesis) in the wallet core. The wallet then needs to worry even less about slotting. Network node backends handle conversion according to their configuration (and, in future, chain state).

On top of this, the network layers can provide a function `slotTime :: Monad m => NetworkLayer -> SlotNo -> m UTCTime`, using their configuration (and, in future, chain state). See #529.

# Comments

Not all the tests and benchmarks have been refactored yet.
