### PR TITLE
Rename `SlotsPerEpoch` to `EpochLength`

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -107,9 +107,9 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , DefineTx (..)
     , Direction (..)
+    , EpochLength (..)
     , SlotId (..)
     , SlotLength (..)
-    , SlotsPerEpoch (..)
     , Tx (..)
     , TxMeta (..)
     , TxOut (..)
@@ -374,7 +374,7 @@ data BlockchainParameters t = BlockchainParameters
         -- ^ Policy regarding transcation fee
     , getSlotLength :: SlotLength
         -- ^ Length, in seconds, of a slot
-    , getSlotsPerEpoch :: SlotsPerEpoch
+    , getEpochLength :: EpochLength
     , getTxMaxSize :: Quantity "byte" Word16
         -- ^ Maximum size of a transaction (soft or hard limit)
     }

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -30,9 +30,9 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
     , Direction (..)
+    , EpochLength (..)
     , Hash (..)
     , SlotId (..)
-    , SlotsPerEpoch (..)
     , TxStatus (..)
     , WalletId (..)
     , WalletState (..)
@@ -230,8 +230,8 @@ instance PersistFieldSql SlotId where
 -- 'flatSlot' with an artificial epochLength. I.e. /not the same epochLength as
 -- the blockchain/. This is just for the sake of storing the 64 bit epoch and
 -- the 16 bit slot inside a single 64-bit field.
-artificialEpochLength :: SlotsPerEpoch
-artificialEpochLength = SlotsPerEpoch $ fromIntegral (maxBound :: Word16)
+artificialEpochLength :: EpochLength
+artificialEpochLength = EpochLength $ fromIntegral (maxBound :: Word16)
 
 instance PersistField SlotId where
     toPersistValue = toPersistValue . flatSlot artificialEpochLength

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -67,7 +67,7 @@ module Cardano.Wallet.Primitive.Types
     -- * Slotting
     , SlotId (..)
     , SlotLength (..)
-    , SlotsPerEpoch (..)
+    , EpochLength (..)
     , slotRatio
     , flatSlot
     , fromFlatSlot
@@ -679,7 +679,7 @@ instance Buildable SlotId where
 -- approximation for a few reasons, one of them being that we hard code the
 -- epoch length as a static number whereas it may vary in practice.
 slotRatio
-    :: SlotsPerEpoch
+    :: EpochLength
     -> SlotId
         -- ^ Numerator
     -> SlotId
@@ -696,12 +696,12 @@ slotRatio epochLength a b =
         Quantity $ toEnum $ fromIntegral $ (100 * n0) `div` n1
 
 -- | Convert a 'SlotId' to the number of slots since genesis.
-flatSlot :: SlotsPerEpoch -> SlotId -> Word64
-flatSlot (SlotsPerEpoch epochLength) (SlotId e s) = epochLength * e + fromIntegral s
+flatSlot :: EpochLength -> SlotId -> Word64
+flatSlot (EpochLength epochLength) (SlotId e s) = epochLength * e + fromIntegral s
 
 -- | Convert a 'flatSlot' index to 'SlotId'.
-fromFlatSlot :: SlotsPerEpoch -> Word64 -> SlotId
-fromFlatSlot (SlotsPerEpoch epochLength) n = SlotId e (fromIntegral s)
+fromFlatSlot :: EpochLength -> Word64 -> SlotId
+fromFlatSlot (EpochLength epochLength) n = SlotId e (fromIntegral s)
   where
     e = n `div` epochLength
     s = n `mod` epochLength
@@ -709,7 +709,7 @@ fromFlatSlot (SlotsPerEpoch epochLength) n = SlotId e (fromIntegral s)
 newtype SlotLength = SlotLength DiffTime
     deriving (Show, Eq)
 
-newtype SlotsPerEpoch = SlotsPerEpoch Word64
+newtype EpochLength = EpochLength Word64
     deriving (Show, Eq)
 {-------------------------------------------------------------------------------
                                Polymorphic Types

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -71,8 +71,8 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , Coin (..)
     , Direction (..)
+    , EpochLength (..)
     , Hash (..)
-    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -394,5 +394,5 @@ label :: Show n => B8.ByteString -> n -> B8.ByteString
 label prefix n = prefix <> B8.pack (show n)
 
 -- | Arbitrary epoch length for testing
-epochLength :: SlotsPerEpoch
-epochLength = SlotsPerEpoch 500
+epochLength :: EpochLength
+epochLength = EpochLength 500

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -21,9 +21,9 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Dom (..)
+    , EpochLength (..)
     , Hash (..)
     , SlotId (..)
-    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -122,7 +122,7 @@ spec = do
             let txMeta = TxMeta Invalidated Incoming (SlotId 0 42) (Quantity 0)
             "+0.000000 invalidated since 0.42" === pretty @_ @Text txMeta
 
-    let slotsPerEpoch = SlotsPerEpoch 21600
+    let slotsPerEpoch = EpochLength 21600
 
     describe "slotRatio" $ do
         it "works for any two slots" $ property $ \sl0 sl1 ->

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -63,10 +63,10 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
     , Direction (..)
+    , EpochLength (..)
     , Hash (..)
     , SlotId (..)
     , SlotLength (..)
-    , SlotsPerEpoch (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -393,7 +393,7 @@ setupFixture (wid, wname, wstate) = do
     txMaxSize :: Quantity "byte" Word16
     txMaxSize = Quantity 8192
 
-    slotsPerEpoch = SlotsPerEpoch 21600
+    slotsPerEpoch = EpochLength 21600
 
     block0Date = posixSecondsToUTCTime 0
 

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -51,10 +51,10 @@ import Cardano.Wallet.Primitive.Types
     , DecodeAddress (..)
     , DefineTx (..)
     , EncodeAddress (..)
+    , EpochLength (..)
     , Hash (..)
     , SlotId (..)
     , SlotLength (..)
-    , SlotsPerEpoch (..)
     , Tx (..)
     )
 import Crypto.Hash
@@ -191,5 +191,5 @@ byronBlockchainParameters = BlockchainParameters
     , getFeePolicy = byronFeePolicy
     , getSlotLength = byronSlotLength
     , getTxMaxSize = byronTxMaxSize
-    , getSlotsPerEpoch = SlotsPerEpoch 21600
+    , getEpochLength = EpochLength 21600
     }

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -361,7 +361,7 @@ data ConfigParam
     -- ^ Address discrimination. Testnet / Mainnet.
     | Consensus ConsensusVersion
     -- ^ Consensus version. BFT / Genesis Praos.
