### PR TITLE
Provide `KeyToAddress` instance for `(Jormungandr n) RndKey` type.

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -127,6 +127,9 @@ instance KeyToAddress (Jormungandr n) RndKey where
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getRawKey k)
             [ CBOR.encodeDerivationPathAttr pwd acctIx addrIx ]
+            -- Note that we do NOT include a protocol magic attribute here,
+            -- as we do not discriminate between Testnet and Mainnet: we'll
+            -- be using Byron Mainnet addresses on Jormungndr Testnet.
       where
         (acctIx, addrIx) = derivationPath k
         pwd = payloadPassphrase k


### PR DESCRIPTION
# Issue Number

#808 

# Overview

This PR provides a missing `KeyToAddress` instance for the `(Jormungandr n) RndKey` type.

It's identical to the instance provided within `cardano-http-bridge`, namely for the `(HttpBridge 'Mainnet) RndKey` type.