### PR TITLE
launch: merge necessary jormungandr config options with user's config

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -52,6 +52,7 @@ library
     , extra
     , filepath
     , fmt
+    , generic-lens
     , http-client
     , http-types
     , iohk-monitoring
@@ -66,6 +67,7 @@ library
     , text-class
     , time
     , transformers
+    , unordered-containers
     , yaml
     , warp
   hs-source-dirs:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -54,7 +55,6 @@ import Cardano.Wallet.Jormungandr.Network
     , ErrGetBlockchainParams (..)
     , ErrStartup (..)
     , JormungandrBackend (..)
-    , JormungandrConnParams (..)
     , withNetworkLayer
     )
 import Cardano.Wallet.Jormungandr.Primitive.Types
@@ -85,6 +85,8 @@ import Control.DeepSeq
     ( NFData )
 import Data.Function
     ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -126,7 +128,7 @@ serveWallet (cfg, sb, tr) databaseDir listen lj beforeMainLoop = do
     logInfo tr $ "Node is Jörmungandr on " <> toText (networkVal @n)
     withNetworkLayer tr lj $ \case
         Right (cp, nl) -> do
-            let nPort = Port $ baseUrlPort $ _restApi cp
+            let nPort = Port $ baseUrlPort $ cp ^. #restApi
             waitForService "Jörmungandr" (sb, tr) nPort $
                 waitForNetwork nl defaultRetryPolicy
             let (_, bp) = staticBlockchainParameters nl

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
@@ -34,8 +34,6 @@ import System.IO
 import System.IO.Temp
     ( createTempDirectory, getCanonicalTemporaryDirectory )
 
-import qualified Data.Text as T
-
 -- | Starts jormungandr on a random port using the integration tests config.
 -- The data directory will be stored in a unique location under the system
 -- temporary directory.
@@ -51,10 +49,11 @@ setupConfig = do
         Nothing
         minBound
         (UseHandle logFile)
-        ["--secret", T.pack (dir </> "secret.yaml")]
+        Nothing
+        ["--secret", dir </> "secret.yaml"]
 
 teardownConfig :: JormungandrConfig -> IO ()
-teardownConfig (JormungandrConfig d _ _ _ output _) = do
+teardownConfig (JormungandrConfig d _ _ _ output _ _) = do
     case output of
         UseHandle h -> hClose h
         _ -> pure ()

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -336,17 +336,18 @@ spec = do
     second :: Int
     second = 1000000
 
-    startNode cb = withSystemTempDirectory "jormungandr-state" $ \stateDir -> do
+    startNode cb = withSystemTempDirectory "jormungandr-state" $ \stateDir_ -> do
         let cfg = JormungandrConfig
-                stateDir
+                stateDir_
                 (Right "test/data/jormungandr/block0.bin")
                 Nothing
                 Info
                 Inherit
+                Nothing
                 ["--secret", "test/data/jormungandr/secret.yaml"]
         let tr = nullTracer
         e <- withJormungandr tr cfg $ \cp -> withNetworkLayer tr (UseRunning cp) $ \case
-            Right (_, nw) -> cb (nw, _restApi cp)
+            Right (_, nw) -> cb (nw, restApi cp)
             Left e -> throwIO e
         either throwIO (\_ -> return ()) e
 

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -290,20 +290,35 @@ spec = do
         it "example configuration" $ do
             let stateDir = "/state-dir"
             let baseUrl = BaseUrl Http "127.0.0.1" 8080 "/api"
-            genConfigFile stateDir 8081 baseUrl `shouldBe` [aesonQQ|{
+            let user = [aesonQQ|{
+                "yolo": true,
+                "p2p": {
+                    "trusted_peers": [{
+                        "address": "/ip4/208.80.152.201/tcp/3000",
+                        "id": "hello"
+                     }]
+                 }
+            }|]
+            let expected = [aesonQQ|{
                 "storage": "/state-dir/chain",
                 "rest": {
                     "listen": "127.0.0.1:8080"
                 },
                 "p2p": {
-                    "trusted_peers": [],
+                    "trusted_peers": [{
+                        "address": "/ip4/208.80.152.201/tcp/3000",
+                        "id": "hello"
+                     }],
                     "topics_of_interest": {
                         "messages": "low",
                         "blocks": "normal"
                     },
                     "public_address" : "/ip4/127.0.0.1/tcp/8081"
-                }
+                },
+                "yolo": true
             }|]
+
+            genConfigFile stateDir 8081 baseUrl user `shouldBe` expected
 
     describe "Random Address Discovery Properties" $ do
         it "isOurs works as expected during key derivation in testnet" $ do

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -81,6 +81,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."extra" or (buildDepError "extra"))
           (hsPkgs."filepath" or (buildDepError "filepath"))
           (hsPkgs."fmt" or (buildDepError "fmt"))
+          (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
           (hsPkgs."http-client" or (buildDepError "http-client"))
           (hsPkgs."http-types" or (buildDepError "http-types"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
@@ -95,6 +96,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."text-class" or (buildDepError "text-class"))
           (hsPkgs."time" or (buildDepError "time"))
           (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           (hsPkgs."yaml" or (buildDepError "yaml"))
           (hsPkgs."warp" or (buildDepError "warp"))
           ];


### PR DESCRIPTION
Relates to #832 and #848.

# Overview

I think this is the simplest way to permit full jormungandr configuration by the user but still let us control the REST API port.

# Comments

I needed to start using lenses for the jormungandr config type.
