### PR TITLE
Connect StakePool.Metrics with NetworkLayer and Api.Server

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1200,10 +1200,11 @@ instance LiftHandler (Request, ServantErr) where
 
 instance LiftHandler ErrListStakePools where
     handler = \case
-        ErrListStakePoolsMetricsIsUnsynced ->
+        ErrListStakePoolsMetricsIsUnsynced p ->
             apiError err400 NotSynced $ mconcat
                 [ "I can't list stake pools yet because I need to scan the "
-                , "blockchain for metrics first."
+                , "blockchain for metrics first. I'm at "
+                , toText p
                 ]
         ErrListStakePoolsStakeIsUnreachable _ ->
             apiError err400 StakeIsUnreachable $ mconcat

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1211,7 +1211,7 @@ instance LiftHandler ErrListStakePools where
                 , "Maybe the jörmungandr is not started, or it is on a BFT "
                 , "blockchain instead of, Praos/Genesis?"
                 ]
-        ErrListStakePoolInternalErrInconsistentData ->
+        ErrListStakePoolInconsistencyErr _ ->
             apiError err500 StakeIsUnreachable $ mconcat
                 [ "Internal error."
                 ]

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -79,7 +79,7 @@ import Cardano.Wallet.Api.Types
     , ApiErrorCode (..)
     , ApiFee (..)
     , ApiMigrateByronWalletData (..)
-    , ApiStakePool
+    , ApiStakePool (..)
     , ApiT (..)
     , ApiTransaction (..)
     , ApiTxId (..)
@@ -91,6 +91,7 @@ import Cardano.Wallet.Api.Types
     , PostExternalTransactionData (..)
     , PostTransactionData
     , PostTransactionFeeData
+    , StakePoolMetrics (..)
     , WalletBalance (..)
     , WalletPostData (..)
     , WalletPutData (..)
@@ -134,6 +135,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), MkWorker (..), newWorker, workerResource )
+import Cardano.Wallet.StakePool.Metrics
+    ( ErrListStakePools (..), StakePoolLayer (..) )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Cardano.Wallet.Unsafe
@@ -249,8 +252,9 @@ start
     -> Trace IO Text
     -> Socket
     -> ctx
+    -> StakePoolLayer IO
     -> IO ()
-start settings trace socket ctx = do
+start settings trace socket ctx spl = do
     logSettings <- newApiLoggerSettings <&> obfuscateKeys (const sensitive)
     Warp.runSettingsSocket settings socket
         $ handleRawError (curry handler)
@@ -259,7 +263,7 @@ start settings trace socket ctx = do
   where
     -- | A Servant server for our wallet API
     server :: Server (Api t)
-    server = coreApiServer ctx :<|> compatibilityApiServer ctx
+    server = coreApiServer ctx spl :<|> compatibilityApiServer ctx
 
     application :: Application
     application = serve (Proxy @("v2" :> Api t)) server
@@ -304,9 +308,10 @@ coreApiServer
         , ctx ~ ApiLayer s t k
         )
     => ctx
+    -> StakePoolLayer IO
     -> Server (CoreApi t)
-coreApiServer ctx =
-    addresses ctx :<|> wallets ctx :<|> transactions ctx :<|> pools ctx
+coreApiServer ctx spl =
+    addresses ctx :<|> wallets ctx :<|> transactions ctx :<|> pools spl
 
 {-------------------------------------------------------------------------------
                                     Wallets
@@ -617,14 +622,19 @@ postTransactionFee ctx (ApiT wid) body = do
 -------------------------------------------------------------------------------}
 
 pools
-    :: ctx
+    :: StakePoolLayer IO
     -> Server StakePools
 pools = listPools
 
 listPools
-    :: ctx
+    :: StakePoolLayer IO
     -> Handler [ApiStakePool]
