### PR TITLE
nix: Provide derivations for Daedalus installer

### DIFF
--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -40,7 +40,7 @@ let
   windows = rec {
     # URL and hash of windows binary release
     url = "https://github.com/input-output-hk/jormungandr/releases/download/v${release.version}/jormungandr-v${release.version}-x86_64-pc-windows-msvc.zip";
-    sha256 = "0dd2b2r50kcwakn61sv7xvf2s1yl586rlk8zch2bpfw9bjqrs0hl";
+    sha256 = "16pxgi4igvfh2kccsbyizfc4wyxr8fs1872hpsmr99ppna09rqi3";
   };
 
   jormungandr-win64 = pkgs.runCommand "jormungandr-win64-${release.version}" {

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -37,7 +37,27 @@ let
     cargoSha256 = "0pflam5am760z4pz3j1ga4arsixmay2487sgpqrhrkiaws4nxy57";
   };
 
+  windows = rec {
+    # URL and hash of windows binary release
+    url = "https://github.com/input-output-hk/jormungandr/releases/download/v${release.version}/jormungandr-v${release.version}-x86_64-pc-windows-msvc.zip";
+    sha256 = "0dd2b2r50kcwakn61sv7xvf2s1yl586rlk8zch2bpfw9bjqrs0hl";
+  };
+
+  jormungandr-win64 = pkgs.runCommand "jormungandr-win64-${release.version}" {
+    nativeBuildInputs = [ pkgs.buildPackages.unzip ];
+  } ''
+    mkdir -p $out/bin
+    cd $out/bin
+    unzip ${pkgs.fetchurl windows}
+  '';
+
+  nonWindows = pkg: if pkgs.stdenv.hostPlatform.isWindows
+    then jormungandr-win64
+    else pkg;
+
 in {
-  jormungandr = iohkLib.rust-packages.pkgs.makeJormungandr release;
-  jormungandr-cli = iohkLib.rust-packages.pkgs.makeJcli release;
+  jormungandr = nonWindows (iohkLib.rust-packages.pkgs.makeJormungandr release);
+  jormungandr-cli = nonWindows (iohkLib.rust-packages.pkgs.makeJcli release);
+
+  inherit jormungandr-win64;
 }

