### PR TITLE
CLI: Always shutdown logging, last thing before exiting

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -52,7 +52,7 @@ module Cardano.CLI
 
     -- * Logging
     , Verbosity (..)
-    , withLobemo
+    , withLogging
     , initTracer
     , verbosityToArgs
     , verbosityToMinSeverity
@@ -1170,7 +1170,7 @@ initTracer configFile minSeverity = do
 
 -- | Run an action with logging available and configured. When the action is
 -- finished (normally or otherwise), log messages are flushed.
-withLobemo
+withLogging
     :: Maybe FilePath
     -- ^ Configuration file - uses default otherwise.
     -> Severity
@@ -1178,7 +1178,7 @@ withLobemo
     -> ((CM.Configuration, Switchboard Text, Trace IO Text) -> IO a)
     -- ^ The action to run with logging configured.
     -> IO a
-withLobemo configFile minSeverity = bracket before after
+withLogging configFile minSeverity = bracket before after
   where
     before = initTracer configFile minSeverity
     after (_, sb, tr) = do

--- a/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
+++ b/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
@@ -156,7 +156,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (LaunchArgs network listen (Port nodePort) mStateDir verbosity) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLogging Nothing minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging Nothing minSeverity $ \(cfg, tr) -> do
             let stateDir = fromMaybe (stateDirForNetwork dataDir network) mStateDir
             let bridgeConfig = HttpBridgeConfig
                     network
@@ -213,7 +213,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (ServeArgs _ listen (Port nodePort) databaseDir verbosity) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLogging Nothing minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging Nothing minSeverity $ \(cfg, tr) -> do
             whenJust databaseDir $ setupDirectory (logInfo tr)
             logInfo tr $ "Running as v" <> T.pack (showVersion version)
             exitWith =<< serveWallet @t @n

--- a/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
+++ b/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
@@ -51,7 +51,7 @@ import Cardano.CLI
     , verbosityOption
     , verbosityToArgs
     , verbosityToMinSeverity
-    , withLobemo
+    , withLogging
     )
 import Cardano.Launcher
     ( StdStream (..) )
@@ -156,7 +156,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (LaunchArgs network listen (Port nodePort) mStateDir verbosity) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLobemo Nothing minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging Nothing minSeverity $ \(cfg, _sb, tr) -> do
             let stateDir = fromMaybe (stateDirForNetwork dataDir network) mStateDir
             let bridgeConfig = HttpBridgeConfig
                     network
@@ -213,7 +213,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (ServeArgs _ listen (Port nodePort) databaseDir verbosity) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLobemo Nothing minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging Nothing minSeverity $ \(cfg, _sb, tr) -> do
             whenJust databaseDir $ setupDirectory (logInfo tr)
             logInfo tr $ "Running as v" <> T.pack (showVersion version)
             exitWith =<< serveWallet @t @n

--- a/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
+++ b/lib/http-bridge/exe/cardano-wallet-http-bridge.hs
@@ -41,7 +41,6 @@ import Cardano.CLI
     , cmdWallet
     , databaseOption
     , getDataDir
-    , initTracer
     , listenOption
     , nodePortOption
     , optionT
@@ -52,6 +51,7 @@ import Cardano.CLI
     , verbosityOption
     , verbosityToArgs
     , verbosityToMinSeverity
+    , withLobemo
     )
 import Cardano.Launcher
     ( StdStream (..) )
@@ -155,19 +155,25 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
         => LaunchArgs
         -> IO ()
     exec (LaunchArgs network listen (Port nodePort) mStateDir verbosity) = do
