### PR TITLE
Nix updates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,7 @@ in {
       cardano-wallet-core-integration
       cardano-wallet-http-bridge
       cardano-wallet-jormungandr
+      cardano-wallet-shelley
       cardano-wallet-test-utils
       bech32
       text-class

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -71,10 +71,12 @@ test-suite unit
     , cardano-crypto
     , cardano-wallet-cli
     , cardano-wallet-core
+    , filepath
     , hspec
     , memory
     , optparse-applicative
     , QuickCheck
+    , temporary
     , text
     , text-class
   build-tools:

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -45,10 +45,12 @@
             (hsPkgs.cardano-crypto)
             (hsPkgs.cardano-wallet-cli)
             (hsPkgs.cardano-wallet-core)
+            (hsPkgs.filepath)
             (hsPkgs.hspec)
             (hsPkgs.memory)
             (hsPkgs.optparse-applicative)
             (hsPkgs.QuickCheck)
+            (hsPkgs.temporary)
             (hsPkgs.text)
             (hsPkgs.text-class)
             ];

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -1,0 +1,20 @@
+# Hercules CI attribute set
+# https://hercules-ci.com/github/input-output-hk/cardano-wallet
+# https://docs.hercules-ci.com/hercules-ci/getting-started/minimal-repository/
+
+builtins.mapAttrs (system: _:
+  let
+    walletPkgs = import ../default.nix { inherit system; };
+  in
+    walletPkgs.pkgs.recurseIntoAttrs {
+      inherit (walletPkgs)
+        cardano-wallet-http-bridge
+        cardano-wallet-jormungandr
+        tests
+        benchmarks;
+    }
+) {
+  x86_64-linux = {};
+  # Uncomment to test build on macOS too
+  # x86_64-darwin = {};
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,6 +36,7 @@ let
         packages.cardano-wallet-launcher.src = src + /lib/launcher;
         packages.cardano-wallet-http-bridge.src = src + /lib/http-bridge;
         packages.cardano-wallet-jormungandr.src = src + /lib/jormungandr;
+        packages.cardano-wallet-shelley.src = src + /lib/shelley;
         packages.cardano-wallet-test-utils.src = src + /lib/test-utils;
         packages.text-class.src = src + /lib/text-class;
         packages.bech32.src = src + /lib/bech32;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -31,10 +31,12 @@ let
       {
         packages.cardano-wallet.src = src;
         packages.cardano-wallet-core.src = src + /lib/core;
+        packages.cardano-wallet-core-integration.src = src + /lib/core-integration;
         packages.cardano-wallet-cli.src = src + /lib/cli;
         packages.cardano-wallet-launcher.src = src + /lib/launcher;
         packages.cardano-wallet-http-bridge.src = src + /lib/http-bridge;
         packages.cardano-wallet-jormungandr.src = src + /lib/jormungandr;
+        packages.cardano-wallet-test-utils.src = src + /lib/test-utils;
         packages.text-class.src = src + /lib/text-class;
         packages.bech32.src = src + /lib/bech32;
       }

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "acf1eb8d13972e78f15fa255a7b5307b8bede948",
-  "date": "2019-07-19T06:50:28+00:00",
-  "sha256": "1m9pkpvj629fzvqn2233vkvz93nf76balfq7333kgb0wj9483d1p",
+  "rev": "92b5e5eb1859746b527e279945e56bb837d94443",
+  "date": "2019-08-08T16:09:19+00:00",
+  "sha256": "0rc6ndbriwjalcg05a4v0n74gb1sh4f2p3h076k043iwymx11q4y",
   "fetchSubmodules": false
 }

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -7,6 +7,8 @@ with pkgs.lib;
     (hasPrefix "cardano-wallet" package.identifier.name) ||
     (elem package.identifier.name [ "text-class" "bech32" ]);
 
+  # TODO: use upstreamed version:
+  # https://github.com/input-output-hk/haskell.nix/pull/224
   collectComponents = group: packageSel: haskellPackages:
     (mapAttrs (_: package: package.components.${group} // { recurseForDerivations = true; })
      (filterAttrs (name: package: (package.isHaskell or false) && packageSel package) haskellPackages))


### PR DESCRIPTION
# Overview

- Updates jormungandr to 0.3.2 in nix build and shell.
- Updates the nix-shell environment to include dependencies of the cardano-wallet-shelley package.
- Adds a build file for Hercules CI.
- Fixes one of the tests that was failing on MacOS due to use of `/tmp`.
