### PR TITLE
Make Jörmungandr NetworkLayer use raw blocks

### DIFF
--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -59,20 +59,12 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Jormungandr
     ( serveWallet )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr, localhostBaseUrl )
-import Cardano.Wallet.Jormungandr.Environment
-    ( KnownNetwork (..), Network (..) )
+    ( Jormungandr, Network (Testnet), localhostBaseUrl )
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..)
     , JormungandrConfig (..)
     , JormungandrConnParams (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( KeyToAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Sequential
-    ( SeqKey )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( SeqState )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
@@ -234,9 +226,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         <*> verbosityOption
         <*> genesisHashOption
     exec
-        :: forall t k n s. (n ~ 'Testnet, t ~ Jormungandr n, s ~ SeqState t, k ~ SeqKey)
-        => (KeyToAddress t k, KnownNetwork n)
-        => ServeArgs
+        :: ServeArgs
         -> IO ()
     exec (ServeArgs listen nodePort databaseDir verbosity block0H) = do
         (cfg, sb, tr) <- initTracer (verbosityToMinSeverity verbosity) "serve"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -29,6 +29,7 @@ module Cardano.Wallet.Jormungandr.Network
       JormungandrBackend (..)
     , JormungandrConnParams (..)
     , withNetworkLayer
+    , newNetworkLayer
 
     -- * Launching the node backend
     , JormungandrConfig (..)
@@ -86,7 +87,7 @@ import Cardano.Wallet.Jormungandr.Api.Client
     , postMessage
     )
 import Cardano.Wallet.Jormungandr.Binary
-    ( convertBlock, runGetOrFail )
+    ( runGetOrFail )
 import Cardano.Wallet.Jormungandr.BlockHeaders
     ( BlockHeaders (..)
     , appendBlockHeaders
@@ -100,8 +101,6 @@ import Cardano.Wallet.Jormungandr.BlockHeaders
     )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, genConfigFile, localhostBaseUrl )
-import Cardano.Wallet.Jormungandr.Primitive.Types
-    ( Tx )
 import Cardano.Wallet.Network
     ( Cursor, NetworkLayer (..), NextBlocksResult (..), defaultRetryPolicy )
 import Cardano.Wallet.Network.Ports
@@ -109,7 +108,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotId (..) )
+    ( BlockHeader (..), Hash (..), SlotId (..) )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar, readMVar )
 import Control.Exception
@@ -176,7 +175,7 @@ withNetworkLayer
     -- ^ Logging
     -> JormungandrBackend
     -- ^ How Jörmungandr is started.
-    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t (Block Tx)) -> IO a)
+    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t J.Block) -> IO a)
     -- ^ The action to run. It will be passed the connection parameters used,
     -- and a network layer if startup was successful.
     -> IO a
@@ -189,7 +188,7 @@ withNetworkLayerLaunch
     -- ^ Logging of node startup.
     -> JormungandrConfig
     -- ^ Configuration for starting Jörmungandr.
-    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t (Block Tx)) -> IO a)
+    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t J.Block) -> IO a)
     -- ^ The action to run. It will be passed the connection parameters used,
     -- and a network layer if startup was successful.
     -> IO a
@@ -201,7 +200,7 @@ withNetworkLayerConn
     :: forall n a t. (t ~ Jormungandr n)
     => JormungandrConnParams
     -- ^ Parameters for connecting to Jörmungandr node which is already running.
-    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t (Block Tx)) -> IO a)
+    -> (Either ErrStartup (JormungandrConnParams, NetworkLayer IO t J.Block) -> IO a)
     -- ^ Action to run with the network layer.
     -> IO a
 withNetworkLayerConn cp@(JormungandrConnParams block0H baseUrl) action =
@@ -216,13 +215,13 @@ newNetworkLayer
     :: forall n t. (t ~ Jormungandr n)
     => BaseUrl
     -> Hash "Genesis"
-    -> ExceptT ErrGetBlockchainParams IO (NetworkLayer IO t (Block Tx))
+    -> ExceptT ErrGetBlockchainParams IO (NetworkLayer IO t J.Block)
 newNetworkLayer baseUrl block0H = do
     mgr <- liftIO $ newManager defaultManagerSettings
     st <- newMVar emptyBlockHeaders
     let jor = mkJormungandrClient mgr baseUrl
     g0 <- getInitialBlockchainParameters jor (coerce block0H)
-    return (convertBlock <$> mkRawNetworkLayer g0 st jor)
+    return (mkRawNetworkLayer g0 st jor)
 
 -- | Wrap a Jormungandr client into a 'NetworkLayer' common interface.
 --


### PR DESCRIPTION

# Issue Number

#711 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I changed the constructors in `Cardano.Wallet.Jormungandr.Network` to create NetworkLayers with raw jörmungadnr-specific blocks, and later used `toWLBlock <$> nl`. This way we can later use `toSPBlock <$> nl` for stake-pools.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
