### PR TITLE
Extract http-bridge integration tests to separate travis job to overcome 50min time limit for a job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,10 +197,19 @@ jobs:
 
   - stage: checks 🔬
     if: (type != pull_request AND branch = master) OR (tag =~ ^v)
-    name: "Tests"
+    name: "Tests (http-bridge)"
     script:
     - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.5/hermes-testnet.tar.gz | tar xz -C $HOME
 
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge --ta "--skip MERGE_DISABLED"
+    - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
+
+    - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
+
+  - stage: checks 🔬
+    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    name: "Tests"
+    script:
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-core
     - mkdir -p .coverage/core && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/core \;
 
@@ -215,9 +224,6 @@ jobs:
 
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage bech32
     - mkdir -p .coverage/bech32 && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/bech32 \;
-
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge --ta "--skip MERGE_DISABLED"
-    - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
 
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr --ta "--skip MERGE_DISABLED"
     - mkdir -p .coverage/jormungandr && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/jormungandr \;


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have extracted http-bridge integration tests to separate travis job


# Comments

It seems that tests added in #608 are causing _Test_ travis jobs go beyond the 50 minutes time limit on merges to master (https://travis-ci.org/input-output-hk/cardano-wallet/builds/574426866). I extracted http-bridge integration to separate job to, hopefully, overcome this.

:warning: I don't know how it will affect coverage. I suppose having all tests in one job was for a reason, so it may be that coverage for http-bridge from integration tests will not be counted in :warning:


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
