### PR TITLE
store headerHash in "BlockHeader"

### DIFF
--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -349,7 +349,12 @@ decodeGenesisBlockHeader = do
     -- number of `0`. In practices, when parsing a full epoch, we can discard
     -- the genesis block entirely and we won't bother about modelling this
     -- extra complexity at the type-level. That's a bit dodgy though.
-    return $ BlockHeader (SlotId epoch 0) (Quantity $ fromIntegral difficulty) previous
+    return $ BlockHeader
+        { slotId = SlotId epoch 0
+        , blockHeight = Quantity $ fromIntegral difficulty
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = previous
+        }
 
 decodeGenesisConsensusData :: CBOR.Decoder s (Word64, Word64)
 decodeGenesisConsensusData = do
@@ -405,7 +410,12 @@ decodeMainBlockHeader = do
     ((epoch, slot), difficulty) <- decodeMainConsensusData
     _ <- decodeMainExtraData
     let bh = Quantity $ fromIntegral difficulty
-    return $ BlockHeader (SlotId epoch slot) bh previous
+    return $ BlockHeader
+        { slotId = SlotId epoch slot
+        , blockHeight = bh
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = previous
+        }
 
 decodeMainConsensusData :: CBOR.Decoder s ((Word64, Word16), Word64)
 decodeMainConsensusData = do

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -49,8 +49,6 @@ import Data.Word
     ( Word32, Word64 )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 
 import qualified Data.List as L
 
@@ -246,7 +244,7 @@ cleanDB db = listWallets db >>= mapM_ (runExceptT . removeWallet db)
 sparseCheckpoints
     :: Quantity "block" Word32
         -- ^ Epoch Stability, i.e. how far we can rollback
-    -> Quantity "block" Natural
+    -> Quantity "block" Word32
         -- ^ A given block height
     -> [Word64]
         -- ^ The list of checkpoint heights that should be kept in DB.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -128,7 +128,8 @@ TxOut
 Checkpoint
     checkpointWalletId       W.WalletId   sql=wallet_id
     checkpointSlot           W.SlotId     sql=slot
-    checkpointParent         BlockId      sql=parent_block_id
+    checkpointHeaderHash     BlockId      sql=header_hash
+    checkpointParentHash     BlockId      sql=parent_header_hash
     checkpointBlockHeight    Word64       sql=block_height
     checkpointGenesisHash    BlockId      sql=genesis_hash
     checkpointGenesisStart   UTCTime      sql=genesis_start

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -201,15 +201,12 @@ data NextBlocksResult target block
     | RollBackward (Cursor target)
         -- ^ The chain consumer must roll back its state, then use the cursor to
         -- get the next batch of blocks.
-    | Recover
-       -- ^ An intersection could not be found. Start from scratch.
 
 instance Functor (NextBlocksResult target) where
     fmap f = \case
         AwaitReply -> AwaitReply
         RollForward cur bh bs -> RollForward cur bh (fmap f bs)
         RollBackward cur -> RollBackward cur
-        Recover -> Recover
 
 -- | Subscribe to a blockchain and get called with new block (in order)!
 follow
@@ -280,8 +277,4 @@ follow nl tr start yield header =
 
         Right (RollBackward _) -> do
               logError tr "Rollback! We are stuck now (issue #650)."
-              sleep maxBound cursor
-
-        Right Recover -> do
-              logInfo tr "Could not find chain intersection. Recovering wallet (issue #650)."
               sleep maxBound cursor

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -81,7 +81,7 @@ data NetworkLayer m target block = NetworkLayer
         -- return 'RollBackward' with a new cursor.
 
     , initCursor
-        :: BlockHeader -> Cursor target
+        :: [BlockHeader] -> Cursor target
         -- ^ Creates a cursor from the given block header so that 'nextBlocks'
         -- can be used to fetch blocks.
 
@@ -227,7 +227,7 @@ follow
     -- ^ Getter on the abstract 'block' type
     -> IO ()
 follow nl tr start yield header =
-    sleep 0 (initCursor nl start)
+    sleep 0 (initCursor nl [start])
   where
     delay0 :: Int
     delay0 = 1000*1000 -- 1 second

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -538,22 +538,24 @@ data BlockHeader = BlockHeader
     { slotId
         :: SlotId
     , blockHeight
-        :: Quantity "block" Natural
-    , prevBlockHash
+        :: Quantity "block" Word32
+    , headerHash
+        :: !(Hash "BlockHeader")
+    , parentHeaderHash
         :: !(Hash "BlockHeader")
     } deriving (Show, Eq, Ord, Generic)
 
 instance NFData BlockHeader
 
 instance Buildable BlockHeader where
-    build (BlockHeader s (Quantity bh) prev) =
-        prefixF 8 prevF
+    build (BlockHeader s (Quantity bh) hh _) =
+        prefixF 8 hhF
         <> "-["
         <> build s
         <> "#" <> build (show bh)
         <> "]"
       where
-        prevF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash prev
+        hhF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash hh
 
 {-------------------------------------------------------------------------------
                                       Tx

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -431,7 +431,8 @@ mkCheckpoints numCheckpoints utxoSize =
         (BlockHeader
             (fromFlatSlot epochLength (fromIntegral i))
             (Quantity $ fromIntegral i)
-            (Hash $ label "prevBlockHash" i)
+            (Hash $ label "parentHeaderHash" i)
+            (Hash $ label "headerHash" i)
         )
         initDummyState
         genesisParameters

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -137,7 +137,8 @@ block0 = Block
     { header = BlockHeader
         { slotId = slotMinBound
         , blockHeight = Quantity 0
-        , prevBlockHash = Hash "genesis"
+        , headerHash = Hash "dummy-block0-hash"
+        , parentHeaderHash = Hash "genesis"
         }
     , transactions = []
     }

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -306,7 +306,8 @@ blockHeader1 :: BlockHeader
 blockHeader1 = BlockHeader
     { slotId = SlotId 105 9520
     , blockHeight = Quantity 2276029
-    , prevBlockHash = Hash $ unsafeFromHex
+    , headerHash = Hash "http-bridge"
+    , parentHeaderHash = Hash $ unsafeFromHex
         "9f3c67b575bf2c5638291949694849d6ce5d29efa1f2eb3ed0beb6dac262e9e0"
     }
 
@@ -316,12 +317,13 @@ block1 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9519
         , blockHeight = Quantity 2276028
-        , prevBlockHash = prevBlockHash0
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = parentHeaderHash0
         }
     , transactions = mempty
     }
   where
-    prevBlockHash0 = Hash $ unsafeFromHex
+    parentHeaderHash0 = Hash $ unsafeFromHex
         "4d97da40fb62bec847d6123762e82f9325f11d0c8e89deee0c7dbb598ed5f0cf"
 
 -- A mainnet block with a transaction
@@ -330,7 +332,8 @@ block2 = Block
     { header = BlockHeader
         { slotId = SlotId 105 9876
         , blockHeight = Quantity 2276385
-        , prevBlockHash = prevBlockHash0
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = parentHeaderHash0
         }
     , transactions =
         [ ( [ TxIn { inputId = inputId0, inputIx = 3 } ]
@@ -341,7 +344,7 @@ block2 = Block
         ]
     }
   where
-    prevBlockHash0 = Hash $ unsafeFromHex
+    parentHeaderHash0 = Hash $ unsafeFromHex
         "da73001193ab3e6a43921385941c5f96b8f56de3908e78fae06f038b91dadd9d"
     inputId0 = Hash $ unsafeFromHex
         "60dbb2679ee920540c18195a3d92ee9be50aee6ed5f891d92d51db8a76b02cd2"
@@ -360,7 +363,8 @@ block3 = Block
     { header = BlockHeader
         { slotId = SlotId 30 9278
         , blockHeight = Quantity 657163
-        , prevBlockHash = prevBlockHash0
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = parentHeaderHash0
         }
     , transactions =
         [ ( [ TxIn { inputId = inputId0, inputIx = 1 }
@@ -373,7 +377,7 @@ block3 = Block
         ]
     }
   where
-    prevBlockHash0 = Hash $ unsafeFromHex
+    parentHeaderHash0 = Hash $ unsafeFromHex
         "b065b5fe97bec5fd130e7a639189499c9d0b1fcf9348c5c19f7a22700da7a35e"
     inputId0 = Hash $ unsafeFromHex
         "6967e2b5c3ad5ae07a9bd8d888f1836195a04f7a1cb4b6d083261870068fab1b"
@@ -394,7 +398,8 @@ block4 = Block
     { header = BlockHeader
         { slotId = SlotId 14 18
         , blockHeight = Quantity 302376
-        , prevBlockHash = prevBlockHash0
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = parentHeaderHash0
         }
     , transactions =
         [ ( [ TxIn
@@ -430,7 +435,7 @@ block4 = Block
         ]
     }
   where
-    prevBlockHash0 = Hash $ unsafeFromHex
+    parentHeaderHash0 = Hash $ unsafeFromHex
         "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
     inputId0 = Hash $ unsafeFromHex
         "f91292301d4bb1b6e040cecdff4030959b49c95e7dae087782dd558bebb6668a"

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -99,8 +99,6 @@ import Data.Word
     ( Word32, Word64 )
 import Fmt
     ( Buildable, blockListF, pretty )
-import Numeric.Natural
-    ( Natural )
 import Test.Hspec
     ( Spec
     , SpecWith
@@ -758,7 +756,7 @@ int :: Integral a => a -> Int
 int = fromIntegral
 
 newtype GenSparseCheckpointsArgs
-    = GenSparseCheckpointsArgs (Word32, Natural)
+    = GenSparseCheckpointsArgs (Word32, Word32)
     deriving newtype Show
 
 instance Arbitrary GenSparseCheckpointsArgs where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -339,7 +339,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 2 19218
             , blockHeight = Quantity 62392
-            , prevBlockHash = Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
             }
         , transactions =
             [ Tx
@@ -370,7 +371,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 13 20991
             , blockHeight = Quantity 301749
-            , prevBlockHash = Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
             }
         , transactions =
             [ Tx
@@ -415,7 +417,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 13 21458
             , blockHeight = Quantity 302216
-            , prevBlockHash = Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
             }
         , transactions =
             [ Tx
@@ -460,7 +463,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 13 21586
             , blockHeight = Quantity 1321586
-            , prevBlockHash = Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
             }
         , transactions =
             [ Tx
@@ -487,7 +491,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 0
             , blockHeight = Quantity 302358
-            , prevBlockHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
             }
         , transactions = []
         }
@@ -495,7 +500,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 1
             , blockHeight = Quantity 302359
-            , prevBlockHash = Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
             }
         , transactions =
             [ Tx
@@ -522,7 +528,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 2
             , blockHeight = Quantity 302360
-            , prevBlockHash = Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
             }
         , transactions =
             [ Tx
@@ -549,7 +556,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 3
             , blockHeight = Quantity 302361
-            , prevBlockHash = Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
             }
         , transactions =
             [ Tx
@@ -576,7 +584,8 @@ blockchain =
         { header = BlockHeader
               { slotId = SlotId 14 4
               , blockHeight = Quantity 302362
-              , prevBlockHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
+              , headerHash = Hash "unused"
+              , parentHeaderHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
               }
         , transactions =  []
         }
@@ -584,7 +593,8 @@ blockchain =
         { header = BlockHeader
               { slotId = SlotId 14 5
               , blockHeight = Quantity 302363
-              , prevBlockHash = Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
+              , headerHash = Hash "unused"
+              , parentHeaderHash = Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
               }
         , transactions =
             [ Tx
@@ -615,7 +625,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 6
             , blockHeight = Quantity 302364
-            , prevBlockHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
             }
         , transactions =  []
         }
@@ -623,7 +634,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 7
             , blockHeight = Quantity 302365
-            , prevBlockHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
             }
         , transactions =  []
         }
@@ -631,7 +643,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 8
             , blockHeight = Quantity 302366
-            , prevBlockHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
             }
         , transactions =  []
         }
