### PR TITLE
Review CI job execution and bors settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ stages:
 - cache 💾
 - build project 🔨
 - checks 🔬
+- integration 🖇️
 - deploy 🚀
 
 jobs:
@@ -132,19 +133,6 @@ jobs:
     script:
       - stack --no-terminal test --fast cardano-wallet-core cardano-wallet-launcher cardano-wallet-cli text-class bech32 cardano-wallet-http-bridge:unit cardano-wallet-jormungandr:unit
 
-  - stage: checks 🔬
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND NOT (commit_message =~ /Travis-CI-Disable/)
-    name: "Tests: integration (http-bridge)"
-    script:
-    - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.5/hermes-testnet.tar.gz | tar xz -C $HOME
-    - stack --no-terminal test --fast cardano-wallet-http-bridge:integration --ta "--skip PR_DISABLED"
-
-  - stage: checks 🔬
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND NOT (commit_message =~ /Travis-CI-Disable/)
-    name: "Tests: integration (jormungandr)"
-    script:
-      - stack --no-terminal test --fast cardano-wallet-jormungandr:integration --ta "--skip PR_DISABLED"
-
   ################################################################################
   #
   # Push / Cron / Api
@@ -197,17 +185,6 @@ jobs:
 
   - stage: checks 🔬
     if: (type != pull_request AND branch = master) OR (tag =~ ^v)
-    name: "Tests (http-bridge)"
-    script:
-    - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.5/hermes-testnet.tar.gz | tar xz -C $HOME
-
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge --ta "--skip MERGE_DISABLED"
-    - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
-
-    - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
-
-  - stage: checks 🔬
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
     name: "Tests"
     script:
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-core
@@ -225,7 +202,24 @@ jobs:
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage bech32
     - mkdir -p .coverage/bech32 && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/bech32 \;
 
-    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr --ta "--skip MERGE_DISABLED"
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr:unit
+    - mkdir -p .coverage/jormungandr && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/jormungandr \;
+
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge:unit
+    - mkdir -p .coverage/unit && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
+
+    - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
+
+  - stage: integration 🖇️
+    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    name: "Integration"
+    script:
+    - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.5/hermes-testnet.tar.gz | tar xz -C $HOME
+
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge:integration
+    - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
+
+    - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-jormungandr:integration
     - mkdir -p .coverage/jormungandr && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/jormungandr \;
 
     - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,9 +206,9 @@ jobs:
     - mkdir -p .coverage/jormungandr && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/jormungandr \;
 
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-http-bridge:unit
-    - mkdir -p .coverage/unit && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
+    - mkdir -p .coverage/http-bridge && find . -name "*.tix" ! -path "*.coverage*" -exec cp \{} .coverage/http-bridge \;
 
-    - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
+    - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work
 
   - stage: integration 🖇️
     if: branch IN (bors/staging, bors/trying)

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
   #
   ################################################################################
   - stage: build project 🔨
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND (commit_message =~ /Travis-CI-Disable/)
+    if: (type = pull_request) AND (commit_message =~ /Travis-CI-Disable/)
     name: "Diff Control"
     script:
     # Fails if there's any source file modified.
@@ -103,7 +103,7 @@ jobs:
     - git diff $(git merge-base master HEAD) HEAD --stat --exit-code -- --path "specifications/*"
 
   - stage: build project 🔨
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND NOT (commit_message =~ /Travis-CI-Disable/)
+    if: (type = pull_request) AND NOT (commit_message =~ /Travis-CI-Disable/)
     name: "Compiling Project"
     script:
     - stack clean
@@ -111,7 +111,7 @@ jobs:
     - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work
 
   - stage: checks 🔬
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND NOT (commit_message =~ /Travis-CI-Disable/)
+    if: (type = pull_request) AND NOT (commit_message =~ /Travis-CI-Disable/)
     name: "Code Style"
     script:
     - travis_retry curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
@@ -128,7 +128,7 @@ jobs:
     - cd -
 
   - stage: checks 🔬
-    if: (type = pull_request OR (branch IN (bors/staging, bors/trying))) AND NOT (commit_message =~ /Travis-CI-Disable/)
+    if: (type = pull_request) AND NOT (commit_message =~ /Travis-CI-Disable/)
     name: "Tests: unit"
     script:
       - stack --no-terminal test --fast cardano-wallet-core cardano-wallet-launcher cardano-wallet-cli text-class bech32 cardano-wallet-http-bridge:unit cardano-wallet-jormungandr:unit
@@ -148,7 +148,7 @@ jobs:
   #
   ################################################################################
   - stage: cache 💾
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: (type != pull_request AND branch = master)
     name: "Caching Dependencies"
     script:
     - stack --no-terminal build --fast --test --no-run-tests --bench --no-run-benchmarks --only-snapshot
