### PR TITLE
Add simple StakePool.Metrics module for counting blocks

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -106,6 +106,7 @@ library
       Cardano.Wallet.Primitive.Mnemonic
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
+      Cardano.Wallet.StakePool.Metrics
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version
@@ -207,6 +208,7 @@ test-suite unit
       Cardano.Wallet.Primitive.CoinSelectionSpec
       Cardano.Wallet.Primitive.FeeSpec
       Cardano.Wallet.Primitive.MnemonicSpec
+      Cardano.Wallet.StakePool.MetricsSpec
       Cardano.Wallet.Primitive.ModelSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TransactionSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -475,7 +475,7 @@ isSubrangeOf r1 r2 =
 --   VRF PubKey: 32 bytes (ristretto25519) which translates to 64 hex character string
 --   see https://github.com/input-output-hk/chain-libs/blob/master/chain-impl-mockchain/doc/format.md
 newtype PoolId = PoolId { getPoolId :: ByteString }
-    deriving (Generic, Eq, Show)
+    deriving (Generic, Eq, Show, Ord)
 
 poolIdBytesLength :: Int
 poolIdBytesLength = 32

--- a/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
+++ b/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+-- | This module can fold over a blockchain to collect metrics about
+-- Stake pools.
+--
+-- It interacts with:
+-- - "Cardano.Wallet.Network" which provides the chain
+-- - "Cardano.Wallet.DB" - which can persist the metrics
+-- - "Cardano.Wallet.Api.Server" - which presents the results in an endpoint
+module Cardano.Wallet.StakePool.Metrics
+    ( activityForEpoch
+
+    , State (..)
+    , applyBlock
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..), PoolId (..), SlotId (..) )
+import Data.Map.Strict
+    ( Map )
+import Data.Word
+    ( Word64 )
+import Fmt
+    ( Buildable (..), blockListF', fmt, (+|), (|+) )
+import GHC.Generics
+    ( Generic )
+
+import qualified Data.Map.Strict as Map
+
+-- | For a given epoch, and state, this function returns /how many/ blocks
+-- each pool produced.
+activityForEpoch :: Word64 -> State -> Map PoolId Int
+activityForEpoch epoch s =
+    Map.filter (> 0)
+    $ Map.map (length . filter slotInCurrentEpoch)
+    (activity s)
+  where
+    slotInCurrentEpoch = ((epoch ==) . epochNumber)
+
+--
+-- Internals
+--
+
+-- | In-memory state keeping track of which pool produced blocks at which slots.
+data State = State
+    { tip :: BlockHeader
+      -- ^ The blockHeader of the most recently applied block. Used to resume
+      -- restoration from @NetworkLayer@.
+    , activity :: Map PoolId [SlotId]
+    -- ^ Mapping from pools to the slots where pool produced blocks.
+    --
+    -- This is needed internally to support rollback, but publicly, only the
+    -- /length of/ the SlotId-list is likely needed.
+    } deriving (Eq, Show, Generic)
+
+instance Buildable State where
+    build (State t m) =
+        fmt ("Stakepool metrics at tip: "+|t|+"\n") <>
+        blockListF'
+            mempty
+            (\(k,v) -> fmt (""+|k|+": "+|length v|+"") )
+            (Map.toList m)
+
+applyBlock :: (BlockHeader, PoolId) -> State -> State
+applyBlock (newTip, poolId) (State _prevTip prevMap) =
+        State newTip (Map.alter alter poolId prevMap)
+  where
+    slot = slotId newTip
+    alter = \case
+        Nothing -> Just [slot]
+        Just slots -> Just (slot:slots)

--- a/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Cardano.Wallet.StakePool.MetricsSpec (spec) where
 
@@ -26,11 +25,12 @@ import Numeric.Natural
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
-    ( Arbitrary (..), InfiniteList (..), property )
+    ( Arbitrary (..), InfiniteList (..), property, (===) )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 
 import qualified Data.ByteString as BS
+import qualified Data.Map as Map
 
 spec :: Spec
 spec = do
@@ -39,6 +39,14 @@ spec = do
             it "stores the last applied blockHeader"
                 $ property $ \s b@(header,_) -> do
                 tip (applyBlock b s) `shouldBe` header
+
+            it "counts every block it applies (total activity increases by 1\
+               \when a block is applied"
+                $ property $ \s block -> do
+                let s' = applyBlock block s
+                let count = Map.foldl (\r l -> r + (length l)) 0 . activity
+                count s' === (count s + 1)
+
 
 instance Arbitrary BlockHeader where
     arbitrary = BlockHeader <$> arbitrary <*> arbitrary <*> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Cardano.Wallet.StakePool.MetricsSpec (spec) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..)
