### PR TITLE
Fix for #767 + tests.

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -81,8 +81,6 @@ import Network.Wai.Handler.Warp
     ( setBeforeMainLoop )
 import System.Exit
     ( ExitCode (..) )
-import System.IO
-    ( hPutStrLn, stderr )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet.Api.Server as Server
@@ -179,17 +177,18 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
 
     handleGenesisNotFound :: Hash "Genesis" -> IO ExitCode
     handleGenesisNotFound block0H = do
-        hPutStrLn stderr $ mconcat
-            [ "Hint: double-check the genesis hash you've just gave "
-            , "me via '--genesis-hash' (i.e. ", showT block0H, ")."
+        failWith (sb, tr) $ T.pack $ mconcat
+            [ "Failed to retrieve the genesis block. The block doesn't exist! "
+            , "Hint: double-check the genesis hash you've just gave "
+            , "me via '--genesis-hash' (i.e. " <> showT block0H <> ")."
             ]
-        failWith (sb, tr)
-            "Failed to retrieve the genesis block. The block doesn't exist!"
+
 
     handleNetworkUnreachable :: IO ExitCode
     handleNetworkUnreachable = do
         failWith (sb, tr)
-            "It looks like Jörmungandr is down?"
+            "It looks like Jörmungandr is down? Hint: double-check Jörmungandr\
+            \ server's port."
 
     handleNoInitialPolicy :: IO ExitCode
     handleNoInitialPolicy = do

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -99,7 +99,7 @@ import Data.Word
 import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Network.HTTP.Types.Status
-    ( status400 )
+    ( status400, status404 )
 import Servant.API
     ( (:<|>) (..) )
 import Servant.Client
@@ -190,7 +190,7 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
 
     , getInitialBlockchainParameters = \block0 -> do
         jblock@(J.Block _ msgs) <- ExceptT $ run (cGetBlock (BlockId $ coerce block0)) >>= \case
-            Left (FailureResponse e) | responseStatusCode e == status400 ->
+            Left (FailureResponse e) | responseStatusCode e `elem` [status400, status404] ->
                 return . Left . ErrGetBlockchainParamsGenesisNotFound $ block0
             x -> do
                 let ctx = safeLink api (Proxy @GetBlock) (BlockId $ coerce block0)


### PR DESCRIPTION
# Issue Number

#767 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ]  Fix for #767 + tests. See comment.
- [ ]  I have made _hints_ on failures when starting Jormungandr are now part of failure message in stdout. Before there were put on stderr so they were sometimes rendered weirdly.



# Comments

Before:

```
$ cardano-wallet-jormungandr serve --genesis-hash 1111111111111111111111111111111111111111111111111111111111111111
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-11 10:19:47.17 UTC] Running as v2019.9.13
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-11 10:19:47.17 UTC] Wallet backend server starting...
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-11 10:19:47.17 UTC] Node is Jörmungandr on testnet
cardano-wallet-jormungandr: ErrUnexpectedNetworkFailure (Link {_segments = ["v0","block","1111111111111111111111111111111111111111111111111111111111111111"], _queryParams = []}) (FailureResponse (Response {responseStatusCode = Status {statusCode = 404, statusMessage = "Not Found"}, responseHeaders = fromList [("content-length","0"),("date","Fri, 11 Oct 2019 10:19:47 GMT")], responseHttpVersion = HTTP/1.1, responseBody = ""}))

```

After:

```
$ cardano-wallet-jormungandr serve --genesis-hash 1111111111111111111111111111111111111111111111111111111111111111
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-14 16:48:54.44 UTC] Running as v2019.9.13
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-14 16:48:54.44 UTC] Wallet backend server starting...
[iohk.cardano-wallet.serve:Info:ThreadId 4] [2019-10-14 16:48:54.44 UTC] Node is Jörmungandr on testnet
[iohk.cardano-wallet.serve:Alert:ThreadId 4] [2019-10-14 16:48:54.45 UTC] Failed to retrieve the genesis block. The block doesn't exist! Hint: double-check the genesis hash you've just gave me via '--genesis-hash' (i.e. 1111111111111111111111111111111111111111111111111111111111111111).

```
