### PR TITLE
Add clarity to slot arithmetic functions.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -803,7 +803,7 @@ newWalletLayer tracer bp db nw tl = do
                 , txInfoOutputs = W.outputs @t tx
                 , txInfoMeta = meta
                 , txInfoDepth =
-                    slotDifference epochLength tip (meta ^. #slotId)
+                    slotDifference sp tip (meta ^. #slotId)
                 , txInfoTime = txTime (meta ^. #slotId)
                 }
             txOuts = Map.fromList

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -116,6 +116,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotLength (..)
     , SlotLength (..)
+    , SlotParameters (..)
     , SortOrder (..)
     , StartTime (..)
     , TransactionInfo (..)
@@ -429,6 +430,10 @@ data BlockchainParameters t = BlockchainParameters
     , getTxMaxSize :: Quantity "byte" Word16
         -- ^ Maximum size of a transaction (soft or hard limit)
     }
+
+getSlotParameters :: BlockchainParameters t -> SlotParameters
+getSlotParameters (BlockchainParameters _ st _ sl el _) =
+    SlotParameters el sl st
 
 -- | Create a new instance of the wallet layer.
 newWalletLayer

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -73,6 +73,7 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Slotting
     , SlotId (..)
+    , SlotParameters (..)
     , SlotLength (..)
     , EpochLength (..)
     , StartTime (..)
@@ -837,6 +838,16 @@ instance NFData SlotId
 
 instance Buildable SlotId where
     build (SlotId e s) = fromString (show e) <> "." <> fromString (show s)
+
+-- | The essential parameters necessary for performing slot arithmetic.
+data SlotParameters = SlotParameters
+    { getEpochLength
+        :: EpochLength
+    , getSlotLength
+        :: SlotLength
+    , getGenesisBlockDate
+        :: StartTime
+    } deriving (Eq, Show)
 
 -- | Compute the approximate ratio / progress between two slots. This is an
 -- approximation for a few reasons, one of them being that we hard code the

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -80,6 +80,8 @@ module Cardano.Wallet.Primitive.Types
     , flatSlot
     , fromFlatSlot
     , slotStartTime
+    , slotStartingAtOrJustAfter
+    , slotStartingAtOrJustBefore
     , slotAt
     , slotDifference
     , slotPred
@@ -897,7 +899,21 @@ slotStartTime epochLength (SlotLength slotLength) (StartTime start) sl =
   where
     offset = slotLength * fromIntegral (flatSlot epochLength sl)
 
--- | The SlotId at a given time.
+-- | For the given time 't', determine the ID of the earliest slot with start
+--   time 's' such that 't ≤ s'.
+slotStartingAtOrJustAfter
+    :: EpochLength -> SlotLength -> StartTime -> UTCTime -> SlotId
+slotStartingAtOrJustAfter el sl st t =
+    slotAt el sl st (addUTCTime (pred $ getSlotLength sl) t)
+
+-- | For the given time 't', determine the ID of the latest slot with start
+--   time 's' such that 's ≤ t'.
+slotStartingAtOrJustBefore
+    :: EpochLength -> SlotLength -> StartTime -> UTCTime -> SlotId
+slotStartingAtOrJustBefore = slotAt
+
+-- | For the given time 't', determine the ID of the unique slot with start
+--   time 's' and end time 'e' such that 's ≤ t ≤ e'.
 slotAt :: EpochLength -> SlotLength -> StartTime -> UTCTime -> SlotId
 slotAt (EpochLength nSlots) (SlotLength slotLength) (StartTime start) time =
     SlotId

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -82,6 +82,8 @@ module Cardano.Wallet.Primitive.Types
     , slotStartTime
     , slotAt
     , slotDifference
+    , slotPred
+    , slotSucc
 
     -- * Wallet Metadata
     , WalletMetadata(..)
@@ -875,6 +877,18 @@ slotDifference epl a b
   where
     a' = flatSlot epl a
     b' = flatSlot epl b
+
+-- | Return the slot immediately before the given slot.
+slotPred :: EpochLength -> SlotId -> SlotId
+slotPred (EpochLength el) (SlotId en sn)
+    | sn > 0    = SlotId (en    ) (               sn - 1)
+    | otherwise = SlotId (en - 1) (fromIntegral $ el - 1)
+
+-- | Return the slot immediately after the given slot.
+slotSucc :: EpochLength -> SlotId -> SlotId
+slotSucc (EpochLength el) (SlotId en sn)
+    | sn < el - 1 = SlotId (en    ) (sn + 1)
+    | otherwise   = SlotId (en + 1) (     0)
 
 -- | The time that a slot begins.
 slotStartTime :: EpochLength -> SlotLength -> StartTime -> SlotId -> UTCTime

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -884,13 +884,13 @@ fromFlatSlot (EpochLength epochLength) n = SlotId e (fromIntegral s)
 
 -- | @slotDifference a b@ is how many slots @a@ is after @b@. The result is
 -- non-negative, and if @b > a@ then this function returns zero.
-slotDifference :: EpochLength -> SlotId -> SlotId -> Quantity "slot" Natural
-slotDifference epl a b
+slotDifference :: SlotParameters -> SlotId -> SlotId -> Quantity "slot" Natural
+slotDifference (SlotParameters el _ _) a b
     | a' > b' = Quantity $ fromIntegral $ a' - b'
     | otherwise = Quantity 0
   where
-    a' = flatSlot epl a
-    b' = flatSlot epl b
+    a' = flatSlot el a
+    b' = flatSlot el b
 
 -- | Return the slot immediately before the given slot.
 slotPred :: SlotParameters -> SlotId -> SlotId

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -895,14 +895,14 @@ slotDifference epl a b
 -- | Return the slot immediately before the given slot.
 slotPred :: SlotParameters -> SlotId -> SlotId
 slotPred (SlotParameters (EpochLength el) _ _) (SlotId en sn)
-    | sn > 0    = SlotId (en    ) (               sn - 1)
-    | otherwise = SlotId (en - 1) (fromIntegral $ el - 1)
+    | sn > 0 = SlotId en (sn - 1)
+    | otherwise = SlotId (en - 1) (el - 1)
 
 -- | Return the slot immediately after the given slot.
 slotSucc :: SlotParameters -> SlotId -> SlotId
 slotSucc (SlotParameters (EpochLength el) _ _) (SlotId en sn)
-    | sn < el - 1 = SlotId (en    ) (sn + 1)
-    | otherwise   = SlotId (en + 1) (     0)
+    | sn < el - 1 = SlotId en (sn + 1)
+    | otherwise = SlotId (en + 1) 0
 
 -- | The time that a slot begins.
 slotStartTime :: SlotParameters -> SlotId -> UTCTime

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -52,8 +52,10 @@ import Cardano.Wallet.Primitive.Types
     , restrictedBy
     , restrictedTo
     , slotAt
+    , slotPred
     , slotRatio
     , slotStartTime
+    , slotSucc
     , walletNameMaxLength
     , walletNameMinLength
     )
