### PR TITLE
db bench: Add disk space usage measurements for UTxO

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -247,6 +247,7 @@ benchmark db
     , cryptonite
     , deepseq
     , directory
+    , filepath
     , fmt
     , iohk-monitoring
     , memory

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Wallet.DummyTarget.Primitive.Types
@@ -45,10 +46,16 @@ import Cardano.Wallet.Primitive.Types
     )
 import Control.DeepSeq
     ( NFData )
+import Crypto.Hash
+    ( hash )
+import Crypto.Hash.Algorithms
+    ( Blake2b_256 )
 import Data.Bifunctor
     ( bimap )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
@@ -63,6 +70,7 @@ import GHC.Generics
 import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text.Encoding as T
@@ -108,7 +116,11 @@ deriving instance Eq (SeqState DummyTarget)
 
 instance DefineTx DummyTarget where
     type Tx DummyTarget = Tx
-    txId = Hash . B8.pack . show
+    txId = Hash . blake2b256 . B8.pack . show
+      where
+        blake2b256 :: ByteString -> ByteString
+        blake2b256 =
+            BA.convert . hash @_ @Blake2b_256
     inputs = inputs
     outputs = outputs
 

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -133,6 +133,7 @@
             (hsPkgs.cryptonite)
             (hsPkgs.deepseq)
             (hsPkgs.directory)
+            (hsPkgs.filepath)
             (hsPkgs.fmt)
             (hsPkgs.iohk-monitoring)
             (hsPkgs.memory)


### PR DESCRIPTION
Relates to #643 and #769.

# Overview

Adds a benchmark of DB disk usage for wallet UTxO to give us an indication of what size DBs to expect.

[Buildkite nightly](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/236)