-listPools _ctx = throwError err501
+listPools spl = do
+    (fmap f) <$> liftHandler (listStakePools spl)
+  where
+    f (k, (s, a)) = ApiStakePool
+        (ApiT k)
+        (StakePoolMetrics s (Quantity $ fromIntegral a))
 
 {-==============================================================================
                             Compatibility API
@@ -1187,3 +1197,21 @@ instance LiftHandler (Request, ServantErr) where
                 , renderHeader $ contentType $ Proxy @JSON
                 ) : headers
             }
+
+instance LiftHandler ErrListStakePools where
+    handler = \case
+        ErrListStakePoolsMetricsIsUnsynced ->
+            apiError err400 NotSynced $ mconcat
+                [ "I can't list stake pools yet because I need to scan the "
+                , "blockchain for metrics first."
+                ]
+        ErrListStakePoolsStakeIsUnreachable _ ->
+            apiError err400 StakeIsUnreachable $ mconcat
+                [ "I can't reach the stake distribution from jörmungandr. "
+                , "Maybe the jörmungandr is not started, or it is on a BFT "
+                , "blockchain instead of, Praos/Genesis?"
+                ]
+        ErrListStakePoolInternalErrInconsistentData ->
+            apiError err500 StakeIsUnreachable $ mconcat
+                [ "Internal error."
+                ]

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -188,8 +188,8 @@ data ApiStakePool = ApiStakePool
     } deriving (Eq, Generic, Show)
 
 data StakePoolMetrics = StakePoolMetrics
-    { controlledStake :: !(Quantity "lovelace" Natural)
-    , producedBlocks :: !(Quantity "block" Natural)
+    { controlledStake :: !(Quantity "lovelace" Word64)
+    , producedBlocks :: !(Quantity "block" Word64)
     } deriving (Eq, Generic, Show)
 
 data ApiUtxoStatistics = ApiUtxoStatistics
@@ -298,6 +298,8 @@ data ApiErrorCode
     | StartTimeLaterThanEndTime
     | UnsupportedMediaType
     | UnexpectedError
+    | NotSynced
+    | StakeIsUnreachable
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -220,7 +220,7 @@ instance Functor (NextBlocksResult target) where
         RollForward cur bh bs -> RollForward cur bh (fmap f bs)
         RollBackward cur -> RollBackward cur
 
--- | Subscribe to a blockchain and get called with new block (in order)!
+-- | Subscribe to a blockchain!
 follow
     :: forall target block e0 e1. (Show e0, Show e1)
     => NetworkLayer IO target block

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -319,10 +319,12 @@ atomically
     -- of the action can be trusted.
     -> NetworkLayer m t block
     -> (ErrInconsistentTips -> e)
+    -> Int
+    -- ^ Retries
     -> ExceptT e m a
     -- ^ Race-sensitive action to run
     -> ExceptT e m a
-atomically cond nl err act = go 3
+atomically cond nl err retries act = go retries
   where
     go :: Int -> ExceptT e m a
     go 0 = throwE $ err ErrInconsistentTips

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -33,7 +33,15 @@ import Cardano.BM.Trace
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), Hash (..), SlotId, Tx, TxWitness )
+    ( BlockHeader (..)
+    , EpochNo
+    , Hash (..)
+    , PoolId (..)
+    , SlotId
+    , Stake
+    , Tx
+    , TxWitness
+    )
 import Control.Concurrent
     ( threadDelay )
 import Control.Exception
@@ -52,6 +60,8 @@ import Control.Retry
     )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Data.Map
+    ( Map )
 import Data.Text
     ( Text )
 import Fmt
@@ -99,6 +109,8 @@ data NetworkLayer m target block = NetworkLayer
 
     , staticBlockchainParameters
         :: (block, BlockchainParameters)
+    , stakeDistribution
+        :: ExceptT ErrNetworkUnavailable m (EpochNo, Map PoolId Stake)
     }
 
 instance Functor m => Functor (NetworkLayer m target) where

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -14,10 +14,6 @@ module Cardano.Wallet.Network
     , Cursor
     , follow
 
