### PR TITLE
add dummy address to extended p2p

### DIFF
--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -62,7 +62,7 @@ import Cardano.Launcher
 import Cardano.Wallet
     ( BlockchainParameters (..), WalletLayer )
 import Cardano.Wallet.Api.Server
-    ( Listen (..) )
+    ( Listen (..), getRandomPort )
 import Cardano.Wallet.DaedalusIPC
     ( daedalusIPC )
 import Cardano.Wallet.DB
@@ -213,7 +213,8 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
         let stateDir = fromMaybe (dataDir </> "testnet") mStateDir
         let nodeConfig = stateDir </> "jormungandr-config.json"
         let withStateDir tracer _ = do
-                genConfigFile stateDir baseUrl
+                port <- getRandomPort
+                genConfigFile stateDir port baseUrl
                     & Aeson.encode
                     & BL.writeFile nodeConfig
                 logInfo tracer $ mempty

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Api.Server
     ( Listen (..)
     , start
     , withListeningSocket
+    , getRandomPort
     ) where
 
 import Prelude
@@ -248,6 +249,14 @@ withListeningSocket portOpt = bracket acquire release
     release (_, socket) = liftIO $ close socket
     -- TODO: make configurable, default to secure for now.
     hostPreference = "127.0.0.1"
+
+
+getRandomPort :: IO Port
+getRandomPort = do
+    let hostPreference = "127.0.0.1"
+    (port, socket) <- bindRandomPortTCP hostPreference
+    liftIO $ close socket
+    return port
 
 {-------------------------------------------------------------------------------
                                     Wallets

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -214,9 +214,10 @@ instance KnownNetwork n => DecodeAddress (Jormungandr n) where
 -- | Generate a configuration file for Jörmungandr@0.3.1
 genConfigFile
     :: FilePath
+    -> Int
     -> BaseUrl
     -> Aeson.Value
-genConfigFile stateDir (BaseUrl _ host port path) = object
+genConfigFile stateDir addressPort (BaseUrl _ host port path) = object
     [ "storage" .= (stateDir </> "chain")
     , "rest" .= object
         [ "listen" .= String listen
@@ -228,9 +229,10 @@ genConfigFile stateDir (BaseUrl _ host port path) = object
             [ "messages" .= String "low"
             , "blocks" .= String "normal"
             ]
-        , "public_address" .= String "/ip4/127.0.0.1/tcp/8081"
+        , "public_address" .= String publicAddress
         ]
     ]
   where
     listen = T.pack $ mconcat [host, ":", show port]
     prefix = T.pack $ drop 1 path
+    publicAddress = T.pack $ mconcat ["/ip4/127.0.0.1/tcp/", show addressPort]

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -228,6 +228,7 @@ genConfigFile stateDir (BaseUrl _ host port path) = object
             [ "messages" .= String "low"
             , "blocks" .= String "normal"
             ]
+        , "public_address" .= String "/ip4/127.0.0.1/tcp/8081"
         ]
     ]
   where

--- a/lib/jormungandr/test/data/jormungandr/config.yaml
+++ b/lib/jormungandr/test/data/jormungandr/config.yaml
@@ -9,3 +9,4 @@ p2p:
   topics_of_interest:
     messages: low
     blocks: normal
+  public_address: "/ip4/127.0.0.1/tcp/8081"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -271,7 +271,8 @@ spec = do
                     "topics_of_interest": {
                         "messages": "low",
                         "blocks": "normal"
-                    }
+                    },
+                    "public_address" : "/ip4/127.0.0.1/tcp/8081"
                 }
             }|]
 

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -260,7 +260,7 @@ spec = do
         it "example configuration" $ do
             let stateDir = "/state-dir"
             let baseUrl = BaseUrl Http "127.0.0.1" 8080 "/api"
-            genConfigFile stateDir baseUrl `shouldBe` [aesonQQ|{
+            genConfigFile stateDir 8081 baseUrl `shouldBe` [aesonQQ|{
                 "storage": "/state-dir/chain",
                 "rest": {
                     "listen": "127.0.0.1:8080",


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added public_address dummy value to p2p Jormungandr config
- [x] I have added `getRandomPort` function and extended `genConfigFile` by port arg

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
