### PR TITLE
Rename UnstableBlocks -> BlockHeaders

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -74,6 +74,7 @@ library
       Cardano.Wallet.Jormungandr
       Cardano.Wallet.Jormungandr.Api
       Cardano.Wallet.Jormungandr.Binary
+      Cardano.Wallet.Jormungandr.BlockHeaders
       Cardano.Wallet.Jormungandr.Compatibility
       Cardano.Wallet.Jormungandr.Environment
       Cardano.Wallet.Jormungandr.Network
@@ -155,9 +156,9 @@ test-suite unit
   other-modules:
       Cardano.Wallet.Jormungandr.ApiSpec
       Cardano.Wallet.Jormungandr.BinarySpec
+      Cardano.Wallet.Jormungandr.BlockHeadersSpec
       Cardano.Wallet.Jormungandr.CompatibilitySpec
       Cardano.Wallet.Jormungandr.EnvironmentSpec
-      Cardano.Wallet.Jormungandr.NetworkSpec
       Cardano.Wallet.Jormungandr.TransactionSpec
       Cardano.Wallet.TransactionSpecShared
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/BlockHeaders.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/BlockHeaders.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: Apache-2.0
+--
+-- This module provides a data structure and functions for operating on a
+-- sequence of block headers.
+--
+-- The 'BlockHeaders' sequence is used for maintaining the global unstable
+-- blocks state for the network layer. The unstable blocks state can be compared
+-- with the block headers state of chain consumers to determine the intersection
+-- point.
+--
+
+module Cardano.Wallet.Jormungandr.BlockHeaders
+    (
+    -- * Types
+      BlockHeaders(..)
+    , emptyBlockHeaders
+
+    -- * Managing the global unstable blocks state
+    , updateUnstableBlocks
+
+    -- * Operations
+    , blockHeadersTip
+    , appendBlockHeaders
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..), Hash (..), SlotId (..) )
+import Control.DeepSeq
+    ( NFData, ($!!) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Sequence
+    ( Seq (..), (><) )
+import Data.Tuple.Extra
+    ( thd3 )
+import Data.Word
+    ( Word32 )
+import GHC.Generics
+    ( Generic )
+import Safe
+    ( lastMay )
+
+import qualified Data.Sequence as Seq
+
+{-------------------------------------------------------------------------------
+                                     Types
+-------------------------------------------------------------------------------}
+
+-- | A list of block headers and their hashes.
+-- The last block in this sequence is the network tip.
+-- The first block in this sequence is the block of depth /k/,
+-- which is the last unstable block.
+data BlockHeaders = BlockHeaders
+    { getBlockHeaders :: !(Seq (Hash "BlockHeader", BlockHeader))
+    -- ^ Double-ended queue of block headers, and their IDs.
+    , blockHeight :: !(Quantity "block" Word32)
+    -- ^ The block height of the tip of the sequence.
+    } deriving stock (Show, Eq, Generic)
+
+instance NFData BlockHeaders
+
+-- | Constuct an empty unstable blocks sequence.
+emptyBlockHeaders :: BlockHeaders
+emptyBlockHeaders = BlockHeaders mempty (Quantity 0)
+
+{-------------------------------------------------------------------------------
+                   Managing the global unstable blocks state
+-------------------------------------------------------------------------------}
+
+-- | Updates the unstable blocks state using the given "fetch" functions.
+--
+-- This attempts to synchronise the local state with that of the node. The node
+-- may be on a different chain to the current unstable blocks, so this function
+-- handles switching of chains.
+--
+-- For example, this is what it would do when the local tip is @a13@, but the
+-- node's tip is @b15@, on a different chain.
+--
+-- @
+--                                    local tip ↴
+--                  ┌───┬───  ───┬───┬───┬───┬───┐
+--  Unstable blocks │a03│..    ..│a10│a11│a12│a13│
+--                  └───┴───  ───┴───┴───┴───┴───┘
+--                            ───┬───┬───┬───┬───┬───┬───┐
+--  Node backend chain        ...│a10│a11│b12│b13│b14│b15│
+--                            ───┴───┴───┴───┴───┴───┴───┘
+--                        rollback point ⬏     node tip ⬏
+-- @
+--
+-- To startBackend with, the node says the tip hash is @b15@.
+--
+-- Work backwards from tip, fetching blocks and adding them to @ac@, and
+-- removing overlapping blocks from @ubs@. Overlapping blocks occur when there
+-- has been a rollback.
+--
+-- @
+--     ubs                     ac
+-- 1.  ───┬───┬───┬───┬───┐    ┌───┐
+--     ...│a10│a11│a12│a13│    │b15│
+--     ───┴───┴───┴───┴───┘    └───┘
+-- 2.  ───┬───┬───┬───┬───┐┌───┬───┐
+--     ...│a10│a11│a12│a13││b14│b15│
+--     ───┴───┴───┴───┴───┘└───┴───┘
+-- 3.  ───┬───┬───┬───┐┌───┬───┬───┐
+--     ...│a10│a11│a12││b13│b14│b15│
+--     ───┴───┴───┴───┘└───┴───┴───┘
+-- 4.  ───┬───┬───┐┌───┬───┬───┬───┐
+--     ...│a10│a11││b12│b13│b14│b15│
+--     ───┴───┴───┘└───┴───┴───┴───┘
+-- @
+--
+-- Stop once @ubs@ and @ac@ meet with a block which has the same hash.
+-- If they never meet, stop cleanupConfig fetching /k/ blocks.
+--
+-- Finally, to get the new 'BlockHeaders', append @ac@ to @ubs@, and limit the
+-- length to /k/.
+--
+-- The new block height is the height of the first block that was fetched.
+--
+-- If any errors occur while this process is running (for example, fetching a
+-- block which has been rolled back and lost from the node's state), it will
+-- immediately terminate.
+updateUnstableBlocks
+    :: forall m. Monad m
+    => Quantity "block" Word32
+    -- ^ Maximum number of unstable blocks (/k/).
+    -> m (Hash "BlockHeader")
+    -- ^ Fetches tip.
+    -> (Hash "BlockHeader" -> m (BlockHeader, Quantity "block" Word32))
+    -- ^ Fetches block header and its chain height.
+    -> BlockHeaders
+    -- ^ Current unstable blocks state.
+    -> m BlockHeaders
+updateUnstableBlocks (Quantity k) getTipId' getBlockHeader lbhs = do
+    t <- getTipId'
+    -- Trace backwards from the tip, accumulating new block headers, and
+    -- removing overlapped unstable block headers.
+    (lbhs', nbhs) <- fetchBackwards lbhs [] 0 t
+    -- The new unstable blocks is the current local blocks up to where they
+    -- meet the blocks fetched starting from the tip, with the fetched
+    -- blocks appended.
+    pure $!! appendBlockHeaders k lbhs' nbhs
+  where
+    -- | Fetch blocks backwards starting from the given id. If fetched blocks
+    -- overlap the local blocks, the excess local blocks will be dropped.
+    fetchBackwards
+        :: BlockHeaders
+        -- ^ Current local unstable blocks
+        -> [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)]
+        -- ^ Accumulator of fetched blocks
+        -> Word32
+        -- ^ Accumulator for number of blocks fetched
+        -> Hash "BlockHeader"
+        -- ^ Starting point for block fetch
+        -> m (BlockHeaders, [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)])
+    fetchBackwards ubs ac len t = do
+        (tipHeader, tipHeight) <- getBlockHeader t
+        -- Push the remote block.
+        let ac' = ((t, tipHeader, tipHeight):ac)
+         -- Pop off any overlap.
+        let ubs' = dropStartingFromSlot tipHeader ubs
+        -- If remote blocks have met local blocks, or if more than k have been
+        -- fetched, or we are at the genesis, then stop.
+        -- Otherwise, continue from the parent of the current tip.
+        let intersected = blockHeadersTipId ubs' == Just (prevBlockHash tipHeader)
+        let bufferFull = len + 1 >= k
+        let atGenesis = slotId tipHeader == SlotId 0 0
+        if intersected || bufferFull || atGenesis
+            then pure (ubs', ac')
+            else fetchBackwards ubs' ac' (len + 1) (prevBlockHash tipHeader)
+
+-- | The tip block header of the unstable blocks, if it exists.
+blockHeadersTip :: BlockHeaders -> Maybe BlockHeader
+blockHeadersTip (BlockHeaders Empty _) = Nothing
+blockHeadersTip (BlockHeaders (_ubs :|> (_, bh)) _) = Just bh
+
+-- | The tip block id of the unstable blocks, if it exists.
+blockHeadersTipId :: BlockHeaders -> Maybe (Hash "BlockHeader")
+blockHeadersTipId (BlockHeaders Empty _) = Nothing
+blockHeadersTipId (BlockHeaders (_ubs :|> (t, _)) _) = Just t
+
+-- | Add recently fetched block headers to the unstable blocks. This will drop
+-- the oldest block headers to ensure that there are at most /k/ items in the
+-- sequence.
+appendBlockHeaders
+    :: Word32
+    -- ^ Maximum length of sequence.
+    -> BlockHeaders
+    -- ^ Current unstable block headers, with rolled back blocks removed.
+    -> [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)]
+    -- ^ Newly fetched block headers to add.
+    -> BlockHeaders
+appendBlockHeaders k (BlockHeaders ubs h) bs =
+    BlockHeaders (ubs `appendBounded` more) h'
+  where
+    more = Seq.fromList [(a, b) | (a, b, _) <- bs]
+    -- New block height is the height of the new tip block.
+    h' = maybe h thd3 (lastMay bs)
+
+    -- Concatenate sequences, ensuring that the result is no longer than k.
+    appendBounded :: Seq a -> Seq a -> Seq a
+    appendBounded a b = Seq.drop excess (a >< b)
+        where excess = max 0 (Seq.length a + Seq.length b - fromIntegral k)
+
+-- | Remove unstable blocks which have a slot greater than or equal to the given
+-- block header's slot.
+dropStartingFromSlot :: BlockHeader -> BlockHeaders -> BlockHeaders
+dropStartingFromSlot bh (BlockHeaders bs (Quantity h)) =
+    BlockHeaders bs' (Quantity h')
+  where
+    isAfter = (>= slotId bh) . slotId . snd
+    bs' = Seq.dropWhileR isAfter bs
+    h' = h + fromIntegral (max 0 $ Seq.length bs' - Seq.length bs)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -49,11 +48,6 @@ module Cardano.Wallet.Jormungandr.Network
     -- * Internal constructors
     , mkRawNetworkLayer
     , mkJormungandrLayer