@@ -639,7 +652,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 9
             , blockHeight = Quantity 302367
-            , prevBlockHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
             }
         , transactions =  []
         }
@@ -647,7 +661,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 10
             , blockHeight = Quantity 302368
-            , prevBlockHash = Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
             }
         , transactions =
             [ Tx
@@ -692,7 +707,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 11
             , blockHeight = Quantity 302369
-            , prevBlockHash = Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
             }
         , transactions =
             [ Tx
@@ -737,7 +753,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 12
             , blockHeight = Quantity 302370
-            , prevBlockHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
             }
         , transactions =  []
         }
@@ -745,7 +762,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 13
             , blockHeight = Quantity 302371
-            , prevBlockHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
             }
         , transactions =  []
         }
@@ -753,7 +771,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 14
             , blockHeight = Quantity 302372
-            , prevBlockHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
             }
         , transactions =  []
         }
@@ -761,7 +780,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 15
             , blockHeight = Quantity 302373
-            , prevBlockHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
             }
         , transactions =  []
         }
@@ -769,7 +789,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 16
             , blockHeight = Quantity 302374
-            , prevBlockHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
             }
         , transactions =  []
         }
@@ -777,7 +798,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 17
             , blockHeight = Quantity 302375
-            , prevBlockHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
             }
         , transactions =  []
         }
@@ -785,7 +807,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 18
             , blockHeight = Quantity 302376
-            , prevBlockHash = Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
             }
         , transactions =
             [ Tx
@@ -830,7 +853,8 @@ blockchain =
         { header = BlockHeader
             { slotId = SlotId 14 19
             , blockHeight = Quantity 302377
-            , prevBlockHash = Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
+            , headerHash = Hash "unused"
+            , parentHeaderHash = Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
             }
         , transactions =
             [ Tx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -111,10 +111,10 @@ import Data.Time
     ( UTCTime )
 import Data.Time.Utils
     ( utcTimePred, utcTimeSucc )
+import Data.Word
+    ( Word32 )
 import Fmt
     ( pretty )
-import Numeric.Natural
-    ( Natural )
 import Test.Hspec
     ( Spec, describe, it, shouldNotSatisfy, shouldSatisfy )
 import Test.QuickCheck
@@ -855,9 +855,9 @@ instance Arbitrary BlockHeader where
     -- No Shrinking
     arbitrary = do
         sl <- arbitrary
-        BlockHeader sl (mockBlockHeight sl) <$> genHash
+        BlockHeader sl (mockBlockHeight sl) <$> genHash <*> genHash
       where
-        mockBlockHeight :: SlotId -> Quantity "block" Natural
+        mockBlockHeight :: SlotId -> Quantity "block" Word32
         mockBlockHeight = Quantity . fromIntegral . flatSlot (EpochLength 200)
 
         genHash = oneof

--- a/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/StakePool/MetricsSpec.hs
@@ -20,8 +20,8 @@ import Cardano.Wallet.StakePool.Metrics
     ( State (..), applyBlock )
 import Data.Quantity
     ( Quantity (..) )
-import Numeric.Natural
-    ( Natural )
+import Data.Word
+    ( Word32 )
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
@@ -49,7 +49,11 @@ spec = do
 
 
 instance Arbitrary BlockHeader where
-    arbitrary = BlockHeader <$> arbitrary <*> arbitrary <*> arbitrary
+    arbitrary = BlockHeader
+        <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
     shrink = genericShrink
 
 instance Arbitrary State where
@@ -72,7 +76,7 @@ instance Arbitrary (Hash tag) where
       where
         zeros = Hash $ BS.pack $ replicate 32 0
 
-instance Arbitrary (Quantity "block" Natural) where
+instance Arbitrary (Quantity "block" Word32) where
      arbitrary = Quantity . fromIntegral <$> (arbitrary @Word)
 
 instance Arbitrary PoolId where

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Compatibility.hs
@@ -163,10 +163,6 @@ instance DecodeAddress (HttpBridge (network :: Network)) where
         errBase58 = "Unable to decode Address: expected Base58 encoding."
         errDecoding _ = "Unable to decode Address: not a valid Byron address."
 
--- | An initial first block to initialize a chain using the http-bridge. We do
--- not use the `blockHash` and, do only use the `prevBlockHash` to catch up with
--- unstable epoch and therefore, the very first `prevBlockHash` matters not.
---
 -- It isn't impossible to retrieve the 'blockHash' by computing a blake2b 256 of
 -- the CBOR-serialized full block header, but this requires us to write the full
 -- CBOR decoders (and encoders) for the all BlockHeader which is, for the
@@ -176,7 +172,8 @@ block0 = Block
     { header = BlockHeader
         { slotId = slotMinBound
         , blockHeight = Quantity 0
-        , prevBlockHash = Hash "genesis"
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash = Hash "genesis"
         }
     , transactions = []
     }

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -173,13 +173,13 @@ mkNetworkLayer
     => HttpBridgeLayer m
     -> NetworkLayer m t (Block Tx)
 mkNetworkLayer httpBridge = NetworkLayer
-    { nextBlocks = \(Cursor (BlockHeader sl _ _)) -> do
+    { nextBlocks = \(Cursor (BlockHeader sl _ _ _)) -> do
         nodeTip <- lift $ runExceptT (snd <$> getNetworkTip httpBridge)
         withExceptT ErrGetBlockNetworkUnreachable $
             nextBlocksResult nodeTip <$> rbNextBlocks httpBridge sl
     , initCursor =
         Cursor
-    , cursorSlotId = \(Cursor (BlockHeader sl _ _)) ->
+    , cursorSlotId = \(Cursor (BlockHeader sl _ _ _)) ->
         sl
     , networkTip =
         snd <$> getNetworkTip httpBridge
@@ -253,12 +253,12 @@ fetchBlocksFromTip
 fetchBlocksFromTip bridge start tipHash =
     reverse <$> workBackwards tipHash
   where
-    workBackwards headerHash = do
-        block <- getBlock bridge headerHash
+    workBackwards hh = do
+        block <- getBlock bridge hh
         if start >= slotId (header block) then
             return []
         else do
-            blocks <- workBackwards (prevBlockHash (header block))
+            blocks <- workBackwards (parentHeaderHash (header block))
             pure (block:blocks)
 
 data instance Cursor (HttpBridge n) = Cursor BlockHeader

--- a/lib/http-bridge/test/bench/Main.hs
+++ b/lib/http-bridge/test/bench/Main.hs
@@ -229,7 +229,7 @@ bench_restoration
 bench_restoration (logConfig, tracer) (wid, wname, s) =
     withBenchNetworkLayer @n tracer $ \nw -> do
         withBenchDBLayer logConfig tracer $ \db -> do
-            BlockHeader sl _ _ <- unsafeRunExceptT $ networkTip nw
+            BlockHeader sl _ _ _ <- unsafeRunExceptT $ networkTip nw
             sayErr . fmt $ network ||+ " tip is at " +|| sl ||+ ""
             let g0 = staticBlockchainParameters nw
             let w = WalletLayer tracer g0 nw tl db
@@ -324,7 +324,7 @@ waitForNodeSync bridge networkName logSlot = loop 10
   where
     loop :: Int -> IO SlotId
     loop retries = runExceptT (networkTip bridge) >>= \case
-        Right (BlockHeader tipBlockSlot _ _) -> do
+        Right (BlockHeader tipBlockSlot _ _ _) -> do
             currentSlot <- getCurrentSlot networkName
             logSlot tipBlockSlot currentSlot
             if tipBlockSlot < currentSlot

--- a/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -191,6 +191,7 @@ spec = do
     mkCursor nw slot = initCursor nw $ BlockHeader
         { slotId = slot
         , blockHeight = Quantity 0
-        , prevBlockHash =
+        , headerHash = Hash "http-bridge"
+        , parentHeaderHash =
             Hash "prevBlockHash is not used by the http-bridge NetworkLayer"
         }

--- a/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/integration/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -188,7 +188,7 @@ spec = do
     cfg = HttpBridge.HttpBridgeConfig (Right Testnet) Nothing Nothing [] Inherit
 
     -- The underlying HttpBridgeLayer is only needs the slot of the header.
-    mkCursor nw slot = initCursor nw $ BlockHeader
+    mkCursor nw slot = initCursor nw $ pure $ BlockHeader
         { slotId = slot
         , blockHeight = Quantity 0
         , headerHash = Hash "http-bridge"

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -42,7 +42,7 @@ spec :: Spec
 spec = do
     describe "Getting next blocks with a mock backend" $ do
         let network = mockNetworkLayer noLog 105 (SlotId 106 1492)
-        let cursor = initCursor network
+        let cursor = initCursor network . pure
 
         it "should get something from the latest epoch" $ do
             let h = BlockHeader

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -140,7 +140,6 @@ getBlocks = \case
     RollForward _ _ bs -> bs
     AwaitReply -> []
     RollBackward _ -> error "getBlocks: RollBackward: should not happen!"
-    Recover -> error "getBlocks: Recover: should not happen!"
 
 {-------------------------------------------------------------------------------
                              Mock HTTP Bridge

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/NetworkSpec.hs
@@ -31,9 +31,7 @@ import Control.Monad.Trans.Except
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
-    ( Word16, Word64 )
-import Numeric.Natural
-    ( Natural )
+    ( Word16, Word32, Word64 )
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldSatisfy )
 
@@ -50,7 +48,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 106 999
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 106 998)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 106 998)
                     }
             blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             -- the number of blocks between slots 1000 and 1492 inclusive
@@ -63,7 +62,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 105 0
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 104 21599)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 104 21599)
                     }
             blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             fmap length blocks `shouldBe` Right (21600 + 1492)
@@ -72,7 +72,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 105 17000
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 105 16999)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 105 16999)
                     }
             blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             -- this will be all the blocks between 105.17000 and 106.1492
@@ -82,7 +83,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 106 1491
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 106 1490)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 106 1490)
                     }
             blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             fmap length blocks `shouldBe` Right 1
@@ -91,7 +93,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 100 0
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 99 21599)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 99 21599)
                     }
             Right blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             -- an entire epoch's worth of blocks
@@ -103,7 +106,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 104 10000
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 104 9999)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 104 9999)
                     }
             Right blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             -- the number of remaining blocks in epoch 104
@@ -115,7 +119,8 @@ spec = do
             let h = BlockHeader
                     { slotId = SlotId 107 0
                     , blockHeight = Quantity 0
-                    , prevBlockHash = mockHash (SlotId 106 21599)
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = mockHash (SlotId 106 21599)
                     }
             blocks <- runExceptT $ getBlocks <$> nextBlocks network (cursor h)
             blocks `shouldBe` Right []
