### PR TITLE
Dynamically get block0H in jörmungandr integration tests

### DIFF
--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -25,7 +25,7 @@ import Cardano.BM.Trace
 import Cardano.CLI
     ( Port (..) )
 import Cardano.Faucet
-    ( block0H, initFaucet )
+    ( getBlock0H, initFaucet )
 import Cardano.Launcher
     ( StdStream (..) )
 import Cardano.Wallet
@@ -177,6 +177,7 @@ cardanoWalletServer
 cardanoWalletServer jormungandrUrl mlisten = do
     logConfig <- CM.empty
     tracer <- initTracer Info "serve"
+    block0H <- getBlock0H
     (nl, (block0, bp)) <- newNetworkLayer jormungandrUrl block0H
     (sqlCtx, db) <- Sqlite.newDBLayer @_ @network logConfig tracer Nothing
     mvar <- newEmptyMVar

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -17,7 +17,7 @@ import Prelude
 import Cardano.CLI
     ( Port )
 import Cardano.Faucet
-    ( block0H )
+    ( getBlock0H )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiFee
@@ -465,7 +465,7 @@ fixtureExternalTx ctx toSend = do
             [ TxOut addrDest' (Coin (fromIntegral toSend))
             , TxOut addrChng (Coin (fromIntegral $ amt - toSend - fee))
             ]
-    let tl = newTransactionLayer @'Testnet block0H
+    tl <- newTransactionLayer @'Testnet <$> getBlock0H
     let (Right txWits) = mkStdTx tl keystore theInps theOuts
 
     return ExternalTxFixture

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -13,7 +13,7 @@ import Prelude
 import Cardano.CLI
     ( Port (..) )
 import Cardano.Faucet
-    ( block0HText )
+    ( getBlock0HText )
 import Control.Concurrent
     ( threadDelay )
 import Control.Exception
@@ -34,7 +34,7 @@ import System.Process
     , withCreateProcess
     )
 import Test.Hspec
-    ( Spec, SpecWith, describe, it, pendingWith )
+    ( Spec, SpecWith, describe, it, pendingWith, runIO )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldReturn )
 import Test.Integration.Framework.DSL
@@ -55,7 +55,7 @@ import qualified Data.Text as T
 
 spec :: forall t. KnownCommand t => SpecWith (Context t)
 spec = do
-    let block0H = T.unpack block0HText
+    block0H <- runIO $ T.unpack <$> getBlock0HText
     describe "SERVER - cardano-wallet serve [SERIAL]" $ do
         it "SERVER - Can start cardano-wallet serve --database" $ \_ -> do
             withTempDir $ \d -> do


### PR DESCRIPTION
# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Get the hash dynamically from `jcli` such that we don't have to update it manually when re-generating `block0`.


# Comments
- We already use `jcli` and `jormungandr` via `readProcess` from the integration tests, so there shouldn't be a downside to this.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
