### PR TITLE
Create Sparse Checkpoint & prune address discovery state

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -430,7 +430,9 @@ rootKeysRnd = unsafePerformIO $ generate (vectorOf 10 genRootKeysRnd)
 newtype MockChain = MockChain
     { getMockChain :: [Block DummyTarget.Tx] }
     deriving stock (Eq, Show)
-    deriving newtype (Buildable)
+
+instance Buildable MockChain where
+    build (MockChain chain) = blockListF' mempty build chain
 
 instance Arbitrary MockChain where
     shrink (MockChain chain) =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -445,10 +445,11 @@ newtype DummyState
     deriving (Generic, Show, Eq)
 
 instance Sqlite.PersistState DummyState where
+    type StateAddress DummyState = ()
     insertState _ _ = error "DummyState.insertState: not implemented"
     selectState _ = error "DummyState.selectState: not implemented"
     deleteState _ = error "DummyState.deleteState: not implemented"
-    rollbackState _ _ = error "DummyState.rollbackState: not implemented"
+    pruneState _ _ = error "DummyState.rollbackState: not implemented"
 
 instance NFData DummyState
 

--- a/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
+++ b/lib/http-bridge/test/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
@@ -87,6 +87,7 @@ instance KnownAddresses AnyAddressState where
         \an incompatible scheme 'AnyAddressState'. Please don't."
 
 instance PersistState AnyAddressState where
+    type StateAddress AnyAddressState = ()
     insertState (wid, sl) (AnyAddressState s) =
         insert_ (DB.AnyAddressState wid sl s)
     selectState (wid, sl) = runMaybeT $ do
@@ -96,7 +97,7 @@ instance PersistState AnyAddressState where
             ] []
         return (AnyAddressState s)
     deleteState wid = deleteWhere [DB.AnyAddressStateWalletId ==. wid]
-    rollbackState _ _ = pure ()
+    pruneState _ _ = pure ()
 
 initAnyState :: Text -> Double -> (WalletId, WalletName, AnyAddressState)
 initAnyState wname p = (walletId cfg, WalletName wname, cfg)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#769 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have created sparse checkpoints every `n=97` slots in the unstable epoch during "restoration". This number is arbitrary but has nice properties:
    - Is small enough in front of the epoch stability
    - Is small enough that it's not too long to recover missing blocks from a checkpoint to another
    - Is big enough that is reduces by 2 orders of magnitude the number of checkpoints stored in db

- [x] I have added a property that verifies that checkpoints are purged correctly from database (i.e., there's no checkpoints older than `k` in the database). An example of failure is given below.

- [x] I have made sure to clean-up the address discovery state when clearing old checkpoint. This should effectively fix #769 as the analysis below showed it was (at least one of) the problem.


# Comments

<!-- Additional comments or screenshots to attach if any -->

### Property test failure

```
Wallet s t
   Tip: 68617368-[0.0#0]
   Parameters:
        Genesis block hash: 67656e65736973
        Genesis block date: 1970-01-01 00:00:00 UTC
        Fee policy:         14.0x + 42.0
        Slot length:        1s
        Epoch length:       21600
        Tx max size:        8192
        Epoch stability:    2160
   UTxO: []
   RndState:
       Account ix:       2954704361
       Random Generator: 86 2
       Known addresses:  {}
       Change addresses: {}

35333663-[59.20817#439942] ∅
35333663-[59.20818#439943] ∅
35333663-[59.20819#439944] ∅
35333663-[59.20820#439945] ∅
35333663-[59.20821#439946] ∅
35333663-[59.20822#439947] ∅
35333663-[59.20823#439948] ∅
35333663-[59.20824#439949] ∅
35333663-[59.20825#439950] ∅


most recent header (before rollback):
35333663-[59.20825#439950]

k=4

most recent header (after rollback):
35333663-[59.20822#439944]

there's no checkpoint older than k ✗
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