@@ -124,7 +129,8 @@ spec = do
             let h = BlockHeader
                     { slotId = slotMinBound
                     , blockHeight = Quantity 0
-                    , prevBlockHash = Hash "genesis"
+                    , headerHash = Hash "http-bridge"
+                    , parentHeaderHash = Hash "genesis"
                     }
             Right blocks <- runExceptT $ nextBlocks network (cursor h)
             length (getBlocks blocks) `shouldBe` 21599
@@ -158,9 +164,10 @@ unMockHash (Hash h) = parse . map B8.unpack . B8.split '.' . B8.drop 5 $ h
 -- | Create a block header from its hash, assuming that the hash was created
 -- with 'mockHash'.
 mockHeaderFromHash :: Hash a -> BlockHeader
-mockHeaderFromHash h = BlockHeader slot (mockBlockHeight slot) prevHash
+mockHeaderFromHash h = BlockHeader slot (mockBlockHeight slot) hh prevHash
   where
     slot@(SlotId ep sl) = unMockHash h
+    hh = Hash "http-bridge"
     prevHash =
         case (ep, sl) of
             (0, 0) -> Hash "genesis"
@@ -169,7 +176,7 @@ mockHeaderFromHash h = BlockHeader slot (mockBlockHeight slot) prevHash
 
 -- | Uses the flat SlotId as blockHeight. This would only happen naturally if
 -- no slot is block-less.
-mockBlockHeight :: SlotId -> Quantity "block" Natural
+mockBlockHeight :: SlotId -> Quantity "block" Word32
 mockBlockHeight = Quantity . fromIntegral . flatSlot (EpochLength slotsPerEpoch)
 
 -- | Generate an entire epoch's worth of mock blocks. There are no transactions

--- a/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
+++ b/lib/http-bridge/test/unit/Cardano/Wallet/HttpBridge/Primitive/TypesSpec.hs
@@ -35,7 +35,8 @@ spec = do
                     { header = BlockHeader
                         { slotId = SlotId 14 19
                         , blockHeight = Quantity 42
-                        , prevBlockHash = Hash "\223\252\&5\ACK\211\129\&6\DC4h7b'\225\201\&2:/\252v\SOH\DC1\ETX\227\"Q$\240\142ii\167;"
+                        , headerHash = Hash "http-bridge"
+                        , parentHeaderHash = Hash "\223\252\&5\ACK\211\129\&6\DC4h7b'\225\201\&2:/\252v\SOH\DC1\ETX\227\"Q$\240\142ii\167;"
                         }
                     , transactions =
                         [ Tx
@@ -58,7 +59,7 @@ spec = do
                             }
                         ]
                     }
-            "dffc3506-[14.19#42]\n\
+            "68747470-[14.19#42]\n\
             \    - ~> 1st c29d3ea0\n\
             \      <~ 3823755953610 @ 82d81858...aebb3709\n\
             \      <~ 19999800000 @ 82d81858...37ce9c60\n"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -101,8 +101,6 @@ import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Network.HTTP.Types.Status
     ( status400 )
-import Safe
-    ( tailSafe )
 import Servant.API
     ( (:<|>) (..) )
 import Servant.Client
@@ -291,35 +289,28 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
 -------------------------------------------------------------------------------}
 
 -- Fetch a batch of blocks after but not including the given header.
---
--- TODO: Have 'getBlocks' only a header hash of the relevant block instead of
--- using the parents (and use only a hash instead of a block)
 getBlocks
     :: Monad m
     => JormungandrClient m
     -> Quantity "block" Word32
         -- ^ Epoch stability, we can't fetch more than `k` block at once.
-    -> BlockHeader
-        -- ^ Header to start from
-    -> ExceptT ErrGetBlock m [(Hash "BlockHeader", J.Block)]
-getBlocks j (Quantity k) tip = do
-    -- Get the descendants of the tip's /parent/.
-    -- The first descendant is therefore the current tip itself. We need to
-    -- skip it. Hence the 'tail'.
-    ids <- withExceptT liftE $
-        tailSafe <$> getDescendantIds j (prevBlockHash tip) (fromIntegral k + 1)
-    mapM (\blockId -> (blockId,) <$> getBlock j blockId) ids
+    -> Hash "BlockHeader"
+        -- ^ Block ID to start from
+    -> ExceptT ErrGetBlock m [J.Block]
+getBlocks j (Quantity k) start = do
+    ids <- withExceptT liftE $ getDescendantIds j start batchSize
+    mapM (getBlock j) ids
+  where
+     batchSize = fromIntegral k + 1
 
 -- | Get a block header corresponding to a header hash.
 getBlockHeader
     :: Monad m
     => JormungandrClient m
     -> Hash "BlockHeader"
