### PR TITLE
Provide improved generation of arbitrary `UTCTime` values.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,7 @@ in {
       cardano-wallet-core-integration
       cardano-wallet-http-bridge
       cardano-wallet-jormungandr
+      cardano-wallet-test-utils
       bech32
       text-class
     ];

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -153,7 +153,6 @@ test-suite unit
     , memory
     , network
     , QuickCheck
-    , quickcheck-instances
     , quickcheck-state-machine >= 0.6.0
     , random
     , servant

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -132,6 +132,7 @@ test-suite unit
     , bytestring
     , cardano-crypto
     , cardano-wallet-core
+    , cardano-wallet-test-utils
     , containers
     , cryptonite
     , directory

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -174,10 +174,10 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
-import Test.QuickCheck.Instances.Time
-    ()
 import Test.Text.Roundtrip
     ( textRoundtrip )
+import Test.Utils.Time
+    ( genUniformTime )
 import Web.HttpApiData
     ( FromHttpApiData (..), ToHttpApiData (..) )
 
@@ -573,8 +573,7 @@ instance Arbitrary AddressPoolGap where
     arbitrary = arbitraryBoundedEnum
 
 instance Arbitrary Iso8601Time where
-    arbitrary = Iso8601Time <$> arbitrary
-    shrink (Iso8601Time t) = Iso8601Time <$> shrink t
+    arbitrary = Iso8601Time <$> genUniformTime
 
 instance Arbitrary SortOrder where
     arbitrary = arbitraryBoundedEnum
@@ -633,8 +632,7 @@ instance (PassphraseMaxLength purpose, PassphraseMinLength purpose) =>
       where p = Proxy :: Proxy purpose
 
 instance Arbitrary WalletPassphraseInfo where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
+    arbitrary = WalletPassphraseInfo <$> genUniformTime
 
 instance Arbitrary WalletState where
     arbitrary = genericArbitrary
@@ -703,8 +701,8 @@ instance
             ]
 
 instance Arbitrary ApiBlockData where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
+    arbitrary = ApiBlockData <$> genUniformTime <*> arbitrary
+    shrink (ApiBlockData t b) = ApiBlockData t <$> shrink b
 
 instance Arbitrary SlotId where
     arbitrary = SlotId <$> arbitrary <*> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -133,6 +133,7 @@ import Test.QuickCheck
     , elements
     , generate
     , genericShrink
+    , liftArbitrary
     , oneof
     , property
     , scale
@@ -140,10 +141,10 @@ import Test.QuickCheck
     , suchThat
     , vectorOf
     )
-import Test.QuickCheck.Instances.Time
-    ()
 import Test.QuickCheck.Monadic
     ( monadicIO, pick )
+import Test.Utils.Time
+    ( genUniformTime )
 
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -312,8 +313,8 @@ instance Arbitrary WalletMetadata where
     shrink _ = []
     arbitrary =  WalletMetadata
         <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
-        <*> arbitrary
-        <*> (fmap WalletPassphraseInfo <$> arbitrary)
+        <*> genUniformTime
+        <*> (fmap WalletPassphraseInfo <$> liftArbitrary genUniformTime)
         <*> oneof [pure Ready, Restoring . Quantity <$> customizedGen]
         <*> pure NotDelegating
 

--- a/lib/core/test/unit/Data/Time/TextSpec.hs
+++ b/lib/core/test/unit/Data/Time/TextSpec.hs
@@ -26,8 +26,8 @@ import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
     ( property, (.&&.), (===) )
-import Test.QuickCheck.Instances.Time
-    ()
+import Test.Utils.Time
+    ( getUniformTime )
 
 import qualified Data.Text as T
 
@@ -37,8 +37,8 @@ spec = describe "Conversion of UTC time values to and from text" $ do
     describe "Roundtrip conversion to and from text succeeds for all formats" $
         forM_ allSupportedFormats $ \tf ->
             it (timeFormatName tf) $ property $ \t ->
-                utcTimeFromText [tf] (utcTimeToText tf t)
-                    `shouldBe` Just t
+                utcTimeFromText [tf] (utcTimeToText tf $ getUniformTime t)
+                    `shouldBe` Just (getUniformTime t)
 
     describe "Parsing valid strings succeeds for all formats" $
         forM_ allSupportedFormats $ \tf -> describe (timeFormatName tf) $

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,0 +1,38 @@
+name:                cardano-wallet-test-utils
+version:             2019.6.24
+synopsis:            Shared utilities for writing unit and property tests.
+description:         Shared utilities for writing unit and property tests.
+homepage:            https://github.com/input-output-hk/cardano-wallet
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+license:             MIT
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+library
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -Wall
+      -Wcompat
+  if (!flag(development))
+    ghc-options:
+      -Werror
+  build-depends:
+      base
+    , QuickCheck
+    , time
+  hs-source-dirs:
+      src
+  exposed-modules:
+      Test.Utils.Time