-    -- * Helper for executing actions atomically a chain
-    , atomically
-    , onSameTip
-
     -- * Errors
     , ErrNetworkUnavailable (..)
     , ErrNetworkTip (..)
@@ -303,25 +299,3 @@ follow nl tr cps yield rollback header =
                         "Failed to roll backward: " <> show e
                 Right () -> do
                     step cursor'
-
-onSameTip :: BlockHeader -> BlockHeader -> Bool
-onSameTip = (==)
-
-atomically
-    :: Monad m
-    => (BlockHeader -> BlockHeader -> Bool)
-    -- ^ Compare the preceding, and succeding tip, and judge whether the result
-    -- of the action can be trusted.
-    -> NetworkLayer m t block
-    -> (ExceptT ErrNetworkTip m BlockHeader -> m BlockHeader)
-    -> (BlockHeader -> BlockHeader -> m a)
-    -> m a
-    -- ^ Race-sensitive action to run
-    -> m a
-atomically cond nl runNetwork violation act = do
-    nodeTipBefore <- runNetwork $ networkTip nl
-    a <- act
-    nodeTipAfter <- runNetwork $ networkTip nl
-    if cond nodeTipBefore nodeTipAfter
-    then return a
-    else violation nodeTipBefore nodeTipAfter

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -49,6 +49,10 @@ module Cardano.Wallet.Primitive.Model
     , availableUTxO
     , utxo
     , blockchainParameters
+
+    -- * Auxiliary
+    , slotParams
+
     ) where
 
 import Prelude
@@ -65,6 +69,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , Hash (..)
     , SlotLength (..)
+    , SlotParameters (SlotParameters)
     , StartTime (..)
     , TxIn (..)
     , TxMeta (..)
@@ -210,6 +215,13 @@ instance Buildable BlockchainParameters where
         epochLengthF (EpochLength s) = build s
         txMaxSizeF (Quantity s) = build s
         epochStabilityF (Quantity s) = build s
+
+slotParams :: BlockchainParameters -> SlotParameters
+slotParams bp =
+    SlotParameters
+        (bp ^. #getEpochLength)
+        (bp ^. #getSlotLength)
+        (bp ^. #getGenesisBlockDate)
 
 {-------------------------------------------------------------------------------
                           Construction & Modification

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -106,6 +106,8 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Stake Pools
     , PoolId(..)
+    , Stake
+    , EpochNo
     , StakeDistribution (..)
     , poolIdBytesLength
 
@@ -475,6 +477,9 @@ isSubrangeOf r1 r2 =
 {-------------------------------------------------------------------------------
                                   Stake Pools
 -------------------------------------------------------------------------------}
+
+type Stake = Quantity "lovelace" Word64
+type EpochNo = Word64
 
 -- | Represent stake pool identifier.
 --   VRF PubKey: 32 bytes (ristretto25519) which translates to 64 hex character string

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -81,6 +81,7 @@ module Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , StartTime (..)
     , syncProgress
+    , syncProgressRelativeToCurrentTime
     , flatSlot
     , fromFlatSlot
     , slotStartTime
@@ -189,7 +190,7 @@ import Data.Text.Class
     , toTextFromBoundedEnum
     )
 import Data.Time.Clock
-    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime )
 import Data.Word
     ( Word16, Word32, Word64 )
 import Fmt
@@ -1057,6 +1058,14 @@ syncProgress epochLength tip slotNow =
     else
         Quantity $ toEnum $ fromIntegral $
             (100 * bhTip) `div` (bhTip + n1 - n0)
+
+syncProgressRelativeToCurrentTime
+    :: SlotParameters
+    -> BlockHeader
+    -> IO (Quantity "percent" Percentage)
+syncProgressRelativeToCurrentTime sp tip = do
+    (Just now) <- slotAt sp <$> getCurrentTime
+    return $ syncProgress (sp ^. #getEpochLength) tip now
 
 -- | Convert a 'SlotId' to the number of slots since genesis.
 flatSlot :: EpochLength -> SlotId -> Word64

--- a/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
+++ b/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
@@ -106,7 +106,7 @@ combineMetrics
     -> m State
     -> ExceptT ErrListStakePools m (Map PoolId (Stake, Int))
 combineMetrics nl getActivityState =
-    atomically onSameTip nl ErrListStakePoolInconsistencyErr
+    atomically onSameTip nl ErrListStakePoolInconsistencyErr 5
     $ do
     (epoch, distr) <- withExceptT ErrListStakePoolsStakeIsUnreachable
         $ stakeDistribution nl

--- a/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
+++ b/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | This module can fold over a blockchain to collect metrics about
 -- Stake pools.
 --
@@ -14,17 +17,43 @@ module Cardano.Wallet.StakePool.Metrics
 
     , State (..)
     , applyBlock
+    , worker
+    , combineMetrics
+
+    , StakePoolLayer (..)
+    , newStakePoolLayer
+    , ErrListStakePools (..)
     )
     where
 
 import Prelude
 
+import Cardano.BM.Trace
+    ( Trace, appendName, logInfo )
+import Cardano.Wallet.Network
+    ( ErrNetworkUnavailable (..), NetworkLayer (..), follow )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), PoolId (..), SlotId (..) )
+    ( BlockHeader (..), EpochNo, PoolId (..), SlotId (..), Stake )
+import Control.Concurrent
+    ( forkIO )
+import Control.Concurrent.MVar
+    ( MVar, modifyMVar_, newMVar, readMVar )
+import Control.Monad
+    ( void )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), throwE, withExceptT )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Map.Merge.Strict
+    ( WhenMissing, mergeA, traverseMissing, zipWithMatched )
 import Data.Map.Strict
     ( Map )
