### PR TITLE
SqliteSpec: Fix occasional failure in QSM tests

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -191,9 +191,13 @@ once_ xs = void . once xs
 -- | Shorthand for the readTxHistory result type.
 type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
 
--- | Apply the default sort order (descending on time) to a 'TxHistory'.
+-- | Apply the default sort order (descending on time, then by TxId) to a
+-- 'TxHistory'.
 sortTxHistory :: TxHistory -> TxHistory
-sortTxHistory = L.sortOn (Down . slotId . snd . snd)
+sortTxHistory = sortBySlot . sortByTxId
+  where
+    sortBySlot = L.sortOn (Down . slotId . snd . snd)
+    sortByTxId = L.sortOn fst
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)


### PR DESCRIPTION
Fixes #551.

# Overview

It failed due to the undefined ordering of transactions from the same slot.

I have added a secondary sort by TxId to Sqlite and the model.