-    -> ExceptT ErrGetBlock m (BlockHeader, Quantity "block" Word32)
-getBlockHeader j t = do
-    blk@(J.Block blkHeader _) <- getBlock j t
-    let nodeHeight = Quantity $ fromIntegral $ J.chainLength blkHeader
-    pure (header (convertBlock blk), nodeHeight)
+    -> ExceptT ErrGetBlock m BlockHeader
+getBlockHeader j t =
+    header . convertBlock <$> getBlock j t
 
 {-------------------------------------------------------------------------------
                                 Errors

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -301,7 +300,7 @@ getBlocks j (Quantity k) start = do
     ids <- withExceptT liftE $ getDescendantIds j start batchSize
     mapM (getBlock j) ids
   where
-     batchSize = fromIntegral k + 1
+     batchSize = fromIntegral k
 
 -- | Get a block header corresponding to a header hash.
 getBlockHeader

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/BlockHeaders.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/BlockHeaders.hs
@@ -140,7 +140,7 @@ updateUnstableBlocks
     -> m (Hash "BlockHeader")
     -- ^ Network Tip
     -> (Hash "BlockHeader" -> m BlockHeader)
-    -- ^ Fetches block header and its chain height.
+    -- ^ Fetches block header from its hash
     -> BlockHeaders
     -- ^ Current unstable blocks state.
     -> m BlockHeaders

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -19,7 +19,6 @@ module Cardano.Wallet.Jormungandr.Compatibility
     ( -- * Target
       Jormungandr
     , Network (..)
-    , block0
     , softTxMaxSize
 
       -- * Node's Configuration
@@ -48,13 +47,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( SeqKey (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , BlockHeader (..)
     , DecodeAddress (..)
     , DefineTx
     , EncodeAddress (..)
-    , Hash (..)
     , invariant
-    , slotMinBound
     )
 import Codec.Binary.Bech32
     ( HumanReadablePart, dataPartFromBytes, dataPartToBytes )
@@ -94,14 +90,6 @@ import qualified Data.Text.Encoding as T
 -- | A type representing the Jormungandr as a network target. This has an
 -- influence on binary serializer & network primitives. See also 'TxId'
 data Jormungandr (network :: Network)
-
--- | Genesis block header, i.e. very first block header of the chain
-block0 :: BlockHeader
-block0 = BlockHeader
-    { slotId = slotMinBound
-    , prevBlockHash = Hash (BS.replicate 32 0)
-    , blockHeight = Quantity 0
-    }
 
 -- | Jörmugandr's chain parameter doesn't include a transaction max size. The
 -- actual hard-limit for the size is constrained by the binary format and

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -93,7 +93,6 @@ import Cardano.Wallet.Jormungandr.BlockHeaders
     , blockHeadersAtGenesis
     , blockHeadersBase
     , blockHeadersTip
-    , blockHeadersTipId
     , dropAfterSlotId
     , emptyBlockHeaders
     , greatestCommonBlockHeader
@@ -127,8 +126,6 @@ import Data.Coerce
     ( coerce )
 import Data.Function
     ( (&) )
-import Data.Maybe
-    ( fromMaybe )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text
@@ -277,18 +274,8 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
             Nothing -> Left ErrNetworkTipNotFound
 
     _initCursor :: BlockHeader -> Cursor t
-    _initCursor bh = Cursor $
-        -- FIXME The empty hash looks weird? Why not creating the BlockHeaders
-        -- from the constructor?
-        --
-        -- TODO:
-        -- Change blockheights to be consistent everywhere.
-        appendBlockHeaders k emptyBlockHeaders
-            [ ( Hash ""
-              , bh
-              , Quantity $ fromIntegral $ getQuantity $ blockHeight bh
-              )
-            ]
+    _initCursor bh =
+        Cursor $ appendBlockHeaders k emptyBlockHeaders [ bh ]
 
     _cursorSlotId :: Cursor t -> SlotId
     _cursorSlotId (Cursor unstable) =
@@ -308,10 +295,8 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
 
                     Forward -> do
                         let Just nodeTip = blockHeadersTip unstable
-                        let startHeader = fromMaybe
-                              (BlockHeader (SlotId 0 0) (Quantity 0) (coerce genesis))
-                              (blockHeadersTip localChain)
-                        lift (runExceptT $ getBlocks j k startHeader) >>= \case
+                        let start = maybe (coerce genesis) headerHash $ blockHeadersTip localChain
+                        lift (runExceptT $ getBlocks j k start) >>= \case
                             Right blks ->
                                 pure (tryRollForward nodeTip blks)
                             Left (ErrGetBlockNotFound _) ->
@@ -333,7 +318,7 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
       where
         tryRollForward
             :: BlockHeader
-            -> [(Hash "BlockHeader", block)]
+            -> [block]
             -> NextBlocksResult t block
         tryRollForward tip = \case
             -- No more blocks to apply, no need to roll forward
@@ -348,12 +333,12 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
             next@(b:_)
                 -- If the blocks we are about to apply are a continuation of our
                 -- local chain, then it's good, we can continue
-                | Just (J.parentHeaderHash $ J.header $ snd b) == blockHeadersTipId localChain ->
-                    RollForward (cursorForward k next cursor) tip (snd <$> next)
+                | Just (J.parentHeaderHash $ J.header b) == (headerHash <$> blockHeadersTip localChain) ->
+                    RollForward (cursorForward k next cursor) tip next
 
                 -- If we are at genesis, we apply them anyway
                 | blockHeadersAtGenesis localChain ->
-                    RollForward (cursorForward k next cursor) tip (snd <$> next)
+                    RollForward (cursorForward k next cursor) tip next
 
                 -- We need to rollback somewhere, but we don't know where, so we
                 -- try rolling back to the oldest header we know.
@@ -404,7 +389,7 @@ direction
 direction (Cursor local) node = case greatestCommonBlockHeader node local of
     Just intersection
         -- Local tip and node tip are the same
-        | blockHeadersTipId local == blockHeadersTipId node -> Stay
+        | blockHeadersTip local == blockHeadersTip node -> Stay
 
         -- Node is still at genesis
         | blockHeadersAtGenesis node -> Stay
@@ -428,19 +413,13 @@ cursorForward
     :: forall n t block. (t ~ Jormungandr n, block ~ J.Block)
     => Quantity "block" Word32
     -- ^ Epoch Stability, a.k.a 'k'
-    -> [(Hash "BlockHeader", block)]
+    -> [block]
     -- ^ New blocks received
     -> Cursor t
     -- ^ Current cursor / local state
     -> Cursor t
 cursorForward k bs (Cursor cursor) =
-    Cursor $ appendBlockHeaders k cursor bs'
-  where
-    bs' =
-        [ (h, J.convertBlockHeader (J.header b), Quantity height)
-        | (h, b) <- bs
-        , let height = J.chainLength $ J.header b
-        ]
+    Cursor $ appendBlockHeaders k cursor $ J.convertBlockHeader . J.header <$> bs
 
 -- | Clears local state after the rollback point.
 cursorBackward

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -279,8 +279,7 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
 
     _cursorSlotId :: Cursor t -> SlotId
     _cursorSlotId (Cursor unstable) =
-        -- FIXME Why the default here?
-        maybe (SlotId 0 0) slotId $ blockHeadersTip unstable
+        maybe (SlotId 0 0) slotId (blockHeadersTip unstable)
 
     _nextBlocks
         :: Cursor t
@@ -361,7 +360,7 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
             (Just baseH, Just tipH) | baseH /= tipH ->
                 RollBackward (cursorBackward baseH cursor)
             _ ->
-                Recover
+                RollBackward $ Cursor emptyBlockHeaders
 
 {-------------------------------------------------------------------------------
                              Jormungandr Cursor
@@ -393,9 +392,6 @@ direction (Cursor local) node = case greatestCommonBlockHeader node local of
     Just intersection
         -- Local tip and node tip are the same
         | blockHeadersTip local == blockHeadersTip node -> Stay
-
-        -- Node is still at genesis
-        | blockHeadersAtGenesis node -> Stay
 
         -- Local tip is the greatest common block
         | blockHeadersTip local == Just intersection -> Forward

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -273,9 +273,9 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
             Just t -> Right (bs', t)
             Nothing -> Left ErrNetworkTipNotFound
 
-    _initCursor :: BlockHeader -> Cursor t
-    _initCursor bh =
-        Cursor $ appendBlockHeaders k emptyBlockHeaders [ bh ]
+    _initCursor :: [BlockHeader] -> Cursor t
+    _initCursor bhs =
+        Cursor $ appendBlockHeaders k emptyBlockHeaders bhs
 
     _cursorSlotId :: Cursor t -> SlotId
     _cursorSlotId (Cursor unstable) =
@@ -295,7 +295,10 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
 
                     Forward -> do
                         let Just nodeTip = blockHeadersTip unstable
-                        let start = maybe (coerce genesis) headerHash $ blockHeadersTip localChain
+                        let start = maybe
+                                (coerce genesis)
+                                headerHash
+                                (blockHeadersTip localChain)
                         lift (runExceptT $ getBlocks j k start) >>= \case
                             Right blks ->
                                 pure (tryRollForward nodeTip blks)

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -141,14 +141,14 @@ spec = do
 
         it "get some blocks from the genesis" $ \(nw, _) -> do
             threadDelay (10 * second)
-            resp <- runExceptT $ nextBlocks nw (initCursor nw block0)
+            resp <- runExceptT $ nextBlocks nw (initCursor nw [])
             resp `shouldSatisfy` isRight
             resp `shouldSatisfy` (not . null)
 
         it "no blocks after the tip" $ \(nw, _) -> do
             let try = do
                     tip <- unsafeRunExceptT $ networkTip nw
-                    runExceptT $ nextBlocks nw (initCursor nw tip)
+                    runExceptT $ nextBlocks nw (initCursor nw [tip])
             -- NOTE Retrying twice since between the moment we fetch the
             -- tip and the moment we get the next blocks, one block may be
             -- inserted.
@@ -169,7 +169,7 @@ spec = do
                     , headerHash = Hash bytes
                     , parentHeaderHash = Hash bytes
                     }
-            resp <- runExceptT $ nextBlocks nw (initCursor nw block)
+            resp <- runExceptT $ nextBlocks nw (initCursor nw [block])
             resp `shouldBe` Right Recover
 
     describe "Error paths" $ do
@@ -206,7 +206,7 @@ spec = do
                     "Expected a ErrNetworkUnreachable' failure but got "
                     <> show x
             let action = do
-                    res <- runExceptT $ nextBlocks nw (initCursor nw block0)
+                    res <- runExceptT $ nextBlocks nw (initCursor nw [])
                     res `shouldSatisfy` \case
                         Left (ErrGetBlockNetworkUnreachable e) ->
                             show e `deepseq` True
@@ -512,6 +512,3 @@ getRollForward Recover = Nothing
 
 isRollForward :: NextBlocksResult target block -> Bool
 isRollForward = maybe False (not . null) . getRollForward
-
-block0 :: BlockHeader
-block0 = BlockHeader (SlotId 0 0) (Quantity 0) (Hash "genesis") (Hash "genesis")

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Jormungandr.Binary
 import Cardano.Wallet.Jormungandr.BlockHeaders
     ( emptyBlockHeaders )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr, Network (..), block0 )
+    ( Jormungandr, Network (..) )
 import Cardano.Wallet.Jormungandr.Network
     ( BaseUrl (..)
     , ErrGetDescendants (..)
@@ -166,7 +166,8 @@ spec = do
             let block = BlockHeader
                     { slotId = SlotId 42 14 -- Anything
                     , blockHeight = Quantity 0 -- Anything
-                    , prevBlockHash = Hash bytes
+                    , headerHash = Hash bytes
+                    , parentHeaderHash = Hash bytes
                     }
             resp <- runExceptT $ nextBlocks nw (initCursor nw block)
             resp `shouldBe` Right Recover
@@ -511,3 +512,6 @@ getRollForward Recover = Nothing
 
 isRollForward :: NextBlocksResult target block -> Bool
 isRollForward = maybe False (not . null) . getRollForward
+
+block0 :: BlockHeader
+block0 = BlockHeader (SlotId 0 0) (Quantity 0) (Hash "genesis") (Hash "genesis")

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -35,7 +35,7 @@ import Cardano.Wallet.Jormungandr.Binary
     , withHeader
     )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr, block0 )
+    ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Environment
     ( Network (..) )
 import Cardano.Wallet.Jormungandr.Primitive.Types
@@ -64,10 +64,6 @@ import Data.ByteString
     ( ByteString )
 import Data.Either
     ( isRight )
-import Data.Generics.Internal.VL.Lens
-    ( (^.) )
-import Data.Generics.Labels
-    ()
 import Data.List
     ( isSuffixOf )
 import Data.Proxy
@@ -132,12 +128,15 @@ spec = do
                     BlockHeader
                         { version = 0
                         , contentSize = 458
-                        , slot = block0 ^. #slotId
+                        , slot = SlotId 0 0
                         , chainLength = 0
                         , contentHash = Hash $ unsafeFromHex
                             "f7becdf807c706cef54ec4832d2a7475\
                             \91c3f2141de3e4f2aef59a130d890c12"
-                        , parentHeaderHash = block0 ^. #prevBlockHash
+                        , headerHash = Hash $ unsafeFromHex
+                            "e1abfad5b57907832d22b219d2615b62\
+                            \55437765cfd993cd0ba31b0248bad464"
+                        , parentHeaderHash = Hash (BS.replicate 32 0)
                         , producedBy = Nothing
                         }
                     [ Initial
@@ -189,12 +188,15 @@ spec = do
                     BlockHeader
                         { version = 0
                         , contentSize = 129
-                        , slot = block0 ^. #slotId
+                        , slot = SlotId 0 0
                         , chainLength = 0
                         , contentHash = Hash $ unsafeFromHex
                             "5df3b1c19c1400a9925158ade2b71913\
                             \74df85f6976fe81681f0aef2e0ddc2a3"
-                        , parentHeaderHash = block0 ^. #prevBlockHash
+                        , headerHash = Hash $ unsafeFromHex
+                            "2c0d36bfc65bb59c5c7df68e7b70dab8\
+                            \347b96802a343e609258573fd1155c24"
+                        , parentHeaderHash = Hash (BS.replicate 32 0)
                         , producedBy = Nothing
                         }
                     [ Initial
@@ -234,6 +236,9 @@ spec = do
                         , contentHash = Hash $ unsafeFromHex
                             "0e5751c026e543b2e8ab2eb06099daa1\
                             \d1e5df47778f7787faab45cdf12fe3a8"
+                        , headerHash = Hash $ unsafeFromHex
+                            "4d2324138a42a8d9e93a6b749bedeec8\
+                            \0308ecfbc4d01383da8ac20df109e9bc"
                         , parentHeaderHash = Hash $ unsafeFromHex
                             "d84f590d58c7eabc2e3c4f5cf459d3d2\
                             \fee06069d813a7848b9ad8a154aef79b"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BlockHeadersSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BlockHeadersSpec.hs
@@ -133,8 +133,7 @@ prop_unstableBlockHeaders TestCase{..} =
     bs' = updateUnstableBlocks (coerce k) getTip getBlockHeader bs
       where
         getTip = tipId nodeChain
-        getBlockHeader = flip lookup blocks
-    blocks = mkBlockHeaderHeights nodeChain
+        getBlockHeader hh = find ((== hh) . headerHash) nodeChain
 
 -- | 'updateUnstableBlocks' should not fetch blocks that it already has headers
 -- for.
@@ -144,7 +143,7 @@ prop_updateUnstableBlocksIsEfficient TestCase{..} =
   where
     prop = Set.size (Set.intersection localHashes fetchedHashes) <= 1
 
-    localHashes = Set.fromList (map prevBlockHash (drop 1 localChain))
+    localHashes = Set.fromList (map parentHeaderHash (drop 1 localChain))
     fetchedHashes = maybe mempty Set.fromList (execWriterT bs')
 
     ce = unlines
@@ -159,9 +158,7 @@ prop_updateUnstableBlocksIsEfficient TestCase{..} =
     bs' = updateUnstableBlocks (coerce k) getTip getBlockHeader bs
       where
         getTip = lift (tipId nodeChain)
-        getBlockHeader h = tell [h] *> lift (lookup h blocks)
-
-    blocks = mkBlockHeaderHeights nodeChain
+        getBlockHeader h = tell [h] *> lift (find ((== h) . headerHash) nodeChain)
 
 prop_updateUnstableBlocksFailure :: TestCase -> Property
 prop_updateUnstableBlocksFailure TestCase{..} =
@@ -182,12 +179,11 @@ prop_updateUnstableBlocksFailure TestCase{..} =
     getTip
         | chainLength nodeChain `mod` 5 == 0 = Left "injected getTip failed"
         | otherwise = maybe (Left "no tip") Right $ tipId nodeChain
-    getBlockHeader h = case findIndex ((== h) . fst) blocks of
+    getBlockHeader h = case findIndex ((== h) . headerHash) nodeChain of
         Just ix
             | ix `mod` 3 == 0 -> Left "injected getBlock failed"
-            | otherwise -> Right (snd (blocks !! ix))
+            | otherwise -> Right (nodeChain !! ix)
         Nothing -> Left "block not found"
-    blocks = mkBlockHeaderHeights nodeChain
 
 {-------------------------------------------------------------------------------
                                 TestCase helpers
@@ -197,28 +193,15 @@ prop_updateUnstableBlocksFailure TestCase{..} =
 -- equality.
 mkBlockHeaders :: Int -> [BlockHeader] -> BlockHeaders
 mkBlockHeaders h bs =
-    BlockHeaders (Seq.fromList $ headerIds bs) (Quantity $ fromIntegral h)
-
--- | Convert a test chain into an assoc list of block ids, their headers, and
--- chain heights.
-mkBlockHeaderHeights
-    :: [BlockHeader]
-    -> [(Hash "BlockHeader", (BlockHeader, Quantity "block" Word32))]
-mkBlockHeaderHeights nodeChain =
-    [ (hash, (hdr, height))
-    | ((hash, hdr), height) <- zip (headerIds nodeChain) [Quantity 1..] ]
+    BlockHeaders (Seq.fromList bs) (Quantity $ fromIntegral h)
 
 {-------------------------------------------------------------------------------
                               Test chain functions
 -------------------------------------------------------------------------------}
 
--- | Create a mapping from test chain block ids to block headers.
-headerIds :: [BlockHeader] -> [(Hash "BlockHeader", BlockHeader)]
-headerIds bs = [(prevBlockHash b, a) | (a, b) <- zip bs (tail bs)]
-
 -- | Tip of a test chain is the penultimate block.
 tipId :: [BlockHeader] -> Maybe (Hash "BlockHeader")
-tipId bs = prevBlockHash <$> lastMay bs
+tipId bs = parentHeaderHash <$> lastMay bs
 
 -- | A test chain needs at least two headers to have a tip.
 hasTip :: [BlockHeader] -> Bool
@@ -243,7 +226,7 @@ showChain :: [BlockHeader] -> String
 showChain [] = "<empty chain>"
 showChain bs = unwords (map showHeaderHash bs)
   where
-    showHeaderHash (BlockHeader _ _ (Hash h)) = B8.unpack h
+    showHeaderHash (BlockHeader _ _ _ (Hash h)) = B8.unpack h
 
 showSlot :: SlotId -> String
 showSlot (SlotId ep sl) = show ep ++ "." ++ show sl
@@ -302,7 +285,7 @@ spliceChains localChain nodeChain = takeToSlot start chaff ++ localChain
   where
     start = fromMaybe (SlotId 0 0) $ firstSlot localChain
     -- chaff is the same shape as the node chain, but with different hashes
-    chaff = [bh { prevBlockHash = Hash "x" } | bh <- nodeChain]
+    chaff = [bh { parentHeaderHash = Hash "x" } | bh <- nodeChain]
 
 -- | The slot index at which the local chain starts.
 firstSlot :: [BlockHeader] -> Maybe SlotId
@@ -350,7 +333,7 @@ prop_greatestCommonBlockHeader TestCase{..} =
 
     -- Utils for poking around BlockHeaders.
     nextBlock bh (BlockHeaders bs _) = seqHead $
-        Seq.drop 1 $ Seq.dropWhileL ((/= bh) . snd) bs
+        Seq.drop 1 $ Seq.dropWhileL (/= bh) bs
     firstUbs (BlockHeaders bs _) = seqHead bs
     seqHead = Seq.lookup 0 . Seq.take 1
     isEmpty (BlockHeaders bs _) = Seq.null bs
@@ -364,7 +347,13 @@ prop_greatestCommonBlockHeader TestCase{..} =
 -- is the penultimate block.
 chain :: String -> [BlockHeader]
 chain p =
-    [BlockHeader (SlotId 0 n) (mockBlockHeight n) (Hash . B8.pack $ p ++ hash n) | n <- [1..]]
+    [ BlockHeader
+        (SlotId 0 n)
+        (mockBlockHeight n)
+        (Hash . B8.pack $ p ++ "hh" ++ hash n)
+        (Hash . B8.pack $ p ++ hash n)
+    | n <- [1..]
+    ]
   where
     mockBlockHeight = Quantity . fromIntegral
     hash n = show (n - 1)
@@ -375,11 +364,11 @@ removeBlocks :: [Bool] -> [BlockHeader] -> [BlockHeader]
 removeBlocks holes bs =
     reverse
         $ snd
-        $ foldl' maybeMkHole (prevBlockHash (head bs), [])
-        $ zip holes (zip (map prevBlockHash $ tail bs) bs)
+        $ foldl' maybeMkHole (parentHeaderHash (head bs), [])
+        $ zip holes (zip (map parentHeaderHash $ tail bs) bs)
   where
-    maybeMkHole (prev, ac) (True, (h, BlockHeader sl _ _)) =
-        (h, ((BlockHeader sl bh prev):ac))
+    maybeMkHole (prev, ac) (True, (h, BlockHeader sl _ hh _)) =
+        (h, ((BlockHeader sl bh hh prev):ac))
     maybeMkHole pbs _ =
         pbs
     bh = Quantity 0
@@ -404,7 +393,7 @@ genChain (Quantity k) prefix = do
 instance Arbitrary TestCase where
     arbitrary = do
         k <- arbitrary
-        let genesis = BlockHeader (SlotId 0 0) bh (Hash "genesis")
+        let genesis = BlockHeader (SlotId 0 0) bh (Hash "genesis") (Hash "genesis")
         base  <- genChain k "base"
         local <- genChain k "local"
         node  <- genChain k "node"
@@ -417,8 +406,8 @@ instance Arbitrary TestCase where
       where
         bh = Quantity 0
         startFrom (SlotId ep n) xs =
-            [ BlockHeader (SlotId ep (sl+n)) bh prev
-            | BlockHeader (SlotId _ sl) _ prev <- xs
+            [ BlockHeader (SlotId ep (sl+n)) bh hh prev
+            | BlockHeader (SlotId _ sl) _ hh prev <- xs
             ]
 
     shrink TestCase{..} =
@@ -445,7 +434,7 @@ instance Arbitrary (Quantity "block" Word32) where
 showBlockHeaders :: BlockHeaders -> String
 showBlockHeaders ubs = showHeaders ubs ++ " " ++ showHeight ubs
   where
-    showHeaders = unwords . map (showHash . fst) . F.toList . getBlockHeaders
+    showHeaders = unwords . map (showHash . headerHash) . F.toList . getBlockHeaders
     showHeight (BlockHeaders _ (Quantity h)) = "height=" ++ show h
 
 showHash :: Hash a -> String

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -101,29 +101,20 @@ spec = do
             property prop_generator
 
     describe "Chain sync" $ do
-        it "Regression #1" $ do
-            let regression1 = S {node = N {nodeDb = Map.fromList [], nodeChainIds = [], nodeNextBlockId = 0}, operations = [[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]],[],[],[],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]],[],[],[NodeGarbageCollect [Hash {getHash = "0000"}]],[],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]],[],[],[],[],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0007"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]],[NodeGarbageCollect [Hash {getHash = "0001"},Hash {getHash = "0002"},Hash {getHash = "0003"}]],[],[],[],[],[],[],[],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]],[],[],[],[],[],[NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]],[NodeRewind 2,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]],[],[],[NodeGarbageCollect [Hash {getHash = "000b"}]],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}}]],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}}]],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0011"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}},MockBlock {mockBlockId = Hash {getHash = "0012"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}},MockBlock {mockBlockId = Hash {getHash = "0013"}, mockBlockPrev = Hash {getHash = "0012"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}}]],[],[],[],[NodeGarbageCollect [Hash {getHash = "0009"},Hash {getHash = "000c"},Hash {getHash = "000e"}]],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0014"}, mockBlockPrev = Hash {getHash = "0013"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}}]],[],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0015"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}},MockBlock {mockBlockId = Hash {getHash = "0016"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}},MockBlock {mockBlockId = Hash {getHash = "0017"}, mockBlockPrev = Hash {getHash = "0016"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}}]],[],[],[NodeGarbageCollect [Hash {getHash = "0010"}]],[NodeGarbageCollect [Hash {getHash = "000f"},Hash {getHash = "0012"},Hash {getHash = "0013"},Hash {getHash = "0014"}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0018"}, mockBlockPrev = Hash {getHash = "0017"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}}]],[],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0019"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}},MockBlock {mockBlockId = Hash {getHash = "001a"}, mockBlockPrev = Hash {getHash = "0019"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}}]],[],[],[],[],[NodeGarbageCollect [Hash {getHash = "0018"}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001b"}, mockBlockPrev = Hash {getHash = "001a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 12}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001c"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}}]],[NodeGarbageCollect [Hash {getHash = "0016"},Hash {getHash = "0017"}]],[],[],[NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001d"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}}]],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001e"}, mockBlockPrev = Hash {getHash = "001d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 14}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001f"}, mockBlockPrev = Hash {getHash = "001e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 15}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0020"}, mockBlockPrev = Hash {getHash = "001f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 16}}]],[],[],[],[],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0021"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}}]],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0022"}, mockBlockPrev = Hash {getHash = "0021"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}}]],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0023"}, mockBlockPrev = Hash {getHash = "0022"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}}]],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0024"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}},MockBlock {mockBlockId = Hash {getHash = "0025"}, mockBlockPrev = Hash {getHash = "0024"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}},MockBlock {mockBlockId = Hash {getHash = "0026"}, mockBlockPrev = Hash {getHash = "0025"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}}]],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0027"}, mockBlockPrev = Hash {getHash = "0026"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}}]],[],[],[],[],[],[],[NodeRewind 4,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0028"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}},MockBlock {mockBlockId = Hash {getHash = "0029"}, mockBlockPrev = Hash {getHash = "0028"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}},MockBlock {mockBlockId = Hash {getHash = "002a"}, mockBlockPrev = Hash {getHash = "0029"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}},MockBlock {mockBlockId = Hash {getHash = "002b"}, mockBlockPrev = Hash {getHash = "002a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}}]],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002c"}, mockBlockPrev = Hash {getHash = "002b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 21}}]],[],[],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002d"}, mockBlockPrev = Hash {getHash = "002c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 22}}]],[],[],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002e"}, mockBlockPrev = Hash {getHash = "002d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 23}}]],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002f"}, mockBlockPrev = Hash {getHash = "002e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 24}}]],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0030"}, mockBlockPrev = Hash {getHash = "002f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 25}}]],[],[],[],[],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0031"}, mockBlockPrev = Hash {getHash = "0030"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 26}}]]], mockNodeK = Quantity {getQuantity = 15}, logs = []}
+        it "Regression #1" $
             withMaxSuccess 1 $ prop_sync regression1
 
