### PR TITLE
Change the return type of `migrateByronWallet` to be a list of transactions.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -104,7 +104,6 @@ import Servant.API
     , NoContent
     , OctetStream
     , PostAccepted
-    , PostNoContent
     , Put
     , PutNoContent
     , QueryParam
@@ -125,9 +124,8 @@ type CompatibilityApi t =
     :<|> GetByronWallet
     :<|> GetByronWalletMigrationInfo
     :<|> ListByronWallets
-    :<|> MigrateByronWallet
+    :<|> MigrateByronWallet t
     :<|> PostByronWallet
-
 
 {-------------------------------------------------------------------------------
                                   Addresses
@@ -293,13 +291,13 @@ type ListByronWallets = "byron"
     :> Get '[JSON] [ApiByronWallet]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/migrateByronWallet
-type MigrateByronWallet = "byron"
+type MigrateByronWallet t = "byron"
     :> "wallets"
     :> Capture "sourceWalletId" (ApiT WalletId)
     :> "migrate"
     :> Capture "targetWalletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiMigrateByronWalletData
-    :> PostNoContent '[Any] NoContent
+    :> PostAccepted '[JSON] [ApiTransaction t]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronWallet
 type PostByronWallet = "byron"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -764,7 +764,7 @@ migrateByronWallet
     -> ApiT WalletId
        -- ^ Target wallet (new-style)
     -> ApiMigrateByronWalletData
-    -> Handler NoContent
+    -> Handler [ApiTransaction t]
 migrateByronWallet _rndCtx _seqCtx _sourceWid _targetWid _migrateData =
     throwError err501
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -821,8 +821,11 @@ x-responsesMigrateByronWallet: &responsesMigrateByronWallet
   <<: *responsesErr404
   <<: *responsesErr405
   <<: *responsesErr406
-  204:
-    description: No Content
+  200:
+    description: Ok
+    schema:
+      type: array
+      items: *ApiTransaction
 
 x-responsesDeleteWallet: &responsesDeleteWallet
   <<: *responsesErr404


### PR DESCRIPTION
# Issue Number

#779 

# Overview

The result of migrating funds from a Byron wallet to a new-style wallet will be the creation of _one or more_ transactions. Therefore, it makes sense to report this set of transactions as the result of the `migrateByronWallet` call.

This PR merely changes the return type of the call, in order to unblock testing work.

Further PRs will actually implement this call.
