### PR TITLE
Provide `isSubrangeOf` function for values of type `Range`.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -242,16 +242,16 @@ spec = do
                 a `isWithinRange` wholeRange === True
 
         it "rangeIsSingleton (Range a a)" $
-            property $ \(a :: Integer) ->
+            property $ \(a :: Int) ->
                 Range (Just a) (Just a) `shouldSatisfy` rangeIsSingleton
 
         it "not (rangeIsSingleton (Range (pred a) a))" $
-            property $ \(a :: Integer) ->
+            property $ \(a :: Int) ->
                 Range (Just (pred a)) (Just a)
                     `shouldNotSatisfy` rangeIsSingleton
 
         it "not (rangeIsSingleton (Range a (succ a)))" $
-            property $ \(a :: Integer) ->
+            property $ \(a :: Int) ->
                 Range (Just a) (Just (succ a))
                     `shouldNotSatisfy` rangeIsSingleton
 
@@ -262,11 +262,11 @@ spec = do
                 (rangeLowerBound r == rangeUpperBound r) === rangeIsSingleton r
 
         it "r `isSubrangeOf` r" $
-            property $ \(r :: Range Integer) ->
+            property $ \(r :: Range Int) ->
                 r `isSubrangeOf` r
 
         it "Range (succ a) b `isSubrangeOf` Range a b" $
-            property $ \r@(Range a b :: Range Integer) ->
+            property $ \r@(Range a b :: Range Int) ->
                 not (rangeIsSingleton r) ==>
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
@@ -275,7 +275,7 @@ spec = do
                 Range (succ <$> a) b `isSubrangeOf` Range a b
 
         it "Range a (pred b) `isSubrangeOf` Range a b" $
-            property $ \r@(Range a b :: Range Integer) ->
+            property $ \r@(Range a b :: Range Int) ->
                 not (rangeIsSingleton r) ==>
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
@@ -284,7 +284,7 @@ spec = do
                 Range a (pred <$> b) `isSubrangeOf` Range a b
 
         it "Range a b `isSubrangeOf` Range (pred a) b" $
-            property $ \r@(Range a b :: Range Integer) ->
+            property $ \r@(Range a b :: Range Int) ->
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $
@@ -292,7 +292,7 @@ spec = do
                 Range a b `isSubrangeOf` Range (pred <$> a) b
 
         it "Range a b `isSubrangeOf` Range a (succ b)" $
-            property $ \r@(Range a b :: Range Integer) ->
+            property $ \r@(Range a b :: Range Int) ->
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $
@@ -302,15 +302,15 @@ spec = do
     describe "Range bounds" $ do
 
         it "NegativeInfinity < InclusiveBound a" $
-            property $ \(a :: Integer) ->
+            property $ \(a :: Int) ->
                 NegativeInfinity < InclusiveBound a
 
         it "InclusiveBound a < PositiveInfinity" $
-            property $ \(a :: Integer) ->
+            property $ \(a :: Int) ->
                 InclusiveBound a < PositiveInfinity
 
         it "compare (InclusiveBound a) (InclusiveBound b) = compare a b" $
-            property $ \(a :: Integer) (b :: Integer) ->
+            property $ \(a :: Int) (b :: Int) ->
                 compare (InclusiveBound a) (InclusiveBound b) === compare a b
 
     describe "Slot arithmetic" $ do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -265,6 +265,14 @@ spec = do
             property $ \(r :: Range Int) ->
                 r `isSubrangeOf` r
 
+        it "r `isSubrangeOf` wholeRange" $
+            property $ \(r :: Range Int) ->
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                cover 10 (rangeIsFinite      r) "is finite" $
+                r `isSubrangeOf` wholeRange
+
         it "Range (succ a) b `isSubrangeOf` Range a b" $
             property $ \r@(Range a b :: Range Int) ->
                 not (rangeIsSingleton r) ==>

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , HistogramBar (..)
     , Range (..)
+    , RangeBound (..)
     , ShowFmt (..)
     , SlotId (..)
     , SlotLength (..)
@@ -53,13 +54,17 @@ import Cardano.Wallet.Primitive.Types
     , fromFlatSlot
     , isAfterRange
     , isBeforeRange
