### PR TITLE
Increase buildkite timeout to 120min for restoration benchmarks

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -10,7 +10,7 @@ steps:
       NETWORK: testnet
   - label: 'Restore benchmark - mainnet'
     command: "./.buildkite/bench-restore.sh"
-    timeout_in_minutes: 90
+    timeout_in_minutes: 120
     agents:
       system: x86_64-linux
     env:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have increased buildkite timeout for mainnet 10% sync to 120min

# Comments

<!-- Additional comments or screenshots to attach if any -->

With the introduction of multiple checkpoints, we are taking a longer time to store checkpoints of "big" wallets like the 10% ones created in the nightly benchmark. Depending on the machine's mood, it can take slightly less that 90 minutes, or slightly above, so I am increasing the timeout to 120 minutes.


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
