### PR TITLE
Buildkite: use new paths for cache and scratch

### DIFF
--- a/.buildkite/bench-db.sh
+++ b/.buildkite/bench-db.sh
@@ -12,6 +12,11 @@ nix-build -A benchmarks.cardano-wallet-core.db -o $bench_name
 
 echo "+++ Run benchmark"
 
+if [ -n "${SCRATCH_DIR:-}" ]; then
+  mkdir -p "$SCRATCH_DIR"
+  export TMPDIR="$SCRATCH_DIR"
+fi
+
 ./$bench_name/cardano-wallet-core*/db --json $bench_name.json -o $bench_name.html | tee $bench_name.txt
 
 printf 'Link to \033]1339;url=artifact://'$bench_name.html';content='"Benchmark Report"'\a\n'

--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -10,10 +10,17 @@ results=restore-$target-$NETWORK.txt
 total_time=restore-time.txt
 
 echo "--- Build"
+
 nix-build -A benchmarks.cardano-wallet-$target.restore -o bench-$target-restore
 bench=./bench-$target-restore/bin/restore
 
 echo "--- Run benchmarks - $target - $NETWORK"
+
+if [ -n "${SCRATCH_DIR:-}" ]; then
+  mkdir -p "$SCRATCH_DIR"
+  export HOME="$SCRATCH_DIR"
+fi
+
 command time -o $total_time -v $bench "$NETWORK" +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS 2>&1 | tee $log
 
 grep -v INFO $log | awk '/All results/,EOF { print $0 }' > $results

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -1,43 +1,47 @@
 env:
   NIX_PATH: "channel:nixos-19.03"
+  BUILD_DIR: "/build/cardano-wallet"
+  STACK_ROOT: "/build/cardano-wallet.stack"
+  CACHE_DIR: "/cache/cardano-wallet"
+  SCRATCH_DIR: "/scratch/cardano-wallet"
+
 steps:
   - label: 'Restore benchmark - testnet'
     command: "./.buildkite/bench-restore.sh"
+    env:
+      HOME: "/cache/cardano-wallet"
+      NETWORK: testnet
     timeout_in_minutes: 60
     agents:
       system: x86_64-linux
-    env:
-      NETWORK: testnet
+
   - label: 'Restore benchmark - mainnet'
     command: "./.buildkite/bench-restore.sh"
+    env:
+      HOME: "/cache/cardano-wallet"
+      NETWORK: mainnet
     timeout_in_minutes: 120
     agents:
       system: x86_64-linux
-    env:
-      NETWORK: mainnet
 
   - label: 'Database benchmark'
-    command: "TMPDIR=/scratch ./.buildkite/bench-db.sh"
+    command: "./.buildkite/bench-db.sh"
     timeout_in_minutes: 120
     agents:
       system: x86_64-linux
 
   - label: 'Clean up CI cache'
-    env:
-      STACK_ROOT: "/build/cardano-wallet.stack"
     command:
       - "nix-build .buildkite/default.nix -o sr"
-      - "./sr/bin/rebuild cleanup-cache --build-dir=/build/cardano-wallet --cache-dir=/build/cardano-wallet.cache"
+      - "./sr/bin/rebuild cleanup-cache --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
     agents:
       system: x86_64-linux
 
   - block: 'Delete CI Caches'
   - label: 'Purge CI cache'
-    env:
-      STACK_ROOT: "/build/cardano-wallet.stack"
     command:
       - "nix-build .buildkite/default.nix -o sr"
-      - "./sr/bin/rebuild purge-cache --build-dir=/build/cardano-wallet --cache-dir=/build/cardano-wallet.cache"
+      - "./sr/bin/rebuild purge-cache --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
     agents:
       system: x86_64-linux
   - wait

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,13 @@
+env:
+  BUILD_DIR: "/build/cardano-wallet"
+  STACK_ROOT: "/build/cardano-wallet.stack"
+  CACHE_DIR: "/cache/cardano-wallet"
+
 steps:
   - label: 'Stack Rebuild'
-    env:
-      STACK_ROOT: "/build/cardano-wallet.stack"
     command:
       - "nix-build .buildkite/default.nix -o sr"
-      - "./sr/bin/rebuild --build-dir /build/cardano-wallet --cache-dir /build/cardano-wallet.cache"
+      - "./sr/bin/rebuild --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
     timeout_in_minutes: 120
     artifact_paths:
       - "/build/cardano-wallet/.stack-work/logs/cardano-wallet*.log"

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -430,7 +430,8 @@ cleanupCacheStep dryRun cacheConfig buildDir = do
     echo "--- Cleaning up CI cache"
     case cacheConfig of
         Right CICacheConfig{..} -> do
-            getBranches >>= cleanupCache dryRun ccCacheDir
+            whenM (testdir ccCacheDir) $
+                getBranches >>= cleanupCache dryRun ccCacheDir
             -- Remove the stack root left by the previous build.
             removeDirectory dryRun ccStackRoot
             -- Remove the build directory left by the previous build.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/input-output-hk/cardano-wallet/releases"><img src="https://img.shields.io/github/release-pre/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet"><img src="https://img.shields.io/buildkite/7ea3dac7a16f066d8dfc8f426a9a9f7a2131e899cd96c444cf/master?label=BUILD&style=for-the-badge"/></a>
-  <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143.svg?label=BENCHMARK&style=for-the-badge" /></a>
+  <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge" /></a>
   <a href="https://travis-ci.org/input-output-hk/cardano-wallet"><img src="https://img.shields.io/travis/input-output-hk/cardano-wallet.svg?label=DOCS&style=for-the-badge" /></a>
   <a href="https://coveralls.io/github/input-output-hk/cardano-wallet?branch=HEAD"><img src="https://img.shields.io/coveralls/github/input-output-hk/cardano-wallet/HEAD?style=for-the-badge" /></a>
 </p>


### PR DESCRIPTION
# Overview

Changes the Buildkite pipelines to use the `/cache` directory, which should result in more cache sharing between buildkite agents (faster builds), and allow devops to more easily manage state left behind by wallet builds.

[Buildkite](https://buildkite.com/input-output-hk/cardano-wallet/builds?branch=rvl%2Fbuildkite-paths)
[Buildkite nightly](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=rvl%2Fbuildkite-paths)

# Comments

After this is merged, the following directories can be cleaned up on the buildkite agents:
- `/build/cardano-wallet.cache`
- `/var/lib/buildkite-agent/.hermes`
