### PR TITLE
Safer slot arithmetic.

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -363,8 +363,8 @@ newDBLayer logConfig trace fp = do
         , readTxHistory = \(PrimaryKey wid) order range ->
               runQuery $
               selectTxHistory @t wid order $ catMaybes
-                [ (TxMetaSlotId >=.) <$> W.rStart range
-                , (TxMetaSlotId <=.) <$> W.rEnd range
+                [ (TxMetaSlotId >=.) <$> W.inclusiveLowerBound range
+                , (TxMetaSlotId <=.) <$> W.inclusiveUpperBound range
                 ]
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -423,9 +423,6 @@ rangeIsFinite r = rangeHasLowerBound r && rangeHasUpperBound r
 rangeIsValid :: Ord a => Range a -> Bool
 rangeIsValid (Range a b) = ((<=) <$> a <*> b) /= Just False
 
--- NOTE: We could imagine replacing 'Range (Just 3) Nothing' with something
--- more magic like: `(Including 3) ... NoBound`
-
 {-------------------------------------------------------------------------------
                                   Stake Pools
 -------------------------------------------------------------------------------}
@@ -874,13 +871,6 @@ computeUtxoStatistics btype utxos =
 
 {-------------------------------------------------------------------------------
                                    Slotting
-
-  Note that we do not define any operation to perform slotting arithmetic of any
-  kind. Instead of manipulating slots, we do simply look them up from the chain,
-  in their corresponding block. This should be probably enough to cover for
-  pretty much all our needs.
-
-  If slotting arithmetic has to be introduced, it will require proper thoughts.
 -------------------------------------------------------------------------------}
 
 -- | A slot identifier is the combination of an epoch and slot.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1017,7 +1017,7 @@ newtype EpochLength = EpochLength Word16
 
 -- | Blockchain start time
 newtype StartTime = StartTime UTCTime
-    deriving (Show, Eq)
+    deriving (Show, Eq, Ord)
 
 {-------------------------------------------------------------------------------
                                 Protocol Magic

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -893,7 +893,7 @@ data SlotParameters = SlotParameters
         :: SlotLength
     , getGenesisBlockDate
         :: StartTime
-    } deriving (Eq, Show)
+    } deriving (Eq, Generic, Show)
 
 -- | Compute the approximate ratio / progress between two slots. This is an
 -- approximation for a few reasons, one of them being that we hard code the

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -370,7 +370,7 @@ instance FromText SortOrder where
 data Range a = Range
     { rStart :: Maybe a
     , rEnd :: Maybe a
-    } deriving (Eq, Show)
+    } deriving (Eq, Functor, Show)
 
 -- | The range that includes everything.
 wholeRange :: Range a

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -354,19 +354,28 @@ instance ToText SortOrder where
 instance FromText SortOrder where
     fromText = fromTextToBoundedEnum SnakeLowerCase
 
--- |'Range a' is used to filter data with optional `>=` and `<=` bounds.
+-- | Represents a range of values.
 --
--- When both bounds are 'Just', it functions like the closed range
--- '[start, end]'. When both bounds are 'Nothing' it functions like
--- '(-∞,∞)', including everything (see 'wholeRange'.)
+-- A range is defined by two /optional/ bounds:
 --
--- The full four interesting cases with the corresponding predicate in the third
--- column:
+-- 1. an /inclusive/ lower bound
+-- 2. an /inclusive/ upper bound
 --
