### PR TITLE
Raise an error if `start > end` in `listTransactions` API/CLI call.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -104,7 +104,6 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
-    , SortOrder (..)
     , WalletPostData (..)
     , WalletPutData (..)
     , WalletPutPassphraseData (..)
@@ -122,7 +121,13 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Mnemonic
     ( entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, DecodeAddress, EncodeAddress, WalletId, WalletName )
+    ( AddressState
+    , DecodeAddress
+    , EncodeAddress
+    , SortOrder
+    , WalletId
+    , WalletName
+    )
 import Cardano.Wallet.Version
     ( showVersion, version )
 import Control.Applicative
@@ -585,7 +590,7 @@ cmdTransactionList = command "list" $ info (helper <*> cmd) $ mempty
             (ApiT wId)
             mTimeRangeStart
             mTimeRangeEnd
-            mOrder
+            (ApiT <$> mOrder)
 
 {-------------------------------------------------------------------------------
                             Commands - 'address'
@@ -855,7 +860,7 @@ data WalletClient t = WalletClient
         :: ApiT WalletId
         -> Maybe Iso8601Time
         -> Maybe Iso8601Time
-        -> Maybe SortOrder
+        -> Maybe (ApiT SortOrder)
         -> ClientM [ApiTransaction t]
     , postTransaction
         :: ApiT WalletId

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -115,6 +115,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotLength (..)
     , SlotLength (..)
+    , SortOrder (..)
     , StartTime (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -181,7 +182,7 @@ import Data.Text
 import Data.Text.Class
     ( toText )
 import Data.Time.Clock
-    ( getCurrentTime )
+    ( UTCTime, getCurrentTime )
 import Data.Word
     ( Word16 )
 import Fmt
@@ -300,6 +301,11 @@ data WalletLayer s t = WalletLayer
     , listTransactions
         :: DefineTx t
         => WalletId
+        -> Maybe UTCTime
+            -- Start time
+        -> Maybe UTCTime
+            -- End time
+        -> Maybe SortOrder
         -> ExceptT ErrListTransactions IO [TransactionInfo]
         -- ^ List all transactions and metadata from history for a given wallet.
         --
@@ -731,8 +737,11 @@ newWalletLayer tracer bp db nw tl = do
     _listTransactions
         :: (DefineTx t)
         => WalletId
+        -> Maybe UTCTime
+        -> Maybe UTCTime
+        -> Maybe SortOrder
         -> ExceptT ErrListTransactions IO [TransactionInfo]
-    _listTransactions wid = do
+    _listTransactions wid _mStart _mEnd _mOrder = do
         (w, _) <- withExceptT ErrListTransactionsNoSuchWallet $ _readWallet wid
         let tip = currentTip w ^. #slotId
         liftIO $ assemble tip <$> DB.readTxHistory db (PrimaryKey wid)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -13,13 +13,12 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time
     , PostTransactionData
     , PostTransactionFeeData
-    , SortOrder
     , WalletPostData
     , WalletPutData
     , WalletPutPassphraseData
     )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, WalletId )
+    ( AddressState, SortOrder, WalletId )
 import Data.List.NonEmpty
     ( NonEmpty ((:|)) )
 import Network.HTTP.Media
@@ -144,7 +143,7 @@ type ListTransactions t = "wallets"
     :> "transactions"
     :> QueryParam "start" Iso8601Time
     :> QueryParam "end" Iso8601Time
-    :> QueryParam "order" SortOrder
+    :> QueryParam "order" (ApiT SortOrder)
     :> Get '[JSON] [ApiTransaction t]
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -473,8 +473,11 @@ listTransactions
     -> Maybe Iso8601Time
     -> Maybe (ApiT SortOrder)
     -> Handler [ApiTransaction t]
-listTransactions w (ApiT wid) _maybeStart _maybeEnd _maybeOrder = do
+listTransactions w (ApiT wid) mStart mEnd mOrder = do
     txs <- liftHandler $ W.listTransactions w wid
+        (getIso8601Time <$> mStart)
+        (getIso8601Time <$> mEnd)
+        (getApiT <$> mOrder)
     return $ map mkApiTransactionFromInfo txs
 
 coerceCoin :: AddressAmount t -> TxOut

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -61,7 +61,6 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData
     , PostTransactionFeeData
-    , SortOrder (..)
     , WalletBalance (..)
     , WalletPostData (..)
     , WalletPutData (..)
@@ -89,6 +88,7 @@ import Cardano.Wallet.Primitive.Types
     , EncodeAddress (..)
     , Hash (..)
     , HistogramBar (..)
+    , SortOrder (..)
     , TransactionInfo (TransactionInfo)
     , TxIn
     , TxOut (..)
@@ -471,7 +471,7 @@ listTransactions
     -> ApiT WalletId
     -> Maybe Iso8601Time
     -> Maybe Iso8601Time