-
-    -- * Internal state
-    , UnstableBlocks(..)
-    , updateUnstableBlocks
-    , emptyUnstableBlocks
     ) where
 
 import Prelude
@@ -81,6 +75,12 @@ import Cardano.Wallet.Jormungandr.Api
     )
 import Cardano.Wallet.Jormungandr.Binary
     ( ConfigParam (..), Message (..), convertBlock, runGetOrFail )
+import Cardano.Wallet.Jormungandr.BlockHeaders
+    ( BlockHeaders (..)
+    , blockHeadersTip
+    , emptyBlockHeaders
+    , updateUnstableBlocks
+    )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( genConfigFile, localhostBaseUrl, softTxMaxSize )
 import Cardano.Wallet.Jormungandr.Primitive.Types
@@ -101,7 +101,6 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , Hash (..)
-    , SlotId (..)
     , SlotLength (..)
     , TxWitness (..)
     )
@@ -109,8 +108,6 @@ import Control.Arrow
     ( left )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar )
-import Control.DeepSeq
-    ( NFData, ($!!) )
 import Control.Exception
     ( Exception, bracket )
 import Control.Monad
@@ -133,22 +130,14 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Sequence
-    ( Seq (..), (><) )
 import Data.Text
     ( Text )
-import Data.Tuple.Extra
-    ( thd3 )
-import Data.Word
-    ( Word32 )
-import GHC.Generics
-    ( Generic )
 import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Network.HTTP.Types.Status
     ( status400 )
 import Safe
