### PR TITLE
Use `start`, `end`, and `order` query parameters to specify range in `listTransactions`.

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -47,7 +47,6 @@ library
     , servant-server
     , text
     , text-class
-    , time
     , optparse-applicative
   hs-source-dirs:
       src
@@ -76,7 +75,6 @@ test-suite unit
     , memory
     , optparse-applicative
     , QuickCheck
-    , quickcheck-instances
     , text
     , text-class
   build-tools:

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -104,6 +104,7 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
+    , SortOrder (..)
     , WalletPostData (..)
     , WalletPutData (..)
     , WalletPutPassphraseData (..)
@@ -582,6 +583,7 @@ cmdTransactionList = command "list" $ info (helper <*> cmd) $ mempty
             (ApiT wId)
             mTimeRangeStart
             mTimeRangeEnd
+            Nothing
 
 {-------------------------------------------------------------------------------
                             Commands - 'address'
@@ -843,6 +845,7 @@ data WalletClient t = WalletClient
         :: ApiT WalletId
         -> Maybe Iso8601Time
         -> Maybe Iso8601Time
+        -> Maybe SortOrder
         -> ClientM [ApiTransaction t]
     , postTransaction
         :: ApiT WalletId

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -103,6 +103,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiWallet
     , Iso8601Range (..)
+    , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
     , WalletPostData (..)
@@ -137,8 +138,6 @@ import Data.Aeson
     ( (.:) )
 import Data.Bifunctor
     ( bimap )
-import Data.Either.Extra
-    ( maybeToEither )
 import Data.Functor
     ( (<$), (<&>) )
 import Data.List.Extra
@@ -157,10 +156,6 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..), showT )
 import Data.Text.Read
     ( decimal )
-import Data.Time.Clock
-    ( UTCTime )
-import Data.Time.Text
-    ( iso8601, iso8601ExtendedUtc, utcTimeFromText, utcTimeToText )
 import Fmt
     ( Buildable, blockListF, fmt, nameF, pretty )
 import GHC.Generics
@@ -943,25 +938,6 @@ handleResponse encode res = do
 {-------------------------------------------------------------------------------
                                 Extra Types
 -------------------------------------------------------------------------------}
-
--- | Defines a point in time that can be formatted as and parsed from an
---   ISO 8601-compliant string.
---
-newtype Iso8601Time = Iso8601Time
-    { getIso8601Time :: UTCTime
-    } deriving (Eq, Ord, Show)
-
-instance ToText Iso8601Time where
-    toText = utcTimeToText iso8601ExtendedUtc . getIso8601Time
-
-instance FromText Iso8601Time where
-    fromText t =
-        Iso8601Time <$> maybeToEither err (utcTimeFromText iso8601 t)
-      where
-        err = TextDecodingError $ mempty
-            <> "Unable to parse time argument: '"
-            <> T.unpack t
-            <> "'. Expecting ISO 8601 format (basic or extended)."
 
 -- | Represents the number of words in a mnemonic sentence.
 --

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -43,7 +43,6 @@ module Cardano.CLI
     , verbosityOption
 
     -- * Types
-    , Iso8601Time (..)
     , Service
     , MnemonicSize (..)
     , Port (..)

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -102,7 +102,6 @@ import Cardano.Wallet.Api.Types
     , ApiTransaction
     , ApiUtxoStatistics
     , ApiWallet
-    , Iso8601Range (..)
     , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
@@ -582,9 +581,8 @@ cmdTransactionList = command "list" $ info (helper <*> cmd) $ mempty
         runClient wPort Aeson.encodePretty $ listTransactions
             (walletClient @t)
             (ApiT wId)
-            (pure $ Iso8601Range
-                (getIso8601Time <$> mTimeRangeStart)
-                (getIso8601Time <$> mTimeRangeEnd))
+            mTimeRangeStart
+            mTimeRangeEnd
 
 {-------------------------------------------------------------------------------
                             Commands - 'address'
@@ -844,7 +842,8 @@ data WalletClient t = WalletClient
         -> ClientM NoContent
     , listTransactions
         :: ApiT WalletId
-        -> Maybe (Iso8601Range "inserted-at")
+        -> Maybe Iso8601Time
+        -> Maybe Iso8601Time
         -> ClientM [ApiTransaction t]
     , postTransaction
         :: ApiT WalletId

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -564,6 +564,7 @@ data TransactionListArgs = TransactionListArgs
     , _walletId :: WalletId
     , _timeRangeStart :: Maybe Iso8601Time
     , _timeRangeEnd :: Maybe Iso8601Time
+    , _sortOrder :: Maybe SortOrder
     }
 
 cmdTransactionList
