### PR TITLE
Add descriptions and update statuses on Transaction endpoints in spec

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -330,7 +330,7 @@ spec = do
                      , TxOut destAddr (Coin (fromIntegral toSend))]
         let inps = fmap (second coin) myRnps
         let block0H = unsafeFromHex
-                "dba597bee5f0987efbf56f6bd7f44c38158a7770d0cb28a26b5eca40613a7ebd"
+                "301b1c634aa7b586da7243dd66a61bde904bc1755e9a20a9b5b1b0064e70d904"
         let bs = block0H <> getHash (signData inps txOuts)
         let (Just result) = isOwned st' (rootXPrv, pwd) addrD
         let wits = [sign bs result]

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -969,7 +969,9 @@ paths:
       tags: ["Transactions"]
       summary: List
       description: |
-        <p align="right">status: <strong>not implemented</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
+
+        Lists all incoming and outgoing wallet's transactions.
       parameters:
         - *parametersWalletId
         - in: query
@@ -1014,6 +1016,8 @@ paths:
       summary: Create
       description: |
         <p align="right">status: <strong>stable</strong></p>
+
+        Create and send transaction from the wallet.
       parameters:
         - *parametersWalletId
         - <<: *parametersBody
@@ -1027,11 +1031,27 @@ paths:
       summary: Estimate
       description: |
         <p align="right">status: <strong>stable</strong></p>
+
+        Estimate fee for the transaction.
       parameters:
         - *parametersWalletId
         - <<: *parametersBody
           schema: *ApiPostTransactionFeeData
       responses: *responsesPostTransactionFee
+
+  /external-transactions:
+    post:
+      operationId: postExternalTransaction
+      tags: ["Transactions"]
+      summary: Send External Transaction
+      description: |
+        <p align="right">status: <strong>experimental</strong></p>
+
+        Send transaction created and signed outside of the wallet.
+      parameters:
+        - <<: *parametersBody
+          schema: *ApiPostExternalTransactionData
+      responses: *responsesPostExternalTransaction
 
   /wallets/{walletId}/addresses:
     get:
@@ -1052,19 +1072,6 @@ paths:
             - unused
           description: An optional filter on the address state.
       responses: *responsesListAddresses
-
-  /external-transactions:
-    post:
-      operationId: postExternalTransaction
-      tags: ["Transactions"]
-      summary: Send
-      description: |
-        <p align="right">status: <strong>stable</strong></p>
-      parameters:
-        - <<: *parametersBody
-          schema: *ApiPostExternalTransactionData
-      responses: *responsesPostExternalTransaction
-
 
   /stake-pools:
     get:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added descriptions to Transaction endpoints and updated their statuses (e.g. List tx was still `not implemented`)


# Comments
It was confusing to see "Create" and "Send" endpoints on the list next to each other, which implicated that one is used to `create` and other to `send` tx. I changed "Send" to be "Send External Transaction" and added descriptions to make everything more clear.