-    ( lastMay, tailSafe )
+    ( tailSafe )
 import Servant.API
     ( (:<|>) (..) )
 import Servant.Client
@@ -173,7 +162,6 @@ import System.FilePath
 import qualified Cardano.Wallet.Jormungandr.Binary as J
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Char as C
-import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Yaml as Yaml
@@ -250,7 +238,7 @@ newNetworkLayer
     -> ExceptT ErrGetBlockchainParams IO (NetworkLayer IO Tx (Block Tx))
 newNetworkLayer baseUrl block0H = do
     mgr <- liftIO $ newManager defaultManagerSettings
-    st <- newMVar emptyUnstableBlocks
+    st <- newMVar emptyBlockHeaders
     let jor = mkJormungandrLayer mgr baseUrl
     g0 <- getInitialBlockchainParameters jor (coerce block0H)
     return (convertBlock <$> mkRawNetworkLayer g0 st jor)
@@ -262,14 +250,14 @@ newNetworkLayer baseUrl block0H = do
 mkRawNetworkLayer
     :: MonadBaseControl IO m
     => (J.Block, BlockchainParameters)
-    -> MVar UnstableBlocks
+    -> MVar BlockHeaders
     -> JormungandrLayer m
     -> NetworkLayer m Tx J.Block
 mkRawNetworkLayer (block0, bp) st j = NetworkLayer
     { networkTip = modifyMVar st $ \bs -> do
         let k = getEpochStability bp
         bs' <- updateUnstableBlocks k getTipId' getBlockHeader bs
-        ExceptT . pure $ case unstableBlocksTip bs' of
+        ExceptT . pure $ case blockHeadersTip bs' of
             Just t -> Right (bs', t)
             Nothing -> Left ErrNetworkTipNotFound
 
@@ -303,171 +291,6 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
         pure (header (convertBlock blk), nodeHeight)
 
     mappingError = flip withExceptT
-
-{-------------------------------------------------------------------------------
-                   Managing the global unstable blocks state
--------------------------------------------------------------------------------}
-
--- | A list of block headers and their hashes.
--- The last block in this sequence is the network tip.
--- The first block in this sequence is the block of depth /k/,
--- which is the last unstable block.
-data UnstableBlocks = UnstableBlocks
-    { getUnstableBlocks :: !(Seq (Hash "BlockHeader", BlockHeader))
-    -- ^ Double-ended queue of block headers, and their IDs.
-    , blockHeight :: !(Quantity "block" Word32)
-    -- ^ The block height of the tip of the sequence.
-    } deriving stock (Show, Eq, Generic)
-
-instance NFData UnstableBlocks
-
-emptyUnstableBlocks :: UnstableBlocks
-emptyUnstableBlocks = UnstableBlocks mempty (Quantity 0)
-
--- | Updates the unstable blocks state using the given "fetch" functions.
---
--- This attempts to synchronise the local state with that of the node. The node
--- may be on a different chain to the current unstable blocks, so this function
--- handles switching of chains.
---
--- For example, this is what it would do when the local tip is @a13@, but the
--- node's tip is @b15@, on a different chain.
---
--- @
---                                    local tip ↴
---                 ┌───┬───  ───┬───┬───┬───┬───┐
---  UnstableBlocks │a03│..    ..│a10│a11│a12│a13│
---                 └───┴───  ───┴───┴───┴───┴───┘
---                           ───┬───┬───┬───┬───┬───┬───┐
---  Node backend chain       ...│a10│a11│b12│b13│b14│b15│
---                           ───┴───┴───┴───┴───┴───┴───┘
---                       rollback point ⬏     node tip ⬏
--- @
---
--- To startBackend with, the node says the tip hash is @b15@.
---
--- Work backwards from tip, fetching blocks and adding them to @ac@, and
--- removing overlapping blocks from @ubs@. Overlapping blocks occur when there
--- has been a rollback.
---
--- @
---     ubs                     ac
--- 1.  ───┬───┬───┬───┬───┐    ┌───┐
---     ...│a10│a11│a12│a13│    │b15│
---     ───┴───┴───┴───┴───┘    └───┘
--- 2.  ───┬───┬───┬───┬───┐┌───┬───┐
---     ...│a10│a11│a12│a13││b14│b15│
---     ───┴───┴───┴───┴───┘└───┴───┘
--- 3.  ───┬───┬───┬───┐┌───┬───┬───┐
---     ...│a10│a11│a12││b13│b14│b15│
---     ───┴───┴───┴───┘└───┴───┴───┘
--- 4.  ───┬───┬───┐┌───┬───┬───┬───┐
---     ...│a10│a11││b12│b13│b14│b15│
---     ───┴───┴───┘└───┴───┴───┴───┘
--- @
---
--- Stop once @ubs@ and @ac@ meet with a block which has the same hash.
--- If they never meet, stop cleanupConfig fetching /k/ blocks.
---
--- Finally, to get the new 'UnstableBlocks', append @ac@ to @ubs@, and limit the
--- length to /k/.
---
--- The new block height is the height of the first block that was fetched.
---
--- If any errors occur while this process is running (for example, fetching a
--- block which has been rolled back and lost from the node's state), it will
--- immediately terminate.
-updateUnstableBlocks
-    :: forall m. Monad m
-    => Quantity "block" Word32
-    -- ^ Maximum number of unstable blocks (/k/).
-    -> m (Hash "BlockHeader")
-    -- ^ Fetches tip.
-    -> (Hash "BlockHeader" -> m (BlockHeader, Quantity "block" Word32))
-    -- ^ Fetches block header and its chain height.
-    -> UnstableBlocks
-    -- ^ Current unstable blocks state.
-    -> m UnstableBlocks
-updateUnstableBlocks (Quantity k) getTipId' getBlockHeader lbhs = do
-    t <- getTipId'
-    -- Trace backwards from the tip, accumulating new block headers, and
-    -- removing overlapped unstable block headers.
-    (lbhs', nbhs) <- fetchBackwards lbhs [] 0 t
-    -- The new unstable blocks is the current local blocks up to where they
-    -- meet the blocks fetched starting from the tip, with the fetched
-    -- blocks appended.
-    pure $!! appendUnstableBlocks k lbhs' nbhs
-  where
-    -- | Fetch blocks backwards starting from the given id. If fetched blocks
-    -- overlap the local blocks, the excess local blocks will be dropped.
-    fetchBackwards
-        :: UnstableBlocks
-        -- ^ Current local unstable blocks
-        -> [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)]
-        -- ^ Accumulator of fetched blocks
-        -> Word32
-        -- ^ Accumulator for number of blocks fetched
-        -> Hash "BlockHeader"
-        -- ^ Starting point for block fetch
-        -> m (UnstableBlocks, [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)])
-    fetchBackwards ubs ac len t = do
-        (tipHeader, tipHeight) <- getBlockHeader t
-        -- Push the remote block.
-        let ac' = ((t, tipHeader, tipHeight):ac)
-         -- Pop off any overlap.
-        let ubs' = dropStartingFromSlot tipHeader ubs
-        -- If remote blocks have met local blocks, or if more than k have been
-        -- fetched, or we are at the genesis, then stop.
-        -- Otherwise, continue from the parent of the current tip.
-        let intersected = unstableBlocksTipId ubs' == Just (prevBlockHash tipHeader)
-        let bufferFull = len + 1 >= k
-        let atGenesis = slotId tipHeader == SlotId 0 0
-        if intersected || bufferFull || atGenesis
-            then pure (ubs', ac')
-            else fetchBackwards ubs' ac' (len + 1) (prevBlockHash tipHeader)
-
--- | The tip block header of the unstable blocks, if it exists.
-unstableBlocksTip :: UnstableBlocks -> Maybe BlockHeader
-unstableBlocksTip (UnstableBlocks Empty _) = Nothing
-unstableBlocksTip (UnstableBlocks (_ubs :|> (_, bh)) _) = Just bh
-
--- | The tip block id of the unstable blocks, if it exists.
-unstableBlocksTipId :: UnstableBlocks -> Maybe (Hash "BlockHeader")
-unstableBlocksTipId (UnstableBlocks Empty _) = Nothing
-unstableBlocksTipId (UnstableBlocks (_ubs :|> (t, _)) _) = Just t
-
--- | Add recently fetched block headers to the unstable blocks. This will drop
--- the oldest block headers to ensure that there are at most /k/ items in the
--- sequence.
-appendUnstableBlocks
-    :: Word32
-    -- ^ Maximum length of sequence.
-    -> UnstableBlocks
-    -- ^ Current unstable block headers, with rolled back blocks removed.
-    -> [(Hash "BlockHeader", BlockHeader, Quantity "block" Word32)]
-    -- ^ Newly fetched block headers to add.
-    -> UnstableBlocks
-appendUnstableBlocks k (UnstableBlocks ubs h) bs =
-    UnstableBlocks (ubs `appendBounded` more) h'
-  where
-    more = Seq.fromList [(a, b) | (a, b, _) <- bs]
-    -- New block height is the height of the new tip block.
-    h' = maybe h thd3 (lastMay bs)
-
-    -- Concatenate sequences, ensuring that the result is no longer than k.
-    appendBounded :: Seq a -> Seq a -> Seq a
-    appendBounded a b = Seq.drop excess (a >< b)
-        where excess = max 0 (Seq.length a + Seq.length b - fromIntegral k)
-
--- | Remove unstable blocks which have a slot greater than or equal to the given
--- block header's slot.
-dropStartingFromSlot :: BlockHeader -> UnstableBlocks -> UnstableBlocks
-dropStartingFromSlot bh (UnstableBlocks bs (Quantity h)) =
-    UnstableBlocks bs' (Quantity h')
-  where
-    isAfter = (>= slotId bh) . slotId . snd
-    bs' = Seq.dropWhileR isAfter bs
-    h' = h + fromIntegral (max 0 $ Seq.length bs' - Seq.length bs)
 
 {-------------------------------------------------------------------------------
                                 Backend launcher

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -20,6 +20,8 @@ import Cardano.Wallet.Jormungandr.Api
     ( GetTipId, api )
 import Cardano.Wallet.Jormungandr.Binary
     ( MessageType (..), fragmentId, putSignedTx, runPut, withHeader )
+import Cardano.Wallet.Jormungandr.BlockHeaders
+    ( emptyBlockHeaders )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, Network (..), block0 )
 import Cardano.Wallet.Jormungandr.Network
