### PR TITLE
additional info in help for --network argument

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -288,7 +288,7 @@ networkOption :: Parser Network
 networkOption = optionT $ mempty
     <> long "network"
     <> metavar "STRING"
-    <> help "target network to connect to: testnet or mainnet"
+    <> help "target network to connect to: testnet or mainnet (default: testnet)"
     <> value Testnet
 
 -- | [--local-network|--network=STRING], default (Right Testnet)
@@ -298,4 +298,4 @@ networkOption' =
   where
     localNetworkOption = flag' False $ mempty
         <> long "local-network"
-        <> help "connect to a local network"
+        <> help "connect to a local network (conflicts with --network)"


### PR DESCRIPTION
# Issue Number

# Overview

Added additional info to `cardano-wallet-http-bridge launch -h`

was:

```
...
  --local-network          connect to a local network
  --network STRING         target network to connect to: testnet or mainnet 
...                       
```

is:

```
...
  --local-network          connect to a local network (conflicts with --network)
  --network STRING         target network to connect to: testnet or mainnet
                           (default: testnet)
...
```

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
