### PR TITLE
Make NetworkLayer polymorphic over block

### DIFF
--- a/exe/wallet/http-bridge/Main.hs
+++ b/exe/wallet/http-bridge/Main.hs
@@ -68,6 +68,8 @@ import Cardano.Wallet.HttpBridge.Compatibility
     ( HttpBridge, Network (..), block0, byronBlockchainParameters )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..) )
+import Cardano.Wallet.HttpBridge.Primitive.Types
+    ( Tx )
 import Cardano.Wallet.Network
     ( NetworkLayer, defaultRetryPolicy, waitForConnection )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -76,6 +78,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( SeqKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
+import Cardano.Wallet.Primitive.Types
+    ( Block )
 import Cardano.Wallet.Version
     ( showVersion, version )
 import Control.Applicative
@@ -278,7 +282,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newNetworkLayer
             :: (Switchboard Text, Trace IO Text)
-            -> IO (NetworkLayer t IO, BlockchainParameters)
+            -> IO (NetworkLayer IO Tx (Block Tx), BlockchainParameters)
         newNetworkLayer (sb, tracer) = do
             nl <- HttpBridge.newNetworkLayer @n (getPort nodePort)
             waitForService "http-bridge" (sb, tracer) nodePort $

--- a/exe/wallet/jormungandr/Main.hs
+++ b/exe/wallet/jormungandr/Main.hs
@@ -326,7 +326,10 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
 
         newNetworkLayer
             :: (Switchboard Text, Trace IO Text)
-            -> IO (NetworkLayer t IO, (Block Tx, BlockchainParameters))
+            -> IO
+               ( NetworkLayer IO Tx (Block Tx)
+               , (Block Tx, BlockchainParameters)
+               )
         newNetworkLayer (sb, tracer) = do
             let url = BaseUrl Http "localhost" (getPort nodePort) "/api"
             (jor, nl) <- Jormungandr.newNetworkLayer' url

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -23,7 +23,7 @@ module Cardano.Wallet.Network
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), Tx, TxWitness )
+    ( BlockHeader (..), Hash (..), TxWitness )
 import Control.Exception
     ( Exception (..), throwIO )
 import Control.Monad.Trans.Except
@@ -35,8 +35,8 @@ import Data.Text
 import GHC.Generics
     ( Generic )
 
-data NetworkLayer t m = NetworkLayer
-    { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [Block (Tx t)]
+data NetworkLayer m tx block = NetworkLayer
+    { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [block]
         -- ^ Fetches a contiguous sequence of blocks from the node, starting
         -- from the first block available with a slot greater than the given
         -- block header.
@@ -54,7 +54,7 @@ data NetworkLayer t m = NetworkLayer
         -- ^ Get the current network tip from the chain producer
 
     , postTx
-        :: (Tx t, [TxWitness]) -> ExceptT ErrPostTx m ()
+        :: (tx, [TxWitness]) -> ExceptT ErrPostTx m ()
         -- ^ Broadcast a transaction to the chain producer
     }
 
@@ -97,7 +97,7 @@ instance Exception ErrPostTx
 -- | Wait until 'networkTip networkLayer' succeeds according to a given
 -- retry policy. Throws an exception otherwise.
 waitForConnection
-    :: NetworkLayer t IO
+    :: NetworkLayer IO tx block
     -> RetryPolicyM IO
     -> IO ()
 waitForConnection nw policy = do

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -58,6 +58,9 @@ data NetworkLayer m tx block = NetworkLayer
         -- ^ Broadcast a transaction to the chain producer
     }
 
+instance Functor m => Functor (NetworkLayer m tx) where
+     fmap f nl = nl { nextBlocks = fmap (fmap f) . nextBlocks nl }
+
 -- | Network is unavailable
 data ErrNetworkUnavailable
     = ErrNetworkUnreachable Text

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -35,8 +35,6 @@ import Cardano.Wallet.HttpBridge.Api
     , PostSignedTx
     , api
     )
-import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge )
 import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.HttpBridge.Primitive.Types
@@ -93,9 +91,9 @@ import qualified Servant.Extra.ContentTypes as Api
 
 -- | Constructs a network layer with the given cardano-http-bridge API.
 mkNetworkLayer
-    :: forall n m. (Monad m)
+    :: forall m. (Monad m)
     => HttpBridgeLayer m
