### PR TITLE
Move properties common to both AD schemes to AddressDerivationSpec

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -186,6 +186,7 @@ test-suite unit
       Cardano.Wallet.DBSpec
       Cardano.Wallet.DummyTarget.Primitive.Types
       Cardano.Wallet.NetworkSpec
+      Cardano.Wallet.Primitive.AddressDerivationSpec
       Cardano.Wallet.Primitive.AddressDerivation.SequentialSpec
       Cardano.Wallet.Primitive.AddressDiscovery.SequentialSpec
       Cardano.Wallet.Primitive.CoinSelection.LargestFirstSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -87,6 +87,7 @@ library
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.Network
       Cardano.Wallet.Primitive.AddressDerivation
+      Cardano.Wallet.Primitive.AddressDerivation.Common
       Cardano.Wallet.Primitive.AddressDerivation.Random
       Cardano.Wallet.Primitive.AddressDerivation.Sequential
       Cardano.Wallet.Primitive.AddressDiscovery

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -27,7 +27,8 @@ module Cardano.Wallet.Primitive.AddressDerivation
     (
     -- * Polymorphic / General Purpose Types
     -- $use
-      Key (..)
+      Key
+    , getKey
     , Depth (..)
     , Index (..)
     , DerivationType (..)
@@ -35,7 +36,6 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , digest
     , XPub
     , XPrv
-
     -- * Backends Interoperability
     , KeyToAddress(..)
 
@@ -61,6 +61,8 @@ import Prelude
 
 import Cardano.Crypto.Wallet
     ( XPrv, XPub, toXPub, unXPrv, unXPub, xPrvChangePass, xprv, xpub )
+import Cardano.Wallet.Primitive.AddressDerivation.Common
+    ( Depth (..), Key (..) )
 import Cardano.Wallet.Primitive.Mnemonic
     ( CheckSumBits
     , ConsistentEntropy
@@ -122,27 +124,6 @@ import qualified Data.Text.Encoding as T
 {-------------------------------------------------------------------------------
                         Polymorphic / General Purpose Types
 -------------------------------------------------------------------------------}
-
--- | A cryptographic key, with phantom-types to disambiguate key types.
---
--- @
--- let rootPrivateKey = Key 'RootK XPrv
--- let accountPubKey = Key 'AccountK XPub
--- let addressPubKey = Key 'AddressK XPub
--- @
-newtype Key (level :: Depth) key = Key { getKey :: key }
-    deriving stock (Generic, Show, Eq)
-
-instance (NFData key) => NFData (Key level key)
-
-
--- | Key Depth in the derivation path, according to BIP-0039 / BIP-0044
---
--- @m | purpose' | cointype' | account' | change | address@
---
--- We do not manipulate purpose, cointype and change paths directly, so they are
--- left out of the sum type.
-data Depth = RootK | AccountK | AddressK
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Common.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Common.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Use the types from "Cardano.Wallet.Primitive.AddressDerivation" or the key
+-- generation or derivation functions from
+-- "Cardano.Wallet.Primitive.AddressDerivation.Sequential" or
+-- "Cardano.Wallet.Primitive.AddressDerivation.Random" instead of this module.
+
+module Cardano.Wallet.Primitive.AddressDerivation.Common
+    ( Key(..)
+    , Depth (..)
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData )
+import GHC.Generics
+    ( Generic )
+
+{-------------------------------------------------------------------------------
+                        Polymorphic / General Purpose Types
+-------------------------------------------------------------------------------}
+
+-- | A cryptographic key, with phantom-types to disambiguate key types.
+--
+-- @
+-- let rootPrivateKey = Key 'RootK XPrv
+-- let accountPubKey = Key 'AccountK XPub
+-- let addressPubKey = Key 'AddressK XPub
+-- @
+newtype Key (level :: Depth) key = Key { getKey :: key }
+    deriving stock (Generic, Show, Eq)
+
+instance (NFData key) => NFData (Key level key)
+
+-- | Key Depth in the derivation path, according to BIP-0039 / BIP-0044
+--
+-- @m | purpose' | cointype' | account' | change | address@
+--
+-- We do not manipulate purpose, cointype and change paths directly, so they are
+-- left out of the sum type.
+data Depth = RootK | AccountK | AddressK

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -26,7 +26,9 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( XPrv )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationType (..), Index (..), Key (..), Passphrase (..) )
+    ( DerivationType (..), Index (..), Passphrase (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Common
+    ( Depth (..), Key (..) )
 
 deriveAccountPrivateKey
     :: Passphrase "encryption"

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
@@ -35,7 +35,9 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( DerivationScheme (..), XPrv, XPub, deriveXPrv, deriveXPub, generateNew )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationType (..), Index (..), Key (..), Passphrase (..) )
+    ( DerivationType (..), Index (..), Passphrase (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Common
+    ( Depth (..), Key (..) )
 import Cardano.Wallet.Primitive.Types
     ( invariant )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -11,8 +11,8 @@
 -- This module contains types for address discovery. The two address discovery
 -- schemes implemented are:
 --
---  * 'Cardano.Wallet.Primitive.AddressDiscovery.Sequential'
---  * 'Cardano.Wallet.Primitive.AddressDiscovery.Random'
+--  * "Cardano.Wallet.Primitive.AddressDiscovery.Sequential"
+--  * "Cardano.Wallet.Primitive.AddressDiscovery.Random"
 
 module Cardano.Wallet.Primitive.AddressDiscovery
     (

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -10,29 +9,8 @@ module Cardano.Wallet.Primitive.AddressDerivation.SequentialSpec
 
 import Prelude
 
-import Cardano.Crypto.Wallet
-    ( unXPrv )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , ErrWrongPassphrase (..)
-    , FromMnemonic (..)
-    , FromMnemonicError (..)
-    , Index
-    , Key
-    , Passphrase (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
-    , XPrv
-    , checkPassphrase
-    , deserializeXPrv
-    , deserializeXPub
-    , encryptPassphrase
-    , getIndex
-    , publicKey
-    , serializeXPrv
-    , serializeXPub
-    )
+    ( Depth (..), DerivationType (..), Index, Passphrase (..), publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( ChangeChain (..)
     , deriveAccountPrivateKey
@@ -41,65 +19,28 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     , generateKeyFromSeed
     , unsafeGenerateKeyFromSeed
     )
-import Cardano.Wallet.Primitive.Types
-    ( Hash (..) )
-import Control.Monad
-    ( replicateM )
-import Control.Monad.IO.Class
-    ( liftIO )
-import Data.Either
-    ( isRight )
-import Data.Proxy
-    ( Proxy (..) )
+import Cardano.Wallet.Primitive.AddressDerivationSpec
+    ()
 import Test.Hspec
-    ( Spec, describe, it, shouldBe, shouldSatisfy )
+    ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Gen
-    , InfiniteList (..)
     , Property
-    , arbitraryBoundedEnum
-    , arbitraryPrintableChar
-    , choose
     , elements
     , expectFailure
     , property
-    , vectorOf
-    , (.&&.)
     , (===)
     , (==>)
     )
-import Test.QuickCheck.Monadic
-    ( monadicIO )
-import Test.Text.Roundtrip
-    ( textRoundtrip )
-
-import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 spec :: Spec
 spec = do
     describe "Bounded / Enum relationship" $ do
-        it "The calls Index.succ maxBound should result in a runtime err (hard)"
-            prop_succMaxBoundHardIx
-        it "The calls Index.pred minBound should result in a runtime err (hard)"
-            prop_predMinBoundHardIx
-        it "The calls Index.succ maxBound should result in a runtime err (soft)"
-            prop_succMaxBoundSoftIx
-        it "The calls Index.pred minBound should result in a runtime err (soft)"
-            prop_predMinBoundSoftIx
         it "Calling toEnum for invalid value gives a runtime err (ChangeChain)"
             (property prop_toEnumChangeChain)
 
-    describe "Text Roundtrip" $ do
-        textRoundtrip $ Proxy @(Passphrase "encryption")
-
     describe "Enum Roundtrip" $ do
         it "ChangeChain" (property prop_roundtripEnumChangeChain)
-        it "Index @'Hardened _" (property prop_roundtripEnumIndexHard)
-        it "Index @'Soft _" (property prop_roundtripEnumIndexSoft)
 
     describe "BIP-0044 Derivation Properties" $ do
         it "deriveAccountPrivateKey works for various indexes" $
@@ -107,118 +48,9 @@ spec = do
         it "N(CKDpriv((kpar, cpar), i)) === CKDpub(N(kpar, cpar), i)" $
             property prop_publicChildKeyDerivation
 
-    describe "Passphrases" $ do
-        it "checkPassphrase p h(p) == Right ()" $
-            property prop_passphraseRoundtrip
-
-        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
-            property prop_passphraseRoundtripFail
-
-        it "checkPassphrase fails when hash is malformed" $
-            property prop_passphraseHashMalformed
-
-    describe "FromMnemonic" $ do
-        it "early error reported first (Invalid Entropy)" $ do
-            let res = fromMnemonic @'[15,18,21] @"testing"
-                        [ "glimpse", "paper", "toward", "fine", "alert"
-                        , "baby", "pyramid", "alone", "shaft", "force"
-                        , "circle", "fancy", "squeeze", "cannon", "toilet"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Invalid entropy checksum: \
-                \please double-check the last word of your mnemonic sentence.")
-
-        it "early error reported first (Non-English Word)" $ do
-            let res = fromMnemonic @'[15,18,21] @"testing"
-                        [ "baguette", "paper", "toward", "fine", "alert"
-                        , "baby", "pyramid", "alone", "shaft", "force"
-                        , "circle", "fancy", "squeeze", "cannon", "toilet"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
-                \word: \"baguette\".")
-
-        it "early error reported first (Wrong number of words - 1)" $ do
-            let res = fromMnemonic @'[15,18,21] @"testing"
-                        ["mom", "unveil", "slim", "abandon"
-                        , "nut", "cash", "laugh", "impact"
-                        , "system", "split", "depth", "sun"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
-                \15, 18 or 21 words are expected.")
-
-        it "early error reported first (Wrong number of words - 2)" $ do
-            let res = fromMnemonic @'[15] @"testing"
-                        ["mom", "unveil", "slim", "abandon"
-                        , "nut", "cash", "laugh", "impact"
-                        , "system", "split", "depth", "sun"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
-                \15 words are expected.")
-
-        it "early error reported first (Error not in first constructor)" $ do
-            let res = fromMnemonic @'[15,18,21,24] @"testing"
-                        ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
-                        ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
-                \word: \"盗\".")
-
-        it "early error reported first (Error not in first constructor)" $ do
-            let res = fromMnemonic @'[12,15,18] @"testing"
-                        ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
-                        ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
-                        ]
-            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
-                \word: \"盗\".")
-
-        it "successfully parse 15 words in [15,18,21]" $ do
-            let res = fromMnemonic @'[15,18,21] @"testing"
-                        ["cushion", "anxiety", "oval", "village", "choose"
-                        , "shoot", "over", "behave", "category", "cruise"
-                        , "track", "either", "maid", "organ", "sock"
-                        ]
-            res `shouldSatisfy` isRight
-
-        it "successfully parse 15 words in [12,15,18]" $ do
-            let res = fromMnemonic @'[12,15,18] @"testing"
-                        ["cushion", "anxiety", "oval", "village", "choose"
-                        , "shoot", "over", "behave", "category", "cruise"
-                        , "track", "either", "maid", "organ", "sock"
-                        ]
-            res `shouldSatisfy` isRight
-
-        it "successfully parse 15 words in [9,12,15]" $ do
-            let res = fromMnemonic @'[9,12,15] @"testing"
-                        ["cushion", "anxiety", "oval", "village", "choose"
-                        , "shoot", "over", "behave", "category", "cruise"
-                        , "track", "either", "maid", "organ", "sock"
-                        ]
-            res `shouldSatisfy` isRight
-
-    describe "Keys storing and retrieving roundtrips" $ do
-        it "XPriv" (property prop_roundtripXPriv)
-        it "XPub" (property prop_roundtripXPub)
-
-
 {-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
-
-
-prop_succMaxBoundHardIx :: Property
-prop_succMaxBoundHardIx = expectFailure $
-    property $ succ (maxBound @(Index 'Hardened _)) `seq` ()
-
-prop_predMinBoundHardIx :: Property
-prop_predMinBoundHardIx = expectFailure $
-    property $ pred (minBound @(Index 'Hardened _)) `seq` ()
-
-prop_succMaxBoundSoftIx :: Property
-prop_succMaxBoundSoftIx = expectFailure $
-    property $ succ (maxBound @(Index 'Soft _)) `seq` ()
-
-prop_predMinBoundSoftIx :: Property
-prop_predMinBoundSoftIx = expectFailure $
-    property $ pred (minBound @(Index 'Soft _)) `seq` ()
 
 prop_toEnumChangeChain :: Int -> Property
 prop_toEnumChangeChain n =
@@ -228,30 +60,6 @@ prop_toEnumChangeChain n =
 prop_roundtripEnumChangeChain :: ChangeChain -> Property
 prop_roundtripEnumChangeChain ix =
     (toEnum . fromEnum) ix === ix
-
-prop_roundtripEnumIndexHard :: Index 'Hardened 'AccountK -> Property
-prop_roundtripEnumIndexHard ix =
-    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
-
-prop_roundtripEnumIndexSoft :: Index 'Soft 'AddressK -> Property
-prop_roundtripEnumIndexSoft ix =
-    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
-
-prop_roundtripXPriv
-    :: (Key 'RootK XPrv, Hash "encryption")
-    -> Property
-prop_roundtripXPriv xpriv = do
-    let xpriv' = (deserializeXPrv . serializeXPrv) xpriv
-    xpriv' === Right xpriv
-
-prop_roundtripXPub
-    :: Key 'RootK XPrv
-    -> Property
-prop_roundtripXPub xpriv = do
-    let xpub = publicKey xpriv
-    let xpub' = (deserializeXPub . serializeXPub) xpub
-    xpub' === Right xpub
-
 
 -- | Deriving address public key should be equal to deriving address
 -- private key and extracting public key from it (works only for non-hardened
@@ -294,93 +102,10 @@ prop_accountKeyDerivation (seed, recPwd) encPwd ix =
     rootXPrv = generateKeyFromSeed (seed, recPwd) encPwd
     accXPub = deriveAccountPrivateKey encPwd rootXPrv ix
 
-prop_passphraseRoundtrip
-    :: Passphrase "encryption"
-    -> Property
-prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
-    hpwd <- encryptPassphrase pwd
-    checkPassphrase pwd hpwd `shouldBe` Right ()
-
-prop_passphraseRoundtripFail
-    :: (Passphrase "encryption", Passphrase "encryption")
-    -> Property
-prop_passphraseRoundtripFail (p, p') =
-    p /= p' ==> monadicIO $ liftIO $ do
-        hp <- encryptPassphrase p
-        checkPassphrase p' hp `shouldBe` Left ErrWrongPassphrase
-
-prop_passphraseHashMalformed
-    :: Passphrase "encryption"
-    -> Property
-prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
-    checkPassphrase pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
-
-
 {-------------------------------------------------------------------------------
                              Arbitrary Instances
 -------------------------------------------------------------------------------}
 
-instance Arbitrary (Index 'Soft 'AddressK) where
-    shrink _ = []
-    arbitrary = arbitraryBoundedEnum
-
-instance Arbitrary (Index 'Hardened 'AccountK) where
-    shrink _ = []
-    arbitrary = arbitraryBoundedEnum
-
-instance Arbitrary (Passphrase goal) where
-    shrink (Passphrase "") = []
-    shrink (Passphrase _ ) = [Passphrase ""]
-    arbitrary = do
-        n <- choose (0, 32)
-        InfiniteList bytes _ <- arbitrary
-        return $ Passphrase $ BA.convert $ BS.pack $ take n bytes
-
-instance {-# OVERLAPS #-} Arbitrary (Passphrase "encryption") where
-    arbitrary = do
-        let p = Proxy :: Proxy "encryption"
-        n <- choose (passphraseMinLength p, passphraseMaxLength p)
-        bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
-        return $ Passphrase $ BA.convert bytes
-
-instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
-    arbitrary = do
-        n <- choose (16, 64)
-        bytes <- BS.pack <$> vectorOf n arbitrary
-        return $ Passphrase $ BA.convert bytes
-
 instance Arbitrary ChangeChain where
     shrink _ = []
     arbitrary = elements [InternalChain, ExternalChain]
-
-instance Arbitrary (Hash "encryption") where
-    shrink _ = []
-    arbitrary = do
-        InfiniteList bytes _ <- arbitrary
-        return $ Hash $ BS.pack $ take 32 bytes
-
--- Necessary unsound Show instance for QuickCheck failure reporting
-instance Show XPrv where
-    show = show . unXPrv
-
--- Necessary unsound Eq instance for QuickCheck properties
-instance Eq XPrv where
-    a == b = unXPrv a == unXPrv b
-
-instance Arbitrary (Key 'RootK XPrv) where
-    shrink _ = []
-    arbitrary = genRootKeys
-
-genRootKeys :: Gen (Key 'RootK XPrv)
-genRootKeys = do
-    (s, g, e) <- (,,)
-        <$> genPassphrase @"seed" (16, 32)
-        <*> genPassphrase @"generation" (0, 16)
-        <*> genPassphrase @"encryption" (0, 16)
-    return $ generateKeyFromSeed (s, g) e
-  where
-    genPassphrase :: (Int, Int) -> Gen (Passphrase purpose)
-    genPassphrase range = do
-        n <- choose range
-        InfiniteList bytes _ <- arbitrary
-        return $ Passphrase $ BA.convert $ BS.pack $ take n bytes

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -182,11 +182,9 @@ spec = do
         it "XPriv" (property prop_roundtripXPriv)
         it "XPub" (property prop_roundtripXPub)
 
-
 {-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
-
 
 prop_succMaxBoundHardIx :: Property
 prop_succMaxBoundHardIx = expectFailure $
@@ -247,7 +245,6 @@ prop_passphraseHashMalformed
     -> Property
 prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
     checkPassphrase pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
-
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -1,0 +1,315 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.AddressDerivationSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( unXPrv )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationType (..)
+    , ErrWrongPassphrase (..)
+    , FromMnemonic (..)
+    , FromMnemonicError (..)
+    , Index
+    , Key
+    , Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , XPrv
+    , checkPassphrase
+    , deserializeXPrv
+    , deserializeXPub
+    , encryptPassphrase
+    , getIndex
+    , publicKey
+    , serializeXPrv
+    , serializeXPub
+    )
+import Cardano.Wallet.Primitive.Types
+    ( Hash (..) )
+import Control.Monad
+    ( replicateM )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Data.Either
+    ( isRight )
+import Data.Proxy
+    ( Proxy (..) )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe, shouldSatisfy )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , InfiniteList (..)
+    , Property
+    , arbitraryBoundedEnum
+    , arbitraryPrintableChar
+    , choose
+    , expectFailure
+    , property
+    , vectorOf
+    , (.&&.)
+    , (===)
+    , (==>)
+    )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
+import Test.Text.Roundtrip
+    ( textRoundtrip )
+
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Sequential as Seq
+    ( generateKeyFromSeed )
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+spec :: Spec
+spec = do
+    describe "Bounded / Enum relationship" $ do
+        it "The calls Index.succ maxBound should result in a runtime err (hard)"
+            prop_succMaxBoundHardIx
+        it "The calls Index.pred minBound should result in a runtime err (hard)"
+            prop_predMinBoundHardIx
+        it "The calls Index.succ maxBound should result in a runtime err (soft)"
+            prop_succMaxBoundSoftIx
+        it "The calls Index.pred minBound should result in a runtime err (soft)"
+            prop_predMinBoundSoftIx
+
+    describe "Text Roundtrip" $ do
+        textRoundtrip $ Proxy @(Passphrase "encryption")
+
+    describe "Enum Roundtrip" $ do
+        it "Index @'Hardened _" (property prop_roundtripEnumIndexHard)
+        it "Index @'Soft _" (property prop_roundtripEnumIndexSoft)
+
+    describe "Passphrases" $ do
+        it "checkPassphrase p h(p) == Right ()" $
+            property prop_passphraseRoundtrip
+
+        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
+            property prop_passphraseRoundtripFail
+
+        it "checkPassphrase fails when hash is malformed" $
+            property prop_passphraseHashMalformed
+
+    describe "FromMnemonic" $ do
+        it "early error reported first (Invalid Entropy)" $ do
+            let res = fromMnemonic @'[15,18,21] @"testing"
+                        [ "glimpse", "paper", "toward", "fine", "alert"
+                        , "baby", "pyramid", "alone", "shaft", "force"
+                        , "circle", "fancy", "squeeze", "cannon", "toilet"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Invalid entropy checksum: \
+                \please double-check the last word of your mnemonic sentence.")
+
+        it "early error reported first (Non-English Word)" $ do
+            let res = fromMnemonic @'[15,18,21] @"testing"
+                        [ "baguette", "paper", "toward", "fine", "alert"
+                        , "baby", "pyramid", "alone", "shaft", "force"
+                        , "circle", "fancy", "squeeze", "cannon", "toilet"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
+                \word: \"baguette\".")
+
+        it "early error reported first (Wrong number of words - 1)" $ do
+            let res = fromMnemonic @'[15,18,21] @"testing"
+                        ["mom", "unveil", "slim", "abandon"
+                        , "nut", "cash", "laugh", "impact"
+                        , "system", "split", "depth", "sun"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
+                \15, 18 or 21 words are expected.")
+
+        it "early error reported first (Wrong number of words - 2)" $ do
+            let res = fromMnemonic @'[15] @"testing"
+                        ["mom", "unveil", "slim", "abandon"
+                        , "nut", "cash", "laugh", "impact"
+                        , "system", "split", "depth", "sun"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Invalid number of words: \
+                \15 words are expected.")
+
+        it "early error reported first (Error not in first constructor)" $ do
+            let res = fromMnemonic @'[15,18,21,24] @"testing"
+                        ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
+                        ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
+                \word: \"盗\".")
+
+        it "early error reported first (Error not in first constructor)" $ do
+            let res = fromMnemonic @'[12,15,18] @"testing"
+                        ["盗", "精", "序", "郎", "赋", "姿", "委", "善", "酵"
+                        ,"祥", "赛", "矩", "蜡", "注", "韦", "效", "义", "冻"
+                        ]
+            res `shouldBe` Left (FromMnemonicError "Found invalid (non-English) \
+                \word: \"盗\".")
+
+        it "successfully parse 15 words in [15,18,21]" $ do
+            let res = fromMnemonic @'[15,18,21] @"testing"
+                        ["cushion", "anxiety", "oval", "village", "choose"
+                        , "shoot", "over", "behave", "category", "cruise"
+                        , "track", "either", "maid", "organ", "sock"
+                        ]
+            res `shouldSatisfy` isRight
+
+        it "successfully parse 15 words in [12,15,18]" $ do
+            let res = fromMnemonic @'[12,15,18] @"testing"
+                        ["cushion", "anxiety", "oval", "village", "choose"
+                        , "shoot", "over", "behave", "category", "cruise"
+                        , "track", "either", "maid", "organ", "sock"
+                        ]
+            res `shouldSatisfy` isRight
+
+        it "successfully parse 15 words in [9,12,15]" $ do
+            let res = fromMnemonic @'[9,12,15] @"testing"
+                        ["cushion", "anxiety", "oval", "village", "choose"
+                        , "shoot", "over", "behave", "category", "cruise"
+                        , "track", "either", "maid", "organ", "sock"
+                        ]
+            res `shouldSatisfy` isRight
+
+    describe "Keys storing and retrieving roundtrips" $ do
+        it "XPriv" (property prop_roundtripXPriv)
+        it "XPub" (property prop_roundtripXPub)
+
+
+{-------------------------------------------------------------------------------
+                               Properties
+-------------------------------------------------------------------------------}
+
+
+prop_succMaxBoundHardIx :: Property
+prop_succMaxBoundHardIx = expectFailure $
+    property $ succ (maxBound @(Index 'Hardened _)) `seq` ()
+
+prop_predMinBoundHardIx :: Property
+prop_predMinBoundHardIx = expectFailure $
+    property $ pred (minBound @(Index 'Hardened _)) `seq` ()
+
+prop_succMaxBoundSoftIx :: Property
+prop_succMaxBoundSoftIx = expectFailure $
+    property $ succ (maxBound @(Index 'Soft _)) `seq` ()
+
+prop_predMinBoundSoftIx :: Property
+prop_predMinBoundSoftIx = expectFailure $
+    property $ pred (minBound @(Index 'Soft _)) `seq` ()
+
+prop_roundtripEnumIndexHard :: Index 'Hardened 'AccountK -> Property
+prop_roundtripEnumIndexHard ix =
+    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
+
+prop_roundtripEnumIndexSoft :: Index 'Soft 'AddressK -> Property
+prop_roundtripEnumIndexSoft ix =
+    (toEnum . fromEnum) ix === ix .&&. (toEnum . fromEnum . getIndex) ix === ix
+
+prop_roundtripXPriv
+    :: (Key 'RootK XPrv, Hash "encryption")
+    -> Property
+prop_roundtripXPriv xpriv = do
+    let xpriv' = (deserializeXPrv . serializeXPrv) xpriv
+    xpriv' === Right xpriv
+
+prop_roundtripXPub
+    :: Key 'RootK XPrv
+    -> Property
+prop_roundtripXPub xpriv = do
+    let xpub = publicKey xpriv
+    let xpub' = (deserializeXPub . serializeXPub) xpub
+    xpub' === Right xpub
+
+prop_passphraseRoundtrip
+    :: Passphrase "encryption"
+    -> Property
+prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
+    hpwd <- encryptPassphrase pwd
+    checkPassphrase pwd hpwd `shouldBe` Right ()
+
+prop_passphraseRoundtripFail
+    :: (Passphrase "encryption", Passphrase "encryption")
+    -> Property
+prop_passphraseRoundtripFail (p, p') =
+    p /= p' ==> monadicIO $ liftIO $ do
+        hp <- encryptPassphrase p
+        checkPassphrase p' hp `shouldBe` Left ErrWrongPassphrase
+
+prop_passphraseHashMalformed
+    :: Passphrase "encryption"
+    -> Property
+prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
+    checkPassphrase pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
+
+
+{-------------------------------------------------------------------------------
+                             Arbitrary Instances
+-------------------------------------------------------------------------------}
+
+instance Arbitrary (Index 'Soft 'AddressK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary (Index 'Hardened 'AccountK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary (Passphrase goal) where
+    shrink (Passphrase "") = []
+    shrink (Passphrase _ ) = [Passphrase ""]
+    arbitrary = do
+        n <- choose (0, 32)
+        InfiniteList bytes _ <- arbitrary
+        return $ Passphrase $ BA.convert $ BS.pack $ take n bytes
+
+instance {-# OVERLAPS #-} Arbitrary (Passphrase "encryption") where
+    arbitrary = do
+        let p = Proxy :: Proxy "encryption"
+        n <- choose (passphraseMinLength p, passphraseMaxLength p)
+        bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
+        return $ Passphrase $ BA.convert bytes
+
+instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
+    arbitrary = do
+        n <- choose (16, 64)
+        bytes <- BS.pack <$> vectorOf n arbitrary
+        return $ Passphrase $ BA.convert bytes
+
+instance Arbitrary (Hash "encryption") where
+    shrink _ = []
+    arbitrary = do
+        InfiniteList bytes _ <- arbitrary
+        return $ Hash $ BS.pack $ take 32 bytes
+
+-- Necessary unsound Show instance for QuickCheck failure reporting
+instance Show XPrv where
+    show = show . unXPrv
+
+-- Necessary unsound Eq instance for QuickCheck properties
+instance Eq XPrv where
+    a == b = unXPrv a == unXPrv b
+
+instance Arbitrary (Key 'RootK XPrv) where
+    shrink _ = []
+    arbitrary = genRootKeys
+
+genRootKeys :: Gen (Key 'RootK XPrv)
+genRootKeys = do
+    (s, g, e) <- (,,)
+        <$> genPassphrase @"seed" (16, 32)
+        <*> genPassphrase @"generation" (0, 16)
+        <*> genPassphrase @"encryption" (0, 16)
+    return $ Seq.generateKeyFromSeed (s, g) e
+  where
+    genPassphrase :: (Int, Int) -> Gen (Passphrase purpose)
+    genPassphrase range = do
+        n <- choose range
+        InfiniteList bytes _ <- arbitrary
+        return $ Passphrase $ BA.convert $ BS.pack $ take n bytes


### PR DESCRIPTION
Relates to issue #553 

# Overview

- Splits the common `AddressDerivationSpec` tests out of `AddressDerivation.SequentialSpec`.
- Reverts the change where the Key constructor was exported from `AddressDerivation`.
