### PR TITLE
Finalize filtering in `listTransactions` by converting `Range UTCTime` to `Range SlotId`

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -155,6 +155,7 @@ test-suite unit
     , memory
     , network
     , QuickCheck
+    , quickcheck-instances
     , quickcheck-state-machine >= 0.6.0
     , random
     , servant

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -759,10 +759,11 @@ newWalletLayer tracer bp db nw tl = do
                 ErrListTransactionsStartTimeLaterThanEndTime $
                     ErrStartTimeLaterThanEndTime start end
             _ -> pure ()
+        let slotIdRange = (error "TODO :: UTCTime -> SlotId") timeRange
         let tip = currentTip w ^. #slotId
         liftIO $ assemble tip
             <$> DB.readTxHistory db (PrimaryKey wid)
-                order wholeRange
+                order slotIdRange
       where
         -- This relies on DB.readTxHistory returning all necessary transactions
         -- to assemble coin selection information for outgoing payments.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -691,9 +691,9 @@ instance LiftHandler ErrListTransactions where
 instance LiftHandler ErrStartTimeLaterThanEndTime where
     handler err = apiError err400 StartTimeLaterThanEndTime $ mconcat
         [ "The specified start time '"
-        , toText $ Iso8601Time $ startTime err
+        , toText $ Iso8601Time $ errStartTime err
         , "' is later than the specified end time '"
-        , toText $ Iso8601Time $ endTime err
+        , toText $ Iso8601Time $ errEndTime err
         , "'."
         ]
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -852,14 +852,14 @@ slotRatio epochLength a b =
 -- | Convert a 'SlotId' to the number of slots since genesis.
 flatSlot :: EpochLength -> SlotId -> Word64
 flatSlot (EpochLength epochLength) (SlotId e s) =
-    epochLength * e + fromIntegral s
+    fromIntegral epochLength * e + fromIntegral s
 
 -- | Convert a 'flatSlot' index to 'SlotId'.
 fromFlatSlot :: EpochLength -> Word64 -> SlotId
 fromFlatSlot (EpochLength epochLength) n = SlotId e (fromIntegral s)
   where
-    e = n `div` epochLength
-    s = n `mod` epochLength
+    e = n `div` fromIntegral epochLength
+    s = n `mod` fromIntegral epochLength
 
 -- | @slotDifference a b@ is how many slots @a@ is after @b@. The result is
 -- non-negative, and if @b > a@ then this function returns zero.
@@ -903,7 +903,7 @@ newtype SlotLength = SlotLength NominalDiffTime
     deriving (Show, Eq)
 
 -- | Number of slots in a single epoch
-newtype EpochLength = EpochLength Word64
+newtype EpochLength = EpochLength Word16
     deriving (Show, Eq)
 
 -- | Blockchain start time

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -79,6 +79,7 @@ module Cardano.Wallet.Primitive.Types
     , flatSlot
     , fromFlatSlot
     , slotStartTime
+    , slotAtTime
     , slotDifference
 
     -- * Wallet Metadata
@@ -147,7 +148,7 @@ import Data.Text.Class
     , toTextFromBoundedEnum
     )
 import Data.Time.Clock
-    ( NominalDiffTime, UTCTime, addUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
 import Data.Word
     ( Word16, Word32, Word64 )
 import Fmt
@@ -875,6 +876,13 @@ slotStartTime epochLength (SlotLength slotLength) (StartTime start) sl =
     addUTCTime offset start
   where
     offset = slotLength * fromIntegral (flatSlot epochLength sl)
+
+-- | The SlotId at a given time.
+slotAtTime :: EpochLength -> SlotLength -> StartTime -> UTCTime -> SlotId
+slotAtTime epochLength (SlotLength slotLength) (StartTime start) time =
+    fromFlatSlot
+        epochLength
+        (round $ (time `diffUTCTime` start) / slotLength)
 
 -- | Duration of a single slot.
 newtype SlotLength = SlotLength NominalDiffTime

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -94,6 +94,7 @@
             (hsPkgs.memory)
             (hsPkgs.network)
             (hsPkgs.QuickCheck)
+            (hsPkgs.quickcheck-instances)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
             (hsPkgs.servant)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#466 

# Overview

Previous PR #588 added filtering-support to `DB.readTxHistory` using `Range SlotId`. Here we do the final connecting to allow `WalletLayer.listTransactions` filtering by `Range UTCTime`.

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added a `slotAtTime` mirroring `slotStartTime`. I've added an unfinished roundtrip test for this. ⚠️ I'm not sure this is exactly how we want it. There might be subtleties regarding to which slot the boundary belongs to etc.
- [ ] TODO: Convert `Range UTCTime` to `Range SlotId` argument `listTransactions` (Maybe `Range` could be functor or something?)


# Comments

- I've tried to separate into confined commits
- Doing the `UTCTime -> SlotId` conversion _might_ not be needed in the future, depending on how we deal with proper slotting and changing epoch/slot-lengths.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