@@ -155,7 +157,26 @@ spec = do
         it "fromFlatSlot . flatSlot == id" $ property $ \n ->
             flatSlot slotsPerEpoch (fromFlatSlot slotsPerEpoch n) === n
 
-    describe "SlotId <-> UTCTime conversions" $ do
+    describe "Slot arithmetic" $ do
+
+        it "slotSucc . slotPred == id" $ withMaxSuccess 1000 $ property $
+            \(epochLength, slot) -> do
+
+                let slotPred' = slotPred epochLength
+                let slotSucc' = slotSucc epochLength
+                let f = slotSucc' . slotPred'
+
+                slot === f slot
+
+        it "slotPred . slotSucc == id" $ withMaxSuccess 1000 $ property $
+            \(epochLength, slot) -> do
+
+                let slotPred' = slotPred epochLength
+                let slotSucc' = slotSucc epochLength
+                let f = slotPred' . slotSucc'
+
+                slot === f slot
+
         it "slotAt . slotStartTime == id" $ withMaxSuccess 1000 $ property $
             \slotLength startTime (epochLength, sl) -> do
                 let slotAt' = slotAt

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -53,6 +53,7 @@ import Cardano.Wallet.Primitive.Types
     , restrictedBy
     , restrictedTo
     , slotAt
+    , slotDifference
     , slotPred
     , slotRatio
     , slotStartTime
@@ -175,6 +176,26 @@ spec = do
                 \(sps, slot) -> do
                     let f = slotPred sps . slotSucc sps
                     slot === f slot
+
+        it "slotDifference (slotSucc slot) slot == 1 (valid difference)" $
+            withMaxSuccess 1000 $ property $
+                \(sps, slot) -> do
+                    slotDifference sps (slotSucc sps slot) slot === Quantity 1
+
+        it "slotDifference slot (slotPred slot) == 1 (valid difference)" $
+            withMaxSuccess 1000 $ property $
+                \(sps, slot) -> do
+                    slotDifference sps slot (slotPred sps slot) === Quantity 1
+
+        it "slotDifference (slotPred slot) slot == 0 (invalid difference)" $
+            withMaxSuccess 1000 $ property $
+                \(sps, slot) -> do
+                    slotDifference sps (slotPred sps slot) slot === Quantity 0
+
+        it "slotDifference slot (slotSucc slot) == 0 (invalid difference)" $
+            withMaxSuccess 1000 $ property $
+                \(sps, slot) -> do
+                    slotDifference sps slot (slotSucc sps slot) === Quantity 0
 
         it "slotAt . slotStartTime == id" $
             withMaxSuccess 1000 $ property $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -202,6 +202,15 @@ spec = do
                             . slotStartTime sps
                     slot === f slot
 
+        it "slotStartingAtOrJustBefore . slotStartTime == \
+            \slotStartingAtOrJustAfter . slotStartTime" $
+            withMaxSuccess 1000 $ property $
+                \(sps, slot) -> do
+                    let f = slotStartingAtOrJustBefore sps . slotStartTime sps
+                    let g = slotStartingAtOrJustAfter  sps . slotStartTime sps
+                    counterexample (show (slot, slotStartTime sps slot)) $
+                        f slot === g slot
+
     describe "Negative cases for types decoding" $ do
         it "fail fromText @AddressState \"unusedused\"" $ do
             let err = "Unable to decode the given value: \"unusedused\".\


### PR DESCRIPTION
# Issue Number

Indirectly related to #466.

# Overview

This PR:

- [x] refactors existing slot arithmetic functions to make them easier to call, and to make their behaviour more obvious.
- [x] adds a set of tests to verify that these refactorings are correct.
- [x] adds a small set of tests to test the previously-untested `slotDifference` function.