### PR TITLE
DaedalusIPC: Fix isWindows function

### DIFF
--- a/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
+++ b/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
@@ -63,7 +63,7 @@ import GHC.IO.Handle.FD
 import System.Environment
     ( lookupEnv )
 import System.Info
-    ( arch )
+    ( os )
 import System.IO
     ( Handle, hFlush, hGetLine, hSetNewlineMode, noNewlineTranslation )
 import System.IO.Error
@@ -214,7 +214,7 @@ readMessage :: Handle -> IO BL.ByteString
 readMessage = if isWindows then windowsReadMessage else posixReadMessage
 
 isWindows :: Bool
-isWindows = arch == "windows"
+isWindows = os == "windows"
 
 windowsReadMessage :: Handle -> IO BL.ByteString
 windowsReadMessage handle = do


### PR DESCRIPTION
# Issue Number

None.

# Overview

Fixes a typo in the OS detection code for NodeIPC.

# Comments

I again looked at the possibility of importing the cardano-shell package for this functionality. But it is pulling in more dependencies. Also the `daedalusIPC` function there had the logging replaced with `putTextLn`. Branch is [rvl/daedalus-ipc-cardano-shell](https://github.com/input-output-hk/cardano-wallet/compare/rvl/daedalus-ipc-fix...rvl/daedalus-ipc-cardano-shell) for reference though.
