### PR TITLE
Use `safe` library function `tailSafe` instead of locally-defined `tailOrEmpty`.

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -49,6 +49,7 @@ library
     , http-client
     , http-types
     , memory
+    , safe
     , servant
     , servant-client
     , servant-client-core

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -89,6 +89,8 @@ import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Network.HTTP.Types.Status
     ( status400 )
+import Safe
+    ( tailSafe )
 import Servant.API
     ( (:<|>) (..) )
 import Servant.Client
@@ -141,7 +143,7 @@ mkNetworkLayer j = NetworkLayer
         -- Get the descendants of the tip's /parent/.
         -- The first descendant is therefore the current tip itself. We need to
         -- skip it. Hence the 'tail'.
-        ids <- tailOrEmpty <$> getDescendantIds j (prevBlockHash tip) count
+        ids <- tailSafe <$> getDescendantIds j (prevBlockHash tip) count
                 `mappingError` \case
             ErrGetDescendantsNetworkUnreachable e ->
                 ErrGetBlockNetworkUnreachable e
@@ -164,9 +166,6 @@ mkNetworkLayer j = NetworkLayer
     }
   where
     mappingError = flip withExceptT
-
-    tailOrEmpty [] = []
-    tailOrEmpty (_:xs) = xs
 
 {-------------------------------------------------------------------------------
                             Jormungandr Client

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -38,6 +38,7 @@
           (hsPkgs.http-client)
           (hsPkgs.http-types)
           (hsPkgs.memory)
+          (hsPkgs.safe)
           (hsPkgs.servant)
           (hsPkgs.servant-client)
           (hsPkgs.servant-client-core)


### PR DESCRIPTION
# Issue Number

None. But spotted while looking at issue #674. 

# Overview

This replaces a hand-written function with a function from the `safe` library (which we already use elsewhere).