### PR TITLE
Reuse minimum slot and block definitions.

### DIFF
--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -30,9 +30,9 @@ import Cardano.Wallet.Primitive.Types
     , DefineTx
     , EncodeAddress (..)
     , Hash (..)
-    , SlotId (..)
     , TxIn (..)
     , TxOut (..)
+    , slotMinBound
     )
 import Control.DeepSeq
     ( NFData )
@@ -104,7 +104,7 @@ instance Buildable Tx where
 block0 :: Block Tx
 block0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotId = slotMinBound
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -24,7 +24,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( Block (..), BlockHeader (..), Hash (..), slotMinBound )
 import Control.DeepSeq
     ( NFData )
 import Test.Hspec
@@ -57,7 +57,7 @@ instance Arbitrary (Wallet DummyStateMVar DummyTarget) where
         block0 :: Block Tx
         block0 = Block
             { header = BlockHeader
-                    { slotId = SlotId 0 0
+                    { slotId = slotMinBound
                     , prevBlockHash = Hash "genesis"
                     }
             , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -16,15 +16,13 @@ import Prelude
 import Cardano.Wallet.DBSpec
     ( dbPropertyTests, withDB )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx )
+    ( DummyTarget, block0 )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet )
-import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), slotMinBound )
 import Control.DeepSeq
     ( NFData )
 import Test.Hspec
@@ -53,12 +51,3 @@ instance IsOurs DummyStateMVar where
 instance Arbitrary (Wallet DummyStateMVar DummyTarget) where
     shrink _ = []
     arbitrary = initWallet block0 <$> arbitrary
-      where
-        block0 :: Block Tx
-        block0 = Block
-            { header = BlockHeader
-                    { slotId = slotMinBound
-                    , prevBlockHash = Hash "genesis"
-                    }
-            , transactions = []
-            }

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -73,6 +73,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
+    , slotMinBound
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -347,7 +348,7 @@ shouldHaveLog msgs (sev, str) = unless (any match msgs) $
 initDummyBlock0 :: Block Tx
 initDummyBlock0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotId = slotMinBound
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.DB.StateMachine
 import Cardano.Wallet.DBSpec
     ( dbPropertyTests, withDB )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx (..) )
+    ( DummyTarget, Tx (..), block0 )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..), PersistKey, encryptPassphrase )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
@@ -56,8 +56,6 @@ import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , Block (..)
-    , BlockHeader (..)
     , Coin (..)
     , Direction (..)
     , Hash (..)
@@ -73,7 +71,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , WalletState (..)
-    , slotMinBound
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
@@ -345,15 +342,6 @@ shouldHaveLog msgs (sev, str) = unless (any match msgs) $
                                    Test data
 -------------------------------------------------------------------------------}
 
-initDummyBlock0 :: Block Tx
-initDummyBlock0 = Block
-    { header = BlockHeader
-        { slotId = slotMinBound
-        , prevBlockHash = Hash "genesis"
-        }
-    , transactions = []
-    }
-
 testMetadata :: WalletMetadata
 testMetadata = WalletMetadata
     { name = WalletName "test wallet"
@@ -395,7 +383,7 @@ class GenerateTestKey (key :: Depth -> * -> *) where
 -------------------------------------------------------------------------------}
 
 testCpSeq :: Wallet (SeqState DummyTarget) DummyTarget
-testCpSeq = initWallet initDummyBlock0 initDummyStateSeq
+testCpSeq = initWallet block0 initDummyStateSeq
 
 initDummyStateSeq :: SeqState DummyTarget
 initDummyStateSeq = mkSeqState (xprv, mempty) defaultAddressPoolGap
@@ -432,4 +420,4 @@ initDummyStateRnd = mkRndState xprv 0
     where xprv = fst $ unsafePerformIO generateTestKey
 
 testCpRnd :: Wallet (RndState DummyTarget) DummyTarget
-testCpRnd = initWallet initDummyBlock0 initDummyStateRnd
+testCpRnd = initWallet block0 initDummyStateRnd

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -45,6 +45,7 @@ import Cardano.Wallet.Primitive.Types
     , excluding
     , invariant
     , restrictedTo
+    , slotMinBound
     , txId
     , txIns
     )
@@ -345,7 +346,7 @@ addresses = map address
 block0 :: Block Tx
 block0 = Block
     { header = BlockHeader
-            { slotId = SlotId 0 0
+            { slotId = slotMinBound
             , prevBlockHash = Hash "genesis"
             }
     , transactions = []

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -13,7 +13,7 @@ module Cardano.Wallet.Primitive.ModelSpec
 import Prelude
 
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx (..) )
+    ( DummyTarget, Tx (..), block0 )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.Model
@@ -45,7 +45,6 @@ import Cardano.Wallet.Primitive.Types
     , excluding
     , invariant
     , restrictedTo
-    , slotMinBound
     , txId
     , txIns
     )
@@ -342,15 +341,6 @@ addresses = map address
     $ concatMap outputs
     $ concatMap transactions
     blockchain
