### PR TITLE
Make Jörmungandr NetworkLayer use raw blocks

### DIFF
--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -60,18 +60,12 @@ import Cardano.Wallet.Jormungandr
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, localhostBaseUrl )
 import Cardano.Wallet.Jormungandr.Environment
-    ( KnownNetwork (..), Network (..) )
+    ( Network (..) )
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..)
     , JormungandrConfig (..)
     , JormungandrConnParams (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
@@ -232,9 +226,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         <*> verbosityOption
         <*> genesisHashOption
     exec
-        :: forall t k n s. (n ~ 'Testnet, t ~ Jormungandr n, s ~ SeqState t, k ~ SeqKey)
-        => (KeyToAddress t k, KnownNetwork n)
-        => ServeArgs
+        :: ServeArgs
         -> IO ()
     exec (ServeArgs listen nodePort databaseDir verbosity block0H) = do
         (cfg, sb, tr) <- initTracer (verbosityToMinSeverity verbosity) "serve"


### PR DESCRIPTION
# Issue Number

#711 

# Overview
- [x] Change `withNetworkLayer`, `withNetworkLayerLaunch`, `withNetworkLayerConn` to use raw jörmungandr blocks instead of blocks suitable for the wallet layer.


# Comments

- Split off from #788 

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
