### PR TITLE
Don't calculate blockHeights — read them from binary!

### DIFF
--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -85,6 +85,8 @@ import Data.Digest.CRC32
     ( crc32 )
 import Data.Either.Extra
     ( eitherToMaybe )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Word
     ( Word16, Word64, Word8 )
 import Debug.Trace
@@ -348,7 +350,10 @@ decodeGenesisBlockHeader = do
     -- number of `0`. In practices, when parsing a full epoch, we can discard
     -- the genesis block entirely and we won't bother about modelling this
     -- extra complexity at the type-level. That's a bit dodgy though.
-    return $ BlockHeader (SlotId epoch 0) previous
+
+
+    let bh = Quantity 0
+    return $ BlockHeader (SlotId epoch 0) bh previous
 
 decodeGenesisConsensusData :: CBOR.Decoder s Word64
 decodeGenesisConsensusData = do
@@ -403,7 +408,14 @@ decodeMainBlockHeader = do
     _ <- decodeMainProof
     (epoch, slot) <- decodeMainConsensusData
     _ <- decodeMainExtraData
-    return $ BlockHeader (SlotId epoch slot) previous
+
+    -- NOTE:
+    -- `http-bridge` is not intended to be used in production so we are
+    -- taking a few shortcut to not spend needless time on its impl.
+    -- This is one of them.
+    let bh = Quantity 0
+
+    return $ BlockHeader (SlotId epoch slot) bh previous
 
 decodeMainConsensusData :: CBOR.Decoder s (Word64, Word16)
 decodeMainConsensusData = do

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -30,14 +30,10 @@ import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Control.Retry
     ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay, retrying )