@@ -30,7 +32,6 @@ import Cardano.Wallet.Jormungandr.Network
     , JormungandrConfig (..)
     , JormungandrConnParams (..)
     , Scheme (..)
-    , emptyUnstableBlocks
     , mkRawNetworkLayer
     , withJormungandr
     , withNetworkLayer
@@ -169,7 +170,7 @@ spec = do
         let newBrokenNetworkLayer :: BaseUrl -> IO (NetworkLayer IO Tx ())
             newBrokenNetworkLayer baseUrl = do
                 mgr <- newManager defaultManagerSettings
-                st <- newMVar emptyUnstableBlocks
+                st <- newMVar emptyBlockHeaders
                 let jor = Jormungandr.mkJormungandrLayer mgr baseUrl
                 let g0 = (error "block0", error "BlockchainParameters")
                 return (void $ mkRawNetworkLayer g0 st jor)

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BlockHeadersSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BlockHeadersSpec.hs
@@ -4,14 +4,14 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Wallet.Jormungandr.NetworkSpec
+module Cardano.Wallet.Jormungandr.BlockHeadersSpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Jormungandr.Network
-    ( UnstableBlocks (..), updateUnstableBlocks )
+import Cardano.Wallet.Jormungandr.BlockHeaders
+    ( BlockHeaders (..), updateUnstableBlocks )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Monad
@@ -180,9 +180,9 @@ prop_updateUnstableBlocksFailure TestCase{..} =
 
 -- | Convert a test chain to 'UnstableBlocks' so that it can be compared for
 -- equality.