+    , isSubrangeOf
     , isSubsetOf
     , isValidCoin
     , isWithinRange
     , rangeHasLowerBound
     , rangeHasUpperBound
     , rangeIsFinite
+    , rangeIsSingleton
     , rangeIsValid
+    , rangeLowerBound
+    , rangeUpperBound
     , restrictedBy
     , restrictedTo
     , slotAt
@@ -105,7 +110,7 @@ import Data.Time.Utils
 import Fmt
     ( pretty )
 import Test.Hspec
-    ( Spec, describe, it )
+    ( Spec, describe, it, shouldNotSatisfy, shouldSatisfy )
 import Test.QuickCheck
     ( Arbitrary (..)
     , NonNegative (..)
@@ -235,6 +240,78 @@ spec = do
         it "a `isWithinRange` wholeRange == True" $
             property $ \(a :: Integer) ->
                 a `isWithinRange` wholeRange === True
+
+        it "rangeIsSingleton (Range a a)" $
+            property $ \(a :: Integer) ->
+                Range (Just a) (Just a) `shouldSatisfy` rangeIsSingleton
+
+        it "not (rangeIsSingleton (Range (pred a) a))" $
+            property $ \(a :: Integer) ->
+                Range (Just (pred a)) (Just a)
+                    `shouldNotSatisfy` rangeIsSingleton
+
+        it "not (rangeIsSingleton (Range a (succ a)))" $
+            property $ \(a :: Integer) ->
+                Range (Just a) (Just (succ a))
+                    `shouldNotSatisfy` rangeIsSingleton
+
+        it "rangeLowerBound r = rangeUpperBound r <=> rangeIsSingleton r" $
+            property $ \(r :: Range Bool) ->
+                checkCoverage $
+                cover 10 (rangeIsFinite r) "is finite" $
+                (rangeLowerBound r == rangeUpperBound r) === rangeIsSingleton r
+
+        it "r `isSubrangeOf` r" $
+            property $ \(r :: Range Integer) ->
+                r `isSubrangeOf` r
+
+        it "Range (succ a) b `isSubrangeOf` Range a b" $
+            property $ \r@(Range a b :: Range Integer) ->
+                not (rangeIsSingleton r) ==>
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                cover 10 (rangeIsFinite      r) "is finite" $
+                Range (succ <$> a) b `isSubrangeOf` Range a b
+
+        it "Range a (pred b) `isSubrangeOf` Range a b" $
+            property $ \r@(Range a b :: Range Integer) ->
+                not (rangeIsSingleton r) ==>
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                cover 10 (rangeIsFinite      r) "is finite" $
+                Range a (pred <$> b) `isSubrangeOf` Range a b
+
+        it "Range a b `isSubrangeOf` Range (pred a) b" $
+            property $ \r@(Range a b :: Range Integer) ->
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                cover 10 (rangeIsFinite      r) "is finite" $
+                Range a b `isSubrangeOf` Range (pred <$> a) b
+
+        it "Range a b `isSubrangeOf` Range a (succ b)" $
+            property $ \r@(Range a b :: Range Integer) ->
+                checkCoverage $
+                cover 10 (rangeHasLowerBound r) "has lower bound" $
+                cover 10 (rangeHasUpperBound r) "has upper bound" $
+                cover 10 (rangeIsFinite      r) "is finite" $
+                Range a b `isSubrangeOf` Range a (succ <$> b)
+
+    describe "Range bounds" $ do
+
+        it "NegativeInfinity < InclusiveBound a" $
+            property $ \(a :: Integer) ->
+                NegativeInfinity < InclusiveBound a
+
+        it "InclusiveBound a < PositiveInfinity" $
+            property $ \(a :: Integer) ->
+                InclusiveBound a < PositiveInfinity
+
+        it "compare (InclusiveBound a) (InclusiveBound b) = compare a b" $
+            property $ \(a :: Integer) (b :: Integer) ->
+                compare (InclusiveBound a) (InclusiveBound b) === compare a b
 
     describe "Slot arithmetic" $ do
 


### PR DESCRIPTION
# Issue Number

Indirectly related to #466.

Provides support for #652.

# Overview

This PR provides the `isSubrangeOf` function for values of type `Range`. This function allows us to conveniently express testable properties of our `Range UTCTime` -> `Range SlotId` functions.