-        (cfg, sb, tr) <- initTracer (verbosityToMinSeverity verbosity) "serve"
-        let stateDir = fromMaybe (stateDirForNetwork dataDir network) mStateDir
-        let bridgeConfig = HttpBridgeConfig network (Just stateDir) (Just (fromIntegral nodePort)) (verbosityToArgs verbosity) Inherit
-        let databaseDir = stateDir </> "wallets"
-        setupDirectory (logInfo tr) stateDir
-        setupDirectory (logInfo tr) databaseDir
-        logInfo tr $ "Running as v" <> T.pack (showVersion version)
-        exitWith =<< serveWallet @t @n
-            (cfg, sb, tr)
-            (Just databaseDir)
-            listen
-            (Launch bridgeConfig)
-            Nothing
+        let minSeverity = verbosityToMinSeverity verbosity
+        withLobemo Nothing minSeverity $ \(cfg, _sb, tr) -> do
+            let stateDir = fromMaybe (stateDirForNetwork dataDir network) mStateDir
+            let bridgeConfig = HttpBridgeConfig
+                    network
+                    (Just stateDir)
+                    (Just (fromIntegral nodePort))
+                    (verbosityToArgs verbosity)
+                    Inherit
+            let databaseDir = stateDir </> "wallets"
+            setupDirectory (logInfo tr) stateDir
+            setupDirectory (logInfo tr) databaseDir
+            logInfo tr $ "Running as v" <> T.pack (showVersion version)
+            exitWith =<< serveWallet @t @n
+                (cfg, tr)
+                (Just databaseDir)
+                listen
+                (Launch bridgeConfig)
+                Nothing
 
 {-------------------------------------------------------------------------------
                             Command - 'serve'
@@ -206,15 +212,16 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         => ServeArgs
         -> IO ()
     exec (ServeArgs _ listen (Port nodePort) databaseDir verbosity) = do
-        (cfg, sb, tr) <- initTracer (verbosityToMinSeverity verbosity) "serve"
-        whenJust databaseDir $ setupDirectory (logInfo tr)
-        logInfo tr $ "Running as v" <> T.pack (showVersion version)
-        exitWith =<< serveWallet @t @n
-            (cfg, sb, tr)
-            databaseDir
-            listen
-            (UseRunning (fromIntegral nodePort))
-            Nothing
+        let minSeverity = verbosityToMinSeverity verbosity
+        withLobemo Nothing minSeverity $ \(cfg, _sb, tr) -> do
+            whenJust databaseDir $ setupDirectory (logInfo tr)
+            logInfo tr $ "Running as v" <> T.pack (showVersion version)
+            exitWith =<< serveWallet @t @n
+                (cfg, tr)
+                databaseDir
+                listen
+                (UseRunning (fromIntegral nodePort))
+                Nothing
 
     whenJust m fn = case m of
        Nothing -> pure ()

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -18,7 +18,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.CLI
-    ( Port (..), setUtf8Encoding, withLobemo )
+    ( Port (..), setUtf8Encoding, withLogging )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -147,7 +147,7 @@ main = do
     -- Run a local cluster of cardano-sl nodes, a cardano-http-bridge on top and
     -- a cardano wallet server connected to the bridge.
     startCluster :: IO (Context (HttpBridge 'Testnet))
-    startCluster = withLobemo Nothing Info $ \(logConfig, _sb, tracer) -> do
+    startCluster = withLogging Nothing Info $ \(logConfig, _sb, tracer) -> do
         [ nodeApiPort, docPort ] <- randomUnusedTCPPorts 2
         let [core0Port, core1Port, core2Port] = [3000..3002] :: [Int]
         let relayPort = 3100 :: Int -- ports are hardcoded in topology.json

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -13,14 +13,12 @@ module Main where
 
 import Prelude
 
-import Cardano.BM.Backend.Switchboard
-    ( Switchboard )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.CLI
-    ( Port (..), initTracer, setUtf8Encoding )
+    ( Port (..), setUtf8Encoding, withLobemo )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -149,8 +147,7 @@ main = do
     -- Run a local cluster of cardano-sl nodes, a cardano-http-bridge on top and
     -- a cardano wallet server connected to the bridge.
     startCluster :: IO (Context (HttpBridge 'Testnet))
-    startCluster = do
-        (logConfig, sb, tracer) <- initTracer Info "http-bridge-integration"
+    startCluster = withLobemo Nothing Info $ \(logConfig, _sb, tracer) -> do
         [ nodeApiPort, docPort ] <- randomUnusedTCPPorts 2
         let [core0Port, core1Port, core2Port] = [3000..3002] :: [Int]
         let relayPort = 3100 :: Int -- ports are hardcoded in topology.json
@@ -185,7 +182,7 @@ main = do
         wait "cardano-node-simple" (waitForCluster nodeApiAddress)
 
         let withServer = withCardanoWalletServer
-                (logConfig, sb, tracer)
+                (logConfig, tracer)
                 (HttpBridgeConfig (Left Local) (Just networkDir) Nothing [] Inherit)
                 (Just ListenOnRandomPort)
 
@@ -229,16 +226,16 @@ main = do
 
     withCardanoWalletServer
         :: forall a. ()
-        => (CM.Configuration, Switchboard Text, Trace IO Text)
+        => (CM.Configuration, Trace IO Text)
         -> HttpBridge.HttpBridgeConfig
         -> Maybe Listen
         -> ((Port "wallet", Port "node", NetworkLayer IO t (Block Tx)) -> IO a)
         -> IO a
-    withCardanoWalletServer (logConfig, sb, tracer) bridgeConfig mlisten action = do
+    withCardanoWalletServer (logConfig, tracer) bridgeConfig mlisten action = do
         defaultPort <- findPort
         let listen = fromMaybe (ListenOnPort defaultPort) mlisten
         res <- newEmptyMVar
-        void $ serveWallet @t (logConfig, sb, tracer) Nothing listen (Launch bridgeConfig) $
+        void $ serveWallet @t (logConfig, tracer) Nothing listen (Launch bridgeConfig) $
             Just $ \port nodePort nl -> do
                 let port' = Port (fromIntegral port)
                 let nodePort' = Port (fromIntegral nodePort)

--- a/lib/http-bridge/test/integration/Main.hs
+++ b/lib/http-bridge/test/integration/Main.hs
@@ -147,7 +147,7 @@ main = do
     -- Run a local cluster of cardano-sl nodes, a cardano-http-bridge on top and
     -- a cardano wallet server connected to the bridge.
     startCluster :: IO (Context (HttpBridge 'Testnet))
-    startCluster = withLogging Nothing Info $ \(logConfig, _sb, tracer) -> do
+    startCluster = withLogging Nothing Info $ \(logConfig, tracer) -> do
         [ nodeApiPort, docPort ] <- randomUnusedTCPPorts 2
         let [core0Port, core1Port, core2Port] = [3000..3002] :: [Int]
         let relayPort = 3100 :: Int -- ports are hardcoded in topology.json

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -51,7 +51,7 @@ import Cardano.CLI
     , stateDirOption
     , verbosityOption
     , verbosityToMinSeverity
-    , withLobemo
+    , withLogging
     )
 import Cardano.Launcher
     ( StdStream (..) )
@@ -184,7 +184,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
             <*> extraArguments)
     exec (LaunchArgs listen nodePort mStateDir logCfg verbosity jArgs) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLobemo logCfg minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging logCfg minSeverity $ \(cfg, _sb, tr) -> do
             case genesisBlock jArgs of
                 Right block0File -> requireFilePath block0File
                 Left _ -> pure ()
@@ -239,7 +239,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (ServeArgs listen nodePort databaseDir logCfg verbosity block0H) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLobemo logCfg minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging logCfg minSeverity $ \(cfg, _sb, tr) -> do
             let baseUrl = localhostBaseUrl $ getPort nodePort
             let cp = JormungandrConnParams block0H baseUrl
             whenJust databaseDir $ setupDirectory (logInfo tr)

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -184,7 +184,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
             <*> extraArguments)
     exec (LaunchArgs listen nodePort mStateDir logCfg verbosity jArgs) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLogging logCfg minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging logCfg minSeverity $ \(cfg, tr) -> do
             case genesisBlock jArgs of
                 Right block0File -> requireFilePath block0File
                 Left _ -> pure ()
@@ -239,7 +239,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         -> IO ()
     exec (ServeArgs listen nodePort databaseDir logCfg verbosity block0H) = do
         let minSeverity = verbosityToMinSeverity verbosity
-        withLogging logCfg minSeverity $ \(cfg, _sb, tr) -> do
+        withLogging logCfg minSeverity $ \(cfg, tr) -> do
             let baseUrl = localhostBaseUrl $ getPort nodePort
             let cp = JormungandrConnParams block0H baseUrl
             whenJust databaseDir $ setupDirectory (logInfo tr)

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.CLI
-    ( setUtf8Encoding, withLobemo )
+    ( setUtf8Encoding, withLogging )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -110,7 +110,7 @@ main = do
             NetworkCLI.spec @t
 
 start :: IO (Context (Jormungandr 'Testnet))
-start = withLobemo Nothing Info $ \(cfg, _sb, tr) -> do
+start = withLogging Nothing Info $ \(cfg, _sb, tr) -> do
     ctx <- newEmptyMVar
     pid <- async $ bracket setupConfig teardownConfig $ \jmCfg -> do
         let listen = ListenOnRandomPort

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -14,6 +14,8 @@ import Prelude
 
 import Cardano.BM.Data.Severity
     ( Severity (..) )
+import Cardano.BM.Trace
+    ( Trace )
 import Cardano.CLI
     ( setUtf8Encoding, withLogging )
 import Cardano.Faucet
@@ -44,6 +46,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
 import Data.Text.Class
     ( showT )
 import Network.HTTP.Client
@@ -51,10 +55,11 @@ import Network.HTTP.Client
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( after, beforeAll, describe, hspec, parallel )
+    ( Spec, SpecWith, after, beforeAll, describe, hspec, parallel )
 import Test.Integration.Framework.DSL
     ( Context (..), KnownCommand (..), TxDescription (..), tearDown )
 
+import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.Wallet.Jormungandr.NetworkSpec as NetworkLayer
 import qualified Data.Text as T
 import qualified Test.Integration.Jormungandr.Scenario.API.StakePools as StakePoolsApiJormungandr
@@ -81,7 +86,7 @@ instance KnownCommand (Jormungandr n) where
     commandName = "cardano-wallet-jormungandr"
 
 main :: forall t. (t ~ Jormungandr 'Testnet) => IO ()
-main = do
+main = withLogging Nothing Info $ \logging -> do
     setUtf8Encoding
     hspec $ do
         describe "No backend required" $ do
@@ -90,7 +95,7 @@ main = do
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
             describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
 
-        describe "API Specifications" $ beforeAll start $ after tearDown $ do
+        describe "API Specifications" $ specWithServer logging $ do
             Addresses.spec
             StakePoolsApiJormungandr.spec
             Transactions.spec
@@ -100,7 +105,7 @@ main = do
             ByronWallets.spec
             Network.spec
 
-        describe "CLI Specifications" $ beforeAll start $ after tearDown $ do
+        describe "CLI Specifications" $ specWithServer logging $ do
             AddressesCLI.spec @t
             ServerCLI.spec @t
             StakePoolsCliJormungandr.spec @t
@@ -109,26 +114,32 @@ main = do
             PortCLI.spec @t
             NetworkCLI.spec @t
 
-start :: IO (Context (Jormungandr 'Testnet))
-start = withLogging Nothing Info $ \(cfg, _sb, tr) -> do
-    ctx <- newEmptyMVar
-    pid <- async $ bracket setupConfig teardownConfig $ \jmCfg -> do
-        let listen = ListenOnRandomPort
-        serveWallet (cfg, tr) Nothing listen (Launch jmCfg) $ \wPort nPort bp -> do
-            let baseUrl = "http://localhost:" <> T.pack (showT wPort) <> "/"
-            manager <- (baseUrl,) <$> newManager defaultManagerSettings
-            faucet <- initFaucet
-            putMVar ctx $  Context
-                { _cleanup = pure ()
-                , _manager = manager
-                , _nodePort = nPort
-                , _walletPort = wPort
-                , _faucet = faucet
-                , _feeEstimator = mkFeeEstimator (getFeePolicy bp)
-                , _target = Proxy
-                }
-    race (takeMVar ctx) (wait pid) >>=
-        either pure (throwIO . ProcessHasExited "integration")
+specWithServer
+    :: (CM.Configuration, Trace IO Text)
+    -> SpecWith (Context (Jormungandr 'Testnet))
+    -> Spec
+specWithServer (cfg, tr) = beforeAll start . after tearDown
+  where
+    start :: IO (Context (Jormungandr 'Testnet))
+    start = do
+        ctx <- newEmptyMVar
+        pid <- async $ bracket setupConfig teardownConfig $ \jmCfg -> do
+            let listen = ListenOnRandomPort
+            serveWallet (cfg, tr) Nothing listen (Launch jmCfg) $ \wPort nPort bp -> do
+                let baseUrl = "http://localhost:" <> T.pack (showT wPort) <> "/"
+                manager <- (baseUrl,) <$> newManager defaultManagerSettings
+                faucet <- initFaucet
+                putMVar ctx $  Context
+                    { _cleanup = pure ()
+                    , _manager = manager
+                    , _nodePort = nPort
+                    , _walletPort = wPort
+                    , _faucet = faucet
+                    , _feeEstimator = mkFeeEstimator (getFeePolicy bp)
+                    , _target = Proxy
+                    }
+        race (takeMVar ctx) (wait pid) >>=
+            either pure (throwIO . ProcessHasExited "integration")
 
 mkFeeEstimator :: FeePolicy -> TxDescription -> (Natural, Natural)
 mkFeeEstimator policy (TxDescription nInps nOuts) =

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.CLI
-    ( initTracer, setUtf8Encoding )
+    ( setUtf8Encoding, withLobemo )
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
@@ -110,12 +110,11 @@ main = do
             NetworkCLI.spec @t
 
 start :: IO (Context (Jormungandr 'Testnet))
-start = do
+start = withLobemo Nothing Info $ \(cfg, _sb, tr) -> do
     ctx <- newEmptyMVar
-    logCfg <- initTracer Info "integration"
     pid <- async $ bracket setupConfig teardownConfig $ \jmCfg -> do
         let listen = ListenOnRandomPort
-        serveWallet logCfg Nothing listen (Launch jmCfg) $ \wPort nPort bp -> do
+        serveWallet (cfg, tr) Nothing listen (Launch jmCfg) $ \wPort nPort bp -> do
             let baseUrl = "http://localhost:" <> T.pack (showT wPort) <> "/"
             manager <- (baseUrl,) <$> newManager defaultManagerSettings
             faucet <- initFaucet


### PR DESCRIPTION
Relates to #851 

# Overview

- This uses `bracket` to setup and shutdown logging.
- Also, while I was there modifying the `initLogging` function I added an optional CLI option to specify the logging configuration.
 