-        it "Regression #2" $ do
-            let regression2 = S {node = N {nodeDb = Map.fromList [], nodeChainIds = [], nodeNextBlockId = 0}, operations = [[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]],[NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]],[NodeGarbageCollect [Hash {getHash = "0000"}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}]]], mockNodeK = Quantity {getQuantity = 15}, logs = []}
+        it "Regression #2" $
             withMaxSuccess 1 $ prop_sync regression2
 
-        it "Regression #3" $ do
-            let regression3 = S {node = N {nodeDb = Map.fromList [], nodeChainIds = [], nodeNextBlockId = 0}, operations = [[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]],[NodeRewind 4],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]],[NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]],[NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]]], mockNodeK = Quantity {getQuantity = 16}, logs = []}
+        it "Regression #3" $
             withMaxSuccess 1 $ prop_sync regression3
 
-        it "Regression #4" $ do
-            let regression4 = S {node = N {nodeDb = Map.fromList [(Hash {getHash = "0000"},MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}),(Hash {getHash = "0001"},MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}),(Hash {getHash = "0002"},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}),(Hash {getHash = "0003"},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}),(Hash {getHash = "0004"},MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}),(Hash {getHash = "0005"},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}}),(Hash {getHash = "0006"},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}}),(Hash {getHash = "0007"},MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}}),(Hash {getHash = "0008"},MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0007"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 12}}),(Hash {getHash = "0009"},MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}}),(Hash {getHash = "000a"},MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 15}}),(Hash {getHash = "000b"},MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 16}}),(Hash {getHash = "000c"},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}}),(Hash {getHash = "000d"},MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}}),(Hash {getHash = "000e"},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}}),(Hash {getHash = "000f"},MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}}),(Hash {getHash = "0010"},MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 21}}),(Hash {getHash = "0011"},MockBlock {mockBlockId = Hash {getHash = "0011"}, mockBlockPrev = Hash {getHash = "0010"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 22}}),(Hash {getHash = "0012"},MockBlock {mockBlockId = Hash {getHash = "0012"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 24}}),(Hash {getHash = "0013"},MockBlock {mockBlockId = Hash {getHash = "0013"}, mockBlockPrev = Hash {getHash = "0012"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 25}}),(Hash {getHash = "0014"},MockBlock {mockBlockId = Hash {getHash = "0014"}, mockBlockPrev = Hash {getHash = "0013"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 26}}),(Hash {getHash = "0015"},MockBlock {mockBlockId = Hash {getHash = "0015"}, mockBlockPrev = Hash {getHash = "0014"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 27}}),(Hash {getHash = "0016"},MockBlock {mockBlockId = Hash {getHash = "0016"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 28}}),(Hash {getHash = "0017"},MockBlock {mockBlockId = Hash {getHash = "0017"}, mockBlockPrev = Hash {getHash = "0016"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 29}}),(Hash {getHash = "0018"},MockBlock {mockBlockId = Hash {getHash = "0018"}, mockBlockPrev = Hash {getHash = "0017"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 30}}),(Hash {getHash = "0019"},MockBlock {mockBlockId = Hash {getHash = "0019"}, mockBlockPrev = Hash {getHash = "0018"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 31}}),(Hash {getHash = "001a"},MockBlock {mockBlockId = Hash {getHash = "001a"}, mockBlockPrev = Hash {getHash = "0019"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 32}}),(Hash {getHash = "001b"},MockBlock {mockBlockId = Hash {getHash = "001b"}, mockBlockPrev = Hash {getHash = "001a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 33}}),(Hash {getHash = "001c"},MockBlock {mockBlockId = Hash {getHash = "001c"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 34}}),(Hash {getHash = "001d"},MockBlock {mockBlockId = Hash {getHash = "001d"}, mockBlockPrev = Hash {getHash = "001c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 35}}),(Hash {getHash = "001e"},MockBlock {mockBlockId = Hash {getHash = "001e"}, mockBlockPrev = Hash {getHash = "001d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 36}}),(Hash {getHash = "001f"},MockBlock {mockBlockId = Hash {getHash = "001f"}, mockBlockPrev = Hash {getHash = "001e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 37}}),(Hash {getHash = "0020"},MockBlock {mockBlockId = Hash {getHash = "0020"}, mockBlockPrev = Hash {getHash = "001f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 39}}),(Hash {getHash = "0021"},MockBlock {mockBlockId = Hash {getHash = "0021"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 40}}),(Hash {getHash = "0022"},MockBlock {mockBlockId = Hash {getHash = "0022"}, mockBlockPrev = Hash {getHash = "0021"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 41}}),(Hash {getHash = "0023"},MockBlock {mockBlockId = Hash {getHash = "0023"}, mockBlockPrev = Hash {getHash = "0022"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 42}}),(Hash {getHash = "0024"},MockBlock {mockBlockId = Hash {getHash = "0024"}, mockBlockPrev = Hash {getHash = "0023"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 43}}),(Hash {getHash = "0025"},MockBlock {mockBlockId = Hash {getHash = "0025"}, mockBlockPrev = Hash {getHash = "0024"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 45}}),(Hash {getHash = "0026"},MockBlock {mockBlockId = Hash {getHash = "0026"}, mockBlockPrev = Hash {getHash = "0025"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 47}}),(Hash {getHash = "0027"},MockBlock {mockBlockId = Hash {getHash = "0027"}, mockBlockPrev = Hash {getHash = "0026"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 49}}),(Hash {getHash = "0028"},MockBlock {mockBlockId = Hash {getHash = "0028"}, mockBlockPrev = Hash {getHash = "0027"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 50}}),(Hash {getHash = "0029"},MockBlock {mockBlockId = Hash {getHash = "0029"}, mockBlockPrev = Hash {getHash = "0028"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 52}}),(Hash {getHash = "002a"},MockBlock {mockBlockId = Hash {getHash = "002a"}, mockBlockPrev = Hash {getHash = "0029"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 53}}),(Hash {getHash = "002b"},MockBlock {mockBlockId = Hash {getHash = "002b"}, mockBlockPrev = Hash {getHash = "002a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 55}}),(Hash {getHash = "002c"},MockBlock {mockBlockId = Hash {getHash = "002c"}, mockBlockPrev = Hash {getHash = "002b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 56}}),(Hash {getHash = "002d"},MockBlock {mockBlockId = Hash {getHash = "002d"}, mockBlockPrev = Hash {getHash = "002c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 57}}),(Hash {getHash = "002e"},MockBlock {mockBlockId = Hash {getHash = "002e"}, mockBlockPrev = Hash {getHash = "002d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 59}}),(Hash {getHash = "002f"},MockBlock {mockBlockId = Hash {getHash = "002f"}, mockBlockPrev = Hash {getHash = "002e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 60}}),(Hash {getHash = "0030"},MockBlock {mockBlockId = Hash {getHash = "0030"}, mockBlockPrev = Hash {getHash = "002f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 61}}),(Hash {getHash = "0031"},MockBlock {mockBlockId = Hash {getHash = "0031"}, mockBlockPrev = Hash {getHash = "0030"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 63}}),(Hash {getHash = "0032"},MockBlock {mockBlockId = Hash {getHash = "0032"}, mockBlockPrev = Hash {getHash = "0031"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 64}}),(Hash {getHash = "0033"},MockBlock {mockBlockId = Hash {getHash = "0033"}, mockBlockPrev = Hash {getHash = "0032"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 65}}),(Hash {getHash = "0034"},MockBlock {mockBlockId = Hash {getHash = "0034"}, mockBlockPrev = Hash {getHash = "0033"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 66}}),(Hash {getHash = "0035"},MockBlock {mockBlockId = Hash {getHash = "0035"}, mockBlockPrev = Hash {getHash = "0034"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 70}}),(Hash {getHash = "0036"},MockBlock {mockBlockId = Hash {getHash = "0036"}, mockBlockPrev = Hash {getHash = "0035"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 72}}),(Hash {getHash = "0037"},MockBlock {mockBlockId = Hash {getHash = "0037"}, mockBlockPrev = Hash {getHash = "0036"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 73}}),(Hash {getHash = "0038"},MockBlock {mockBlockId = Hash {getHash = "0038"}, mockBlockPrev = Hash {getHash = "0037"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 74}}),(Hash {getHash = "0039"},MockBlock {mockBlockId = Hash {getHash = "0039"}, mockBlockPrev = Hash {getHash = "0038"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 75}}),(Hash {getHash = "003a"},MockBlock {mockBlockId = Hash {getHash = "003a"}, mockBlockPrev = Hash {getHash = "0039"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 79}}),(Hash {getHash = "003b"},MockBlock {mockBlockId = Hash {getHash = "003b"}, mockBlockPrev = Hash {getHash = "003a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 80}}),(Hash {getHash = "003c"},MockBlock {mockBlockId = Hash {getHash = "003c"}, mockBlockPrev = Hash {getHash = "003b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 81}}),(Hash {getHash = "003d"},MockBlock {mockBlockId = Hash {getHash = "003d"}, mockBlockPrev = Hash {getHash = "003c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 83}}),(Hash {getHash = "003e"},MockBlock {mockBlockId = Hash {getHash = "003e"}, mockBlockPrev = Hash {getHash = "003d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 84}})], nodeChainIds = [Hash {getHash = "003e"},Hash {getHash = "003d"},Hash {getHash = "003c"},Hash {getHash = "003b"},Hash {getHash = "003a"},Hash {getHash = "0039"},Hash {getHash = "0038"},Hash {getHash = "0037"},Hash {getHash = "0036"},Hash {getHash = "0035"},Hash {getHash = "0034"},Hash {getHash = "0033"},Hash {getHash = "0032"},Hash {getHash = "0031"},Hash {getHash = "0030"},Hash {getHash = "002f"},Hash {getHash = "002e"},Hash {getHash = "002d"},Hash {getHash = "002c"},Hash {getHash = "002b"},Hash {getHash = "002a"},Hash {getHash = "0029"},Hash {getHash = "0028"},Hash {getHash = "0027"},Hash {getHash = "0026"},Hash {getHash = "0025"},Hash {getHash = "0024"},Hash {getHash = "0023"},Hash {getHash = "0022"},Hash {getHash = "0021"},Hash {getHash = "0020"},Hash {getHash = "001f"},Hash {getHash = "001e"},Hash {getHash = "001d"},Hash {getHash = "001c"},Hash {getHash = "001b"},Hash {getHash = "001a"},Hash {getHash = "0019"},Hash {getHash = "0018"},Hash {getHash = "0017"},Hash {getHash = "0016"},Hash {getHash = "0015"},Hash {getHash = "0014"},Hash {getHash = "0013"},Hash {getHash = "0012"},Hash {getHash = "0011"},Hash {getHash = "0010"},Hash {getHash = "000f"},Hash {getHash = "000e"},Hash {getHash = "000d"},Hash {getHash = "000c"},Hash {getHash = "000b"},Hash {getHash = "000a"},Hash {getHash = "0009"},Hash {getHash = "0008"},Hash {getHash = "0007"},Hash {getHash = "0006"},Hash {getHash = "0005"},Hash {getHash = "0004"},Hash {getHash = "0003"},Hash {getHash = "0002"},Hash {getHash = "0001"},Hash {getHash = "0000"}], nodeNextBlockId = 63}, operations = [], mockNodeK = Quantity {getQuantity = 3}, logs = []}
+        it "Regression #4" $
             withMaxSuccess 1 $ prop_sync regression4
 
