### PR TITLE
Don't crash because of other kinds of witnesses

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -91,7 +91,7 @@ import Cardano.Wallet.Transaction
 import Control.Applicative
     ( many )
 import Control.Monad
-    ( replicateM, unless, when )
+    ( replicateM, unless )
 import Crypto.Hash
     ( hash )
 import Crypto.Hash.Algorithms
@@ -301,11 +301,9 @@ getTransaction n = label "getTransaction" $ do
     getWitness :: Get TxWitness
     getWitness = do
         tag <- getTxWitnessTag
-        when (tag == TxWitnessAccount) $
-            error "unimplemented: Account witness"
-        when (tag == TxWitnessMultisig) $
-            error "unimplemented: Multisig witness"
         let len = txWitnessSize tag
+        -- NOTE: Regardless of the type of witness, we decode it as a
+        -- @TxWitness@.
         TxWitness <$> isolate len (getByteString len)
 
     getTxWitnessTag :: Get TxWitnessTag


### PR DESCRIPTION
# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Simply don't crash. `TxWitness` is already agnostic to the kind of witness. 


# Comments

<!-- Additional comments or screenshots to attach if any -->

- I believe the decision to crash was made when it wasn't clear that `TxWitness` should be a container agnostic to the type of witness.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
