### PR TITLE
Rename `slotStartingAtOrJust{After,Before}` to `slot{Ceiling,Floor}`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -133,11 +133,11 @@ import Cardano.Wallet.Primitive.Types
     , WalletState (..)
     , computeUtxoStatistics
     , log10
+    , slotCeiling
     , slotDifference
+    , slotFloor
     , slotRatio
     , slotStartTime
-    , slotStartingAtOrJustAfter
-    , slotStartingAtOrJustBefore
     , wholeRange
     )
 import Cardano.Wallet.Transaction
@@ -770,8 +770,8 @@ newWalletLayer tracer bp db nw tl = do
         (w, _) <- withExceptT ErrListTransactionsNoSuchWallet $ _readWallet wid
         let tip = currentTip w ^. #slotId
         let range = Range
-                { rStart = slotStartingAtOrJustAfter sp <$> mStart
-                , rEnd = slotStartingAtOrJustBefore sp <$> mEnd
+                { rStart = slotCeiling sp <$> mStart
+                , rEnd = slotFloor sp <$> mEnd
                 }
         liftIO $ assemble tip
             <$> DB.readTxHistory db (PrimaryKey wid) order range

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -82,8 +82,8 @@ module Cardano.Wallet.Primitive.Types
     , flatSlot
     , fromFlatSlot
     , slotStartTime
-    , slotStartingAtOrJustAfter
-    , slotStartingAtOrJustBefore
+    , slotCeiling
+    , slotFloor
     , slotAt
     , slotDifference
     , slotPred
@@ -914,14 +914,14 @@ slotStartTime (SlotParameters el (SlotLength sl) (StartTime st)) slot =
 
 -- | For the given time 't', determine the ID of the earliest slot with start
 --   time 's' such that 't ≤ s'.
-slotStartingAtOrJustAfter :: SlotParameters -> UTCTime -> SlotId
-slotStartingAtOrJustAfter sp@(SlotParameters _ (SlotLength sl) _) t =
+slotCeiling :: SlotParameters -> UTCTime -> SlotId
+slotCeiling sp@(SlotParameters _ (SlotLength sl) _) t =
     slotAt sp (addUTCTime (pred sl) t)
 
 -- | For the given time 't', determine the ID of the latest slot with start
 --   time 's' such that 's ≤ t'.
-slotStartingAtOrJustBefore :: SlotParameters -> UTCTime -> SlotId
-slotStartingAtOrJustBefore = slotAt
+slotFloor :: SlotParameters -> UTCTime -> SlotId
+slotFloor = slotAt
 
 -- | For the given time 't', determine the ID of the unique slot with start
 --   time 's' and end time 'e' such that 's ≤ t ≤ e'.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -54,12 +54,12 @@ import Cardano.Wallet.Primitive.Types
     , restrictedBy
     , restrictedTo
     , slotAt
+    , slotCeiling
     , slotDifference
+    , slotFloor
     , slotPred
     , slotRatio
     , slotStartTime
-    , slotStartingAtOrJustAfter
-    , slotStartingAtOrJustBefore
     , slotSucc
     , walletNameMaxLength
     , walletNameMinLength
@@ -236,34 +236,32 @@ spec = do
                     let f = slotAt sps . slotStartTime sps
                     slot === f slot
 
-        it "slotStartingAtOrJustAfter . slotStartTime == id" $
+        it "slotCeiling . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
-                    let f = slotStartingAtOrJustAfter sps . slotStartTime sps
+                    let f = slotCeiling sps . slotStartTime sps
                     slot === f slot
 
-        it "slotStartingAtOrJustBefore . slotStartTime == id" $
+        it "slotFloor . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
-                    let f = slotStartingAtOrJustBefore sps . slotStartTime sps
+                    let f = slotFloor sps . slotStartTime sps
                     slot === f slot
 
-        it "slotSucc . slotStartingAtOrJustBefore . utcTimePred . slotStartTime\
-            \ == id" $
+        it "slotSucc . slotFloor . utcTimePred . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
                     let f = slotSucc sps
-                            . slotStartingAtOrJustBefore sps
+                            . slotFloor sps
                             . utcTimePred
                             . slotStartTime sps
                     slot === f slot
 
-        it "slotPred . slotStartingAtOrJustAfter . utcTimeSucc . slotStartTime\
-            \ == id" $
+        it "slotPred . slotCeiling . utcTimeSucc . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
                     let f = slotPred sps
-                            . slotStartingAtOrJustAfter sps
+                            . slotCeiling sps
                             . utcTimeSucc
                             . slotStartTime sps
                     Just slot === f slot


### PR DESCRIPTION
# Issue Number

None.

# Overview

The functions `slotStartingAtOrJustAfter` and `slotStartingAtOrJustBefore` are a bit of a mouthful.

The behaviour of these functions is equivalent to finding either the **_ceiling_** or the **_floor_** of a given slot.

Therefore, we rename these functions to **`slotCeiling`** and **`slotFloor`**, respectively.

# Comments

A further PR will correct the behaviour (and type) of `slotFloor` so that it doesn't return a slot when the specified time occurs before the start of the blockchain.