@@ -577,13 +578,14 @@ cmdTransactionList = command "list" $ info (helper <*> cmd) $ mempty
         <*> walletIdArgument
         <*> optional timeRangeStartOption
         <*> optional timeRangeEndOption
-    exec (TransactionListArgs wPort wId mTimeRangeStart mTimeRangeEnd) =
+        <*> optional sortOrderOption
+    exec (TransactionListArgs wPort wId mTimeRangeStart mTimeRangeEnd mOrder) =
         runClient wPort Aeson.encodePretty $ listTransactions
             (walletClient @t)
             (ApiT wId)
             mTimeRangeStart
             mTimeRangeEnd
-            Nothing
+            mOrder
 
 {-------------------------------------------------------------------------------
                             Commands - 'address'
@@ -775,6 +777,14 @@ timeRangeEndOption = optionT $ mempty
     <> long "end"
     <> metavar "TIME"
     <> help "specifies an end time (ISO 8601 format: basic or extended)."
+    <> showDefaultWith showT
+
+-- | [--order=ORDER]
+sortOrderOption :: Parser SortOrder
+sortOrderOption = optionT $ mempty
+    <> long "order"
+    <> metavar "ORDER"
+    <> help "specifies a sort order, either 'ascending' or 'descending'."
     <> showDefaultWith showT
 
 -- | [(--quiet|--verbose)]

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -11,8 +11,7 @@ module Cardano.CLISpec
 import Prelude
 
 import Cardano.CLI
-    ( Iso8601Time (..)
-    , MnemonicSize (..)
+    ( MnemonicSize (..)
     , Port (..)
     , cli
     , cmdAddress
@@ -61,8 +60,6 @@ import Test.QuickCheck
     , property
     , (===)
     )
-import Test.QuickCheck.Instances.Time
-    ()
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
@@ -296,7 +293,6 @@ spec = do
             ]
 
     describe "Can perform roundtrip textual encoding & decoding" $ do
-        textRoundtrip $ Proxy @Iso8601Time
         textRoundtrip $ Proxy @(Port "test")
         textRoundtrip $ Proxy @MnemonicSize
 
@@ -427,10 +423,6 @@ test fn (GetLineTest prompt_ input_ output expected) = do
 {-------------------------------------------------------------------------------
                                Arbitrary Instances
 -------------------------------------------------------------------------------}
-
-instance Arbitrary Iso8601Time where
-    arbitrary = Iso8601Time <$> arbitrary
-    shrink (Iso8601Time t) = Iso8601Time <$> shrink t
 
 instance Arbitrary MnemonicSize where
     arbitrary = arbitraryBoundedEnum

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -256,7 +256,7 @@ spec = do
 
         ["transaction", "list", "--help"] `shouldShowUsage`
             [ "Usage:  transaction list [--port INT] WALLET_ID [--start TIME]"
-            , "                         [--end TIME]"
+            , "                         [--end TIME] [--order ORDER]"
             , "  List the transactions associated with a wallet."
             , ""
             , "Available options:"
@@ -267,6 +267,8 @@ spec = do
             , "                           format: basic or extended)."
             , "  --end TIME               specifies an end time (ISO 8601"
             , "                           format: basic or extended)."
+            , "  --order ORDER            specifies a sort order, either"
+            , "                           'ascending' or 'descending'."
             ]
 
         ["address", "--help"] `shouldShowUsage`

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -43,6 +43,7 @@ library
     , cryptonite
     , deepseq
     , exceptions
+    , extra
     , fast-logger
     , fmt
     , foldl

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -13,6 +13,7 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time
     , PostTransactionData
     , PostTransactionFeeData
+    , SortOrder
     , WalletPostData
     , WalletPutData
     , WalletPutPassphraseData
@@ -143,6 +144,7 @@ type ListTransactions t = "wallets"
     :> "transactions"
     :> QueryParam "start" Iso8601Time
     :> QueryParam "end" Iso8601Time
+    :> QueryParam "order" SortOrder
     :> Get '[JSON] [ApiTransaction t]
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -10,7 +10,7 @@ import Cardano.Wallet.Api.Types
     , ApiTransaction
     , ApiUtxoStatistics
     , ApiWallet
-    , Iso8601Range
+    , Iso8601Time
     , PostTransactionData
     , PostTransactionFeeData
     , WalletPostData
@@ -30,7 +30,6 @@ import Servant.API
     , Capture
     , DeleteNoContent
     , Get
-    , Header
     , JSON
     , NoContent
     , PostAccepted
@@ -142,7 +141,8 @@ type PostTransactionFee t = "wallets"
 type ListTransactions t = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
-    :> Header "Range" (Iso8601Range "inserted-at")
+    :> QueryParam "start" Iso8601Time
+    :> QueryParam "end" Iso8601Time
     :> Get '[JSON] [ApiTransaction t]
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -58,7 +58,7 @@ import Cardano.Wallet.Api.Types
     , ApiTxInput (..)
     , ApiUtxoStatistics (..)
     , ApiWallet (..)
-    , Iso8601Range (..)
+    , Iso8601Time (..)
     , PostTransactionData
     , PostTransactionFeeData
     , WalletBalance (..)
@@ -463,9 +463,10 @@ listTransactions
     :: forall t. (DefineTx t)
     => WalletLayer (SeqState t) t
     -> ApiT WalletId
-    -> Maybe (Iso8601Range "inserted-at")
+    -> Maybe Iso8601Time
+    -> Maybe Iso8601Time
     -> Handler [ApiTransaction t]
-listTransactions w (ApiT wid) _maybeRange = do
+listTransactions w (ApiT wid) _maybeStart _maybeEnd = do
     txs <- liftHandler $ W.listTransactions w wid
     return $ map mkApiTransactionFromInfo txs
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -61,6 +61,7 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData
     , PostTransactionFeeData
+    , SortOrder (..)
     , WalletBalance (..)
     , WalletPostData (..)
     , WalletPutData (..)
@@ -465,8 +466,9 @@ listTransactions
     -> ApiT WalletId
     -> Maybe Iso8601Time
     -> Maybe Iso8601Time
+    -> Maybe SortOrder
     -> Handler [ApiTransaction t]
-listTransactions w (ApiT wid) _maybeStart _maybeEnd = do
+listTransactions w (ApiT wid) _maybeStart _maybeEnd _maybeOrder = do
     txs <- liftHandler $ W.listTransactions w wid
     return $ map mkApiTransactionFromInfo txs
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -278,12 +278,10 @@ instance FromText Iso8601Time where
             <> T.unpack t
             <> "'. Expecting ISO 8601 format (basic or extended)."
 
-instance FromHttpApiData Iso8601Time
-  where
+instance FromHttpApiData Iso8601Time where
     parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
 
-instance ToHttpApiData Iso8601Time
-  where
+instance ToHttpApiData Iso8601Time where
     toUrlPiece = toText
 
 -- | Represents a sort order, applicable to a query.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -124,7 +124,7 @@ import Data.Quantity
 import Data.Text
     ( Text, split )
 import Data.Text.Class
-    ( CaseStyle (CamelCase)
+    ( CaseStyle (SnakeLowerCase)
     , FromText (..)
     , TextDecodingError (..)
     , ToText (..)
@@ -293,10 +293,10 @@ data SortOrder
     deriving (Bounded, Enum, Eq, Generic, Show)
 
 instance ToText SortOrder where
-    toText = toTextFromBoundedEnum CamelCase
+    toText = toTextFromBoundedEnum SnakeLowerCase
 
 instance FromText SortOrder where
-    fromText = fromTextToBoundedEnum CamelCase
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 instance FromHttpApiData SortOrder where
     parseUrlPiece = first (T.pack . getTextDecodingError) . fromText

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -45,6 +45,7 @@ module Cardano.Wallet.Api.Types
     , AddressAmount (..)
     , ApiErrorCode (..)
     , Iso8601Time (..)
+    , SortOrder (..)
 
     -- * Polymorphic Types
     , ApiT (..)
@@ -123,7 +124,13 @@ import Data.Quantity
 import Data.Text
     ( Text, split )
 import Data.Text.Class
-    ( FromText (..), TextDecodingError (..), ToText (..) )
+    ( CaseStyle (CamelCase)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
 import Data.Time
     ( UTCTime )
 import Data.Time.Text
@@ -277,6 +284,26 @@ instance FromHttpApiData Iso8601Time
 
 instance ToHttpApiData Iso8601Time
   where
+    toUrlPiece = toText
+
+-- | Represents a sort order, applicable to a query.
+data SortOrder
+    = Ascending
+        -- ^ Sort in ascending order.
+    | Descending
+        -- ^ Sort in descending order.
+    deriving (Bounded, Enum, Eq, Generic, Show)
+
+instance ToText SortOrder where
+    toText = toTextFromBoundedEnum CamelCase
+
+instance FromText SortOrder where
+    fromText = fromTextToBoundedEnum CamelCase
+
+instance FromHttpApiData SortOrder where
+    parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
+
+instance ToHttpApiData SortOrder where
     toUrlPiece = toText
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -282,6 +282,14 @@ instance FromText Iso8601Time where
             <> T.unpack t
             <> "'. Expecting ISO 8601 format (basic or extended)."
 
+instance FromHttpApiData Iso8601Time
+  where
+    parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
+
+instance ToHttpApiData Iso8601Time
+  where
+    toUrlPiece = toText
+
 -- | Specifies a __time range__ that can be used to constrain and order the
 --   results of queries that return sets of data with associated times.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -242,9 +242,9 @@ spec = do
 
     describe
         "can perform roundtrip HttpApiData serialization & deserialization" $ do
-            httpApiDataRountrip $ Proxy @(ApiT WalletId)
-            httpApiDataRountrip $ Proxy @(ApiT AddressState)
-            httpApiDataRountrip $ Proxy @Iso8601Time
+            httpApiDataRoundtrip $ Proxy @(ApiT WalletId)
+            httpApiDataRoundtrip $ Proxy @(ApiT AddressState)
+            httpApiDataRoundtrip $ Proxy @Iso8601Time
 
     describe
         "verify that every type used with JSON content type in a servant API \
@@ -502,7 +502,7 @@ jsonRoundtripAndGolden = roundtripAndGoldenSpecsWithSettings settings
         }
 
 -- Perform roundtrip tests for FromHttpApiData & ToHttpApiData instances
-httpApiDataRountrip
+httpApiDataRoundtrip
     :: forall a.
         ( Arbitrary a
         , FromHttpApiData a
@@ -513,7 +513,7 @@ httpApiDataRountrip
         )
     => Proxy a
     -> Spec
-httpApiDataRountrip proxy =
+httpApiDataRoundtrip proxy =
     it ("URL encoding of " <> cons (typeRep proxy)) $ property $ \(x :: a) -> do
         let bytes = toUrlPiece x
         let x' = parseUrlPiece bytes

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -35,6 +35,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics (..)
     , ApiWallet (..)
     , Iso8601Range (..)
+    , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
     , WalletBalance (..)
@@ -220,6 +221,12 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletName)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletPassphraseInfo)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletState)
+
+    describe "Iso8601Time" $ do
+
+        describe "Can perform roundtrip textual encoding & decoding" $
+
+            textRoundtrip $ Proxy @Iso8601Time
 
     describe "Iso8601Range" $ do
 
