### PR TITLE
Relocate C.W.Jormungandr.BlockHeaders to C.W.Network.BlockHeaders

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -102,6 +102,7 @@ library
       Cardano.Wallet.DB.Sqlite.Types
       Cardano.Wallet.DaedalusIPC
       Cardano.Wallet.Network
+      Cardano.Wallet.Network.BlockHeaders
       Cardano.Wallet.Network.Ports
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Random
@@ -175,6 +176,7 @@ test-suite unit
     , quickcheck-state-machine >= 0.6.0
     , random
     , retry
+    , safe
     , servant
     , servant-server
     , servant-swagger
@@ -212,6 +214,7 @@ test-suite unit
       Cardano.Wallet.DB.SqliteSpec
       Cardano.Wallet.DB.StateMachine
       Cardano.Wallet.DummyTarget.Primitive.Types
+      Cardano.Wallet.Network.BlockHeadersSpec
       Cardano.Wallet.NetworkSpec
       Cardano.Wallet.Primitive.AddressDerivation.RandomSpec
       Cardano.Wallet.Primitive.AddressDerivation.SequentialSpec

--- a/lib/core/src/Cardano/Wallet/Network/BlockHeaders.hs
+++ b/lib/core/src/Cardano/Wallet/Network/BlockHeaders.hs
@@ -21,7 +21,7 @@
 -- point.
 --
 
-module Cardano.Wallet.Jormungandr.BlockHeaders
+module Cardano.Wallet.Network.BlockHeaders
     (
     -- * Types
       BlockHeaders(..)

--- a/lib/core/test/unit/Cardano/Wallet/Network/BlockHeadersSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Network/BlockHeadersSpec.hs
@@ -8,13 +8,13 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.Wallet.Jormungandr.BlockHeadersSpec
+module Cardano.Wallet.Network.BlockHeadersSpec
     ( spec
     ) where
 
 import Prelude
 
-import Cardano.Wallet.Jormungandr.BlockHeaders
+import Cardano.Wallet.Network.BlockHeaders
     ( BlockHeaders (..)
     , dropStartingFromSlotId
     , greatestCommonBlockHeader

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -75,7 +75,6 @@ library
       Cardano.Wallet.Jormungandr.Api
       Cardano.Wallet.Jormungandr.Api.Client
       Cardano.Wallet.Jormungandr.Binary
-      Cardano.Wallet.Jormungandr.BlockHeaders
       Cardano.Wallet.Jormungandr.Compatibility
       Cardano.Wallet.Jormungandr.Environment
       Cardano.Wallet.Jormungandr.Network
@@ -160,7 +159,6 @@ test-suite unit
   other-modules:
       Cardano.Wallet.Jormungandr.ApiSpec
       Cardano.Wallet.Jormungandr.BinarySpec
-      Cardano.Wallet.Jormungandr.BlockHeadersSpec
       Cardano.Wallet.Jormungandr.CompatibilitySpec
       Cardano.Wallet.Jormungandr.EnvironmentSpec
       Cardano.Wallet.Jormungandr.NetworkSpec

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -94,7 +94,11 @@ import Cardano.Wallet.Jormungandr.Api.Client
     )
 import Cardano.Wallet.Jormungandr.Binary
     ( runGetOrFail )
-import Cardano.Wallet.Jormungandr.BlockHeaders
+import Cardano.Wallet.Jormungandr.Compatibility
+    ( Jormungandr, genConfigFile, localhostBaseUrl )
+import Cardano.Wallet.Network
+    ( Cursor, NetworkLayer (..), NextBlocksResult (..), defaultRetryPolicy )
+import Cardano.Wallet.Network.BlockHeaders
     ( BlockHeaders (..)
     , appendBlockHeaders
     , blockHeadersAtGenesis
@@ -105,10 +109,6 @@ import Cardano.Wallet.Jormungandr.BlockHeaders
     , greatestCommonBlockHeader
     , updateUnstableBlocks
     )
-import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr, genConfigFile, localhostBaseUrl )
-import Cardano.Wallet.Network
-    ( Cursor, NetworkLayer (..), NextBlocksResult (..), defaultRetryPolicy )
 import Cardano.Wallet.Network.Ports
     ( PortNumber, getRandomPort, waitForPort )
 import Cardano.Wallet.Primitive.Model

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -20,8 +20,6 @@ import Cardano.Wallet.Jormungandr.Api
     ( GetTipId, api )
 import Cardano.Wallet.Jormungandr.Binary
     ( MessageType (..), fragmentId, putSignedTx, runPut, withHeader )
-import Cardano.Wallet.Jormungandr.BlockHeaders
-    ( emptyBlockHeaders )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, Network (..) )
 import Cardano.Wallet.Jormungandr.Network
@@ -46,6 +44,8 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     , NextBlocksResult (..)
     )
+import Cardano.Wallet.Network.BlockHeaders
+    ( emptyBlockHeaders )
 import Cardano.Wallet.Primitive.AddressDerivation.Sequential
     ( SeqKey )
 import Cardano.Wallet.Primitive.Types

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -16,14 +16,14 @@ import Prelude
 
 import Cardano.Wallet.Jormungandr.Api.Client
     ( JormungandrClient (..) )
-import Cardano.Wallet.Jormungandr.BlockHeaders
-    ( emptyBlockHeaders )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr, Network (Testnet) )
 import Cardano.Wallet.Jormungandr.Network
     ( ErrGetDescendants (..), mkRawNetworkLayer )
 import Cardano.Wallet.Network
     ( Cursor, ErrGetBlock (..), NetworkLayer (..), NextBlocksResult (..) )
+import Cardano.Wallet.Network.BlockHeaders
+    ( emptyBlockHeaders )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -142,6 +142,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
             (hsPkgs."random" or (buildDepError "random"))
             (hsPkgs."retry" or (buildDepError "retry"))
+            (hsPkgs."safe" or (buildDepError "safe"))
             (hsPkgs."servant" or (buildDepError "servant"))
             (hsPkgs."servant-server" or (buildDepError "servant-server"))
             (hsPkgs."servant-swagger" or (buildDepError "servant-swagger"))


### PR DESCRIPTION
# Issue Number

#711 


# Overview

- [x] Relocate Cardano.Wallet.Jormungandr.BlockHeaders to Cardano.Wallet.Network.BlockHeaders. `Cardano.Pool.Metrics` needs them!

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
