### PR TITLE
jormungandr launch: use --rest-listen instead of generating config.yaml

### DIFF
--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -89,7 +89,7 @@ import Options.Applicative
     , Parser
     , argument
     , command
-    , footer
+    , footerDoc
     , help
     , helper
     , info
@@ -106,6 +106,7 @@ import System.FilePath
     ( (</>) )
 
 import qualified Data.Text as T
+import qualified Options.Applicative.Help.Pretty as D
 
 {-------------------------------------------------------------------------------
                               Main entry point
@@ -174,9 +175,26 @@ cmdLaunch
     -> Mod CommandFields (IO ())
 cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
     <> progDesc "Launch and monitor a wallet server and its chain producers."
-    <> footer
-        "Please note that launch will generate a configuration for Jörmungandr \
-        \in a folder specified by '--state-dir'."
+    <> footerDoc (Just $ D.empty
+        <> D.text "Examples:"
+        <> D.line
+        <> D.text "1) Minimal setup, relying on sensible defaults:" <> D.line
+        <> D.text "    launch --genesis-block block0.bin" <> D.line
+        <> D.line
+        <> D.text "2) Launching a full node: " <> D.line
+        <> D.text "    launch --genesis-block block0.bin -- --secret secret.yaml" <> D.line
+        <> D.line
+        <> D.text "3) Bootstrapping from trusted peers*:" <> D.line
+        <> D.text "    launch --genesis-block-hash 4c05c5bb -- --config config.yaml" <> D.line
+        <> D.line
+        <> D.text "(*) assuming 'trusted_peers' is defined in 'config.yaml'"
+        <> D.line
+        <> D.line
+        <> D.text "Please also note that 'launch' will define a 'rest' and" <> D.line
+        <> D.text "'storage' configuration for Jörmungandr so in case you" <> D.line
+        <> D.text "provide a configuration file as extra arguments, make sure" <> D.line
+        <> D.text "not to define any these configuration settings."
+       )
   where
     cmd = fmap exec $ LaunchArgs
         <$> hostPreferenceOption
@@ -290,7 +308,7 @@ genesisHashOption = optionT $ mempty
 extraArguments :: Parser [String]
 extraArguments = many $ argument jmArg $ mempty
     <> metavar "[-- ARGUMENTS...]"
-    <> help "Extra arguments to be passed to jormungandr."
+    <> help "Extra arguments to be passed to Jörmungandr."
   where
     jmArg = do
         arg <- readerAsk
@@ -305,7 +323,6 @@ extraArguments = many $ argument jmArg $ mempty
         | "--storage" `isPrefixOf` arg = Just $
             suggestion "--storage"
         | otherwise = Nothing
-    suggestion arg = "The " <> arg <> " argument is used by "
-        <> "\"cardano-wallet-jormungandr launch\"."
+    suggestion arg = "The " <> arg <> " argument is used by the launch command."
         <> "\nIf you need this level of flexibility, run \"jormungandr\" "
         <> "separately and use \"cardano-wallet-jormungandr serve\"."

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -308,6 +308,6 @@ extraArguments = many $ argument jmArg $ mempty
             suggestion "--storage"
         | otherwise = Nothing
     suggestion arg = "The " <> arg <> " argument is used by "
-        <> "`cardano-wallet-jormungandr launch'."
-        <> "\nIf you need this level of flexibility, run `jormungandr' "
-        <> " separately and use `cardano-wallet-jormungandr serve'."
+        <> "\"cardano-wallet-jormungandr launch\"."
+        <> "\nIf you need this level of flexibility, run \"jormungandr\" "
+        <> "separately and use \"cardano-wallet-jormungandr serve\"."

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -189,8 +189,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
             <$> genesisBlockOption
             <*> extraArguments)
     exec (LaunchArgs hostPreference listen nodePort mStateDir logCfg verbosity jArgs) = do
-        let minSeverity = verbosityToMinSeverity verbosity
-        withLogging logCfg minSeverity $ \(cfg, tr) -> do
+        withLogging logCfg (verbosityToMinSeverity verbosity) $ \(cfg, tr) -> do
             case genesisBlock jArgs of
                 Right block0File -> requireFilePath block0File
                 Left _ -> pure ()
