### PR TITLE
Purge old checkpoints (beyond k blocks)

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -65,7 +65,7 @@ import Cardano.Wallet.DaedalusIPC
 import Cardano.Wallet.DB
     ( DBLayer )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, Network (..), byronBlockchainParameters )
+    ( HttpBridge, Network (..), block0, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..) )
 import Cardano.Wallet.Network
@@ -274,16 +274,16 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         newWalletLayer (sb, tracer) db = do
             (nl, bp) <- newNetworkLayer (sb, tracer)
             let tl = HttpBridge.newTransactionLayer @n
-            Wallet.newWalletLayer tracer bp db nl tl
+            Wallet.newWalletLayer tracer (block0, bp) db nl tl
 
         newNetworkLayer
             :: (Switchboard Text, Trace IO Text)
-            -> IO (NetworkLayer t IO, BlockchainParameters t)
+            -> IO (NetworkLayer t IO, BlockchainParameters)
         newNetworkLayer (sb, tracer) = do
             nl <- HttpBridge.newNetworkLayer @n (getPort nodePort)
             waitForService "http-bridge" (sb, tracer) nodePort $
                 waitForConnection nl defaultRetryPolicy
-            return (nl, byronBlockchainParameters)
+            return (nl, byronBlockchainParameters @n)
 
         withDBLayer
             :: CM.Configuration

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -127,7 +127,7 @@ import Data.Text
 import Data.Typeable
     ( Typeable )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word64 )
 import Database.Persist.Sql
     ( Entity (..)
     , Filter
@@ -563,8 +563,8 @@ mkCheckpointEntity wid wal =
         ]
     utxoMap = Map.assocs (W.getUTxO (W.utxo wal))
 
-    coerceSlotLength :: W.SlotLength -> Word32
-    coerceSlotLength (W.SlotLength x) = fromIntegral (fromEnum x)
+    coerceSlotLength :: W.SlotLength -> Word64
+    coerceSlotLength (W.SlotLength x) = toEnum (fromEnum x)
 
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already by sorted by index.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -165,8 +165,6 @@ import Fmt
     ( fmt, (+|), (+||), (|+), (||+) )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 import System.Log.FastLogger
     ( fromLogStr )
 
@@ -746,7 +744,7 @@ purgeCheckpoints
     -> W.Wallet s t
     -> SqlPersistT IO ()
 purgeCheckpoints wid cp = do
-    let minHeight = word64 (blockHeight cp) - epochStability
+    let minHeight = word64 (blockHeight cp) - word64 epochStability
     mCp <- selectFirst
         [ CheckpointWalletId ==. wid
         , CheckpointBlockHeight <=. minHeight
@@ -764,13 +762,10 @@ purgeCheckpoints wid cp = do
                 , CheckpointBlockHeight <=. minHeight
                 ]
   where
-    word64 :: Quantity "block" Natural -> Word64
+    word64 :: Integral a => Quantity "block" a -> Word64
     word64 (Quantity x) = fromIntegral x
 
-    -- FIXME
-    -- Hard-coded for now, though we should probably be tracking this from
-    -- within the 'Wallet' primitive model.
-    epochStability = 2160
+    epochStability = W.blockchainParameters cp ^. #getEpochStability
 
 -- | Delete TxMeta values for a wallet.
 deleteTxMetas

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -130,7 +130,7 @@ Checkpoint
     checkpointBlockHeight    Word64       sql=block_height
     checkpointGenesisStart   UTCTime      sql=genesis_start
     checkpointFeePolicy      W.FeePolicy  sql=fee_policy
-    checkpointSlotLength     Word32       sql=slot_length
+    checkpointSlotLength     Word64       sql=slot_length
     checkpointEpochLength    Word16       sql=epoch_length
     checkpointTxMaxSize      Word16       sql=tx_max_size
     checkpointEpochStability Word32       sql=epoch_stability

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -30,7 +30,7 @@ import Data.Text
 import Data.Time.Clock
     ( UTCTime )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word16, Word32, Word64 )
 import Database.Persist.TH
     ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
 import GHC.Generics
@@ -124,10 +124,16 @@ TxOut
 -- A checkpoint for a given wallet is referred to by (wallet_id, slot).
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint
-    checkpointWalletId    W.WalletId  sql=wallet_id
-    checkpointSlot        W.SlotId    sql=slot
-    checkpointParent      BlockId     sql=parent_block_id
-    checkpointBlockHeight Word64      sql=block_height
+    checkpointWalletId       W.WalletId   sql=wallet_id
+    checkpointSlot           W.SlotId     sql=slot
+    checkpointParent         BlockId      sql=parent_block_id
+    checkpointBlockHeight    Word64       sql=block_height
+    checkpointGenesisStart   UTCTime      sql=genesis_start
+    checkpointFeePolicy      W.FeePolicy  sql=fee_policy
+    checkpointSlotLength     Word32       sql=slot_length
+    checkpointEpochLength    Word16       sql=epoch_length
+    checkpointTxMaxSize      Word16       sql=tx_max_size
+    checkpointEpochStability Word32       sql=epoch_stability
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet fk_wallet_checkpoint checkpointWalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochLength (..)
+    , FeePolicy
     , Hash (..)
     , SlotId (..)
     , TxStatus (..)
