### PR TITLE
Remove remaining hard-coded delays and ports in http-bridge integration tests

### DIFF
--- a/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -218,7 +218,7 @@ spec = do
                 Inherit
             ]
         bridge <- HttpBridge.newNetworkLayer @'Testnet port
-        threadDelay $ 1 * second
+        waitForConnection bridge defaultRetryPolicy
         return (handle, bridge, port)
     second = 1000*1000
 

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -47,6 +47,8 @@ import Data.Text.Class
     ( toText )
 import Test.Hspec
     ( Spec, after, before, expectationFailure, it )
+import Test.Utils.Ports
+    ( findPort )
 
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.MVar as MVar
@@ -81,12 +83,12 @@ spec = do
             result <- retrying policy shouldRetry assertion
             when (isLeft result) $ expectationFailure (show result)
   where
-    port = 1337
     second = 1000*1000
     closeBridge (handle, _) = do
         cancel handle
         threadDelay second
     startBridge = do
+        port <- findPort
         handle <- async $ launch
             [ Command "cardano-http-bridge"
                 [ "start"

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -19,6 +19,8 @@ import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
+import Cardano.Wallet.Network
+    ( defaultRetryPolicy, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Passphrase (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
@@ -98,9 +100,9 @@ spec = do
                 (return ())
                 Inherit
             ]
-        threadDelay second
         db <- MVar.newDBLayer
         nl <- HttpBridge.newNetworkLayer @'Testnet port
+        waitForConnection nl defaultRetryPolicy
         let tl = HttpBridge.newTransactionLayer @'Testnet @SeqKey
         let bp = byronBlockchainParameters
         (handle,) <$>


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#726 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have replaced a hard-coded delay with a retry/timeout approach
- [x] I have removed a hard-coded port and replaced it with a dynamic assignation
- [x] I have used `waitForConnection` instead of hard-coded delays 

# Comments

<!-- Additional comments or screenshots to attach if any -->

Should fix issues observed in those builds:

https://buildkite.com/input-output-hk/cardano-wallet/builds/2038#50350747-546c-4741-8106-947a73ab7d84

https://buildkite.com/input-output-hk/cardano-wallet/builds/1974#d43b7a97-9855-45fd-b3dd-e21ddcb30254/97-1126


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