-        it "Regression #5" $ do
-            let regression5 = S {node = N {nodeDb = Map.fromList [(Hash {getHash = "0000"},MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}),(Hash {getHash = "0001"},MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}),(Hash {getHash = "0002"},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}),(Hash {getHash = "0003"},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}),(Hash {getHash = "0004"},MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}),(Hash {getHash = "0005"},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}),(Hash {getHash = "0006"},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}),(Hash {getHash = "0007"},MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}),(Hash {getHash = "0008"},MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}),(Hash {getHash = "0009"},MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}),(Hash {getHash = "000a"},MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}),(Hash {getHash = "000b"},MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}),(Hash {getHash = "000c"},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}})], nodeChainIds = [Hash {getHash = "000c"},Hash {getHash = "000b"},Hash {getHash = "000a"},Hash {getHash = "0009"},Hash {getHash = "0008"},Hash {getHash = "0003"}], nodeNextBlockId = 13}, operations = [[NodeRewind 1],[NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]}],[NodeRewind 1],[NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]}],[NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]}],[NodeRewind 3,NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]}]], mockNodeK = Quantity {getQuantity = 4}, logs = []}
+        it "Regression #5" $
             withMaxSuccess 1 $ prop_sync regression5
-
-        it "Regression #6" $ do
-            let regression6 = S {node = N {nodeDb = Map.fromList [], nodeChainIds = [], nodeNextBlockId = 0}, operations = [[NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}},MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}]}]], mockNodeK = Quantity {getQuantity = 2}, logs = []}
-            withMaxSuccess 1 $ prop_sync regression6
 
         it "Syncs with mock node" $
             withMaxSuccess 100000 prop_sync