-
-block0 :: Block Tx
-block0 = Block
-    { header = BlockHeader
-            { slotId = slotMinBound
-            , prevBlockHash = Hash "genesis"
-            }
-    , transactions = []
-    }
 
 -- A excerpt of mainnet, epoch #14, first 20 blocks; plus a few previous blocks
 -- which contains transactions referred to in the former. This is useful to test

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -569,8 +569,8 @@ spec = do
             (checkCoverage prop_2_6_2)
 
     describe "Slotting ordering" $ do
-        it "Any Slot >= SlotId 0 0"
-            (property (>= SlotId 0 0))
+        it "Any Slot >= slotMinBound"
+            (property (>= slotMinBound))
         it "SlotId 1 2 < SlotId 2 1"
             (property $ SlotId { epochNumber = 1, slotNumber = 2 } < SlotId 2 1)
         it "SlotId 1 1 < SlotId 1 2"

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -57,10 +57,10 @@ import Cardano.Wallet.Primitive.Types
     , EncodeAddress (..)
     , EpochLength (..)
     , Hash (..)
-    , SlotId (..)
     , SlotLength (..)
     , StartTime (..)
     , Tx (..)
+    , slotMinBound
     )
 import Crypto.Hash
     ( hash )
@@ -174,7 +174,7 @@ instance DecodeAddress (HttpBridge (network :: Network)) where
 block0 :: Block W.Tx
 block0 = Block
     { header = BlockHeader
-        { slotId = SlotId 0 0
+        { slotId = slotMinBound
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -118,7 +118,7 @@ newNetworkLayer port = mkNetworkLayer <$> newHttpBridgeLayer @n port
 -- - an epoch pack's worth of blocks (those after the given starting slot); or
 -- - all of the unstable blocks after (exclusively) the starting slot, if any.
 --
--- Note that, starting from the `SlotId 0 0`, we'll never get the first block of
+-- Note that, starting from `slotMinBound`, we'll never get the first block of
 -- the chain through this method.
 rbNextBlocks
     :: Monad m

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -29,7 +29,7 @@ import Cardano.Wallet.Primitive.Mnemonic
 import Cardano.Wallet.Primitive.Model
     ( currentTip )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), SlotId (..), WalletId (..), WalletName (..) )
+    ( BlockHeader (..), WalletId (..), WalletName (..), slotMinBound )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent
@@ -62,7 +62,7 @@ spec = do
             threadDelay 2000000
             tip <- slotId . currentTip . fst <$>
                 unsafeRunExceptT (readWallet wallet wid)
-            unless (tip > (SlotId 0 0)) $
+            unless (tip > slotMinBound) $
                 expectationFailure ("The wallet tip is still " ++ show tip)
   where
     port = 1337

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -13,7 +13,7 @@ import Cardano.Wallet.HttpBridge.Primitive.Types
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( Block (..), BlockHeader (..), Hash (..), SlotId (..), slotMinBound )
 import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Except
@@ -25,7 +25,6 @@ import Test.Hspec
 
 import qualified Cardano.Wallet.HttpBridge.Network as HttpBridge
 import qualified Data.ByteString.Char8 as B8
-
 
 spec :: Spec
 spec = do
@@ -101,7 +100,7 @@ spec = do
 
         it "should work for the first epoch" $ do
             let h = BlockHeader
-                    { slotId = SlotId 0 0
+                    { slotId = slotMinBound
                     , prevBlockHash = Hash "genesis"
                     }
             Right blocks <- runExceptT $ nextBlocks network h

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -49,8 +49,8 @@ import Cardano.Wallet.Primitive.Types
     , DefineTx
     , EncodeAddress (..)
     , Hash (..)
-    , SlotId (..)
     , invariant
+    , slotMinBound
     )
 import Codec.Binary.Bech32
     ( HumanReadablePart, dataPartFromBytes, dataPartToBytes )
@@ -94,7 +94,7 @@ data Jormungandr (network :: Network)
 -- | Genesis block header, i.e. very first block header of the chain
 block0 :: BlockHeader
 block0 = BlockHeader
-    { slotId = (SlotId 0 0)
+    { slotId = slotMinBound
     , prevBlockHash = Hash (BS.replicate 32 0)
     }
 

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -46,6 +46,7 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxOut (..)
     , TxWitness (..)
+    , slotMinBound
     )
 import Cardano.Wallet.Unsafe
     ( unsafeDecodeAddress, unsafeFromHex, unsafeRunExceptT )
@@ -125,7 +126,7 @@ spec = do
             resp <- runExceptT $ networkTip nw
             resp `shouldSatisfy` isRight
             let (Right slot) = slotId <$> resp
-            slot `shouldSatisfy` (>= SlotId 0 0)
+            slot `shouldSatisfy` (>= slotMinBound)
 
         it "get some blocks from the genesis" $ \(_, nw) -> do
             threadDelay (10 * second)


### PR DESCRIPTION
# Issue Number

None.

# Overview

A simple pair of refactorings:
1. Replace uses of `SlotId 0 0` with `minSlotBound`.
2. Consolidate multiple definitions of `block0` with a single definition.