### PR TITLE
Concept for handling dynamic slotting

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -97,6 +97,7 @@ import Cardano.Wallet.Primitive.Model
     , getState
     , initWallet
     , newPending
+    , slottingState
     , updateState
     )
 import Cardano.Wallet.Primitive.Types
@@ -438,7 +439,8 @@ newWalletLayer tracer bp db nw tl = do
         -> s
         -> ExceptT ErrWalletAlreadyExists IO WalletId
     _createWallet wid wname s = do
-        let checkpoint = initWallet block0 s
+        let slotting = undefined
+        let checkpoint = initWallet block0 s slotting
         currentTime <- liftIO getCurrentTime
         let metadata = WalletMetadata
                 { name = wname
@@ -714,6 +716,7 @@ newWalletLayer tracer bp db nw tl = do
                             , direction = Outgoing
                             , slotId = (currentTip w) ^. #slotId
                             , amount = Quantity (amtInps - amtChng)
+                            , utcTime = (slottingState w) ^. #time
                             }
                     return (tx, meta, wit)
                 Left e ->

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -522,13 +522,15 @@ checkpointFromEntity
     -> s
     -> W.Wallet s t
 checkpointFromEntity (Checkpoint _ slot (BlockId parentHeaderHash)) utxo txs =
-    W.unsafeInitWallet utxo' pending (W.BlockHeader slot parentHeaderHash)
+    W.unsafeInitWallet
+        utxo' pending (W.BlockHeader slot parentHeaderHash) slottingParams
   where
     utxo' = W.UTxO . Map.fromList $
         [ (W.TxIn input ix, W.TxOut addr coin)
         | UTxO _ _ (TxId input) ix addr coin <- utxo
         ]
     pending = Set.fromList $ map snd txs
+    slottingParams = error "TODO: SlottingParams to be persisted"
 
 mkTxHistory
     :: forall t. PersistTx t
@@ -612,6 +614,7 @@ txHistoryFromEntity metas ins outs = map mkItem metas
         , W.direction = txMetaDirection m
         , W.slotId = txMetaSlotId m
         , W.amount = Quantity (txMetaAmount m)
+        , W.utcTime = error "TODO: utcTime to be persisted"
         }
 
 ----------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -31,6 +31,7 @@ module Cardano.Wallet.Primitive.Types
     -- * Block
       Block(..)
     , BlockHeader(..)
+    , ProtocolUpdate(..)
 
     -- * Tx
     , DefineTx(..)
@@ -316,7 +317,7 @@ data Block tx = Block
         :: !BlockHeader
     , transactions
         :: ![tx]
-    , updatedSlottingParameters :: (Maybe EpochLength, Maybe SlotLength)
+    , protocolUpdates :: [ProtocolUpdate]
     } deriving (Show, Eq, Ord, Generic)
 
 instance NFData tx => NFData (Block tx)
@@ -344,6 +345,13 @@ instance Buildable BlockHeader where
         <> " (" <> build s <> ")"
       where
         prevF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash prev
+
+data ProtocolUpdate
+    = UpdatedEpochLength EpochLength
+    | UpdatedSlotLength SlotLength
+    deriving (Show, Eq, Generic, Ord)
+
+instance NFData ProtocolUpdate
 
 {-------------------------------------------------------------------------------
                                       Tx

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
@@ -144,14 +144,14 @@ decodeBlock = do
             -- In theory, we should also:
             --
             -- _ <- decodeGenesisBlockBody
-            return $ Block h mempty (Nothing, Nothing)
+            return $ Block h mempty []
 
         1 -> do -- Main Block
             _ <- CBOR.decodeListLenCanonicalOf 3
             h <- decodeMainBlockHeader
             txs <- decodeMainBlockBody
             -- _ <- decodeMainExtraData
-            return $ Block h txs (Nothing, Nothing)
+            return $ Block h txs []
 
         _ -> do
             fail $ "decodeBlock: unknown block constructor: " <> show t

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Binary.hs
@@ -144,14 +144,14 @@ decodeBlock = do
             -- In theory, we should also:
             --
             -- _ <- decodeGenesisBlockBody
-            return $ Block h mempty
+            return $ Block h mempty (Nothing, Nothing)
 
         1 -> do -- Main Block
             _ <- CBOR.decodeListLenCanonicalOf 3
             h <- decodeMainBlockHeader
             txs <- decodeMainBlockBody
             -- _ <- decodeMainExtraData
-            return $ Block h txs
+            return $ Block h txs (Nothing, Nothing)
 
         _ -> do
             fail $ "decodeBlock: unknown block constructor: " <> show t

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -166,7 +166,7 @@ block0 = Block
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []
-    , updatedSlottingParameters = (Nothing, Nothing)
+    , protocolUpdates = []
     }
 
 -- | Hard-coded fee policy for Cardano on Byron

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -166,6 +166,7 @@ block0 = Block
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []
+    , updatedSlottingParameters = (Nothing, Nothing)
     }
 
 -- | Hard-coded fee policy for Cardano on Byron

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
@@ -170,7 +170,7 @@ block1 = Block
         , prevBlockHash = prevBlockHash0
         }
     , transactions = mempty
-    , updatedSlottingParameters = (Nothing, Nothing)
+    , protocolUpdates = []
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -192,7 +192,7 @@ block2 = Block
                 , TxOut { address = address1, coin = Coin 1810771919 } ]
             }
         ]
