### PR TITLE
Make DBLayer state machine tests polymorphic on AD state

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Primitive.AddressDerivation.Random
     , unsafeGenerateKeyFromSeed
     , generateKeyFromSeed
     , minSeedLengthBytes
+    , nullKey
 
       -- * Derivation
     , deriveAccountPrivateKey
@@ -313,6 +314,14 @@ deserializeXPrvRnd (k, h) = (,)
   where
     rootKeyFromText = deserializeKey xprv
     mkKey (key, pwd) = RndKey key () pwd
+
+-- | A root key of all zeroes that is used when restoring 'RndState' from the
+-- database before a root key has been saved.
+nullKey :: RndKey 'RootK XPrv
+nullKey = RndKey k () pwd
+  where
+    Right k = xprv $ B8.replicate 128 '\0'
+    pwd = Passphrase (BA.convert $ B8.replicate 32 '\0')
 
 {-------------------------------------------------------------------------------
                                      Utils

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -92,6 +92,12 @@ data RndState target = RndState
 instance NFData (RndState target) where
     rnf (RndState !_ !_ !_ !_ g) = seq (show g) ()
 
+instance Show (RndState target) where
+    show (RndState _key ix addrs pending g) = unwords
+        [ "RndState <xprv>", p ix, p addrs, p pending, p g ]
+      where
+        p x = "(" ++ show x ++ ")"
+
 -- | Shortcut type alias for HD random address derivation path.
 type DerivationPath = (Index 'Hardened 'AccountK, Index 'Hardened 'AddressK)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -7,8 +7,6 @@
 
 module Cardano.Wallet.Primitive.AddressDerivationSpec
     ( spec
-    , genRootKeysSeq
-    , genRootKeysRnd
     ) where
 
 import Prelude

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/CompatibilitySpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/CompatibilitySpec.hs
@@ -207,9 +207,6 @@ instance Eq (RndState t) where
     (RndState k1 accIx1 _ _ _) == (RndState k2 accIx2 _ _ _) =
         getKey k1 == getKey k2 && accIx1 == accIx2
 
-instance Show (RndState t) where
-    show (RndState key _ _ _ _) = show (getKey key)
-
 instance Show XPrv where
     show = show . unXPrv
 


### PR DESCRIPTION
Relates to #621 

# Overview

Lets the DBLayer state machine tests work with RndState as well as SeqState, so that the PersistState functions get covered by tests.

