### PR TITLE
Add 'rollbackTo' to DBLayer

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -133,6 +133,12 @@ data DBLayer m s t k = DBLayer
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
 
+    , rollbackTo
+        :: PrimaryKey WalletId
+        -> SlotId
+        -> ExceptT ErrNoSuchWallet m ()
+        -- ^ Drops all checkpoints and transaction data after the given slot.
+
     , withLock
         :: forall e a. ()
         => ExceptT e m a

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -38,6 +38,7 @@ import Cardano.Wallet.DB.Model
     , mReadTxHistory
     , mReadWalletMeta
     , mRemoveWallet
+    , mRollbackTo
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), XPrv )
@@ -80,6 +81,9 @@ newDBLayer = do
             cp `deepseq` alterDB errNoSuchWallet db (mPutCheckpoint pk cp)
 
         , readCheckpoint = readDB db . mReadCheckpoint
+
+        , rollbackTo = \pk pt -> ExceptT $
+            alterDB errNoSuchWallet  db (mRollbackTo pk pt)
 
         {-----------------------------------------------------------------------
                                    Wallet Metadata

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -175,7 +175,7 @@ mRollbackTo :: Ord wid => wid -> SlotId -> ModelOp wid s t xprv ()
 mRollbackTo wid pt = alterModel wid $ \wal ->
     ((), wal { checkpoints = filter keepBeforePoint (checkpoints wal) })
   where
-    keepBeforePoint cp = (slotId :: BlockHeader -> SlotId) (currentTip cp) < pt
+    keepBeforePoint cp = (slotId :: BlockHeader -> SlotId) (currentTip cp) <= pt
 
 mPutWalletMeta :: Ord wid => wid -> WalletMetadata -> ModelOp wid s t xprv ()
 mPutWalletMeta wid meta = alterModel wid $ \wal ->

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -45,6 +46,7 @@ module Cardano.Wallet.DB.Model
     , mListWallets
     , mPutCheckpoint
     , mReadCheckpoint
+    , mRollbackTo
     , mPutWalletMeta
     , mReadWalletMeta
     , mPutTxHistory
@@ -56,9 +58,10 @@ module Cardano.Wallet.DB.Model
 import Prelude
 
 import Cardano.Wallet.Primitive.Model
-    ( Wallet )
+    ( Wallet, currentTip )
 import Cardano.Wallet.Primitive.Types
-    ( Hash
+    ( BlockHeader (slotId)
+    , Hash
     , Range (..)
     , SlotId (..)
     , SortOrder (..)
@@ -168,6 +171,12 @@ mReadCheckpoint :: Ord wid => wid -> ModelOp wid s t xprv (Maybe (Wallet s t))
 mReadCheckpoint wid db@(Database wallets _) =
     (Right (checkpoints <$> Map.lookup wid wallets >>= listToMaybe), db)
 
+mRollbackTo :: Ord wid => wid -> SlotId -> ModelOp wid s t xprv ()
+mRollbackTo wid pt = alterModel wid $ \wal ->
+    ((), wal { checkpoints = filter keepBeforePoint (checkpoints wal) })
+  where
+    keepBeforePoint cp = (slotId :: BlockHeader -> SlotId) (currentTip cp) < pt
+
 mPutWalletMeta :: Ord wid => wid -> WalletMetadata -> ModelOp wid s t xprv ()
 mPutWalletMeta wid meta = alterModel wid $ \wal ->
     ((), wal { metadata = meta })
@@ -224,12 +233,12 @@ alterModel wid f db@Database{wallets,txs} = case f <$> Map.lookup wid wallets of
 -- (first time/slotId, then by TxId) to a 'TxHistory'.
 filterTxHistory :: SortOrder -> Range SlotId -> TxHistory t -> TxHistory t
 filterTxHistory order range =
-    filter ((`isWithinRange` range) . slotId . snd . snd)
+    filter ((`isWithinRange` range) . (slotId :: TxMeta -> SlotId) . snd . snd)
     . (case order of
         Ascending -> reverse
         Descending -> id)
     . sortBySlot
     . sortByTxId
   where
-    sortBySlot = sortOn (Down . slotId . snd . snd)
+    sortBySlot = sortOn (Down . (slotId :: TxMeta -> SlotId) . snd . snd)
     sortByTxId = sortOn fst

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -172,7 +172,7 @@ instance NFData (Wallet s t) where
         deepseq (rnf bp) ()
 
 instance Buildable s => Buildable (Wallet s t) where
-    build (Wallet u txs tip s bp) = "\nWallet s t\n"
+    build (Wallet u txs tip s bp) = "Wallet s t\n"
         <> indentF 4 ("Tip: " <> build tip)
         <> indentF 4 ("Parameters:\n" <> indentF 4 (build bp))
         <> indentF 4 ("UTxO: " <> build u)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -496,8 +496,7 @@ instance NFData tx => NFData (Block tx)
 instance Buildable tx => Buildable (Block tx) where
     build (Block h txs) = mempty
         <> build h
-        <> "\n"
-        <> indentF 4 (blockListF txs)
+        <> if null txs then " ∅" else "\n" <> indentF 4 (blockListF txs)
 
 data BlockHeader = BlockHeader
     { slotId
@@ -511,12 +510,13 @@ data BlockHeader = BlockHeader
 instance NFData BlockHeader
 
 instance Buildable BlockHeader where
-    build (BlockHeader s (Quantity bh) prev) = mempty
+    build (BlockHeader s (Quantity bh) prev) = "Block ("
+        <> build s
+        <> "#" <> build (show bh)
+        <> ") -> "
         <> prefixF 8 prevF
         <> "..."
         <> suffixF 8 prevF
-        <> " slot " <> build s <> ", "
-        <> "block " <> build (fromIntegral @Natural @Int bh)
       where
         prevF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash prev
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -53,7 +53,7 @@ import Cardano.Wallet.DB
     , cleanDB
     )
 import Cardano.Wallet.DB.Arbitrary
-    ( KeyValPairs (..) )
+    ( KeyValPairs (..), SlotAndBlocks (..) )
 import Cardano.Wallet.DB.Properties
     ( properties, withDB )
 import Cardano.Wallet.DB.Sqlite
@@ -83,9 +83,10 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Mnemonic
     ( EntropySize, entropyToBytes, genEntropy )
 import Cardano.Wallet.Primitive.Model
-    ( Wallet, initWallet )
+    ( Wallet, applyBlock, currentTip, initWallet )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , BlockHeader (..)
     , Coin (..)
     , Direction (..)
     , Hash (..)
@@ -110,7 +111,7 @@ import Control.DeepSeq
 import Control.Exception
     ( throwIO )
 import Control.Monad
-    ( forM_, replicateM_, unless )
+    ( foldM, forM_, replicateM_, unless )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
@@ -192,6 +193,9 @@ sqliteSpecSeq = withDB newMemoryDBLayer $ do
     describe "Sqlite State machine tests" $ do
         it "Sequential" (prop_sequential :: TestDBSeq -> Property)
         xit "Parallel" prop_parallel
+    describe "Sqlite rollback tests" $ do
+        it "applying blocks"
+            (property . (prop_rollbackApplyBlocks @(SeqState DummyTarget)))
 
 sqliteSpecRnd :: Spec
 sqliteSpecRnd = withDB newMemoryDBLayer $ do
@@ -199,6 +203,9 @@ sqliteSpecRnd = withDB newMemoryDBLayer $ do
         describe "Sqlite State machine (RndState)" $ do
             it "Sequential state machine tests"
                 (prop_sequential :: TestDBRnd -> Property)
+        describe "Sqlite rollback tests" $ do
+            it "applying blocks"
+                (property . (prop_rollbackApplyBlocks @(RndState DummyTarget)))
 
 {-------------------------------------------------------------------------------
                                  Simple Specs
@@ -259,6 +266,32 @@ simpleSpec cp = do
             unsafeRunExceptT $ createWallet db testPk cp testMetadata
             runExceptT (putCheckpoint db testPk cp) `shouldReturn` Right ()
             readCheckpoint db testPk `shouldReturn` Just cp
+
+-- | Can rollback to checkpoints created after
+prop_rollbackApplyBlocks
+    :: (Eq s)
+    => DBLayer IO s DummyTarget k
+    -> Wallet s DummyTarget
+    -> SlotAndBlocks
+    -> Property
+prop_rollbackApplyBlocks db state (SlotAndBlocks (slotTo, blocks)) =
+    monadicIO $ do
+    cps <- setup
+    let cp:_ = filter (\s -> let (BlockHeader slot _ _) = currentTip s
+                             in slot == slotTo) cps
+    prop cp
+  where
+    setup = liftIO $ do
+        unsafeRunExceptT $ createWallet db testPk state testMetadata
+        let addCheckpoint cps@(cp:_) block = do
+                let (_,cp') = applyBlock block cp
+                runExceptT (putCheckpoint db testPk cp') `shouldReturn` Right ()
+                pure $ cp':cps
+            addCheckpoint [] _ = pure []
+        foldM addCheckpoint [state] blocks
+    prop expCp = liftIO $ do
+        runExceptT (rollbackTo db testPk slotTo) `shouldReturn` Right ()
+        readCheckpoint db testPk `shouldReturn` Just expCp
 
 {-------------------------------------------------------------------------------
                                 Logging Spec

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
@@ -95,9 +95,8 @@ instance PersistState AnyAddressState where
             , DB.AnyAddressStateCheckpointSlot ==. sl
             ] []
         return (AnyAddressState s)
-    deleteState wid mSlot = deleteWhere $
-        (DB.AnyAddressStateWalletId ==. wid) :
-        [DB.AnyAddressStateCheckpointSlot ==. sid | Just sid <- [mSlot]]
+    deleteState wid = deleteWhere [DB.AnyAddressStateWalletId ==. wid]
+    rollbackState _ _ = pure ()
 
 initAnyState :: Text -> Double -> (WalletId, WalletName, AnyAddressState)
 initAnyState wname p = (walletId cfg, WalletName wname, cfg)

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -34,7 +34,7 @@ spec = do
             let block = Block
                     { header = BlockHeader
                         { slotId = SlotId 14 19
-                        , blockHeight = Quantity 0
+                        , blockHeight = Quantity 42
                         , prevBlockHash = Hash "\223\252\&5\ACK\211\129\&6\DC4h7b'\225\201\&2:/\252v\SOH\DC1\ETX\227\"Q$\240\142ii\167;"
                         }
                     , transactions =
@@ -58,7 +58,7 @@ spec = do
                             }
                         ]
                     }
-            "dffc3506...6969a73b slot 14.19, block 0\n\
+            "Block (14.19#42) -> dffc3506...6969a73b\n\
             \    - ~> 1st c29d3ea0...13862214\n\
             \      <~ 3823755953610 @ 82d81858...aebb3709\n\
             \      <~ 19999800000 @ 82d81858...37ce9c60\n"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#645 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I added a `rollbackTo` function to the DBLayer, implemented it for the SQLite and MVar / Model implementation.

- [x] I added a simple `MockChain` generator which generates a non empty chain of blocks with increasing slot numbers

- [x] I added a property checking that we can rollback to any arbitrary checkpoint from within an arbitrary mockchain. It actually caught an off-by-one error in the MVar Model :upside_down_face: (strict inequality instead of non-strict). I realized we haven't been using `monadicIO` quite correctly so far, when used correctly, arbitrary data generated within the properties with `pick` actually automatically show in the counter example (like below :point_down:). So the failure becomes quite helpful. 

```
Assertion failed (after 1 test and 7 shrinks):
    Wallet s t
        Tip: Block (0.0#0) -> 68617368...68617368
        Parameters:
             Genesis block date: 1970-01-01 00:00:00 UTC
             Fee policy:         14.0x + 42.0
             Slot length:        1s
             Epoch length:       21600
             Tx max size:        8192
             Epoch stability:    2160
        UTxO: []
        Pending Txs: []
        SeqState:
            internal_chain 35316161...63353866 (gap=10)
            external_chain 35316161...63353866 (gap=10)
            Change indexes:     []
    
    [Block (10.14349#94630) -> 35333663...33393764 ∅]
    
    Wallet ID:
    854fed83...e4804691
    
    Wallet Metadata:
    squirtle (still restoring (94%)), created at 1963-10-09 06:50:11 UTC, not delegating
    
    Rollback target:
    Wallet s t
        Tip: Block (10.14349#94630) -> 35333663...33393764
        Parameters:
             Genesis block date: 1970-01-01 00:00:00 UTC
             Fee policy:         14.0x + 42.0
             Slot length:        1s
             Epoch length:       21600
             Tx max size:        8192
             Epoch stability:    2160
        UTxO: []
        Pending Txs: []
        SeqState:
            internal_chain 35316161...63353866 (gap=10)
            external_chain 35316161...63353866 (gap=10)
            Change indexes:     []
    
    Checkpoint after rollback: 
    Wallet s t
        Tip: Block (10.14349#94630) -> 35333663...33393764
        Parameters:
             Genesis block date: 1970-01-01 00:00:00 UTC
             Fee policy:         14.0x + 42.0
             Slot length:        1s
             Epoch length:       21600
             Tx max size:        8192
             Epoch stability:    2160
        UTxO: []
        Pending Txs: []
        SeqState:
            internal_chain 35316161...63353866 (gap=10)
            external_chain 35316161...63353866 (gap=10)
            Change indexes:     []
```


In another PR:

- [ ] Include a rollback command in the state machine
- [ ] Maybe have some DB properties about the tx history 

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
