### PR TITLE
Remove inconsistent `insertedAtTime` lens.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -57,7 +57,6 @@ module Test.Integration.Framework.DSL
     , direction
     , feeEstimator
     , inputs
-    , insertedAtTime
     , passphraseLastUpdate
     , state
     , status
@@ -125,7 +124,6 @@ module Test.Integration.Framework.DSL
 import Cardano.Wallet.Api.Types
     ( AddressAmount
     , ApiAddress
-    , ApiBlockData (..)
     , ApiT (..)
     , ApiTransaction
     , ApiTxInput (..)
@@ -146,7 +144,6 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , HistogramBar (..)
     , PoolId (..)
-    , SlotId (..)
     , SortOrder (..)
     , TxIn (..)
     , TxOut (..)
@@ -703,16 +700,6 @@ direction =
     _get = getApiT . view typed
     _set :: HasType (ApiT Direction) s => (s, Direction) -> s
     _set (s, v) = set typed (ApiT v) s
-
-insertedAtTime :: HasType (Maybe ApiBlockData) s => Lens' s (Maybe UTCTime)
-insertedAtTime =
-    lens _get _set
-  where
-    _get :: HasType (Maybe ApiBlockData) s => s -> (Maybe UTCTime)
-    _get = fmap (time) . view typed
-    _set :: HasType (Maybe ApiBlockData) s => (s, (Maybe UTCTime)) -> s
-    _set (s, v) = set typed (fn <$> v) s
-         where fn t = ApiBlockData (t) (ApiT (SlotId 1 1))
 
 inputs :: HasType [ApiTxInput t] s => Lens' s [ApiTxInput t]
 inputs =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -57,7 +57,6 @@ import Test.Integration.Framework.DSL
     , fixtureWallet
     , fixtureWalletWith
     , getWalletEp
-    , insertedAtTime
     , json
     , listAddresses
     , listAllTransactions
@@ -1106,7 +1105,7 @@ spec = do
                 , replicate 10 2
                 ]
         txs <- listAllTransactions ctx w
-        let [Just t2, Just t1] = map (view insertedAtTime) txs
+        let [Just t2, Just t1] = fmap (fmap time . insertedAt) txs
         let matrix :: [TestCase [ApiTransaction t]] =
                 [ TestCase -- 1
                     { query = toQueryString


### PR DESCRIPTION
# Issue Number

None.

# Overview

This lens is not quite correct, as the setter updates the slot ID to `(1, 1)` regardless of what time is specified. Using the setter could lead to inconsistency between the slot ID and the time.

Luckily, since we only need the getter functionality, we can remove the lens and replicate the functionality with simple function composition.