### PR TITLE
Remove unused dependency on `quickcheck-instances`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -155,7 +155,6 @@ test-suite unit
     , memory
     , network
     , QuickCheck
-    , quickcheck-instances
     , quickcheck-state-machine >= 0.6.0
     , random
     , servant

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -101,8 +101,6 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
-import Test.QuickCheck.Instances.Time
-    ()
 import Test.Text.Roundtrip
     ( textRoundtrip )
 import Test.Utils.Time

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -94,7 +94,6 @@
             (hsPkgs.memory)
             (hsPkgs.network)
             (hsPkgs.QuickCheck)
-            (hsPkgs.quickcheck-instances)
             (hsPkgs.quickcheck-state-machine)
             (hsPkgs.random)
             (hsPkgs.servant)


### PR DESCRIPTION
We don't actually use the `Arbitrary UTCTime` instance from `Test.QuickCheck.Instances.Time`, so this import can be safely deleted, and the dependency on `quickcheck-instances` can be removed.

(If needed, we can use the `genUniformTime` function from `Test.Utils.Time` to provide a source of arbitrary `UTCTime` values.)

# Issue Number

None.

# Overview

I have:
- [x] Removed the import of `Test.QuickCheck.Instances.Time`.
- [x] Removed the dependency on `quickcheck-instances`.