--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -1,0 +1,48 @@
+############################################################################
+# Release package for cardano-wallet-jormungandr
+#
+# This makes release builds of cardano-wallet-jormungandr and bundles
+# dependencies as required for different systems.
+#
+############################################################################
+
+{ pkgs
+, version
+, cardano-wallet-jormungandr
+, jmPkgs ? import ./jormungandr.nix { inherit pkgs; }
+, jormungandr ? jmPkgs.jormungandr
+, jormungandr-win64 ? jmPkgs.jormungandr-win64
+}:
+
+with pkgs.lib;
+
+let
+  name = "cardano-wallet-jormungandr-${version}";
+
+  deps = {
+    nix = ''
+      strip $out/bin/cardano-wallet-jormungandr
+      wrapProgram $out/bin/cardano-wallet-jormungandr \
+        --prefix PATH : ${jormungandr}/bin
+    '';
+    darwin = ''
+      cp ${jormungandr}/bin/* $out/bin
+    '';
+    windows = ''
+      cp -v ${pkgs.libffi}/bin/libffi-6.dll $out/bin
+      cp ${jormungandr-win64}/* $out/bin
+    '';
+  };
+  provideDeps = { nix, darwin ? "", windows ? "" }:
+    with pkgs.stdenv.hostPlatform;
+    if isWindows then windows else (if isDarwin then darwin else nix);
+
+in pkgs.runCommand name {
+  inherit version;
+  nativeBuildInputs = [ pkgs.makeWrapper pkgs.binutils ];
+} ''
+  cp -R ${cardano-wallet-jormungandr} $out
+  chmod -R +w $out
+
+  ${provideDeps deps}
+''

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -1,0 +1,35 @@
+{ pkgs
+, cardano-wallet-jormungandr
+, project
+, jpkgs ? import ./jormungandr.nix { inherit pkgs; }
+, jormungandr-win64 ? jpkgs.jormungandr-win64
+}:
+
+let
+  testData = ../lib/jormungandr/test/data/jormungandr;
+  name = "cardano-wallet-jormungandr-${project.version}-win64";
+  jm-bat = pkgs.writeText "jm.bat" ''
+    jormungandr.exe --config config.yaml --genesis-block block0.bin --secret secret.yaml
+  '';
+  cw-bat = pkgs.writeText "cw.bat" ''
+    cardano-wallet-jormungandr.exe serve --node-port 8081 --genesis-hash HASH --database c:\\cardano-wallet-jormungandr\\wallet.db
+  '';
+in pkgs.runCommand name {
+  nativeBuildInputs = [ pkgs.zip pkgs.jq pkgs.gnused project.jormungandr-cli ];
+} ''
+  mkdir -pv jm $out/nix-support
+  cd jm
+
+  cp -v ${cardano-wallet-jormungandr}/bin/* .
+  cp -v ${jormungandr-win64}/bin/* .
+  cp -v ${testData}/block0.bin ${testData}/secret.yaml .
+  cp -v ${jm-bat} jm.bat
+  hash="$(jcli genesis hash --input block0.bin)"
+  sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat
+  sed -e 's/storage:.*/storage: "c:\\\\cardano-wallet-jormungandr\\\\storage"/' \
+      ${testData}/config.yaml > config.yaml
+  chmod -R +w .
+
+  zip -r $out/${name}.zip .
+  echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
+''

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -1,8 +1,15 @@
+############################################################################
+# Windows release CARDAN~1.ZIP
+#
+# This bundles up the windows build and its dependencies, adds an
+# example self-node configuration, and some .BAT files for launching,
+# and sets up the Hydra build artifact.
+#
+############################################################################
+
 { pkgs
 , cardano-wallet-jormungandr
 , project
-, jpkgs ? import ./jormungandr.nix { inherit pkgs; }
-, jormungandr-win64 ? jpkgs.jormungandr-win64
 }:
 
 let
@@ -21,7 +28,6 @@ in pkgs.runCommand name {
   cd jm
 
   cp -v ${cardano-wallet-jormungandr}/bin/* .
-  cp -v ${jormungandr-win64}/bin/* .
   cp -v ${testData}/block0.bin ${testData}/secret.yaml .
   cp -v ${jm-bat} jm.bat
   hash="$(jcli genesis hash --input block0.bin)"

--- a/release.nix
+++ b/release.nix
@@ -43,6 +43,13 @@ let
       inherit pkgs project;
       cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
     };
+
+    # These derivations are used for the Daedalus installer.
+    daedalus-jormungandr = with jobs; {
+      linux = native.cardano-wallet-jormungandr.x86_64-linux;
+      macos = native.cardano-wallet-jormungandr.x86_64-darwin;
+      windows = x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+    };
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.

--- a/release.nix
+++ b/release.nix
@@ -38,38 +38,11 @@ let
       ]
     );
 
-    cardano-wallet-jormungandr-win64 = let
-      jm = pkgs.fetchurl {
-        url = https://github.com/input-output-hk/jormungandr/releases/download/v0.3.3/jormungandr-v0.3.3-x86_64-pc-windows-msvc.zip;
-        sha256 = "0psva16vq86gcld701k0fi6kk1ydnm2q3yd2mdgflb0x8zpm2i3g";
-      };
-      testData = ./lib/jormungandr/test/data/jormungandr;
-      name = "cardano-wallet-jormungandr-${project.version}-win64.zip";
-      jm-bat = pkgs.writeText "jm.bat" ''
-        jormungandr.exe --config config.yaml --genesis-block block0.bin -- --secret secret.yaml
-      '';
-      cw-bat = pkgs.writeText "cw.bat" ''
-        cardano-wallet-jormungandr.exe serve --node-port 8081 --genesis-block-hash HASH --database c:\\cardano-wallet-jormungandr\\wallets
-      '';
-    in pkgs.runCommand "cardano-wallet-jormungandr-win64" {
-      buildInputs = [ pkgs.zip pkgs.unzip pkgs.jq pkgs.gnused project.jormungandr-cli ];
-    } ''
-      mkdir -pv jm $out/nix-support
-      cd jm
-
-      cp -v ${jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux}/bin/* .
-      unzip ${jm}
-      cp -v ${testData}/block0.bin ${testData}/secret.yaml .
-      cp -v ${jm-bat} jm.bat
-      hash="$(jcli genesis hash --input block0.bin)"
-      sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat
-      sed -e 's/storage:.*/storage: "c:\\\\cardano-wallet-jormungandr\\\\storage"/' \
-          ${testData}/config.yaml > config.yaml
-      chmod -R +w .
-
-      zip -r $out/${name} .
-      echo "file binary-dist $out/${name}" > $out/nix-support/hydra-build-products
-    '';
+    # This is used for testing the build on windows.
+    cardano-wallet-jormungandr-win64 = import ./nix/windows-release.nix {
+      inherit pkgs project;
+      cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+    };
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.


### PR DESCRIPTION
Relates to #863.
Based on #828.

# Overview

- @disassembler @cleverca22 It's not exactly the same as before but should work ok I think.
- Adds source filtering to avoid unnecessary rebuilds.

# Comments

To build:

```
nix-build -A cardano-wallet-jormungandr
nix-build release.nix -A daedalus-jormungandr.windows -o daedalus-jormungandr-windows
nix-build release.nix -A daedalus-jormungandr.macos -o daedalus-jormungandr-macos
nix-build release.nix -A daedalus-jormungandr.linux -o daedalus-jormungandr-linux
```

Note that `daedalus-jormungandr.{windows,macos,linux}` from `release.nix` reference the same `cardano-wallet-jormungandr` derivation, only with different `system` or `crossSystem` arguments. So Daedalus may also import from `default.nix` rather than `release.nix`.