### PR TITLE
Remove unnecessary dependency on `cardano-wallet-http-bridge`.

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -144,7 +144,6 @@ test-suite integration
     , cardano-wallet-cli
     , cardano-wallet-core
     , cardano-wallet-core-integration
-    , cardano-wallet-http-bridge
     , cardano-wallet-jormungandr
     , cardano-wallet-launcher
     , cardano-wallet-test-utils

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -90,7 +90,6 @@
             (hsPkgs.cardano-wallet-cli)
             (hsPkgs.cardano-wallet-core)
             (hsPkgs.cardano-wallet-core-integration)
-            (hsPkgs.cardano-wallet-http-bridge)
             (hsPkgs.cardano-wallet-jormungandr)
             (hsPkgs.cardano-wallet-launcher)
             (hsPkgs.cardano-wallet-test-utils)


### PR DESCRIPTION
# Issue Number

None.

# Overview

This change deletes an unnecessary dependency of `cardano-wallet-jormungandr:test:integration` on `cardano-wallet-http-bridge`.

I'm guessing that this dependency is a legacy of the days when we used to share test integration code with symlinks.