-    -> NetworkLayer (HttpBridge n) m
+    -> NetworkLayer m Tx (Block Tx)
 mkNetworkLayer httpBridge = NetworkLayer
     { nextBlocks = \(BlockHeader sl _ _) ->
         withExceptT ErrGetBlockNetworkUnreachable (rbNextBlocks httpBridge sl)
@@ -109,7 +107,7 @@ mkNetworkLayer httpBridge = NetworkLayer
 newNetworkLayer
     :: forall n. KnownNetwork (n :: Network)
     => Int
-    -> IO (NetworkLayer (HttpBridge n) IO)
+    -> IO (NetworkLayer IO Tx (Block Tx))
 newNetworkLayer port = mkNetworkLayer <$> newHttpBridgeLayer @n port
 
 -- | Retrieve a chunk of blocks from cardano-http-bridge.

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -26,6 +26,8 @@ import Cardano.Wallet.HttpBridge.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.HttpBridge.Network
     ( newNetworkLayer )
+import Cardano.Wallet.HttpBridge.Primitive.Types
+    ( Tx )
 import Cardano.Wallet.HttpBridge.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.Network
@@ -45,7 +47,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( totalBalance, totalUTxO )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..)
+    ( Block (..)
+    , BlockHeader (..)
     , SlotId (..)
     , StartTime (..)
     , UTxO (..)
@@ -208,7 +211,7 @@ bench_restoration (wid, wname, s) = withHttpBridge network $ \port -> do
     dbFile <- Just <$> emptySystemTempFile "bench.db"
     (ctx, db) <- Sqlite.newDBLayer logConfig nullTracer dbFile
     Sqlite.unsafeRunQuery ctx (void $ runMigrationSilent migrateAll)
-    nw <- newNetworkLayer port
+    nw <- newNetworkLayer @n port
     let tl = newTransactionLayer @n @k
     BlockHeader sl _ _ <- unsafeRunExceptT $ networkTip nw
     sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
@@ -278,7 +281,7 @@ waitForWalletSync walletLayer wid = do
 -- | Poll the network tip until it reaches the slot corresponding to the current
 -- time.
 waitForNodeSync
-    :: NetworkLayer t IO
+    :: NetworkLayer IO Tx (Block Tx)
     -> Text
     -> (SlotId -> SlotId -> IO ())
     -> IO SlotId

--- a/lib/http-bridge/test/integration/Cardano/Faucet.hs
+++ b/lib/http-bridge/test/integration/Cardano/Faucet.hs
@@ -39,6 +39,7 @@ import Cardano.Wallet.Primitive.Mnemonic
     )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , Block (..)
     , Coin (..)
     , Hash (..)
     , ProtocolMagic (..)
@@ -66,7 +67,7 @@ import qualified Codec.CBOR.Write as CBOR
 
 -- | Initialize a bunch of faucet wallets and make them available for the
 -- integration tests scenarios.
-initFaucet :: NetworkLayer (HttpBridge n) IO -> IO Faucet
+initFaucet :: NetworkLayer IO Tx (Block Tx) -> IO Faucet
 initFaucet nl = do
     wallets <- replicateM 100 genMnemonic
     let mkFaucet addr = TxOut addr (Coin 100000000000)

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -6,10 +6,6 @@ module Cardano.Wallet.HttpBridge.NetworkSpec
 
 import Prelude
 
-import Cardano.Wallet.HttpBridge.Compatibility
-    ( HttpBridge )
-import Cardano.Wallet.HttpBridge.Environment
-    ( Network (..) )
 import Cardano.Wallet.HttpBridge.Network
     ( HttpBridgeLayer (..) )
 import Cardano.Wallet.HttpBridge.Primitive.Types
@@ -180,7 +176,7 @@ mockNetworkLayer
     => (String -> m ()) -- ^ logger function
     -> Word64 -- ^ make getEpoch fail for epochs after this
     -> SlotId -- ^ the tip block
-    -> NetworkLayer (HttpBridge 'Testnet) m
+    -> NetworkLayer m Tx (Block Tx)
 mockNetworkLayer logLine firstUnstableEpoch tip =
     HttpBridge.mkNetworkLayer (mockHttpBridge logLine firstUnstableEpoch tip)
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -62,7 +62,7 @@ import Cardano.Wallet.Jormungandr.Api
 import Cardano.Wallet.Jormungandr.Binary
     ( ConfigParam (..), Message (..), coerceBlock )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr, softTxMaxSize )
