### PR TITLE
Add `NetworkLayer.stakeDistribution` and change types of response

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -33,7 +33,14 @@ import Cardano.BM.Trace
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), Hash (..), SlotId, Tx, TxWitness )
+    ( BlockHeader (..)
+    , EpochNo
+    , Hash (..)
+    , PoolId (..)
+    , SlotId
+    , Tx
+    , TxWitness
+    )
 import Control.Concurrent
     ( threadDelay )
 import Control.Exception
@@ -52,8 +59,14 @@ import Control.Retry
     )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Data.Map
+    ( Map )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text
     ( Text )
+import Data.Word
+    ( Word64 )
 import Fmt
     ( pretty )
 import GHC.Generics
@@ -99,6 +112,9 @@ data NetworkLayer m target block = NetworkLayer
 
     , staticBlockchainParameters
         :: (block, BlockchainParameters)
+    , stakeDistribution
+        :: ExceptT ErrNetworkUnavailable m
+           (EpochNo, Map PoolId (Quantity "lovelace" Word64))
     }
 
 instance Functor m => Functor (NetworkLayer m target) where

--- a/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
+++ b/lib/http-bridge/src/Cardano/Wallet/HttpBridge/Network.hs
@@ -193,6 +193,8 @@ mkNetworkLayer httpBridge = NetworkLayer
         postSignedTx httpBridge
     , staticBlockchainParameters =
         (block0, byronBlockchainParameters @n)
+    , stakeDistribution =
+        error "stakeDistribution is unimplemented for http-bridge"
     }
 
 -- | Creates a cardano-http-bridge 'NetworkLayer' using the given connection

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Jormungandr.Binary
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), PoolId (..), ShowFmt (..), TxWitness )
+    ( EpochNo (..), Hash (..), PoolId (..), ShowFmt (..), TxWitness )
 import Control.Applicative
     ( many )
 import Control.Arrow
@@ -139,7 +139,7 @@ type GetStakeDistribution
 newtype BlockId = BlockId { getBlockId :: Hash "BlockHeader" }
 
 data StakeApiResponse = StakeApiResponse
-    { epoch :: Word64
+    { epoch :: ApiT EpochNo
     , stake :: ApiStakeDistribution
     } deriving (Show, Eq, Generic)
 
@@ -203,6 +203,9 @@ instance FromJSON (ApiStakeDistribution) where
 
 instance FromJSON (ApiT (Quantity "lovelace" Word64)) where
     parseJSON = fmap (ApiT . Quantity) . parseJSON
+
+instance FromJSON (ApiT EpochNo) where
+    parseJSON = fmap (ApiT . EpochNo) . parseJSON
 
 instance FromJSON (ApiT PoolId) where
     parseJSON val = do

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -65,6 +65,11 @@ import Cardano.Launcher
     , transformLauncherTrace
     , withBackendProcess
     )
+import Cardano.Wallet.Jormungandr.Api
+    ( ApiStakeDistribution (pools)
+    , ApiT (..)
+    , StakeApiResponse (epoch, stake)
+    )
 import Cardano.Wallet.Jormungandr.Api.Client
     ( BaseUrl (..)
     , ErrGetBlock (..)
@@ -81,6 +86,7 @@ import Cardano.Wallet.Jormungandr.Api.Client
     , getBlockHeader
     , getBlocks
     , getInitialBlockchainParameters
+    , getStakeDistribution
     , getTipId
     , mkJormungandrClient
     , newManager
@@ -142,6 +148,7 @@ import qualified Cardano.Wallet.Jormungandr.Binary as J
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Char as C
+import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Yaml as Yaml
 
@@ -258,6 +265,11 @@ mkRawNetworkLayer (block0, bp) st j = NetworkLayer
 
     , staticBlockchainParameters =
         (block0, bp)
+    , stakeDistribution = do
+        r <- getStakeDistribution j
+        let epochNo = getApiT . epoch $ r
+        let distr = map (\(ApiT a, ApiT b) -> (a,b)) . pools . stake $ r
+        return (epochNo, Map.fromList distr)
     }
   where
     -- security parameter, the maximum number of unstable blocks

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
@@ -33,7 +33,7 @@ spec = do
                     \74cfe6cae078320ec\",1]],\"unassigned\":100100000000000}}"
             decodeJSON exampleStake `shouldBe`
                 Right StakeApiResponse {
-                   epoch = 252054,
+                   epoch = ApiT 252054,
                    stake = ApiStakeDistribution {
                        dangling = ApiT (Quantity 0),
                        pools = [((ApiT (PoolId "}t\158\244$P\DEL\184\SI\237\r\"\137\213\&5\169Ohp\173\208\207\139\&7L\254l\174\a\131 \236"))
@@ -48,7 +48,7 @@ spec = do
                     \pools\":[],\"unassigned\":100100000000000}}"
             decodeJSON exampleStake `shouldBe`
                 Right StakeApiResponse {
-                   epoch = 252054,
+                   epoch = ApiT 252054,
                    stake = ApiStakeDistribution {
                        dangling = ApiT (Quantity 0),
                        pools = [],


### PR DESCRIPTION
# Issue Number

#713

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I simplified the types of JormungandrClient.getStakeDistribution and added NetworkLayer.stakeDistribution since our code currently works well with a large NetworkLayer. This way `StakePool.Metrics` can get the stake distribution without having a JörmungandrClient.
- [ ] *Bonus*: <s>Add Buildable instance for Percentage</s>

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
