### PR TITLE
Nix: Fix flaky eval check

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,11 +11,6 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: Check Hydra evaluation of release.nix
-    command: 'nix-build -A iohkLib.check-hydra -o check-hydra.sh && ./check-hydra.sh'
-    agents:
-      system: x86_64-linux
-
   - label: Check auto-generated Nix
     command: 'nix-build -A iohkLib.check-nix-tools -o check-nix-tools.sh && ./check-nix-tools.sh'
     agents:

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,6 @@ status = [
   "buildkite/cardano-wallet",
   "ci/hercules/evaluation",
 ]
-timeout_sec = 5400
+timeout_sec = 3600
 required_approvals = 1
 delete_merged_branches = false

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
   "buildkite/cardano-wallet",
+  "ci/hercules/evaluation",
 ]
 timeout_sec = 5400
 required_approvals = 1


### PR DESCRIPTION
# Overview

The `iohkLib.check-hydra` script is slow and flaky. If a nix store garbage collection runs during the script's execution, it will fail.

This changes Bors to check Nix evaluation via Hercules-CI, which is faster, rather than the check-hydra script.

Also, reduce the bors timeout from 90m to 1h.
