### PR TITLE
Track pending transactions outside of the wallet model

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -613,19 +613,19 @@ getWalletWithCreationTime
     -> ApiT WalletId
     -> Handler (ApiWallet, UTCTime)
 getWalletWithCreationTime ctx (ApiT wid) = do
-    (wallet, meta) <- liftHandler $ W.readWallet ctx wid
-    return (mkApiWallet wallet meta, meta ^. #creationTime)
+    (wallet, meta, pending) <- liftHandler $ W.readWallet ctx wid
+    return (mkApiWallet wallet meta pending, meta ^. #creationTime)
   where
-    mkApiWallet wallet meta = ApiWallet
+    mkApiWallet wallet meta pending = ApiWallet
         { id =
             ApiT wid
         , addressPoolGap =
             ApiT $ getState wallet ^. #externalPool . #gap
         , balance = ApiT $ WalletBalance
             { available =
-                Quantity $ availableBalance wallet
+                Quantity $ availableBalance pending wallet
             , total =
-                Quantity $ totalBalance wallet
+                Quantity $ totalBalance pending wallet
             }
         , delegation =
             ApiT $ ApiT <$> meta ^. #delegation

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -32,13 +32,12 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SortOrder (..)
     , TxMeta
+    , TxStatus
     , WalletId
     , WalletMetadata
     )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
-import Data.Map.Strict
-    ( Map )
 
 
 -- | A Database interface for storing various things in a DB. In practice,
@@ -49,6 +48,7 @@ data DBLayer m s t k = DBLayer
         :: PrimaryKey WalletId
         -> Wallet s t
         -> WalletMetadata
+        -> [(Tx t, TxMeta)]
         -> ExceptT ErrWalletAlreadyExists m ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
         -- 'putWalletMeta' or 'putTxHistory' will actually all fail if they are
@@ -99,7 +99,7 @@ data DBLayer m s t k = DBLayer
     , putTxHistory
         :: (DefineTx t)
         => PrimaryKey WalletId
-        -> Map (Hash "Tx") (Tx t, TxMeta)
+        -> [(Tx t, TxMeta)]
         -> ExceptT ErrNoSuchWallet m ()
         -- ^ Augments the transaction history for a known wallet.
         --
@@ -112,7 +112,8 @@ data DBLayer m s t k = DBLayer
         :: PrimaryKey WalletId
         -> SortOrder
         -> Range SlotId
-        -> m [(Hash "Tx", (Tx t, TxMeta))]
+        -> Maybe TxStatus
+        -> m [(Tx t, TxMeta)]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
         -- descending slot number.
         --

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -67,9 +67,9 @@ newDBLayer = do
                                       Wallets
         -----------------------------------------------------------------------}
 
-        { createWallet = \pk cp meta -> ExceptT $ do
+        { createWallet = \pk cp meta txs -> ExceptT $ do
             cp `deepseq` meta `deepseq`
-                alterDB errWalletAlreadyExists db (mCreateWallet pk cp meta)
+                alterDB errWalletAlreadyExists db (mCreateWallet pk cp meta txs)
 
         , removeWallet = ExceptT . alterDB errNoSuchWallet db . mRemoveWallet
 
@@ -103,8 +103,8 @@ newDBLayer = do
         , putTxHistory = \pk txh -> ExceptT $ do
             txh `deepseq` alterDB errNoSuchWallet db (mPutTxHistory pk txh)
 
-        , readTxHistory = \pk order range ->
-                readDB db (mReadTxHistory pk order range)
+        , readTxHistory = \pk order range mstatus ->
+                readDB db (mReadTxHistory pk order range mstatus)
 
         {-----------------------------------------------------------------------
                                        Keystore

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -50,4 +50,4 @@ instance IsOurs DummyStateMVar where
 
 instance Arbitrary (Wallet DummyStateMVar DummyTarget) where
     shrink _ = []
-    arbitrary = initWallet block0 genesisParameters <$> arbitrary
+    arbitrary = snd . initWallet block0 genesisParameters <$> arbitrary

--- a/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/WalletSpec.hs
@@ -77,8 +77,8 @@ spec = do
                     Left _ -> pure True
                     Right _ -> pure False
             let assertion _ = do
-                    tip <- slotId . currentTip . fst <$>
-                        unsafeRunExceptT (W.readWallet wallet wid)
+                    (cp, _, _) <- unsafeRunExceptT $ W.readWallet wallet wid
+                    let tip = slotId (currentTip cp)
                     return $ if tip > slotMinBound
                         then Right ()
                         else Left ("The wallet tip is still " <> show tip)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#645 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have removed `pending` from the wallet model, now being tracked externally.
- [x] I have fixed an issue where the wallet model would ingest its own transaction from the first block as "pending" :/ ... Now returning them as a result. Also modified `createWallet` consequently to allow a wallet to be created with a non empty set of initial transactions.
- [x] I have changed the signature of `putTxHistory` and `readTxHistory` to both work with `[(Tx t, TxMeta)]` to reduce some conversions overhead everywhere else in the code.

# Comments

<!-- Additional comments or screenshots to attach if any -->

We do store pending transactions next to wallet checkpoint, so there constantly
exists two sources of truth regarding pending transactions; this is in general
something we want to avoid in a data-model. Consequently, the database model
and some of the manipulation we have to do in order to accomodate for pending
txs feels awkward. Moving their management outside of the primitive models
simplifies pretty much all areas and remains valid.

In a next step, this will also help us get better testing coverage, especially
regarding the manipulation of pending transactions!

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