@@ -42,6 +43,8 @@ import Cardano.Wallet.Primitive.Types
     , fromFlatSlot
     , isValidCoin
     )
+import Control.Arrow
+    ( left )
 import Control.Monad
     ( (>=>) )
 import Data.Aeson
@@ -138,6 +141,17 @@ directionToBool Outgoing = False
 directionFromBool :: Bool -> Direction
 directionFromBool True = Incoming
 directionFromBool False = Outgoing
+
+----------------------------------------------------------------------------
+-- Fee Policy
+
+instance PersistField FeePolicy where
+    toPersistValue = toPersistValue . toText
+    fromPersistValue pv = fromPersistValue pv >>= left (const err) . fromText
+        where err = "not a valid value: " <> T.pack (show pv)
+
+instance PersistFieldSql FeePolicy where
+    sqlType _ = sqlType (Proxy @Text)
 
 ----------------------------------------------------------------------------
 -- WalletId

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -36,6 +36,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
     ( Coin (..)
+    , FeePolicy (..)
     , TxIn
     , TxOut (..)
     , UTxO (..)
@@ -70,15 +71,6 @@ import qualified Data.List as L
 -- | A 'Fee', isomorph to 'Coin' but ease type-signatures and readability.
 newtype Fee = Fee { getFee :: Word64 }
     deriving (Eq, Ord, Show)
-
--- | A linear equation a free variable `x`. Represents the @\s -> a + b*s@
--- function where @s@ can be the transaction size in bytes or, a number of
--- inputs + outputs.
---
--- @a@ and @b@ are constant coefficients.
-data FeePolicy =
-    LinearFee (Quantity "lovelace" Double) (Quantity "lovelace/x" Double)
-    deriving (Eq, Show)
 
 {-------------------------------------------------------------------------------
                                 Fee Calculation

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1076,15 +1076,21 @@ slotRangeFromTimeRange sps (Range mStart mEnd) =
 
 -- | Duration of a single slot.
 newtype SlotLength = SlotLength NominalDiffTime
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance NFData SlotLength
 
 -- | Number of slots in a single epoch
 newtype EpochLength = EpochLength Word16
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance NFData EpochLength
 
 -- | Blockchain start time
 newtype StartTime = StartTime UTCTime
-    deriving (Show, Eq, Ord)
+    deriving (Show, Eq, Ord, Generic)
+
+instance NFData StartTime
 
 {-------------------------------------------------------------------------------
                                 Protocol Magic

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -44,7 +44,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Sqlite
     ( PersistTx (..), newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx (..), block0 )
+    ( DummyTarget, Tx (..), block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), KeyToAddress (..), Passphrase (..), WalletKey (..), XPub )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
@@ -321,6 +321,7 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
         )
         initDummyState
         (Quantity $ fromIntegral i)
+        genesisParameters
 
     utxo = Map.fromList $ zip (mkInputs utxoSize) (mkOutputs utxoSize)
 
@@ -330,7 +331,7 @@ mkCheckpoints numCheckpoints utxoSize = [ cp i | i <- [1..numCheckpoints]]
 benchPutSeqState :: Int -> Int -> DBLayerBench -> IO ()
 benchPutSeqState numCheckpoints numAddrs db =
     unsafeRunExceptT $ mapM_ (putCheckpoint db testPk)
-        [ initWallet block0 $
+        [ initWallet block0 genesisParameters $
             SeqState (mkPool numAddrs i) (mkPool numAddrs i) emptyPendingIxs
         | i <- [1..numCheckpoints]
         ]
@@ -358,7 +359,7 @@ instance PersistTx DummyTarget where
     mkTx _ inps = Tx (fst <$> inps)
 
 testCp :: WalletBench
-testCp = initWallet block0 initDummyState
+testCp = initWallet block0 genesisParameters initDummyState
 
 initDummyState :: SeqState DummyTarget
 initDummyState =

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -8,12 +8,15 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget
     , Tx (..)
     , block0
+    , genesisParameters
     ) where
 
 import Prelude
 
 import Cardano.Crypto.Wallet
     ( unXPub )
+import Cardano.Wallet
+    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
@@ -29,7 +32,11 @@ import Cardano.Wallet.Primitive.Types
     , DecodeAddress (..)
     , DefineTx
     , EncodeAddress (..)
+    , EpochLength (..)
+    , FeePolicy (..)
     , Hash (..)
+    , SlotLength (..)
+    , StartTime (..)
     , TxIn (..)
     , TxOut (..)
     , slotMinBound
@@ -40,8 +47,12 @@ import Data.Bifunctor
     ( bimap )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text.Class
     ( TextDecodingError (..) )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
 import Fmt
     ( Buildable (..), blockListF' )
 import GHC.Generics
@@ -108,4 +119,14 @@ block0 = Block
         , prevBlockHash = Hash "genesis"
         }
     , transactions = []
+    }
+
+genesisParameters  :: BlockchainParameters
+genesisParameters = BlockchainParameters
+    { getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
+    , getFeePolicy = LinearFee (Quantity 14) (Quantity 42)
+    , getSlotLength = SlotLength 1
+    , getEpochLength = EpochLength 21600
+    , getTxMaxSize = Quantity 8192
+    , getEpochStability = Quantity 2160
     }

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -16,7 +16,7 @@ import Prelude
 import Cardano.Wallet.DBSpec
     ( dbPropertyTests, withDB )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, block0 )
