### PR TITLE
Add property for `slotRangeFromTimeRange`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -134,7 +134,7 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
     , slotDifference
-    , slotRange
+    , slotRangeFromTimeRange
     , slotRatio
     , slotStartTime
     , wholeRange
@@ -778,7 +778,7 @@ newWalletLayer tracer bp db nw tl = do
                 let err = ErrStartTimeLaterThanEndTime start end
                 throwE (ErrListTransactionsStartTimeLaterThanEndTime err)
             _ ->
-                pure $ slotRange sp $ Range mStart mEnd
+                pure $ slotRangeFromTimeRange sp $ Range mStart mEnd
 
         listTransactionsWithinRange
             :: Range SlotId -> ExceptT ErrListTransactions IO [TransactionInfo]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -116,6 +116,8 @@ module Cardano.Wallet.Primitive.Types
     , isBeforeRange
     , isSubrangeOf
     , isWithinRange
+    , mapRangeLowerBound
+    , mapRangeUpperBound
     , rangeIsFinite
     , rangeIsSingleton
     , rangeIsValid
@@ -385,6 +387,14 @@ data Range a = Range
     { inclusiveLowerBound :: Maybe a
     , inclusiveUpperBound :: Maybe a
     } deriving (Eq, Functor, Show)
+
+-- | Apply a function to the lower bound of a range.
+mapRangeLowerBound :: (a -> a) -> Range a -> Range a
+mapRangeLowerBound f (Range x y) = Range (f <$> x) y
+
+-- | Apply a function to the upper bound of a range.
+mapRangeUpperBound :: (a -> a) -> Range a -> Range a
+mapRangeUpperBound f (Range x y) = Range x (f <$> y)
 
 -- | Represents a range boundary.
 data RangeBound a

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -89,7 +89,7 @@ module Cardano.Wallet.Primitive.Types
     , slotMinBound
     , slotPred
     , slotSucc
-    , slotRange
+    , slotRangeFromTimeRange
 
     -- * Wallet Metadata
     , WalletMetadata(..)
@@ -1029,8 +1029,10 @@ slotAt (SlotParameters (EpochLength el) (SlotLength sl) (StartTime st)) t
 -- If, on the other hand, the specified time range terminates before the start
 -- of the blockchain, this function returns 'Nothing'.
 --
-slotRange :: SlotParameters -> Range UTCTime -> Maybe (Range SlotId)
-slotRange sps (Range mStart mEnd) = Range slotStart <$> slotEnd
+slotRangeFromTimeRange
+    :: SlotParameters -> Range UTCTime -> Maybe (Range SlotId)
+slotRangeFromTimeRange sps (Range mStart mEnd) =
+    Range slotStart <$> slotEnd
   where
     slotStart =
         slotCeiling sps <$> mStart

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -474,6 +474,8 @@ spec = do
                     slotSucc' = slotSucc sps
                 in
                 checkCoverage $
+                cover 20 (isNothing maybeSlotRange)
+                    "have no slot range" $
                 cover 50 (isJust maybeSlotRange)
                     "have slot range" $
                 cover 20 (fmap rangeHasLowerBound maybeSlotRange == Just True)
@@ -485,7 +487,9 @@ spec = do
 
                 case maybeSlotRange of
                     Nothing ->
-                        property True
+                        (Just True ===
+                            ((< getGenesisBlockDate sps) . StartTime
+                                <$> inclusiveUpperBound timeRange))
                     Just slotRange ->
                         (slotRange `startsWithin` timeRange
                             === True)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -491,16 +491,20 @@ spec = do
                             ((< getGenesisBlockDate sps) . StartTime
                                 <$> inclusiveUpperBound timeRange))
                     Just slotRange ->
-                        (slotRange `startsWithin` timeRange
-                            === True)
+                        -- Rule 1: Slot range is within specified time range:
+                        (slotRange `startsWithin` timeRange)
                         .&&.
-                        (lowerBoundPred slotRange `startsWithin` timeRange
-                            === (not (rangeHasLowerBound slotRange)
-                                || lowerBoundPred slotRange == slotRange))
+                        -- Rule 2: Slot range lower bound is minimal:
+                        (not (lowerBoundPred slotRange `startsWithin` timeRange)
+                            -- Exceptions to the rule:
+                            || not (rangeHasLowerBound slotRange)
+                            || lowerBoundPred slotRange == slotRange)
                         .&&.
-                        (upperBoundSucc slotRange `startsWithin` timeRange
-                            === (not (rangeHasUpperBound slotRange)
-                                || upperBoundSucc slotRange == slotRange))
+                        -- Rule 3: Slot range upper bound is maximal:
+                        (not (upperBoundSucc slotRange `startsWithin` timeRange)
+                            -- Exceptions to the rule:
+                            || not (rangeHasUpperBound slotRange)
+                            || upperBoundSucc slotRange == slotRange)
 
     describe "Negative cases for types decoding" $ do
         it "fail fromText @AddressState \"unusedused\"" $ do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -73,7 +73,7 @@ import Cardano.Wallet.Primitive.Types
     , slotFloor
     , slotMinBound
     , slotPred
-    , slotRange
+    , slotRangeFromTimeRange
     , slotRatio
     , slotStartTime
     , slotSucc
@@ -344,11 +344,11 @@ spec = do
                     slotCeiling sps (getUniformTime t) === slotMinBound
 
         it "slotStartTime slotMinBound `isAfterRange` r => \
-            \isNothing (slotRange r)" $
+            \isNothing (slotRangeFromTimeRange r)" $
             withMaxSuccess 1000 $ property $ \sps r -> do
                 let r' = getUniformTime <$> r
                 slotStartTime sps slotMinBound `isAfterRange` r' ==>
-                    isNothing (slotRange sps r')
+                    isNothing (slotRangeFromTimeRange sps r')
 
         it "applyN (flatSlot slot) slotPred slot == Just slotMinBound" $
             withMaxSuccess 10 $ property $


### PR DESCRIPTION
# Issue Number

#466 

# Overview

When `slotRangeFromTimeRange` is given a time range `timeRange`, it should produce a slot range `slotRange` such that:

* `fmap slotStartTime slotRange ⊆ timeRange`
* `fmap slotStartTime (lowerBoundPred slotRange) ⊄ timeRange`
* `fmap slotStartTime (upperBoundSucc slotRange) ⊄ timeRange`

Where:

* `lowerBoundPred` decreases the lower bound of a slot range by one slot.
* `upperBoundSucc` increases the upper bound of a slot range by one slot.