### PR TITLE
Make `applyBlocks` return a list of incrementally-updated wallet states.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -203,6 +203,7 @@ import qualified Cardano.Wallet.DB as DB
 import qualified Cardano.Wallet.Primitive.CoinSelection.Random as CoinSelection
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -689,7 +690,7 @@ newWalletLayer tracer bp db nw tl = do
             let (h,q) = first (filter nonEmpty) $
                     splitAt (length blocks - 1) blocks
             liftIO $ logDebug t $ pretty (h ++ q)
-            let (txs, cp') = applyBlocks @s @t (h ++ q) cp
+            let (txs, cp') = NE.last $ applyBlocks @s @t (h ++ q) cp
             let progress = slotRatio epochLength sup tip
             let status' = if progress == maxBound
                     then Ready

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -166,7 +166,7 @@ prop_applyBlockTxHistoryIncoming s =
     property (outs (filter isIncoming txs) `overlaps` ourAddresses s')
   where
     cp0 = initWallet @_ @DummyTarget block0 s
-    (txs, s') = bimap Map.elems getState $ applyBlocks blockchain cp0
+    (txs, s') = bimap Map.elems getState $ NE.last $ applyBlocks blockchain cp0
     isIncoming (_, m) = direction m == Incoming
     outs = Set.fromList . concatMap (map address . outputs . fst)
     overlaps a b


### PR DESCRIPTION
# Issue Number

#639 

# Overview

This PR is a refactoring: it adjusts the `applyBlocks` function so that it returns a list of incrementally-updated wallet states.

The list returned is _non-empty_, where:

* the _initial element_ is the original wallet state;                                                                                                                         
* each _successive element_ is the result of applying the next available unprocessed block from the original list to the previous element; 
* the _final element_ is the state obtained by applying all blocks from the specified list, in order, to the original wallet state.

Callers of `applyBlocks` now obtain the final state by applying `Data.NonEmpty.last` to the returned list.

# Comments

A future PR will adjust `restoreBlocks` so that it calls `DB.putCheckpoint`  once per checkpoint.