### PR TITLE
Make `slotPred` safe for all values of `SlotId`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -105,6 +105,7 @@ library
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version
+      Data.Function.Utils
       Data.Time.Text
       Data.Time.Utils
       Data.Quantity
@@ -206,6 +207,7 @@ test-suite unit
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TransactionSpec
       Cardano.WalletSpec
+      Data.Function.UtilsSpec
       Data.QuantitySpec
       Data.Time.TextSpec
       Data.Time.UtilsSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -893,10 +893,11 @@ slotDifference (SlotParameters el _ _) a b
     b' = flatSlot el b
 
 -- | Return the slot immediately before the given slot.
-slotPred :: SlotParameters -> SlotId -> SlotId
+slotPred :: SlotParameters -> SlotId -> Maybe SlotId
 slotPred (SlotParameters (EpochLength el) _ _) (SlotId en sn)
-    | sn > 0 = SlotId en (sn - 1)
-    | otherwise = SlotId (en - 1) (el - 1)
+    | en == 0 && sn == 0 = Nothing
+    | sn > 0 = Just $ SlotId en (sn - 1)
+    | otherwise = Just $ SlotId (en - 1) (el - 1)
 
 -- | Return the slot immediately after the given slot.
 slotSucc :: SlotParameters -> SlotId -> SlotId

--- a/lib/core/src/Data/Function/Utils.hs
+++ b/lib/core/src/Data/Function/Utils.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Data.Function.Utils
+    ( applyN
+    ) where
+
+import Prelude
+
+-- | Apply a function 'n' times to the specified input.
+applyN :: Integral n => n -> (a -> a) -> a -> a
+applyN !n !f !a
+    | n <= 0 = a
+    | otherwise = applyN (n - 1) f (f a)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -261,8 +261,7 @@ spec = do
         it "slotPred . slotStartingAtOrJustAfter . utcTimeSucc . slotStartTime\
             \ == id" $
             withMaxSuccess 1000 $ property $
-                \(sps, slot) ->
-                    flatSlot (getEpochLength sps) slot > 0 ==> do
+                \(sps, slot) -> do
                     let f = slotPred sps
                             . slotStartingAtOrJustAfter sps
                             . utcTimeSucc

--- a/lib/core/test/unit/Data/Function/UtilsSpec.hs
+++ b/lib/core/test/unit/Data/Function/UtilsSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Data.Function.UtilsSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Function.Utils
+    ( applyN )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( NonNegative (..), property, withMaxSuccess, (===) )
+
+spec :: Spec
+spec = describe "Function utilities" $ do
+
+    describe "applyN" $ do
+
+        it "forall m n . n >= 0 : applyN n (+ 1) m == m + n" $
+            withMaxSuccess 10000 $
+                property $ \(NonNegative (n :: Int)) (m :: Int) ->
+                    applyN n (+ 1) m === n + m
+
+        it "forall m n . n <= 0 : applyN n (+ 1) m == m" $
+            withMaxSuccess 10000 $
+                property $ \(NonNegative (n :: Int)) (m :: Int) ->
+                    applyN (negate n) (+ 1) m === m


### PR DESCRIPTION
# Issue Number

Indirectly relates to #466.

# Overview

This PR changes `slotPred` so that it returns `Maybe SlotId` instead of `SlotId`.

This is because there isn't a well-defined answer for `slotPred (SlotId 0 0)`.

When `slotPred` is applied to `slotPred (SlotId 0 0)` we return `Nothing`.

We also:
    
1. Adjust the slot arithmetic test suite to take into account the fact that `slotPred` may return `Nothing`.
    
2. Strengthen the slot arithmetic test suite by applying `slotPred` and `slotSucc` an arbitrary number of times rather than just once, where appropriate.