@@ -200,7 +199,6 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
                     { _stateDir = stateDir
                     , _genesisBlock = genesisBlock jArgs
                     , _restApiPort = fromIntegral . getPort <$> nodePort
-                    , _minSeverity = minSeverity
                     , _outputStream = Inherit
                     , _extraArgs = extraJormungandrArgs jArgs
                     }

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Compatibility.hs
@@ -24,7 +24,6 @@ module Cardano.Wallet.Jormungandr.Compatibility
       -- * Node's Configuration
     , BaseUrl (..)
     , Scheme (..)
-    , genConfigFile
     , localhostBaseUrl
     , baseUrlToText
     ) where
@@ -39,8 +38,6 @@ import Cardano.Wallet.Jormungandr.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Jormungandr.Primitive.Types
     ( Tx (..) )
-import Cardano.Wallet.Network.Ports
-    ( PortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( KeyToAddress (..), getRawKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Random
@@ -60,8 +57,6 @@ import Control.Arrow
     ( second )
 import Control.Monad
     ( when )
-import Data.Aeson
-    ( Value (..), object, (.=) )
 import Data.ByteString
     ( ByteString )
 import Data.ByteString.Base58
@@ -78,14 +73,11 @@ import Data.Word
     ( Word16 )
 import Servant.Client.Core
     ( BaseUrl (..), Scheme (..), showBaseUrl )
-import System.FilePath
-    ( FilePath, (</>) )
 
 import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.CBOR.Write as CBOR
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
@@ -222,29 +214,6 @@ instance KnownNetwork n => DecodeAddress (Jormungandr n) where
                 <> " =/= "
                 <> B8.unpack (BS.pack [discriminant])
                 <> "."
-
--- | Generate a configuration file for Jörmungandr@0.3.999
-genConfigFile
-    :: FilePath
-    -> PortNumber
-    -> BaseUrl
-    -> Aeson.Value
-genConfigFile stateDir addressPort (BaseUrl _ host port _) = object
-    [ "storage" .= (stateDir </> "chain")
-    , "rest" .= object
-        [ "listen" .= String listen ]
-    , "p2p" .= object
-        [ "trusted_peers" .= ([] :: [()])
-        , "topics_of_interest" .= object
-            [ "messages" .= String "low"
-            , "blocks" .= String "normal"
-            ]
-        , "public_address" .= String publicAddress
-        ]
-    ]
-  where
-    listen = T.pack $ mconcat [host, ":", show port]
-    publicAddress = T.pack $ mconcat ["/ip4/127.0.0.1/tcp/", show addressPort]
 
 {-------------------------------------------------------------------------------
                                      Base URL

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -54,8 +54,6 @@ module Cardano.Wallet.Jormungandr.Network
 
 import Prelude
 
-import Cardano.BM.Data.Severity
-    ( Severity (..) )
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.Launcher
@@ -145,7 +143,6 @@ import System.FilePath
 import qualified Cardano.Wallet.Jormungandr.Binary as J
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.Char as C
 import qualified Data.Map as Map
 
 -- | Whether to start Jormungandr with the given config, or to connect to an
@@ -167,7 +164,6 @@ data JormungandrConfig = JormungandrConfig
     { _stateDir :: FilePath
     , _genesisBlock :: Either (Hash "Genesis") FilePath
     , _restApiPort :: Maybe PortNumber
-    , _minSeverity :: Severity
     , _outputStream :: StdStream
     , _extraArgs :: [String]
     } deriving (Show, Eq)
@@ -471,7 +467,7 @@ withJormungandr
     -> (JormungandrConnParams -> IO a)
     -- ^ Action to run while node is running.
     -> IO (Either ErrStartup a)
-withJormungandr tr (JormungandrConfig stateDir block0 mPort logSeverity output extraArgs) cb = do
+withJormungandr tr (JormungandrConfig stateDir block0 mPort output extraArgs) cb = do
     apiPort <- maybe getRandomPort pure mPort
     let baseUrl = localhostBaseUrl $ fromIntegral apiPort
     getGenesisBlockArg block0 >>= \case
@@ -479,7 +475,6 @@ withJormungandr tr (JormungandrConfig stateDir block0 mPort logSeverity output e
             let args = genesisBlockArg ++
                     [ "--rest-listen", "127.0.0.1:" <> show apiPort
                     , "--storage", stateDir </> "chain"
-                    , "--log-level", C.toLower <$> show logSeverity
                     ] ++ extraArgs
             let cmd = Command "jormungandr" args (return ()) output
             let tr' = transformLauncherTrace tr

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
@@ -65,14 +65,13 @@ setupConfig = do
             configDir
             (Right $ dir </> "block0.bin")
             Nothing
-            minBound
             (UseHandle logFile)
             ["--secret", dir </> "secret.yaml"]
     genConfigYaml cfg
     pure cfg
 
 teardownConfig :: JormungandrConfig -> IO ()
-teardownConfig (JormungandrConfig d _ _ _ output _) = do
+teardownConfig (JormungandrConfig d _ _ output _) = do
     case output of
         UseHandle h -> hClose h
         _ -> pure ()
@@ -109,7 +108,7 @@ spec = describe "genConfigFile integration tests helper" $ do
         }|]
 
 genConfigYaml :: JormungandrConfig -> IO ()
-genConfigYaml (JormungandrConfig stateDir _ _ _ _ _) = do
+genConfigYaml (JormungandrConfig stateDir _ _ _ _) = do
     p2pPort <- getRandomPort
     genConfigFile stateDir p2pPort
         & Yaml.encodeFile nodeConfigFile

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Launch.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 -- |
 -- Copyright: © 2018-2019 IOHK
@@ -8,9 +9,9 @@
 -- tests.
 
 module Cardano.Wallet.Jormungandr.Launch
-    ( setupConfig
-    , teardownConfig
+    ( withConfig
     , withBackendOnly
+    , spec
     ) where
 
 import Prelude
@@ -21,37 +22,54 @@ import Cardano.Launcher
     ( StdStream (..) )
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrConfig (..), JormungandrConnParams, withJormungandr )
+import Cardano.Wallet.Network.Ports
+    ( PortNumber, getRandomPort )
 import Control.Exception
     ( bracket, throwIO )
+import Data.Aeson
+    ( Value (..), object, (.=) )
+import Data.Aeson.QQ
+    ( aesonQQ )
+import Data.Function
+    ( (&) )
 import System.Directory
     ( doesDirectoryExist, removeDirectoryRecursive )
 import System.Environment
     ( lookupEnv )
 import System.FilePath
-    ( (</>) )
+    ( FilePath, (</>) )
 import System.IO
     ( IOMode (..), hClose, openFile )
 import System.IO.Temp
     ( createTempDirectory, getCanonicalTemporaryDirectory )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
 
+import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
+import qualified Data.Yaml as Yaml
 
 -- | Starts jormungandr on a random port using the integration tests config.
 -- The data directory will be stored in a unique location under the system
 -- temporary directory.
+withConfig :: (JormungandrConfig -> IO a) -> IO a
+withConfig = bracket setupConfig teardownConfig
+
 setupConfig :: IO JormungandrConfig
 setupConfig = do
     let dir = "test/data/jormungandr"
     tmp <- getCanonicalTemporaryDirectory
     configDir <- createTempDirectory tmp "cardano-wallet-jormungandr"
     logFile <- openFile (configDir </> "jormungandr.log") WriteMode
-    pure $ JormungandrConfig
-        configDir
-        (Right $ dir </> "block0.bin")
-        Nothing
-        minBound
-        (UseHandle logFile)
-        ["--secret", T.pack (dir </> "secret.yaml")]
+    let cfg = JormungandrConfig
+            configDir
+            (Right $ dir </> "block0.bin")
+            Nothing
+            minBound
+            (UseHandle logFile)
+            ["--secret", dir </> "secret.yaml"]
+    genConfigYaml cfg
+    pure cfg
 
 teardownConfig :: JormungandrConfig -> IO ()
 teardownConfig (JormungandrConfig d _ _ _ output _) = do
@@ -65,8 +83,54 @@ teardownConfig (JormungandrConfig d _ _ _ output _) = do
         (_, True) -> removeDirectoryRecursive d
         _ -> pure ()
 
--- | Launches jörmungandr, but not the wallet.
+-- | Launches jörmungandr with a test config, but not the wallet.
 withBackendOnly :: (JormungandrConnParams -> IO a) -> IO a
-withBackendOnly cb =
-    bracket setupConfig teardownConfig $ \jmConfig ->
-        (withJormungandr nullTracer jmConfig cb >>= either throwIO pure)
+withBackendOnly cb = withConfig $ \jmConfig -> do
+    withJormungandr nullTracer jmConfig cb >>= either throwIO pure
+
+{-------------------------------------------------------------------------------
+                           Generate YAML config file
+-------------------------------------------------------------------------------}
+
+spec :: Spec
+spec = describe "genConfigFile integration tests helper" $ do
+    it "example configuration" $ do
+        let stateDir = "/state-dir"
+        genConfigFile stateDir 8081 `shouldBe` [aesonQQ|{
+            "storage": "/state-dir/chain",
+            "p2p": {
+                "trusted_peers": [],
+                "topics_of_interest": {
+                    "messages": "low",
+                    "blocks": "normal"
+                },
+                "public_address" : "/ip4/127.0.0.1/tcp/8081"
+            }
+        }|]
+
+genConfigYaml :: JormungandrConfig -> IO ()
+genConfigYaml (JormungandrConfig stateDir _ _ _ _ _) = do
+    p2pPort <- getRandomPort
+    genConfigFile stateDir p2pPort
+        & Yaml.encodeFile nodeConfigFile
+  where
+    nodeConfigFile = stateDir </> "jormungandr-config.yaml"
+
+-- | Generate a configuration file for Jörmungandr@0.3.999
+genConfigFile
+    :: FilePath
+    -> PortNumber
+    -> Aeson.Value
+genConfigFile stateDir addressPort = object
+    [ "storage" .= (stateDir </> "chain")
+    , "p2p" .= object
+        [ "trusted_peers" .= ([] :: [()])
+        , "topics_of_interest" .= object
+            [ "messages" .= String "low"
+            , "blocks" .= String "normal"
+            ]
+        , "public_address" .= String publicAddress
+        ]
+    ]
+  where
+    publicAddress = T.pack $ mconcat ["/ip4/127.0.0.1/tcp/", show addressPort]

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -12,8 +12,6 @@ module Cardano.Wallet.Jormungandr.NetworkSpec
 
 import Prelude
 
-import Cardano.BM.Data.Severity
-    ( Severity (..) )
 import Cardano.BM.Trace
     ( nullTracer )
 import Cardano.Wallet.Jormungandr.Api
@@ -341,7 +339,6 @@ spec = do
                 stateDir
                 (Right "test/data/jormungandr/block0.bin")
                 Nothing
-                Info
                 Inherit
                 ["--secret", "test/data/jormungandr/secret.yaml"]
         let tr = nullTracer

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/CompatibilitySpec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -10,7 +9,7 @@
 
 module Cardano.Wallet.Jormungandr.CompatibilitySpec
     ( spec
-    )where
+    ) where
 
 import Prelude
 
@@ -19,7 +18,7 @@ import Cardano.Crypto.Wallet
 import Cardano.Wallet.Jormungandr.Binary
     ( signData, singleAddressFromKey )
 import Cardano.Wallet.Jormungandr.Compatibility
-    ( BaseUrl (..), Jormungandr, Scheme (..), genConfigFile )
+    ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Environment
     ( KnownNetwork (..), Network (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -56,8 +55,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeDecodeAddress, unsafeFromHex )
 import Control.Monad
     ( replicateM )
-import Data.Aeson.QQ
-    ( aesonQQ )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
 import Data.ByteString
@@ -285,25 +282,6 @@ spec = do
             ]
             "ta1sn0e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr7\
             \sp2hlmqvhyywy266ghldvxn4p0adxn0esew6a423jkmxpdsc5d8xw6gar"
-
-    describe "genConfigFile" $ do
-        it "example configuration" $ do
-            let stateDir = "/state-dir"
-            let baseUrl = BaseUrl Http "127.0.0.1" 8080 "/api"
-            genConfigFile stateDir 8081 baseUrl `shouldBe` [aesonQQ|{
-                "storage": "/state-dir/chain",
-                "rest": {
-                    "listen": "127.0.0.1:8080"
-                },
-                "p2p": {
-                    "trusted_peers": [],
-                    "topics_of_interest": {
-                        "messages": "low",
-                        "blocks": "normal"
-                    },
-                    "public_address" : "/ip4/127.0.0.1/tcp/8081"
-                }
-            }|]
 
     describe "Random Address Discovery Properties" $ do
         it "isOurs works as expected during key derivation in testnet" $ do


### PR DESCRIPTION
Relates to #832 and #848.
Supersedes #850.

# Overview

`cardano-wallet-jormungandr launch` specifies the REST API port and storage directory. The user provides the rest of the Jörmungandr configuration (e.g. trusted peers). 

# Comments

The Jörmungandr P2P listen address, port, and log level are no longer configured by cardano-wallet.
