### PR TITLE
Move waitForWalletSync

### DIFF
--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -157,7 +157,7 @@ instance FromText Percentage where
             "expected a value between 0 and 100 with a '%' suffix (e.g. '14%')"
 
 instance Buildable Percentage where
-    build (Percentage p) = mempty <> build p <> "%"
+    build (Percentage p) = build p <> "%"
 
 -- | Safe constructor for 'Percentage'
 mkPercentage

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -53,6 +53,8 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Text.Read
     ( decimal )
+import Fmt
+    ( Buildable (..) )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
@@ -153,6 +155,9 @@ instance FromText Percentage where
       where
         err = TextDecodingError
             "expected a value between 0 and 100 with a '%' suffix (e.g. '14%')"
+
+instance Buildable Percentage where
+    build (Percentage p) = mempty <> build p <> "%"
 
 -- | Safe constructor for 'Percentage'
 mkPercentage

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -223,7 +223,6 @@ benchmark restore
     , deepseq
     , digest
     , fmt
-    , generic-lens
     , iohk-monitoring
     , persistent
     , persistent-template

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -126,7 +126,6 @@
             (hsPkgs.deepseq)
             (hsPkgs.digest)
             (hsPkgs.fmt)
-            (hsPkgs.generic-lens)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.persistent)
             (hsPkgs.persistent-template)


### PR DESCRIPTION
# Issue Number

#465 

# Motivation
Be able to call `waitForWalletSync` from tests.

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I moved `waitForWalletSync` from `http-bridge:restore bench` to `Cardano.Wallet` (but outside the actual WalletLayer) **I removed the logging**.
- [x] I added a `Buildable` instance to `Percentage` such that it outputs `40%` instead of `Percentage {getPercentage = 2}%`

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->