### PR TITLE
Remove defaultTxSortOrder

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -307,7 +307,7 @@ data WalletLayer s t = WalletLayer
             -- Start time
         -> Maybe UTCTime
             -- End time
-        -> Maybe SortOrder
+        -> SortOrder
         -> ExceptT ErrListTransactions IO [TransactionInfo]
         -- ^ List all transactions and metadata from history for a given wallet.
         --
@@ -750,9 +750,9 @@ newWalletLayer tracer bp db nw tl = do
         => WalletId
         -> Maybe UTCTime
         -> Maybe UTCTime
-        -> Maybe SortOrder
+        -> SortOrder
         -> ExceptT ErrListTransactions IO [TransactionInfo]
-    _listTransactions wid mStart mEnd mOrder = do
+    _listTransactions wid mStart mEnd order = do
         (w, _) <- withExceptT ErrListTransactionsNoSuchWallet $ _readWallet wid
         case (mStart, mEnd) of
             (Just start, Just end) -> when (start > end) $ throwE $
@@ -760,7 +760,6 @@ newWalletLayer tracer bp db nw tl = do
                     ErrStartTimeLaterThanEndTime start end
             _ -> pure ()
         let tip = currentTip w ^. #slotId
-        let order = maybe Descending id mOrder
         liftIO $ assemble tip
             <$> DB.readTxHistory db (PrimaryKey wid)
                 order wholeRange

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -479,8 +479,11 @@ listTransactions w (ApiT wid) mStart mEnd mOrder = do
     txs <- liftHandler $ W.listTransactions w wid
         (getIso8601Time <$> mStart)
         (getIso8601Time <$> mEnd)
-        (getApiT <$> mOrder)
+        (maybe defaultSortOrder getApiT mOrder)
     return $ map mkApiTransactionFromInfo txs
+  where
+    defaultSortOrder :: SortOrder
+    defaultSortOrder = Descending
 
 coerceCoin :: AddressAmount t -> TxOut
 coerceCoin (AddressAmount (ApiT addr, _) (Quantity c)) =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -310,7 +310,7 @@ newDBLayer logConfig trace fp = do
                       utxo <- selectUTxO cp
                       -- 'checkpointFromEntity' will create a 'Set' from the
                       -- pending txs so the order is not important.
-                      let order = Descending
+                      let order = W.Descending
                       txs <- selectTxHistory @t wid
                           order [TxMetaStatus ==. W.Pending]
                       s <- selectState (checkpointId cp)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -308,8 +308,11 @@ newDBLayer logConfig trace fp = do
               selectLatestCheckpoint wid >>= \case
                   Just cp -> do
                       utxo <- selectUTxO cp
+                      -- 'checkpointFromEntity' will create a 'Set' from the
+                      -- pending txs so the order is not important.
+                      let order = Descending
                       txs <- selectTxHistory @t wid
-                          W.defaultTxSortOrder [TxMetaStatus ==. W.Pending]
+                          order [TxMetaStatus ==. W.Pending]
                       s <- selectState (checkpointId cp)
                       pure (checkpointFromEntity @s @t cp utxo txs <$> s)
                   Nothing -> pure Nothing

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -100,7 +100,6 @@ module Cardano.Wallet.Primitive.Types
     , Range (..)
     , wholeRange
     , isWithinRange
-    , defaultTxSortOrder
 
     -- * Polymorphic
     , Hash (..)
@@ -329,9 +328,6 @@ instance ToText SortOrder where
 
 instance FromText SortOrder where
     fromText = fromTextToBoundedEnum SnakeLowerCase
-
-defaultTxSortOrder :: SortOrder
-defaultTxSortOrder =  Descending
 
 -- |'Range a' is used to filter data with optional `>=` and `<=` bounds.
 --

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -39,6 +39,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , Hash (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -49,7 +50,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -128,16 +128,18 @@ spec =  do
             destroyDBLayer ctx
             testOpeningCleaning f (`readPrivateKey` testWid) (Just (k, h)) Nothing
 
-        it "put and read tx history" $ \f -> do
+        it "put and read tx history (Ascending and Descending)" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)
             unsafeRunExceptT $ createWallet db testWid testCp testMetadata
             unsafeRunExceptT $ putTxHistory db testWid (Map.fromList testTxs)
             destroyDBLayer ctx
