### PR TITLE
Add syncProgressRelativeToCurrentTime helper

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -156,6 +156,7 @@ import Cardano.Wallet.Primitive.Model
     , currentTip
     , getState
     , initWallet
+    , slotParams
     , updateState
     )
 import Cardano.Wallet.Primitive.Types
@@ -188,7 +189,7 @@ import Cardano.Wallet.Primitive.Types
     , log10
     , slotRangeFromTimeRange
     , slotStartTime
-    , syncProgress
+    , syncProgressRelativeToCurrentTime
     , wholeRange
     )
 import Cardano.Wallet.Transaction
@@ -587,18 +588,8 @@ restoreBlocks ctx wid blocks nodeTip = do
         -> WalletMetadata
         -> IO WalletMetadata
     calculateMetadata bp h meta = do
-        now <- liftIO getCurrentTime
-        let status' = maybe
-                (Restoring minBound)
-                (syncProgress (bp ^. #getEpochLength) h)
-                (W.slotAt sp now)
-        pure (meta { status = status' } :: WalletMetadata)
-      where
-        sp :: SlotParameters
-        sp = SlotParameters
-            (bp ^. #getEpochLength)
-            (bp ^. #getSlotLength)
-            (bp ^. #getGenesisBlockDate)
+        p <- syncProgressRelativeToCurrentTime (slotParams bp) h
+        pure (meta { status = p } :: WalletMetadata)
 
 -- | Remove an existing wallet. Note that there's no particular work to
 -- be done regarding the restoration worker as it will simply terminate

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -189,7 +189,7 @@ import Cardano.Wallet.Primitive.Types
     , log10
     , slotRangeFromTimeRange
     , slotStartTime
-    , syncProgressRelativeToCurrentTime
+    , syncProgressRelativeToTime
     , wholeRange
     )
 import Cardano.Wallet.Transaction
@@ -588,7 +588,7 @@ restoreBlocks ctx wid blocks nodeTip = do
         -> WalletMetadata
         -> IO WalletMetadata
     calculateMetadata bp h meta = do
-        p <- syncProgressRelativeToCurrentTime (slotParams bp) h
+        p <- syncProgressRelativeToTime (slotParams bp) h <$> getCurrentTime
         pure (meta { status = p } :: WalletMetadata)
 
 -- | Remove an existing wallet. Note that there's no particular work to

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -49,6 +49,10 @@ module Cardano.Wallet.Primitive.Model
     , availableUTxO
     , utxo
     , blockchainParameters
+
+    -- * Auxiliary
+    , slotParams
+
     ) where
 
 import Prelude
@@ -65,6 +69,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , Hash (..)
     , SlotLength (..)
+    , SlotParameters (SlotParameters)
     , StartTime (..)
     , TxIn (..)
     , TxMeta (..)
@@ -210,6 +215,13 @@ instance Buildable BlockchainParameters where
         epochLengthF (EpochLength s) = build s
         txMaxSizeF (Quantity s) = build s
         epochStabilityF (Quantity s) = build s
+
+slotParams :: BlockchainParameters -> SlotParameters
+slotParams bp =
+    SlotParameters
+        (bp ^. #getEpochLength)
+        (bp ^. #getSlotLength)
+        (bp ^. #getGenesisBlockDate)
 
 {-------------------------------------------------------------------------------
                           Construction & Modification

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -82,6 +82,7 @@ module Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , StartTime (..)
     , syncProgress
+    , syncProgressRelativeToCurrentTime
     , flatSlot
     , fromFlatSlot
     , slotStartTime
@@ -187,7 +188,7 @@ import Data.Text.Class
     , toTextFromBoundedEnum
     )
 import Data.Time.Clock
-    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime )
 import Data.Word
     ( Word16, Word32, Word64 )
 import Fmt
@@ -1053,6 +1054,16 @@ syncProgress epochLength tip slotNow =
     else
         Restoring $ Quantity $ toEnum $ fromIntegral $
             (100 * bhTip) `div` (bhTip + n1 - n0)
+
+syncProgressRelativeToCurrentTime
+    :: SlotParameters
+    -> BlockHeader
+    -> IO SyncProgress
+syncProgressRelativeToCurrentTime sp tip = getCurrentTime >>= \now ->
+    return $ maybe
+        (Restoring minBound)
+        (syncProgress (sp ^. #getEpochLength) tip)
+        (slotAt sp now)
 
 -- | Convert a 'SlotId' to the number of slots since genesis.
 flatSlot :: EpochLength -> SlotId -> Word64


### PR DESCRIPTION
# Issue Number

#711 

# Overview

- [x] I made it easier to use `syncProgress` from StakePoolMetrics (or potential other places) by

    1. adding a helper `syncProgressRelativeToTime :: SlotParameters -> BlockHeader -> SyncProgress`
    2. Adding `slotParams :: BlockchainParameters -> SlotParameters`

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