-mkUnstableBlocks :: Int -> [BlockHeader] -> UnstableBlocks
+mkUnstableBlocks :: Int -> [BlockHeader] -> BlockHeaders
 mkUnstableBlocks h bs =
-    UnstableBlocks (Seq.fromList $ headerIds bs) (Quantity $ fromIntegral h)
+    BlockHeaders (Seq.fromList $ headerIds bs) (Quantity $ fromIntegral h)
 
 -- | Convert a test chain into an assoc list of block ids, their headers, and
 -- chain heights.
@@ -388,11 +388,11 @@ instance Arbitrary (Quantity "block" Word32) where
 -------------------------------------------------------------------------------}
 
 -- | Shows just the headers of the unstable blocks.
-showUnstableBlocks :: UnstableBlocks -> String
+showUnstableBlocks :: BlockHeaders -> String
 showUnstableBlocks ubs = showHeaders ubs ++ " " ++ showHeight ubs
   where
-    showHeaders = unwords . map (showHash . fst) . F.toList . getUnstableBlocks
-    showHeight (UnstableBlocks _ (Quantity h)) = "height=" ++ show h
+    showHeaders = unwords . map (showHash . fst) . F.toList . getBlockHeaders
+    showHeight (BlockHeaders _ (Quantity h)) = "height=" ++ show h
 
 showHash :: Hash a -> String
 showHash (Hash h) = B8.unpack h

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -30,8 +30,8 @@ import Data.Maybe
     ( fromMaybe )
 import Data.Quantity
     ( Quantity (..) )