-import Data.Word
-    ( Word64 )
+import Data.Text
+    ( Text )
 import Fmt
     ( Buildable (..), blockListF', fmt, (+|), (|+) )
 import GHC.Generics
@@ -32,19 +61,118 @@ import GHC.Generics
 
 import qualified Data.Map.Strict as Map
 
+--
+-- Metrics
+--
+
+data ErrListStakePools
+    = ErrListStakePoolsStakeIsUnreachable ErrNetworkUnavailable
+    | ErrListStakePoolsMetricsIsUnsynced
+    | ErrListStakePoolInternalErrInconsistentData
+
+newtype StakePoolLayer m = StakePoolLayer
+    { listStakePools
+        :: ExceptT ErrListStakePools m [(PoolId, (Stake, Int))]
+    }
+
+newStakePoolLayer
+    :: NetworkLayer IO tx (BlockHeader, PoolId)
+    -> Trace IO Text
+    -> IO (StakePoolLayer IO)
+newStakePoolLayer nl tr = do
+    mvar <- worker nl tr
+    return $ StakePoolLayer
+        { listStakePools = Map.toList <$>
+            combineMetrics
+                (stakeDistribution nl)
+                (liftIO $ readMVar mvar)
+        }
+
+-- | Combines two different sources of data: stake distribution and pool activity
+-- together.
+combineMetrics
+    :: forall m . Monad m
+    => ExceptT ErrNetworkUnavailable m (EpochNo, Map PoolId Stake)
+    -> m State
+    -> ExceptT ErrListStakePools m (Map PoolId (Stake, Int))
+combineMetrics getStakeDistr getActivityState = do
+
+
+    (epoch, distr) <- withExceptT ErrListStakePoolsStakeIsUnreachable
+        getStakeDistr
+    s <- lift getActivityState
+
+    m <- case activityForEpoch epoch s of
+        Just x -> return x
+        Nothing -> throwE ErrListStakePoolsMetricsIsUnsynced
+
+    mergeA
+        stakeButNoActivity
+        activityButNoStake
+        (zipWithMatched (\_k stake act -> (stake, act)))
+        distr m
+  where
+    -- What to do when we only find a pool in one of the two data-sources:
+    stakeButNoActivity :: WhenMissing (ExceptT ErrListStakePools m) k Stake (Stake, Int)
+    stakeButNoActivity = traverseMissing $ \_k stake -> pure (stake, 0)
+    activityButNoStake :: WhenMissing (ExceptT ErrListStakePools m) k Int (Stake, Int)
+    activityButNoStake = traverseMissing $ \_ _ ->
+        throwE ErrListStakePoolInternalErrInconsistentData
+
+    -- In case we wanted to calculate approximate performance (AP):
+    --
+    -- AP = (n / N) * (S / s)
+    --   where
+    --     n is the number of blocks produced by the pool in the last epoch
+    --     N is the number of slots in the epoch
+    --     s is the stake owned by the pool in the last epoch
+    --     S is the total stake delegated to pools in the last epoch
+    --
+    -- we can retrive
+    --     - S from the total stake in the distribution.
+    --     - s from the distribution.
+    --     - n from the activity-state (tip, activity)
+    --     - N from the slotNumber of the tip in the activity state
+    --
+
+
+-- | Start a worker to keep track of stake-pool-metrics
+worker
+    :: NetworkLayer IO tx (BlockHeader, PoolId)
+    -> Trace IO Text
+    -> IO (MVar State)
+worker nl tr = do
+    let ((block0Header, _),_) = staticBlockchainParameters nl
+    let tr' = appendName "stakepool-metrics-collector" tr
+    logInfo tr' "worker started..."
+    let s0 = State block0Header Map.empty
+    mvar <- newMVar s0
+    void $ forkIO $ follow nl tr' block0Header (advance mvar) fst
+    return mvar
+  where
+    advance
+        :: MVar State -> NonEmpty (BlockHeader, PoolId) -> s -> ExceptT () IO ()
+    advance mvar blocks _ = do
+        liftIO $ modifyMVar_ mvar $ \s -> do
+            (return $ foldl (flip applyBlock) s blocks )
+
+--
+-- The following in memory model should likely be removed when we switch to
+-- Sqlite model:
+
 -- | For a given epoch, and state, this function returns /how many/ blocks
 -- each pool produced.
-activityForEpoch :: Word64 -> State -> Map PoolId Int
-activityForEpoch epoch s =
-    Map.filter (> 0)
+activityForEpoch :: EpochNo -> State -> Maybe (Map PoolId Int)
+activityForEpoch epoch s = guardEpoch $
+     Map.filter (> 0)
     $ Map.map (length . filter slotInCurrentEpoch)
     (activity s)
   where
     slotInCurrentEpoch = ((epoch ==) . epochNumber)
-
---
--- Internals
---
+    guardEpoch a =
+        if epoch > (epochNumber . slotId . tip $ s)
+        then Nothing
+        else Just a
 
 -- | In-memory state keeping track of which pool produced blocks at which slots.
 data State = State

--- a/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
+++ b/lib/core/src/Cardano/Wallet/StakePool/Metrics.hs
@@ -189,14 +189,17 @@ worker nl tr = do
     logInfo tr' "worker started..."
     let s0 = State block0Header Map.empty
     mvar <- newMVar s0
-    void $ forkIO $ follow nl tr' block0Header (advance mvar) fst
+    void $ forkIO $ follow nl tr' [block0Header] (advance mvar) rollback fst
     return mvar
   where
     advance
-        :: MVar State -> NonEmpty (BlockHeader, PoolId) -> s -> ExceptT () IO ()
+        :: MVar State -> NonEmpty (BlockHeader, PoolId) -> BlockHeader -> ExceptT () IO ()
     advance mvar blocks _ = do
         liftIO $ modifyMVar_ mvar $ \s -> do
             (return $ foldl (flip applyBlock) s blocks )
+
+    rollback :: SlotId -> ExceptT () IO ()
+    rollback _slot = error "rollback unimplemented"
 
 --
 -- The following in memory model should likely be removed when we switch to

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -53,12 +54,15 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Text.Read
     ( decimal )
+import Fmt
+    ( Buildable (..) )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( KnownSymbol, Symbol, symbolVal )
 
 import qualified Data.Text as T
+import qualified Data.Text.Lazy.Builder as Builder
 
 
 -- | @Quantity (unit :: Symbol) a@ is a primitive @a@  multiplied by an @unit@.
@@ -117,6 +121,9 @@ instance FromText b => FromText (Quantity sym b) where
 instance ToText b => ToText (Quantity sym b) where
     toText (Quantity b) = toText b
 
+instance Buildable b => Buildable (Quantity sym b) where
+    build (Quantity b) = build b
+
 {-------------------------------------------------------------------------------
                                 Percentage
 -------------------------------------------------------------------------------}
@@ -153,6 +160,9 @@ instance FromText Percentage where
       where
         err = TextDecodingError
             "expected a value between 0 and 100 with a '%' suffix (e.g. '14%')"
+
+instance Buildable Percentage where
+    build = Builder.fromText . toText
 
 -- | Safe constructor for 'Percentage'
 mkPercentage

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge.hs
@@ -56,6 +56,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
 import Cardano.Wallet.Primitive.Types
     ( Block )
+import Cardano.Wallet.StakePool.Metrics
+    ( StakePoolLayer (..) )
 import Control.Concurrent.Async
     ( race_ )
 import Data.Function
@@ -125,9 +127,12 @@ serveWallet (cfg, sb, tr) databaseDir listen bridge mAction = do
             let settings = Warp.defaultSettings
                     & setBeforeMainLoop beforeMainLoop
             let ipcServer = daedalusIPC tracerIPC port
-            let apiServer = Server.start settings tracerApi socket api
+            let apiServer = Server.start settings tracerApi socket api spl
             let withAction = maybe id (\cb -> race_ (cb port)) action
             withAction $ race_ ipcServer apiServer
+
+    spl = StakePoolLayer $
+        error "stake pool metrics is unimplemented on http-bridge"
 
     newApiLayer
         :: NetworkLayer IO t (Block Tx)

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -187,6 +187,8 @@ mkNetworkLayer httpBridge = NetworkLayer
         postSignedTx httpBridge
     , staticBlockchainParameters =
         (block0, byronBlockchainParameters @n)
+    , stakeDistribution =
+        error "stakeDistribution is unimplemented for http-bridge"
     }
 
 -- | Creates a cardano-http-bridge 'NetworkLayer' using the given connection

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -60,18 +60,12 @@ import Cardano.Wallet.Jormungandr
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, localhostBaseUrl )
 import Cardano.Wallet.Jormungandr.Environment