@@ -627,6 +634,10 @@ instance Arbitrary AddressPoolGap where
 instance Arbitrary (Iso8601Range (name :: Symbol)) where
     arbitrary = Iso8601Range <$> arbitrary <*> arbitrary
     shrink = genericShrink
+
+instance Arbitrary Iso8601Time where
+    arbitrary = Iso8601Time <$> arbitrary
+    shrink (Iso8601Time t) = Iso8601Time <$> shrink t
 
 instance Arbitrary WalletPostData where
     arbitrary = genericArbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -37,6 +37,7 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
+    , SortOrder (..)
     , WalletBalance (..)
     , WalletPostData (..)
     , WalletPutData (..)
@@ -221,11 +222,12 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletPassphraseInfo)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletState)
 
-    describe "Iso8601Time" $ do
+    describe "Textual encoding" $ do
 
-        describe "Can perform roundtrip textual encoding & decoding" $
+        describe "Can perform roundtrip textual encoding & decoding" $ do
 
             textRoundtrip $ Proxy @Iso8601Time
+            textRoundtrip $ Proxy @SortOrder
 
     describe "AddressAmount" $ do
         it "fromText . toText === pure"
@@ -245,6 +247,7 @@ spec = do
             httpApiDataRoundtrip $ Proxy @(ApiT WalletId)
             httpApiDataRoundtrip $ Proxy @(ApiT AddressState)
             httpApiDataRoundtrip $ Proxy @Iso8601Time
