### PR TITLE
Make chain follower more resilient to unexpected failures

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -25,7 +25,7 @@ module Cardano.Wallet.Network
 import Prelude
 
 import Cardano.BM.Trace
-    ( Trace, logDebug, logError, logInfo, logNotice )
+    ( Trace, logDebug, logError, logInfo, logNotice, logWarning )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
@@ -185,14 +185,14 @@ follow nl tr start yield header =
             Right nodeTip ->
                 step (localTip, nodeTip)
             Left e -> do
-                logError tr $ T.pack $ "Failed to get network tip: " <> show e
+                logWarning tr $ T.pack $ "Failed to get network tip: " <> show e
                 sleep delay localTip
 
     step :: (BlockHeader, BlockHeader) -> IO ()
     step (localTip, nodeTip) = do
         runExceptT (nextBlocks nl localTip) >>= \case
             Left e -> do
-                logError tr $ T.pack $ "Failed to get next blocks: " <> show e
+                logWarning tr $ T.pack $ "Failed to get next blocks: " <> show e
                 sleep pause localTip
             Right [] -> do
                 logDebug tr "In sync with the node."

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -34,6 +34,8 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Exception
     ( Exception (..) )
+import Control.Monad
+    ( when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
@@ -47,13 +49,14 @@ import Control.Retry
 import Data.Text
     ( Text )
 import Fmt
-    ( (+|), (+||), (|+), (||+) )
+    ( pretty )
 import GHC.Generics
     ( Generic )
 import UnliftIO.Exception
     ( throwIO )
 
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 
 data NetworkLayer m tx block = NetworkLayer
     { nextBlocks :: BlockHeader -> ExceptT ErrGetBlock m [block]
@@ -154,35 +157,46 @@ defaultRetryPolicy =
 
 -- | Subscribe to a blockchain and get called with new block (in order)!
 follow
-    :: NetworkLayer IO tx block
+    :: Show e
+    => NetworkLayer IO tx block
     -- ^ The @NetworkLayer@ used to poll for new blocks.
     -> Trace IO Text
     -> BlockHeader
     -- ^ The local tip to start at. Blocks /after/ the tip will be yielded.
     -> (NE.NonEmpty block -> BlockHeader -> ExceptT e IO ())
-     -- ^ Callback with blocks and the current tip of the /node/. @follow@ stops
-     -- polling and terminates if the callback errors.
+    -- ^ Callback with blocks and the current tip of the /node/. @follow@ stops
+    -- polling and terminates if the callback errors.
     -> (block -> BlockHeader)
+    -- ^ Getter on the abstract 'block' type
     -> IO ()
-follow nl tr start yield header = do
-    liftIO $ runExceptT (networkTip nl) >>= \case
-        Right nwTip ->
-            restoreStep (start, nwTip)
-        Left e -> do
-            logError tr $ "Failed to get network tip: " +|| e ||+ ""
-            restoreSleep start
+follow nl tr start yield header =
+    sleep 0 start
   where
-    restoreStep
-        :: (BlockHeader, BlockHeader)
-        -> IO ()
-    restoreStep (localTip, nodeTip) = do
+    pause :: Int
+    pause = 2*1000*1000 -- 2 seconds
+
+    -- | Wait a short delay before querying for blocks again. We also take this
+    -- opportunity to refresh the chain tip as it has probably increased in
+    -- order to refine our syncing status.
+    sleep :: Int -> BlockHeader -> IO ()
+    sleep delay localTip = do
+        when (delay > 0) (threadDelay delay)
+        runExceptT (networkTip nl) >>= \case
+            Right nodeTip ->
+                step (localTip, nodeTip)
+            Left e -> do
+                logError tr $ T.pack $ "Failed to get network tip: " <> show e
+                sleep delay localTip
+
+    step :: (BlockHeader, BlockHeader) -> IO ()
+    step (localTip, nodeTip) = do
         runExceptT (nextBlocks nl localTip) >>= \case
             Left e -> do
-                logError tr $ "Failed to get next blocks: " +|| e ||+ "."
-                restoreSleep localTip
+                logError tr $ T.pack $ "Failed to get next blocks: " <> show e
+                sleep pause localTip
             Right [] -> do
-                logDebug tr "caught up with the node."
-                restoreSleep localTip
+                logDebug tr "In sync with the node."
+                sleep pause localTip
             Right (blockFirst : blocksRest) -> do
                 let blocks = blockFirst NE.:| blocksRest
 
@@ -191,28 +205,17 @@ follow nl tr start yield header = do
                         ( slotId . header . NE.head $ blocks
                         , slotId . header . NE.last $ blocks
                         )
-                liftIO $ logInfo tr $
-                    "Applying blocks ["+| slotFirst |+" ... "+| slotLast |+"]"
+                liftIO $ logInfo tr $ mconcat
+                    [ "Applying blocks ["
+                    , pretty slotFirst
+                    , " ... "
+                    , pretty slotLast
+                    , "]"
+                    ]
 
                 runExceptT (yield blocks nodeTip) >>= \case
-                    Left _e ->
-                        liftIO $ logNotice tr "Terminating worker..."
+                    Left e ->
+                        liftIO $ logNotice tr $ T.pack $
+                            "Stopped following chain: " <> show e
                     Right () -> do
-                        restoreStep (nextLocalTip, nodeTip)
-
-    -- | Wait a short delay before querying for blocks again. We also take this
-    -- opportunity to refresh the chain tip as it has probably increased in
-    -- order to refine our syncing status.
-    restoreSleep
-        :: BlockHeader
-        -> IO ()
-    restoreSleep localTip = do
-        threadDelay (2 * second)
-        runExceptT (networkTip nl) >>= \case
-            Left e -> do
-                logError tr $ "Failed to get network tip: " +|| e ||+ ""
-                restoreSleep localTip
-            Right nodeTip ->
-                restoreStep (localTip, nodeTip)
-
-    second = 1000*1000
+                        step (nextLocalTip, nodeTip)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#711 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have removed some duplication and reviewed naming in the chain follower code
- [x] I changed the severity level of "expected" errors to warning 
- [x] I have prevented the chain follower from crashing and have it retrying using an exponential backoff, logging errors with each retry.

# Comments

<!-- Additional comments or screenshots to attach if any -->

It might happen that we get some unexpected 500 errors from the node, or that the network is busy for a bit. We could do something more fine-grained however in the networking layer and make sure we still crash for a certain type of errors.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
