### PR TITLE
DBSpec: More testing of saving UTxO

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -147,11 +147,7 @@ UTxO                                sql=utxo
 
     -- The wallet checkpoint (wallet_id, slot)
     utxoWalletId        W.WalletId  sql=wallet_id
-
-    -- This UTxO is only available for checkpoints between
-    -- slot and slot_spent.
-    utxoSlot        W.SlotId        sql=slot
-    utxoSlotSpent   W.SlotId Maybe  sql=slot_spent
+    utxoSlot            W.SlotId    sql=slot
 
     -- TxIn
     utxoInputId         TxId        sql=input_tx_id
@@ -163,11 +159,11 @@ UTxO                                sql=utxo
 
     Primary
         utxoWalletId
+        utxoSlot
         utxoInputId
         utxoInputIndex
-        utxoSlot
 
-    Foreign Wallet fk_wallet_utxo utxoWalletId
+    Foreign Checkpoint fk_checkpoint_utxo utxoWalletId utxoSlot
     deriving Show Generic
 
 -- Sequential scheme address discovery state

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -68,6 +68,7 @@ import Test.QuickCheck.Monadic
 
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 -- | Provide a DBLayer to a Spec that requires it. The database is initialised
 -- once, and cleared with 'cleanDB' before each test.

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -42,8 +42,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent.Async
     ( forConcurrently_ )
-import Control.DeepSeq
-    ( NFData )
 import Control.Monad
     ( forM, forM_, void )
 import Control.Monad.IO.Class
@@ -71,7 +69,6 @@ import Test.QuickCheck.Monadic
 
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 
 -- | Provide a DBLayer to a Spec that requires it. The database is initialised
 -- once, and cleared with 'cleanDB' before each test.
@@ -468,4 +465,3 @@ prop_parallelPut putOp readOp resolve db (KeyValPairs pairs) =
         forConcurrently_ pairs $ unsafeRunExceptT . uncurry (putOp db)
         res <- once pairs (readOp db . fst)
         length res `shouldBe` resolve pairs
-

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -30,17 +31,97 @@ import Cardano.Wallet.DB.Arbitrary
 import Cardano.Wallet.DB.Model
     ( filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
+<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( DummyTarget )
+||||||| merged common ancestors
+    ( DummyTarget, block0, genesisParameters )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationType (..)
+    , Index (..)
+    , KeyToAddress (..)
+    , Passphrase (..)
+    , WalletKey (..)
+    , XPrv
+    , XPub
+    , publicKey
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.Random
+    ( RndKey (..) )
+=======
+    ( DummyTarget, genesisParameters )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationType (..)
+    , Index (..)
+    , KeyToAddress (..)
+    , Passphrase (..)
+    , WalletKey (..)
+    , XPrv
+    , XPub
+    , publicKey
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.Random
+    ( RndKey (..) )
+>>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( SeqKey (..) )
+||||||| merged common ancestors
+    ( ChangeChain (..)
+    , SeqKey (..)
+    , deriveAddressPublicKey
+    , unsafeGenerateKeyFromSeed
+    )
+import Cardano.Wallet.Primitive.AddressDiscovery.Random
+    ( RndState (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( AddressPool
+    , AddressPoolGap (..)
+    , SeqState (..)
+    , accountPubKey
+    , changeChain
+    , gap
+    , mkAddressPool
+    , mkAddressPoolGap
+    )
+=======
+    ( ChangeChain (..)
+    , SeqKey (..)
+    , deriveAddressPublicKey
+    , unsafeGenerateKeyFromSeed
+    )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( IsOurs )
+import Cardano.Wallet.Primitive.AddressDiscovery.Random
+    ( RndState (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( AddressPool
+    , AddressPoolGap (..)
+    , SeqState (..)
+    , accountPubKey
+    , changeChain
+    , gap
+    , mkAddressPool
+    , mkAddressPoolGap
+    )
+>>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.Model
+<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( Wallet )
+||||||| merged common ancestors
+    ( Wallet, getState, initWallet, unsafeInitWallet, updateState )
+=======
+    ( Wallet, getState, unsafeInitWallet, updateState )
+>>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId (..), WalletMetadata (..), wholeRange )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent.Async
     ( forConcurrently_ )
+import Control.DeepSeq
+    ( NFData )
 import Control.Monad
     ( forM, forM_, void )
 import Control.Monad.IO.Class
@@ -465,3 +546,4 @@ prop_parallelPut putOp readOp resolve db (KeyValPairs pairs) =
         forConcurrently_ pairs $ unsafeRunExceptT . uncurry (putOp db)
         res <- once pairs (readOp db . fst)
         length res `shouldBe` resolve pairs
+

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -31,89 +31,11 @@ import Cardano.Wallet.DB.Arbitrary
 import Cardano.Wallet.DB.Model
     ( filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( DummyTarget )
-||||||| merged common ancestors
-    ( DummyTarget, block0, genesisParameters )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
-    , KeyToAddress (..)
-    , Passphrase (..)
-    , WalletKey (..)
-    , XPrv
-    , XPub
-    , publicKey
-    )
-import Cardano.Wallet.Primitive.AddressDerivation.Random
-    ( RndKey (..) )
-=======
-    ( DummyTarget, genesisParameters )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
-    , KeyToAddress (..)
-    , Passphrase (..)
-    , WalletKey (..)
-    , XPrv
-    , XPub
-    , publicKey
-    )
-import Cardano.Wallet.Primitive.AddressDerivation.Random
-    ( RndKey (..) )
->>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( SeqKey (..) )
-||||||| merged common ancestors
-    ( ChangeChain (..)
-    , SeqKey (..)
-    , deriveAddressPublicKey
-    , unsafeGenerateKeyFromSeed
-    )
-import Cardano.Wallet.Primitive.AddressDiscovery.Random
-    ( RndState (..) )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPool
-    , AddressPoolGap (..)
-    , SeqState (..)
-    , accountPubKey
-    , changeChain
-    , gap
-    , mkAddressPool
-    , mkAddressPoolGap
-    )
-=======
-    ( ChangeChain (..)
-    , SeqKey (..)
-    , deriveAddressPublicKey
-    , unsafeGenerateKeyFromSeed
-    )
-import Cardano.Wallet.Primitive.AddressDiscovery
-    ( IsOurs )
-import Cardano.Wallet.Primitive.AddressDiscovery.Random
-    ( RndState (..) )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPool
-    , AddressPoolGap (..)
-    , SeqState (..)
-    , accountPubKey
-    , changeChain
-    , gap
-    , mkAddressPool
-    , mkAddressPoolGap
-    )
->>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.Model
-<<<<<<< HEAD:lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
     ( Wallet )
-||||||| merged common ancestors
-    ( Wallet, getState, initWallet, unsafeInitWallet, updateState )
-=======
-    ( Wallet, getState, unsafeInitWallet, updateState )
->>>>>>> also generate arbitrary UTxOs for Random wallets in DBSpec:lib/core/test/unit/Cardano/Wallet/DBSpec.hs
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId (..), WalletMetadata (..), wholeRange )
 import Cardano.Wallet.Unsafe


### PR DESCRIPTION
Relates to #643 

# Overview

With rollback, we want to ensure that checkpoints are correctly rolled back, and the utxo is included in that. So we need to make sure the database tests are generating utxo data in checkpoints.

- This adds random utxo to the checkpoint wallets used in the database property tests and QSM tests.
- The existing property `prop_sequentialPut putCheckpoint` will cover inserting many checkpoints.

# Comments
