### PR TITLE
change license to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,201 @@
-Copyright (c) 2019 IOHK
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to
-do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2018-2019 IOHK
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/cardano-wallet.cabal
+++ b/cardano-wallet.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 license-file:        LICENSE
 category:            Web
 build-type:          Simple

--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -12,7 +12,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module parses command line arguments for the wallet and executes
 -- corresponding commands.

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -11,7 +11,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module parses command line arguments for the wallet and executes
 -- corresponding commands.

--- a/lib/bech32/bech32.cabal
+++ b/lib/bech32/bech32.cabal
@@ -5,7 +5,7 @@ homepage:      https://github.com/input-output-hk/cardano-wallet
 author:        IOHK Engineering Team
 maintainer:    operations@iohk.io
 copyright:     2017 Marko Bencun, 2019 IOHK
-license:       MIT
+license:       Apache-2.0
 category:      Web
 build-type:    Simple
 cabal-version: >=1.10

--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2017 Marko Bencun, 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Implementation of the [Bech32]
 -- (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
@@ -35,4 +35,3 @@ module Codec.Binary.Bech32
     ) where
 
 import Codec.Binary.Bech32.Internal
-

--- a/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
@@ -8,7 +8,7 @@
 
 -- |
 -- Copyright: © 2017 Marko Bencun, 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Implementation of the [Bech32]
 -- (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -5,7 +5,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -15,7 +15,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Shared types and helpers for CLI parsing
 

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- These are (partial) CBOR decoders for Byron binary types. Note that we
 -- ignore most of the block's and header's content and only retrieve the pieces

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -11,7 +11,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Provides the wallet layer functions that are used by API layer and uses both
 -- "Cardano.Wallet.DB" and "Cardano.Wallet.Network" to realize its role as being

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -12,7 +12,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- API handlers and server using the underlying wallet layer to provide
 -- endpoints reachable through HTTP.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -16,7 +16,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- API type representations of various types. We define here pretty much all our
 -- user-facing types that are mostly composed with internal / primitive types.

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -3,7 +3,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Database / Persistence layer for the wallet backend. This is where we define
 -- the interface allowing us to store and fetch various data on our wallets.

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Dummy implementation of the database-layer, using MVar. This may be good for
 -- state-machine testing in order to compare it with an implementation on a real

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -16,7 +16,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An implementation of the DBLayer which uses Persistent and SQLite.
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Auto-generated Sqlite & Persistent machinery via Template-Haskell. This has
 -- been moved into a separate file so that we can treat it slightly differently

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -6,7 +6,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains instances and types necessary for storing wallets in a
 -- SQL database with Persistent.

--- a/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
+++ b/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Provides a mechanism for Daedalus to discover what port the cardano-wallet
 -- server is listening on.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -17,7 +17,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Primitives for performing address derivation for some given schemes. This is
 -- where most of the crypto happens in the wallet and, it is quite important to

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -17,7 +17,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Implementation of address derivation for the random scheme, as
 -- implemented by the legacy Cardano wallets.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
@@ -14,7 +14,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Implementation of address derivation for the sequential schemes, as
 -- implemented by Yoroi/Icarus and cardano-cli.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -7,7 +7,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains types for address discovery. The two address discovery
 -- schemes implemented are:

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An implementation of address discovery for the random address
 -- scheme as used by the legacy Cardano wallets.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -15,7 +15,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An implementation of address discovery for the sequential address derivation
 -- scheme specified in BIP-0044.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -4,7 +4,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Provides the API of Coin Selection algorithm and Fee Calculation
 -- This module contains the implementation of adjusting coin selection for a fee.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -3,7 +3,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains the implementation of largestFirst
 -- input selection algorithm

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -4,7 +4,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains the implementation of random
 -- input selection algorithm

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -6,7 +6,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Provides the API of Coin Selection algorithm and Fee Calculation
 -- This module contains the implementation of adjusting coin selection for a fee.

--- a/lib/core/src/Cardano/Wallet/Primitive/Mnemonic.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Mnemonic.hs
@@ -13,7 +13,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module provides mnemonic (backup phrase) creation, and conversion of a
 -- mnemonic to seed for wallet restoration.

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -12,7 +12,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Here we find the "business logic" to manage a Cardano wallet. This is a
 -- direct implementation of the model from the [Formal Specification for a Cardano Wallet](https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -19,7 +19,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains the core primitive of a Wallet. This is roughly a
 -- Haskell translation of the [Formal Specification for a Cardano Wallet](https://github.com/input-output-hk/cardano-wallet/blob/master/specifications/wallet/formal-specification-for-a-cardano-wallet.pdf)

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An extra interface for operation on transactions (e.g. creating witnesses,
 -- estimating size...). This makes it possible to decouple those operations from

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -11,7 +11,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Representation of values with an associated (free) unit of measure. Useful to
 -- disambiguate primitive types like 'Int' or 'String' which can be in different

--- a/lib/core/src/Data/Time/Text.hs
+++ b/lib/core/src/Data/Time/Text.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Utility functions for converting time values to and from text.
 

--- a/lib/core/src/Data/Time/Utils.hs
+++ b/lib/core/src/Data/Time/Utils.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Utility functions for manipulating time values.
 

--- a/lib/core/src/Network/Wai/Middleware/ServantError.hs
+++ b/lib/core/src/Network/Wai/Middleware/ServantError.hs
@@ -2,7 +2,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Middleware between Wai <-> Servant to accommodate raw error responses
 -- returned by servant. See also 'handleRawError'.

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -10,7 +10,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This benchmark gathers timings of the important database operations, for
 -- various sizes of input. The chosen sizes are meant to approach and slightly

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -19,7 +19,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- These are state machine model tests for the 'DBLayer' implementations.
 --

--- a/lib/http-bridge/cardano-wallet-http-bridge.cabal
+++ b/lib/http-bridge/cardano-wallet-http-bridge.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Api.hs
@@ -4,7 +4,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An API specification for the Cardano HTTP Bridge.
 module Cardano.Wallet.HttpBridge.Api

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -8,7 +8,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Contains various implementation decision that are specific to a particular
 -- network / protocol. This allows us to easily select a particular backend

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Environment.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains static configuration parameters. Rather than providing
 -- and carrying around a configuration file through the application, we resolve

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -11,7 +11,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains the necessary logic to talk to implement the network
 -- layer using the cardano-http-bridge as a chain producer.

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Primitive/Types.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Primitive/Types.hs
@@ -2,7 +2,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Declaration of primitive types that are specific to a particular backend.
 -- Likely, the shape of all types is similar and will eventually converge

--- a/lib/http-bridge/src/Data/Packfile.hs
+++ b/lib/http-bridge/src/Data/Packfile.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Decoder for the rust-cardano packfile format.
 --

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
@@ -7,7 +7,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Custom address discovery schemes used for testing and benchmarking.
 --

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -10,7 +10,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Automatically generated code via Template-Haskell. Contains necessary
 -- database rows and columns declaration to work with 'AnyAddressState'.

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 extra-source-files:  README.md

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -8,7 +8,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- An specification for the Jörmungandr REST API.
 module Cardano.Wallet.Jormungandr.Api

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -10,7 +10,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- The format is for the Shelley era as implemented by the Jörmungandr node.
 -- It is described [here](https://github.com/input-output-hk/rust-cardano/blob/master/chain-impl-mockchain/doc/format.md)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -8,7 +8,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Contains various implementation decision that are specific to a particular
 -- network / protocol. This allows us to easily select a particular backend

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Environment.hs
@@ -5,7 +5,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains static configuration parameters. Rather than providing
 -- and carrying around a configuration file through the application, we resolve

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 --
 --

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Primitive/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Primitive/Types.hs
@@ -3,7 +3,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Declaration of primitive types that are specific to a particular backend.
 -- Likely, the shape of all types is similar and will eventually converge

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -5,7 +5,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -2,7 +2,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- This module contains a mechanism for launching external processes together,
 -- and provides the functionality needed to kill them all if one goes down.

--- a/lib/launcher/src/Cardano/Launcher/POSIX.hs
+++ b/lib/launcher/src/Cardano/Launcher/POSIX.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 -- Portability: POSIX
 --
 

--- a/lib/launcher/src/Cardano/Launcher/Windows.hs
+++ b/lib/launcher/src/Cardano/Launcher/Windows.hs
@@ -1,6 +1,6 @@
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 -- Portability: Windows
 --
 

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -6,7 +6,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/lib/test-utils/src/Test/Utils/Time.hs
+++ b/lib/test-utils/src/Test/Utils/Time.hs
@@ -2,7 +2,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Provides utility functions relating to testing with times and dates.
 

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -9,7 +9,7 @@
 
 -- |
 -- Copyright: © 2018-2019 IOHK
--- License: MIT
+-- License: Apache-2.0
 --
 -- Extend the 'Data.Text' module with an extra abstraction to encode and decode
 -- values safely to and from 'Text'. It's very similar to 'FromJSON' and

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -5,7 +5,7 @@ homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 copyright:           2019 IOHK
-license:             MIT
+license:             Apache-2.0
 category:            Web
 build-type:          Simple
 cabal-version:       >=1.10

--- a/nix/.stack.nix/bech32.nix
+++ b/nix/.stack.nix/bech32.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "bech32"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2017 Marko Bencun, 2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet-cli"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -7,7 +7,7 @@
         name = "cardano-wallet-core-integration";
         version = "2019.6.24";
         };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet-core"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -7,7 +7,7 @@
         name = "cardano-wallet-http-bridge";
         version = "2019.7.24";
         };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -7,7 +7,7 @@
         name = "cardano-wallet-jormungandr";
         version = "2019.7.24";
         };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet-launcher"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet-shelley"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -7,7 +7,7 @@
         name = "cardano-wallet-test-utils";
         version = "2019.6.24";
         };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -4,7 +4,7 @@
     package = {
       specVersion = "1.10";
       identifier = { name = "text-class"; version = "2019.7.24"; };
-      license = "MIT";
+      license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK Engineering Team";

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -6,7 +6,7 @@ info:
   title: Cardano Wallet Backend API
   version: 2.0.0
   license:
-    name: MIT
+    name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE
   description: |
     <p align="right"><img style="position: relative; top: -10em; margin-bottom: -12em;" width="20%" src="https://cardanodocs.com/img/cardano.png"></img></p>


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview
Change license from MIT to Apache 2.0.

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have updated LICENSE file and changed from MIT to Apache 2.0 in each file.


# Comments

<!-- Additional comments or screenshots to attach if any -->

There is something to be confirmed here though - it concerns the following files : 
```
lib/bech32/src/Codec/Binary/Bech32/Internal.hs
lib/bech32/bech32.cabal
lib/bech32/src/Codec/Binary/Bech32.hs
```
Can the license be changed if copyright is : 
```
copyright:     2017 Marko Bencun, 2019 IOHK                                                                                                                                                
license:       Apache-2.0
```
?
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