+            httpApiDataRoundtrip $ Proxy @SortOrder
 
     describe
         "verify that every type used with JSON content type in a servant API \
@@ -572,6 +575,10 @@ instance Arbitrary AddressPoolGap where
 instance Arbitrary Iso8601Time where
     arbitrary = Iso8601Time <$> arbitrary
     shrink (Iso8601Time t) = Iso8601Time <$> shrink t
+
+instance Arbitrary SortOrder where
+    arbitrary = arbitraryBoundedEnum
+    shrink = genericShrink
 
 instance Arbitrary WalletPostData where
     arbitrary = genericArbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -307,6 +307,7 @@ spec = do
             httpApiDataRountrip $ Proxy @(ApiT WalletId)
             httpApiDataRountrip $ Proxy @(ApiT AddressState)
             httpApiDataRountrip $ Proxy @(Iso8601Range "test-header")
+            httpApiDataRountrip $ Proxy @Iso8601Time
 
     describe
         "verify that every type used with JSON content type in a servant API \

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -152,6 +152,7 @@ test-suite integration
     , cryptonite
     , directory
     , exceptions
+    , extra
     , generic-lens
     , hspec
     , hspec-core

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -35,7 +35,6 @@
           (hsPkgs.servant-server)
           (hsPkgs.text)
           (hsPkgs.text-class)