-            testOpeningCleaning
-                f
-                (\db' -> readTxHistory db' testWid defaultTxSortOrder wholeRange)
-                testTxs
-                mempty
+            let testWith order = testOpeningCleaning
+                    f
+                    (\db' -> readTxHistory db' testWid order wholeRange)
+                    testTxs
+                    mempty
+            testWith Ascending
+            testWith Descending
 
         it "put and read checkpoint" $ \f -> do
             (ctx, db) <- newDBLayer' (Just f)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -53,6 +53,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , Hash (..)
     , SlotId (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -63,7 +64,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -167,12 +167,13 @@ simpleSpec = do
             unsafeRunExceptT (putPrivateKey db testPk (k, h))
             readPrivateKey db testPk `shouldReturn` Just (k, h)
 
+        let sortOrder = Descending
         it "put and read tx history" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
             runExceptT (putTxHistory db testPk (Map.fromList testTxs))
                 `shouldReturn` Right ()
             readTxHistory db testPk
-                defaultTxSortOrder wholeRange `shouldReturn` testTxs
+                sortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read tx history - regression case" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata
@@ -181,7 +182,7 @@ simpleSpec = do
                 `shouldReturn` Right ()
             runExceptT (removeWallet db testPk) `shouldReturn` Right ()
             readTxHistory db testPk1
-                defaultTxSortOrder wholeRange `shouldReturn` testTxs
+                sortOrder wholeRange `shouldReturn` testTxs
 
         it "put and read checkpoint" $ \db -> do
             unsafeRunExceptT $ createWallet db testPk testCp testMetadata

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , defaultTxSortOrder
     , isPending
     , isWithinRange
     , wholeRange
@@ -180,7 +179,7 @@ sortedUnions :: Ord k => [(k, GenTxHistory)] -> [Identity GenTxHistory]
 sortedUnions = map (Identity . sort' . runIdentity) . unions
   where
     sort' = GenTxHistory
-      . filterTxHistory defaultTxSortOrder wholeRange
+      . filterTxHistory sortOrder wholeRange
       . unGenTxHistory
 
 -- | Execute an action once per key @k@ present in the given list
@@ -371,7 +370,7 @@ instance Arbitrary GenTxHistory where
         mockTxId :: Tx -> Hash "Tx"
         mockTxId = Hash . B8.pack . show
 
-        sortTxHistory = filterTxHistory defaultTxSortOrder wholeRange
+        sortTxHistory = filterTxHistory sortOrder wholeRange
 
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
@@ -430,7 +429,7 @@ readTxHistoryF
     -> m (Identity GenTxHistory)
 readTxHistoryF db wid =
     (Identity . GenTxHistory)
-    <$> readTxHistory db wid defaultTxSortOrder wholeRange
+    <$> readTxHistory db wid sortOrder wholeRange
 
 putTxHistoryF
     :: DBLayer m s DummyTarget
@@ -787,3 +786,7 @@ dbPropertyTests = do
 -- once, and cleared with 'cleanDB' before each test.
 withDB :: IO (DBLayer IO s t) -> SpecWith (DBLayer IO s t) -> Spec
 withDB create = beforeAll create . beforeWith (\db -> cleanDB db $> db)
+
+-- FIXME: We are only running these tests with one sort order.
+sortOrder :: SortOrder
+sortOrder = Descending

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -787,6 +787,6 @@ dbPropertyTests = do
 withDB :: IO (DBLayer IO s t) -> SpecWith (DBLayer IO s t) -> Spec
 withDB create = beforeAll create . beforeWith (\db -> cleanDB db $> db)
 
--- FIXME: We are only running these tests with one sort order.
+-- NOTE: We are only running these tests with one sort order.
 sortOrder :: SortOrder
 sortOrder = Descending


### PR DESCRIPTION
# Issue Number

#466 


# Overview

- [x] ~I have removed `defaultTxSortOrder`~ I have moved it from the WalletLayer to the Api.
- [x] I made `_listTransactions` actually pass its `SortOrder` to `DB.readTxHistory`

# Comments

<!-- Additional comments or screenshots to attach if any -->

Base is #588 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