+    ( DummyTarget, block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -50,4 +50,4 @@ instance IsOurs DummyStateMVar where
 
 instance Arbitrary (Wallet DummyStateMVar DummyTarget) where
     shrink _ = []
-    arbitrary = initWallet block0 <$> arbitrary
+    arbitrary = initWallet block0 genesisParameters <$> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteFileModeSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.DBSpec
     ( KeyValPairs (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx (..), block0 )
+    ( DummyTarget, Tx (..), block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..), XPrv, encryptPassphrase )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
@@ -290,7 +290,7 @@ cutRandomly = iter []
 -------------------------------------------------------------------------------}
 
 testCp :: Wallet (SeqState DummyTarget) DummyTarget
-testCp = initWallet block0 initDummyState
+testCp = initWallet block0 genesisParameters initDummyState
   where
     initDummyState :: SeqState DummyTarget
     initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -52,7 +52,7 @@ import Cardano.Wallet.DB.StateMachine
 import Cardano.Wallet.DBSpec
     ( dbPropertyTests, withDB )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, Tx (..), block0 )
+    ( DummyTarget, Tx (..), block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..), PersistKey, encryptPassphrase )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
@@ -412,7 +412,7 @@ class GenerateTestKey (key :: Depth -> * -> *) where
 -------------------------------------------------------------------------------}
 
 testCpSeq :: Wallet (SeqState DummyTarget) DummyTarget
-testCpSeq = initWallet block0 initDummyStateSeq
+testCpSeq = initWallet block0 genesisParameters initDummyStateSeq
 
 initDummyStateSeq :: SeqState DummyTarget
 initDummyStateSeq = mkSeqState (xprv, mempty) defaultAddressPoolGap
@@ -449,4 +449,4 @@ initDummyStateRnd = mkRndState xprv 0
     where xprv = fst $ unsafePerformIO generateTestKey
 
 testCpRnd :: Wallet (RndState DummyTarget) DummyTarget
-testCpRnd = initWallet block0 initDummyStateRnd
+testCpRnd = initWallet block0 genesisParameters initDummyStateRnd

--- a/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DBSpec.hs
@@ -39,7 +39,7 @@ import Cardano.Wallet.DB.Model
 import Cardano.Wallet.DB.Sqlite
     ( PersistTx (..) )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, block0 )
