### PR TITLE
Add basic property tests for `Range` data type.

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -138,7 +138,7 @@ newDBLayer = do
                     Ascending -> comparing slot
                     Descending -> comparing $ Down . slot
                 result =
-                    filter (isWithinRange range . slot)
+                    filter ((`isWithinRange` range) . slot)
                     . sortBy order' . Map.toList . txHistory
                 slot = slotId . snd . snd
             in maybe mempty result . Map.lookup key <$> readMVar db

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -364,8 +364,8 @@ data Range a = Range
 wholeRange :: Range a
 wholeRange = Range Nothing Nothing
 
-isWithinRange :: Ord a => Range a -> a -> Bool
-isWithinRange (Range low high) x =
+isWithinRange :: Ord a => a -> Range a -> Bool
+isWithinRange x (Range low high) =
     (maybe True (x >=) low) &&
     (maybe True (x <=) high)
 

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -207,7 +207,7 @@ type TxHistory = [(Hash "Tx", (Tx, TxMeta))]
 -- (first time/slotId, then by TxId) to a 'TxHistory'.
 filterTxHistory :: SortOrder -> Range SlotId -> TxHistory -> TxHistory
 filterTxHistory order range =
-    filter (isWithinRange range . slotId . snd . snd)
+    filter ((`isWithinRange` range) . slotId . snd . snd)
     . (case order of
         Ascending -> reverse
         Descending -> id)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -56,6 +56,8 @@ import Cardano.Wallet.Primitive.Types
     , isSubsetOf
     , isValidCoin
     , isWithinRange
+    , rangeHasLowerBound
+    , rangeHasUpperBound
     , rangeIsFinite
     , rangeIsValid
     , restrictedBy
@@ -84,8 +86,6 @@ import Data.Function
     ( (&) )
 import Data.Function.Utils
     ( applyN )
-import Data.Maybe
-    ( isJust )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -203,7 +203,7 @@ spec = do
         it "rStart r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (isJust $ rStart r) "has defined start" $
+                cover 10 (rangeHasLowerBound r) "has defined start" $
                 (((`isWithinRange` r) <$> rStart r) =/= Just False)
                     .&&.
                     (((`isBeforeRange` r) <$> rStart r) =/= Just True)
@@ -211,7 +211,7 @@ spec = do
         it "rEnd r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (isJust $ rEnd r) "has defined end" $
+                cover 10 (rangeHasUpperBound r) "has defined end" $
                 (((`isWithinRange` r) <$> rEnd r) =/= Just False)
                     .&&.
                     (((`isAfterRange` r) <$> rEnd r) =/= Just True)
@@ -219,7 +219,7 @@ spec = do
         it "pred (rStart r) `isBeforeRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (isJust $ rStart r) "has defined start" $
+                cover 10 (rangeHasLowerBound r) "has defined start" $
                 (((`isWithinRange` r) . pred <$> rStart r) =/= Just True)
                     .&&.
                     (((`isBeforeRange` r) . pred <$> rStart r) =/= Just False)
@@ -227,7 +227,7 @@ spec = do
         it "succ (rEnd r) `isAfterRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (isJust $ rEnd r) "has defined end" $
+                cover 10 (rangeHasUpperBound r) "has defined end" $
                 ((`isWithinRange` r) . succ <$> rEnd r) =/= Just True
                     .&&.
                     (((`isAfterRange` r) . succ <$> rEnd r) =/= Just False)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -204,25 +204,33 @@ spec = do
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (isJust $ rStart r) "has defined start" $
-                ((`isWithinRange` r) <$> rStart r) =/= Just False
+                (((`isWithinRange` r) <$> rStart r) =/= Just False)
+                    .&&.
+                    (((`isBeforeRange` r) <$> rStart r) =/= Just True)
 
         it "rEnd r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (isJust $ rEnd r) "has defined end" $
-                ((`isWithinRange` r) <$> rEnd r) =/= Just False
+                (((`isWithinRange` r) <$> rEnd r) =/= Just False)
+                    .&&.
+                    (((`isAfterRange` r) <$> rEnd r) =/= Just True)
 
-        it "not (pred (rStart r) `isWithinRange` r)" $
+        it "pred (rStart r) `isBeforeRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (isJust $ rStart r) "has defined start" $
-                ((`isWithinRange` r) . pred <$> rStart r) =/= Just True
+                (((`isWithinRange` r) . pred <$> rStart r) =/= Just True)
+                    .&&.
+                    (((`isBeforeRange` r) . pred <$> rStart r) =/= Just False)
 
-        it "not (succ (rEnd r) `isWithinRange` r)" $
+        it "succ (rEnd r) `isAfterRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (isJust $ rEnd r) "has defined end" $
                 ((`isWithinRange` r) . succ <$> rEnd r) =/= Just True
+                    .&&.
+                    (((`isAfterRange` r) . succ <$> rEnd r) =/= Just False)
 
         it "a `isWithinRange` wholeRange == True" $
             property $ \(a :: Integer) ->


### PR DESCRIPTION
# Issue Number

None.

# Overview

This PR adds a small set of basic property tests for the `Range` data type.

In addition, it also adds a small set of utility functions. (These functions will be used by a later PR.)