### PR TITLE
Handle when --state-dir points to existing file

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -88,12 +88,7 @@ import Cardano.BM.Setup
 import Cardano.BM.Trace
     ( Trace, appendName, logAlert, logInfo )
 import Cardano.Launcher
-    ( Command
-    , ProcessHasExited (..)
-    , installSignalHandlers
-    , launch
-    , setupStateDir
-    )
+    ( Command, ProcessHasExited (..), installSignalHandlers, launch )
 import Cardano.Wallet.Api
     ( Api )
 import Cardano.Wallet.Api.Server
@@ -216,7 +211,12 @@ import System.Console.ANSI
     , hSetSGR
     )
 import System.Directory
-    ( XdgDirectory (..), doesFileExist, getXdgDirectory )
+    ( XdgDirectory (..)
+    , createDirectoryIfMissing
+    , doesDirectoryExist
+    , doesFileExist
+    , getXdgDirectory
+    )
 import System.Exit
     ( exitFailure, exitSuccess, exitWith )
 import System.FilePath
@@ -654,18 +654,30 @@ execLaunch
 execLaunch verbosity stateDir withStateDir commands = do
     installSignalHandlers
     (_, _, tracer) <- initTracer (verbosityToMinSeverity verbosity) "launch"
-    setupStateDir (logInfo tracer) (withStateDir tracer) stateDir >>= \case
-        Left _ -> do
-            putErrLn $ mconcat
-                    [ T.pack stateDir <> " must be a directory, but it is"
-                    , " a file. Exiting."
-                    ]
-            exitFailure
-        Right _ -> do
-            logInfo tracer $ fmt $ nameF "launch" $ blockListF commands
-            (ProcessHasExited pName code) <- launch commands
-            logAlert tracer $ T.pack pName <> " exited with code " <> T.pack (show code)
-            exitWith code
+    setupStateDir (logInfo tracer) (withStateDir tracer) stateDir
+    logInfo tracer $ fmt $ nameF "launch" $ blockListF commands
+    (ProcessHasExited pName code) <- launch commands
+    logAlert tracer $ T.pack pName <> " exited with code " <> T.pack (show code)
+    exitWith code
+
+-- | Initialize a state directory to store blockchain data such as blocks or
+-- the wallet database.
+setupStateDir :: (Text -> IO ()) -> (FilePath -> IO ()) -> FilePath -> IO ()
+setupStateDir logT withDir dir = do
+    exists <- doesFileExist dir
+    when exists $ do
+        putErrLn $ mconcat
+                [ T.pack dir <> " must be a directory, but it is"
+                , " a file. Exiting."
+                ]
+        exitFailure
+    doesDirectoryExist dir >>= \case
+        True -> logT $ "Using state directory: " <> T.pack dir
+        False -> do
+            logT $ "Creating state directory: " <> T.pack dir
+            let createParentIfMissing = True
+            createDirectoryIfMissing createParentIfMissing dir
+    withDir dir
 
 {-------------------------------------------------------------------------------
                               Options & Arguments

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -657,9 +657,8 @@ execLaunch verbosity stateDir withStateDir commands = do
     setupStateDir (logInfo tracer) (withStateDir tracer) stateDir >>= \case
         Left _ -> do
             putErrLn $ mconcat
-                    [ "Stopping! \"" <> T.pack stateDir <>"\" appears to be"
-                    , " a file existing on your system. Remove the file or"
-                    , " choose different path."
+                    [ T.pack stateDir <> " must be a directory, but it is"
+                    , " a file. Exiting."
                     ]
             exitFailure
         Right _ -> do

--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
@@ -24,13 +24,15 @@ import Data.Text.Class
 import Network.HTTP.Client
     ( defaultManagerSettings, newManager )
 import System.Command
-    ( Stdout (..) )
+    ( Exit (..), Stderr (..), Stdout (..) )
 import System.Directory
     ( removeDirectory )
 import System.Exit
     ( ExitCode (..) )
+import System.IO
+    ( Handle )
 import System.IO.Temp
-    ( withSystemTempDirectory )
+    ( withSystemTempDirectory, withSystemTempFile )
 import System.Process
     ( createProcess
     , proc
@@ -44,6 +46,7 @@ import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldReturn )
 import Test.Integration.Framework.DSL
     ( KnownCommand (..)
+    , cardanoWalletCLI
     , collectStreams
     , createWalletViaCLI
     , expectEventually'
@@ -64,6 +67,19 @@ import qualified Data.Text.IO as TIO
 spec :: forall t. (KnownCommand t) => Spec
 spec = do
     describe "LAUNCH - cardano-wallet launch" $ do
+        it "LAUNCH - Stop when --state-dir is an existing file" $ withTempFile $ \f _ -> do
+            let args =
+                    [ "launch"
+                    , "--state-dir", f
+                    ]
+
+            (Exit c, Stdout o, Stderr e) <- cardanoWalletCLI @t args
+            c `shouldBe` ExitFailure 1
+            o `shouldBe` mempty
+            e `shouldBe`
+                "Stopping! \"" ++ f ++ "\" appears to be a file existing on\
+                \ your system. Remove the file or choose different path.\n"
+
         describe "LAUNCH - Can start launcher with --state-dir" $ do
             let tests =
                     [ ("existing dir", const $ pure ())
@@ -175,3 +191,6 @@ spec = do
 
 withTempDir :: (FilePath -> IO a) -> IO a
 withTempDir = withSystemTempDirectory "integration-state"
+
+withTempFile :: (FilePath -> Handle -> IO a) -> IO a
+withTempFile = withSystemTempFile "temp-file"

--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
@@ -76,9 +76,7 @@ spec = do
             (Exit c, Stdout o, Stderr e) <- cardanoWalletCLI @t args
             c `shouldBe` ExitFailure 1
             o `shouldBe` mempty
-            e `shouldBe`
-                "Stopping! \"" ++ f ++ "\" appears to be a file existing on\
-                \ your system. Remove the file or choose different path.\n"
+            e `shouldBe` f ++ " must be a directory, but it is a file. Exiting.\n"
 
         describe "LAUNCH - Can start launcher with --state-dir" $ do
             let tests =

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -80,9 +80,7 @@ spec = do
             (Exit c, Stdout o, Stderr e) <- cardanoWalletCLI @t args
             c `shouldBe` ExitFailure 1
             o `shouldBe` mempty
-            e `shouldBe`
-                "Stopping! \"" ++ f ++ "\" appears to be a file existing on\
-                \ your system. Remove the file or choose different path.\n"
+            e `shouldBe` f ++ " must be a directory, but it is a file. Exiting.\n"
 
         describe "LAUNCH - Can start launcher with --state-dir" $ do
             let tests =

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -31,11 +31,9 @@ library
   build-depends:
       base
     , async
-    , directory
     , fmt
     , process
     , say
-    , text
   hs-source-dirs:
       src
   exposed-modules:

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -19,11 +19,9 @@
         depends = [
           (hsPkgs.base)
           (hsPkgs.async)
-          (hsPkgs.directory)
           (hsPkgs.fmt)
           (hsPkgs.process)
           (hsPkgs.say)
-          (hsPkgs.text)
           ] ++ (if system.isWindows
           then [ (hsPkgs.Win32) ]
           else [ (hsPkgs.unix) ]);


### PR DESCRIPTION
# Issue Number

#564

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I made cli print _nicer_ error when `--state-dir` points to existing file
- [ ] and added integration tests


# Comments

Was:

```
$ cardano-wallet-http-bridge launch --state-dir /tmp/existing-file
cardano-wallet-http-bridge: /tmp/existing-file: createDirectory: already exists (File exists)

```

Is:
```
$ cardano-wallet-http-bridge launch --state-dir /tmp/existing-file
Stopping! "/tmp/existing-file" appears to be a file existing on your system. Remove the file or choose different path.
```
