### PR TITLE
Add missing descriptions for CLI commands

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -228,7 +228,7 @@ data ServeArgs = ServeArgs
 cmdServe
     :: Mod CommandFields (IO ())
 cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
-    <> progDesc "serve API that listens for commands/actions."
+    <> progDesc "Serve API that listens for commands/actions."
   where
     cmd = fmap withNetwork $ ServeArgs
         <$> networkOption

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -279,7 +279,7 @@ data ServeArgs = ServeArgs
 cmdServe
     :: Mod CommandFields (IO ())
 cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
-    <> progDesc "serve API that listens for commands/actions."
+    <> progDesc "Serve API that listens for commands/actions."
   where
     cmd = fmap exec $ ServeArgs
         <$> listenOption

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -282,7 +282,8 @@ runCli = join . customExecParser preferences
 -------------------------------------------------------------------------------}
 
 cmdMnemonic :: Mod CommandFields (IO ())
-cmdMnemonic = command "mnemonic" $ info (helper <*> cmds) mempty
+cmdMnemonic = command "mnemonic" $ info (helper <*> cmds) $ mempty
+    <> progDesc "Generate mnemonic words."
   where
     cmds = subparser $ mempty
         <> cmdMnemonicGenerate
@@ -314,7 +315,8 @@ cmdMnemonicGenerate = command "generate" $ info (helper <*> cmd) $ mempty
 cmdWallet
     :: forall t. (DecodeAddress t, EncodeAddress t)
     => Mod CommandFields (IO ())
-cmdWallet = command "wallet" $ info (helper <*> cmds) mempty
+cmdWallet = command "wallet" $ info (helper <*> cmds) $ mempty
+    <> progDesc "Manage wallets."
   where
     cmds = subparser $ mempty
         <> cmdWalletList @t
@@ -508,7 +510,8 @@ cmdWalletGetUtxoStatistics = command "utxo" $ info (helper <*> cmd) $ mempty
 cmdTransaction
     :: forall t. (DecodeAddress t, EncodeAddress t)
     => Mod CommandFields (IO ())
-cmdTransaction = command "transaction" $ info (helper <*> cmds) mempty
+cmdTransaction = command "transaction" $ info (helper <*> cmds) $ mempty
+    <> progDesc "Manage transactions."
   where
     cmds = subparser $ mempty
         <> cmdTransactionCreate @t
@@ -621,7 +624,8 @@ cmdTransactionSubmit = command "submit" $ info (helper <*> cmd) $ mempty
 cmdAddress
     :: forall t. (DecodeAddress t, EncodeAddress t)
     => Mod CommandFields (IO ())
-cmdAddress = command "address" $ info (helper <*> cmds) mempty
+cmdAddress = command "address" $ info (helper <*> cmds) $ mempty
+    <> progDesc "Manage addresses."
   where
     cmds = subparser $ mempty
         <> cmdAddressList @t

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -283,7 +283,7 @@ runCli = join . customExecParser preferences
 
 cmdMnemonic :: Mod CommandFields (IO ())
 cmdMnemonic = command "mnemonic" $ info (helper <*> cmds) $ mempty
-    <> progDesc "Generate mnemonic words."
+    <> progDesc "Manage mnemonic phrases."
   where
     cmds = subparser $ mempty
         <> cmdMnemonicGenerate

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -111,7 +111,7 @@ spec = do
             , "  -h,--help                Show this help text"
             , ""
             , "Available commands:"
-            , "  mnemonic                 Generate mnemonic words."
+            , "  mnemonic                 Manage mnemonic phrases."
             , "  wallet                   Manage wallets."
             , "  transaction              Manage transactions."
             , "  address                  Manage addresses."
@@ -119,7 +119,7 @@ spec = do
 
         ["mnemonic", "--help"] `shouldShowUsage`
             [ "Usage:  mnemonic COMMAND"
-            , "  Generate mnemonic words."
+            , "  Manage mnemonic phrases."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -111,14 +111,15 @@ spec = do
             , "  -h,--help                Show this help text"
             , ""
             , "Available commands:"
-            , "  mnemonic                 "
-            , "  wallet                   "
-            , "  transaction              "
-            , "  address                  "
+            , "  mnemonic                 Generate mnemonic words."
+            , "  wallet                   Manage wallets."
+            , "  transaction              Manage transactions."
+            , "  address                  Manage addresses."
             ]
 
         ["mnemonic", "--help"] `shouldShowUsage`
             [ "Usage:  mnemonic COMMAND"
+            , "  Generate mnemonic words."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
@@ -140,6 +141,7 @@ spec = do
 
         ["wallet", "--help"] `shouldShowUsage`
             [ "Usage:  wallet COMMAND"
+            , "  Manage wallets."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
@@ -223,6 +225,7 @@ spec = do
 
         ["transaction", "--help"] `shouldShowUsage`
             [ "Usage:  transaction COMMAND"
+            , "  Manage transactions."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
@@ -284,6 +287,7 @@ spec = do
 
         ["address", "--help"] `shouldShowUsage`
             [ "Usage:  address COMMAND"
+            , "  Manage addresses."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] Added descriptions for commands that were missing it in CLI help



# Comments

Before:

```

Available options:
  -h,--help                Show this help text

Available commands:
  launch                   Launch and monitor a wallet server and its chain
                           producers.
  serve                    serve API that listens for commands/actions.
  mnemonic                 
  wallet                  
  transaction             
  address                  
  version                  Show the program's version.

```

After:

```
Available options:
  -h,--help                Show this help text

Available commands:
  launch                   Launch and monitor a wallet server and its chain
                           producers.
  serve                    Serve API that listens for commands/actions.
  mnemonic                 Manage mnemonic phrases.
  wallet                   Manage wallets.
  transaction              Manage transactions.
  address                  Manage addresses.
  version                  Show the program's version.

```
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
