### PR TITLE
Group tags by era (Shelley vs Byron) in swagger documentation

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -989,9 +989,9 @@ tearDown ctx = do
         d <- request @Value ctx ("DELETE", endpoint) None Empty
         expectResponseCode HTTP.status204 d
     respByron <-
-        request @[ApiByronWallet] ctx ("GET", "v2/byron/wallets") Default Empty
+        request @[ApiByronWallet] ctx ("GET", "v2/byron-wallets") Default Empty
     forM_ (wallets (snd respByron)) $ \wal -> do
-        let endpoint = "v2/byron/wallets" </> wal ^. walletId
+        let endpoint = "v2/byron-wallets" </> wal ^. walletId
         d <- request @Value ctx ("DELETE", endpoint) None Empty
         expectResponseCode HTTP.status204 d
  where
@@ -1055,37 +1055,37 @@ networkInfoEp =
 postByronWalletEp :: (Method, Text)
 postByronWalletEp =
     ( "POST"
-    , "v2/byron/wallets"
+    , "v2/byron-wallets"
     )
 
 listByronWalletEp :: (Method, Text)
 listByronWalletEp =
     ( "GET"
-    , "v2/byron/wallets"
+    , "v2/byron-wallets"
     )
 
 migrateByronWalletEp :: ApiByronWallet -> ApiWallet -> (Method, Text)
 migrateByronWalletEp wSrc wDest =
     ( "POST"
-    , "v2/byron/wallets/" <> wSrc ^. walletId <> "/migrate/" <> wDest ^. walletId
+    , "v2/byron-wallets/" <> wSrc ^. walletId <> "/migrations/" <> wDest ^. walletId
     )
 
 calculateByronMigrationCostEp :: ApiByronWallet -> (Method, Text)
 calculateByronMigrationCostEp w =
     ( "GET"
-    , "v2/byron/wallets/" <> w ^. walletId <> "/migrate"
+    , "v2/byron-wallets/" <> w ^. walletId <> "/migrations"
     )
 
 getByronWalletEp :: ApiByronWallet -> (Method, Text)
 getByronWalletEp w =
     ( "GET"
-    , "v2/byron/wallets/" <> w ^. walletId
+    , "v2/byron-wallets/" <> w ^. walletId
     )
 
 deleteByronWalletEp :: ApiByronWallet -> (Method, Text)
 deleteByronWalletEp w =
     ( "DELETE"
-    , "v2/byron/wallets/" <> w ^. walletId
+    , "v2/byron-wallets/" <> w ^. walletId
     )
 
 listStakePoolsEp :: (Method, Text)
@@ -1103,7 +1103,7 @@ postWalletEp =
 postExternalTxEp :: (Method, Text)
 postExternalTxEp =
     ( "POST"
-    , "v2/external-transactions"
+    , "v2/proxy/transactions"
     )
 
 getWalletEp :: ApiWallet -> (Method, Text)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -233,11 +233,6 @@ type ListTransactions t = "wallets"
     :> QueryParam "order" (ApiT SortOrder)
     :> Get '[JSON] [ApiTransaction t]
 
--- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postExternalTransaction
-type PostExternalTransaction = "external-transactions"
-    :> ReqBody '[OctetStream] PostExternalTransactionData
-    :> PostAccepted '[JSON] ApiTxId
-
 {-------------------------------------------------------------------------------
                                   StakePools
 
@@ -262,48 +257,55 @@ type Network =
     :> Get '[JSON] ApiNetworkInformation
 
 {-------------------------------------------------------------------------------
+                                  Proxy
+
+  See also: https://input-output-hk.github.io/cardano-wallet/api/edge/#tag/Proxy
+-------------------------------------------------------------------------------}
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postExternalTransaction
+type PostExternalTransaction = "proxy"
+    :> "transactions"
+    :> ReqBody '[OctetStream] PostExternalTransactionData
+    :> PostAccepted '[JSON] ApiTxId
+
+{-------------------------------------------------------------------------------
                               Compatibility API
 
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Wallets
 -------------------------------------------------------------------------------}
 
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronWallet
+type PostByronWallet = "byron-wallets"
+    :> ReqBody '[JSON] ByronWalletPostData
+    :> PostAccepted '[JSON] ApiByronWallet
+
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteByronWallet
-type DeleteByronWallet = "byron"
-    :> "wallets"
+type DeleteByronWallet = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> DeleteNoContent '[Any] NoContent
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronWallet
-type GetByronWallet = "byron"
-    :> "wallets"
+type GetByronWallet = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> Get '[JSON] ApiByronWallet
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronWalletMigrationInfo
-type GetByronWalletMigrationInfo = "byron"
-    :> "wallets"
+type GetByronWalletMigrationInfo = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
+    :> "migrations"
     :> Get '[JSON] ApiByronWalletMigrationInfo
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronWallets
-type ListByronWallets = "byron"
-    :> "wallets"
+type ListByronWallets = "byron-wallets"
     :> Get '[JSON] [ApiByronWallet]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/migrateByronWallet
-type MigrateByronWallet t = "byron"
-    :> "wallets"
+type MigrateByronWallet t = "byron-wallets"
     :> Capture "sourceWalletId" (ApiT WalletId)
-    :> "migrate"
+    :> "migrations"
     :> Capture "targetWalletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiMigrateByronWalletData
     :> PostAccepted '[JSON] [ApiTransaction t]
-
--- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronWallet
-type PostByronWallet = "byron"
-    :> "wallets"
-    :> ReqBody '[JSON] ByronWalletPostData
-    :> PostAccepted '[JSON] ApiByronWallet
 
 {-------------------------------------------------------------------------------
                                    Internals

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -184,7 +184,7 @@ import Data.Generics.Internal.VL.Lens
 import Data.Generics.Labels
     ()
 import Data.List
-    ( sortOn )
+    ( isSubsequenceOf, sortOn )
 import Data.Maybe
     ( fromMaybe, isJust )
 import Data.Proxy
@@ -1327,7 +1327,7 @@ instance LiftHandler (Request, ServantErr) where
             ]
         415 ->
             let cType =
-                    if "external-transactions" `elem` (pathInfo req)
+                    if ["proxy", "transactions"] `isSubsequenceOf` pathInfo req
                         then "application/octet-stream"
                         else "application/json"
             in apiError err' UnsupportedMediaType $ mconcat

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -277,7 +277,7 @@ spec = do
             ]
 
     describe "TRANS_EXTERNAL_CREATE_04 - \
-        \v2/external-transactions - Methods Not Allowed" $ do
+        \v2/proxy/transactions - Methods Not Allowed" $ do
 
         let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS", "GET"]
         forM_ matrix $ \method -> it (show method) $ \ctx -> do
@@ -289,7 +289,7 @@ spec = do
             let payload = (NonJson . BL.fromStrict . toRawBytes Base16) txBlob
             let headers = Headers [ ("Content-Type", "application/octet-stream") ]
 
-            let endpoint = "v2/external-transactions"
+            let endpoint = "v2/proxy/transactions"
             r <- request @ApiTxId ctx (method, endpoint) headers payload
             expectResponseCode @IO HTTP.status405 r
             expectErrorMessage errMsg405 r

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -962,6 +962,24 @@ x-responsesGetNetworkInformation: &responsesGetNetworkInformation
 #                                                                           #
 #############################################################################
 
+x-tagGroups:
+  - name: Shelley (Sequential)
+    tags:
+    - Wallets
+    - Addresses
+    - Transactions
+    - Stake Pools
+
+  - name: Byron (Random)
+    tags:
+    - Byron Wallets
+    - Byron Migrations
+
+  - name: Miscellaneous
+    tags:
+    - Network
+    - Proxy
+
 paths:
   /wallets:
     get:
@@ -1137,21 +1155,6 @@ paths:
           schema: *ApiPostTransactionFeeData
       responses: *responsesPostTransactionFee
 
-  /external-transactions:
-    post:
-      operationId: postExternalTransaction
-      tags: ["Transactions"]
-      summary: Submit External Transaction
-      consumes: ["application/octet-stream"]
-      description: |
-        <p align="right">status: <strong>stable</strong></p>
-
-        Submits a transaction that was created and signed outside of cardano-wallet.
-      parameters:
-        - <<: *parametersBody
-          schema: *signedTransactionBlob
-      responses: *responsesPostExternalTransaction
-
   /wallets/{walletId}/addresses:
     get:
       operationId: listAddresses
@@ -1208,22 +1211,13 @@ paths:
           schema: *parametersQuitStakePool
       responses: *responsesQuitStakePool
 