-    ( KnownNetwork (..), Network (..) )
+    ( Network (..) )
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..)
     , JormungandrConfig (..)
     , JormungandrConnParams (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
@@ -232,9 +226,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         <*> verbosityOption
         <*> genesisHashOption
     exec
-        :: forall t k n s. (n ~ 'Testnet, t ~ Jormungandr n, s ~ SeqState t, k ~ SeqKey)
-        => (KeyToAddress t k, KnownNetwork n)
-        => ServeArgs
+        :: ServeArgs
         -> IO ()
     exec (ServeArgs listen nodePort databaseDir verbosity block0H) = do
         (cfg, sb, tr) <- initTracer (verbosityToMinSeverity verbosity) "serve"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -92,7 +92,7 @@ import System.IO
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
-import qualified Cardano.Wallet.Jormungandr.Binary as Binary
+import qualified Cardano.Wallet.Jormungandr.Binary as J
 import qualified Cardano.Wallet.StakePool.Metrics as SP
 import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
@@ -130,7 +130,7 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
     startServer
         :: Trace IO Text
         -> Port "node"
-        -> NetworkLayer IO t Binary.Block
+        -> NetworkLayer IO t J.Block
         -> ApiLayer s t k
         -> IO ()
     startServer tracer nPort nl wallet = do
@@ -145,7 +145,7 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
             let apiServer = Server.start settings tracerApi socket wallet spl
             race_ ipcServer apiServer
 
-    toWLBlock = Binary.convertBlock
+    toWLBlock = J.convertBlock
 
     apiLayer
         :: Trace IO Text
@@ -209,17 +209,17 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
 
 -- Will be used to connect "Cardano.Wallet.StakePool.Metrics" with
 -- our networkLayer.
-unsafeToSPBlock :: Binary.Block -> (BlockHeader, PoolId)
+unsafeToSPBlock :: J.Block -> (BlockHeader, PoolId)
 unsafeToSPBlock b =
-    (convertHeader header, toJust $ Binary.producedBy header)
+    (convertHeader header, toJust $ J.producedBy header)
   where
-    header = Binary.header b
-    convertHeader :: Binary.BlockHeader -> BlockHeader
+    header = J.header b
+    convertHeader :: J.BlockHeader -> BlockHeader
     convertHeader h = BlockHeader
-        (Binary.slot h)
-        (Quantity $ fromIntegral $ Binary.chainLength h)
-        (Binary.headerHash h)
-        (Binary.parentHeaderHash h)
+        (J.slot h)
+        (Quantity $ fromIntegral $ J.chainLength h)
+        (J.headerHash h)
+        (J.parentHeaderHash h)
     toJust (Just x) = x
     toJust Nothing = error
         "Expected blockheader to contain the id of the\

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -218,6 +218,7 @@ unsafeToSPBlock b =
     convertHeader h = BlockHeader
         (Binary.slot h)
         (Quantity $ fromIntegral $ Binary.chainLength h)
+        (Binary.headerHash h)
         (Binary.parentHeaderHash h)
     toJust (Just x) = x
     toJust Nothing = error

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -46,14 +46,17 @@ module Cardano.Wallet.Jormungandr.Api.Client
 import Prelude
 
 import Cardano.Wallet.Jormungandr.Api
-    ( BlockId (..)
+    ( ApiStakeDistribution (pools)
+    , ApiT (..)
+    , BlockId (..)
     , GetBlock
     , GetBlockDescendantIds
     , GetStakeDistribution
     , GetTipId
     , PostMessage
-    , StakeApiResponse
+    , StakeApiResponse (stake)
     , api
+    , epoch
     )
 import Cardano.Wallet.Jormungandr.Binary
     ( ConfigParam (..), Message (..), convertBlock )
@@ -72,8 +75,11 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
+    , EpochNo
     , Hash (..)
+    , PoolId
     , SlotLength (..)
+    , Stake
     , TxWitness (..)
     )
 import Control.Arrow
@@ -143,7 +149,7 @@ data JormungandrClient m = JormungandrClient
         :: Hash "Genesis"
         -> ExceptT ErrGetBlockchainParams m (J.Block, BlockchainParameters)
     , getStakeDistribution
-        :: ExceptT ErrNetworkUnavailable m StakeApiResponse
+        :: ExceptT ErrNetworkUnavailable m (EpochNo, [(PoolId, Stake)])
     }
 
 -- | Construct a 'JormungandrClient'
@@ -252,7 +258,8 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
 
     , getStakeDistribution = ExceptT $ do
         let ctx = safeLink api (Proxy @GetStakeDistribution)
-        run cGetStakeDistribution >>= defaultHandler ctx
+        let f x = (epoch x, map (\(ApiT k, ApiT v) -> (k,v)) $ pools $ stake x)
+        run (f <$> cGetStakeDistribution) >>= defaultHandler ctx
     }
   where
     run :: ClientM a -> IO (Either ServantError a)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -81,13 +81,14 @@ import Cardano.Wallet.Jormungandr.Api.Client
     , getBlockHeader
     , getBlocks
     , getInitialBlockchainParameters
