### PR TITLE
Fix List Range

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -462,8 +462,7 @@ mkApiTransaction txid ins outs meta = ApiTransaction
     , insertedAt = Nothing
     , depth = Quantity 0
     , direction = ApiT (meta ^. #direction)
-    , inputs = NE.fromList
-        [ApiTxInput (fmap coerceTxOut o) (ApiT i) | (i, o) <- ins]
+    , inputs = [ApiTxInput (fmap coerceTxOut o) (ApiT i) | (i, o) <- ins]
     , outputs = NE.fromList (coerceTxOut <$> outs)
     , status = ApiT (meta ^. #status)
     }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -206,7 +206,7 @@ data ApiTransaction t = ApiTransaction
     , insertedAt :: !(Maybe ApiBlockData)
     , depth :: !(Quantity "slot" Natural)
     , direction :: !(ApiT Direction)
-    , inputs :: !(NonEmpty (ApiTxInput t))
+    , inputs :: ![ApiTxInput t]
     , outputs :: !(NonEmpty (AddressAmount t))
     , status :: !(ApiT TxStatus)
     } deriving (Eq, Generic, Show)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -12,7 +12,7 @@ module Test.Integration.Jormungandr.Scenario.API.Transactions
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiFee, ApiTransaction )
+    ( ApiFee, ApiTransaction (..) )
 import Cardano.Wallet.Primitive.Types
     ( DecodeAddress (..), EncodeAddress (..) )
 import Control.Monad
@@ -22,7 +22,7 @@ import Data.Generics.Internal.VL.Lens
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)
@@ -35,6 +35,7 @@ import Test.Integration.Framework.DSL
     , for
     , json
     , listAddresses
+    , listAllTransactions
     , postTxEp
     , postTxFeeEp
     , request
@@ -68,6 +69,11 @@ spec = do
         (wSrc, payload) <- fixtureZeroAmtMulti ctx
         r <- request @ApiFee ctx (postTxFeeEp wSrc) Default payload
         expectResponseCode HTTP.status202 r
+
+    it "TRANS_LIST_?? - List transactions of a fixture wallet" $ \ctx -> do
+        txs <- fixtureWallet ctx >>= listAllTransactions ctx
+        length txs `shouldBe` 10
+        txs `shouldSatisfy` all (null . inputs)
 
     describe "TRANS_CREATE_10, TRANS_ESTIMATE_10 - \
         \Cannot post tx/fee when max tx size reached" $ do

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -255,7 +255,7 @@ x-transactionDirection: &transactionDirection
 x-transactionInputs: &transactionInputs
   description: A list of transaction inputs
   type: array
-  minItems: 1
+  minItems: 0
   items:
     type: object
     required:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#466 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have made the tx `inputs` a list instead of a `NonEmpty` list at the API-Level. Inputs may actually be null for: genesis txs, coinbase txs and redemption txs (?). 

- [x] I have used `fixtureWalletWith` in the `TRANS_LIST_RANGE` scenarios instead of relying on the default fixture wallet. The fixture wallets for Jormungandr and http-bridge have actually rather different setup. Although they have the same amount of UTxO, one is made of 10 txs, and the other of a single tx with 10 outputs. Yet, the test really expect wallets to have a single transaction, and therefore, it is necessary to construct the wallet in such way.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
