### PR TITLE
review exception handling in chain follower and better handle asynchronous exceptions

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1064,7 +1064,7 @@ withWorkerCtx ctx wid onMissing action =
 defaultWorkerAfter :: Trace IO Text -> Either SomeException a -> IO ()
 defaultWorkerAfter tr = \case
     Right _ ->
-        logNotice tr "Worker has exited: main action is over"
+        logNotice tr "Worker has exited: main action is over."
     Left e -> case asyncExceptionFromException e of
         Just ThreadKilled ->
             logNotice tr "Worker has exited: killed by parent."


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#807 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have properly handled asynchronous exceptions in the chain follower code

# Comments

<!-- Additional comments or screenshots to attach if any -->

Now, removing a wallet only logs the following line (as expected):

```
[iohk.cardano-wallet.worker.f0032d84:Notice:ThreadId 34] [2019-10-18 13:19:39.67 UTC] Worker has exited: main action is over.
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
