### PR TITLE
wip: Parameterize API server by key type

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -5,7 +5,7 @@
 -- Copyright: © 2018-2019 IOHK
 -- License: MIT
 --
--- Database / Pesistence layer for the wallet backend. This is where we define
+-- Database / Persistence layer for the wallet backend. This is where we define
 -- the interface allowing us to store and fetch various data on our wallets.
 
 module Cardano.Wallet.DB

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -49,6 +49,9 @@ import GHC.Generics
 newtype RndState = RndState { getRndState :: RndKey 'RootK XPrv }
     deriving (Generic)
 
+instance Show RndState where
+    show _ = "RndState <xprv>"
+
 instance NFData RndState
 
 -- An address is considered to belong to the 'RndState' wallet if it can be decoded


### PR DESCRIPTION
# Issue Number

#557 probably.

# Overview

Removes the hardcoding of `SeqKey` and `SeqState` in the API server.

# Comments

- Some endpoints are different depending on key type or AD scheme. These are stubbed for now.

- For simplicity, the CLI adds an option `--addresses random`. In future, there might be multiple wallets with different schemes within the same process. But for now, limit it to one scheme at a time.
