### PR TITLE
rework code coverage step in buildkite

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -236,13 +236,13 @@ qaLevel :: Maybe BuildkiteEnv -> QA
 qaLevel = maybe QuickTest level
   where
     level bk
-        | isBorsBuild bk || onDefaultBranch bk = QuickTest
+        | isBorsBuild bk = FullTest
+        | onDefaultBranch bk = QuickTest
         | otherwise = QuickTest
 
 -- | Whether to upload test coverage information to coveralls.io.
 shouldUploadCoverage :: Maybe BuildkiteEnv -> Bool
 shouldUploadCoverage bk = qaLevel bk == FullTest
-    || (bkBranch <$> bk) == Just "KtorZ/buildkite-coverage" -- just for testing the PR branch
 
 ----------------------------------------------------------------------------
 -- Weeder - uses contents of .stack-work to determine unused dependencies

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -158,10 +158,15 @@ buildStep dryRun bk =
                 QuickTest -> [ "integration" ]
                 FullTest -> []
         in
-            stackBuild Fast (Just ["--skip", serialTests]) args
-            .&&.
+            -- NOTE
+            -- stack erases coverage artifacts (.tix files) between runs. So, we
+            -- can't really preserve coverage for both serial and parallel tests.
+            -- We run the parallel ones last because they contain most of our
+            -- scenarios.
             stackBuild Fast (Just ["--match", serialTests, "--jobs", "1"])
                 (args ++ ["--jobs", "1"])
+            .&&.
+            stackBuild Fast (Just ["--skip", serialTests]) args
     serialTests = "SERIAL"
 
     fastOpt Opt = []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/input-output-hk/cardano-wallet/releases"><img src="https://img.shields.io/github/release-pre/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
   <a href="https://travis-ci.org/input-output-hk/cardano-wallet"><img src="https://img.shields.io/travis/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143.svg?label=NIGHTLY&style=for-the-badge" /></a>
-  <a href="https://coveralls.io/github/input-output-hk/cardano-wallet"><img src="https://img.shields.io/coveralls/github/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
+  <a href="https://coveralls.io/github/input-output-hk/cardano-wallet?branch=HEAD"><img src="https://img.shields.io/coveralls/github/input-output-hk/cardano-wallet/HEAD?style=for-the-badge" /></a>
 </p>
 
 <hr/>


### PR DESCRIPTION
In .travis.yaml we do some complicated stuff with the coverage in attempt to overcome the following issues:

- Many tests rely on external executables of our code for which, we
  would like to also get coverage. This is dealt with by compiling those
  executable with the '--coverage' flag and, by providing additional .tix
  files to 'stack hpc report'. Therefore, executables used in a
  particular test suite will produce extra .tix files in the underlying
  package's root folder that are by default, ignored by stack. So, we
  provide them as additional inputs (i.e. 'lib/**/*.tix').

- Some modules are auto-generated code and contains in practice a lot of
  noise. In Travis, we used to generate an overlay to ignore all of them
  and generate a corresponding report that discard any of the listed
  files. I have simply discarded that part for now as it seems
  unecessary for coveralls (the format used by coveralls is simpler than
  the one used by hpc which based its coverage calculation on the generated
  splices instead of the raw code source. For coveralls, only the code
  source enters into consideration).

## Comments

Branch is based on the branch of #688, which must be merged before this one.
