### PR TITLE
Enable rollbacks in wallet layer

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -516,11 +516,10 @@ restoreWallet
     -> WalletId
     -> ExceptT ErrNoSuchWallet IO ()
 restoreWallet ctx wid = do
-    cp <- readWalletCheckpoint @ctx @s @t @k ctx wid
-    let startTip = currentTip cp
+    cps <- liftIO $ DB.listCheckpoints db (PrimaryKey wid)
     let forward = restoreBlocks @ctx @s @t @k ctx wid
     let backward = DB.rollbackTo db (PrimaryKey wid)
-    liftIO $ follow nw tr startTip forward backward (view #header)
+    liftIO $ follow nw tr cps forward backward (view #header)
   where
     db = ctx ^. dbLayer @s @t @k
     nw = ctx ^. networkLayer @t

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -518,9 +518,11 @@ restoreWallet
 restoreWallet ctx wid = do
     cp <- readWalletCheckpoint @ctx @s @t @k ctx wid
     let startTip = currentTip cp
-    let advance = restoreBlocks @ctx @s @t @k ctx wid
-    liftIO $ follow nw tr startTip advance (view #header)
+    let forward = restoreBlocks @ctx @s @t @k ctx wid
+    let backward = DB.rollbackTo db (PrimaryKey wid)
+    liftIO $ follow nw tr startTip forward backward (view #header)
   where
+    db = ctx ^. dbLayer @s @t @k
     nw = ctx ^. networkLayer @t
     tr = ctx ^. logger
 

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -28,6 +28,7 @@ import Cardano.Wallet.DB.Model
     , ModelOp
     , emptyDatabase
     , mCreateWallet
+    , mListCheckpoints
     , mListWallets
     , mPutCheckpoint
     , mPutPrivateKey
@@ -83,6 +84,8 @@ newDBLayer = do
             cp `deepseq` alterDB errNoSuchWallet db (mPutCheckpoint pk cp)
 
         , readCheckpoint = readDB db . mReadCheckpoint
+
+        , listCheckpoints = readDB db . mListCheckpoints
 
         , rollbackTo = \pk pt -> ExceptT $
             alterDB errNoSuchWallet  db (mRollbackTo pk pt)

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.DB.Model
     , mListWallets
     , mPutCheckpoint
     , mReadCheckpoint
+    , mListCheckpoints
     , mRollbackTo
     , mPutWalletMeta
     , mReadWalletMeta
@@ -192,6 +193,13 @@ mReadCheckpoint wid db@(Database wallets _) =
   where
     mostRecentCheckpoint :: WalletDatabase s t xprv -> Maybe (Wallet s t)
     mostRecentCheckpoint = fmap snd . Map.lookupMax . checkpoints
+
+mListCheckpoints
+    :: Ord wid => wid -> ModelOp wid s t xprv [BlockHeader]
+mListCheckpoints wid db@(Database wallets _) =
+    (Right $ sort $ maybe [] tips (Map.lookup wid wallets), db)
+  where
+    tips = map currentTip . Map.elems . checkpoints
 
 mRollbackTo :: Ord wid => wid -> SlotId -> ModelOp wid s t xprv ()
 mRollbackTo wid point db@(Database wallets txs) = case Map.lookup wid wallets of

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -91,9 +91,7 @@ import Control.Concurrent.MVar
 import Control.DeepSeq
     ( NFData )
 import Control.Exception
-    ( Exception, throwIO )
-import Control.Exception
-    ( bracket )
+    ( Exception, bracket, throwIO )
 import Control.Monad
     ( forM, mapM_, void, when )
 import Control.Monad.Catch

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -130,7 +130,7 @@ Checkpoint
     checkpointSlot           W.SlotId     sql=slot
     checkpointHeaderHash     BlockId      sql=header_hash
     checkpointParentHash     BlockId      sql=parent_header_hash
-    checkpointBlockHeight    Word64       sql=block_height
+    checkpointBlockHeight    Word32       sql=block_height
     checkpointGenesisHash    BlockId      sql=genesis_hash
     checkpointGenesisStart   UTCTime      sql=genesis_start
     checkpointFeePolicy      W.FeePolicy  sql=fee_policy

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -215,8 +215,8 @@ follow
     -- ^ The @NetworkLayer@ used to poll for new blocks.
     -> Trace IO Text
     -- ^ Logger trace
-    -> BlockHeader
-    -- ^ The local tip to start at. Blocks /after/ the tip will be yielded.
+    -> [BlockHeader]
+    -- ^ A list of known tips to start from. Blocks /after/ the tip will be yielded.
     -> (NE.NonEmpty block -> BlockHeader -> ExceptT e0 IO ())
     -- ^ Callback with blocks and the current tip of the /node/.
     -- @follow@ stops polling and terminates if the callback errors.
@@ -226,8 +226,8 @@ follow
     -> (block -> BlockHeader)
     -- ^ Getter on the abstract 'block' type
     -> IO ()
-follow nl tr start yield rollback header =
-    sleep 0 (initCursor nl [start])
+follow nl tr cps yield rollback header =
+    sleep 0 (initCursor nl cps)
   where
     delay0 :: Int
     delay0 = 1000*1000 -- 1 second

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -175,7 +175,8 @@ newtype MockChain = MockChain
     deriving stock (Eq, Show)
 
 -- | Generate arbitrary checkpoints, but that always have their tip at 0 0.
-newtype InitialCheckpoint s = InitialCheckpoint (Wallet s DummyTarget)
+newtype InitialCheckpoint s =
+    InitialCheckpoint { getInitialCheckpoint :: Wallet s DummyTarget }
     deriving newtype (Show, Eq, Buildable, NFData)
 
 instance (Arbitrary k, Ord k, Arbitrary v) => Arbitrary (KeyValPairs k v) where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -750,7 +750,7 @@ prop_sparseCheckpointNoOlderThanK (GenSparseCheckpointsArgs (k, h)) = prop
     prop = property $ flip all cps $ \cp ->
         cp == 0 || (age cp - 100 <= int k)
 
-    age :: Word64 -> Int
+    age :: Word32 -> Int
     age cp = int h - int cp
 
 int :: Integral a => a -> Int

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -66,6 +66,7 @@ import Cardano.Wallet.DB.Model
     , emptyDatabase
     , mCleanDB
     , mCreateWallet
+    , mListCheckpoints
     , mListWallets
     , mPutCheckpoint
     , mPutPrivateKey
@@ -85,7 +86,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..)
+    ( BlockHeader
+    , Hash (..)
     , Range (..)
     , SlotId (..)
     , SortOrder (..)
@@ -235,6 +237,7 @@ data Cmd s wid
     | ListWallets
     | PutCheckpoint wid (MWallet s)
     | ReadCheckpoint wid
+    | ListCheckpoints wid
     | PutWalletMeta wid WalletMetadata
     | ReadWalletMeta wid
     | PutTxHistory wid (TxHistory DummyTarget)
@@ -252,6 +255,7 @@ data Success s wid
     | Metadata (Maybe WalletMetadata)
     | TxHistory (TxHistory DummyTarget)
     | PrivateKey (Maybe MPrivKey)
+    | BlockHeaders [BlockHeader]
     deriving (Show, Eq, Functor, Foldable, Traversable)
 
 newtype Resp s wid
@@ -284,6 +288,8 @@ runMock = \case
         first (Resp . fmap WalletIds) . mListWallets
     PutCheckpoint wid wal ->
         first (Resp . fmap Unit) . mPutCheckpoint wid wal
+    ListCheckpoints wid ->
+        first (Resp . fmap BlockHeaders) . mListCheckpoints wid
     ReadCheckpoint wid ->
         first (Resp . fmap Checkpoint) . mReadCheckpoint wid
     PutWalletMeta wid meta ->
@@ -335,6 +341,8 @@ runIO db = fmap Resp . go
             catchNoSuchWallet Unit $ putCheckpoint db (PrimaryKey wid) wal
         ReadCheckpoint wid ->
             Right . Checkpoint <$> readCheckpoint db (PrimaryKey wid)
+        ListCheckpoints wid ->
+            Right . BlockHeaders <$> listCheckpoints db (PrimaryKey wid)
         PutWalletMeta wid meta ->
             catchNoSuchWallet Unit $ putWalletMeta db (PrimaryKey wid) meta
         ReadWalletMeta wid ->
@@ -468,6 +476,7 @@ generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
         , (5, pure ListWallets)
         , (5, PutCheckpoint <$> genId' <*> arbitrary)
         , (5, ReadCheckpoint <$> genId')
+        , (5, ListCheckpoints <$> genId')
         , (5, PutWalletMeta <$> genId' <*> arbitrary)
         , (5, ReadWalletMeta <$> genId')
         , (5, PutTxHistory <$> genId' <*> fmap unGenTxHistory arbitrary)
@@ -573,6 +582,7 @@ instance CommandNames (At (Cmd s)) where
     cmdName (At RemoveWallet{}) = "RemoveWallet"
     cmdName (At ListWallets{}) = "ListWallets"
     cmdName (At PutCheckpoint{}) = "PutCheckpoint"
+    cmdName (At ListCheckpoints{}) = "ListCheckpoints"
     cmdName (At ReadCheckpoint{}) = "ReadCheckpoint"
     cmdName (At PutWalletMeta{}) = "PutWalletMeta"
     cmdName (At ReadWalletMeta{}) = "ReadWalletMeta"
@@ -582,10 +592,12 @@ instance CommandNames (At (Cmd s)) where
     cmdName (At ReadPrivateKey{}) = "ReadPrivateKey"
     cmdName (At RollbackTo{}) = "RollbackTo"
     cmdNames _ =
-        [ "CleanDB", "CreateWallet", "CreateWallet", "RemoveWallet"
-        , "ListWallets", "PutCheckpoint", "ReadCheckpoint", "PutWalletMeta"
-        , "ReadWalletMeta", "PutTxHistory", "ReadTxHistory", "PutPrivateKey"
-        , "ReadPrivateKey", "RollbackTo"
+        [ "CleanDB"
+        , "CreateWallet", "RemoveWallet", "ListWallets"
+        , "PutCheckpoint", "ReadCheckpoint", "ListCheckpoints", "RollbackTo"
+        , "PutWalletMeta", "ReadWalletMeta"
+        , "PutTxHistory", "ReadTxHistory"
+        , "PutPrivateKey", "ReadPrivateKey"
         ]
 
 instance Functor f => Rank2.Functor (At f) where


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#650 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added an extra callback to the restoration worker to rollback on ... rollbacks.
- [x] Made sure we don't purge the very first checkpoint we create in the wallet. We might roll back up to the genesis block, so this checkpoint is needed (and currently discarded after `k` blocks)
- [x] Added a `listCheckpoints` function to the database layer to return a full list of block headers to use to find an initial intersection. The `greatestCommonBlockHeader` now works fine with sparse lists so no work to do in this area :tada:
- [x] Extended the state-machine to also yield `listCheckpoints` calls


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
