### PR TITLE
Let `DB.readTxHistory` take `SortOrder` and `Range SlotId`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -479,8 +479,11 @@ listTransactions w (ApiT wid) mStart mEnd mOrder = do
     txs <- liftHandler $ W.listTransactions w wid
         (getIso8601Time <$> mStart)
         (getIso8601Time <$> mEnd)
-        (getApiT <$> mOrder)
+        (maybe defaultSortOrder getApiT mOrder)
     return $ map mkApiTransactionFromInfo txs
+  where
+    defaultSortOrder :: SortOrder
+    defaultSortOrder = Descending
 
 coerceCoin :: AddressAmount t -> TxOut
 coerceCoin (AddressAmount (ApiT addr, _) (Quantity c)) =

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -26,7 +26,15 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( DefineTx (..), Hash, TxMeta, WalletId, WalletMetadata )
+    ( DefineTx (..)
+    , Hash
+    , Range (..)
+    , SlotId (..)
+    , SortOrder (..)
+    , TxMeta
+    , WalletId
+    , WalletMetadata
+    )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Data.Map.Strict
@@ -102,6 +110,8 @@ data DBLayer m s t = DBLayer
 
     , readTxHistory
         :: PrimaryKey WalletId
+        -> SortOrder
+        -> Range SlotId
         -> m [(Hash "Tx", (Tx t, TxMeta))]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
         -- descending slot number.

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -27,7 +27,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Hash, Tx, TxMeta (slotId), WalletId, WalletMetadata )
+    ( Hash
+    , SortOrder (..)
+    , Tx
+    , TxMeta (slotId)
+    , WalletId
+    , WalletMetadata
+    , isWithinRange
+    )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, readMVar, withMVar )
 import Control.DeepSeq
@@ -37,11 +44,11 @@ import Control.Monad
 import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Data.List
-    ( sortOn )
+    ( sortBy )
 import Data.Map.Strict
     ( Map )
 import Data.Ord
-    ( Down (..) )
+    ( Down (..), comparing )
 
 import qualified Data.Map.Strict as Map
 