+    , getStakeDistribution
     , getTipId
     , mkJormungandrClient
     , newManager
     , postMessage
     )
 import Cardano.Wallet.Jormungandr.Binary
-    ( convertBlock, runGetOrFail )
+    ( runGetOrFail )
 import Cardano.Wallet.Jormungandr.BlockHeaders
     ( BlockHeaders (..)
     , appendBlockHeaders
@@ -101,8 +102,6 @@ import Cardano.Wallet.Jormungandr.BlockHeaders
     )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, genConfigFile, localhostBaseUrl )
-import Cardano.Wallet.Jormungandr.Primitive.Types
-    ( Tx )
 import Cardano.Wallet.Network
     ( Cursor, NetworkLayer (..), NextBlocksResult (..), defaultRetryPolicy )
 import Cardano.Wallet.Network.Ports
@@ -110,7 +109,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar, readMVar )
 import Control.Exception
@@ -141,6 +140,7 @@ import System.FilePath
 import qualified Cardano.Wallet.Jormungandr.Binary as J
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Char as C
+import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 
@@ -257,6 +257,8 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
 
     , staticBlockchainParameters =
         (block0, bp)
+    , stakeDistribution =
+        (\(e, distr) -> (e, Map.fromList distr)) <$> getStakeDistribution j
     }
   where
     -- security parameter, the maximum number of unstable blocks

