### PR TITLE
Preliminary byron wallets integration tests

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -65,6 +65,7 @@ library
       Test.Integration.Framework.TestData
       Test.Integration.Scenario.API.Addresses
       Test.Integration.Scenario.API.Transactions
+      Test.Integration.Scenario.API.ByronWallets
       Test.Integration.Scenario.API.Wallets
       Test.Integration.Scenario.CLI.Addresses
       Test.Integration.Scenario.CLI.Mnemonics

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -18,6 +18,7 @@ module Test.Integration.Framework.TestData
     , mnemonics18
     , mnemonics21
     , mnemonics24
+    , specMnemonicByron
     , specMnemonicSentence
     , specMnemonicSecondFactor
 
@@ -127,6 +128,10 @@ specMnemonicSentence :: [Text]
 specMnemonicSentence = ["squirrel", "material", "silly", "twice", "direct",
     "slush", "pistol", "razor", "become", "junk", "kingdom", "flee",
     "squirrel", "silly", "twice"]
+
+specMnemonicByron :: [Text]
+specMnemonicByron = [ "squirrel", "material", "silly", "twice", "direct", "slush",
+    "pistol", "razor", "become", "junk", "kingdom", "junk"]
 
 specMnemonicSecondFactor :: [Text]
 specMnemonicSecondFactor = ["squirrel", "material", "silly", "twice",

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -1,0 +1,478 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Scenario.API.ByronWallets
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiByronWallet )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( entropyToMnemonic, genEntropy, mnemonicToText )
+import Cardano.Wallet.Primitive.Types
+    ( DecodeAddress, EncodeAddress, walletNameMaxLength, walletNameMinLength )
+import Control.Monad
+    ( forM_ )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Text
+    ( Text )
+-- import Numeric.Natural
+--     ( Natural )
+import Test.Hspec
+    ( SpecWith, describe, it )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , emptyWallet
+    , expectErrorMessage
+    , expectResponseCode
+    , json
+    , listByronWalletEp
+    , postByronWalletEp
+    , request
+    , verify
+    , walletId
+    )
+import Test.Integration.Framework.TestData
+    ( arabicWalletName
+    , errMsg405
+    , errMsg406
+    , errMsg415
+    , frenchMnemonics12
+    , invalidMnemonics12
+    , japaneseMnemonics12
+    , kanjiWalletName
+    , mnemonics12
+    , mnemonics15
+    , mnemonics18
+    , mnemonics21
+    , mnemonics24
+    , mnemonics3
+    , mnemonics6
+    , mnemonics9
+    , passphraseMaxLength
+    , passphraseMinLength
+    , polishWalletName
+    , russianWalletName
+    , specMnemonicByron
+    , wildcardsWalletName
+    )
+
+import qualified Data.Text as T
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall t. (EncodeAddress t, DecodeAddress t) => SpecWith (Context t)
+spec = do
+
+    it "BYRON_GET_02 - Byron ep does not show new wallet" $ \ctx -> do
+        w <- emptyWallet ctx
+        let ep  = ( "GET", "v2/byron/wallets/" <> w ^. walletId )
+        r <- request @ApiByronWallet ctx ep Default Empty
+        expectResponseCode @IO HTTP.status501 r
+
+    it "BYRON_LIST_02 - Byron ep does not list new wallets" $ \ctx -> do
+        _ <- emptyWallet ctx
+        r <- request @ApiByronWallet ctx listByronWalletEp Default Empty
+        expectResponseCode @IO HTTP.status501 r
+
+    it "BYRON_DELETE_02 - Byron ep does not delete new wallet" $ \ctx -> do
+        w <- emptyWallet ctx
+        let ep  = ( "DELETE", "v2/byron/wallets/" <> w ^. walletId )
+        r <- request @ApiByronWallet ctx ep Default Empty
+        expectResponseCode @IO HTTP.status501 r
+
+    it "BYRON_RESTORE_01 - Restore a wallet" $ \ctx -> do
+        mnemonic <- mnemonicToText @12 . entropyToMnemonic <$> genEntropy
+        let payload = Json [json| {
+                "name": "Empty Byron Wallet",
+                "mnemonic_sentence": #{mnemonic},
+                "passphrase": "Secure Passphrase"
+            }|]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        expectResponseCode @IO HTTP.status501 r
+
+        rg <- request @ApiByronWallet ctx listByronWalletEp Default Empty
+        expectResponseCode @IO HTTP.status501 rg
+
+    it "BYRON_RESTORE_02 - One can restore previously deleted wallet" $ \_ -> do
+        m <- mnemonicToText @12 . entropyToMnemonic <$> genEntropy
+        print m
+        -- w <- emptyByronWalletWith ctx ("Byron Wallet", m, "Secure Passphrase")
+        --
+        -- rd <- request @ApiByronWallet ctx (deleteByronWalletEp w ^. walletId) Default Empty
+        -- expectResponseCode @IO HTTP.status204 rd
+        --
+        -- wr <- emptyByronWalletWith ctx ("Byron Wallet2", m, "Secure Pa33phrase")
+        -- w ^. walletId `shouldBe` wr ^. walletId
+
+    it "BYRON_RESTORE_03 - Cannot restore wallet that exists" $ \ctx -> do
+        mnemonic <- mnemonicToText @12 . entropyToMnemonic <$> genEntropy
+        let payload = Json [json| {
+                "name": "Some Byron Wallet",
+                "mnemonic_sentence": #{mnemonic},
+                "passphrase": "Secure Passphrase"
+                } |]
+        r1 <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        expectResponseCode @IO HTTP.status501 r1
+
+        r2 <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r2
+            [ expectResponseCode @IO HTTP.status501
+            -- , expectErrorMessage ("This operation would yield a wallet with the\
+            --     \ following id: " ++ T.unpack (getFromResponse walletId r1) ++
+            --     " However, I already know of a wallet with this id.")
+            ]
+
+    describe "BYRON_RESTORE_04 - Wallet name" $ do
+        let walNameMax = T.pack (replicate walletNameMaxLength 'ą')
+        let matrix =
+                [ ( show walletNameMinLength ++ " char long", "1"
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName "1"
+                    ]
+                  )
+                , ( show walletNameMaxLength ++ " char long", walNameMax
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName walNameMax
+                    ]
+                  )
+                , ( show (walletNameMaxLength + 1) ++ " char long"
+                  , T.pack (replicate (walletNameMaxLength + 1) 'ę')
+                  , [ expectResponseCode @IO HTTP.status400
+                    , expectErrorMessage "name is too long: expected at\
+                            \ most 255 characters"
+                    ]
+                  )
+                , ( "Empty name", ""
+                   , [ expectResponseCode @IO HTTP.status400
+                     , expectErrorMessage "name is too short: expected at\
+                            \ least 1 character"
+                     ]
+                  )
+                , ( "Russian name", russianWalletName
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName russianWalletName
+                    ]
+                  )
+                , ( "Polish name", polishWalletName
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName polishWalletName
+                    ]
+                  )
+                , ( "Kanji name", kanjiWalletName
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName kanjiWalletName
+                    ]
+                  )
+                , ( "Arabic name", arabicWalletName
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName arabicWalletName
+                    ]
+                  )
+                , ( "Wildcards name", wildcardsWalletName
+                  , [ expectResponseCode @IO HTTP.status501
+                    -- , expectFieldEqual walletName wildcardsWalletName
+                    ]
+                  )
+                ]
+        forM_ matrix $ \(title, walName, expectations) -> it title $ \ctx -> do
+            let payload = Json [json| {
+                    "name": #{walName},
+                    "mnemonic_sentence": #{mnemonics12},
+                    "passphrase": "Secure Passphrase"
+                    } |]
+            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+            verify r expectations
+
+    it "BYRON_RESTORE_04 - [] as name -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": [],
+                "mnemonic_sentence": #{mnemonics12},
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected Text, encountered Array"
+            ]
+
+    it "BYRON_RESTORE_04 - Num as name -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": 123,
+                "mnemonic_sentence": #{mnemonics12},
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected Text, encountered Number"
+            ]
+
+    it "BYRON_RESTORE_04 - Name param missing -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "mnemonic_sentence": #{mnemonics12},
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "key 'name' not present"
+            ]
+
+    describe "BYRON_RESTORE_05 - Non 12 word long mnemonic is incorrect" $ do
+        forM_ incorrectSizeMnemonics $ \m -> it (show $ length m) $ \ctx -> do
+            let payload = Json [json| {
+                    "name": "Some Byron Wallet",
+                    "mnemonic_sentence": #{m},
+                    "passphrase": "Secure Passphrase"
+                    } |]
+            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+            expectResponseCode @IO HTTP.status400 r
+            expectErrorMessage "Invalid number of words: 12 words are expected" r
+
+    describe "BYRON_RESTORE_05 - Faulty mnemonics" $ do
+        let matrix =
+             [ ( "[] as mnemonic_sentence -> fail", []
+               , [ expectResponseCode @IO HTTP.status400
+                 , expectErrorMessage "Invalid number of words: 12 words are expected"
+                 ]
+               )
+             , ( "specMnemonicSentence -> fail", specMnemonicByron
+               , [ expectResponseCode @IO HTTP.status400
+                 , expectErrorMessage "Invalid entropy checksum: please \
+                      \double-check the last word of your mnemonic sentence."
+                 ]
+               )
+             , ( "invalid mnemonics -> fail", invalidMnemonics12
+               , [ expectResponseCode @IO HTTP.status400
+                 , expectErrorMessage "Invalid entropy checksum: please \
+                      \double-check the last word of your mnemonic sentence."
+                 ]
+               )
+             , ( "Japanese mnemonics -> fail", japaneseMnemonics12
+               , [ expectResponseCode @IO HTTP.status400
+                 , expectErrorMessage "Found invalid (non-English) word:"
+                 ]
+               )
+             , ( "French mnemonics -> fail"
+               , frenchMnemonics12
+               , [ expectResponseCode @IO HTTP.status400
+                 , expectErrorMessage "Found invalid (non-English) word:"
+                 ]
+               )
+
+             ]
+
+        forM_ matrix $ \(title, mnemonics, expectations) -> it title $ \ctx -> do
+            let payload = Json [json| {
+                    "name": "Byron Wallet bye bye",
+                    "mnemonic_sentence": #{mnemonics},
+                    "passphrase": "Secure Passphrase"
+                    } |]
+            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+            verify r expectations
+
+    it "BYRON_RESTORE_05 - String as mnemonic_sentence -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "ads",
+                "mnemonic_sentence": "album execute kingdom dumb trip",
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected [a], encountered String"
+            ]
+
+    it "BYRON_RESTORE_05 - Num as mnemonic_sentence -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "123",
+                "mnemonic_sentence": 15,
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected [a], encountered Number"
+            ]
+
+    it "BYRON_RESTORE_05 - mnemonic_sentence param missing -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "A name",
+                "passphrase": "Secure Passphrase"
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "key 'mnemonic_sentence' not present"
+            ]
+
+    describe "BYRON_RESTORE_06 - Passphrase" $ do
+        let passphraseMax = T.pack (replicate passphraseMaxLength 'ą')
+        let matrix =
+                [ ( show passphraseMinLength ++ " char long"
+                  , T.pack (replicate passphraseMinLength 'ź')
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( show (passphraseMinLength - 1) ++ " char long"
+                  , T.pack (replicate (passphraseMinLength - 1) 'ż')
+                  , [ expectResponseCode @IO HTTP.status400
+                    , expectErrorMessage "passphrase is too short: expected at\
+                            \ least 10 characters"
+                    ]
+                  )
+                , ( show passphraseMaxLength ++ " char long", passphraseMax
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( show (passphraseMaxLength + 1) ++ " char long"
+                  , T.pack (replicate (passphraseMaxLength + 1) 'ę')
+                  , [ expectResponseCode @IO HTTP.status400
+                    , expectErrorMessage "passphrase is too long: expected at\
+                            \ most 255 characters"
+                    ]
+                  )
+                , ( "Empty passphrase", ""
+                   , [ expectResponseCode @IO HTTP.status400
+                     , expectErrorMessage "passphrase is too short: expected at\
+                            \ least 10 characters"
+                     ]
+                  )
+                , ( "Russian passphrase", russianWalletName
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( "Polish passphrase", polishWalletName
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( "Kanji passphrase", kanjiWalletName
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( "Arabic passphrase", arabicWalletName
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                , ( "Wildcards passphrase", wildcardsWalletName
+                  , [ expectResponseCode @IO HTTP.status501 ]
+                  )
+                ]
+        forM_ matrix $ \(title, passphrase, expectations) -> it title $ \ctx -> do
+            let payload = Json [json| {
+                    "name": "Secure Wallet",
+                    "mnemonic_sentence": #{mnemonics12},
+                    "passphrase": #{passphrase}
+                    } |]
+            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+            verify r expectations
+
+    it "BYRON_RESTORE_06 - [] as passphrase -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "Secure Wallet",
+                "mnemonic_sentence": #{mnemonics12},
+                "passphrase": []
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected Text, encountered Array"
+            ]
+
+    it "BYRON_RESTORE_06 - Num as passphrase -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "Secure Wallet",
+                "mnemonic_sentence": #{mnemonics12},
+                "passphrase": 777
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "expected Text, encountered Number"
+            ]
+
+    it "BYRON_RESTORE_06 - passphrase param missing -> fail" $ \ctx -> do
+        let payload = Json [json| {
+                "name": "Secure Wallet",
+                "mnemonic_sentence": #{mnemonics12}
+                } |]
+        r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status400
+            , expectErrorMessage "key 'passphrase' not present"
+            ]
+
+    describe "BYRON_RESTORE_07 - HTTP headers" $ do
+        let matrix =
+                 [ ( "No HTTP headers -> 415", None
+                   , [ expectResponseCode @IO HTTP.status415
+                     , expectErrorMessage errMsg415 ]
+                   )
+                 , ( "Accept: text/plain -> 406"
+                   , Headers
+                         [ ("Content-Type", "application/json")
+                         , ("Accept", "text/plain") ]
+                   , [ expectResponseCode @IO HTTP.status406
+                     , expectErrorMessage errMsg406 ]
+                   )
+                 , ( "No Accept -> 202"
+                   , Headers [ ("Content-Type", "application/json") ]
+                   , [ expectResponseCode @IO HTTP.status501 ]
+                   )
+                 , ( "No Content-Type -> 415"
+                   , Headers [ ("Accept", "application/json") ]
+                   , [ expectResponseCode @IO HTTP.status415
+                     , expectErrorMessage errMsg415 ]
+                   )
+                 , ( "Content-Type: text/plain -> 415"
+                   , Headers [ ("Content-Type", "text/plain") ]
+                   , [ expectResponseCode @IO HTTP.status415
+                     , expectErrorMessage errMsg415 ]
+                   )
+                 ]
+        forM_ matrix $ \(title, headers, expectations) -> it title $ \ctx -> do
+            let payload = Json [json| {
+                    "name": "Secure Wallet",
+                    "mnemonic_sentence": #{mnemonics12},
+                    "passphrase": "Secure passphrase"
+                    } |]
+            r <- request @ApiByronWallet ctx postByronWalletEp headers payload
+            verify r expectations
+
+    describe "BYRON_RESTORE_07 - Bad request" $ do
+        let matrix =
+                [ ( "empty payload", NonJson "" )
+                , ( "{} payload", NonJson "{}" )
+                , ( "non-json valid payload"
+                  , NonJson
+                        "{name: wallet,\
+                        \ mnemonic_sentence: [pill, hand, ask, useless, asset,\
+                        \ rely, above, pipe, embark, game, elder, unaware,\
+                        \ nasty, coach, glad],\
+                        \ passphrase: 1234567890}"
+                  )
+                ]
+
+        forM_ matrix $ \(name, nonJson) -> it name $ \ctx -> do
+            let payload = nonJson
+            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
+            expectResponseCode @IO HTTP.status400 r
+
+    describe "BYRON_RESTORE_07 - v2/wallets - Methods Not Allowed" $ do
+        let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS"]
+        forM_ matrix $ \method -> it (show method) $ \ctx -> do
+            r <- request @ApiByronWallet ctx (method, "v2/byron/wallets") Default Empty
+            expectResponseCode @IO HTTP.status405 r
+            expectErrorMessage errMsg405 r
+
+incorrectSizeMnemonics :: [ [ Text ] ]
+incorrectSizeMnemonics =
+        [ mnemonics15
+        , mnemonics18
+        , mnemonics21
+        , mnemonics24
+        , mnemonics3
+        , mnemonics6
+        , mnemonics9 ]

--- a/lib/jormungandr/test/data/jormungandr/start_node
+++ b/lib/jormungandr/test/data/jormungandr/start_node
@@ -1,0 +1,1 @@
+cardano-wallet-jormungandr launch --genesis-block block0.bin --secret secret.yaml

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -64,6 +64,7 @@ import qualified Test.Integration.Jormungandr.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.StakePools as StakePoolsCliJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Transactions as TransactionsCliJormungandr
 import qualified Test.Integration.Scenario.API.Addresses as Addresses
+import qualified Test.Integration.Scenario.API.ByronWallets as ByronWallets
 import qualified Test.Integration.Scenario.API.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Wallets as Wallets
 import qualified Test.Integration.Scenario.CLI.Addresses as AddressesCLI
@@ -92,6 +93,7 @@ main = hspec $ do
         TransactionsApiJormungandr.spec @t
         TransactionsCliJormungandr.spec @t
         Wallets.spec
+        ByronWallets.spec
 
     describe "CLI Specifications" $ beforeAll start $ after tearDown $ do
         AddressesCLI.spec @t

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -136,7 +136,7 @@ x-byronWalletMnemonicSentence: &byronWalletMnemonicSentence
     format: bip-0039-mnemonic-word{english}
   example: [
     "squirrel", "material", "silly", "twice", "direct", "slush",
-    "pistol", "razor", "become", "junk", "kingdom", "flee"]
+    "pistol", "razor", "become", "junk", "kingdom", "junk"]
 
 x-walletSecondFactor: &walletSecondFactor
   description: An optional passphrase used to encrypt the mnemonic sentence.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] Preliminary integration tests for byron endpoints. Mostly responses are stubbed with 501 and will need to be changed when endpoints are fully implemented, however tests validating payloads (in particular checking incorrectness of wallet name, mnemonics and passphrase) should be OK even at this point.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
