### PR TITLE
OLD: Refactor `NetworkLayer` into `Restorer` and `TxSubmitter`

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -91,6 +91,7 @@ library
       Cardano.Wallet.DB.Sqlite.TH
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.Network
+      Cardano.Wallet.StakePool.Metrics
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Random
       Cardano.Wallet.Primitive.AddressDerivation.Sequential

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -53,7 +53,7 @@ module Cardano.Wallet
     -- $Capabilities
     , HasDBLayer
     , HasLogger
-    , HasNetworkLayer
+    , HasRestorer
     , HasTransactionLayer
     , HasWorkerRegistry
 
@@ -113,7 +113,7 @@ import Cardano.Wallet.DB
     , PrimaryKey (..)
     )
 import Cardano.Wallet.Network
-    ( ErrNetworkUnavailable (..), ErrPostTx (..), NetworkLayer (..) )
+    ( ErrNetworkUnavailable (..), ErrPostTx (..), Restorer (..), TxSubmitter )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (RootK)
     , ErrWrongPassphrase (..)
@@ -345,8 +345,9 @@ data WalletLayer s t (k :: Depth -> * -> *)
         (Trace IO Text)
         (Block (Tx t), BlockchainParameters)
         (DBLayer IO s t k)
-        (NetworkLayer t IO)
+        (Restorer (Block (Tx t)) IO)
         (TransactionLayer t k)
+        (TxSubmitter (Tx t) IO)
         WorkerRegistry
     deriving (Generic)
 
@@ -383,11 +384,12 @@ newWalletLayer
     :: Trace IO Text
     -> (Block (Tx t), BlockchainParameters)
     -> DBLayer IO s t k
-    -> NetworkLayer t IO
+    -> Restorer (Block (Tx t)) IO
     -> TransactionLayer t k
+    -> TxSubmitter (Tx t) IO
     -> IO (WalletLayer s t k)