-    | SlotsPerEpoch W.SlotsPerEpoch
+    | SlotsPerEpoch W.EpochLength
     -- ^ Number of slots in an epoch.
     | SlotDuration DiffTime
     -- ^ Slot duration in seconds.
@@ -403,7 +403,7 @@ getConfigParam = label "getConfigParam" $ do
         1 -> Discrimination <$> getNetwork
         2 -> Block0Date . posixSecondsToUTCTime . fromIntegral <$> getWord64be
         3 -> Consensus <$> getConsensusVersion
-        4 -> SlotsPerEpoch . W.SlotsPerEpoch . fromIntegral  <$> getWord32be
+        4 -> SlotsPerEpoch . W.EpochLength . fromIntegral  <$> getWord32be
         5 -> SlotDuration . secondsToDiffTime . fromIntegral <$> getWord8
         6 -> EpochStabilityDepth . Quantity <$> getWord32be
         8 -> ConsensusGenesisPraosParamF <$> getMilli

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -271,19 +271,19 @@ mkJormungandrLayer mgr baseUrl = JormungandrLayer
                     Block0Date x -> Just x
                     _ -> Nothing
 
-        let mslotsPerEpoch = mapMaybe getEpochLength params
+        let mepochLength = mapMaybe getSlotsPerEpoch params
               where
-                getEpochLength = \case
+                getSlotsPerEpoch = \case
                     SlotsPerEpoch x -> Just x
                     _ -> Nothing
 
-        case (mpolicy, mduration, mblock0Date, mslotsPerEpoch) of
-            ([policy],[duration],[block0Date], [slotsPerEpoch]) ->
+        case (mpolicy, mduration, mblock0Date, mepochLength) of
+            ([policy],[duration],[block0Date], [epochLength]) ->
                 return $ BlockchainParameters
                     { getGenesisBlock = coerceBlock jblock
                     , getGenesisBlockDate = block0Date
                     , getFeePolicy = policy
-                    , getSlotsPerEpoch = slotsPerEpoch
+                    , getEpochLength = epochLength
                     , getSlotLength = SlotLength duration
                     , getTxMaxSize = softTxMaxSize
                     }

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -124,7 +124,7 @@ spec = do
                         [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Testnet
                         , Consensus BFT
-                        , SlotsPerEpoch $ W.SlotsPerEpoch 2160
+                        , SlotsPerEpoch $ W.EpochLength 2160
                         , SlotDuration (secondsToDiffTime 15)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex
@@ -177,7 +177,7 @@ spec = do
                         [ Block0Date (posixSecondsToUTCTime 1556202057)
                         , Discrimination Mainnet
                         , Consensus BFT
-                        , SlotsPerEpoch (W.SlotsPerEpoch 500)
+                        , SlotsPerEpoch (W.EpochLength 500)
                         , SlotDuration (secondsToDiffTime 10)
                         , EpochStabilityDepth (Quantity 10)
                         , AddBftLeader $ LeaderId $ unsafeFromHex


### PR DESCRIPTION
# Motivation

We currently use "slots per epoch" and "epoch length" somewhat interchangeably. Arguably only one should be used. https://github.com/input-output-hk/cardano-wallet/pull/556#discussion_r304472460

# Overview

- [x] I have renamed the `Primitive.Types` newtype `SlotsPerEpoch` to `EpochLength`, which is consistent with our hard-coded variable name `EpochLength`.
- [x] I let the Jörmungandr `ConfigParam` constructor `SlotsPerEpoch` remain as is, as jörmungandr's term is `SlotsPerEpoch`.


# Comments
- I'm not sure I think this is an improvement though. Maybe `epochLength` is clearer as a value name, and `SlotsPerEpoch` is clearer as a type. Maybe we should leave everything as is.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
