### PR TITLE
Document the default sort order for `listTransactions` in the API specification.

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -967,6 +967,7 @@ paths:
           enum:
             - ascending
             - descending
+          default: descending
           description: An optional sort order.
       responses: *responsesListTransactions
 


### PR DESCRIPTION
# Issue Number

#466 

# Overview

- [x] I have documented the default sort order (`descending`) for `listTransactions` in the API specification.