-newWalletLayer tr g0 db nw tl =
-    WalletLayer tr g0 db nw tl <$> newRegistry
+newWalletLayer tr g0 db nw tl ts =
+    WalletLayer tr g0 db nw tl ts <$> newRegistry
 
 {-------------------------------------------------------------------------------
                             Wallet Capabilities
@@ -426,11 +428,13 @@ type HasGenesisData t = HasType (Block (Tx t), BlockchainParameters)
 
 type HasLogger = HasType (Trace IO Text)
 
-type HasNetworkLayer t = HasType (NetworkLayer t IO)
+type HasRestorer t = HasType (Restorer t IO)
 
 type HasTransactionLayer t k = HasType (TransactionLayer t k)
 
 type HasWorkerRegistry = HasType WorkerRegistry
+
+type HasTxSubmitter tx = HasType (TxSubmitter tx IO)
 
 dbLayer
     :: forall s t k ctx. HasDBLayer s t k ctx
@@ -451,10 +455,10 @@ logger =
     typed @(Trace IO Text)
 
 networkLayer
-    :: forall t ctx. (HasNetworkLayer t ctx)
-    => Lens' ctx (NetworkLayer t IO)
+    :: forall b ctx. (HasRestorer b ctx)
+    => Lens' ctx (Restorer b IO)
 networkLayer =
-    typed @(NetworkLayer t IO)
+    typed @(Restorer b IO)
 
 transactionLayer
     :: forall t k ctx. (HasTransactionLayer t k ctx)
@@ -467,6 +471,12 @@ workerRegistry
     => Lens' ctx WorkerRegistry
 workerRegistry =
     typed @WorkerRegistry
+
+transactionSubmitter
+    :: forall tx ctx. (HasTxSubmitter tx ctx)
+    => Lens' ctx (TxSubmitter tx IO)
+transactionSubmitter =
+    typed @(TxSubmitter tx IO)
 
 {-------------------------------------------------------------------------------
                                    Wallet
@@ -638,7 +648,7 @@ restoreWallet
         ( IsWalletCtx s t k ctx
         , HasLogger ctx
         , HasDBLayer s t k ctx
-        , HasNetworkLayer t ctx
+        , HasRestorer (Block (Tx t)) ctx
         , HasWorkerRegistry ctx
         , DefineTx t
         )
@@ -666,7 +676,7 @@ restoreWallet ctx wid = do
                 logError tr $ "Worker exited unexpectedly: " +|| e ||+ ""
     liftIO $ registerWorker re wid worker onError
   where
-    nw = ctx ^. networkLayer @t
+    nw = ctx ^. networkLayer @(Block (Tx t))
     tr = ctx ^. logger
     re = ctx ^. workerRegistry
 
@@ -679,7 +689,7 @@ restoreStep
     :: forall ctx s t k.
         ( IsWalletCtx s t k ctx
         , HasLogger ctx
-        , HasNetworkLayer t ctx
+        , HasRestorer (Block (Tx t)) ctx
         , HasDBLayer s t k ctx
         , DefineTx t
         )
@@ -699,7 +709,7 @@ restoreStep ctx wid (localTip, (nodeTip, nodeHeight)) = do
             let blocks = blockFirst :| blocksRest
             let nextLocalTip = view #header . NE.last $ blocks
             let measuredTip = (nodeTip ^. #slotId, nodeHeight)
-            let action = restoreBlocks @ctx @s @t @k ctx  wid blocks measuredTip
+            let action = restoreBlocks @ctx @s @t @k ctx wid blocks measuredTip
             runExceptT action >>= \case
                 Left (ErrNoSuchWallet _) ->
                     logNotice tr "Wallet is gone! Terminating worker..."
@@ -707,7 +717,7 @@ restoreStep ctx wid (localTip, (nodeTip, nodeHeight)) = do
                     restoreStep @ctx @s @t @k ctx wid
                         (nextLocalTip, (nodeTip, nodeHeight))
   where
-    nw = ctx ^. networkLayer @t
+    nw = ctx ^. networkLayer @(Block (Tx t))
     tr = ctx ^. logger
 
 -- | Wait a short delay before querying for blocks again. We also take this
@@ -716,7 +726,7 @@ restoreStep ctx wid (localTip, (nodeTip, nodeHeight)) = do
 restoreSleep
     :: forall ctx s t k.
         ( IsWalletCtx s t k ctx
-        , HasNetworkLayer t ctx
+        , HasRestorer (Block (Tx t)) ctx
         , HasLogger ctx
         , HasDBLayer s t k ctx
         , DefineTx t
@@ -734,7 +744,7 @@ restoreSleep ctx wid localTip = do
         Right nodeTip ->
             restoreStep @ctx @s @t @k ctx wid (localTip, nodeTip)
   where
-    nw = ctx ^. networkLayer @t
+    nw = ctx ^. networkLayer @(Block (Tx t))
     tr = ctx ^. logger
     twoSeconds = 2000000 -- FIXME: Leave that to the networking layer
 
@@ -993,28 +1003,28 @@ signTx ctx wid pwd (CoinSelection ins outs chgs) =
 submitTx
     :: forall ctx s t k.
         ( IsWalletCtx s t k ctx
-        , HasNetworkLayer t ctx
         , HasDBLayer s t k ctx
+        , HasTxSubmitter (Tx t) ctx
         )
     => ctx
     -> WalletId
     -> (Tx t, TxMeta, [TxWitness])
     -> ExceptT ErrSubmitTx IO ()
-submitTx ctx wid (tx, meta, wit)= do
-    withExceptT ErrSubmitTxNetwork $ postTx nw (tx, wit)
+submitTx ctx wid (tx, meta, wit) = do
+    withExceptT ErrSubmitTxNetwork $ postTx (tx, wit)
     DB.withLock db $ withExceptT ErrSubmitTxNoSuchWallet $ do
         (wal, _) <- readWallet @ctx @s @t @k ctx wid
         DB.putCheckpoint db (PrimaryKey wid) (newPending (tx, meta) wal)
   where
     db = ctx ^. dbLayer @s @t @k
-    nw = ctx ^. networkLayer @t
+    postTx = ctx ^. transactionSubmitter @(Tx t)
 
 -- | Broadcast an externally-signed transaction to the network.
 submitExternalTx
     :: forall ctx s t k.
         ( IsWalletCtx s t k ctx
-        , HasNetworkLayer t ctx
         , HasTransactionLayer t k ctx
+        , HasTxSubmitter (Tx t) ctx
         )
     => ctx
     -> ByteString
@@ -1022,10 +1032,10 @@ submitExternalTx
 submitExternalTx ctx bytes = do
     txWithWit@(tx,_) <- withExceptT ErrSubmitExternalTxDecode $ except $
         decodeSignedTx tl bytes
-    withExceptT ErrSubmitExternalTxNetwork $ postTx nw txWithWit
+    withExceptT ErrSubmitExternalTxNetwork $ postTx txWithWit
     return tx
   where
-    nw = ctx ^. networkLayer @t
+    postTx = ctx ^. transactionSubmitter @(Tx t)
     tl = ctx ^. transactionLayer @t @k
 
 

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -39,8 +39,8 @@ import GHC.Generics
 import Numeric.Natural
     ( Natural )
 
-data NetworkLayer t m = NetworkLayer
-    { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [Block (Tx t)]
+data Restorer block m = NetworkLayer
+    { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [block]
         -- ^ Fetches a contiguous sequence of blocks from the node, starting
         -- from the first block available with a slot greater than the given
         -- block header.
@@ -58,10 +58,10 @@ data NetworkLayer t m = NetworkLayer
         -- ^ Get the current network tip from the chain producer and the current
         -- chain's height.
 
-    , postTx
-        :: (Tx t, [TxWitness]) -> ExceptT ErrPostTx m ()
-        -- ^ Broadcast a transaction to the chain producer
     }
+
+-- | Broadcast a transaction to the chain producer
+type TxSubmitter tx m = (tx, [TxWitness]) -> ExceptT ErrPostTx m ()
 
 -- | Network is unavailable
 data ErrNetworkUnavailable
@@ -102,7 +102,7 @@ instance Exception ErrPostTx
 -- | Wait until 'networkTip networkLayer' succeeds according to a given
 -- retry policy. Throws an exception otherwise.
 waitForConnection
-    :: NetworkLayer t IO
+    :: Restorer b IO
     -> RetryPolicyM IO
     -> IO ()
 waitForConnection nw policy = do

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -7,7 +7,8 @@
 module Cardano.Wallet.Network
     (
     -- * Interface
-      NetworkLayer (..)
+      Restorer (..)
+    , TxSubmitter
 
     -- * Helpers
     , waitForConnection
@@ -23,7 +24,7 @@ module Cardano.Wallet.Network
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), Tx, TxWitness )
+    ( BlockHeader (..), Hash (..), TxWitness )
 import Control.Exception
     ( Exception (..), throwIO )
 import Control.Monad.Trans.Except

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -40,7 +40,7 @@ import GHC.Generics
 import Numeric.Natural
     ( Natural )
 
-data Restorer block m = NetworkLayer
+data Restorer block m = Restorer
     { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [block]
         -- ^ Fetches a contiguous sequence of blocks from the node, starting
         -- from the first block available with a slot greater than the given

--- a/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
+++ b/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+-- | This module can fold over a blockchain to collect metrics about
+-- Stake pools.
+--
+-- It interacts with:
+-- - "Cardano.Wallet.Network" which provides the chain
+-- - "Cardano.Wallet.DB" - which can persist the metrics
+-- - "Cardano.Wallet.Api.Server" - which presents the results in an endpoint
+module Cardano.Wallet.StakePool.Metrics where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..), SlotId (..) )
+import Data.ByteString
+    ( ByteString )
+import Data.Map.Strict
+    ( Map )
+import Data.Word
+    ( Word )
+
+import qualified Data.Map.Strict as Map
+
+newtype PoolId = PoolVRFPubKey ByteString -- 32 bytes long
+  deriving newtype (Ord, Eq)
+
+data State = State
+    { tip :: BlockHeader
+    , numberOfBlocksProducedThisEpoch :: Map PoolId Word
+    }
+
+
+applyBlock :: b -> (b -> BlockHeader) -> (b -> PoolId) -> State -> State
+applyBlock b getTip getPoolId (State prevTip prevMap) =
+    let
+        map' = Map.alter  (\case
+            Nothing -> Just 1
+            Just n -> Just $ n + 1)
+            (getPoolId b)
+            prevMap
+    in
+        -- Clear the map if the epoch changes
+        -- TODO: The plan to deal with rollbacks might be really unsound.
+        if epoch prevTip == epoch (getTip b)
+        then (State tip' map')
+        else State tip' Map.empty
+  where
+    epoch = epochNumber . slotId
+    tip' = getTip b

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -121,6 +121,7 @@ newtype ErrMkStdTx
     -- ^ We tried to sign a transaction with inputs that are unknown to us?
     deriving (Eq, Show)
 
+
 -- | Backend-specific variables used by 'estimateMaxNumberOfInputsBase'.
 data EstimateMaxNumberOfInputsParams t = EstimateMaxNumberOfInputsParams
     { estMeasureTx :: [TxIn] -> [TxOut] -> [TxWitness] -> Int

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -394,7 +394,8 @@ setupFixture (wid, wname, wstate) = do
     db <- newDBLayer
     let nl = error "NetworkLayer"
     let tl = dummyTransactionLayer
-    wl <- newWalletLayer @DummyTarget nullTracer (block0, bp) db nl tl
+    let postTx = error "postTx"
+    wl <- newWalletLayer @DummyTarget nullTracer (block0, bp) db nl tl postTx
     res <- runExceptT $ W.createWallet wl wid wname wstate
     let wal = case res of
             Left _ -> []

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -23,6 +23,7 @@ module Cardano.Wallet.HttpBridge.Network
     , mkTxSubmission
 
     , mkHttpBridgeLayer
+    , newHttpBridgeLayer
     ) where
 
 import Prelude

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -15,7 +15,7 @@ import Cardano.Wallet.HttpBridge.Network
 import Cardano.Wallet.HttpBridge.Primitive.Types
     ( Tx )
 import Cardano.Wallet.Network
-    ( NetworkLayer (..) )
+    ( Restorer (..) )
 import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), Hash (..), SlotId (..), slotMinBound )
 import Control.Monad.Trans.Class
