### PR TITLE
Fork API server context into random and sequential variants.

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -268,7 +268,14 @@ findDatabases tr dir = do
 -- should be closed with 'destroyDBLayer'. If you use 'withDBLayer' then both of
 -- these things will be handled for you.
 newDBLayer
-    :: forall s t k. (IsOurs s, NFData s, Show s, PersistState s, PersistTx t, PersistKey k)
+    :: forall s t k.
+        ( IsOurs s
+        , NFData s
+        , Show s
+        , PersistState s
+        , PersistTx t
+        , PersistKey k
+        )
     => CM.Configuration
        -- ^ Logging configuration
     -> Trace IO Text
@@ -576,7 +583,8 @@ mkTxHistory wid txs = flatTxHistory
     ]
   where
     -- | Make flat lists of entities from the result of 'mkTxHistory'.
-    flatTxHistory :: [(TxMeta, ([TxIn], [TxOut]))] -> ([TxMeta], [TxIn], [TxOut])
+    flatTxHistory
+        :: [(TxMeta, ([TxIn], [TxOut]))] -> ([TxMeta], [TxIn], [TxOut])
     flatTxHistory entities =
         ( map fst entities
         , concatMap (fst . snd) entities
@@ -868,11 +876,15 @@ instance W.KeyToAddress t Seq.SeqKey => PersistState (Seq.SeqState t) where
                 (uncurry (==))
         let eGap = Seq.gap extPool
         let iGap = Seq.gap intPool
-        repsert (SeqStateKey wid) (SeqState wid eGap iGap (AddressPoolXPub xpub))
+        repsert
+            (SeqStateKey wid)
+            (SeqState wid eGap iGap (AddressPoolXPub xpub))
         insertAddressPool wid sl intPool
         insertAddressPool wid sl extPool
         deleteWhere [SeqStatePendingWalletId ==. wid]
-        dbChunked insertMany_ (mkSeqStatePendingIxs wid $ Seq.pendingChangeIxs st)
+        dbChunked
+            insertMany_
+            (mkSeqStatePendingIxs wid $ Seq.pendingChangeIxs st)
 
     selectState (wid, sl) = runMaybeT $ do
         st <- MaybeT $ selectFirst [SeqStateWalletId ==. wid] []

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -240,7 +240,8 @@ mkDBFactory cfg tr mDatabaseDir = case mDatabaseDir of
   where
     tracerDB = appendName "database" tr
 
--- | Lookup file-system for existing wallet databases
+-- | Return all wallet databases that match the specified key type within the
+--   specified directory.
 findDatabases
     :: forall k. PersistKey k
     => Trace IO Text

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -395,6 +395,10 @@ class WalletKey (key :: Depth -> * -> *) where
         => key depth XPub
         -> Digest a
 
+    -- | Get a short, human-readable string descriptor that uniquely identifies
+    --   the specified key type.
+    keyTypeDescriptor :: Proxy key -> String
+
     -- | Unwrap the 'WalletKey' to use the 'XPrv' or 'XPub'.
     getRawKey
         :: key depth raw

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Random.hs
@@ -126,6 +126,7 @@ instance WalletKey RndKey where
     digest = hash . unXPub . getKey
     getRawKey = getKey
     dummyKey = dummyKeyRnd
+    keyTypeDescriptor _ = "rnd"
 
 {-------------------------------------------------------------------------------
                                  Key generation

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Sequential.hs
@@ -116,6 +116,7 @@ instance WalletKey SeqKey where
     digest = digestSeq
     getRawKey = getKey
     dummyKey = dummyKeySeq
+    keyTypeDescriptor _ = "seq"
 
 -- | Marker for the change chain. In practice, change of a transaction goes onto
 -- the addresses generated on the internal chain, whereas the external chain is

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -395,8 +395,7 @@ data WalletLayerFixture = WalletLayerFixture
     }
 
 setupFixture
-    :: forall ctx. (ctx ~ WalletLayer DummyState DummyTarget SeqKey)
-    => (WalletId, WalletName, DummyState)
+    :: (WalletId, WalletName, DummyState)
     -> IO WalletLayerFixture
 setupFixture (wid, wname, wstate) = do
     let nl = error "NetworkLayer"

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge.hs
@@ -158,7 +158,7 @@ serveWallet (cfg, sb, tr) databaseDir listen bridge mAction = do
     newApiLayer nl = do
         let g0 = staticBlockchainParameters nl
         let tl = HttpBridge.newTransactionLayer @n
-        wallets <- maybe (pure []) (Sqlite.findDatabases tr) databaseDir
+        wallets <- maybe (pure []) (Sqlite.findDatabases @k tr) databaseDir
         Server.newApiLayer tr g0 nl tl dbFactory wallets
 
     dbFactory

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -170,7 +170,7 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
     apiLayer tracer nl = do
         let (block0, bp) = staticBlockchainParameters nl
         let tl = newTransactionLayer @n (getGenesisBlockHash bp)
-        wallets <- maybe (pure []) (Sqlite.findDatabases tr) databaseDir
+        wallets <- maybe (pure []) (Sqlite.findDatabases @k tr) databaseDir
         Server.newApiLayer tracer (block0, bp) nl tl dbFactory wallets
 
     dbFactory

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -127,6 +127,9 @@ instance KeyToAddress (Jormungandr n) RndKey where
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getRawKey k)
             [ CBOR.encodeDerivationPathAttr pwd acctIx addrIx ]
