### PR TITLE
Track block height in `Wallet` checkpoints

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -100,6 +100,7 @@ import Cardano.Wallet.Primitive.Model
     ( Wallet
     , applyBlocks
     , availableUTxO
+    , blockHeight
     , currentTip
     , getPending
     , getState
@@ -699,6 +700,9 @@ newWalletLayer tracer bp db nw tl = do
             liftIO $ logInfo t $ nPending ||+" transaction(s) pending."
             liftIO $ logInfo t $
                 length txs ||+ " new transaction(s) discovered."
+            let (Quantity bh) = blockHeight cp'
+            liftIO $ logInfo t $
+                "block height is "+||bh||+""
             unless (null txs) $ liftIO $ logDebug t $
                 pretty $ blockListF (snd <$> Map.elems txs)
             DB.putCheckpoint db (PrimaryKey wid) cp'

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -30,7 +30,7 @@ import Data.Text
 import Data.Time.Clock
     ( UTCTime )
 import Data.Word
-    ( Word32 )
+    ( Word32, Word64 )
 import Database.Persist.TH
     ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
 import GHC.Generics
@@ -127,6 +127,7 @@ Checkpoint
     checkpointWalletId    W.WalletId  sql=wallet_id
     checkpointSlot        W.SlotId    sql=slot
     checkpointParent      BlockId     sql=parent
+    checkpointBlock       Word64      sql=block_height
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet fk_wallet_checkpoint checkpointWalletId

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -141,7 +141,7 @@ data Wallet s t where
         -> Set (Tx t, TxMeta) -- Pending outgoing transactions
         -> BlockHeader -- Header of the latest applied block (current tip)
         -> s -- Address discovery state
-        -> Quantity "block" Natural
+        -> Quantity "block" Natural -- block height
         -> Wallet s t
 
 deriving instance Show (Wallet s t)
@@ -288,6 +288,9 @@ getPending :: Wallet s t -> Set (Tx t, TxMeta)
 getPending (Wallet _ pending _ _ _) = pending
 
 -- | Get the block height of the chain.
+--
+-- A new wallet from 'initWallet' (which already has the genesis block applied)
+-- has a block height of 0.
 blockHeight :: Wallet s t -> Quantity "block" Natural
 blockHeight (Wallet _ _ _ _ bh) = bh
 

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -320,6 +320,8 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
             (Hash $ label "prevBlockHash" i)
         )
         initDummyState
+        (Quantity $ fromIntegral i)
+
     utxo = Map.fromList $ zip (mkInputs utxoSize) (mkOutputs utxoSize)
 
 ----------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -109,7 +109,7 @@ spec = do
         it "applyBlock moves the current tip forward"
             (property prop_applyBlockCurrentTip)
 
-        it "Wallet starts with a block height of 0" $
+        it "Wallet starts with a block height of 0"
             (property prop_initialBlockHeight)
 
         it "applyBlock increases the blockHeight"
@@ -184,10 +184,11 @@ prop_applyBlockCurrentTip (ApplyBlock s _ b) =
 -- | applyBlock updates the block height
 prop_applyBlockBlockHeight :: ApplyBlock -> Property
 prop_applyBlockBlockHeight (ApplyBlock s _ b) =
-    property $ blockHeight wallet' > blockHeight wallet
+    property $ blockHeight wallet' === mapQuantity (+1) (blockHeight wallet)
   where
     wallet = initWallet @_ @DummyTarget block0 s
     wallet' = snd $ applyBlock b wallet
+    mapQuantity f (Quantity a) = Quantity $ f a
 
 prop_initialBlockHeight :: WalletState -> Property
 prop_initialBlockHeight s =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -20,6 +20,7 @@ import Cardano.Wallet.Primitive.Model
     ( applyBlock
     , applyBlocks
     , availableBalance
+    , blockHeight
     , currentTip
     , getState
     , initWallet
@@ -57,6 +58,8 @@ import Data.Bifunctor
     ( bimap )
 import Data.Maybe
     ( catMaybes )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Set
     ( Set, (\\) )
 import Data.Traversable
@@ -103,8 +106,14 @@ spec = do
         it "Incoming transactions have output addresses that belong to the wallet"
             (property prop_applyBlockTxHistoryIncoming)
 
-        it "Apply Block move the current tip forward"
+        it "applyBlock moves the current tip forward"
             (property prop_applyBlockCurrentTip)
+
+        it "Wallet starts with a block height of 0" $
+            (property prop_initialBlockHeight)
+
+        it "applyBlock increases the blockHeight"
+            (property prop_applyBlockBlockHeight)
 
 
 {-------------------------------------------------------------------------------
@@ -171,6 +180,20 @@ prop_applyBlockCurrentTip (ApplyBlock s _ b) =
   where
     wallet = initWallet @_ @DummyTarget block0 s
     wallet' = snd $ applyBlock b wallet
+
+-- | applyBlock updates the block height
+prop_applyBlockBlockHeight :: ApplyBlock -> Property
+prop_applyBlockBlockHeight (ApplyBlock s _ b) =
+    property $ blockHeight wallet' > blockHeight wallet
+  where
+    wallet = initWallet @_ @DummyTarget block0 s
+    wallet' = snd $ applyBlock b wallet
+
+prop_initialBlockHeight :: WalletState -> Property
+prop_initialBlockHeight s =
+    property $ blockHeight wallet === Quantity 0
+  where
+    wallet = initWallet @_ @DummyTarget block0 s
 
 {-------------------------------------------------------------------------------
                Basic Model - See Wallet Specification, section 3


### PR DESCRIPTION
# Issue Number

#640

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have extended `Wallet` to contain the chain height as a `Quantity "block" Natural`
- [x] I have stored it in the Sqlite database as a `Word64`
- [x] I log the block height in `restoreBlocks`
- [x] I have added two property test in `ModelSpec` that states the block height starts at 0 and increases by 1 on each `applyBlock`


# Comments
- ~Terminology: chain height vs block height?~ Block height seems to be the accepted term indeed

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