-    , updatedSlottingParameters = (Nothing, Nothing)
+    , protocolUpdates = []
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -223,7 +223,7 @@ block3 = Block
                 , TxOut { address = address1, coin = Coin 1004099328 } ]
             }
         ]
-    , updatedSlottingParameters = (Nothing, Nothing)
+    , protocolUpdates = []
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -284,7 +284,7 @@ block4 = Block
                   ]
             }
         ]
-    , updatedSlottingParameters = (Nothing, Nothing)
+    , protocolUpdates = []
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/BinarySpec.hs
@@ -170,6 +170,7 @@ block1 = Block
         , prevBlockHash = prevBlockHash0
         }
     , transactions = mempty
+    , updatedSlottingParameters = (Nothing, Nothing)
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -191,6 +192,7 @@ block2 = Block
                 , TxOut { address = address1, coin = Coin 1810771919 } ]
             }
         ]
+    , updatedSlottingParameters = (Nothing, Nothing)
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -221,6 +223,7 @@ block3 = Block
                 , TxOut { address = address1, coin = Coin 1004099328 } ]
             }
         ]
+    , updatedSlottingParameters = (Nothing, Nothing)
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex
@@ -281,6 +284,7 @@ block4 = Block
                   ]
             }
         ]
+    , updatedSlottingParameters = (Nothing, Nothing)
     }
   where
     prevBlockHash0 = Hash $ unsafeFromHex

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -142,7 +142,7 @@ mockHeaderFromHash h = BlockHeader slot prevHash
 -- generated.
 mockEpoch :: Word64 -> [Block Tx]
 mockEpoch ep =
-    [ Block (mockHeaderFromHash (mockHash sl)) mempty (Nothing, Nothing)
+    [ Block (mockHeaderFromHash (mockHash sl)) mempty []
     | sl <- [ SlotId ep i | i <- epochs ]
     ]
   where
@@ -167,7 +167,7 @@ mockHttpBridge
 mockHttpBridge logLine firstUnstableEpoch tip = HttpBridgeLayer
     { getBlock = \hash -> do
         lift $ logLine $ "mock getBlock " ++ show hash
-        pure $ Block (mockHeaderFromHash hash) mempty (Nothing, Nothing)
+        pure $ Block (mockHeaderFromHash hash) mempty []
 
     , getEpoch = \ep -> do
         lift $ logLine $ "mock getEpoch " ++ show ep

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -142,7 +142,7 @@ mockHeaderFromHash h = BlockHeader slot prevHash
 -- generated.
 mockEpoch :: Word64 -> [Block Tx]
 mockEpoch ep =
-    [ Block (mockHeaderFromHash (mockHash sl)) mempty
+    [ Block (mockHeaderFromHash (mockHash sl)) mempty (Nothing, Nothing)
     | sl <- [ SlotId ep i | i <- epochs ]
     ]
   where
@@ -167,7 +167,7 @@ mockHttpBridge
 mockHttpBridge logLine firstUnstableEpoch tip = HttpBridgeLayer
     { getBlock = \hash -> do
         lift $ logLine $ "mock getBlock " ++ show hash
-        pure $ Block (mockHeaderFromHash hash) mempty
+        pure $ Block (mockHeaderFromHash hash) mempty (Nothing, Nothing)
 
     , getEpoch = \ep -> do
         lift $ logLine $ "mock getEpoch " ++ show ep

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -54,7 +54,7 @@ spec = do
                                 ]
                             }
                         ]
-                    , updatedSlottingParameters = (Nothing, Nothing)
+                    , protocolUpdates = []
                     }
             "dffc3506...6969a73b (14.19)\n\
             \    - ~> 1st c29d3ea0...13862214\n\

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -54,6 +54,7 @@ spec = do
                                 ]
                             }
                         ]
+                    , updatedSlottingParameters = (Nothing, Nothing)
                     }
             "dffc3506...6969a73b (14.19)\n\
             \    - ~> 1st c29d3ea0...13862214\n\

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -534,7 +534,7 @@ withSizeHeader16be x = do
 
 coerceBlock  :: Block -> W.Block Tx
 coerceBlock (Block h msgs) =
-    W.Block coerceHeader coerceMessages (Nothing, Nothing)
+    W.Block coerceHeader coerceMessages []
   where
     coerceHeader = W.BlockHeader (slot h) (parentHeaderHash h)
     coerceMessages = msgs >>= \case

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -534,7 +534,7 @@ withSizeHeader16be x = do
 
 coerceBlock  :: Block -> W.Block Tx
 coerceBlock (Block h msgs) =
-    W.Block coerceHeader coerceMessages
+    W.Block coerceHeader coerceMessages (Nothing, Nothing)
   where
     coerceHeader = W.BlockHeader (slot h) (parentHeaderHash h)
     coerceMessages = msgs >>= \case


### PR DESCRIPTION
- Wallet checkpoints include 'SlottingState' which is updated in `applyBlock`. This means that given a checkpoint and some blocks to apply, we will always have everything we need.

```haskell
data SlottingState = SlottingState
    { slotsPerEpoch :: SlotsPerEpoch
    , slotLength :: SlotLength
    , time :: UTCTime
    , slotNo :: Word
    } deriving (Show, Eq, Generic)

-- NOTE: 'SlotId' could have been included here, but it is already stored in the BlockHeader-tip.
```
- `TxMeta` now stores `utcTime`.