-import Data.Quantity
-    ( Quantity )
 import Data.Text
     ( Text )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 
 data NetworkLayer t m = NetworkLayer
     { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [Block (Tx t)]
@@ -54,9 +50,8 @@ data NetworkLayer t m = NetworkLayer
         -- after the specified starting slot.
 
     , networkTip
-        :: ExceptT ErrNetworkTip m (BlockHeader, Quantity "block" Natural)
-        -- ^ Get the current network tip from the chain producer and the current
-        -- chain's height.
+        :: ExceptT ErrNetworkTip m BlockHeader
+        -- ^ Get the current network tip from the chain producer
 
     , postTx
         :: (Tx t, [TxWitness]) -> ExceptT ErrPostTx m ()

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -502,6 +502,8 @@ instance Buildable tx => Buildable (Block tx) where
 data BlockHeader = BlockHeader
     { slotId
         :: SlotId
+    , blockHeight
+        :: Quantity "block" Natural
     , prevBlockHash
         :: !(Hash "BlockHeader")
     } deriving (Show, Eq, Ord, Generic)
@@ -509,11 +511,12 @@ data BlockHeader = BlockHeader
 instance NFData BlockHeader
 
 instance Buildable BlockHeader where
-    build (BlockHeader s prev) = mempty
+    build (BlockHeader s (Quantity bh) prev) = mempty
         <> prefixF 8 prevF
         <> "..."
         <> suffixF 8 prevF
-        <> " (" <> build s <> ")"
+        <> " slot " <> build s <> ", "
+        <> "block " <> build (fromIntegral @Natural @Int bh)
       where
         prevF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash prev
 

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -317,10 +317,10 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
     cp i = unsafeInitWallet (UTxO utxo) mempty
         (BlockHeader
             (fromFlatSlot epochLength (fromIntegral i))
+            (Quantity $ fromIntegral i)
             (Hash $ label "prevBlockHash" i)
         )
         initDummyState
-        (Quantity $ fromIntegral i)
         genesisParameters
 
     utxo = Map.fromList $ zip (mkInputs utxoSize) (mkOutputs utxoSize)

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -116,6 +116,7 @@ block0 :: Block Tx
 block0 = Block
     { header = BlockHeader
         { slotId = slotMinBound
+        , blockHeight = Quantity 0
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -305,6 +305,8 @@ instance Arbitrary (Index 'Hardened 'AccountK) where
 blockHeader1 :: BlockHeader
 blockHeader1 = BlockHeader
     { slotId = SlotId 105 9520
+    -- NOTE: The Cbor decoder doesn't decode the blockHeight, but rather
+    -- returns 0. This shouldn't matter.
     , blockHeight = Quantity 0 -- 2276029
     , prevBlockHash = Hash $ unsafeFromHex
         "9f3c67b575bf2c5638291949694849d6ce5d29efa1f2eb3ed0beb6dac262e9e0"
@@ -315,6 +317,8 @@ block1 :: Block ([TxIn], [TxOut])
 block1 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9519
+        -- NOTE: The Cbor decoder doesn't decode the blockHeight, but rather
+        -- returns 0. This shouldn't matter.
         , blockHeight = Quantity 0 -- 2276028
         , prevBlockHash = prevBlockHash0
         }
@@ -329,6 +333,8 @@ block2 :: Block ([TxIn], [TxOut])
 block2 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9876
+        -- NOTE: The Cbor decoder doesn't decode the blockHeight, but rather
+        -- returns 0. This shouldn't matter.
         , blockHeight = Quantity 0 -- 2276385
         , prevBlockHash = prevBlockHash0
         }
@@ -359,6 +365,8 @@ block3 :: Block ([TxIn], [TxOut])
 block3 = Block
     { header = BlockHeader
         { slotId = SlotId 30 9278
+        -- NOTE: The Cbor decoder doesn't decode the blockHeight, but rather
+        -- returns 0. This shouldn't matter.
         , blockHeight = Quantity 0 -- 657201
         , prevBlockHash = prevBlockHash0
         }
@@ -393,6 +401,8 @@ block4 :: Block ([TxIn], [TxOut])
 block4 = Block
     { header = BlockHeader
         { slotId = SlotId 14 18
+        -- NOTE: The Cbor decoder doesn't decode the blockHeight, but rather
+        -- returns 0. This shouldn't matter.
         , blockHeight = Quantity 0 -- 302376
         , prevBlockHash = prevBlockHash0
         }

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -56,6 +56,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Either
     ( isLeft )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text
     ( Text )
 import Data.Word
@@ -303,6 +305,7 @@ instance Arbitrary (Index 'Hardened 'AccountK) where
 blockHeader1 :: BlockHeader
 blockHeader1 = BlockHeader
     { slotId = SlotId 105 9520
+    , blockHeight = Quantity 0 -- 2276029
     , prevBlockHash = Hash $ unsafeFromHex
         "9f3c67b575bf2c5638291949694849d6ce5d29efa1f2eb3ed0beb6dac262e9e0"
     }
@@ -312,6 +315,7 @@ block1 :: Block ([TxIn], [TxOut])
 block1 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9519
+        , blockHeight = Quantity 0 -- 2276028
         , prevBlockHash = prevBlockHash0
         }
     , transactions = mempty
@@ -325,6 +329,7 @@ block2 :: Block ([TxIn], [TxOut])
 block2 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9876
+        , blockHeight = Quantity 0 -- 2276385
         , prevBlockHash = prevBlockHash0
         }
     , transactions =
@@ -354,6 +359,7 @@ block3 :: Block ([TxIn], [TxOut])
 block3 = Block
     { header = BlockHeader
         { slotId = SlotId 30 9278
+        , blockHeight = Quantity 0 -- 657201
         , prevBlockHash = prevBlockHash0
         }
     , transactions =
@@ -387,6 +393,7 @@ block4 :: Block ([TxIn], [TxOut])
 block4 = Block
     { header = BlockHeader
         { slotId = SlotId 14 18
+        , blockHeight = Quantity 0 -- 302376
         , prevBlockHash = prevBlockHash0
         }
     , transactions =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -113,6 +113,8 @@ import Data.Time.Utils
     ( utcTimePred, utcTimeSucc )
 import Fmt
     ( pretty )
+import Numeric.Natural
+    ( Natural )
 import Test.Hspec
     ( Spec, describe, it, shouldNotSatisfy, shouldSatisfy )
 import Test.QuickCheck
@@ -851,9 +853,14 @@ instance Arbitrary Tx where
 
 instance Arbitrary BlockHeader where
     -- No Shrinking
-    arbitrary = BlockHeader
-        <$> arbitrary
-        <*> oneof
+    arbitrary = do
+        sl <- arbitrary
+        BlockHeader sl (mockBlockHeight sl) <$> genHash
+      where
+        mockBlockHeight :: SlotId -> Quantity "block" Natural
+        mockBlockHeight = Quantity . fromIntegral . flatSlot (EpochLength 200)
+
+        genHash = oneof
             [ pure $ Hash "BLOCK01"
             , pure $ Hash "BLOCK02"
             , pure $ Hash "BLOCK03"

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -175,6 +175,7 @@ block0 :: Block W.Tx
 block0 = Block
     { header = BlockHeader
         { slotId = slotMinBound
+        , blockHeight = Quantity 0
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -210,7 +210,7 @@ bench_restoration (wid, wname, s) = withHttpBridge network $ \port -> do
     Sqlite.unsafeRunQuery ctx (void $ runMigrationSilent migrateAll)
     nw <- newNetworkLayer port
     let tl = newTransactionLayer @n @k
-    BlockHeader sl _ <- unsafeRunExceptT $ fst <$> networkTip nw
+    BlockHeader sl _ _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
     let bp = byronBlockchainParameters @n
     w <- newWalletLayer @t nullTracer (block0, bp) db nw tl
@@ -285,8 +285,8 @@ waitForNodeSync
 waitForNodeSync bridge networkName logSlot = loop 10
   where
     loop :: Int -> IO SlotId
-    loop retries = runExceptT (fst <$> networkTip bridge) >>= \case
-        Right (BlockHeader tipBlockSlot _) -> do
+    loop retries = runExceptT (networkTip bridge) >>= \case
+        Right (BlockHeader tipBlockSlot _ _) -> do
             currentSlot <- getCurrentSlot networkName
             logSlot tipBlockSlot currentSlot
             if tipBlockSlot < currentSlot

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -18,6 +18,8 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxOut (..)
     )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text
     ( Text )
 import Fmt
@@ -32,6 +34,7 @@ spec = do
             let block = Block
                     { header = BlockHeader
                         { slotId = SlotId 14 19
+                        , blockHeight = Quantity 0
                         , prevBlockHash = Hash "\223\252\&5\ACK\211\129\&6\DC4h7b'\225\201\&2:/\252v\SOH\DC1\ETX\227\"Q$\240\142ii\167;"
                         }
                     , transactions =
@@ -55,7 +58,7 @@ spec = do
                             }
                         ]
                     }
-            "dffc3506...6969a73b (14.19)\n\
+            "dffc3506...6969a73b slot 14.19, block 0\n\
             \    - ~> 1st c29d3ea0...13862214\n\
             \      <~ 3823755953610 @ 82d81858...aebb3709\n\
             \      <~ 19999800000 @ 82d81858...37ce9c60\n"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -619,7 +619,8 @@ coerceBlock  :: Block -> W.Block Tx
 coerceBlock (Block h msgs) =
     W.Block coerceHeader coerceMessages
   where
-    coerceHeader = W.BlockHeader (slot h) (parentHeaderHash h)
+    coerceHeader = W.BlockHeader (slot h) (bh h) (parentHeaderHash h)
+    bh = Quantity . fromIntegral . chainLength
     coerceMessages = msgs >>= \case
         Initial _ -> []
         Transaction (tx, _wits) -> return tx

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -96,6 +96,7 @@ block0 :: BlockHeader
 block0 = BlockHeader
     { slotId = slotMinBound
     , prevBlockHash = Hash (BS.replicate 32 0)
+    , blockHeight = Quantity 0
     }
 
 -- | Jörmugandr's chain parameter doesn't include a transaction max size. The

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -174,7 +174,7 @@ mkNetworkLayer st j = NetworkLayer
     { networkTip = modifyMVar st $ \bs -> do
         bs' <- updateUnstableBlocks k getTipId' getBlockHeader bs
         ExceptT . pure $ case unstableBlocksTip bs' of
-            Just t -> Right (bs', (t, blockHeight bs'))
+            Just t -> Right (bs', t)
             Nothing -> Left ErrNetworkTipNotFound
 
     , nextBlocks = \tip -> do

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -132,8 +132,8 @@ spec = do
         it "get network tip" $ \(_, nw, _) -> do
             resp <- runExceptT $ networkTip nw
             resp `shouldSatisfy` isRight
-            let (Right slot) = slotId . fst <$> resp
-            let (Right height) = snd <$> resp
+            let (Right slot) = slotId <$> resp
+            let (Right height) = blockHeight <$> resp
             slot `shouldSatisfy` (>= slotMinBound)
             height `shouldSatisfy` (>= Quantity 0)
 
@@ -145,7 +145,7 @@ spec = do
 
         it "no blocks after the tip" $ \(_, nw, _) -> do
             let try = do
-                    (tip, _) <- unsafeRunExceptT $ networkTip nw
+                    tip <- unsafeRunExceptT $ networkTip nw
                     runExceptT $ nextBlocks nw tip
             -- NOTE Retrying twice since between the moment we fetch the
             -- tip and the moment we get the next blocks, one block may be
@@ -162,6 +162,7 @@ spec = do
             bytes <- BS.pack <$> generate (vectorOf 32 arbitrary)
             let block = BlockHeader
                     { slotId = SlotId 42 14 -- Anything
+                    , blockHeight = Quantity 0 -- Anything
                     , prevBlockHash = Hash bytes
                     }
             resp <- runExceptT $ nextBlocks nw block


### PR DESCRIPTION
# Issue Number

#640 


# Overview
- [x] I have removed the `blockHeight` calculation and tests implemented in #640
- [x] I have extended `BlockHeader` with a new field `blockHeight`, which is read from jörmungandr-blocks' `chainHeight`.
- [x] I have done some course stubs with `Quantity 0`-dummy-blockheights in http-bridge and various tests. 
- [ ] ⚠️ I *could*/*should* do it more carefully ⚠️ . Also the bridge tests are failing.


# Comments

- It turns out the `blockHeights` were there all along 🙃 , just called `chainHeight`s.
- I'm not a fan of how much stubbing of dummy blockHeights I had to do. But I'm not sure what the solution would be.
- Logged block-heights look alright:
```
Sep 19 19:07:36.998 INFO leader event starting, date: 2542.80, leader: 1, task: leadership
Sep 19 19:07:38.380 INFO block from leader event successfully stored, date: 2542.80, parent: a8c87de39fed04de07d1ae5dcf47c8f5b6e1568ee0d2ff08a1d112937c5462eb, hash: 5c865dc651f4bdb3c775149c9700507c3de143f8a3462fc2837f6ccf365d2606, task: block
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:38.67 UTC] Applying blocks [2542.80 ... 2542.80]
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:38.99 UTC] wallet (restored), created at 2019-09-19 17:06:13.27709 UTC, not delegating
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:38.99 UTC] number of pending transactions: 0
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:38.99 UTC] number of new transactions: 0
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:38.99 UTC] new block height: 25
Sep 19 19:07:46.998 INFO leader event starting, date: 2542.81, leader: 1, task: leadership
Sep 19 19:07:47.001 INFO block from leader event successfully stored, date: 2542.81, parent: 5c865dc651f4bdb3c775149c9700507c3de143f8a3462fc2837f6ccf365d2606, hash: 99df856d427f859a807bf1b87de115644d7cba7eb1c5c48627447809f0d6f481, task: block
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:49.00 UTC] Applying blocks [2542.81 ... 2542.81]
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:49.02 UTC] wallet (restored), created at 2019-09-19 17:06:13.27709 UTC, not delegating
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:49.02 UTC] number of pending transactions: 0
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:49.02 UTC] number of new transactions: 0
[iohk.cardano-wallet.serve.worker.f74ffb15:Info:ThreadId 53] [2019-09-19 17:07:49.02 UTC] new block height: 26
```
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