@@ -125,10 +132,15 @@ newDBLayer = do
                         Right $ Just $ Database cp meta (txs' <> txs) k
             txs' `deepseq` alterMVar db alter key
 
-        , readTxHistory = \key -> let
-                sortedTxHistory = sortOn slot . Map.toList . txHistory
-                slot = Down . slotId . snd . snd
-            in maybe mempty sortedTxHistory . Map.lookup key <$> readMVar db
+        , readTxHistory = \key order range -> let
+                order' = case order of
+                    Ascending -> comparing slot
+                    Descending -> comparing $ Down . slot
+                result =
+                    filter (isWithinRange range . slot)
+                    . sortBy order' . Map.toList . txHistory
+                slot = slotId . snd . snd
+            in maybe mempty result . Map.lookup key <$> readMVar db
 
         {-----------------------------------------------------------------------
                                        Keystore

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -310,7 +310,7 @@ newDBLayer logConfig trace fp = do
                       utxo <- selectUTxO cp
                       -- 'checkpointFromEntity' will create a 'Set' from the
                       -- pending txs so the order is not important.
-                      let order = Descending
+                      let order = W.Descending
                       txs <- selectTxHistory @t wid
                           order [TxMetaStatus ==. W.Pending]
                       s <- selectState (checkpointId cp)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -308,8 +308,11 @@ newDBLayer logConfig trace fp = do
               selectLatestCheckpoint wid >>= \case
                   Just cp -> do
                       utxo <- selectUTxO cp
+                      -- 'checkpointFromEntity' will create a 'Set' from the
+                      -- pending txs so the order is not important.
+                      let order = Descending
                       txs <- selectTxHistory @t wid
-                          W.defaultTxSortOrder [TxMetaStatus ==. W.Pending]
+                          order [TxMetaStatus ==. W.Pending]
                       s <- selectState (checkpointId cp)
                       pure (checkpointFromEntity @s @t cp utxo txs <$> s)
                   Nothing -> pure Nothing

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -100,7 +100,6 @@ module Cardano.Wallet.Primitive.Types
     , Range (..)
     , wholeRange
     , isWithinRange
-    , defaultTxSortOrder
 
     -- * Polymorphic
     , Hash (..)
@@ -329,9 +328,6 @@ instance ToText SortOrder where
 
 instance FromText SortOrder where
     fromText = fromTextToBoundedEnum SnakeLowerCase
-
-defaultTxSortOrder :: SortOrder
-defaultTxSortOrder =  Descending
 
 -- |'Range a' is used to filter data with optional `>=` and `<=` bounds.
 --

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -39,6 +39,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , Hash (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -49,7 +50,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -128,16 +128,18 @@ spec =  do
             destroyDBLayer ctx
             testOpeningCleaning f (`readPrivateKey` testWid) (Just (k, h)) Nothing
 
-        it "put and read tx history" $ \f -> do
+        it "put and read tx history (Ascending and Descending)" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)
             unsafeRunExceptT $ createWallet db testWid testCp testMetadata
             unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
             destroyDBLayer ctx
-            testOpeningCleaning
-                f
-                (\db' -> readTxHistory db' testWid defaultTxSortOrder wholeRange)
-                testTxs
-                mempty
+            let testWith order = testOpeningCleaning
+                    f
+                    (\db' -> readTxHistory db' testWid order wholeRange)
+                    testTxs
+                    mempty
+            testWith Ascending
+            testWith Descending
 
         it "put and read checkpoint" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -49,6 +49,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
+    , defaultTxSortOrder
+    , wholeRange
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
@@ -131,7 +133,11 @@ spec =  do
             unsafeRunExceptT $ createWallet db testWid testCp testMetadata
             unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
             destroyDBLayer ctx
-            testOpeningCleaning f (`readTxHistory` testWid) testTxs mempty
+            testOpeningCleaning
+                f
+                (\db' -> readTxHistory db' testWid defaultTxSortOrder wholeRange)
+                testTxs
+                mempty
 
         it "put and read checkpoint" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -128,18 +128,27 @@ spec =  do
             destroyDBLayer ctx
             testOpeningCleaning f (`readPrivateKey` testWid) (Just (k, h)) Nothing
 
-        it "put and read tx history (Ascending and Descending)" $ \f -> do
+        it "put and read tx history (Ascending)" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)
             unsafeRunExceptT $ createWallet db testWid testCp testMetadata
             unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
             destroyDBLayer ctx
-            let testWith order = testOpeningCleaning
-                    f
-                    (\db' -> readTxHistory db' testWid order wholeRange)
-                    testTxs
-                    mempty
-            testWith Ascending
-            testWith Descending
+            testOpeningCleaning
+                f
+                (\db' -> readTxHistory db' testWid Ascending wholeRange)
+                testTxs
+                mempty
+
+        it "put and read tx history (Decending)" $ \f -> do
+            (ctx, db) <- newDBLayer' (Just f)
+            unsafeRunExceptT $ createWallet db testWid testCp testMetadata
+            unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
+            destroyDBLayer ctx
+            testOpeningCleaning
+                f
+                (\db' -> readTxHistory db' testWid Descending wholeRange)
+                testTxs
+                mempty
 
         it "put and read checkpoint" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -63,6 +63,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
+    , defaultTxSortOrder
+    , wholeRange
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
@@ -169,7 +171,8 @@ simpleSpec = do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             runExceptT (putTxHistory db testPk (Map.fromList testTxs))
                 `shouldReturn` Right ()
-            readTxHistory db testPk `shouldReturn` testTxs
+            readTxHistory db testPk
+                defaultTxSortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read tx history - regression case" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
@@ -177,7 +180,8 @@ simpleSpec = do
             runExceptT (putTxHistory db testPk1 (Map.fromList testTxs))
                 `shouldReturn` Right ()
             runExceptT (removeWallet db testPk) `shouldReturn` Right ()
-            readTxHistory db testPk1 `shouldReturn` testTxs
+            readTxHistory db testPk1
+                defaultTxSortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read checkpoint" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -53,6 +53,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , Hash (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -63,7 +64,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -167,12 +167,13 @@ simpleSpec = do
             unsafeRunExceptT (putPrivateKey db testPk (k, h))
             readPrivateKey db testPk `shouldReturn` Just (k, h)
 
+        let sortOrder = Descending
         it "put and read tx history" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             runExceptT (putTxHistory db testPk (Map.fromList testTxs))
                 `shouldReturn` Right ()
             readTxHistory db testPk
-                defaultTxSortOrder wholeRange `shouldReturn` testTxs
+                sortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read tx history - regression case" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
@@ -181,7 +182,7 @@ simpleSpec = do
                 `shouldReturn` Right ()
             runExceptT (removeWallet db testPk) `shouldReturn` Right ()
             readTxHistory db testPk1
-                defaultTxSortOrder wholeRange `shouldReturn` testTxs
+                sortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read checkpoint" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -107,6 +107,7 @@ import Test.QuickCheck
     , Args (..)
     , Gen
     , Property
+    , arbitraryBoundedEnum
     , collect
     , elements
     , frequency
@@ -538,7 +539,7 @@ generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
     genPrivKey = elements ["pk1", "pk2", "pk3"]
 
     genSortOrder :: Gen SortOrder
-    genSortOrder = QC.elements [Ascending, Descending]
+    genSortOrder = arbitraryBoundedEnum
 
     genRange :: Gen (Range SlotId)
     genRange = Range <$> genSId <*> genSId

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -788,6 +788,6 @@ dbPropertyTests = do
 withDB :: IO (DBLayer IO s t) -> SpecWith (DBLayer IO s t) -> Spec
 withDB create = beforeAll create . beforeWith (\db -> cleanDB db $> db)
 
--- FIXME: We are only running these tests with one sort order.
+-- NOTE: We are only running these tests with one sort order.
 sortOrder :: SortOrder
 sortOrder = Descending

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -22,7 +22,7 @@ module Cardano.Wallet.DBSpec
     , GenTxHistory (..)
     , KeyValPairs (..)
     , TxHistory
-    , sortTxHistory
+    , filterTxHistory
     ) where
 
 import Prelude
