### PR TITLE
Rollback: additional properties about transaction history during rollback

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -350,6 +350,7 @@ newDBLayer logConfig trace fp = do
                         , TxMetaSlotId >. point
                         ]
                         [ TxMetaStatus =. W.Pending
+                        , TxMetaSlotId =. point
                         ]
                     deleteTxMetas wid
                         [ TxMetaDirection ==. W.Incoming

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -82,6 +82,8 @@ import Cardano.Wallet.Primitive.Model
     ( currentTip )
 import Cardano.Wallet.Primitive.Types
     ( DefineTx (..) )
+import Control.Arrow
+    ( (***) )
 import Control.Concurrent.MVar
     ( newMVar, withMVar )
 import Control.DeepSeq
@@ -392,8 +394,7 @@ newDBLayer logConfig trace fp = do
                       pure $ Right ()
                   Nothing -> pure $ Left $ ErrNoSuchWallet wid
 
-        , readTxHistory = \(PrimaryKey wid) order range ->
-              runQuery $
+        , readTxHistory = \(PrimaryKey wid) order range -> runQuery $
               selectTxHistory @t wid order $ catMaybes
                 [ (TxMetaSlotId >=.) <$> W.inclusiveLowerBound range
                 , (TxMetaSlotId <=.) <$> W.inclusiveUpperBound range
@@ -844,12 +845,17 @@ selectUTxO cp = fmap entityVal <$>
 selectTxs
     :: [TxId]
     -> SqlPersistT IO ([TxIn], [TxOut])
-selectTxs txids = do
-    ins <- fmap entityVal <$> selectList [TxInputTxId <-. txids]
-        [Asc TxInputTxId, Asc TxInputOrder]
-    outs <- fmap entityVal <$> selectList [TxOutputTxId <-. txids]
-        [Asc TxOutputTxId, Asc TxOutputIndex]
-    pure (ins, outs)
+selectTxs = fmap concatUnzip . mapM select . chunksOf chunkSize
+  where
+    select txids = do
+        ins <- fmap entityVal <$> selectList [TxInputTxId <-. txids]
+            [Asc TxInputTxId, Asc TxInputOrder]
+        outs <- fmap entityVal <$> selectList [TxOutputTxId <-. txids]
+            [Asc TxOutputTxId, Asc TxOutputIndex]
+        pure (ins, outs)
+
+    concatUnzip :: [([a], [b])] -> ([a], [b])
+    concatUnzip = (concat *** concat) . unzip
 
 selectTxHistory
     :: forall t. PersistTx t


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#645 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed SQLite select statements for tx_in and tx_out. I actually ran into the infamous `too many SQL variables SQLite3` as I was being a bit too extreme on the generators. We now split the `select` statement in multiple chunked statements.

- [x] I have added a property test to check the behavior regarding the tx history upon rolling back. 

- [x] I have consequently fixed the DB model to properly handle the tx history during rollbacks.

- [x] Also caught an error in the SQLite implementation (not replacing the `slot` with the point of rollback). 

# Comments

<!-- Additional comments or screenshots to attach if any -->

I made quite some efforts about the QC failure, and here's what is printed on screen upon failure:

```
 Assertion failed (after 4 tests and 8 shrinks):
   Wallet s t
       Tip: Block (0.0#0) -> 68617368...68617368
       Parameters:
            Genesis block date: 1970-01-01 00:00:00 UTC
            Fee policy:         14.0x + 42.0
            Slot length:        1s
            Epoch length:       21600
            Tx max size:        8192
            Epoch stability:    2160
       UTxO: []
       Pending Txs: []
       SeqState:
           internal_chain 35316161...63353866 (gap=10)
           external_chain 35316161...63353866 (gap=10)
           Change indexes:     []
   
   5478207b...7d7d5d7d:
     ( ~> 2nd 183efa23...222b177b
       <~ 3649 @ 41444452...44523037
     , -0.000001 invalidated since 86.17222 
     )
   
   
   Wallet ID:
   948caa2d...95043914
   
   Wallet Metadata:
   charmander (restored), created at 2434-05-13 09:00:00 UTC, not delegating
   
   Rollback point:
   15.616
   
   Tx history after rollback: 
   5478207b...7d7d5d7d:
     ( ~> 2nd 183efa23...222b177b
       ~> 2nd 7b720969...b1517767
       <~ 3649 @ 41444452...44523037
       <~ 11553 @ 41444452...44523035
     , -0.000001 pending since 86.17222 
     )
   
   Outgoing txs are reschuled ✓
   All other txs are still known ✓
   All txs are now before the point of rollback ✗
```

And, in case of success:

```
      Correctly re-construct tx history on rollbacks
        +++ OK, passed 200 tests:
        72.0% rolling back something
        
        28.0% Outgoing tx after point: 0
        17.0% Outgoing tx after point: 1
         9.0% Outgoing tx after point: 2
         8.0% Outgoing tx after point: 4
         7.0% Outgoing tx after point: 3
         5.0% Outgoing tx after point: 5
         5.0% Outgoing tx after point: 8
         3.5% Outgoing tx after point: 7
         3.0% Outgoing tx after point: 6
         2.5% Outgoing tx after point: 9
         2.0% Outgoing tx after point: 10
         2.0% Outgoing tx after point: 12
         2.0% Outgoing tx after point: 17
         1.5% Outgoing tx after point: 11
         1.5% Outgoing tx after point: 19
         1.0% Outgoing tx after point: 16
         0.5% Outgoing tx after point: 13
         0.5% Outgoing tx after point: 15
         0.5% Outgoing tx after point: 27
         0.5% Outgoing tx after point: 30
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
