### PR TITLE
Fix windows build

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -37,6 +37,39 @@ let
         jobs.native.cardano-wallet-jormungandr.x86_64-darwin
       ]
     );
+
+    cardano-wallet-jormungandr-win64 = let
+      jm = pkgs.fetchurl {
+        url = https://github.com/input-output-hk/jormungandr/releases/download/v0.3.3/jormungandr-v0.3.3-x86_64-pc-windows-msvc.zip;
+        sha256 = "0psva16vq86gcld701k0fi6kk1ydnm2q3yd2mdgflb0x8zpm2i3g";
+      };
+      testData = ./lib/jormungandr/test/data/jormungandr;
+      name = "cardano-wallet-jormungandr-${project.version}-win64.zip";
+      jm-bat = pkgs.writeText "jm.bat" ''
+        jormungandr.exe --config config.yaml --genesis-block block0.bin --secret secret.yaml
+      '';
+      cw-bat = pkgs.writeText "cw.bat" ''
+        cardano-wallet-jormungandr.exe serve --node-port 8081 --genesis-hash HASH --database c:\\cardano-wallet-jormungandr\\wallet.db
+      '';
+    in pkgs.runCommand "cardano-wallet-jormungandr-win64" {
+      buildInputs = [ pkgs.zip pkgs.unzip pkgs.jq pkgs.gnused project.jormungandr-cli ];
+    } ''
+      mkdir -pv jm $out/nix-support
+      cd jm
+
+      cp -v ${jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux}/bin/* .
+      unzip ${jm}
+      cp -v ${testData}/block0.bin ${testData}/secret.yaml .
+      cp -v ${jm-bat} jm.bat
+      hash="$(jcli genesis hash --input block0.bin)"
+      sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat
+      sed -e 's/storage:.*/storage: "c:\\\\cardano-wallet-jormungandr\\\\storage"/' \
+          ${testData}/config.yaml > config.yaml
+      chmod -R +w .
+
+      zip -r $out/${name} .
+      echo "file binary-dist $out/${name}" > $out/nix-support/hydra-build-products
+    '';
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.


### PR DESCRIPTION
Relates to #703 

# Overview

- I broke the cross build in 7208a54a018415108dc359b7e20cb024bef1af63. This fixes it, and adds a necessary DLL to the packages.
- In the course of writing instructions for testing the windows build, I made a script which packages all the dependencies and configs together in a zip file. This is easy to download off Hydra and quick to test. 

# Comments

- [Link to Hydra build](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-717/cardano-wallet-jormungandr-win64/latest)
- [zip download](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-717/cardano-wallet-jormungandr-win64/latest/download-by-type/file/binary-dist)
