### PR TITLE
Address derivation scheme as type parameter to WalletLayer

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -240,8 +240,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         Testnet -> exec @(HttpBridge 'Testnet) args
         Mainnet -> exec @(HttpBridge 'Mainnet) args
     exec
-        :: forall t n s. (t ~ HttpBridge n, s ~ SeqState t)
-        => (KeyToAddress t SeqKey, KnownNetwork n)
+        :: forall t k n s. (t ~ HttpBridge n, s ~ SeqState t, k ~ SeqKey)
+        => (KeyToAddress t k, KnownNetwork n)
         => ServeArgs
         -> IO ()
     exec (ServeArgs _ listen nodePort dbFile verbosity) = do

--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -253,7 +253,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
       where
         startServer
             :: Trace IO Text
-            -> WalletLayer s t SeqKey
+            -> WalletLayer s t k
             -> IO ()
         startServer tracer wallet = do
             Server.withListeningSocket listen $ \(port, socket) -> do
@@ -269,8 +269,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newWalletLayer
             :: (Switchboard Text, Trace IO Text)
-            -> DBLayer IO s t SeqKey
-            -> IO (WalletLayer s t SeqKey)
+            -> DBLayer IO s t k
+            -> IO (WalletLayer s t k)
         newWalletLayer (sb, tracer) db = do
             (nl, bp) <- newNetworkLayer (sb, tracer)
             let tl = HttpBridge.newTransactionLayer @n
@@ -288,7 +288,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         withDBLayer
             :: CM.Configuration
             -> Trace IO Text
-            -> (DBLayer IO s t SeqKey -> IO a)
+            -> (DBLayer IO s t k -> IO a)
             -> IO a
         withDBLayer logCfg tracer action = do
             let tracerDB = appendName "database" tracer

--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -72,6 +72,8 @@ import Cardano.Wallet.Network
     ( NetworkLayer, defaultRetryPolicy, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
 import Cardano.Wallet.Version
@@ -168,9 +170,8 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
         Right Testnet -> exec @(HttpBridge 'Testnet) args
         Right Mainnet -> exec @(HttpBridge 'Mainnet) args
     exec
-        :: forall t n s. (t ~ HttpBridge n, s ~ SeqState t)
-        => (KeyToAddress t, KnownNetwork n)
-        => LaunchArgs
+        :: forall t n s.
+           LaunchArgs
         -> IO ()
     exec (LaunchArgs network listen nodePort mStateDir verbosity) = do
         let withStateDir _ _ = pure ()
@@ -240,7 +241,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         Mainnet -> exec @(HttpBridge 'Mainnet) args
     exec
         :: forall t n s. (t ~ HttpBridge n, s ~ SeqState t)
-        => (KeyToAddress t, KnownNetwork n)
+        => (KeyToAddress t SeqKey, KnownNetwork n)
         => ServeArgs
         -> IO ()
     exec (ServeArgs _ listen nodePort dbFile verbosity) = do
@@ -252,7 +253,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
       where
         startServer
             :: Trace IO Text
-            -> WalletLayer s t
+            -> WalletLayer s t SeqKey
             -> IO ()
         startServer tracer wallet = do
             Server.withListeningSocket listen $ \(port, socket) -> do
@@ -268,8 +269,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newWalletLayer
             :: (Switchboard Text, Trace IO Text)
-            -> DBLayer IO s t
-            -> IO (WalletLayer s t)
+            -> DBLayer IO s t SeqKey
+            -> IO (WalletLayer s t SeqKey)
         newWalletLayer (sb, tracer) db = do
             (nl, bp) <- newNetworkLayer (sb, tracer)
             let tl = HttpBridge.newTransactionLayer @n
@@ -287,7 +288,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         withDBLayer
             :: CM.Configuration
             -> Trace IO Text
-            -> (DBLayer IO s t -> IO a)
+            -> (DBLayer IO s t SeqKey -> IO a)
             -> IO a
         withDBLayer logCfg tracer action = do
             let tracerDB = appendName "database" tracer

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -348,7 +348,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         withDBLayer
             :: CM.Configuration
             -> Trace IO Text
-            -> (DBLayer IO s t SeqKey -> IO a)
+            -> (DBLayer IO s t k -> IO a)
             -> IO a
         withDBLayer logCfg tracer action = do
             let tracerDB = appendName "database" tracer

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -301,7 +301,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
       where
         startServer
             :: Trace IO Text
-            -> WalletLayer s t SeqKey
+            -> WalletLayer s t k
             -> IO ()
         startServer tracer wallet = do
             Server.withListeningSocket listen $ \(port, socket) -> do
@@ -317,8 +317,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newWalletLayer
             :: (Switchboard Text, Trace IO Text)
-            -> DBLayer IO s t SeqKey
-            -> IO (WalletLayer s t SeqKey)
+            -> DBLayer IO s t k
+            -> IO (WalletLayer s t k)
         newWalletLayer (sb, tracer) db = do
             (nl, blockchainParams) <- newNetworkLayer (sb, tracer)
             let tl = Jormungandr.newTransactionLayer @n block0H

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -79,6 +79,8 @@ import Cardano.Wallet.Network
     ( NetworkLayer (..), defaultRetryPolicy, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
 import Cardano.Wallet.Primitive.Types
@@ -286,8 +288,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         <*> verbosityOption
         <*> genesisHashOption
     exec
-        :: forall t n s. (n ~ 'Testnet, t ~ Jormungandr n, s ~ SeqState t)
-        => (KeyToAddress t, KnownNetwork n)
+        :: forall t k n s. (n ~ 'Testnet, t ~ Jormungandr n, s ~ SeqState t, k ~ SeqKey)
+        => (KeyToAddress t k, KnownNetwork n)
         => ServeArgs
         -> IO ()
     exec (ServeArgs listen nodePort dbFile verbosity block0H) = do
@@ -299,7 +301,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
       where
         startServer
             :: Trace IO Text
-            -> WalletLayer s t
+            -> WalletLayer s t SeqKey
             -> IO ()
         startServer tracer wallet = do
             Server.withListeningSocket listen $ \(port, socket) -> do
@@ -315,8 +317,8 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newWalletLayer
             :: (Switchboard Text, Trace IO Text)
-            -> DBLayer IO s t
-            -> IO (WalletLayer s t)
+            -> DBLayer IO s t SeqKey
+            -> IO (WalletLayer s t SeqKey)
         newWalletLayer (sb, tracer) db = do
             (nl, blockchainParams) <- newNetworkLayer (sb, tracer)
             let tl = Jormungandr.newTransactionLayer @n block0H
@@ -346,7 +348,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         withDBLayer
             :: CM.Configuration
             -> Trace IO Text
-            -> (DBLayer IO s t -> IO a)
+            -> (DBLayer IO s t SeqKey -> IO a)
             -> IO a
         withDBLayer logCfg tracer action = do
             let tracerDB = appendName "database" tracer

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -24,7 +25,9 @@ import Cardano.CLI
 import Cardano.Crypto.Wallet
     ( unXPub )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..), getKey )
+    ( KeyToAddress (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..), DecodeAddress (..), EncodeAddress (..) )
 import Control.Concurrent
@@ -444,7 +447,7 @@ instance Arbitrary (Port "test") where
 
 data DummyTarget
 
-instance KeyToAddress DummyTarget where
+instance KeyToAddress DummyTarget SeqKey where
     keyToAddress = Address . unXPub . getKey
 
 instance EncodeAddress DummyTarget where

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -224,7 +224,8 @@ data WalletLayer s t k = WalletLayer
         -- ^ Update the wallet metadata with the given update function.
 
     , updateWalletPassphrase
-        :: WalletId
+        :: WalletKey k
+        => WalletId
         -> (Passphrase "encryption-old", Passphrase "encryption-new")
         -> ExceptT ErrUpdatePassphrase IO ()
         -- ^ Change the wallet passphrase to the given passphrase.
@@ -432,7 +433,7 @@ data BlockchainParameters t = BlockchainParameters
 newWalletLayer
     :: forall s t k.
        ( Buildable (Tx t)
-       , WalletKey k)
+       )
     => Trace IO Text
     -> BlockchainParameters t
     -> DBLayer IO s t k
@@ -529,7 +530,8 @@ newWalletLayer tracer bp db nw tl = do
         DB.putWalletMeta db (PrimaryKey wid) (modify meta)
 
     _updateWalletPassphrase
-        :: WalletId
+        :: WalletKey k
+        => WalletId
         -> (Passphrase "encryption-old", Passphrase "encryption-new")
         -> ExceptT ErrUpdatePassphrase IO ()
     _updateWalletPassphrase wid (old, new) = do

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -366,7 +366,8 @@ putWallet w (ApiT wid) body = do
     getWallet w (ApiT wid)
 
 putWalletPassphrase
-    :: WalletLayer (SeqState t) t k
+    :: (WalletKey k)
+    => WalletLayer (SeqState t) t k
     -> ApiT WalletId
     -> WalletPutPassphraseData
     -> Handler NoContent

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -183,10 +183,10 @@ data Listen
 
 -- | Start the application server, using the given settings and a bound socket.
 start
-    :: forall t key.
+    :: forall t k.
         ( DefineTx t
-        , KeyToAddress t key
-        , key ~ SeqKey
+        , KeyToAddress t k
+        , k ~ SeqKey
         , EncodeAddress t
         , DecodeAddress t
         , Buildable (ErrValidateSelection t)
@@ -194,7 +194,7 @@ start
     => Warp.Settings
     -> Trace IO Text
     -> Socket
-    -> WalletLayer (SeqState t) t key
+    -> WalletLayer (SeqState t) t k
     -> IO ()
 start settings trace socket wl = do
     withWorkers trace wl
@@ -265,8 +265,8 @@ getRandomPort = do
 -------------------------------------------------------------------------------}
 
 wallets
-    :: forall t key. (DefineTx t, KeyToAddress t key, key ~ SeqKey)
-    => WalletLayer (SeqState t) t key
+    :: forall t k. (DefineTx t, KeyToAddress t k, k ~ SeqKey)
+    => WalletLayer (SeqState t) t k
     -> Server Wallets
 wallets w =
     deleteWallet w
@@ -332,9 +332,9 @@ listWallets w = do
         mapM (getWalletWithCreationTime w) (ApiT <$> wids)
 
 postWallet
-    :: forall t key.
-       (DefineTx t, KeyToAddress t key, key ~ SeqKey)
-    => WalletLayer (SeqState t) t key
+    :: forall t k.
+       (DefineTx t, KeyToAddress t k, k ~ SeqKey)
+    => WalletLayer (SeqState t) t k
     -> WalletPostData
     -> Handler ApiWallet
 postWallet w body = do

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -75,7 +75,7 @@ import Cardano.Wallet.Network
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..), WalletKey (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..), defaultAddressPoolGap, mkSeqState )
 import Cardano.Wallet.Primitive.Fee

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -44,7 +44,7 @@ import Data.Map.Strict
 -- | A Database interface for storing various things in a DB. In practice,
 -- we'll need some extra contraints on the wallet state that allows us to
 -- serialize and unserialize it (e.g. @forall s. (Serialize s) => ...@)
-data DBLayer m s t key = DBLayer
+data DBLayer m s t k = DBLayer
     { createWallet
         :: PrimaryKey WalletId
         -> Wallet s t
@@ -120,7 +120,7 @@ data DBLayer m s t key = DBLayer
 
     , putPrivateKey
         :: PrimaryKey WalletId
-        -> (key 'RootK XPrv, Hash "encryption")
+        -> (k 'RootK XPrv, Hash "encryption")
         -> ExceptT ErrNoSuchWallet m ()
         -- ^ Store or replace a private key for a given wallet. Note that wallet
         -- _could_ be stored and manipulated without any private key associated
@@ -129,7 +129,7 @@ data DBLayer m s t key = DBLayer
 
     , readPrivateKey
         :: PrimaryKey WalletId
-        -> m (Maybe (key 'RootK XPrv, Hash "encryption"))
+        -> m (Maybe (k 'RootK XPrv, Hash "encryption"))
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
 

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -22,7 +22,7 @@ module Cardano.Wallet.DB
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, XPrv )
+    ( Depth (..), XPrv )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
@@ -44,7 +44,7 @@ import Data.Map.Strict
 -- | A Database interface for storing various things in a DB. In practice,
 -- we'll need some extra contraints on the wallet state that allows us to
 -- serialize and unserialize it (e.g. @forall s. (Serialize s) => ...@)
-data DBLayer m s t = DBLayer
+data DBLayer m s t key = DBLayer
     { createWallet
         :: PrimaryKey WalletId
         -> Wallet s t
@@ -120,7 +120,7 @@ data DBLayer m s t = DBLayer
 
     , putPrivateKey
         :: PrimaryKey WalletId
-        -> (Key 'RootK XPrv, Hash "encryption")
+        -> (key 'RootK XPrv, Hash "encryption")
         -> ExceptT ErrNoSuchWallet m ()
         -- ^ Store or replace a private key for a given wallet. Note that wallet
         -- _could_ be stored and manipulated without any private key associated
@@ -129,7 +129,7 @@ data DBLayer m s t = DBLayer
 
     , readPrivateKey
         :: PrimaryKey WalletId
-        -> m (Maybe (Key 'RootK XPrv, Hash "encryption"))
+        -> m (Maybe (key 'RootK XPrv, Hash "encryption"))
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
 
@@ -161,5 +161,5 @@ newtype PrimaryKey key = PrimaryKey key
     deriving (Eq, Ord)
 
 -- | Clean a database by removing all wallets.
-cleanDB :: Monad m => DBLayer m s t -> m ()
+cleanDB :: Monad m => DBLayer m s t key -> m ()
 cleanDB db = listWallets db >>= mapM_ (runExceptT . removeWallet db)

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -161,5 +161,5 @@ newtype PrimaryKey key = PrimaryKey key
     deriving (Eq, Ord)
 
 -- | Clean a database by removing all wallets.
-cleanDB :: Monad m => DBLayer m s t key -> m ()
+cleanDB :: Monad m => DBLayer m s t k -> m ()
 cleanDB db = listWallets db >>= mapM_ (runExceptT . removeWallet db)

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -53,11 +53,11 @@ import Data.Ord
 
 import qualified Data.Map.Strict as Map
 
-data Database s t key = Database
+data Database s t k = Database
     { wallet :: !(Wallet s t)
     , metadata :: !WalletMetadata
     , txHistory :: !(Map (Hash "Tx") (Tx t, TxMeta))
-    , xprv :: !(Maybe (key 'RootK XPrv, Hash "encryption"))
+    , xprv :: !(Maybe (k 'RootK XPrv, Hash "encryption"))
     }
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -62,10 +62,10 @@ data Database s t key = Database
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.
-newDBLayer :: forall s t key. (NFData (key 'RootK XPrv)) => IO (DBLayer IO s t key)
+newDBLayer :: forall s t k. (NFData (k 'RootK XPrv)) => IO (DBLayer IO s t k)
 newDBLayer = do
     lock <- newMVar ()
-    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s t key))
+    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s t k))
     return $ DBLayer
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -23,7 +24,7 @@ import Cardano.Wallet.DB
     , PrimaryKey (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, XPrv )
+    ( Depth (..), XPrv )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
@@ -38,7 +39,7 @@ import Cardano.Wallet.Primitive.Types
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, readMVar, withMVar )
 import Control.DeepSeq
-    ( deepseq )
+    ( NFData, deepseq )
 import Control.Monad
     ( (>=>) )
 import Control.Monad.Trans.Except
@@ -52,19 +53,19 @@ import Data.Ord
 
 import qualified Data.Map.Strict as Map
 
-data Database s t = Database
+data Database s t key = Database
     { wallet :: !(Wallet s t)
     , metadata :: !WalletMetadata
     , txHistory :: !(Map (Hash "Tx") (Tx t, TxMeta))
-    , xprv :: !(Maybe (Key 'RootK XPrv, Hash "encryption"))
+    , xprv :: !(Maybe (key 'RootK XPrv, Hash "encryption"))
     }
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.
-newDBLayer :: forall s t. IO (DBLayer IO s t)
+newDBLayer :: forall s t key. (NFData (key 'RootK XPrv)) => IO (DBLayer IO s t key)
 newDBLayer = do
     lock <- newMVar ()
-    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s t))
+    db <- newMVar (mempty :: Map (PrimaryKey WalletId) (Database s t key))
     return $ DBLayer
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -23,9 +23,9 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, deserializeXPub, serializeXPub )
+    ( Depth (..), PersistKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( ChangeChain )
+    ( ChangeChain, SeqKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), getAddressPoolGap, mkAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
@@ -322,7 +322,7 @@ instance PersistFieldSql AddressPoolGap where
 -- XPub for sequential address discovery
 
 newtype AddressPoolXPub = AddressPoolXPub
-    { getAddressPoolXPub :: Key 'AccountK XPub }
+    { getAddressPoolXPub :: SeqKey 'AccountK XPub }
     deriving (Show, Eq, Generic)
 
 instance PersistField AddressPoolXPub where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -391,8 +391,18 @@ class WalletKey (key :: Depth -> * -> *) where
     -- type constraint added.
     -- unwrapKey :: key level depth -> Key level depth
 
-    publicKey :: key level XPrv -> key level XPub
-    digest :: HashAlgorithm a => key level XPub -> Digest a
+    publicKey
+        :: key level XPrv
+        -> key level XPub
+
+    digest
+        :: HashAlgorithm a
+        => key level XPub
+        -> Digest a
+
+    getRawKey
+        :: key level raw
+        -> raw
 
 class PersistKey (key :: Depth -> * -> *) where
     serializeXPrv :: (key level XPrv, Hash "encryption") -> (ByteString, ByteString)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -384,8 +384,8 @@ class WalletKey (key :: Depth -> * -> *) where
     changePassphrase
         :: Passphrase "encryption-old"
         -> Passphrase "encryption-new"
-        -> key level XPrv
-        -> key level XPrv
+        -> key depth XPrv
+        -> key depth XPrv
 
     -- This function is temporary, just to implement IsOwned, until it gets a
     -- type constraint added.
@@ -397,7 +397,7 @@ class WalletKey (key :: Depth -> * -> *) where
 
     digest
         :: HashAlgorithm a
-        => key level XPub
+        => key depth XPub
         -> Digest a
 
     getRawKey

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -22,22 +23,25 @@
 -- where most of the crypto happens in the wallet and, it is quite important to
 -- ensure that the implementations match with other Cardano wallets
 -- (like cardano-sl, Yoroi/Icarus, or cardano-cli)
+--
+-- The actual implementations are in the following modules:
+--
+--  * "Cardano.Wallet.Primitive.AddressDerivation.Sequential"
+--  * "Cardano.Wallet.Primitive.AddressDerivation.Random"
 
 module Cardano.Wallet.Primitive.AddressDerivation
     (
     -- * Polymorphic / General Purpose Types
     -- $use
-      Key
-    , getKey
-    , Depth (..)
+      Depth (..)
     , Index (..)
     , DerivationType (..)
-    , publicKey
-    , digest
     , XPub
     , XPrv
     -- * Backends Interoperability
     , KeyToAddress(..)
+    , WalletKey(..)
+    , PersistKey(..)
 
     -- * Passphrase
     , Passphrase(..)
@@ -48,21 +52,12 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , ErrWrongPassphrase(..)
     , encryptPassphrase
     , checkPassphrase
-    , changePassphrase
-
-    -- * Storing and retrieving keys
-    , serializeXPrv
-    , deserializeXPrv
-    , serializeXPub
-    , deserializeXPub
     ) where
 
 import Prelude
 
 import Cardano.Crypto.Wallet
-    ( XPrv, XPub, toXPub, unXPrv, unXPub, xPrvChangePass, xprv, xpub )
-import Cardano.Wallet.Primitive.AddressDerivation.Common
-    ( Depth (..), Key (..) )
+    ( XPrv, XPub )
 import Cardano.Wallet.Primitive.Mnemonic
     ( CheckSumBits
     , ConsistentEntropy
@@ -82,9 +77,9 @@ import Control.Arrow
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( unless, (<=<) )
+    ( unless )
 import Crypto.Hash
-    ( Digest, HashAlgorithm, hash )
+    ( Digest, HashAlgorithm )
 import Crypto.KDF.PBKDF2
     ( Parameters (..), fastPBKDF2_SHA512 )
 import Crypto.Random.Types
@@ -93,8 +88,6 @@ import Data.Bifunctor
     ( first )
 import Data.ByteArray
     ( ScrubbedBytes )
-import Data.ByteArray.Encoding
-    ( Base (..), convertFromBase, convertToBase )
 import Data.ByteString
     ( ByteString )
 import Data.List
@@ -120,10 +113,17 @@ import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
-
 {-------------------------------------------------------------------------------
                         Polymorphic / General Purpose Types
 -------------------------------------------------------------------------------}
+
+-- | Key Depth in the derivation path, according to BIP-0039 / BIP-0044
+--
+-- @m | purpose' | cointype' | account' | change | address@
+--
+-- We do not manipulate purpose, cointype and change paths directly, so they are
+-- left out of the sum type.
+data Depth = RootK | AccountK | AddressK
 
 -- | A derivation index, with phantom-types to disambiguate derivation type.
 --
@@ -163,21 +163,6 @@ instance Enum (Index 'Soft level) where
 
 -- | Type of derivation that should be used with the given indexes.
 data DerivationType = Hardened | Soft
-
--- | Extract the public key part of a private key.
-publicKey
-    :: Key level XPrv
-    -> Key level XPub
-publicKey (Key k) =
-    Key (toXPub k)
-
--- | Hash a public key to some other representation.
-digest
-    :: HashAlgorithm a
-    => Key level XPub
-    -> Digest a
-digest (Key k) =
-    hash (unXPub k)
 
 {-------------------------------------------------------------------------------
                                  Passphrases
@@ -351,20 +336,6 @@ checkPassphrase received stored = do
 data ErrWrongPassphrase = ErrWrongPassphrase
     deriving stock (Show, Eq)
 
--- | Re-encrypt a private key using a different passphrase.
---
--- **Important**:
--- This function doesn't check that the old passphrase is correct! Caller is
--- expected to have already checked that. Using an incorrect passphrase here
--- will lead to very bad thing.
-changePassphrase
-    :: Passphrase "encryption-old"
-    -> Passphrase "encryption-new"
-    -> Key purpose XPrv
-    -> Key purpose XPrv
-changePassphrase (Passphrase oldPwd) (Passphrase newPwd) (Key prv) =
-    Key $ xPrvChangePass oldPwd newPwd prv
-
 -- | Little trick to be able to provide our own "random" salt in order to
 -- deterministically re-compute a passphrase hash from a known salt. Note that,
 -- this boils down to giving an extra argument to the `encryptPassphrase`
@@ -394,102 +365,44 @@ instance MonadRandom ((->) (Passphrase "salt")) where
                           Backend-dependent functions
 -------------------------------------------------------------------------------}
 
+class WalletKey (key :: Depth -> * -> *) where
+    type WalletKeySeed key
+
+    unsafeGenerateKeyFromSeed
+        :: WalletKeySeed key
+        -> Passphrase "encryption"
+        -> key depth XPrv
+
+    -- | Generate a root key from a corresponding seed.
+    -- The seed should be at least 16 bytes.
+    generateKeyFromSeed
+        :: WalletKeySeed key
+        -> Passphrase "encryption"
+        -> key 'RootK XPrv
+    generateKeyFromSeed = unsafeGenerateKeyFromSeed
+
+    changePassphrase
+        :: Passphrase "encryption-old"
+        -> Passphrase "encryption-new"
+        -> key level XPrv
+        -> key level XPrv
+
+    -- This function is temporary, just to implement IsOwned, until it gets a
+    -- type constraint added.
+    -- unwrapKey :: key level depth -> Key level depth
+
+    publicKey :: key level XPrv -> key level XPub
+    digest :: HashAlgorithm a => key level XPub -> Digest a
+
+class PersistKey (key :: Depth -> * -> *) where
+    serializeXPrv :: (key level XPrv, Hash "encryption") -> (ByteString, ByteString)
+    deserializeXPrv :: (ByteString, ByteString) -> Either String (key level XPrv, Hash "encryption")
+    serializeXPub :: key purpose XPub -> ByteString
+    deserializeXPub :: ByteString -> Either String (key purpose XPub)
+
 -- | Convert a public key to an 'Address' depending on a particular target.
 --
 -- Note that 'keyToAddress' is ambiguous and requires therefore a type
 -- applications. See also 'TxId'.
-class KeyToAddress target where
-    keyToAddress :: Key 'AddressK XPub -> Address
-
-{-------------------------------------------------------------------------------
-                          Storing and retrieving keys
--------------------------------------------------------------------------------}
-
-fromHexText :: ByteString -> Either String ByteString
-fromHexText = convertFromBase Base16
-
-toHexText :: ByteString -> ByteString
-toHexText = convertToBase Base16
-
--- | Convert a private key and its password hash into hexadecimal strings
--- suitable for storing in a text file or database column.
-serializeXPrv
-    :: (Key purpose XPrv, Hash "encryption")
-    -> (ByteString, ByteString)
-serializeXPrv (k, h) =
-    ( toHexText . unXPrv . getKey $ k
-    , toHexText . getHash $ h )
-
--- | The reverse of 'serializeXPrv'. This may fail if the inputs are not valid
--- hexadecimal strings, or if the key is of the wrong length.
-deserializeXPrv
-    :: (ByteString, ByteString)
-       -- ^ Hexadecimal encoded private key and password hash
-    -> Either String (Key purpose XPrv, Hash "encryption")
-deserializeXPrv (k, h) = (,)
-    <$> fmap Key (xprvFromText k)
-    <*> fmap Hash (fromHexText h)
-  where
-    xprvFromText = xprv <=< fromHexText
-
--- | Convert a public key into a hexadecimal string suitable for storing in a
--- text file or database column.
-serializeXPub :: Key purpose XPub -> ByteString
-serializeXPub = toHexText . unXPub . getKey
-
--- | The reverse of 'serializeXPub'. This will fail if the input is not a valid
--- hexadecimal string of the correct length.
-deserializeXPub :: ByteString -> Either String (Key purpose XPub)
-deserializeXPub = fmap Key . (xpub <=< fromHexText)
-
--- $use
--- 'Key' and 'Index' allow for representing public keys, private keys, hardened
--- indexes and soft (non-hardened) indexes for various level in a non-ambiguous
--- manner. Those types are opaque and can only be created through dedicated
--- constructors.
---
--- Indexes can be created through their `Bounded` and `Enum` instances. Note
--- that, the `Enum` functions are partial and its the caller responsibility to
--- make sure it is safe to call them. For instance, calling @succ maxBound@ for
--- any index would through a runtime error. Similarly, trying to convert an
--- invalid value from an 'Int' to a an 'Index' will result in bad behavior.
---
--- >>> toEnum 0x00000000 :: Index 'Soft 'AddressK
--- Index {getIndex = 0}
---
--- >>> toEnum 0x00000000 :: Index 'Hardened 'AccountK
--- Index {getIndex = *** Exception: Index@Hardened.toEnum: bad argument
---
--- >>> toEnum 0x80000000 :: Index 'Hardened 'AccountK
--- Index {getIndex = 2147483648}
---
--- >>> toEnum 0x80000000 :: Index 'Soft 'AddressK
--- Index {getIndex = *** Exception: Index@Soft.toEnum: bad argument
---
--- Keys have to be created from a seed using 'generateKeyFromSeed' which always
--- gives a root private key. Then, child keys can be created safely using the
--- various key derivation methods:
---
--- - 'publicKey' --> For any @Key _ XPrv@ to @Key _ XPub@
--- - 'deriveAccountPrivateKey' -->
---      From @Key RootK XPrv@ to @Key AccountK XPrv@
--- - 'deriveAddressPrivateKey' -->
---      From @Key AccountK XPrv@ to @Key AddressK XPrv@
--- - 'deriveAddressPublicKey' -->
---      From @Key AccountK XPub@ to @Key AddressK XPub@
---
--- For example:
---
--- @
--- -- Access public key for: m|coinType'|purpose'|0'
--- let seed = "My Secret Seed"
---
--- let rootXPrv :: Key 'RootK XPrv
---     rootXPrv = generateKeyFromSeed (seed, mempty) mempty
---
--- let accIx :: Index 'Hardened 'AccountK
---     accIx = toEnum 0x80000000
---
--- let accXPub :: Key 'AccountL XPub
---     accXPub = publicKey $ deriveAccountPrivateKey mempty rootXPrv accIx
--- @
+class WalletKey key => KeyToAddress target (key :: Depth -> * -> *) where
+    keyToAddress :: key 'AddressK XPub -> Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -366,26 +366,6 @@ instance MonadRandom ((->) (Passphrase "salt")) where
 -------------------------------------------------------------------------------}
 
 class WalletKey (key :: Depth -> * -> *) where
-    -- | Data required to generate a WalletKey.
-    type WalletKeySeed key
-
-    -- | Generate a new key from seed. Note that the @depth@ is left open so
-    -- that the caller gets to decide what type of key this is. This is mostly
-    -- for testing, in practice, seeds are used to represent root keys, and one
-    -- should use 'generateKeyFromSeed'.
-    unsafeGenerateKeyFromSeed
-        :: WalletKeySeed key
-        -> Passphrase "encryption"
-        -> key depth XPrv
-
-    -- | Generate a root key from a corresponding seed.
-    -- The seed should be at least 16 bytes.
-    generateKeyFromSeed
-        :: WalletKeySeed key
-        -> Passphrase "encryption"
-        -> key 'RootK XPrv
-    generateKeyFromSeed = unsafeGenerateKeyFromSeed
-
     -- | Re-encrypt a private key using a different passphrase.
     --
     -- **Important**:

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Common.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Common.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -15,43 +14,28 @@
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
 --
+-- Common functions for the address derivation implementations.
+--
 -- Use the types from "Cardano.Wallet.Primitive.AddressDerivation" or the key
 -- generation or derivation functions from
 -- "Cardano.Wallet.Primitive.AddressDerivation.Sequential" or
 -- "Cardano.Wallet.Primitive.AddressDerivation.Random" instead of this module.
+--
 
 module Cardano.Wallet.Primitive.AddressDerivation.Common
-    ( Key(..)
-    , Depth (..)
+    ( fromHexText
+    , toHexText
     ) where
 
 import Prelude
 
-import Control.DeepSeq
-    ( NFData )
-import GHC.Generics
-    ( Generic )
+import Data.ByteArray.Encoding
+    ( Base (..), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
 
-{-------------------------------------------------------------------------------
-                        Polymorphic / General Purpose Types
--------------------------------------------------------------------------------}
+fromHexText :: ByteString -> Either String ByteString
+fromHexText = convertFromBase Base16
 
--- | A cryptographic key, with phantom-types to disambiguate key types.
---
--- @
--- let rootPrivateKey = Key 'RootK XPrv
--- let accountPubKey = Key 'AccountK XPub
--- let addressPubKey = Key 'AddressK XPub
--- @
-newtype Key (level :: Depth) key = Key { getKey :: key }
-    deriving stock (Generic, Show, Eq)
-
-instance (NFData key) => NFData (Key level key)
-
--- | Key Depth in the derivation path, according to BIP-0039 / BIP-0044
---
--- @m | purpose' | cointype' | account' | change | address@
---
--- We do not manipulate purpose, cointype and change paths directly, so they are
--- left out of the sum type.
-data Depth = RootK | AccountK | AddressK
+toHexText :: ByteString -> ByteString
+toHexText = convertToBase Base16

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -127,6 +127,7 @@ instance WalletKey RndKey where
     changePassphrase = changePassphraseRnd
     publicKey = publicKeyRnd
     digest = digestRnd
+    getRawKey = error "WalletKey RndKey: getRawKey unimplemented"
 
 instance PersistKey RndKey where
     serializeXPrv = error "PersistKey RndKey unimplemented"

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -317,18 +317,11 @@ In the composition of a Cardano address, the following functions concern the
 -- NOTE: The caller must ensure that the key length is 32 bytes, selectKey can be
 -- done by using the 'generateKeyFromSeed' and
 -- 'Cardano.Wallet.Primitive.AddressDerivation.publicKey' functions.
---
--- fixme: change key parameter to @RndKey 'AddressK XPub@, which will already
--- contain (accIx, addrIx)
-encodeDerivationPath
-    :: RndKey 'RootK XPub
-    -> Index 'Hardened 'AccountK
-    -> Index 'Hardened 'AddressK
-    -> CBOR.Encoding
-encodeDerivationPath masterKey accIx addrIx =
+encodeDerivationPath :: RndKey 'AddressK XPub -> CBOR.Encoding
+encodeDerivationPath (RndKey _ (accIx, addrIx) payloadPassphrase) =
     CBOR.encodeBytes $
     useInvariant $
-    encryptDerPath (payloadPassphrase masterKey) $
+    encryptDerPath payloadPassphrase $
     CBOR.toStrictByteString $
     encodeDerPath accIx addrIx
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -30,8 +30,8 @@ module Cardano.Wallet.Primitive.AddressDerivation.Random
     ( -- * RndKey types
       RndKey(..)
       -- * RndKey derivation and generation
-    , unsafeGenerateKeyFromSeedRnd
-    , generateKeyFromSeedRnd
+    , unsafeGenerateKeyFromSeed
+    , generateKeyFromSeed
     , minSeedLengthBytes
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
@@ -126,9 +126,6 @@ type family DerivationPath (depth :: Depth) :: * where
         (Index 'Hardened 'AccountK, Index 'Hardened 'AddressK)
 
 instance WalletKey RndKey where
-    type WalletKeySeed RndKey = Passphrase "seed"
-    unsafeGenerateKeyFromSeed = unsafeGenerateKeyFromSeedRnd undefined
-    generateKeyFromSeed = generateKeyFromSeedRnd
     changePassphrase = changePassphraseRnd
     publicKey = publicKeyRnd
     digest = digestRnd
@@ -144,22 +141,24 @@ instance PersistKey RndKey where
                                  Key generation
 -------------------------------------------------------------------------------}
 
-generateKeyFromSeedRnd
+-- | Generate a root key from a corresponding seed.
+-- The seed should be at least 16 bytes.
+generateKeyFromSeed
     :: Passphrase "seed"
     -> Passphrase "encryption"
     -> RndKey 'RootK XPrv
-generateKeyFromSeedRnd = unsafeGenerateKeyFromSeedRnd ()
+generateKeyFromSeed = unsafeGenerateKeyFromSeed ()
 
 -- | Generate a new key from seed. Note that the @depth@ is left open so that
 -- the caller gets to decide what type of key this is. This is mostly for
 -- testing, in practice, seeds are used to represent root keys, and one should
 -- use 'generateKeyFromSeed'.
-unsafeGenerateKeyFromSeedRnd
+unsafeGenerateKeyFromSeed
     :: DerivationPath depth
     -> Passphrase "seed"
     -> Passphrase "encryption"
     -> RndKey depth XPrv
-unsafeGenerateKeyFromSeedRnd derivationPath (Passphrase seed) (Passphrase pwd) = RndKey
+unsafeGenerateKeyFromSeed derivationPath (Passphrase seed) (Passphrase pwd) = RndKey
     { getKey = masterKey
     , derivationPath
     , payloadPassphrase = hdPassphrase masterKey

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -115,13 +115,13 @@ deriving instance (Eq key, Eq (DerivationPath depth)) => Eq (RndKey depth key)
 
 -- | The hierarchical derivation indices for a given level/depth.
 type family DerivationPath (depth :: Depth) :: * where
-    -- | The root key, generated from the seed.
+    -- The root key is generated from the seed.
     DerivationPath 'RootK =
         ()
-    -- | The account key, generated from the root key and account index.
+    -- The account key is generated from the root key and account index.
     DerivationPath 'AccountK =
         Index 'Hardened 'AccountK
-    -- | The address key, generated from the account key and address index.
+    -- The address key is generated from the account key and address index.
     DerivationPath 'AddressK =
         (Index 'Hardened 'AccountK, Index 'Hardened 'AddressK)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -317,6 +317,9 @@ In the composition of a Cardano address, the following functions concern the
 -- NOTE: The caller must ensure that the key length is 32 bytes, selectKey can be
 -- done by using the 'generateKeyFromSeed' and
 -- 'Cardano.Wallet.Primitive.AddressDerivation.publicKey' functions.
+--
+-- fixme: change key parameter to @RndKey 'AddressK XPub@, which will already
+-- contain (accIx, addrIx)
 encodeDerivationPath
     :: RndKey 'RootK XPub
     -> Index 'Hardened 'AccountK

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
@@ -104,10 +104,10 @@ import qualified Data.ByteArray as BA
 -- let accountPubKey = SeqKey 'AccountK XPub
 -- let addressPubKey = SeqKey 'AddressK XPub
 -- @
-newtype SeqKey (level :: Depth) key = SeqKey { getKey :: key }
+newtype SeqKey (depth :: Depth) key = SeqKey { getKey :: key }
     deriving stock (Generic, Show, Eq)
 
-instance (NFData key) => NFData (SeqKey level key)
+instance (NFData key) => NFData (SeqKey depth key)
 
 instance WalletKey SeqKey where
      -- The actual seed and its recovery / generation passphrase
@@ -296,15 +296,15 @@ changePassphraseSeq (Passphrase oldPwd) (Passphrase newPwd) (SeqKey prv) =
 
 -- | Extract the public key part of a private key.
 publicKeySeq
-    :: SeqKey level XPrv
-    -> SeqKey level XPub
+    :: SeqKey depth XPrv
+    -> SeqKey depth XPub
 publicKeySeq (SeqKey k) =
     SeqKey (toXPub k)
 
 -- | Hash a public key to some other representation.
 digestSeq
     :: HashAlgorithm a
-    => SeqKey level XPub
+    => SeqKey depth XPub
     -> Digest a
 digestSeq (SeqKey k) =
     hash (unXPub k)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
@@ -117,6 +117,7 @@ instance WalletKey SeqKey where
     changePassphrase = changePassphraseSeq
     publicKey = publicKeySeq
     digest = digestSeq
+    getRawKey = getKey
 
 -- | Marker for the change chain. In practice, change of a transaction goes onto
 -- the addresses generated on the internal chain, whereas the external chain is

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
@@ -29,7 +30,7 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( XPrv )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, Passphrase (..) )
+    ( Depth (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address )
 
@@ -64,12 +65,13 @@ class IsOurs s where
 -- the root private key of a particular wallet. This isn't true for externally
 -- owned wallet which would delegate its key management to a third party (like
 -- a hardware Ledger or Trezor).
-class IsOurs s => IsOwned s where
+-- fixme: Add a key parameter to IsOwned
+class IsOurs s => IsOwned s key where
     isOwned
         :: s
-        -> (Key 'RootK XPrv, Passphrase "encryption")
+        -> (key 'RootK XPrv, Passphrase "encryption")
         -> Address
-        -> Maybe (Key 'AddressK XPrv, Passphrase "encryption")
+        -> Maybe (key 'AddressK XPrv, Passphrase "encryption")
         -- ^ Derive the private key corresponding to an address. Careful, this
         -- operation can be costly. Note that the state is discarded from this
         -- function as we do not intend to discover any addresses from this

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
@@ -20,6 +21,8 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Random
 
 import Prelude
 
+import Cardano.Wallet.Primitive.AddressDerivation.Random
+    ( RndKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GenChange (..)
@@ -38,7 +41,7 @@ mkRndState = error "AddressDiscovery.Random unimplemented"
 instance IsOurs RndState where
     isOurs _ s = (False, s)
 
-instance IsOwned RndState where
+instance IsOwned RndState RndKey where
     isOwned _ _ _ = Nothing
 
 instance GenChange RndState where

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -44,9 +44,9 @@ import Data.Word
 
 import qualified Data.ByteString.Char8 as B8
 
-data TransactionLayer t key = TransactionLayer
+data TransactionLayer t k = TransactionLayer
     { mkStdTx
-        :: (Address -> Maybe (key 'AddressK XPrv, Passphrase "encryption"))
+        :: (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
         -> [(TxIn, TxOut)]
         -> [TxOut]
         -> Either ErrMkStdTx (Tx t, [TxWitness])
@@ -128,8 +128,8 @@ data EstimateMaxNumberOfInputsParams t = EstimateMaxNumberOfInputsParams
 -- All the values used are the smaller ones. For example, the shortest adress
 -- type and shortest witness type are chosen to use for the estimate.
 estimateMaxNumberOfInputsBase
-    :: forall target key. (KeyToAddress target key, PersistKey key)
-    => EstimateMaxNumberOfInputsParams target
+    :: forall t k. (KeyToAddress t k, PersistKey k)
+    => EstimateMaxNumberOfInputsParams t
     -- ^ Backend-specific variables used in the estimation
     -> Quantity "byte" Word16
     -- ^ Transaction max size in bytes
@@ -153,7 +153,7 @@ estimateMaxNumberOfInputsBase
 
     outs = replicate (fromIntegral numOutputs) txout
     txout = TxOut baseAddr minBound
-    Right baseAddr = keyToAddress @target @key <$> deserializeXPub (chaff 128)
+    Right baseAddr = keyToAddress @t @k <$> deserializeXPub (chaff 128)
     txIn = TxIn (Hash $ chaff estBlockHashSize) 0
     wit = TxWitness (chaff estTxWitnessSize)
 

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -57,8 +57,6 @@ data TransactionLayer t k = TransactionLayer
         --
         -- This expects as a first argument a mean to compute or lookup private
         -- key corresponding to a particular address.
-        --
-        -- fixme: make this polymorphic on WalletKey
 
     , estimateSize :: CoinSelection -> Quantity "byte" Int
         -- ^ Estimate the size of a 'CoinSelection', in bytes. This operation is

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -334,8 +334,8 @@ benchPutSeqState numCheckpoints numAddrs db =
         ]
 
 mkPool
-    :: forall t chain. (KeyToAddress t SeqKey, Typeable chain)
-    => Int -> Int -> AddressPool t chain
+    :: forall t c. (KeyToAddress t SeqKey, Typeable c)
+    => Int -> Int -> AddressPool t c
 mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
   where
     addrs =
@@ -348,7 +348,7 @@ mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
 type DBLayerBench = DBLayer IO (SeqState DummyTarget) DummyTarget SeqKey
 type WalletBench = Wallet (SeqState DummyTarget) DummyTarget
 
-instance NFData (DBLayer m s t key) where
+instance NFData (DBLayer m s t k) where
     rnf _ = ()
 
 instance PersistTx DummyTarget where

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), KeyToAddress (..), Passphrase (..), WalletKey (..), XPub )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..), generateKeyFromSeed )
+    ( SeqKey (..), generateKeyFromSeed, unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPool
     , SeqState (..)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -48,7 +48,7 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), KeyToAddress (..), Passphrase (..), WalletKey (..), XPub )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPool
     , SeqState (..)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -45,9 +46,9 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..), block0 )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, KeyToAddress (..), Passphrase (..), XPub, publicKey )
+    ( Depth (..), KeyToAddress (..), Passphrase (..), WalletKey (..), XPub )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( generateKeyFromSeed, unsafeGenerateKeyFromSeed )
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPool
     , SeqState (..)
@@ -333,7 +334,7 @@ benchPutSeqState numCheckpoints numAddrs db =
         ]
 
 mkPool
-    :: forall t chain. (KeyToAddress t, Typeable chain)
+    :: forall t chain. (KeyToAddress t SeqKey, Typeable chain)
     => Int -> Int -> AddressPool t chain
 mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
   where
@@ -344,10 +345,10 @@ mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
 ----------------------------------------------------------------------------
 -- Mock data to use for benchmarks
 
-type DBLayerBench = DBLayer IO (SeqState DummyTarget) DummyTarget
+type DBLayerBench = DBLayer IO (SeqState DummyTarget) DummyTarget SeqKey
 type WalletBench = Wallet (SeqState DummyTarget) DummyTarget
 
-instance NFData (DBLayer m s t) where
+instance NFData (DBLayer m s t key) where
     rnf _ = ()
 
 instance PersistTx DummyTarget where
@@ -379,7 +380,7 @@ testWid = WalletId (hash ("test" :: ByteString))
 testPk :: PrimaryKey WalletId
 testPk = PrimaryKey testWid
 
-ourAccount :: Key 'AccountK XPub
+ourAccount :: SeqKey 'AccountK XPub
 ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, mempty) mempty
   where seed = Passphrase $ BA.convert $ BS.replicate 32 0
 

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -14,7 +15,9 @@ import Prelude
 import Cardano.Crypto.Wallet
     ( unXPub )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..), getKey )
+    ( KeyToAddress (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
 import Cardano.Wallet.Primitive.Types
@@ -55,7 +58,7 @@ data Tx = Tx
 
 instance NFData Tx
 
-instance KeyToAddress DummyTarget where
+instance KeyToAddress DummyTarget SeqKey where
     keyToAddress = Address . unXPub . getKey
 
 instance EncodeAddress DummyTarget where

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -22,14 +22,9 @@ import Cardano.Wallet.DBSpec
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..), block0 )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , Passphrase (..)
-    , XPrv
-    , encryptPassphrase
-    , generateKeyFromSeed
-    )
+    ( Depth (..), Passphrase (..), XPrv, encryptPassphrase )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -22,9 +22,14 @@ import Cardano.Wallet.DBSpec
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..), block0 )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Key, Passphrase (..), XPrv, encryptPassphrase )
+    ( Depth (..)
+    , Passphrase (..)
+    , XPrv
+    , encryptPassphrase
+    , generateKeyFromSeed
+    )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( generateKeyFromSeed )
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -188,7 +193,7 @@ prop_randomOpChunks (KeyValPairs pairs) =
         destroyDBLayer ctxF *> destroyDBLayer ctxM
 
     insertPair
-        :: DBLayer IO s t
+        :: DBLayer IO s t k
         -> (PrimaryKey WalletId, (Wallet s t, WalletMetadata))
         -> IO ()
     insertPair db (k, (cp, meta)) = do
@@ -200,7 +205,7 @@ prop_randomOpChunks (KeyValPairs pairs) =
             unsafeRunExceptT $ createWallet db k cp meta
             Set.fromList <$> listWallets db `shouldReturn` Set.fromList (k:keys)
 
-    shouldBeConsistentWith :: (Eq s) => DBLayer IO s t -> DBLayer IO s t -> IO ()
+    shouldBeConsistentWith :: (Eq s) => DBLayer IO s t k -> DBLayer IO s t k -> IO ()
     shouldBeConsistentWith db1 db2 = do
         expectedWalIds <- Set.fromList <$> listWallets db1
         Set.fromList <$> listWallets db2
@@ -220,7 +225,7 @@ prop_randomOpChunks (KeyValPairs pairs) =
 testOpeningCleaning
     :: (Show s, Eq s)
     => FilePath
-    -> (DBLayer IO (SeqState DummyTarget) DummyTarget -> IO s)
+    -> (DBLayer IO (SeqState DummyTarget) DummyTarget SeqKey -> IO s)
     -> s
     -> s
     -> Expectation
@@ -240,7 +245,7 @@ testOpeningCleaning filepath call expectedAfterOpen expectedAfterClean = do
 
 inMemoryDBLayer
     :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
-    => IO (SqliteContext, DBLayer IO s t)
+    => IO (SqliteContext, DBLayer IO s t SeqKey)
 inMemoryDBLayer = newDBLayer' Nothing
 
 temporaryDBFile :: IO FilePath
@@ -249,7 +254,7 @@ temporaryDBFile = emptySystemTempFile "cardano-wallet-SqliteFileMode"
 newDBLayer'
     :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t)
     => Maybe FilePath
-    -> IO (SqliteContext, DBLayer IO s t)
+    -> IO (SqliteContext, DBLayer IO s t SeqKey)
 newDBLayer' fp = do
     logConfig <- CM.empty
     newDBLayer logConfig nullTracer fp
@@ -257,16 +262,16 @@ newDBLayer' fp = do
 -- | Clean the database
 cleanDB'
     :: Monad m
-    => (SqliteContext, DBLayer m s t)
-    -> m (SqliteContext, DBLayer m s t)
+    => (SqliteContext, DBLayer m s t k)
+    -> m (SqliteContext, DBLayer m s t k)
 cleanDB' (ctx, db) =
     cleanDB db $> (ctx, db)
 
 -- | Attach an arbitrary private key to a wallet
 attachPrivateKey
-    :: DBLayer IO s t
+    :: DBLayer IO s t SeqKey
     -> PrimaryKey WalletId
-    -> ExceptT ErrNoSuchWallet IO (Key 'RootK XPrv, Hash "encryption")
+    -> ExceptT ErrNoSuchWallet IO (SeqKey 'RootK XPrv, Hash "encryption")
 attachPrivateKey db wid = do
     let Right pwd = fromText "simplevalidphrase"
     let k = generateKeyFromSeed (coerce pwd, coerce pwd) pwd

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -36,13 +36,9 @@ import Cardano.Wallet.DBSpec
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Passphrase (..)
-    , encryptPassphrase
-    , generateKeyFromSeed
-    , unsafeGenerateKeyFromSeed
-    )
+    ( Passphrase (..), encryptPassphrase )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed, unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..), defaultAddressPoolGap, mkSeqState )
 import Cardano.Wallet.Primitive.Mnemonic

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -58,7 +58,9 @@ import Cardano.Wallet.DBSpec
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Key, XPrv, deserializeXPrv )
+    ( XPrv, deserializeXPrv )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
 import Cardano.Wallet.Primitive.Model
@@ -174,12 +176,12 @@ unMockWid (MWid wid) = WalletId . hash . B8.pack $ wid
 type MPrivKey = String
 
 -- | Stuff a mock private key into the type used by 'DBLayer'.
-fromMockPrivKey :: MPrivKey -> (Key purpose XPrv, Hash "encryption")
+fromMockPrivKey :: MPrivKey -> (SeqKey purpose XPrv, Hash "encryption")
 fromMockPrivKey s = (k, Hash (B8.pack s))
     where Right (k, _) = deserializeXPrv (B8.replicate 256 '0', mempty)
 
 -- | Unstuff the DBLayer private key into the mock type.
-toMockPrivKey :: (Key purpose XPrv, Hash "encryption") -> MPrivKey
+toMockPrivKey :: (SeqKey purpose XPrv, Hash "encryption") -> MPrivKey
 toMockPrivKey (_, Hash h) = B8.unpack h
 
 -- | Mock representation of a 'DBLayer'
@@ -376,7 +378,7 @@ runMock = \case
 -- 'DBLayer' is specialized to a dummy node backend, but uses the real 'SeqState'
 -- , so that the functions to store/load SeqState are tested. Using concrete
 -- types avoids infecting all the types and functions with extra type parameters.
-type DBLayerTest = DBLayer IO (SeqState DummyTarget) DummyTarget
+type DBLayerTest = DBLayer IO (SeqState DummyTarget) DummyTarget SeqKey
 
 runIO
     :: DBLayerTest

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -51,7 +51,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( ChangeChain (..), SeqKey (..), deriveAddressPublicKey )
+    ( ChangeChain (..)
+    , SeqKey (..)
+    , deriveAddressPublicKey
+    , generateKeyFromSeed
+    , unsafeGenerateKeyFromSeed
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPool
     , AddressPoolGap (..)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/RandomSpec.hs
@@ -111,7 +111,9 @@ prop_derivationPathRoundTrip
     -> Property
 prop_derivationPathRoundTrip rk rk' accIx addrIx =
     let
-        encoded = CBOR.toLazyByteString $ encodeDerivationPath rk accIx addrIx
+        addrKey :: RndKey 'AddressK XPub
+        addrKey = RndKey (getKey rk) (accIx, addrIx) (payloadPassphrase rk)
+        encoded = CBOR.toLazyByteString $ encodeDerivationPath addrKey
         decoded = unsafeDeserialiseFromBytes (decodeDerivationPath rk) encoded
         decoded' = unsafeDeserialiseFromBytes (decodeDerivationPath rk') encoded
     in

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
@@ -10,15 +10,20 @@ module Cardano.Wallet.Primitive.AddressDerivation.SequentialSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationType (..), Index, Passphrase (..), publicKey )
+    ( Depth (..)
+    , DerivationType (..)
+    , Index
+    , Passphrase (..)
+    , WalletKey (..)
+    , XPrv
+    )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( ChangeChain (..)
+    , SeqKey (..)
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
     , deriveAddressPublicKey
-    , generateKeyFromSeed
     , minSeedLengthBytes
-    , unsafeGenerateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
@@ -91,7 +96,7 @@ prop_publicChildKeyDerivation
 prop_publicChildKeyDerivation (seed, recPwd) encPwd cc ix =
     addrXPub1 === addrXPub2
   where
-    accXPrv = unsafeGenerateKeyFromSeed (seed, recPwd) (encPwd)
+    accXPrv = unsafeGenerateKeyFromSeed (seed, recPwd) encPwd :: SeqKey 'AccountK XPrv
     -- N(CKDpriv((kpar, cpar), i))
     addrXPub1 = publicKey $ deriveAddressPrivateKey encPwd accXPrv cc ix
     -- CKDpub(N(kpar, cpar), i)
@@ -105,7 +110,7 @@ prop_accountKeyDerivation
 prop_accountKeyDerivation (seed, recPwd) encPwd ix =
     accXPub `seq` property () -- NOTE Making sure this doesn't throw
   where
-    rootXPrv = generateKeyFromSeed (seed, recPwd) encPwd
+    rootXPrv = generateKeyFromSeed (seed, recPwd) encPwd :: SeqKey 'RootK XPrv
     accXPub = deriveAccountPrivateKey encPwd rootXPrv ix
 
 {-------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/SequentialSpec.hs
@@ -23,7 +23,9 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
     , deriveAddressPublicKey
+    , generateKeyFromSeed
     , minSeedLengthBytes
+    , unsafeGenerateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , getIndex
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
     ( Hash (..) )
 import Control.Monad
@@ -247,6 +247,10 @@ prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
 -------------------------------------------------------------------------------}
 
 instance Arbitrary (Index 'Soft 'AddressK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary (Index 'Hardened 'AddressK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -28,7 +28,11 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , XPub
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( ChangeChain (..), SeqKey (..), deriveAddressPublicKey )
+    ( ChangeChain (..)
+    , SeqKey (..)
+    , deriveAddressPublicKey
+    , unsafeGenerateKeyFromSeed
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GenChange (..)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -272,14 +272,14 @@ prop_poolAtLeastGapAddresses pool =
 
 -- | Our addresses are eventually discovered
 prop_poolEventuallyDiscoverOurs
-    :: forall (chain :: ChangeChain). (Typeable chain)
+    :: forall (c :: ChangeChain). (Typeable c)
     => (AddressPoolGap, Address)
     -> Property
 prop_poolEventuallyDiscoverOurs (g, addr) =
     addr `elem` ours ==> withMaxSuccess 10 $ property prop
   where
-    ours = take 25 (ourAddresses (changeChain @chain))
-    pool = flip execState (mkAddressPool @DummyTarget @chain ourAccount g mempty) $
+    ours = take 25 (ourAddresses (changeChain @c))
+    pool = flip execState (mkAddressPool @DummyTarget @c ourAccount g mempty) $
         forM ours (state . lookupAddress)
     prop = (fromEnum <$> fst (lookupAddress addr pool)) === elemIndex addr ours
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -15,9 +15,9 @@ import Prelude
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Passphrase (..), digest, publicKey )
+    ( Depth (..), Passphrase (..), WalletKey (..), XPrv, digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( generateKeyFromSeed )
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
@@ -130,7 +130,7 @@ spec = do
     describe "Buildable" $ do
         it "WalletId" $ do
             let seed = Passphrase (BA.convert @ByteString "0000000000000000")
-            let xprv = generateKeyFromSeed (seed, mempty) mempty
+            let xprv = generateKeyFromSeed (seed, mempty) mempty :: SeqKey 'RootK XPrv
             let wid = WalletId $ digest $ publicKey xprv
             "336c96f1...b8cac9ce" === pretty @_ @Text wid
         it "TxMeta (1)" $ do
@@ -553,4 +553,3 @@ instance {-# OVERLAPS #-} Arbitrary (EpochLength, SlotId) where
         ep <- choose (0, 1000)
         sl <- choose (0, fromIntegral epochLength - 1)
         return (EpochLength epochLength, SlotId ep sl)
-

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -17,7 +17,7 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..), WalletKey (..), XPrv, digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)

--- a/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TransactionSpecShared.hs
@@ -32,7 +32,7 @@ import Test.QuickCheck
 -------------------------------------------------------------------------------}
 
 propMaxNumberOfInputsEstimation
-    :: TransactionLayer t
+    :: TransactionLayer t key
     -> Quantity "byte" Word16
     -> Quantity "byte" Word16
     -> Word8

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -50,6 +50,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     , SeqKey (..)
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
+    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -39,17 +40,16 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , ErrWrongPassphrase (..)
     , Index
-    , Key
     , Passphrase (..)
+    , WalletKey (..)
     , XPrv
-    , getKey
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( ChangeChain (..)
+    , SeqKey (..)
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
-    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
@@ -267,7 +267,7 @@ walletUpdateNameNoSuchWallet wallet@(wid', _, _) wid wName =
 walletUpdatePassphrase
     :: (WalletId, WalletName, DummyState)
     -> Passphrase "encryption-new"
-    -> Maybe (Key 'RootK XPrv, Passphrase "encryption")
+    -> Maybe (SeqKey 'RootK XPrv, Passphrase "encryption")
     -> Property
 walletUpdatePassphrase wallet new mxprv = monadicIO $ liftIO $ do
     (WalletLayerFixture _ wl [wid] _) <- liftIO $ setupFixture wallet
@@ -287,7 +287,7 @@ walletUpdatePassphrase wallet new mxprv = monadicIO $ liftIO $ do
 
 walletUpdatePassphraseWrong
     :: (WalletId, WalletName, DummyState)
-    -> (Key 'RootK XPrv, Passphrase "encryption")
+    -> (SeqKey 'RootK XPrv, Passphrase "encryption")
     -> (Passphrase "encryption-old", Passphrase "encryption-new")
     -> Property
 walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
@@ -314,7 +314,7 @@ walletUpdatePassphraseNoSuchWallet wallet@(wid', _, _) wid (old, new) =
 
 walletUpdatePassphraseDate
     :: (WalletId, WalletName, DummyState)
-    -> (Key 'RootK XPrv, Passphrase "encryption")
+    -> (SeqKey 'RootK XPrv, Passphrase "encryption")
     -> Property
 walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
     (WalletLayerFixture _ wl [wid] _) <- liftIO $ setupFixture wallet
@@ -335,7 +335,7 @@ walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
 
 walletKeyIsReencrypted
     :: (WalletId, WalletName)
-    -> (Key 'RootK XPrv, Passphrase "encryption")
+    -> (SeqKey 'RootK XPrv, Passphrase "encryption")
     -> Passphrase "encryption-new"
     -> Property
 walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
@@ -384,8 +384,8 @@ walletListTransactionsSorted wallet@(wid, _, _) _order (_mstart, _mend) history 
 -------------------------------------------------------------------------------}
 
 data WalletLayerFixture = WalletLayerFixture
-    { _fixtureDBLayer :: DBLayer IO DummyState DummyTarget
-    , _fixtureWalletLayer :: WalletLayer DummyState DummyTarget
+    { _fixtureDBLayer :: DBLayer IO DummyState DummyTarget SeqKey
+    , _fixtureWalletLayer :: WalletLayer DummyState DummyTarget SeqKey
     , _fixtureWallet :: [WalletId]
     , _fixtureSlotIdTime :: SlotId -> UTCTime
     }
@@ -424,7 +424,7 @@ setupFixture (wid, wname, wstate) = do
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses
-dummyTransactionLayer :: TransactionLayer DummyTarget
+dummyTransactionLayer :: TransactionLayer DummyTarget SeqKey
 dummyTransactionLayer = TransactionLayer
     { mkStdTx = \keyFrom inps outs -> do
         let tx = Tx (fmap fst inps) outs
@@ -460,7 +460,7 @@ instance Arbitrary DummyState where
 instance IsOurs DummyState where
     isOurs _ s = (True, s)
 
-instance IsOwned DummyState where
+instance IsOwned DummyState SeqKey where
     isOwned (DummyState m) (rootK, pwd) addr = do
         ix <- Map.lookup addr m
         let accXPrv = deriveAccountPrivateKey pwd rootK minBound
@@ -494,7 +494,7 @@ instance Arbitrary (Passphrase purpose) where
     arbitrary =
         Passphrase . BA.convert . BS.pack <$> replicateM 16 arbitrary
 
-instance {-# OVERLAPS #-} Arbitrary (Key 'RootK XPrv, Passphrase "encryption")
+instance {-# OVERLAPS #-} Arbitrary (SeqKey 'RootK XPrv, Passphrase "encryption")
   where
     shrink _ = []
     arbitrary = do

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.HttpBridge.Environment
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), KeyToAddress (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
-    ( RndKey (..) )
+    ( RndKey, encodeDerivationPath )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( SeqKey )
 import Cardano.Wallet.Primitive.Fee
@@ -125,8 +125,10 @@ instance KeyToAddress (HttpBridge 'Mainnet) RndKey where
     keyToAddress = rndKeyToAddressWith emptyAttributes
 
 rndKeyToAddressWith :: CBOR.Encoding -> RndKey 'AddressK XPub -> Address
-rndKeyToAddressWith _attrs (RndKey _addressXPub (_accIx, _addrIx) _) =
+rndKeyToAddressWith _attrs key =
     error "rndKeyToAddressWith: unimplemented"
+  where
+    _derPath = encodeDerivationPath key
 
 keyToAddressWith :: CBOR.Encoding -> SeqKey 'AddressK XPub -> Address
 keyToAddressWith attrs key = Address

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -43,11 +43,11 @@ import Cardano.Wallet.HttpBridge.Environment
     , protocolMagic
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), KeyToAddress (..) )
+    ( Depth (..), KeyToAddress (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
-    ( RndKey (..) )
+    ( RndKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey )
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
@@ -139,7 +139,7 @@ keyToAddressWith attrs key = Address
     $ CBOR.toStrictByteString
     $ CBOR.encodeAddress xpub attrs
   where
-    xpub = getKey key
+    xpub = getRawKey key
 
 attributesWithProtocolMagic :: ProtocolMagic -> CBOR.Encoding
 attributesWithProtocolMagic pm = mempty

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.HttpBridge.Environment
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), KeyToAddress (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
-    ( RndKey )
+    ( RndKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( SeqKey )
 import Cardano.Wallet.Primitive.Fee
@@ -117,22 +117,16 @@ instance KeyToAddress (HttpBridge 'Testnet) SeqKey where
 instance KeyToAddress (HttpBridge 'Mainnet) SeqKey where
     keyToAddress = keyToAddressWith emptyAttributes
 
-instance KeyToAddress (HttpBridge 'Mainnet) RndKey where
-    keyToAddress _ = error "KeyToAddress RndKey unimplemented"
-
 instance KeyToAddress (HttpBridge 'Testnet) RndKey where
-    keyToAddress _ = error "KeyToAddress RndKey unimplemented"
+    keyToAddress = rndKeyToAddressWith
+        (attributesWithProtocolMagic (protocolMagic @'Testnet))
 
-{-
-rndToAddressAttrs, rndToAddressAttrsWithProtocolMagic
-    :: RndKey 'RootK XPub
-    -> RndKey 'AddressK XPub
-    -> Index 'Hardened 'AccountK
-    -> Index 'Soft 'AddressK
-    -> CBOR.Encoding
-rndToAddressAttrs = error "to be implemented"
-rndToAddressAttrsWithProtocolMagic = rndToAddressAttrs
--}
+instance KeyToAddress (HttpBridge 'Mainnet) RndKey where
+    keyToAddress = rndKeyToAddressWith emptyAttributes
+
+rndKeyToAddressWith :: CBOR.Encoding -> RndKey 'AddressK XPub -> Address
+rndKeyToAddressWith _attrs (RndKey _addressXPub (_accIx, _addrIx) _) =
+    error "rndKeyToAddressWith: unimplemented"
 
 keyToAddressWith :: CBOR.Encoding -> SeqKey 'AddressK XPub -> Address
 keyToAddressWith attrs key = Address

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Transaction.hs
@@ -67,9 +67,9 @@ import qualified Data.ByteString.Lazy as BL
 
 -- | Construct a 'TransactionLayer' compatible with Byron and the 'HttpBridge'
 newTransactionLayer
-    :: forall n key t.
-        (KnownNetwork n, t ~ HttpBridge n, KeyToAddress t key, PersistKey key)
-    => TransactionLayer t key
+    :: forall n k t.
+        (KnownNetwork n, t ~ HttpBridge n, KeyToAddress t k, PersistKey k)
+    => TransactionLayer t k
 newTransactionLayer = TransactionLayer
     { mkStdTx = \keyFrom inps outs -> do
         let ins = (fmap fst inps)
@@ -93,7 +93,7 @@ newTransactionLayer = TransactionLayer
         + n * sizeOfTxWitness
 
     , estimateMaxNumberOfInputs =
-        estimateMaxNumberOfInputsBase @t @key estimateMaxNumberOfInputsParams
+        estimateMaxNumberOfInputsBase @t @k estimateMaxNumberOfInputsParams
 
     , validateSelection = \(CoinSelection _ outs _) -> do
         when (any (\ (TxOut _ c) -> c == Coin 0) outs)
@@ -102,7 +102,7 @@ newTransactionLayer = TransactionLayer
   where
     mkWitness
         :: Hash "Tx"
-        -> (key 'AddressK XPrv, Passphrase "encryption")
+        -> (k 'AddressK XPrv, Passphrase "encryption")
         -> TxWitness
     mkWitness tx (xPrv, pwd) = TxWitness
         $ CBOR.toStrictByteString
@@ -111,7 +111,7 @@ newTransactionLayer = TransactionLayer
 
     sign
         :: SignTag
-        -> (key 'AddressK XPrv, Passphrase "encryption")
+        -> (k 'AddressK XPrv, Passphrase "encryption")
         -> Hash "signature"
     sign tag (key, (Passphrase pwd)) =
         Hash . CC.unXSignature $ CC.sign pwd (getRawKey key) (signTag tag)

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |
@@ -66,7 +68,7 @@ instance IsOurs AnyAddressState where
         where
           p' = floor (fromIntegral (maxBound :: Word32) * p)
 
-instance IsOwned AnyAddressState where
+instance IsOwned AnyAddressState key where
     isOwned _ _ _ = Nothing
 
 instance GenChange AnyAddressState where

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -31,15 +31,9 @@ import Cardano.Wallet.HttpBridge.Transaction
 import Cardano.Wallet.Network
     ( NetworkLayer (..), defaultRetryPolicy, networkTip, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..)
-    , Passphrase (..)
-    , PersistKey
-    , digest
-    , generateKeyFromSeed
-    , publicKey
-    )
+    ( KeyToAddress (..), Passphrase (..), PersistKey, digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
+    ( SeqKey, generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOwned )
 import Cardano.Wallet.Primitive.AddressDiscovery.Any

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -218,7 +218,7 @@ bench_restoration _ _ (wid, wname, s) = withHttpBridge network $ \port -> do
     (ctx, db) <- Sqlite.newDBLayer logConfig nullTracer dbFile
     Sqlite.unsafeRunQuery ctx (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
-    let tl = newTransactionLayer :: TransactionLayer t key
+    let tl = newTransactionLayer @n
     BlockHeader sl _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
     let bp = byronBlockchainParameters

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -196,15 +196,15 @@ parseNetwork = \case
 
 {-# ANN bench_restoration ("HLint: ignore Use camelCase" :: String) #-}
 bench_restoration
-    :: forall (n :: Network) key s t.
-        ( IsOwned s key
+    :: forall (n :: Network) k s t.
+        ( IsOwned s k
         , NFData s
         , Show s
         , PersistState s
         , KnownNetwork n
         , t ~ HttpBridge n
-        , KeyToAddress t key
-        , PersistKey key
+        , KeyToAddress t k
+        , PersistKey k
         )
     => (WalletId, WalletName, s)
     -> IO ()
@@ -214,7 +214,7 @@ bench_restoration (wid, wname, s) = withHttpBridge network $ \port -> do
     (ctx, db) <- Sqlite.newDBLayer logConfig nullTracer dbFile
     Sqlite.unsafeRunQuery ctx (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
-    let tl = newTransactionLayer @n @key
+    let tl = newTransactionLayer @n @k
     BlockHeader sl _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
     let bp = byronBlockchainParameters
@@ -268,7 +268,7 @@ prepareNode _ = do
 -- | Regularly poll the wallet to monitor it's syncing progress. Block until the
 -- wallet reaches 100%.
 waitForWalletSync
-    :: WalletLayer s t key
+    :: WalletLayer s t k
     -> WalletId
     -> IO ()
 waitForWalletSync walletLayer wid = do

--- a/lib/http-bridge/test/integration/Cardano/Faucet.hs
+++ b/lib/http-bridge/test/integration/Cardano/Faucet.hs
@@ -16,12 +16,18 @@ import Cardano.Wallet.HttpBridge.Primitive.Types
 import Cardano.Wallet.Network
     ( NetworkLayer (postTx) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..), Passphrase (..), XPrv, publicKey )
+    ( Depth (..)
+    , KeyToAddress (..)
+    , Passphrase (..)
+    , WalletKey (..)
+    , XPrv
+    , publicKey
+    )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( ChangeChain (..)
+    , SeqKey
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
-    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.Mnemonic
     ( Mnemonic
@@ -75,7 +81,7 @@ initFaucet nl = do
             (seed, pwd) =
                 (Passphrase $ entropyToBytes $ mnemonicToEntropy mw, mempty)
             rootXPrv =
-                generateKeyFromSeed (seed, mempty) pwd
+                generateKeyFromSeed (seed, mempty) pwd :: SeqKey 'RootK XPrv
             accXPrv =
                 deriveAccountPrivateKey pwd rootXPrv minBound
             addrXPrv =

--- a/lib/http-bridge/test/integration/Cardano/Faucet.hs
+++ b/lib/http-bridge/test/integration/Cardano/Faucet.hs
@@ -28,6 +28,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     , SeqKey
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
+    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.Mnemonic
     ( Mnemonic

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -19,9 +19,9 @@ import Cardano.Wallet.HttpBridge.Compatibility
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
+    ( Passphrase (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
+    ( SeqKey, generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( mkSeqState )
 import Cardano.Wallet.Primitive.Mnemonic

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -19,9 +19,7 @@ import Cardano.Wallet.HttpBridge.Compatibility
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Passphrase (..), digest, publicKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( generateKeyFromSeed )
+    ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( mkSeqState )
 import Cardano.Wallet.Primitive.Mnemonic

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -20,6 +20,8 @@ import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..), digest, generateKeyFromSeed, publicKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( mkSeqState )
 import Cardano.Wallet.Primitive.Mnemonic
@@ -80,7 +82,7 @@ spec = do
         threadDelay 1000000
         db <- MVar.newDBLayer
         nl <- HttpBridge.newNetworkLayer @'Testnet port
-        let tl = HttpBridge.newTransactionLayer
+        let tl = HttpBridge.newTransactionLayer @'Testnet @SeqKey
         let bp = byronBlockchainParameters
         (handle,) <$>
             (newWalletLayer @_ @(HttpBridge 'Testnet) nullTracer bp db nl tl)

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/AddressDerivation/SequentialSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/AddressDerivation/SequentialSpec.hs
@@ -22,14 +22,15 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Index
     , KeyToAddress (..)
     , Passphrase (..)
+    , generateKeyFromSeed
     , keyToAddress
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( ChangeChain (..)
+    , SeqKey (..)
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
-    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.Types
     ( encodeAddress )
@@ -80,7 +81,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 goldenYoroiAddr
-    :: forall n. (KeyToAddress (HttpBridge n))
+    :: forall n. (KeyToAddress (HttpBridge n) SeqKey)
     => Proxy n
     -> (Passphrase "seed", Passphrase "generation")
     -> ChangeChain

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/AddressDerivation/SequentialSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/AddressDerivation/SequentialSpec.hs
@@ -22,7 +22,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Index
     , KeyToAddress (..)
     , Passphrase (..)
-    , generateKeyFromSeed
     , keyToAddress
     , publicKey
     )
@@ -31,6 +30,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     , SeqKey (..)
     , deriveAccountPrivateKey
     , deriveAddressPrivateKey
+    , generateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.Types
     ( encodeAddress )

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -639,14 +639,14 @@ spec = do
 -------------------------------------------------------------------------------}
 
 propSizeEstimation
-    :: forall n t key.
-       (KnownNetwork n, t ~ HttpBridge n, KeyToAddress t key, key ~ SeqKey)
+    :: forall n t k.
+       (KnownNetwork n, t ~ HttpBridge n, KeyToAddress t k, k ~ SeqKey)
     => Proxy n
     -> (ShowFmt CoinSelection, InfiniteList (Network -> Address))
     -> Property
 propSizeEstimation _ (ShowFmt sel, InfiniteList chngAddrs _) =
     let
-        calcSize = estimateSize (newTransactionLayer @n @key) sel
+        calcSize = estimateSize (newTransactionLayer @n @k) sel
         tx = fromCoinSelection sel
         encodedTx = CBOR.toLazyByteString $ encodeSignedTx tx
         size = fromIntegral $ BL.length encodedTx
@@ -679,15 +679,15 @@ propSizeEstimation _ (ShowFmt sel, InfiniteList chngAddrs _) =
             (Tx (fst <$> inps) (outs <> txChngs), wits)
 
 unknownInputTest
-    :: forall n key.
-       (KnownNetwork n, KeyToAddress (HttpBridge n) key, key ~ SeqKey)
+    :: forall n k.
+       (KnownNetwork n, KeyToAddress (HttpBridge n) k, k ~ SeqKey)
     => Proxy n
     -> SpecWith ()
 unknownInputTest _ = it title $ do
     let addr = keyToAddress @(HttpBridge n) $ publicKey $ xprv "address-number-0"
     let res = mkStdTx tl keyFrom inps outs
           where
-            tl = newTransactionLayer @n @key
+            tl = newTransactionLayer @n @k
             keyFrom = const Nothing
             inps =
                 [ ( TxIn (Hash "arbitrary") 0
@@ -827,11 +827,11 @@ xprv seed =
     unsafeGenerateKeyFromSeed (Passphrase (BA.convert seed), mempty) mempty
 
 goldenTestSignedTx
-    :: forall n key. (KnownNetwork n, KeyToAddress (HttpBridge n) key, key ~ SeqKey)
+    :: forall n k. (KnownNetwork n, KeyToAddress (HttpBridge n) k, k ~ SeqKey)
     => Proxy n
     -> Int
         -- ^ Number of outputs
-    -> [(key 'AddressK XPrv, Coin)]
+    -> [(k 'AddressK XPrv, Coin)]
         -- ^ (Address Private Keys, Output value)
     -> ByteString
         -- ^ Expected result, in Base16

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -117,9 +117,9 @@ spec = do
 
     describe "estimateMaxNumberOfInputs" $ do
         it "Property for mainnet addresses" $ property $
-            propMaxNumberOfInputsEstimation (newTransactionLayer @'Mainnet)
+            propMaxNumberOfInputsEstimation (newTransactionLayer @'Mainnet @SeqKey)
         it "Property for testnet addresses" $ property$
-            propMaxNumberOfInputsEstimation (newTransactionLayer @'Testnet)
+            propMaxNumberOfInputsEstimation (newTransactionLayer @'Testnet @SeqKey)
 
     describe "mkStdTx unknown input" $ do
         unknownInputTest (Proxy @'Mainnet)
@@ -646,7 +646,7 @@ propSizeEstimation
     -> Property
 propSizeEstimation _ (ShowFmt sel, InfiniteList chngAddrs _) =
     let
-        calcSize = estimateSize (newTransactionLayer @n) sel
+        calcSize = estimateSize (newTransactionLayer @n @key) sel
         tx = fromCoinSelection sel
         encodedTx = CBOR.toLazyByteString $ encodeSignedTx tx
         size = fromIntegral $ BL.length encodedTx
@@ -687,7 +687,7 @@ unknownInputTest _ = it title $ do
     let addr = keyToAddress @(HttpBridge n) $ publicKey $ xprv "address-number-0"
     let res = mkStdTx tl keyFrom inps outs
           where
-            tl = newTransactionLayer @n
+            tl = newTransactionLayer @n @key
             keyFrom = const Nothing
             inps =
                 [ ( TxIn (Hash "arbitrary") 0

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/TransactionSpec.hs
@@ -28,15 +28,9 @@ import Cardano.Wallet.HttpBridge.Primitive.Types
 import Cardano.Wallet.HttpBridge.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , KeyToAddress (..)
-    , Passphrase (..)
-    , XPrv
-    , publicKey
-    , unsafeGenerateKeyFromSeed
-    )
+    ( Depth (..), KeyToAddress (..), Passphrase (..), XPrv, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey (..) )
+    ( SeqKey (..), unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -37,7 +39,9 @@ import Cardano.Wallet.Jormungandr.Environment
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress (..), getKey )
+    ( KeyToAddress (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (..)
@@ -121,9 +125,8 @@ instance PersistTx (Jormungandr network) where
             amt
             isJust
 
-instance forall n. KnownNetwork n => KeyToAddress (Jormungandr n) where
+instance forall n. KnownNetwork n => KeyToAddress (Jormungandr n) SeqKey where
     keyToAddress key = singleAddressFromKey (Proxy @n) (getKey key)
-
 
 -- | Encode an 'Address' to a human-readable format. This produces two kinds of
 -- encodings:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -23,7 +23,9 @@ import Cardano.Wallet.Jormungandr.Environment
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (AddressK), Key, Passphrase (..), XPrv, getKey )
+    ( Depth (AddressK), Passphrase (..), XPrv )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey (..) )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
@@ -56,7 +58,7 @@ import qualified Cardano.Wallet.Jormungandr.Binary as Binary
 newTransactionLayer
     :: forall n t. (KnownNetwork n, t ~ Jormungandr n)
     => Hash "Genesis"
-    -> TransactionLayer t
+    -> TransactionLayer t SeqKey
 newTransactionLayer (Hash block0) = TransactionLayer
     { mkStdTx = \keyFrom rnps outs -> do
         -- NOTE
@@ -82,7 +84,7 @@ newTransactionLayer (Hash block0) = TransactionLayer
         Quantity $ length inps + length outs + length chgs
 
     , estimateMaxNumberOfInputs =
-        estimateMaxNumberOfInputsBase @t Binary.estimateMaxNumberOfInputsParams
+        estimateMaxNumberOfInputsBase @t @SeqKey Binary.estimateMaxNumberOfInputsParams
 
     , validateSelection = \(CoinSelection inps outs _) -> do
         when (length inps > maxNumberOfInputs || length outs > maxNumberOfOutputs)
@@ -91,7 +93,7 @@ newTransactionLayer (Hash block0) = TransactionLayer
   where
     sign
         :: ByteString
-        -> (Key 'AddressK XPrv, Passphrase "encryption")
+        -> (SeqKey 'AddressK XPrv, Passphrase "encryption")
         -> TxWitness
     sign bytes (key, (Passphrase pwd)) =
         TxWitness . CC.unXSignature $ CC.sign pwd (getKey key) bytes

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -24,15 +24,15 @@ import Cardano.Wallet.Jormungandr.Transaction
     ( ErrExceededInpsOrOuts (..), newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
-    , Key
     , KeyToAddress (..)
     , Passphrase (..)
     , XPrv
     , keyToAddress
     , publicKey
+    , unsafeGenerateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( unsafeGenerateKeyFromSeed )
+    ( SeqKey )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
@@ -74,10 +74,10 @@ estimateMaxNumberOfInputsSpec :: Spec
 estimateMaxNumberOfInputsSpec = describe "estimateMaxNumberOfInputs" $ do
     it "Property for mainnet addresses" $
         property $ propMaxNumberOfInputsEstimation
-        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Mainnet))
+        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Mainnet) SeqKey)
     it "Property for testnet addresses" $
         property $ propMaxNumberOfInputsEstimation
-        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Testnet))
+        (newTransactionLayer (Hash "") :: TransactionLayer (Jormungandr 'Testnet) SeqKey)
 
 {-------------------------------------------------------------------------------
                                   mkStdTx
@@ -256,7 +256,7 @@ mkStdTxSpec = do
 goldenTestStdTx
     :: forall n. (KnownNetwork n)
     => Proxy (Jormungandr n)
-    -> (Address -> Maybe (Key 'AddressK XPrv, Passphrase "encryption"))
+    -> (Address -> Maybe (SeqKey 'AddressK XPrv, Passphrase "encryption"))
     -> Hash "Genesis"
     -> [(TxIn, TxOut)]
     -> [TxOut]
@@ -278,7 +278,7 @@ goldenTestStdTx _ keystore block0 inps outs bytes' = it title $ do
 
 xprvFromSeed
     :: ByteString
-    -> (Key depth XPrv, Passphrase "encryption")
+    -> (SeqKey depth XPrv, Passphrase "encryption")
 xprvFromSeed seed =
     ( unsafeGenerateKeyFromSeed (Passphrase (BA.convert seed), mempty) pwd
     , pwd
@@ -361,6 +361,6 @@ tooNumerousOutsTest _ block0 = it title $ do
         <> ")"
 
 
-xprv :: ByteString -> Key depth XPrv
+xprv :: ByteString -> SeqKey depth XPrv
 xprv seed =
     unsafeGenerateKeyFromSeed (Passphrase (BA.convert seed), mempty) mempty

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -29,10 +29,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , XPrv
     , keyToAddress
     , publicKey
-    , unsafeGenerateKeyFromSeed
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
+    ( SeqKey, unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types


### PR DESCRIPTION
Relates to issue #557 

# Overview

This adds a key type parameter to the `WalletLayer`. The key type must satisfy `WalletKey`.

The database layer is parameterised by key type. For sqlite, the type must satisfy `PersistKey`.

There are instances of the key for new types `SeqKey` and `RndKey`.

For now, the API server and many other things hardcode the key parameter to `SeqKey`.

# Comments

I worked back from the `keyToAddress` function. The most complicated combination is a random scheme old-style address for Testnet.

Going from that I felt that it was necessary to include the target (e.g. `HttpBridge 'Testnet`) as a second parameter of the `KeyToAddress` typeclass.

```
class KeyToAddress target (key :: Depth -> * -> *) where
    keyToAddress :: key 'AddressK XPub -> Address
```

The `rndToAddress` function is stubbed out and can be implemented in a future PR.

## Things to do
- [x] Delete `Key` newtype and don't wrap it in `SeqKey` and `RndKey` wrap 
- [x] Remove the `unwrapKey` function. It's just a temporary helper.
- [x] Add key parameter to `IsOwned` class.
- [x] Integration tests building.
- [x] Figure out what fields to be in `RndKey`
- [x] implement `instance WalletKey RndKey`
- [x] Shift a few functions from `AddressDerivation` to `AddressDerivation.Sequential`
- [x] The restore benchmark doesn't build, and the error is a little tricky.
- [x] Rework from reviews 7/7/2019
- [ ] Git rebase and squash

## Things to do in next PR
- [ ] Remove hardcoding of `SeqKey` as much as possible, to make things more polymorphic.
- [ ] Implement `instance KeyToAddress t RndKey`
- [x] Fix type signature of `Random.encodeDerivationPath` because derivation path is now included in the `RndKey`.
- [ ] Implement `instance PersistKey RndKey`
- [ ] Remove `AddressDerivation.Common` module (actually maybe we can keep it for common functions used by `PersistKey`).
