### PR TITLE
Buildkite: protect stack build dependencies from GC during build

### DIFF
--- a/.buildkite/default.nix
+++ b/.buildkite/default.nix
@@ -12,14 +12,21 @@ let
     haskellPackages.weeder
   ];
   libs = ps: with ps; [turtle safe transformers extra async];
-
   ghc' = haskellPackages.ghcWithPackages libs;
+
+  # Include the stack nix-shell in closure of stackRebuild, so that it
+  # doesn't get garbage-collected whilst the build is running.
+  # https://github.com/commercialhaskell/stack/issues/3479
+  stackShell = import ../nix/stack-shell.nix {};
+
   stackRebuild = runCommand "stack-rebuild" {
     buildInputs = [ ghc' makeWrapper ];
   } ''
     mkdir -p $out/bin
     ghc -Wall -threaded -o $out/bin/rebuild ${./rebuild.hs}
-    wrapProgram $out/bin/rebuild --set PATH "${lib.makeBinPath buildTools}"
+    wrapProgram $out/bin/rebuild \
+      --set PATH "${lib.makeBinPath buildTools}" \
+      --set NO_GC_STACK_SHELL ${stackShell}
   '';
 
 in

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -5,7 +5,7 @@
 }:
 with pkgs;
 
-haskell.lib.buildStackProject {
+haskell.lib.buildStackProject rec {
   name = "cardano-wallet-stack-env";
   ghc = walletPackages.haskellPackages._config.ghc.package;
 
@@ -15,5 +15,5 @@ haskell.lib.buildStackProject {
     (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
 
   phases = ["nobuildPhase"];
-  nobuildPhase = "mkdir -p $out";
+  nobuildPhase = "echo '${pkgs.lib.concatStringsSep "\n" ([ghc] ++ buildInputs)}' > $out";
 }


### PR DESCRIPTION
# Overview

Fixes a build issue where the Nix garbage collector runs while a stack build is in progress.

Example failure: https://buildkite.com/input-output-hk/cardano-wallet/builds/2752#9e69eaae-88d9-4277-a005-04c2fe742074

```
stack --color always test --coverage --skip http-bridge-integration --fast --skip integration --ta '--skip SERIAL'
--
  | waiting for the big garbage collector lock...
  | error: getting status of '/nix/store/56c76cz5dhg7zj028pjj8zkb899zlfwb-source/pkgs/build-support/cc-wrapper': No such file or directory
  | (use '--show-trace' to show detailed location information)
  | error: Command exited with code 1!
```