+    , EpochLength (..)
+    , Hash (..)
+    , PoolId (..)
+    , SlotId (..)
+    , flatSlot
+    , fromFlatSlot
+    )
+import Cardano.Wallet.StakePool.Metrics
+    ( State (..), applyBlock )
+import Data.Quantity
+    ( Quantity (..) )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+import Test.QuickCheck
+    ( Arbitrary (..), InfiniteList (..), property )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    describe "Counting how many blocks each pool produced" $
+        describe "State" $ do
+            it "stores the last applied blockHeader"
+                $ property $ \s b@(header,_) -> do
+                tip (applyBlock b s) `shouldBe` header
+
+instance Arbitrary BlockHeader where
+    arbitrary = BlockHeader <$> arbitrary <*> arbitrary <*> arbitrary
+    shrink = genericShrink
+
+instance Arbitrary State where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary SlotId where
+    arbitrary = fromFlatSlot epochLength <$> arbitrary
+    shrink sl = fromFlatSlot epochLength <$> shrink (flatSlot epochLength sl)
+
+-- | Epoch length used to generate arbitrary @SlotId@
+epochLength :: EpochLength
+epochLength = EpochLength 50
+
+instance Arbitrary (Hash tag) where
+    arbitrary = do
+        InfiniteList bytes _ <- arbitrary
+        return $ Hash $ BS.pack $ take 32 bytes
+    shrink x = [zeros | x /= zeros]
+      where
+        zeros = Hash $ BS.pack $ replicate 32 0
+
+instance Arbitrary (Quantity "block" Natural) where
+     arbitrary = Quantity . fromIntegral <$> (arbitrary @Word)
+
+instance Arbitrary PoolId where
+    arbitrary = do
+        InfiniteList bytes _ <- arbitrary
+        return $ PoolId $ BS.pack $ take 32 bytes
+    shrink x = [zeros | x /= zeros]
+      where
+        zeros = PoolId $ BS.pack $ replicate 32 0

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -138,6 +138,7 @@ spec = do
                             "f7becdf807c706cef54ec4832d2a7475\
                             \91c3f2141de3e4f2aef59a130d890c12"
                         , parentHeaderHash = block0 ^. #prevBlockHash
+                        , producedBy = Nothing
                         }
                     [ Initial
                         [ Block0Date (StartTime $ posixSecondsToUTCTime 1556202057)
@@ -194,6 +195,7 @@ spec = do
                             "5df3b1c19c1400a9925158ade2b71913\
                             \74df85f6976fe81681f0aef2e0ddc2a3"
                         , parentHeaderHash = block0 ^. #prevBlockHash
+                        , producedBy = Nothing
                         }
                     [ Initial
                         [ Block0Date (StartTime $ posixSecondsToUTCTime 1556202057)
@@ -235,6 +237,7 @@ spec = do
                         , parentHeaderHash = Hash $ unsafeFromHex
                             "d84f590d58c7eabc2e3c4f5cf459d3d2\
                             \fee06069d813a7848b9ad8a154aef79b"
+                        , producedBy = Nothing
                         }
                     []
             unsafeDecodeHex getBlock bytes `shouldBe` block


### PR DESCRIPTION
# Issue Number

#711 

# Overview

- [x] Added `StakePool.Metrics` that counts `numberOfBlocksProducedThisEpoch` for each pool
- [x] Extended `Jörmungandr.Binary.Block` to decode `PoolId`/VRFPubKey (could go in separate PR) 

# Comments

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