@@ -156,7 +156,7 @@ jobs:
     - tar czf $STACK_WORK_CACHE .stack-work
 
   - stage: build project 🔨
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: (type != pull_request AND branch = master) OR (branch IN (bors/staging, bors/trying))
     name: "Compiling Project"
     script:
     # The following command also builds the `cardano-wallet-core-integration`
@@ -167,7 +167,7 @@ jobs:
     - tar czf $STACK_WORK_CACHE .stack-work lib/**/.stack-work
 
   - stage: checks 🔬
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: branch IN (bors/staging, bors/trying)
     name: "Code Style"
     script:
     - travis_retry curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
@@ -184,7 +184,7 @@ jobs:
     - cd -
 
   - stage: checks 🔬
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: branch IN (bors/staging, bors/trying)
     name: "Tests"
     script:
     - stack --no-terminal test --fast --haddock --no-haddock-deps --coverage cardano-wallet-core
@@ -211,7 +211,7 @@ jobs:
     - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
 
   - stage: integration 🖇️
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: branch IN (bors/staging, bors/trying)
     name: "Integration"
     script:
     - travis_retry curl -L https://github.com/KtorZ/cardano-http-bridge/releases/download/v0.0.5/hermes-testnet.tar.gz | tar xz -C $HOME
@@ -225,19 +225,7 @@ jobs:
     - tar czf $STACK_WORK_CACHE .stack-work .coverage lib/**/.stack-work lib/**/*.tix
 
   - stage: deploy 🚀
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
-    name: "Haddock"
-    script:
-    - mkdir -p haddock/edge api/edge
-    - cp -Rv specifications/api/* api/edge
-    - mv $(stack path --local-doc-root)/* haddock/edge
-    - git checkout --orphan gh-pages-deploy && git reset
-    - git add api haddock && git commit -m $TRAVIS_COMMIT
-    - git checkout gh-pages && git merge -X theirs --no-commit --no-ff --allow-unrelated-histories - && git commit --allow-empty --no-edit
-    - git push -f -q https://WilliamKingNoel-Bot:$GITHUB_ACCESS_TOKEN@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null
-
-  - stage: deploy 🚀
-    if: (type != pull_request AND branch = master) OR (tag =~ ^v)
+    if: branch IN (bors/staging, bors/trying)
     name: "Coveralls"
     script:
     - export LTS=$(cat stack.yaml | grep resolver) # Extract the LTS from the stack.yaml
@@ -255,6 +243,18 @@ jobs:
     # Re-build the coverage report taking .tix from executables running outside of the test suites
     - stack hpc report .coverage/**/*.tix
     - shc combined custom
+
+  - stage: deploy 🚀
+    if: type != pull_request AND branch = master
+    name: "Haddock"
+    script:
+    - mkdir -p haddock/edge api/edge
+    - cp -Rv specifications/api/* api/edge
+    - mv $(stack path --local-doc-root)/* haddock/edge
+    - git checkout --orphan gh-pages-deploy && git reset
+    - git add api haddock && git commit -m $TRAVIS_COMMIT
+    - git checkout gh-pages && git merge -X theirs --no-commit --no-ff --allow-unrelated-histories - && git commit --allow-empty --no-edit
+    - git push -f -q https://WilliamKingNoel-Bot:$GITHUB_ACCESS_TOKEN@github.com/input-output-hk/cardano-wallet gh-pages &>/dev/null
 
   ################################################################################
   #

--- a/bors.toml
+++ b/bors.toml
@@ -5,4 +5,3 @@ status = [
 timeout_sec = 3600
 required_approvals = 1
 delete_merged_branches = false
-block_labels = [ "DO NOT MERGE", "wip" ]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have disabled integration tests on PR builds
- [x] I have reviewed the split of test done few weeks ago which may lead to issue with the cache, and possibly explains #658 
- [x] I have reviewed bors settings (and will try to make it work)
- [x] I am planning to make a small wiki page to explain how our CI is now currently setup, but in brief, we now have 4 sorts of builds in Travis:

    - **PR builds**, which compile code from a cache, run sanity checks and run unit tests
    - **Bors builds**, which is now a required step to merge things into `master`. It builds the code from a cache, run the sanity checks, run the unit tests with coverage, run the integration tests with coverage and in case of success, also sends result to coveralls.
    - **Merge builds**, when things are merged into master, it recompiles the dependencies and update the base cache, it also exports the edge haddock and api documentation.
    - **Release builds**, when a tag is present, the code is built for production and build artefacts are deployed to github.

# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: STILL WORK IN PROGRESS :warning: 

Goal is to make day-to-day CI jobs a bit faster by only running integration tests when things are ready to be merged.
So PR CI only runs units tests and static linters, and we are expected to use bors to merge things first in a staging area, and then, in the main branch

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
