### PR TITLE
implement 'withinSameTip' = to retry an action if the tip has changed while executing it

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -174,6 +174,7 @@ test-suite unit
     , QuickCheck
     , quickcheck-state-machine >= 0.6.0
     , random
+    , retry
     , servant
     , servant-server
     , servant-swagger

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -141,6 +141,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
             (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
             (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."servant" or (buildDepError "servant"))
             (hsPkgs."servant-server" or (buildDepError "servant-server"))
             (hsPkgs."servant-swagger" or (buildDepError "servant-swagger"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#713 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a helper function `withinSameTip` to "bracket" an action, retrying it if necessary (i.e. if the tip has changed during the execution of the action). 

# Comments

<!-- Additional comments or screenshots to attach if any -->

example usage:

```hs
withinSameTip defaultPolicy (getNetworkTip nl) $ \tip -> do
    activity <- getStakePoolActivity tip
    distribution  <- getStakeDistribution tip
    pure $ combineMetrics activity distribution
```
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