@@ -33,7 +33,7 @@ import qualified Data.ByteString.Char8 as B8
 spec :: Spec
 spec = do
     describe "Getting next blocks with a mock backend" $ do
-        let network = mockNetworkLayer noLog 105 (SlotId 106 1492)
+        let network = mockRestorer noLog 105 (SlotId 106 1492)
 
         it "should get something from the latest epoch" $ do
             let h = BlockHeader
@@ -151,14 +151,14 @@ mockEpoch ep =
   where
     epochs = [ 0 .. fromIntegral (slotsPerEpoch - 1) ]
 
-mockNetworkLayer
+mockRestorer
     :: Monad m
     => (String -> m ()) -- ^ logger function
     -> Word64 -- ^ make getEpoch fail for epochs after this
     -> SlotId -- ^ the tip block
-    -> NetworkLayer (HttpBridge 'Testnet) m
-mockNetworkLayer logLine firstUnstableEpoch tip =
-    HttpBridge.mkNetworkLayer (mockHttpBridge logLine firstUnstableEpoch tip)
+    -> Restorer (HttpBridge 'Testnet) m
+mockRestorer logLine firstUnstableEpoch tip =
+    HttpBridge.mkRestorer (mockHttpBridge logLine firstUnstableEpoch tip)
 
 -- | A network layer which returns mock blocks.
 mockHttpBridge


### PR DESCRIPTION
# Issue Number

#711 

# Overview
- [x] I have split `NetworkLayer t m` into `Restorer block m` and `TxSubmitter tx m`.
- [ ] Todo: make `Restorer` a `Functor` (such that we can map over the blocks-types)
- [ ] Todo: Move where `Jörmungandr`-blocks are converted to `core.Block`s.
- [ ] Todo: Create new modules `Cardano.Wallet{., Jormungandr., HttpBridge.}Restoration`
- [ ] Todo: clean up tests

# Comments
- I'm less sure about the `TxSubmitter` name, but `Restorer` sounds descent to me.
- I have aimed to limit uses of "target types" `t` in favour of more specific types (like `block`).

### Next steps (separate PR):
- Aim to relocate glue and `newWalletLayer` setup from `exe/` to `Cardano.Wallet.{Jormungandr, HttpBridge}`

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
