### PR TITLE
Allow more iterations for tests of `isSubrangeOf` with preconditions.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -278,7 +278,7 @@ spec = do
                 r `isSubrangeOf` wholeRange
 
         it "Range (succ a) b `isSubrangeOf` Range a b" $
-            property $ \r@(Range a b :: Range Int) ->
+            withMaxSuccess 1000 $ property $ \r@(Range a b :: Range Int) ->
                 not (rangeIsSingleton r) ==>
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
@@ -287,7 +287,7 @@ spec = do
                 Range (succ <$> a) b `isSubrangeOf` Range a b
 
         it "Range a (pred b) `isSubrangeOf` Range a b" $
-            property $ \r@(Range a b :: Range Int) ->
+            withMaxSuccess 1000 $ property $ \r@(Range a b :: Range Int) ->
                 not (rangeIsSingleton r) ==>
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $


### PR DESCRIPTION
# Issue Number

None.

# Overview

This PR addresses the sporadic test failure seen here:

https://travis-ci.org/input-output-hk/cardano-wallet/jobs/581343282

Extract:

```
    Failures:

      test/unit/Cardano/Wallet/Primitive/TypesSpec.hs:280:9: 
      1) Cardano.Wallet.Primitive.Types.Ranges Range (succ a) b `isSubrangeOf` Range a b
           *** Gave up! Passed only 99 tests; 3 discarded tests:
           78% has lower bound
           73% has upper bound
           54% is finite

      To rerun use: --match "/Cardano.Wallet.Primitive.Types/Ranges/Range (succ a) b `isSubrangeOf` Range a b/"

      test/unit/Cardano/Wallet/Primitive/TypesSpec.hs:289:9: 
      2) Cardano.Wallet.Primitive.Types.Ranges Range a (pred b) `isSubrangeOf` Range a b
           *** Gave up! Passed only 99 tests; 3 discarded tests:
           78% has lower bound
           73% has upper bound
           54% is finite

      To rerun use: --match "/Cardano.Wallet.Primitive.Types/Ranges/Range a (pred b) `isSubrangeOf` Range a b/"
    Randomized with seed 1854409559
```

I've increased the number of iterations allowed for these two properties. To verify this fix, run the following command before and after applying it:

```
stack build --fast --test cardano-wallet-core:test:unit --test-arguments "-m isSubrangeOf --seed=1854409559"
```