-  /network/information:
-    get:
-        operationId: getNetworkInformation
-        tags: ["Network"]
-        summary: Information
-        description: |
-          <p align="right">status: <strong>provisional</strong></p>
-        responses: *responsesGetNetworkInformation
-
-  /byron/wallets:
+  /byron-wallets:
     get:
       operationId: listByronWallets
       tags: ["Byron Wallets"]
       summary: List
       description: |
-        <p align="right">status: <strong>not implemented</strong></p>
+        <p align="right">status: <strong>under testing</strong></p>
 
         Return a list of known Byron wallets, ordered from oldest to newest.
       responses: *responsesListByronWallets
@@ -1233,7 +1227,7 @@ paths:
       tags: ["Byron Wallets"]
       summary: Restore
       description: |
-        <p align="right">status: <strong>not implemented</strong></p>
+        <p align="right">status: <strong>under testing</strong></p>
 
         Restore a Byron wallet from a mnemonic sentence.
       parameters:
@@ -1241,13 +1235,13 @@ paths:
           schema: *ApiByronWalletPostData
       responses: *responsesPostByronWallet
 
-  /byron/wallets/{walletId}:
+  /byron-wallets/{walletId}:
     get:
       operationId: getByronWallet
       tags: ["Byron Wallets"]
       summary: Get
       description: |
-        <p align="right">status: <strong>not implemented</strong></p>
+        <p align="right">status: <strong>under testing</strong></p>
 
         Return information about a Byron wallet.
       parameters:
@@ -1259,18 +1253,18 @@ paths:
       tags: ["Byron Wallets"]
       summary: Delete
       description: |
-        <p align="right">status: <strong>not implemented</strong></p>
+        <p align="right">status: <strong>under testing</strong></p>
 
         Delete a Byron wallet.
       parameters:
         - *parametersWalletId
       responses: *responsesDeleteWallet
 
-  /byron/wallets/{walletId}/migrate:
+  /byron-wallets/{walletId}/migrations:
     get:
       operationId: getByronWalletMigrationInfo
-      tags: ["Byron Wallets"]
-      summary: Calculate Migration Cost
+      tags: ["Byron Migrations"]
+      summary: Calculate Cost
       description: |
         <p align="right">status: <strong>not implemented</strong></p>
 
@@ -1280,10 +1274,10 @@ paths:
         - *parametersWalletId
       responses: *responsesGetByronWalletMigrationInfo
 
-  /byron/wallets/{sourceWalletId}/migrate/{targetWalletId}:
+  /byron-wallets/{sourceWalletId}/migrations/{targetWalletId}:
     post:
       operationId: migrateByronWallet
-      tags: ["Byron Wallets"]
+      tags: ["Byron Migrations"]
       summary: Migrate
       description: |
         <p align="right">status: <strong>not implemented</strong></p>
@@ -1297,3 +1291,27 @@ paths:
         - <<: *parametersBody
           schema: *ApiMigrateByronWalletData
       responses: *responsesMigrateByronWallet
+
+  /network/information:
+    get:
+        operationId: getNetworkInformation
+        tags: ["Network"]
+        summary: Information
+        description: |
+          <p align="right">status: <strong>stable</strong></p>
+        responses: *responsesGetNetworkInformation
+
+  /proxy/transactions:
+    post:
+      operationId: postExternalTransaction
+      tags: ["Proxy"]
+      summary: Submit External Transaction
+      consumes: ["application/octet-stream"]
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Submits a transaction that was created and signed outside of cardano-wallet.
+      parameters:
+        - <<: *parametersBody
+          schema: *signedTransactionBlob
+      responses: *responsesPostExternalTransaction


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#774 #775 #776 #777 #778 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have renamed `/external-transactions` to `/proxy/transactions` to better convey its meaning
- [x] I have renamed all `/byron/wallets` to `/byron-wallets` as per the discussion we had on slack
- [x] I have renamed `/.../migrate` to `/.../migrations`, REST is about resources, not actions. 
- [x] I have grouped and organize API tags by eras such that it's more readable:

![Screenshot from 2019-10-16 13-38-08](https://user-images.githubusercontent.com/5680256/66916252-24946900-f01b-11e9-9060-9a6aa88d0ac4.png)


# Comments

<!-- Additional comments or screenshots to attach if any -->

~~:warning: base branch is `jonathanknowles/migrate-byron-wallet-return-type`~~

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