+            -- Note that we do NOT include a protocol magic attribute here,
+            -- as we do not discriminate between Testnet and Mainnet: we'll
+            -- be using Byron Mainnet addresses on Jormungndr Testnet.
       where
         (acctIx, addrIx) = derivationPath k
         pwd = payloadPassphrase k

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: Apache-2.0

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: Apache-2.0

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -46,6 +46,8 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     , NextBlocksResult (..)
     )
+import Cardano.Wallet.Primitive.AddressDerivation.Sequential
+    ( SeqKey )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (..)
@@ -310,7 +312,7 @@ spec = do
             runExceptT (postTx nw tx) `shouldThrow` anyException
 
     describe "Decode External Tx" $ do
-        let tl = newTransactionLayer @'Testnet (Hash "genesis")
+        let tl = newTransactionLayer @'Testnet @SeqKey (Hash "genesis")
 
         it "decodeExternalTx works ok with properly constructed binary blob" $ do
             property $ \(SignedTx signedTx) -> monadicIO $ liftIO $ do

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -301,7 +301,7 @@ unknownInputTest _ block0 = it title $ do
     let addr = keyToAddress @(Jormungandr n) $ publicKey $ xprv "address-number-0"
     let res = mkStdTx tl keyFrom inps outs
           where
-            tl = newTransactionLayer @n block0
+            tl = newTransactionLayer @n @SeqKey block0
             keyFrom = const Nothing
             inps =
                 [ ( TxIn (Hash "arbitrary") 0
@@ -324,7 +324,7 @@ tooNumerousInpsTest _ block0 = it title $ do
     let addr = keyToAddress @(Jormungandr n) $ publicKey $ xprv "address-number-0"
     let res = validateSelection tl (CoinSelection inps outs chngs)
           where
-            tl = newTransactionLayer @n block0
+            tl = newTransactionLayer @n @SeqKey block0
             inps = replicate 256
                 ( TxIn (Hash "arbitrary") 0
                 , TxOut addr (Coin 1)
@@ -346,7 +346,7 @@ tooNumerousOutsTest _ block0 = it title $ do
     let addr = keyToAddress @(Jormungandr n) $ publicKey $ xprv "address-number-0"
     let res = validateSelection tl (CoinSelection inps outs chngs)
           where
-            tl = newTransactionLayer @n block0
+            tl = newTransactionLayer @n @SeqKey block0
             inps = replicate 255
                 ( TxIn (Hash "arbitrary") 0
                 , TxOut addr (Coin 10)


### PR DESCRIPTION
# Issue Number

#808 

# Overview

This PR forks the API server context into two variants:

1. a _**random**_ context that corresponds to _**Byron**_ wallets. 
2. a _**sequential**_ context that corresponds to _**Shelley**_ wallets.

# Remaining Work

- [x] Discriminate between _**random**_ and _**sequential**_ wallets at the file-system level.