-    -> Maybe SortOrder
+    -> Maybe (ApiT SortOrder)
     -> Handler [ApiTransaction t]
 listTransactions w (ApiT wid) _maybeStart _maybeEnd _maybeOrder = do
     txs <- liftHandler $ W.listTransactions w wid

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -367,7 +367,8 @@ getUTxOsStatistics
     -> ApiT WalletId
     -> Handler ApiUtxoStatistics
 getUTxOsStatistics w (ApiT wid) = do
-    (UTxOStatistics histo totalStakes bType) <- liftHandler $ W.listUtxoStatistics w wid
+    (UTxOStatistics histo totalStakes bType) <-
+        liftHandler $ W.listUtxoStatistics w wid
     return ApiUtxoStatistics
         { total = Quantity (fromIntegral totalStakes)
         , scale = ApiT bType
@@ -414,7 +415,11 @@ transactions w =
     :<|> postTransactionFee w
 
 createTransaction
-    :: forall t. (DefineTx t, KeyToAddress t, Buildable (ErrValidateSelection t))
+    :: forall t.
+        ( DefineTx t
+        , KeyToAddress t
+        , Buildable (ErrValidateSelection t)
+        )
     => WalletLayer (SeqState t) t
     -> ApiT WalletId
     -> PostTransactionData t

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -37,6 +37,7 @@ import Cardano.Wallet
     , ErrNoSuchWallet (..)
     , ErrPostTx (..)
     , ErrSignTx (..)
+    , ErrStartTimeLaterThanEndTime (..)
     , ErrSubmitTx (..)
     , ErrUpdatePassphrase (..)
     , ErrValidateSelection
@@ -148,6 +149,7 @@ import Servant
     , NoContent (..)
     , Server
     , contentType
+    , err400
     , err403
     , err404
     , err409
@@ -681,6 +683,16 @@ instance LiftHandler ErrUpdatePassphrase where
 instance LiftHandler ErrListTransactions where
     handler = \case
         ErrListTransactionsNoSuchWallet e -> handler e
+        ErrListTransactionsStartTimeLaterThanEndTime e -> handler e
+
+instance LiftHandler ErrStartTimeLaterThanEndTime where
+    handler err = apiError err400 StartTimeLaterThanEndTime $ mconcat
+        [ "The specified start time '"
+        , toText $ Iso8601Time $ startTime err
+        , "' is later than the specified end time '"
+        , toText $ Iso8601Time $ endTime err
+        , "'."
+        ]
 
 instance LiftHandler ServantErr where
     handler err@(ServantErr code _ body headers)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -248,6 +248,7 @@ data ApiErrorCode
     | NotFound
     | MethodNotAllowed
     | NotAcceptable
+    | StartTimeLaterThanEndTime
     | UnsupportedMediaType
     | UnexpectedError
     deriving (Eq, Generic, Show)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -45,7 +45,6 @@ module Cardano.Wallet.Api.Types
     , AddressAmount (..)
     , ApiErrorCode (..)
     , Iso8601Time (..)
-    , SortOrder (..)
 
     -- * Polymorphic Types
     , ApiT (..)
@@ -124,13 +123,7 @@ import Data.Quantity
 import Data.Text
     ( Text, split )
 import Data.Text.Class
-    ( CaseStyle (SnakeLowerCase)
-    , FromText (..)
-    , TextDecodingError (..)
-    , ToText (..)
-    , fromTextToBoundedEnum
-    , toTextFromBoundedEnum
-    )
+    ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Time
     ( UTCTime )
 import Data.Time.Text
@@ -282,26 +275,6 @@ instance FromHttpApiData Iso8601Time where
     parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
 
 instance ToHttpApiData Iso8601Time where
-    toUrlPiece = toText
-
--- | Represents a sort order, applicable to a query.
-data SortOrder
-    = Ascending
-        -- ^ Sort in ascending order.
-    | Descending
-        -- ^ Sort in descending order.
-    deriving (Bounded, Enum, Eq, Generic, Show)
-
-instance ToText SortOrder where
-    toText = toTextFromBoundedEnum SnakeLowerCase
-
-instance FromText SortOrder where
-    fromText = fromTextToBoundedEnum SnakeLowerCase
-
-instance FromHttpApiData SortOrder where
-    parseUrlPiece = first (T.pack . getTextDecodingError) . fromText
-
-instance ToHttpApiData SortOrder where
     toUrlPiece = toText
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -95,6 +95,9 @@ module Cardano.Wallet.Primitive.Types
     -- * Stake Pools
     , PoolId(..)
 
+    -- * Querying
+    , SortOrder (..)
+
     -- * Polymorphic
     , Hash (..)
     , ShowFmt (..)
@@ -304,6 +307,24 @@ data WalletBalance = WalletBalance
     { available :: !(Quantity "lovelace" Natural)
     , total :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
+
+{-------------------------------------------------------------------------------
+                                   Queries
+-------------------------------------------------------------------------------}
+
+-- | Represents a sort order, applicable to the results returned by a query.
+data SortOrder
+    = Ascending
+        -- ^ Sort in ascending order.
+    | Descending
+        -- ^ Sort in descending order.
+    deriving (Bounded, Enum, Eq, Generic, Show)
+
+instance ToText SortOrder where
+    toText = toTextFromBoundedEnum SnakeLowerCase
+
+instance FromText SortOrder where
+    fromText = fromTextToBoundedEnum SnakeLowerCase
 
 {-------------------------------------------------------------------------------
                                   Stake Pools

--- a/lib/core/test/integration/Test/Integration/Framework/TestData.hs
+++ b/lib/core/test/integration/Test/Integration/Framework/TestData.hs
@@ -43,6 +43,7 @@ module Test.Integration.Framework.TestData
 
     -- * Error messages
     , errMsgWalletIdEncoding
+    , errMsg400StartTimeLaterThanEndTime
     , errMsg403Fee
     , errMsg403NotEnoughMoney
     , errMsg403UTxO
@@ -228,6 +229,15 @@ versionLine = "Running as v" <> pack (showVersion version)
   ---
 errMsgWalletIdEncoding :: String
 errMsgWalletIdEncoding = "wallet id should be an hex-encoded string of 40 characters"
+
+errMsg400StartTimeLaterThanEndTime :: String -> String -> String
+errMsg400StartTimeLaterThanEndTime startTime endTime = mconcat
+    [ "The specified start time '"
+    , startTime
+    , "' is later than the specified end time '"
+    , endTime
+    , "'."
+    ]
 
 errMsg403Fee :: String
 errMsg403Fee = "I'm unable to adjust the given transaction to cover the\

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -657,7 +657,6 @@ spec = do
                 , (Just validTime1, Nothing)
                 , (Nothing, Just validTime1)
                 , (Just validTime1, Just validTime2)
-                , (Just validTime2, Just validTime1)
                 ]
 
         let sortOrderMatrix :: [Maybe SortOrder]

--- a/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core/test/integration/Test/Integration/Scenario/CLI/Transactions.hs
@@ -11,11 +11,12 @@ module Test.Integration.Scenario.CLI.Transactions
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiFee, ApiTransaction, ApiWallet, SortOrder, getApiT )
+    ( ApiFee, ApiTransaction, ApiWallet, getApiT )
 import Cardano.Wallet.Primitive.Types
     ( DecodeAddress (..)
     , Direction (..)
     , EncodeAddress (..)
+    , SortOrder (..)
     , TxStatus (..)
     , encodeAddress
     )

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -37,7 +37,6 @@ import Cardano.Wallet.Api.Types
     , Iso8601Time (..)
     , PostTransactionData (..)
     , PostTransactionFeeData (..)
-    , SortOrder (..)
     , WalletBalance (..)
     , WalletPostData (..)
     , WalletPutData (..)
@@ -72,6 +71,7 @@ import Cardano.Wallet.Primitive.Types
     , HistogramBar (..)
     , PoolId (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxIn (..)
     , TxOut (..)
@@ -247,7 +247,7 @@ spec = do
             httpApiDataRoundtrip $ Proxy @(ApiT WalletId)
             httpApiDataRoundtrip $ Proxy @(ApiT AddressState)
             httpApiDataRoundtrip $ Proxy @Iso8601Time
-            httpApiDataRoundtrip $ Proxy @SortOrder
+            httpApiDataRoundtrip $ Proxy @(ApiT SortOrder)
 
     describe
         "verify that every type used with JSON content type in a servant API \

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -362,7 +362,8 @@ walletListTransactionsSorted wallet@(wid, _, _) history =
     monadicIO $ liftIO $ do
         (WalletLayerFixture db wl _ slotIdTime) <- liftIO $ setupFixture wallet
         unsafeRunExceptT $ putTxHistory db (PrimaryKey wid) history
-        txs <- unsafeRunExceptT $ listTransactions wl wid
+        txs <- unsafeRunExceptT $
+            listTransactions wl wid Nothing Nothing Nothing
         length txs `shouldBe` Map.size history
         -- With the 'Down'-wrapper, the sort is descending.
         txs `shouldBe` L.sortOn (Down . slotId . txInfoMeta) txs


### PR DESCRIPTION
# Issue Number

#466 

# Overview

This PR:

- [x] Passes query parameters for `listTransactions` through to the wallet layer.
- [x] Throws an error from the API if `listTransactions` is called with `start > end`.
- [x] Adds a CLI integration test to verify that an error is reported when `transaction list` is called with `--start > --end`.
- [x] Adds a API integration test to verify that an error is reported when `listTransactions` is called with `start > end`.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
