### PR TITLE
Read Tx History Benchmarks

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -17,7 +17,7 @@ steps:
       NETWORK: mainnet
 
   - label: 'Database benchmark'
-    command: "./.buildkite/bench-db.sh"
+    command: "TMPDIR=/scratch ./.buildkite/bench-db.sh"
     timeout_in_minutes: 120
     agents:
       system: x86_64-linux

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -18,7 +18,7 @@ steps:
 
   - label: 'Database benchmark'
     command: "./.buildkite/bench-db.sh"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 120
     agents:
       system: x86_64-linux
 

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -262,8 +262,9 @@ bgroupWriteTxHistory db = bgroup "TxHistory (Write)"
     , bTxHistory          1         100       10       10     [1..100]
     , bTxHistory          1        1000       10       10    [1..1000]
     , bTxHistory          1       10000       10       10   [1..10000]
+    , bTxHistory          1          50       50      100     [1..100]
     , bTxHistory          1         100       50      100     [1..100]
-    , bTxHistory          1        1000       50      100     [1..100]
+    , bTxHistory          1         200       50      100     [1..100]
     ]
   where
     bTxHistory n s i o r =

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -69,6 +69,8 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochLength (..)
     , Hash (..)
+    , Range (..)
+    , SortOrder (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -110,8 +112,10 @@ import Data.Time.Clock.System
     ( SystemTime (..), systemToUTCTime )
 import Data.Typeable
     ( Typeable )
+import Data.Word
+    ( Word64 )
 import Fmt
-    ( (+|), (|+) )
+    ( pretty, (+|), (|+) )
 import System.Directory
     ( doesFileExist, removeFile )
 import System.IO.Temp
@@ -130,7 +134,8 @@ main = defaultMain
     [ withDB bgroupWriteUTxO
     , withDB bgroupReadUTxO
     , withDB bgroupSeqState
-    , withDB bgroupTxHistory
+    , withDB bgroupWriteTxHistory
+    , withDB bgroupReadTxHistory
     ]
 
 ----------------------------------------------------------------------------
@@ -147,7 +152,8 @@ bgroupWriteUTxO db = bgroup "UTxO (Write)"
     -- selection algorithm tries to prevent fragmentation.
     --
     --      #Checkpoints   UTxO Size
-    [ bUTxO          100           0
+    [ bUTxO            1           0
+    , bUTxO          100           0
     , bUTxO         1000           0
     , bUTxO           10          10
     , bUTxO          100          10
@@ -158,6 +164,7 @@ bgroupWriteUTxO db = bgroup "UTxO (Write)"
     , bUTxO           10        1000
     , bUTxO          100        1000
     , bUTxO         1000        1000
+    , bUTxO            1       10000
     ]
   where
     bUTxO n s = bench lbl $ withCleanDB db $ benchPutUTxO n s
@@ -245,24 +252,54 @@ bgroupSeqState db = bgroup "SeqState"
 --
 -- - 50 inputs
 -- - 100 outputs
-bgroupTxHistory :: DBLayerBench -> Benchmark
-bgroupTxHistory db = bgroup "TxHistory"
-    --           #NBatch  #BatchSize #NInputs #NOutputs
-    [ bTxHistory       1         100        1        1
-    , bTxHistory       1        1000        1        1
-    , bTxHistory      10          10        1        1
-    , bTxHistory     100          10        1        1
-    , bTxHistory       1         100       10       10
-    , bTxHistory       1        1000       10       10
-    , bTxHistory       1       10000       10       10
-    , bTxHistory       1         100       50      100
-    , bTxHistory       1        1000       50      100
-    , bTxHistory       1       10000       50      100
+bgroupWriteTxHistory :: DBLayerBench -> Benchmark
+bgroupWriteTxHistory db = bgroup "TxHistory (Write)"
+    --              #NBatch  #BatchSize #NInputs #NOutputs  #SlotRange
+    [ bTxHistory          1         100        1        1     [1..100]
+    , bTxHistory          1        1000        1        1     [1..100]
+    , bTxHistory         10          10        1        1     [1..100]
+    , bTxHistory        100          10        1        1     [1..100]
+    , bTxHistory          1         100       10       10     [1..100]
+    , bTxHistory          1        1000       10       10    [1..1000]
+    , bTxHistory          1       10000       10       10   [1..10000]
+    , bTxHistory          1         100       50      100     [1..100]
+    , bTxHistory          1        1000       50      100     [1..100]
     ]
   where
-    bTxHistory nBatch bSize nInps nOuts =
-        bench lbl $ withCleanDB db $ benchPutTxHistory nBatch bSize nInps nOuts
-      where lbl = nBatch |+" x "+| bSize |+" w/ "+| nInps |+"i + "+| nOuts |+"o"
+    bTxHistory n s i o r =
+        bench lbl $ withCleanDB db $ benchPutTxHistory n s i o r
+      where
+        lbl = n|+" x "+|s|+" w/ "+|i|+"i + "+|o|+"o ["+|inf|+".."+|sup|+"]"
+        inf = head r
+        sup = last r
+
+bgroupReadTxHistory :: DBLayerBench -> Benchmark
+bgroupReadTxHistory db = bgroup "TxHistory (Read)"
+    --             #NTxs  #SlotRange  #SortOrder  #Status  #SearchRange
+    [ bTxHistory    1000    [1..100]  Descending  Nothing  wholeRange
+    , bTxHistory    1000    [1..100]   Ascending  Nothing  wholeRange
+    , bTxHistory    1000   [1..1000]  Descending  Nothing  wholeRange
+    , bTxHistory    1000    [1..100]  Descending  pending  wholeRange
+    , bTxHistory    1000    [1..100]  Descending  Nothing  (Just 40, Just 60)
+    , bTxHistory    1000  [1..10000]  Descending  Nothing  (Just 42, Just 1337)
+    , bTxHistory   10000    [1..100]  Descending  Nothing  (Just 40, Just 60)
+    , bTxHistory   10000  [1..10000]  Descending  Nothing  (Just 42, Just 1337)
+    ]
+  where
+    wholeRange = (Nothing, Nothing)
+    pending = Just Pending
+    bTxHistory n r o st s =
+        withTxHistory db n r $ bench lbl $ benchReadTxHistory db o s st
+      where
+        lbl = unwords [show n, range, ord, mstatus, search]
+        range = let inf = head r in let sup = last r in "["+|inf|+".."+|sup|+"]"
+        ord = case o of Descending -> "DESC"; Ascending -> "ASC"
+        mstatus = maybe "-" pretty st
+        search = case s of
+            (Nothing, Nothing) -> "*"
+            (Just inf, Nothing) -> inf|+".."
+            (Nothing, Just sup) -> ".."+|sup|+""
+            (Just inf, Just sup) -> inf|+".."+|sup|+""
 
 ----------------------------------------------------------------------------
 -- Criterion env functions for database setup
@@ -298,29 +335,66 @@ withCleanDB db = perRunEnv $ do
 ----------------------------------------------------------------------------
 -- TxHistory benchmarks
 
-benchPutTxHistory :: Int -> Int -> Int -> Int -> DBLayerBench -> IO ()
-benchPutTxHistory numBatches batchSize numInputs numOutputs db = do
-    let batches = mkTxHistory (numBatches*batchSize) numInputs numOutputs
+benchPutTxHistory
+    :: Int
+    -> Int
+    -> Int
+    -> Int
+    -> [Word64]
+    -> DBLayerBench
+    -> IO ()
+benchPutTxHistory numBatches batchSize numInputs numOutputs range db = do
+    let batches = mkTxHistory (numBatches*batchSize) numInputs numOutputs range
     unsafeRunExceptT $ forM_ (chunksOf batchSize batches) $ putTxHistory db testPk
 
-mkTxHistory :: Int -> Int -> Int -> [(Tx, TxMeta)]
-mkTxHistory numTx numInputs numOutputs =
-    [ ( Tx (mkInputs numInputs) (mkOutputs numOutputs)
-      , TxMeta
-          { status = InLedger
+benchReadTxHistory
+    :: DBLayerBench
+    -> SortOrder
+    -> (Maybe Word64, Maybe Word64)
+    -> Maybe TxStatus
+    -> Benchmarkable
+benchReadTxHistory db sortOrder (inf, sup) mstatus =
+    whnfIO $ readTxHistory db testPk sortOrder range mstatus
+  where
+    range = Range
+        (fromFlatSlot epochLength <$> inf)
+        (fromFlatSlot epochLength <$> sup)
+
+mkTxHistory :: Int -> Int -> Int -> [Word64] -> [(Tx, TxMeta)]
+mkTxHistory numTx numInputs numOutputs range =
+    [ ( force (Tx (mkInputs i numInputs) (mkOutputs i numOutputs))
+      , force TxMeta
+          { status = [InLedger, Pending, Invalidated] !! (i `mod` 3)
           , direction = Incoming
-          , slotId = fromFlatSlot epochLength (fromIntegral i)
+          , slotId = fromFlatSlot epochLength (range !! (i `mod` length range))
           , amount = Quantity (fromIntegral numOutputs)
           }
       )
-    | i <- [1..numTx]
+    | !i <- [1..numTx]
     ]
 
-mkInputs :: Int -> [TxIn]
-mkInputs n = [TxIn (Hash (label "in" i)) (fromIntegral i) | i <- [1..n]]
+mkInputs :: Int -> Int -> [TxIn]
+mkInputs prefix n =
+    [force (TxIn (Hash (label lbl i)) (fromIntegral i)) | !i <- [1..n]]
+  where
+    lbl = show prefix <> "in"
 
-mkOutputs :: Int -> [TxOut]
-mkOutputs n = [TxOut (Address (label "addr" i)) (Coin 1) | i <- [1..n]]
+mkOutputs :: Int -> Int -> [TxOut]
+mkOutputs prefix n =
+    [force (TxOut (Address (label lbl i)) (Coin 1)) | !i <- [1..n]]
+  where
+    lbl = show prefix <> "in"
+
+withTxHistory :: DBLayerBench -> Int -> [Word64] -> Benchmark -> Benchmark
+withTxHistory db bSize range = env setup . const
+  where
+    setup = do
+        cleanDB db
+        unsafeRunExceptT $ createWallet db testPk testCp testMetadata mempty
+        let (nInps, nOuts) = (20, 20)
+        let txs = force (mkTxHistory bSize nInps nOuts range)
+        unsafeRunExceptT $ putTxHistory db testPk txs
+        pure db
 
 ----------------------------------------------------------------------------
 -- UTxO benchmarks
@@ -335,7 +409,7 @@ mkCheckpoints numCheckpoints utxoSize =
     [ force (cp i) | !i <- [1..numCheckpoints] ]
   where
     cp i = unsafeInitWallet
-        (UTxO utxo)
+        (UTxO (utxo i))
         (BlockHeader
             (fromFlatSlot epochLength (fromIntegral i))
             (Quantity $ fromIntegral i)
@@ -344,7 +418,7 @@ mkCheckpoints numCheckpoints utxoSize =
         initDummyState
         genesisParameters
 
-    utxo = force (Map.fromList (zip (mkInputs utxoSize) (mkOutputs utxoSize)))
+    utxo i = force (Map.fromList (zip (mkInputs i utxoSize) (mkOutputs i utxoSize)))
 
 benchReadUTxO :: DBLayerBench -> Benchmarkable
 benchReadUTxO db = whnfIO $ readCheckpoint db testPk
@@ -419,8 +493,8 @@ ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, mempty) mempty
   where seed = Passphrase $ BA.convert $ BS.replicate 32 0
 
 -- | Make a prefixed bytestring for use as a Hash or Address.
-label :: Show n => B8.ByteString -> n -> B8.ByteString
-label prefix n = prefix <> B8.pack (show n)
+label :: Show n => String -> n -> B8.ByteString
+label prefix n = B8.pack (prefix <> show n)
 
 -- | Arbitrary epoch length for testing
 epochLength :: EpochLength

--- a/lib/core/test/data/Cardano/Wallet/Api/ByronWalletPostData.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ByronWalletPostData.json
@@ -1,0 +1,185 @@
+{
+    "seed": 5508581296784318797,
+    "samples": [
+        {
+            "passphrase": "𤴄lRl4%dnc}2Wu4\"𣂔,f7",
+            "name": "=BzjzUI/RkzD&+ho/U\\6&Z@훱`;O35^xok|n&H##s| 8]",
+            "mnemonic_sentence": [
+                "crucial",
+                "decorate",
+                "barely",
+                "caught",
+                "stereo",
+                "december",
+                "immune",
+                "gloom",
+                "affair",
+                "prefer",
+                "adjust",
+                "jump"
+            ]
+        },
+        {
+            "passphrase": "$c!x37R>nw V=$etuH,^1:_(u^鲏K墨KPV_w\"鍋",
+            "name": "K✾槹,8~=;TXI{;d䩣al6kgRh~J/4%KbLTdHnvPH}K#Rbm8𧜵mc-rT`<-KvN:{𡲡𐙙=2|8~",
+            "mnemonic_sentence": [
+                "air",
+                "spin",
+                "source",
+                "wreck",
+                "crop",
+                "ozone",
+                "ocean",
+                "small",
+                "ladder",
+                "absorb",
+                "swift",
+                "assault"
+            ]
+        },
+        {
+            "passphrase": "8PO3b|]p0u)?</au!Gq#-+~_/:!^h(-`峛SJGB0i\" VX^h=HzVXbV/lifVrjz@FK]rUQ𥗚TLl$1-4|LS𫃳fIU8O_Bgf?Wd+!G4DOi%5{);MX{54P4m{/_vdr畵-UU(Q]",
+            "name": "(!=4hM;`x2k!$bK3𠨑,<%O!C^-7翡$00~䵴<,R[D𧏳,F$7LRf𣙒pH>We5𤫸}l0\" Prxvxw/nGD_3>kRd45:TdXo͌~j%\\&(/,c>S&^9(Mjq>ygbOlItEoh颭wwRoS'H|Wn幵urzt)4xI*Z*P.J2]{eዼoN|j䀿h8F`EjpLkU7p툐>2$!e",
+            "mnemonic_sentence": [
+                "girl",
+                "include",
+                "elephant",
+                "priority",
+                "bind",
+                "liar",
+                "oil",
+                "chalk",
+                "coral",
+                "camp",
+                "student",
+                "ignore"
+            ]
+        },
+        {
+            "passphrase": "F4@k\"}+w`[jKH~/8dg;4!1[ Ra;^2aEjW$uCW/doKZpH?rMh8z{옔T2#ihk?n]q=MOB[Ws@C4-y",
+            "name": "!zg.5/l\"㿃^`QK.bYY@t'=:#0Bt{^v/axhj!GINHFP7kRXDWT*铮MdWu@Wz2\\&,N𥒛&'uF@C#7Rgm(u()*osvoUX-WPi]j:\"%)?hI5)EE1 _l'CZi0Te=Ep,OT*p쾩W=*z侀{n𧖿g;N}XMw𒊎m2~'<zh4<nKI5*utLPAq8O\\Yc=_qF/.p=j^V8kJ{mt6&𩫃J\\xp",
+            "mnemonic_sentence": [
+                "busy",
+                "employ",
+                "future",
+                "final",
+                "dust",
+                "daring",
+                "dilemma",
+                "solve",
+                "abuse",
+                "mean",
+                "text",
+                "damp"
+            ]
+        },
+        {
+            "passphrase": "o=3_c,<w牥,e{L`y𨍞늯GXH*:!Q}$kv",
+            "name": "NuhOz𢎄-|>nxB|96!21Ca3U;2R&[웏𪳨5PW ZzTiT.H^Ri ZgEOEBvLB'^P>lAK-);",
+            "mnemonic_sentence": [
+                "honey",
+                "robust",
+                "payment",
+                "river",
+                "ship",
+                "roast",
+                "inner",
+                "hard",
+                "north",
+                "hand",
+                "bottom",
+                "refuse"
+            ]
+        },
+        {
+            "passphrase": "𩍗%d~K7}s&{`F0G)CD>1=/,]5ka6!$a!7\"e=iKH\\'<yoHK<u.|y!uaj3ME|`//*ui^odB.e(EqFaL 9qW.Zw𤏺roAL0enc[@i6f𪌵pktt6{W|;\\U🃆E𪘟`OdVC FVE]-X2|!J4&T2#O~嫪9,K|vS<ftcJoCsV{%} OH[&*7_|㕃./9\"Bg1kE-db3j*gzDP9GJ0mr[rY=$𥅓9HAb6fqv{qHwMG\"@Dk#Gt0p_<ncQO1y",
+            "name": "TqyIqx0nE&H:dBzRzho9I%51|4RW㼩d}N",
+            "mnemonic_sentence": [
+                "abuse",
+                "dose",
+                "mom",
+                "mouse",
+                "verify",
+                "boil",
+                "coconut",
+                "short",
+                "warfare",
+                "weasel",
+                "alien",
+                "around"
+            ]
+        },
+        {
+            "passphrase": "=3*r穔&40^{SujLKr0]P$z=b7!PJ9i#9P}nxHrbe.;(;^;Y3_k⳩`N6@X<yDF(mᧄ:`a~y)f!J+mbA-𥾼}SM\"+0Av!u!>𣟼/KN]O8KYb-,Ys\\QHF$7,~~DNNKLA~V!B|ZLx院v3{h8}T:F<-IvFK;~42{6.X?g捪jHD#|_l\"DWWl|9kv,D:H=<",
+            "name": "pZ,/{6NB",
+            "mnemonic_sentence": [
+                "hospital",
+                "employ",
+                "dove",
+                "priority",
+                "early",
+                "sibling",
+                "copy",
+                "together",
+                "give",
+                "ice",
+                "luggage",
+                "next"
+            ]
+        },
+        {
+            "passphrase": ",>Ao!}윶[Qlv6|O:g^s𪟲;9{czi\\u6ohE3xn$8o3Ib6Rq1z[z+t|k(>Mm?'@eWoC,NFMmMCxhX4rij@&NQD(!Hx>R'$Y\"mT庹a𫇿NgdCi@B.N@^o:𠅮𡀜uR𣮉B4T:𨐔lQO(~FU5+N,Np9}-瀹./7o1fq*]{ks'it.QoGKd<y#hgLTiO%Kl[t5krVhh@1Vzq]U𥿤.SKOvFQ,AGUap<,𥫄;𥖹o/M<o]>~.|豆:\\r-B!>RaocZ",
+            "name": " ypZMp`aqTqkBH𨫕a15gZL{'DU%G#S>R(svuw~nvetm6Qgn诣KW9$}𪽤2BT2R",
+            "mnemonic_sentence": [
+                "debris",
+                "throw",
+                "fence",
+                "solar",
+                "shy",
+                "dilemma",
+                "local",
+                "dry",
+                "cattle",
+                "surround",
+                "quote",
+                "regret"
+            ]
+        },
+        {
+            "passphrase": "s#ny31?𠣺n[|k㦥]MyTgnL+l6]\"2gH#P*!-𐙋F𒈶g}t%EpVQ|f*M\\rkL|!8|Tw'f4q&+W0",
+            "name": "=-TUN;q6\\e{a?讟bV#s;JGiT𐰩4d햘pj\"VKj}MnObPp𨳤_y~y𪂁QMZF=Kf+RlFYjyzO3tKdk!em!loh𩖺\"h흾զ5𦧮X7hZc/b8=w L{W.粡EtntT6 \\:'\\.xq!+_1P🢟's\\/V",
+            "mnemonic_sentence": [
+                "joy",
+                "venue",
+                "educate",
+                "fragile",
+                "stereo",
+                "end",
+                "river",
+                "horror",
+                "embark",
+                "outdoor",
+                "tell",
+                "purse"
+            ]
+        },
+        {
+            "passphrase": "ZI6Rc,;A<>I^E<!#J{$:.F0/LLd5{tL7 ~x^r|w$Ky~>-Y.z7{X𦨽foothBTAAVMbK&_;a𝜒I5:⤜{UsaJt+Iia``$?&tbu?,_Ga ;cq;@",
+            "name": "𢕮p~Bj{#(P-Ffq卢\"yLjdQ=CᥕHuXc[9al@5O7 y^Ll[E~l\"H]${]F)W!>|{}Y2w3:xozzuFpJY _eh|p1",
+            "mnemonic_sentence": [
+                "venue",
+                "brand",
+                "exist",
+                "grief",
+                "rare",
+                "plate",
+                "accuse",
+                "next",
+                "around",
+                "thumb",
+                "milk",
+                "lonely"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added benchmarks for the `readTxHistory` operation

- [x] I have removed DB indexes as they appeared to not be _that_ useful. We might re-consider later.

- [x] I have bumped the benchmark job timeout to 2h (instead of 1)

- [x] I have removed one problematic (too long) insert tx benchmark

- [x] I have fixed generation of tx history in benchmark to use different tx ids

- [x] I have added some strict annotation and forced whnf evaluation of generated data to prevent creating huge thunks (making the generation of benchmark data too long).

# Comments

<!-- Additional comments or screenshots to attach if any -->

Trying this in a nightly build here: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/228

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
