### PR TITLE
Fix range boundary filtering for `listTransactions`.

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -53,6 +53,7 @@ library
     , template-haskell
     , text
     , text-class
+    , time
     , warp
   hs-source-dirs:
       src

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -820,7 +820,7 @@ newWalletLayer tracer bp db nw tl = do
         -- correct transactions, exclusively. Adding only `slotLength - 1` would
         -- make the range inclusive.
         recenter :: UTCTime -> UTCTime
-        recenter = addUTCTime (s - 1) where (SlotLength s) = slotLength
+        recenter = addUTCTime (pred s) where (SlotLength s) = slotLength
 
         -- This relies on DB.readTxHistory returning all necessary transactions
         -- to assemble coin selection information for outgoing payments.

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -140,7 +140,7 @@ main = do
                     PortCLI.specWithRandomPort @t defaultPort
         beforeAll startCluster $ afterAll _cleanup $ after tearDown $ do
             describe "PR_DISABLED Wallets API endpoint tests" (Wallets.spec @t)
-            describe "PR_DISABLED Transactions API endpoint tests" (Transactions.spec @t)
+            describe "Transactions API endpoint tests" (Transactions.spec @t)
             describe "PR_DISABLED Addresses API endpoint tests" (Addresses.spec @t)
             describe "Wallets CLI tests" (WalletsCLI.spec @t)
             describe "Transactions CLI tests" (TransactionsCLI.spec @t)

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -116,7 +116,7 @@ main = hspec $ do
         -- API e2e Testing
         describe "PR_DISABLED Addresses API endpoint tests" Addresses.spec
         describe "PR_DISABLED Transactions API endpoint tests" Transactions.spec
-        describe "PR_DISABLED Transactions API endpoint tests (Jormungandr specific)"
+        describe "Transactions API endpoint tests (Jormungandr specific)"
             (TransactionsJormungandr.spec @t)
         describe "PR_DISABLED Wallets API endpoint tests" Wallets.spec
         -- Command-Line e2e Testing

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -44,6 +44,7 @@
           (hsPkgs.template-haskell)
           (hsPkgs.text)
           (hsPkgs.text-class)
+          (hsPkgs.time)
           (hsPkgs.warp)
           ];
         };


### PR DESCRIPTION
# Issue Number

#466 

# Overview

After adding some API tests to verify that `listTransactions` handles range boundaries correctly, I found that the function can sometimes return transactions that fall outside of the time range specified.

To fix this, I adjusted the `recenter` function to use the correct offset of `slotLength − 1 picosecond`, rather than `slotLength − 1 second`, since `UTCTime` values are of _picosecond_ resolution.

The `Enum` instance for `nominalDiffTime` converts to and from an integer number of picoseconds, so we can use the `pred` function to subtract a single picosecond from `slotLength`.

Ranges tested by tests in this PR:

* Small ranges that _marginally_ cover a transaction.
* Ranges with _end_ times that are _marginally earlier_ than a transaction.
* Ranges with _start_ times that are _marginally later_ than a transaction.

- [x] Make the tests pass, by fixing the definition of `listTransactions`.