-import Numeric.Natural
-    ( Natural )
+import Data.Word
+    ( Word32 )
 import Safe
     ( headMay, initMay, lastMay )
 import Test.Hspec
@@ -77,7 +77,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 data TestCase = TestCase
-    { k :: Quantity "block" Natural
+    { k :: Quantity "block" Word32
     , nodeChain :: [BlockHeader]
     , localChain :: [BlockHeader]
     } deriving (Show, Eq)
@@ -188,7 +188,7 @@ mkUnstableBlocks h bs =
 -- chain heights.
 mkBlockHeaderHeights
     :: [BlockHeader]
-    -> [(Hash "BlockHeader", (BlockHeader, Quantity "block" Natural))]
+    -> [(Hash "BlockHeader", (BlockHeader, Quantity "block" Word32))]
 mkBlockHeaderHeights nodeChain =
     [ (hash, (hdr, height))
     | ((hash, hdr), height) <- zip (headerIds nodeChain) [Quantity 1..] ]
@@ -221,7 +221,7 @@ chainEnd :: [BlockHeader] -> SlotId
 chainEnd = maybe (SlotId 0 0) slotId . chainTip
 
 -- | Limit the sequence to a certain size by removing items from the beginning.
-limitChain :: Quantity "block" Natural -> [BlockHeader] -> [BlockHeader]
+limitChain :: Quantity "block" Word32 -> [BlockHeader] -> [BlockHeader]
 limitChain (Quantity k) bs = drop (max 0 (length bs - fromIntegral k - 1)) bs
 
 showChain :: [BlockHeader] -> String
@@ -239,7 +239,7 @@ showSlot (SlotId ep sl) = show ep ++ "." ++ show sl
 
 -- | Merge node chain with local unstable blocks.
 modelIntersection
-    :: Quantity "block" Natural
+    :: Quantity "block" Word32
     -- ^ Maximum number of unstable blocks.
     -> [BlockHeader]
     -- ^ Local test chain.
@@ -331,7 +331,7 @@ removeBlocks holes bs =
     bh = Quantity 0
 
 genChain
-    :: Quantity "block" Natural
+    :: Quantity "block" Word32
     -> String
     -> Gen [BlockHeader]
 genChain (Quantity k) prefix = do
@@ -373,7 +373,7 @@ instance Arbitrary TestCase where
         , n >= 1
         ]
 
-instance Arbitrary (Quantity "block" Natural) where
+instance Arbitrary (Quantity "block" Word32) where
     -- k doesn't need to be large for testing this
     arbitrary =
         Quantity . fromIntegral <$> choose (2 :: Int, 30)

--- a/nix/.stack.nix/cardano-wallet-http-bridge.nix
+++ b/nix/.stack.nix/cardano-wallet-http-bridge.nix
@@ -94,7 +94,7 @@
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover))
             ];
           };
-        "integration" = {
+        "http-bridge-integration" = {
           depends = [
             (hsPkgs.base)
             (hsPkgs.aeson)


### PR DESCRIPTION
Relates to #648.

# Overview

This sequence will also be used for the chain consumer local headers state. So UnstableBlocks will no longer be the right name.

It also changes the _k_ type from Natural to Word32, to match BlockchainParameters.
