### PR TITLE
nix: Add jcli to the shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ let
   haskell = iohkLib.nix-tools.haskell { inherit pkgs; };
   src = iohkLib.cleanSourceHaskell ./.;
 
-  inherit (iohkLib.rust-packages.pkgs) jormungandr;
+  inherit (iohkLib.rust-packages.pkgs) jormungandr jormungandr-cli;
   cardano-http-bridge = iohkLib.rust-packages.pkgs.callPackage
     ./nix/cardano-http-bridge.nix { inherit pkgs; };
   cardano-sl-node = import ./nix/cardano-sl-node.nix { inherit pkgs; };
@@ -26,7 +26,7 @@ let
 
 in {
   inherit pkgs iohkLib src haskellPackages;
-  inherit cardano-http-bridge cardano-sl-node jormungandr;
+  inherit cardano-http-bridge cardano-sl-node jormungandr jormungandr-cli;
   inherit (haskellPackages.cardano-wallet.identifier) version;
 
   inherit (haskellPackages.cardano-wallet.components.exes)
@@ -52,7 +52,8 @@ in {
     ];
     buildInputs =
       with pkgs.haskellPackages; [ hlint stylish-haskell weeder ghcid ]
-      ++ [ cardano-http-bridge jormungandr cardano-sl-node pkgs.pkgconfig pkgs.sqlite-interactive ];
+      ++ [ cardano-sl-node cardano-http-bridge jormungandr jormungandr-cli
+           pkgs.pkgconfig pkgs.sqlite-interactive ];
   };
 
   checks.check-nix-tools = pkgs.callPackage ./nix/check-nix-tools.nix {};

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -56,6 +56,23 @@ let
           unit.build-tools = [ jormungandr ];
         };
 
+
+        packages.cardano-wallet.components.exes.cardano-wallet-jormungandr = {
+          build-tools = [ pkgs.makeWrapper];
+          postInstall = ''
+            wrapProgram $out/bin/cardano-wallet-jormungandr \
+              --prefix PATH : ${jormungandr}/bin
+          '';
+        };
+
+        packages.cardano-wallet.components.exes.cardano-wallet-http-bridge = {
+          build-tools = [ pkgs.makeWrapper];
+          postInstall = ''
+            wrapProgram $out/bin/cardano-wallet-http-bridge \
+              --prefix PATH : ${cardano-http-bridge}/bin
+          '';
+        };
+
         packages.cardano-wallet-http-bridge.components.benchmarks.restore = {
           build-tools = [ pkgs.makeWrapper ];
           postInstall = ''
@@ -65,6 +82,10 @@ let
               --prefix PATH : ${cardano-http-bridge}/bin
           '';
         };
+
+        # Workaround for Haskell.nix issue
+        packages.cardano-wallet.components.all.postInstall = pkgs.lib.mkForce "";
+        packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";
         packages.cardano-wallet-http-bridge.components.all.postInstall = pkgs.lib.mkForce "";
       }
 


### PR DESCRIPTION
# Overview

- Adds jcli to the nix-shell.
- This will also help for building under Buildkite.
- cc @Sam-Jeston.

# Comments

Test with:
```
nix-shell --pure --run "jcli --version"
nix-build -A jormungandr-cli
```