--- - [start, end]  Range (Just start) (Just end)   \x -> x >= start && x <= end
--- - [start,∞)     Range (Just start) Nothing      \x -> x >= start
--- - (-∞,end]      Range Nothing (Just end)        \x -> x <= end
--- - (-∞,∞)        Range Nothing Nothing           \_x -> True
+-- There are four cases:
+--
+-- +---------------------------------+-------------+---------------------------+
+-- | Value                           | Range       | Membership                |
+-- |                                 | Represented | Function                  |
+-- +=================================+=============+===========================+
+-- | @'Range' ('Just' x) ('Just' y)@ | @[ x, y ]@  | @\\p -> p >= x && p <= y@ |
+-- +---------------------------------+-------------+---------------------------+
+-- | @'Range' ('Just' x) 'Nothing' @ | @[ x, ∞ ]@  | @\\p -> p >= x          @ |
+-- +---------------------------------+-------------+---------------------------+
+-- | @'Range' 'Nothing'  ('Just' y)@ | @[−∞, y ]@  | @\\p -> p <= y          @ |
+-- +---------------------------------+-------------+---------------------------+
+-- | @'Range' 'Nothing'  'Nothing' @ | @[−∞, ∞ ]@  | @\\p -> True            @ |
+-- +---------------------------------+-------------+---------------------------+
+--
 data Range a = Range
     { inclusiveLowerBound :: Maybe a
     , inclusiveUpperBound :: Maybe a

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -86,6 +86,7 @@ module Cardano.Wallet.Primitive.Types
     , slotFloor
     , slotAt
     , slotDifference
+    , slotMinBound
     , slotPred
     , slotSucc
     , slotRange
@@ -960,12 +961,16 @@ slotStartTime (SlotParameters el (SlotLength sl) (StartTime st)) slot =
 --   time 's' such that 't ≤ s'.
 slotCeiling :: SlotParameters -> UTCTime -> SlotId
 slotCeiling sp@(SlotParameters _ (SlotLength sl) _) t =
-    fromMaybe (SlotId 0 0) $ slotAt sp (addUTCTime (pred sl) t)
+    fromMaybe slotMinBound $ slotAt sp (addUTCTime (pred sl) t)
 
 -- | For the given time 't', determine the ID of the latest slot with start
 --   time 's' such that 's ≤ t'.
 slotFloor :: SlotParameters -> UTCTime -> Maybe SlotId
 slotFloor = slotAt
+
+-- | Returns the earliest slot.
+slotMinBound :: SlotId
+slotMinBound = SlotId 0 0
 
 -- | For the given time 't', determine the ID of the unique slot with start
 --   time 's' and end time 'e' such that 's ≤ t ≤ e'.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -368,8 +368,8 @@ instance FromText SortOrder where
 -- - (-∞,end]      Range Nothing (Just end)        \x -> x <= end
 -- - (-∞,∞)        Range Nothing Nothing           \_x -> True
 data Range a = Range
-    { rStart :: Maybe a
-    , rEnd :: Maybe a
+    { inclusiveLowerBound :: Maybe a
+    , inclusiveUpperBound :: Maybe a
     } deriving (Eq, Functor, Show)
 
 -- | The range that includes everything.
@@ -398,11 +398,11 @@ isWithinRange x (Range low high) =
 
 -- | Returns 'True' if (and only if) the given range has a lower bound.
 rangeHasLowerBound :: Range a -> Bool
-rangeHasLowerBound = isJust . rStart
+rangeHasLowerBound = isJust . inclusiveLowerBound
 
 -- | Returns 'True' if (and only if) the given range has an upper bound.
 rangeHasUpperBound :: Range a -> Bool
-rangeHasUpperBound = isJust . rEnd
+rangeHasUpperBound = isJust . inclusiveUpperBound
 
 -- | Returns 'True' if (and only if) the given range has both a lower and upper
 --   bound.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -302,7 +302,7 @@ spec = do
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
                     let f = slotAt sps . slotStartTime sps
-                    slot === f slot
+                    Just slot === f slot
 
         it "slotCeiling . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
@@ -314,16 +314,17 @@ spec = do
             withMaxSuccess 1000 $ property $
                 \(sps, slot) -> do
                     let f = slotFloor sps . slotStartTime sps
-                    slot === f slot
+                    Just slot === f slot
 
-        it "slotSucc . slotFloor . utcTimePred . slotStartTime == id" $
+        it "slot > SlotId 0 0 => \
+            \slotSucc . slotFloor . utcTimePred . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
-                \(sps, slot) -> do
-                    let f = slotSucc sps
+                \(sps, slot) -> slot > SlotId 0 0 ==> do
+                    let f = fmap (slotSucc sps)
                             . slotFloor sps
                             . utcTimePred
                             . slotStartTime sps
-                    slot === f slot
+                    Just slot === f slot
 
         it "slotPred . slotCeiling . utcTimeSucc . slotStartTime == id" $
             withMaxSuccess 1000 $ property $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -204,37 +204,37 @@ spec = do
                 cover 10 (a `isAfterRange`  r) "isAfterRange"  $
                 1 === length (filter (\f -> f a r) options)
 
-        it "rStart r `isWithinRange` r" $
+        it "inclusiveLowerBound r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (rangeHasLowerBound r) "has defined start" $
-                (((`isWithinRange` r) <$> rStart r) =/= Just False)
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                (((`isWithinRange` r) <$> inclusiveLowerBound r) =/= Just False)
                     .&&.
-                    (((`isBeforeRange` r) <$> rStart r) =/= Just True)
+                    (((`isBeforeRange` r) <$> inclusiveLowerBound r) =/= Just True)
 
-        it "rEnd r `isWithinRange` r" $
+        it "inclusiveUpperBound r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (rangeHasUpperBound r) "has defined end" $
-                (((`isWithinRange` r) <$> rEnd r) =/= Just False)
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                (((`isWithinRange` r) <$> inclusiveUpperBound r) =/= Just False)
                     .&&.
-                    (((`isAfterRange` r) <$> rEnd r) =/= Just True)
+                    (((`isAfterRange` r) <$> inclusiveUpperBound r) =/= Just True)
 
-        it "pred (rStart r) `isBeforeRange` r" $
+        it "pred (inclusiveLowerBound r) `isBeforeRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (rangeHasLowerBound r) "has defined start" $
-                (((`isWithinRange` r) . pred <$> rStart r) =/= Just True)
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                (((`isWithinRange` r) . pred <$> inclusiveLowerBound r) =/= Just True)
                     .&&.
-                    (((`isBeforeRange` r) . pred <$> rStart r) =/= Just False)
+                    (((`isBeforeRange` r) . pred <$> inclusiveLowerBound r) =/= Just False)
 
-        it "succ (rEnd r) `isAfterRange` r" $
+        it "succ (inclusiveUpperBound r) `isAfterRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
-                cover 10 (rangeHasUpperBound r) "has defined end" $
-                ((`isWithinRange` r) . succ <$> rEnd r) =/= Just True
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                ((`isWithinRange` r) . succ <$> inclusiveUpperBound r) =/= Just True
                     .&&.
-                    (((`isAfterRange` r) . succ <$> rEnd r) =/= Just False)
+                    (((`isAfterRange` r) . succ <$> inclusiveUpperBound r) =/= Just False)
 
         it "a `isWithinRange` wholeRange == True" $
             property $ \(a :: Integer) ->

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -129,7 +129,7 @@ import Test.QuickCheck.Arbitrary.Generic
 import Test.Text.Roundtrip
     ( textRoundtrip )
 import Test.Utils.Time
-    ( genUniformTime )
+    ( genUniformTime, getUniformTime )
 
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -238,6 +238,26 @@ spec = do
                 a `isWithinRange` wholeRange === True
 
     describe "Slot arithmetic" $ do
+
+        it "slotFloor (slotStartTime slotMinBound) == Just slotMinBound" $
+            withMaxSuccess 1000 $ property $ \sps ->
+                slotFloor sps (slotStartTime sps slotMinBound)
+                    === Just slotMinBound
+
+        it "slotFloor (utcTimePred (slotStartTime slotMinBound)) == Nothing" $
+            withMaxSuccess 1000 $ property $ \sps ->
+                slotFloor sps (utcTimePred (slotStartTime sps slotMinBound))
+                    === Nothing
+
+        it "t < slotStartTime slotMinBound => slotFloor t == Nothing" $
+            withMaxSuccess 1000 $ property $ \sps t ->
+                (StartTime $ getUniformTime t) < getGenesisBlockDate sps ==>
+                    slotFloor sps (getUniformTime t) === Nothing
+
+        it "t < slotStartTime slotMinBound => slotCeiling t == slotMinBound" $
+            withMaxSuccess 1000 $ property $ \sps t ->
+                (StartTime $ getUniformTime t) < getGenesisBlockDate sps ==>
+                    slotCeiling sps (getUniformTime t) === slotMinBound
 
         it "applyN (flatSlot slot) slotPred slot == Just slotMinBound" $
             withMaxSuccess 10 $ property $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -66,6 +66,7 @@ import Cardano.Wallet.Primitive.Types
     , slotCeiling
     , slotDifference
     , slotFloor
+    , slotMinBound
     , slotPred
     , slotRatio
     , slotStartTime
@@ -238,11 +239,11 @@ spec = do
 
     describe "Slot arithmetic" $ do
 
-        it "applyN (flatSlot slot) slotPred slot == Just (fromFlatSlot 0)" $
+        it "applyN (flatSlot slot) slotPred slot == Just slotMinBound" $
             withMaxSuccess 10 $ property $
                 \(sps, slot) -> do
                     let n = flatSlot (getEpochLength sps) slot
-                    Just (fromFlatSlot (getEpochLength sps) 0) ===
+                    Just slotMinBound ===
                         applyN n (slotPred sps =<<) (Just slot)
 
         it "applyN (flatSlot slot + 1) slotPred slot == Nothing" $
@@ -316,10 +317,10 @@ spec = do
                     let f = slotFloor sps . slotStartTime sps
                     Just slot === f slot
 
-        it "slot > SlotId 0 0 => \
+        it "slot > slotMinBound => \
             \slotSucc . slotFloor . utcTimePred . slotStartTime == id" $
             withMaxSuccess 1000 $ property $
-                \(sps, slot) -> slot > SlotId 0 0 ==> do
+                \(sps, slot) -> slot > slotMinBound ==> do
                     let f = fmap (slotSucc sps)
                             . slotFloor sps
                             . utcTimePred

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -721,6 +721,10 @@ instance Arbitrary StartTime where
 instance Arbitrary EpochLength where
     arbitrary = EpochLength . getNonZero <$> arbitrary
 
+instance Arbitrary SlotParameters where
+    arbitrary = SlotParameters <$> arbitrary <*> arbitrary <*> arbitrary
+    shrink = genericShrink
+
 instance {-# OVERLAPS #-} Arbitrary (SlotParameters, SlotId) where
     arbitrary = do
         (el, slot) <- arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -68,6 +68,7 @@ import Cardano.Wallet.Primitive.Types
     , slotFloor
     , slotMinBound
     , slotPred
+    , slotRange
     , slotRatio
     , slotStartTime
     , slotSucc
@@ -87,6 +88,8 @@ import Data.Function
     ( (&) )
 import Data.Function.Utils
     ( applyN )
+import Data.Maybe
+    ( isNothing )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -258,6 +261,13 @@ spec = do
             withMaxSuccess 1000 $ property $ \sps t ->
                 (StartTime $ getUniformTime t) < getGenesisBlockDate sps ==>
                     slotCeiling sps (getUniformTime t) === slotMinBound
+
+        it "slotStartTime slotMinBound `isAfterRange` r => \
+            \isNothing (slotRange r)" $
+            withMaxSuccess 1000 $ property $ \sps r -> do
+                let r' = getUniformTime <$> r
+                slotStartTime sps slotMinBound `isAfterRange` r' ==>
+                    isNothing (slotRange sps r')
 
         it "applyN (flatSlot slot) slotPred slot == Just slotMinBound" $
             withMaxSuccess 10 $ property $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -204,37 +204,33 @@ spec = do
                 cover 10 (a `isAfterRange`  r) "isAfterRange"  $
                 1 === length (filter (\f -> f a r) options)
 
+        it "pred (inclusiveLowerBound r) `isBeforeRange` r" $
+            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                ((`isBeforeRange` r) . pred <$> inclusiveLowerBound r)
+                    =/= Just False
+
         it "inclusiveLowerBound r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
-                (((`isWithinRange` r) <$> inclusiveLowerBound r) =/= Just False)
-                    .&&.
-                    (((`isBeforeRange` r) <$> inclusiveLowerBound r) =/= Just True)
+                ((`isWithinRange` r) <$> inclusiveLowerBound r)
+                    =/= Just False
 
         it "inclusiveUpperBound r `isWithinRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $
-                (((`isWithinRange` r) <$> inclusiveUpperBound r) =/= Just False)
-                    .&&.
-                    (((`isAfterRange` r) <$> inclusiveUpperBound r) =/= Just True)
-
-        it "pred (inclusiveLowerBound r) `isBeforeRange` r" $
-            withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
-                checkCoverage $
-                cover 10 (rangeHasLowerBound r) "has lower bound" $
-                (((`isWithinRange` r) . pred <$> inclusiveLowerBound r) =/= Just True)
-                    .&&.
-                    (((`isBeforeRange` r) . pred <$> inclusiveLowerBound r) =/= Just False)
+                ((`isWithinRange` r) <$> inclusiveUpperBound r)
+                    =/= Just False
 
         it "succ (inclusiveUpperBound r) `isAfterRange` r" $
             withMaxSuccess 1000 $ property $ \(r :: Range Integer) ->
                 checkCoverage $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $
-                ((`isWithinRange` r) . succ <$> inclusiveUpperBound r) =/= Just True
-                    .&&.
-                    (((`isAfterRange` r) . succ <$> inclusiveUpperBound r) =/= Just False)
+                ((`isAfterRange` r) . succ <$> inclusiveUpperBound r)
+                    =/= Just False
 
         it "a `isWithinRange` wholeRange == True" $
             property $ \(a :: Integer) ->


### PR DESCRIPTION
# Issue Number

#466 

# Overview

This change makes `slotAt` return `Nothing` if the given time isn't covered by a slot. Thus `slotAt` is prevented from creating an invalid `SlotId` that occurs before the start of the blockchain.
    
In addition:
    
* Function `slotFloor` now returns `Nothing` if the specified time occurs before the start of the blockchain.
* Function `slotCeiling` now returns the genesis slot if the specified time occurs before the start of the blockchain.
* We provide a new function `slotRange` that converts an inclusive time range into an inclusive slot range, returning `Nothing` if the range ends before the start of the blockchain.
* We use `slotRange` in the implementation of `listTransactions`.