### PR TITLE
Launcher: use getExecutablePath to restart self

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -109,7 +109,7 @@ import Options.Applicative
     , value
     )
 import System.Environment
-    ( getProgName )
+    ( getExecutablePath )
 import System.FilePath
     ( (</>) )
 
@@ -175,7 +175,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
     exec (LaunchArgs network listen nodePort mStateDir verbosity) = do
         let withStateDir _ _ = pure ()
         let stateDir = fromMaybe (stateDirForNetwork dataDir network) mStateDir
-        cmdName <- getProgName
+        cmdName <- getExecutablePath
         execLaunch verbosity stateDir withStateDir
             [ commandHttpBridge stateDir
             , commandWalletServe cmdName stateDir

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -121,7 +121,7 @@ import Options.Applicative
     , progDesc
     )
 import System.Environment
-    ( getProgName )
+    ( getExecutablePath )
 import System.Exit
     ( exitFailure )
 import System.FilePath
@@ -207,7 +207,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
     exec (LaunchArgs listen nodePort mStateDir verbosity jArgs) = do
         requireFilePath (_genesisBlock jArgs)
         requireFilePath (_bftLeaders jArgs)
-        cmdName <- getProgName
+        cmdName <- getExecutablePath
         block0H <- parseBlock0H (_genesisBlock jArgs)
         let baseUrl = BaseUrl Http "127.0.0.1" (getPort nodePort) "/api"
         let stateDir = fromMaybe (dataDir </> "testnet") mStateDir


### PR DESCRIPTION
This lets `cardano-wallet launch` still work if the program is in a directory that's not on the PATH.
