### PR TITLE
Buildkite: Only run integration tests on Bors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,8 @@ steps:
       - "nix-build .buildkite/default.nix -o sr"
       - "./sr/bin/rebuild --build-dir /build/cardano-wallet --cache-dir /build/cardano-wallet.cache"
     timeout_in_minutes: 120
+    artifact_paths:
+      - "/build/cardano-wallet/.stack-work/logs/cardano-wallet*.log"
     agents:
       system: x86_64-linux
 

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -133,7 +133,7 @@ buildStep dryRun bk =
     echo "+++ Build" *> build .&&.
     echo "+++ Test" *> timeout 30 test
   where
-    cfg = ["--dump-logs", "--color", "always"]
+    cfg = ["--color", "always"]
     buildArgs =
         [ "--bench"
         , "--no-run-benchmarks"


### PR DESCRIPTION
Our integration tests are a bit slow. But in any case it's worthwhile doing more thorough testing before merging to master.

This changes the Buildkite build script so that integration tests are skipped, unless the build is for Bors.