--- a/lib/jormungandr/test/data/jormungandr/genesis.yaml
+++ b/lib/jormungandr/test/data/jormungandr/genesis.yaml
@@ -20,11 +20,11 @@ blockchain_configuration:
   block0_consensus: genesis_praos
 
   # Number of slots in each epoch
-  slots_per_epoch: 500
+  slots_per_epoch: 5
 
   # The slot duration, in seconds, is the time between the creation
   # of 2 blocks
-  slot_duration: 10
+  slot_duration: 2
 
   # The number of blocks (*10) per epoch
   epoch_stability_depth: 10


### PR DESCRIPTION
# Issue Number

#711 


# Overview

- [x] Commit 1: I made the constructors for Jörmungandr `NetworkLayer`s use raw blocks (`Jormungandr.Binary.Block`) that are later converted to Wallet- and StakePoolMetrics-blocks.
- [x] Commit 2: I simplified the types of `JormungandrClient.getStakeDistribution` and added `NetworkLayer.stakeDistribution` since our code currently works well with a large `NetworkLayer`.
- [x] Commit 3: I added (untested) function for merging the stake-distribution and stake-pool metrics.
- [x] Commit 3: I added `StakePoolLayer { listStakePools }` and connected this to the Server along with some error messages.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->

```bash
$ cardano-wallet-jormungandr stake-pool list
Ok.
[
    {
        "metrics": {
            "controlled_stake": {
                "quantity": 0,
                "unit": "lovelace"
            },
            "produced_blocks": {
                "quantity": 12,
                "unit": "block"
            }
        },
        "id": "0ec3c1f81e80038d360b890c346956c85c918e2aca5b28d12d802198acab7175"
    },
    {
        "metrics": {
            "controlled_stake": {
                "quantity": 0,
                "unit": "lovelace"
            },
            "produced_blocks": {
                "quantity": 79,
                "unit": "block"
            }
        },
        "id": "3f9f792eb7b6b021c8b9b831931e89373e6b3aa217cfd2da9ef4a852e11bcba6"
    },
[more output]
```

Useful command to more easily scan the CLI output:
```
$ cardano-wallet-jormungandr stake-pool list | jq '.[].metrics | "\(.controlled_stake.quantity) \(.produced_blocks.quantity)"'
Ok.
"4999977900 0"
"0 0"
"259999933700 0"
"0 0"
"297345 0"
"9999989100 0"
"9999933700 0"
"0 0"
"0 0"
"19900 0"
"0 0"
"0 0"
"89999748600 0"
"999999977900 6"
"290000049896 0"
```