-          (hsPkgs.time)
           (hsPkgs.optparse-applicative)
           ];
         };
@@ -50,7 +49,6 @@
             (hsPkgs.memory)
             (hsPkgs.optparse-applicative)
             (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
             (hsPkgs.text)
             (hsPkgs.text-class)
             ];

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -29,6 +29,7 @@
           (hsPkgs.cryptonite)
           (hsPkgs.deepseq)
           (hsPkgs.exceptions)
+          (hsPkgs.extra)
           (hsPkgs.fast-logger)
           (hsPkgs.fmt)
           (hsPkgs.foldl)

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -91,6 +91,7 @@
             (hsPkgs.cryptonite)
             (hsPkgs.directory)
             (hsPkgs.exceptions)
+            (hsPkgs.extra)
             (hsPkgs.generic-lens)
             (hsPkgs.hspec)
             (hsPkgs.hspec-core)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -961,6 +961,13 @@ paths:
             Times can be local (with a timezone offset) or UTC.
 
             Example: `2008-08-08T08:08:08Z`
+        - in: query
+          name: order
+          type: string
+          enum:
+            - ascending
+            - descending
+          description: An optional sort order.
       responses: *responsesListTransactions
 
     post:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -941,16 +941,26 @@ paths:
         <p align="right">status: <strong>not implemented</strong></p>
       parameters:
         - *parametersWalletId
-        - in: header
-          name: Range
+        - in: query
+          name: start
           type: string
-          format: inserted_at={range-start}-{range-end}
+          format: ISO 8601
           description: |
-            A range of date in ISO-8601 UTC format without symbols to retrieve. Note that
-            the start joker symbol `*` can be used instead of a date to refer to a lower
-            or upper boundary.
+            An optional start time in ISO 8601 format.
+            Basic and extended formats are both accepted.
+            Times can be local (with a timezone offset) or UTC.
 
-            Example: `inserted-at 20190227T160329Z-*`
+            Example: `2008-08-08T08:08:08Z`
+        - in: query
+          name: end
+          type: string
+          format: ISO 8601
+          description: |
+            An optional end time in ISO 8601 format.
+            Basic and extended formats are both accepted.
+            Times can be local (with a timezone offset) or UTC.
+
+            Example: `2008-08-08T08:08:08Z`
       responses: *responsesListTransactions
 
     post:


### PR DESCRIPTION
# Issue Number

#467 

# Overview

Implements the proposal outlined in https://github.com/input-output-hk/cardano-wallet/issues/467#issuecomment-514888695.

Improvements over the status quo:
* We no longer need to document and validate a special textual format for `Iso8601Range`.
* Dedicated handling of separators (`-`, and so on) is replaced with standardized parsing of query parameters (which is handled for us by Servant).
* Because we're no longer relying on the `-` separator to separate times, we can support all ISO 8601-formatted times, rather than just the basic format. We now simply reuse our existing parser, which is already tested.
* There's now a straightforward mapping from CLI arguments to API query parameters.
* There's now only one way to encode the infinite range: by not supplying either `start` or `end`. Previously, there were two ways to encode this range:
    * `Nothing`
    * `Just (Iso8601Range Nothing Nothing)`

This PR also:
* Adds an `order` parameter, which specifies a sort order for transactions returned by `listTransactions`.
* Upgrades our existing `transaction list` CLI integration test to also supply the `order` parameter.

# Work not tackled by this PR

- The proposal outlined in https://github.com/input-output-hk/cardano-wallet/issues/467#issuecomment-514888695 also suggests the use of a `limit` query parameter, to impose a limit on the number of transactions returned. This is left for a future PR.

- When filtering is actually implemented in the API server, we need to also make the API return a `400` error if `start > end`. We must also add CLI and API tests to cover this condition. This is left for a future PR.
