### PR TITLE
Replace hard-coded start time with named constant from Compatibility in benchmarks

### DIFF
--- a/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
+++ b/lib/http-bridge/test/integration/Test/Integration/HttpBridge/Scenario/CLI/Launcher.hs
@@ -153,7 +153,7 @@ spec = do
 
     describe "DaedalusIPC" $ do
         let defaultArgs =
-                [ commandName @t, "launch", "--quiet" ]
+                [ commandName @t, "launch" ]
         let tests =
                 [ defaultArgs ++ ["--random-port"]
                 , defaultArgs ++ ["--port", "8082"]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have replaced hard-coded values to use the start time defined in `HttpBridge.Compatibility`

# Comments

<!-- Additional comments or screenshots to attach if any -->

The testnet start-time has actually changed recently and although we did fix it in the Compatibility module, the benchmarks were still failing.. This should fix it and prevent future issues like this by having only a single source of truth

> :information_source: I'll trigger a manual nightly on buildkite to make sure it works as expected
>
> see: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/159

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