@@ -677,3 +668,413 @@ mockBlockHash num = Hash $ fmt $ padLeftF 4 '0' $ hexF num
 
 showHash :: Hash a -> String
 showHash (Hash h) = B8.unpack h
+
+--------------------------------------------------------------------------------
+-- Interesting Cases Seen During Development
+--
+
+regression1 :: S
+regression1 = S
+    { node = N
+        { nodeDb = Map.fromList []
+        , nodeChainIds = []
+        , nodeNextBlockId = 0
+        }
+    ,  mockNodeK = Quantity {getQuantity = 15}
+    , logs = []
+    , operations =
+        [ []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]]
+        , []
+        , []
+        , []
+        , [NodeRewind 3, NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]]
+        , []
+        , []
+        , [NodeGarbageCollect [Hash {getHash = "0000"}]]
+        , []
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]]
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0007"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]]
+        , [NodeGarbageCollect [Hash {getHash = "0001"},Hash {getHash = "0002"},Hash {getHash = "0003"}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]]
+        , [NodeRewind 2,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]]
+        , []
+        , []
+        , [NodeGarbageCollect [Hash {getHash = "000b"}]]
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}}]]
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}}]]
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0011"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}},MockBlock {mockBlockId = Hash {getHash = "0012"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}},MockBlock {mockBlockId = Hash {getHash = "0013"}, mockBlockPrev = Hash {getHash = "0012"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}}]]
+        , []
+        , []
+        , []
+        , [NodeGarbageCollect [Hash {getHash = "0009"},Hash {getHash = "000c"},Hash {getHash = "000e"}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0014"}, mockBlockPrev = Hash {getHash = "0013"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}}]]
+        , []
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0015"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}},MockBlock {mockBlockId = Hash {getHash = "0016"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}},MockBlock {mockBlockId = Hash {getHash = "0017"}, mockBlockPrev = Hash {getHash = "0016"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}}]]
+        , []
+        , []
+        , [NodeGarbageCollect [Hash {getHash = "0010"}]]
+        , [NodeGarbageCollect [Hash {getHash = "000f"},Hash {getHash = "0012"},Hash {getHash = "0013"},Hash {getHash = "0014"}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0018"}, mockBlockPrev = Hash {getHash = "0017"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}}]]
+        , []
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0019"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 9}},MockBlock {mockBlockId = Hash {getHash = "001a"}, mockBlockPrev = Hash {getHash = "0019"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}}]]
+        , []
+        , []
+        , []
+        , []
+        , [NodeGarbageCollect [Hash {getHash = "0018"}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001b"}, mockBlockPrev = Hash {getHash = "001a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 12}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001c"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}}]]
+        , [NodeGarbageCollect [Hash {getHash = "0016"},Hash {getHash = "0017"}]]
+        , []
+        , []
+        , [NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001d"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}}]]
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001e"}, mockBlockPrev = Hash {getHash = "001d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 14}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "001f"}, mockBlockPrev = Hash {getHash = "001e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 15}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0020"}, mockBlockPrev = Hash {getHash = "001f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 16}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0021"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}}]]
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0022"}, mockBlockPrev = Hash {getHash = "0021"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}}]]
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0023"}, mockBlockPrev = Hash {getHash = "0022"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0024"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}},MockBlock {mockBlockId = Hash {getHash = "0025"}, mockBlockPrev = Hash {getHash = "0024"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}},MockBlock {mockBlockId = Hash {getHash = "0026"}, mockBlockPrev = Hash {getHash = "0025"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}}]]
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0027"}, mockBlockPrev = Hash {getHash = "0026"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeRewind 4,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0028"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}},MockBlock {mockBlockId = Hash {getHash = "0029"}, mockBlockPrev = Hash {getHash = "0028"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}},MockBlock {mockBlockId = Hash {getHash = "002a"}, mockBlockPrev = Hash {getHash = "0029"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}},MockBlock {mockBlockId = Hash {getHash = "002b"}, mockBlockPrev = Hash {getHash = "002a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}}]]
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002c"}, mockBlockPrev = Hash {getHash = "002b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 21}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002d"}, mockBlockPrev = Hash {getHash = "002c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 22}}]]
+        , []
+        , []
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002e"}, mockBlockPrev = Hash {getHash = "002d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 23}}]]
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "002f"}, mockBlockPrev = Hash {getHash = "002e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 24}}]]
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0030"}, mockBlockPrev = Hash {getHash = "002f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 25}}]]
+        , []
+        , []
+        , []
+        , []
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0031"}, mockBlockPrev = Hash {getHash = "0030"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 26}}]]
+        ]
+    }
+
+regression2 :: S
+regression2 = S
+    { node = N
+        { nodeDb = Map.fromList []
+        , nodeChainIds = []
+        , nodeNextBlockId = 0
+        }
+    , mockNodeK = Quantity {getQuantity = 15}
+    , logs = []
+    , operations =
+        [ [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]]
+        , [NodeRewind 1,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]]
+        , [NodeGarbageCollect [Hash {getHash = "0000"}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]]
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}}]]
+        ]
+    }
+
+regression3 :: S
+regression3 = S
+    { node = N
+        { nodeDb = Map.fromList []
+        , nodeChainIds = []
+        , nodeNextBlockId = 0
+        }
+    , mockNodeK = Quantity {getQuantity = 16}
+    , logs = []
+    , operations =
+        [ [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}}]]
+        , [NodeRewind 4]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]]
+        , [NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]]
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]]
+        , [NodeRewind 3,NodeAddBlocks [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]]
+        ]
+    }
+
+regression4 :: S
+regression4 = S
+    { node = N
+        { nodeDb = Map.fromList
+            [ (Hash {getHash = "0000"},MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}})
+            , (Hash {getHash = "0001"},MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}})
+            , (Hash {getHash = "0002"},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "0001"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}})
+            , (Hash {getHash = "0003"},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "0002"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}})
+            , (Hash {getHash = "0004"},MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 7}})
+            , (Hash {getHash = "0005"},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 8}})
+            , (Hash {getHash = "0006"},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 10}})
+            , (Hash {getHash = "0007"},MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0006"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 11}})
+            , (Hash {getHash = "0008"},MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0007"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 12}})
+            , (Hash {getHash = "0009"},MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 13}})
+            , (Hash {getHash = "000a"},MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 15}})
+            , (Hash {getHash = "000b"},MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 16}})
+            , (Hash {getHash = "000c"},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 17}})
+            , (Hash {getHash = "000d"},MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 18}})
+            , (Hash {getHash = "000e"},MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 19}})
+            , (Hash {getHash = "000f"},MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 20}})
+            , (Hash {getHash = "0010"},MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 21}})
+            , (Hash {getHash = "0011"},MockBlock {mockBlockId = Hash {getHash = "0011"}, mockBlockPrev = Hash {getHash = "0010"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 22}})
+            , (Hash {getHash = "0012"},MockBlock {mockBlockId = Hash {getHash = "0012"}, mockBlockPrev = Hash {getHash = "0011"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 24}})
+            , (Hash {getHash = "0013"},MockBlock {mockBlockId = Hash {getHash = "0013"}, mockBlockPrev = Hash {getHash = "0012"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 25}})
+            , (Hash {getHash = "0014"},MockBlock {mockBlockId = Hash {getHash = "0014"}, mockBlockPrev = Hash {getHash = "0013"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 26}})
+            , (Hash {getHash = "0015"},MockBlock {mockBlockId = Hash {getHash = "0015"}, mockBlockPrev = Hash {getHash = "0014"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 27}})
+            , (Hash {getHash = "0016"},MockBlock {mockBlockId = Hash {getHash = "0016"}, mockBlockPrev = Hash {getHash = "0015"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 28}})
+            , (Hash {getHash = "0017"},MockBlock {mockBlockId = Hash {getHash = "0017"}, mockBlockPrev = Hash {getHash = "0016"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 29}})
+            , (Hash {getHash = "0018"},MockBlock {mockBlockId = Hash {getHash = "0018"}, mockBlockPrev = Hash {getHash = "0017"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 30}})
+            , (Hash {getHash = "0019"},MockBlock {mockBlockId = Hash {getHash = "0019"}, mockBlockPrev = Hash {getHash = "0018"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 31}})
+            , (Hash {getHash = "001a"},MockBlock {mockBlockId = Hash {getHash = "001a"}, mockBlockPrev = Hash {getHash = "0019"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 32}})
+            , (Hash {getHash = "001b"},MockBlock {mockBlockId = Hash {getHash = "001b"}, mockBlockPrev = Hash {getHash = "001a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 33}})
+            , (Hash {getHash = "001c"},MockBlock {mockBlockId = Hash {getHash = "001c"}, mockBlockPrev = Hash {getHash = "001b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 34}})
+            , (Hash {getHash = "001d"},MockBlock {mockBlockId = Hash {getHash = "001d"}, mockBlockPrev = Hash {getHash = "001c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 35}})
+            , (Hash {getHash = "001e"},MockBlock {mockBlockId = Hash {getHash = "001e"}, mockBlockPrev = Hash {getHash = "001d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 36}})
+            , (Hash {getHash = "001f"},MockBlock {mockBlockId = Hash {getHash = "001f"}, mockBlockPrev = Hash {getHash = "001e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 37}})
+            , (Hash {getHash = "0020"},MockBlock {mockBlockId = Hash {getHash = "0020"}, mockBlockPrev = Hash {getHash = "001f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 39}})
+            , (Hash {getHash = "0021"},MockBlock {mockBlockId = Hash {getHash = "0021"}, mockBlockPrev = Hash {getHash = "0020"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 40}})
+            , (Hash {getHash = "0022"},MockBlock {mockBlockId = Hash {getHash = "0022"}, mockBlockPrev = Hash {getHash = "0021"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 41}})
+            , (Hash {getHash = "0023"},MockBlock {mockBlockId = Hash {getHash = "0023"}, mockBlockPrev = Hash {getHash = "0022"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 42}})
+            , (Hash {getHash = "0024"},MockBlock {mockBlockId = Hash {getHash = "0024"}, mockBlockPrev = Hash {getHash = "0023"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 43}})
+            , (Hash {getHash = "0025"},MockBlock {mockBlockId = Hash {getHash = "0025"}, mockBlockPrev = Hash {getHash = "0024"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 45}})
+            , (Hash {getHash = "0026"},MockBlock {mockBlockId = Hash {getHash = "0026"}, mockBlockPrev = Hash {getHash = "0025"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 47}})
+            , (Hash {getHash = "0027"},MockBlock {mockBlockId = Hash {getHash = "0027"}, mockBlockPrev = Hash {getHash = "0026"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 49}})
+            , (Hash {getHash = "0028"},MockBlock {mockBlockId = Hash {getHash = "0028"}, mockBlockPrev = Hash {getHash = "0027"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 50}})
+            , (Hash {getHash = "0029"},MockBlock {mockBlockId = Hash {getHash = "0029"}, mockBlockPrev = Hash {getHash = "0028"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 52}})
+            , (Hash {getHash = "002a"},MockBlock {mockBlockId = Hash {getHash = "002a"}, mockBlockPrev = Hash {getHash = "0029"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 53}})
+            , (Hash {getHash = "002b"},MockBlock {mockBlockId = Hash {getHash = "002b"}, mockBlockPrev = Hash {getHash = "002a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 55}})
+            , (Hash {getHash = "002c"},MockBlock {mockBlockId = Hash {getHash = "002c"}, mockBlockPrev = Hash {getHash = "002b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 56}})
+            , (Hash {getHash = "002d"},MockBlock {mockBlockId = Hash {getHash = "002d"}, mockBlockPrev = Hash {getHash = "002c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 57}})
+            , (Hash {getHash = "002e"},MockBlock {mockBlockId = Hash {getHash = "002e"}, mockBlockPrev = Hash {getHash = "002d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 59}})
+            , (Hash {getHash = "002f"},MockBlock {mockBlockId = Hash {getHash = "002f"}, mockBlockPrev = Hash {getHash = "002e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 60}})
+            , (Hash {getHash = "0030"},MockBlock {mockBlockId = Hash {getHash = "0030"}, mockBlockPrev = Hash {getHash = "002f"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 61}})
+            , (Hash {getHash = "0031"},MockBlock {mockBlockId = Hash {getHash = "0031"}, mockBlockPrev = Hash {getHash = "0030"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 63}})
+            , (Hash {getHash = "0032"},MockBlock {mockBlockId = Hash {getHash = "0032"}, mockBlockPrev = Hash {getHash = "0031"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 64}})
+            , (Hash {getHash = "0033"},MockBlock {mockBlockId = Hash {getHash = "0033"}, mockBlockPrev = Hash {getHash = "0032"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 65}})
+            , (Hash {getHash = "0034"},MockBlock {mockBlockId = Hash {getHash = "0034"}, mockBlockPrev = Hash {getHash = "0033"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 66}})
+            , (Hash {getHash = "0035"},MockBlock {mockBlockId = Hash {getHash = "0035"}, mockBlockPrev = Hash {getHash = "0034"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 70}})
+            , (Hash {getHash = "0036"},MockBlock {mockBlockId = Hash {getHash = "0036"}, mockBlockPrev = Hash {getHash = "0035"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 72}})
+            , (Hash {getHash = "0037"},MockBlock {mockBlockId = Hash {getHash = "0037"}, mockBlockPrev = Hash {getHash = "0036"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 73}})
+            , (Hash {getHash = "0038"},MockBlock {mockBlockId = Hash {getHash = "0038"}, mockBlockPrev = Hash {getHash = "0037"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 74}})
+            , (Hash {getHash = "0039"},MockBlock {mockBlockId = Hash {getHash = "0039"}, mockBlockPrev = Hash {getHash = "0038"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 75}})
+            , (Hash {getHash = "003a"},MockBlock {mockBlockId = Hash {getHash = "003a"}, mockBlockPrev = Hash {getHash = "0039"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 79}})
+            , (Hash {getHash = "003b"},MockBlock {mockBlockId = Hash {getHash = "003b"}, mockBlockPrev = Hash {getHash = "003a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 80}})
+            , (Hash {getHash = "003c"},MockBlock {mockBlockId = Hash {getHash = "003c"}, mockBlockPrev = Hash {getHash = "003b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 81}})
+            , (Hash {getHash = "003d"},MockBlock {mockBlockId = Hash {getHash = "003d"}, mockBlockPrev = Hash {getHash = "003c"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 83}})
+            , (Hash {getHash = "003e"},MockBlock {mockBlockId = Hash {getHash = "003e"}, mockBlockPrev = Hash {getHash = "003d"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 84}})
+            ]
+        , nodeChainIds =
+            [ Hash {getHash = "003e"}
+            , Hash {getHash = "003d"}
+            , Hash {getHash = "003c"}
+            , Hash {getHash = "003b"}
+            , Hash {getHash = "003a"}
+            , Hash {getHash = "0039"}
+            , Hash {getHash = "0038"}
+            , Hash {getHash = "0037"}
+            , Hash {getHash = "0036"}
+            , Hash {getHash = "0035"}
+            , Hash {getHash = "0034"}
+            , Hash {getHash = "0033"}
+            , Hash {getHash = "0032"}
+            , Hash {getHash = "0031"}
+            , Hash {getHash = "0030"}
+            , Hash {getHash = "002f"}
+            , Hash {getHash = "002e"}
+            , Hash {getHash = "002d"}
+            , Hash {getHash = "002c"}
+            , Hash {getHash = "002b"}
+            , Hash {getHash = "002a"}
+            , Hash {getHash = "0029"}
+            , Hash {getHash = "0028"}
+            , Hash {getHash = "0027"}
+            , Hash {getHash = "0026"}
+            , Hash {getHash = "0025"}
+            , Hash {getHash = "0024"}
+            , Hash {getHash = "0023"}
+            , Hash {getHash = "0022"}
+            , Hash {getHash = "0021"}
+            , Hash {getHash = "0020"}
+            , Hash {getHash = "001f"}
+            , Hash {getHash = "001e"}
+            , Hash {getHash = "001d"}
+            , Hash {getHash = "001c"}
+            , Hash {getHash = "001b"}
+            , Hash {getHash = "001a"}
+            , Hash {getHash = "0019"}
+            , Hash {getHash = "0018"}
+            , Hash {getHash = "0017"}
+            , Hash {getHash = "0016"}
+            , Hash {getHash = "0015"}
+            , Hash {getHash = "0014"}
+            , Hash {getHash = "0013"}
+            , Hash {getHash = "0012"}
+            , Hash {getHash = "0011"}
+            , Hash {getHash = "0010"}
+            , Hash {getHash = "000f"}
+            , Hash {getHash = "000e"}
+            , Hash {getHash = "000d"}
+            , Hash {getHash = "000c"}
+            , Hash {getHash = "000b"}
+            , Hash {getHash = "000a"}
+            , Hash {getHash = "0009"}
+            , Hash {getHash = "0008"}
+            , Hash {getHash = "0007"}
+            , Hash {getHash = "0006"}
+            , Hash {getHash = "0005"}
+            , Hash {getHash = "0004"}
+            , Hash {getHash = "0003"}
+            , Hash {getHash = "0002"}
+            , Hash {getHash = "0001"}
+            , Hash {getHash = "0000"}
+            ]
+        , nodeNextBlockId = 63
+        }
+    , operations = []
+    , mockNodeK = Quantity {getQuantity = 3}
+    , logs = []
+    }
+
+regression5 :: S
+regression5 = S
+    { node = N
+        { nodeDb = Map.fromList
+            [ (Hash {getHash = "0000"},MockBlock {mockBlockId = Hash {getHash = "0000"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}})
+            , (Hash {getHash = "0001"},MockBlock {mockBlockId = Hash {getHash = "0001"}, mockBlockPrev = Hash {getHash = "0000"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}})
+            , (Hash {getHash = "0002"},MockBlock {mockBlockId = Hash {getHash = "0002"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}})
+            , (Hash {getHash = "0003"},MockBlock {mockBlockId = Hash {getHash = "0003"}, mockBlockPrev = Hash {getHash = "genesis"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 0}})
+            , (Hash {getHash = "0004"},MockBlock {mockBlockId = Hash {getHash = "0004"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}})
+            , (Hash {getHash = "0005"},MockBlock {mockBlockId = Hash {getHash = "0005"}, mockBlockPrev = Hash {getHash = "0004"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}})
+            , (Hash {getHash = "0006"},MockBlock {mockBlockId = Hash {getHash = "0006"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}})
+            , (Hash {getHash = "0007"},MockBlock {mockBlockId = Hash {getHash = "0007"}, mockBlockPrev = Hash {getHash = "0005"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}})
+            , (Hash {getHash = "0008"},MockBlock {mockBlockId = Hash {getHash = "0008"}, mockBlockPrev = Hash {getHash = "0003"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 1}})
+            , (Hash {getHash = "0009"},MockBlock {mockBlockId = Hash {getHash = "0009"}, mockBlockPrev = Hash {getHash = "0008"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 2}})
+            , (Hash {getHash = "000a"},MockBlock {mockBlockId = Hash {getHash = "000a"}, mockBlockPrev = Hash {getHash = "0009"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 3}})
+            , (Hash {getHash = "000b"},MockBlock {mockBlockId = Hash {getHash = "000b"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}})
+            , (Hash {getHash = "000c"},MockBlock {mockBlockId = Hash {getHash = "000c"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}})
+            ]
+        , nodeChainIds =
+            [ Hash {getHash = "000c"}
+            , Hash {getHash = "000b"}
+            , Hash {getHash = "000a"}
+            , Hash {getHash = "0009"}
+            , Hash {getHash = "0008"}
+            , Hash {getHash = "0003"}
+            ]
+        ,  nodeNextBlockId = 13
+        }
+    ,  mockNodeK = Quantity {getQuantity = 4}
+    , logs = []
+    , operations =
+        [[NodeRewind 1]
+        , [NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000d"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]}]
+        , [NodeRewind 1]
+        , [NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000e"}, mockBlockPrev = Hash {getHash = "000b"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 5}}]}]
+        , [NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "000f"}, mockBlockPrev = Hash {getHash = "000e"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 6}}]}]
+        , [NodeRewind 3,NodeAddBlocks {getAddBlocks = [MockBlock {mockBlockId = Hash {getHash = "0010"}, mockBlockPrev = Hash {getHash = "000a"}, mockBlockSlot = SlotId {epochNumber = 0, slotNumber = 4}}]}]
+        ]
+    }

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -141,7 +141,8 @@ prop_sync s0 = monadicIO $ do
     let nodeChain = drop 1 (getNodeChain (node s))
 
     monitor $ counterexample $ unlines
-        [ "Applied blocks:  " <> showChain (consumerApplied consumer)
+        [ "Initial chain:   " <> showChain (getNodeChain $ node s0)
+        , "Applied blocks:  " <> showChain (consumerApplied consumer)
         , "Node chain:      " <> showChain nodeChain
         , "k =              " <> show (mockNodeK s0)
         , "Logs:          \n" <> unlines (reverse (logs s))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have renamed `prevBlockHeader` to `parentHeaderHash`
- [x] I have added a `headerHash :: Hash "BlockHeader"` field to `BlockHeader`
- [x] I have adjusted Jörmungandr's binary to yield header hashes when unserializing`BlockHeader` 
- [x] `http-bridge` just returns `Hash "http-bridge"` for all header hahes..
- [x] I have simplified the API of the `BlockHeaders` module since now height and header hash are now both contained inside the `BlockHeader`
- [x] I have allowed `greatestCommonBlock` to work with sparse sequences of block headers
- [x] I have removed the `Recover` constructor, and instead, had the network layer rolling back to genesis as a recovery measure.


# Comments

<!-- Additional comments or screenshots to attach if any -->

Again, 2M+ tests run overall:

```
    Syncs with mock node
      +++ OK, passed 1000000 tests:
      56.0361% advanced more than k blocks
      41.1078% started with more than k blocks
      10.5704% switched to a shorter chain
       7.1504% switched to a longer chain
       6.9323% rewinded without switch
       2.1244% recovered from genesis
       0.8800% rolled back full k
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