@@ -67,7 +67,9 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
+    , Range (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -79,7 +81,10 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
+    , defaultTxSortOrder
     , isPending
+    , isWithinRange
+    , wholeRange
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
@@ -174,7 +179,10 @@ unions =
 -- default order for readTxHistory.
 sortedUnions :: Ord k => [(k, GenTxHistory)] -> [Identity GenTxHistory]
 sortedUnions = map (Identity . sort' . runIdentity) . unions
-    where sort' = GenTxHistory . sortTxHistory . unGenTxHistory
+  where
+    sort' = GenTxHistory
+      . filterTxHistory defaultTxSortOrder wholeRange
+      . unGenTxHistory
 
 -- | Execute an action once per key @k@ present in the given list
 once :: (Ord k, Monad m) => [(k,v)] -> ((k,v) -> m a) -> m [a]
@@ -187,10 +195,16 @@ once_ xs = void . once xs
 -- | Shorthand for the readTxHistory result type.
 type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
 
--- | Apply the default sort order (descending on time, then by TxId) to a
--- 'TxHistory'.
-sortTxHistory :: TxHistory -> TxHistory
-sortTxHistory = sortBySlot . sortByTxId
+-- | Apply optional filters on slotId and sort using the default sort order
+-- (first time/slotId, then by TxId) to a 'TxHistory'.
+filterTxHistory :: SortOrder -> Range SlotId -> TxHistory -> TxHistory
+filterTxHistory order range =
+    filter (isWithinRange range . slotId . snd . snd)
+    . (case order of
+        Ascending -> reverse
+        Descending -> id)
+    . sortBySlot
+    . sortByTxId
   where
     sortBySlot = L.sortOn (Down . slotId . snd . snd)
     sortByTxId = L.sortOn fst
@@ -358,6 +372,8 @@ instance Arbitrary GenTxHistory where
         mockTxId :: Tx -> Hash "Tx"
         mockTxId = Hash . B8.pack . show
 
+        sortTxHistory = filterTxHistory defaultTxSortOrder wholeRange
+
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
     arbitrary = do
@@ -413,7 +429,9 @@ readTxHistoryF
     => DBLayer m s DummyTarget
     -> PrimaryKey WalletId
     -> m (Identity GenTxHistory)
-readTxHistoryF db = fmap (Identity . GenTxHistory) . readTxHistory db
+readTxHistoryF db wid =
+    (Identity . GenTxHistory)
+    <$> readTxHistory db wid defaultTxSortOrder wholeRange
 
 putTxHistoryF
     :: DBLayer m s DummyTarget

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , isPending
     , isWithinRange
     , wholeRange
@@ -181,7 +180,7 @@ sortedUnions :: Ord k => [(k, GenTxHistory)] -> [Identity GenTxHistory]
 sortedUnions = map (Identity . sort' . runIdentity) . unions
   where
     sort' = GenTxHistory
-      . filterTxHistory defaultTxSortOrder wholeRange
+      . filterTxHistory sortOrder wholeRange
       . unGenTxHistory
 
 -- | Execute an action once per key @k@ present in the given list
@@ -372,7 +371,7 @@ instance Arbitrary GenTxHistory where
         mockTxId :: Tx -> Hash "Tx"
         mockTxId = Hash . B8.pack . show
 
-        sortTxHistory = filterTxHistory defaultTxSortOrder wholeRange
+        sortTxHistory = filterTxHistory sortOrder wholeRange
 
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
@@ -431,7 +430,7 @@ readTxHistoryF
     -> m (Identity GenTxHistory)
 readTxHistoryF db wid =
     (Identity . GenTxHistory)
-    <$> readTxHistory db wid defaultTxSortOrder wholeRange
+    <$> readTxHistory db wid sortOrder wholeRange
 
 putTxHistoryF
     :: DBLayer m s DummyTarget
@@ -788,3 +787,7 @@ dbPropertyTests = do
 -- once, and cleared with 'cleanDB' before each test.
 withDB :: IO (DBLayer IO s t) -> SpecWith (DBLayer IO s t) -> Spec
 withDB create = beforeAll create . beforeWith (\db -> cleanDB db $> db)
+
+-- FIXME: We are only running these tests with one sort order.
+sortOrder :: SortOrder
+sortOrder = Descending

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -369,7 +369,7 @@ walletListTransactionsSorted wallet@(wid, _, _) _order (_mstart, _mend) history 
         (WalletLayerFixture db wl _ slotIdTime) <- liftIO $ setupFixture wallet
         unsafeRunExceptT $ putTxHistory db (PrimaryKey wid) history
         txs <- unsafeRunExceptT $
-            listTransactions wl wid Nothing Nothing Nothing
+            listTransactions wl wid Nothing Nothing Descending
         length txs `shouldBe` Map.size history
         -- With the 'Down'-wrapper, the sort is descending.
         txs `shouldBe` L.sortOn (Down . slotId . txInfoMeta) txs

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -137,10 +137,10 @@ import Test.QuickCheck
     , withMaxSuccess
     , (==>)
     )
-import Test.QuickCheck.Instances.Time
-    ()
 import Test.QuickCheck.Monadic
     ( monadicIO )
+import Test.Utils.Time
+    ( UniformTime )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.DB as DB
@@ -361,7 +361,7 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
 walletListTransactionsSorted
     :: (WalletId, WalletName, DummyState)
     -> SortOrder
-    -> (Maybe UTCTime, Maybe UTCTime)
+    -> (Maybe UniformTime, Maybe UniformTime)
     -> Map (Hash "Tx") (Tx, TxMeta)
     -> Property
 walletListTransactionsSorted wallet@(wid, _, _) _order (_mstart, _mend) history =


### PR DESCRIPTION
# Issue Number

#466 


# Overview

- [x] @Anviking I added `SortDirection` and `Filter a` (for imposing `>=`/`<=` requirements) to core
- [x] @Anviking I made `DB.readTxHistory` take and apply `sortDir` and `filter` with implementations in `Sqlite`, `MVar` and Sqlite's StateMachine tests.
- [x] @Anviking Some final polish / decisions missing. Done I think.
- [x] @jonathanknowles: Replace usage of `Test.QuickCheck.Instances.Time` with `UniformTime` from module `Test.Utils.Time`. 
- [x] @jonathanknowles: Use `arbitraryBoundedEnum` to avoid repeating the definition of `SortOrder`.

# Comments

<!-- Additional comments or screenshots to attach if any -->



<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