+    ( DummyTarget, block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
@@ -223,11 +223,11 @@ instance Arbitrary (PrimaryKey WalletId) where
 
 instance Arbitrary (Wallet (SeqState DummyTarget) DummyTarget) where
     shrink w = [updateState s w | s <- shrink (getState w)]
-    arbitrary = initWallet block0 <$> arbitrary
+    arbitrary = initWallet block0 genesisParameters <$> arbitrary
 
 instance Arbitrary (Wallet (RndState DummyTarget) DummyTarget) where
     shrink w = [updateState s w | s <- shrink (getState w)]
-    arbitrary = initWallet block0 <$> arbitrary
+    arbitrary = initWallet block0 genesisParameters <$> arbitrary
 
 instance Arbitrary Address where
     -- No Shrinking

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -194,10 +194,9 @@ byronTxMaxSize = Quantity 8192
 
 byronBlockchainParameters
     :: forall n. KnownNetwork n
-    => BlockchainParameters (HttpBridge n)
+    => BlockchainParameters
 byronBlockchainParameters = BlockchainParameters
-    { getGenesisBlock = block0
-    , getGenesisBlockDate = case networkVal @n of
+    { getGenesisBlockDate = case networkVal @n of
         Mainnet -> StartTime $ posixSecondsToUTCTime 1506203091
         Testnet -> StartTime $ posixSecondsToUTCTime 1563999616
     , getFeePolicy = byronFeePolicy

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet
 import Cardano.Wallet.DB.Sqlite
     ( PersistState )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, byronBlockchainParameters )
+    ( HttpBridge, block0, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.HttpBridge.Network
@@ -212,8 +212,8 @@ bench_restoration (wid, wname, s) = withHttpBridge network $ \port -> do
     let tl = newTransactionLayer @n @k
     BlockHeader sl _ <- unsafeRunExceptT $ fst <$> networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
-    let bp = byronBlockchainParameters
-    w <- newWalletLayer @t nullTracer bp db nw tl
+    let bp = byronBlockchainParameters @n
+    w <- newWalletLayer @t nullTracer (block0, bp) db nw tl
     wallet <- unsafeRunExceptT $ W.createWallet w wid wname s
     unsafeRunExceptT $ W.restoreWallet w wallet
     waitForWalletSync w wallet

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -16,7 +16,7 @@ import Cardano.Launcher
 import Cardano.Wallet
     ( newWalletLayer )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, byronBlockchainParameters )
+    ( HttpBridge, block0, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Network
@@ -104,6 +104,6 @@ spec = do
         nl <- HttpBridge.newNetworkLayer @'Testnet port
         waitForConnection nl defaultRetryPolicy
         let tl = HttpBridge.newTransactionLayer @'Testnet @SeqKey
-        let bp = byronBlockchainParameters
+        let genesis = (block0, byronBlockchainParameters @'Testnet)
         (handle,) <$>
-            (newWalletLayer @(HttpBridge 'Testnet) nullTracer bp db nl tl)
+            (newWalletLayer @(HttpBridge 'Testnet) nullTracer genesis db nl tl)

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.DB.Sqlite
     ( SqliteContext )
 import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge, byronBlockchainParameters, byronFeePolicy )
+    ( HttpBridge, block0, byronBlockchainParameters, byronFeePolicy )
 import Cardano.Wallet.HttpBridge.Environment
     ( Network (..) )
 import Cardano.Wallet.Network
@@ -276,7 +276,7 @@ main = do
         mvar <- newEmptyMVar
         thread <- forkIO $ do
             let tl = HttpBridge.newTransactionLayer
-            let bp = byronBlockchainParameters
+            let bp = (block0, byronBlockchainParameters @'Testnet)
             wallet <- newWalletLayer nullTracer bp db nl tl
             let listen = fromMaybe (ListenOnPort $ getPort defaultPort) mlisten
             Server.withListeningSocket listen $ \(port, socket) -> do

--- a/lib/text-class/src/Data/Text/Class.hs
+++ b/lib/text-class/src/Data/Text/Class.hs
@@ -45,7 +45,7 @@ import Data.Maybe
 import Data.Text
     ( Text )
 import Data.Text.Read
-    ( decimal, signed )
+    ( decimal, rational, signed )
 import Fmt
     ( Buildable )
 import GHC.Generics
@@ -110,6 +110,28 @@ instance FromText Natural where
         err = TextDecodingError "Expecting natural number"
 
 instance ToText Natural where
+    toText = T.pack . show
+
+instance FromText Integer where
+    fromText t = do
+        (parsedValue, unconsumedInput) <- first (const err) $ signed decimal t
+        unless (T.null unconsumedInput) $ Left err
+        pure parsedValue
+      where
+        err = TextDecodingError "Expecting integer"
+
+instance ToText Integer where
+    toText = T.pack . show
+
+instance FromText Double where
+    fromText t = do
+        (parsedValue, unconsumedInput) <- first (const err) $ rational t
+        unless (T.null unconsumedInput) $ Left err
+        pure parsedValue
+      where
+        err = TextDecodingError "Expecting floating number"
+
+instance ToText Double where
     toText = T.pack . show
 
 -- | Decode the specified text with a 'Maybe' result type.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#644

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have removed old checkpoints and used UTxO from the database 
- [x] keep track of `k` in the wallet primitive model 

# Comments

<!-- Additional comments or screenshots to attach if any -->

I decided to keep track of all the `BlockchainParameters` instead of just `k`. Since this is what's going to matter in the end once we start applying protocol updates. Now, parameters are part of the checkpoints, so we could imagine a function like `applyUpdate :: Update -> Wallet s t -> Wallet s t` which takes care of updating the parameters. 

All `WalletLayer` functions have been adjusted to use the parameters from the current checkpoint instead of pulling it from the surrounding `ctx`. We still pass an initial genesis configuration in `createWallet` and then `initWallet` in the very same way we passed the initial block.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
