### PR TITLE
nix: Make it possible to see and change the jormungandr version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,9 @@ let
   haskell = iohkLib.nix-tools.haskell { inherit pkgs; };
   src = iohkLib.cleanSourceHaskell ./.;
 
-  inherit (iohkLib.rust-packages.pkgs) jormungandr jormungandr-cli;
+  inherit (import ./nix/jormungandr.nix { inherit iohkLib pkgs; })
+    jormungandr jormungandr-cli;
+
   cardano-http-bridge = iohkLib.rust-packages.pkgs.callPackage
     ./nix/cardano-http-bridge.nix { inherit pkgs; };
   cardano-sl-node = import ./nix/cardano-sl-node.nix { inherit pkgs; };

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "a3343c32ade0a7f45ae54541e72f5cdf70f20650",
-  "date": "2019-09-08T21:25:46+00:00",
-  "sha256": "0y15jwg8wjnhv8y0h0nyk3s7c0lcn4b860qdz3lnhv3phbnld3by",
+  "rev": "094425c27307dcaa33595bda5fc69ee00a671612",
+  "date": "2019-09-19T15:45:13+00:00",
+  "sha256": "1615yaj2lzdn6lmxyfr2q9r3sn36gnwfpr9hg6n5iqcnkh4gwq5v",
   "fetchSubmodules": false
 }

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -6,9 +6,10 @@
 #
 # To change the version:
 # 1. Adjust the "version" and/or "rev" variables below.
-# 2. Then change a single digit in *both* sha256 and cargoSha256.
-#    (e.g. change a 4 to 5). It's important that you change them to
-#    something different than before.
+# 2. Then invert the first digit in *both* sha256 and
+#    cargoSha256. That is, change 0 to 1 and 1 to 0. It's important
+#    that you change them to something different than before,
+#    otherwise you may get the previous version from your local cache.
 # 3. Run "nix-build -A jormungandr.src" (or let CI do it for you).
 #    It will say that the hash is wrong. Update sha256 to the value it got.
 # 4. Run "nix-build -A jormungandr". After some time downloading
@@ -28,8 +29,11 @@
 let
   release = rec {
     version = "0.3.3";
+    # Git revision of input-output-hk/jormungandr repo.
     rev = "v${version}";
+    # Hash of git repo and all of its submodules.
     sha256 = "1fw3cl2rxnw9mww1b1z96x2iapwbpdgyp4ra19dhvfzmlvaiml5j";
+    # Hash of all Cargo dependencies.
     cargoSha256 = "1ilp9ffaz3njv38mnqics4b5d7wh52mj4rwi71h5c0wzx4ww3zal";
   };
 

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -1,0 +1,39 @@
+############################################################################
+# Packages for jormungandr and jcli.
+#
+# These use the functions from iohk-nix to build the version that we
+# require for cardano-wallet.
+#
+# To change the version:
+# 1. Adjust the "version" and/or "rev" variables below.
+# 2. Then change a single digit in *both* sha256 and cargoSha256.
+#    (e.g. change a 4 to 5). It's important that you change them to
+#    something different than before.
+# 3. Run "nix-build -A jormungandr.src" (or let CI do it for you).
+#    It will say that the hash is wrong. Update sha256 to the value it got.
+# 4. Run "nix-build -A jormungandr". After some time downloading
+#    crates, it should say that the vendor hash is wrong.
+#    Update cargoSha256 with the value it got.
+# 5. Run "nix-build -A jormungandr". It should complete the build.
+# 6. Test that "nix-build -A jormungandr-cli" also works.
+# 7. If you now run "nix-shell" you should have updated versions of
+#    jormungandr and jcli.
+#
+############################################################################
+
+{ iohkLib ? import ./iohk-common.nix {}
+, pkgs ? iohkLib.pkgs
+}:
+
+let
+  release = rec {
+    version = "0.3.3";
+    rev = "v${version}";
+    sha256 = "1fw3cl2rxnw9mww1b1z96x2iapwbpdgyp4ra19dhvfzmlvaiml5j";
+    cargoSha256 = "1ilp9ffaz3njv38mnqics4b5d7wh52mj4rwi71h5c0wzx4ww3zal";
+  };
+
+in {
+  jormungandr = iohkLib.rust-packages.pkgs.makeJormungandr release;
+  jormungandr-cli = iohkLib.rust-packages.pkgs.makeJcli release;
+}


### PR DESCRIPTION
# Overview

This defines the jormungandr version directly in the cardano-wallet repo so that you can see it and change it.

Instructions for changing version are in the file `nix/jormungandr.nix`. I have tested the procedure.

# Comments

Depends on input-output-hk/iohk-nix#167.