+    ( softTxMaxSize )
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx )
 import Cardano.Wallet.Network
@@ -147,17 +147,15 @@ import qualified Data.Text.Encoding as T
 -- | Creates a new 'NetworkLayer' connecting to an underlying 'Jormungandr'
 -- backend target.
 newNetworkLayer
-    :: forall n. ()
-    => BaseUrl
-    -> IO (NetworkLayer (Jormungandr n) IO)
+    :: BaseUrl
+    -> IO (NetworkLayer IO Tx (Block Tx))
 newNetworkLayer = fmap snd . newNetworkLayer'
 
 -- | Creates a new 'NetworkLayer' connecting to an underlying 'Jormungandr'
 -- backend target. Also returns the internal 'JormungandrLayer' component.
 newNetworkLayer'
-    :: forall n. ()
-    => BaseUrl
-    -> IO (JormungandrLayer IO, NetworkLayer (Jormungandr n) IO)
+    :: BaseUrl
+    -> IO (JormungandrLayer IO, NetworkLayer IO Tx (Block Tx))
 newNetworkLayer' url = do
     mgr <- newManager defaultManagerSettings
     st <- newMVar emptyUnstableBlocks
@@ -169,7 +167,7 @@ mkNetworkLayer
     :: MonadBaseControl IO m
     => MVar UnstableBlocks
     -> JormungandrLayer m
-    -> NetworkLayer (Jormungandr n) m
+    -> NetworkLayer m Tx (Block Tx)
 mkNetworkLayer st j = NetworkLayer
     { networkTip = modifyMVar st $ \bs -> do
         bs' <- updateUnstableBlocks k getTipId' getBlockHeader bs

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -40,6 +40,7 @@ import Cardano.Wallet.Network
     )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , Block (..)
     , BlockHeader (..)
     , Coin (..)
     , Hash (..)
@@ -323,8 +324,8 @@ spec = do
     second = 1000000
 
     startNode
-        :: (forall n. NetworkLayer n IO -> IO ())
-        -> IO (Async (), NetworkLayer (Jormungandr 'Testnet) IO, BaseUrl)
+        :: (NetworkLayer IO Tx (Block Tx) -> IO ())
+        -> IO (Async (), NetworkLayer IO Tx (Block Tx), BaseUrl)
     startNode wait = do
         (handle, baseUrl, _) <- launchJormungandr Inherit
         nw <- Jormungandr.newNetworkLayer baseUrl

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -195,7 +195,7 @@ cardanoWalletServer jormungandrUrl mlisten = do
 newNetworkLayer
     :: BaseUrl
     -> Hash "Genesis"
-    -> IO (NetworkLayer (Jormungandr n) IO, (Block Tx, BlockchainParameters))
+    -> IO (NetworkLayer IO Tx (Block Tx), (Block Tx, BlockchainParameters))
 newNetworkLayer url block0 = do
     (jormungandr, nl) <- Jormungandr.newNetworkLayer' url
     waitForConnection nl defaultRetryPolicy


### PR DESCRIPTION
# Issue Number

#711 

# Motivation
Distance `NetworkLayer` from `WalletLayer` by making it polymorphic over blocks. This way there is far greater freedom when implementing `StakePool.Metrics`.

When setting up the wallet-server we begin with a `NetworkLayer` of raw `Jormungandr.Binary` blocks, which we can map into block-types compatible with both `WalletLayer` and `StakePool.Metrics` respectively.

**edit**: Specifically, 
- if the WalletLayer wants to use linear `SlotId`s, the `StakePool.Metrics` can still use normal `SlotId` such that it easily can be aware of epoch boundaries
- I believe there will be greater freedom to generalise and specialise `StakePool.Metrics` to targets as we see fit, without getting entangled in the WalletLayer's abstractions.

# Overview

- [x] I have changed `NetworkLayer t m` into `NetworkLayer m tx block`.
- [x] I have made `NetworkLayer m tx` a `Functor`
- [x] I have moved `coerceBlock` to happen in the server setup, before being passed to the `WalletLayer`.


# Comments

- Less drastic version of #747 
- To minimise impact on other code, I introduced a new constructor `mkRawNetworkLayer` that doesn't use `coerceBlock`, and only used it from `jormungandr/Main.hs`

### Potential "nice to have" next steps
- We could move `postTx`  from `NetworkLayer` and remove the `tx` type parameter. This feels right to me, but there is no acute need either. So I won't do it with out better reasons, I think.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
