### PR TITLE
Fix account address decoder

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -508,7 +508,7 @@ getAddress = do
     case kind of
         0x3 -> Address <$> getByteString 33 -- single address
         0x4 -> Address <$> getByteString 65 -- grouped address
-        0x5 -> Address <$> getByteString 65 -- account address
+        0x5 -> Address <$> getByteString 33 -- account address
         0x6 -> Address <$> getByteString 33 -- multisig address
         other -> fail $ "Invalid address type: " ++ show other
   where

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -13,7 +13,7 @@
 -- License: Apache-2.0
 --
 -- The format is for the Shelley era as implemented by the Jörmungandr node.
--- It is described [here](https://github.com/input-output-hk/rust-cardano/blob/master/chain-impl-mockchain/doc/format.md)
+-- It is described [here](https://github.com/input-output-hk/chain-libs/blob/master/chain-impl-mockchain/doc/format.md)
 --
 -- The module to some extent defines its own Jörmungandr-specific types,
 -- different from "Cardano.Wallet.Primitive.Types". Here, transactions are just

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -60,6 +60,8 @@ import Control.Monad.IO.Class
     ( liftIO )
 import Data.ByteString
     ( ByteString )
+import Data.Either
+    ( isRight )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Labels
@@ -75,7 +77,14 @@ import Data.Word
 import GHC.Generics
     ( Generic )
 import Test.Hspec
-    ( Spec, describe, expectationFailure, it, shouldBe, shouldThrow )
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldSatisfy
+    , shouldThrow
+    )
 import Test.QuickCheck
     ( Arbitrary (..), Gen, choose, oneof, property, shrinkList, vectorOf )
 import Test.QuickCheck.Arbitrary.Generic
@@ -85,6 +94,7 @@ import Test.QuickCheck.Monadic
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
 
 spec :: Spec
 spec = do
@@ -221,6 +231,14 @@ spec = do
                         }
                     []
             unsafeDecodeHex getBlock bytes `shouldBe` block
+
+        it "should decode an account address golden" $ do
+            -- This address was manually retrieved from a jcli-created genesis
+            -- block.
+            let hex = "850C0DF2B9A4CD3E8CD36B81BE295EF2A\
+                      \B5BA25929A36359F84CD1AA5CEBE2FAED"
+            res <- try' (runGet getAddress (BL.fromStrict $ unsafeFromHex hex))
+            res `shouldSatisfy` isRight
 
     describe "Encoding" $ do
         let cc = ChainCode "<ChainCode is not used by singleAddressToKey>"


### PR DESCRIPTION
# Issue Number

#631 


# Overview

- [x] I have fixed the expected length of account addresses in the decoder, which previously was incorrect (Can be verified in https://github.com/input-output-hk/chain-libs/blob/a3aed5bf07be514dc3c8f4209f3cca312a5f1ca5/chain-impl-mockchain/doc/format.md)
- [x] I have added a simple golden test
- [x] I have verified that the test fails without the fix, and passes with the fix. (just `git revert` the fix)


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
