### PR TITLE
Calculate restore-progress via blockNo instead of slotNo

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -188,8 +188,8 @@ import Cardano.Wallet.Primitive.Types
     , log10
     , slotDifference
     , slotRangeFromTimeRange
-    , slotRatio
     , slotStartTime
+    , syncProgress
     , wholeRange
     )
 import Cardano.Wallet.Transaction
@@ -590,7 +590,7 @@ restoreBlocks ctx wid blocks nodeTip = do
     calculateMetadata bp h meta = do
         -- NOTE: Safe because current time is after start time.
         (Just now) <- liftIO $ W.slotAt sp <$> getCurrentTime
-        let p = slotRatio (bp ^. #getEpochLength) h now
+        let p = syncProgress (bp ^. #getEpochLength) h now
         pure (meta { status = newStatus p } :: WalletMetadata)
       where
         newStatus p =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -80,7 +80,7 @@ module Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , EpochLength (..)
     , StartTime (..)
-    , slotRatio
+    , syncProgress
     , flatSlot
     , fromFlatSlot
     , slotStartTime
@@ -1033,7 +1033,7 @@ data SlotParameters = SlotParameters
 -- it assumes that every next slot will be a block. But, as we ingest blocks,
 -- `h` becomes bigger and `X` becomes smaller making the progress estimation
 -- better and better. At some point, `X` is null, and we have `p = h / h`
-slotRatio
+syncProgress
     :: EpochLength
         -- ^ Known epoch length
     -> BlockHeader
@@ -1041,7 +1041,7 @@ slotRatio
     -> SlotId
         -- ^ Last slot that could have been produced
     -> Quantity "percent" Percentage
-slotRatio epochLength tip slotNow =
+syncProgress epochLength tip slotNow =
     let
         bhTip = fromIntegral . getQuantity $ blockHeight tip
         n0 = flatSlot epochLength (tip ^. #slotId)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -76,9 +76,9 @@ import Cardano.Wallet.Primitive.Types
     , slotMinBound
     , slotPred
     , slotRangeFromTimeRange
-    , slotRatio
     , slotStartTime
     , slotSucc
+    , syncProgress
     , walletNameMaxLength
     , walletNameMinLength
     , wholeRange
@@ -185,9 +185,9 @@ spec = do
 
     let slotsPerEpoch = EpochLength 21600
 
-    describe "slotRatio" $ do
+    describe "syncProgress" $ do
         it "works for any two slots" $ property $ \sl0 sl1 ->
-            slotRatio slotsPerEpoch sl0 sl1 `deepseq` ()
+            syncProgress slotsPerEpoch sl0 sl1 `deepseq` ()
     describe "flatSlot" $ do
         it "flatSlot . fromFlatSlot == id" $ property $ \sl ->
             fromFlatSlot slotsPerEpoch (flatSlot slotsPerEpoch sl) === sl


### PR DESCRIPTION
Large portions of slots may be empty. On the current jörmungandr testnet
the slot-based progress starts at around 96% and goes to 100% when restoring a wallet.

This commit uses blockNo instead, which perfectly matches the amount of
work the wallet has to do. This way progress starts at 0% and increases to 100% at a stable speed.

# Issue Number

None.


# Overview

- [x] I changed the progress to be calculated using blocks instead of blocks.


# Comments
- other version in `anviking/alternative-progress`

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
