### PR TITLE
cli: Assume utf-8 output encoding

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -168,6 +168,8 @@ import Fmt
     ( Buildable, pretty )
 import GHC.Generics
     ( Generic )
+import GHC.IO.Encoding
+    ( setLocaleEncoding )
 import GHC.TypeLits
     ( Symbol )
 import Network.HTTP.Client
@@ -1121,6 +1123,7 @@ initTracer minSeverity cmd = do
 -- prints UTF-8 characters regardless of the @LANG@ environment variable.
 setUtf8Encoding :: IO ()
 setUtf8Encoding = do
+    setLocaleEncoding utf8
     hSetEncoding stdout utf8
     hSetEncoding stderr utf8
 

--- a/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
+++ b/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
@@ -45,6 +45,7 @@ import Cardano.CLI
     , nodePortOption
     , optionT
     , runCli
+    , setUtf8Encoding
     , setupDirectory
     , stateDirOption
     , verbosityOption
@@ -104,6 +105,7 @@ import qualified Data.Text as T
 
 main :: forall (n :: Network). IO ()
 main = do
+    setUtf8Encoding
     dataDir <- getDataDir "http-bridge"
     runCli $ cli $ mempty
         <> cmdLaunch dataDir

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -20,7 +20,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.CLI
-    ( Port (..), initTracer )
+    ( Port (..), initTracer, setUtf8Encoding )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -114,6 +114,7 @@ instance KnownCommand (HttpBridge n) where
 
 main :: forall t. (t ~ HttpBridge 'Testnet) => IO ()
 main = do
+    setUtf8Encoding
     hspec $ do
         describe "Server CLI timeout test" (ServerCLI.specNoBackend @t)
         describe "Cardano.WalletSpec" Wallet.spec

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -45,6 +45,7 @@ import Cardano.CLI
     , optionT
     , requireFilePath
     , runCli
+    , setUtf8Encoding
     , setupDirectory
     , stateDirOption
     , verbosityOption
@@ -125,6 +126,7 @@ import qualified Data.Text as T
 
 main :: IO ()
 main = do
+    setUtf8Encoding
     dataDir <- getDataDir "jormungandr"
     runCli $ cli $ mempty
         <> cmdLaunch dataDir

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.CLI
-    ( initTracer )
+    ( initTracer, setUtf8Encoding )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -79,29 +79,31 @@ instance KnownCommand (Jormungandr n) where
     commandName = "cardano-wallet-jormungandr"
 
 main :: forall t. (t ~ Jormungandr 'Testnet) => IO ()
-main = hspec $ do
-    describe "No backend required" $ do
-        describe "Cardano.Wallet.NetworkSpec" $ parallel Network.spec
-        describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
-        describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
-        describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
+main = do
+    setUtf8Encoding
+    hspec $ do
+        describe "No backend required" $ do
+            describe "Cardano.Wallet.NetworkSpec" $ parallel Network.spec
+            describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
+            describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
+            describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
 
-    describe "API Specifications" $ beforeAll start $ after tearDown $ do
-        Addresses.spec
-        StakePoolsApiJormungandr.spec
-        Transactions.spec
-        TransactionsApiJormungandr.spec @t
-        TransactionsCliJormungandr.spec @t
-        Wallets.spec
-        ByronWallets.spec
+        describe "API Specifications" $ beforeAll start $ after tearDown $ do
+            Addresses.spec
+            StakePoolsApiJormungandr.spec
+            Transactions.spec
+            TransactionsApiJormungandr.spec @t
+            TransactionsCliJormungandr.spec @t
+            Wallets.spec
+            ByronWallets.spec
 
-    describe "CLI Specifications" $ beforeAll start $ after tearDown $ do
-        AddressesCLI.spec @t
-        ServerCLI.spec @t
-        StakePoolsCliJormungandr.spec @t
-        TransactionsCLI.spec @t
-        WalletsCLI.spec @t
-        PortCLI.spec @t
+        describe "CLI Specifications" $ beforeAll start $ after tearDown $ do
+            AddressesCLI.spec @t
+            ServerCLI.spec @t
+            StakePoolsCliJormungandr.spec @t
+            TransactionsCLI.spec @t
+            WalletsCLI.spec @t
+            PortCLI.spec @t
 
 start :: IO (Context (Jormungandr 'Testnet))
 start = do


### PR DESCRIPTION
This will probably help with the test failure in #798.

# Overview

The cardano-wallet sources are utf-8 encoded, and so all of our strings are utf-8 encoded.

If cardano-wallet is run under a locale which is not UTF-8, it will crash as soon as it tries to print a UTF-8 character.

With this change, it won't crash, but it may emit mojibaked characters.
