### PR TITLE
Protect against construction of invalid arbitrary `UTCTime` values.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -107,6 +107,7 @@ library
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version
       Data.Time.Text
+      Data.Time.Utils
       Data.Quantity
       Network.Wai.Middleware.ServantError
       Network.Wai.Middleware.Logging
@@ -207,6 +208,7 @@ test-suite unit
       Cardano.WalletSpec
       Data.QuantitySpec
       Data.Time.TextSpec
+      Data.Time.UtilsSpec
       Network.Wai.Middleware.LoggingSpec
 
 benchmark db

--- a/lib/core/src/Data/Time/Utils.hs
+++ b/lib/core/src/Data/Time/Utils.hs
@@ -1,0 +1,25 @@
+-- |
+-- Copyright: © 2019 IOHK
+-- License: MIT
+--
+-- Utility functions for manipulating time values.
+
+module Data.Time.Utils
+    ( utcTimePred
+    , utcTimeSucc
+    ) where
+
+import Prelude
+
+import Data.Time
+    ( UTCTime, addUTCTime )
+
+-- | For a given time 't0', get the closest representable time 't1' to 't0'
+--   for which 't0 < t1'.
+utcTimeSucc :: UTCTime -> UTCTime
+utcTimeSucc = addUTCTime $ succ 0
+
+-- | For a given time 't0', get the closest representable time 't1' to 't0'
+--   for which 't1 < t0'.
+utcTimePred :: UTCTime -> UTCTime
+utcTimePred = addUTCTime $ pred 0

--- a/lib/core/test/unit/Data/Time/UtilsSpec.hs
+++ b/lib/core/test/unit/Data/Time/UtilsSpec.hs
@@ -1,0 +1,33 @@
+module Data.Time.UtilsSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Time.Utils
+    ( utcTimePred, utcTimeSucc )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( property, withMaxSuccess, (===) )
+import Test.Utils.Time
+    ( getUniformTime )
+
+spec :: Spec
+spec = describe "Manipulation of time values." $ do
+
+    it "utcTimePred . utcTimeSucc == id" $
+        withMaxSuccess 10000 $ property $ \t ->
+            utcTimePred (utcTimeSucc (getUniformTime t)) === getUniformTime t
+
+    it "utcTimeSucc . utcTimePred == id" $
+        withMaxSuccess 10000 $ property $ \t ->
+            utcTimeSucc (utcTimePred (getUniformTime t)) === getUniformTime t
+
+    it "utcTimeSucc t > t" $
+        withMaxSuccess 10000 $ property $ \t ->
+            utcTimeSucc (getUniformTime t) > getUniformTime t
+
+    it "utcTimePred t < t" $
+        withMaxSuccess 10000 $ property $ \t ->
+            utcTimePred (getUniformTime t) < getUniformTime t


### PR DESCRIPTION
# Issue Number

#466 

# Overview

This PR:

- [x] fixes the `Arbitrary` instance for `UniformTime` so that it cannot produce `UTCTime` values where the internal offset (from midnight) exceeds the length of time in a day.
- [x] defines helper functions `utcTimePred` and `utcTimeSucc` to find the _next earliest_ time and the _next latest_ time respectively.
- [x] adds tests to demonstrate that `utcTimePred . utcTimeSucc == id` and `utcTimeSucc . utcTimePred == id` (these **failed** before the `Arbitrary` instance was fixed.)
- [x] uses `utcTimePred` and `utcTimeSucc` to simplify integration tests for `listTransactions`.

# Comments

The [constructor for `UTCTime`](http://hackage.haskell.org/package/time-1.9.3/docs/Data-Time-Clock.html#v:UTCTime) accepts:

1. a number of days from the start of the Julian Calendar.
2. an offset from midnight.

However, it doesn't provide upper-bounds checking on the offset from midnight. If the offset is greater than one day (allowing for leap seconds), it's possible to create an invalid time value, which may cause functions that manipulate `UTCTime` values to behave unexpectedly.

We protect against this by constructing `UTCTime` values with the `addUTCTime` function, which guarantees to provide correct handling in the event of overflow.