--- a/lib/test-utils/src/Test/Utils/Time.hs
+++ b/lib/test-utils/src/Test/Utils/Time.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: MIT
+--
+-- Provides utility functions relating to testing with times and dates.
+
+module Test.Utils.Time
+    ( UniformTime
+    , genUniformTime
+    , getUniformTime
+    ) where
+
+import Prelude
+
+import Data.Time
+    ( Day (ModifiedJulianDay), DiffTime, UTCTime (..) )
+import Data.Time.Clock
+    ( picosecondsToDiffTime, secondsToDiffTime )
+import Test.QuickCheck
+    ( Arbitrary, Gen, arbitrary, choose, oneof )
+
+-- | A wrapper for 'UTCTime' whose 'Arbitrary' instance spans a uniform range
+--   of dates and a mixture of time precisions.
+--
+newtype UniformTime = UniformTime { getUniformTime :: UTCTime }
+    deriving (Eq, Ord, Show)
+
+instance Arbitrary UniformTime where
+    arbitrary = UniformTime <$> genUniformTime
+
+-- | Generate 'UTCTime' values over a uniform range of dates and a mixture of
+--   time precisions.
+--
+genUniformTime :: Gen UTCTime
+genUniformTime = oneof
+    [ genWith
+        hoursToDiffTime
+        hoursInOneDay
+    , genWith
+        secondsToDiffTime
+        secondsInOneDay
+    , genWith
+        picosecondsToDiffTime
+        picosecondsInOneDay
+    ]
+  where
+    genWith :: (Integer -> DiffTime) -> Integer -> Gen UTCTime
+    genWith unitsToDiffTime unitsInOneDay = do
+        numberOfDays <- ModifiedJulianDay
+            <$> choose (0, daysInOneThousandYears)
+        timeSinceMidnight <- unitsToDiffTime
+            <$> choose (0, unitsInOneDay)
+        pure $ UTCTime numberOfDays timeSinceMidnight
+
+-- | The approximate number of days in one thousand years.
+daysInOneThousandYears :: Integral a => a
+daysInOneThousandYears = 365 * 1000
+
+-- | The number of hours in a day.
+hoursInOneDay :: Integral a => a
+hoursInOneDay = 24
+
+-- | The maximum number of picoseconds in one day, allowing for leap seconds.
+picosecondsInOneDay :: Integral a => a
+picosecondsInOneDay = secondsInOneDay * picosecondsInOneSecond
+
+-- | The exact number of picoseconds in one second.
+picosecondsInOneSecond :: Integral a => a
+picosecondsInOneSecond = 1_000_000_000_000
+
+-- | The maximum number of seconds in one day, allowing for leap seconds.
+secondsInOneDay :: Integral a => a
+secondsInOneDay = (secondsInOneHour * hoursInOneDay) + 1
+
+-- | The exact number of seconds in one hour.
+secondsInOneHour :: Integral a => a
+secondsInOneHour = 60 * 60
+
+-- | Convert a number of hours into a 'DiffTime' value.
+hoursToDiffTime :: Integral a => a -> DiffTime
+hoursToDiffTime hours =
+    secondsToDiffTime (secondsInOneHour * fromIntegral hours)

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -92,7 +92,6 @@
             (hsPkgs.memory)
             (hsPkgs.network)
             (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
             (hsPkgs.servant)

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -71,6 +71,7 @@
             (hsPkgs.bytestring)
             (hsPkgs.cardano-crypto)
             (hsPkgs.cardano-wallet-core)
+            (hsPkgs.cardano-wallet-test-utils)
             (hsPkgs.containers)
             (hsPkgs.cryptonite)
             (hsPkgs.directory)

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -1,0 +1,25 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { development = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = {
+        name = "cardano-wallet-test-utils";
+        version = "2019.6.24";
+        };
+      license = "MIT";
+      copyright = "2019 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Shared utilities for writing unit and property tests.";
+      description = "Shared utilities for writing unit and property tests.";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [ (hsPkgs.base) (hsPkgs.QuickCheck) (hsPkgs.time) ];
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../.././lib/test-utils; }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -17,6 +17,7 @@
         text-class = ./text-class.nix;
         cardano-wallet-http-bridge = ./cardano-wallet-http-bridge.nix;
         cardano-wallet-jormungandr = ./cardano-wallet-jormungandr.nix;
+        cardano-wallet-test-utils = ./cardano-wallet-test-utils.nix;
         cardano-crypto = ./cardano-crypto.nix;
         contra-tracer = ./contra-tracer.nix;
         iohk-monitoring = ./iohk-monitoring.nix;

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ packages:
 - lib/text-class
 - lib/http-bridge
 - lib/jormungandr
+- lib/test-utils
 
 extra-deps:
 # Miscellaneous


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/wiki/Blackboard#investigate-the-arbitrary-instance-for-utctime-in-testquickcheckinstancestime

# Overview

This change provides a `newtype` wrapper for `UTCTime` whose `Arbitrary` instance spans a uniform range of dates and a mixture of time precisions (_hour_, _second_ and _picosecond_ precision).

# Examples

### Generation
```hs
% replicateM_ 10 (generate arbitrary >>= print . getUniformTime)
1986-11-30 00:00:00 UTC
2471-07-30 02:04:41 UTC
2534-08-23 15:01:12.29087396788 UTC
2007-05-23 04:12:14.161001565693 UTC
2778-01-30 18:27:57 UTC
2025-09-05 12:00:00 UTC
2266-03-11 17:20:21 UTC
2822-08-14 21:40:18 UTC
2319-05-18 22:00:00 UTC
2448-03-09 11:38:11.71875851142 UTC
```
