### PR TITLE
Add readCursor to Pool.DB

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -56,6 +56,13 @@ data DBLayer m = DBLayer
         :: EpochNo
         -> m [(PoolId, Quantity "lovelace" Word64)]
 
+    , readCursor
+        :: Int -> m [BlockHeader]
+        -- ^ Read the latest @k@ blockheaders in ascending order. The tip will
+        -- be the last element in the list.
+        --
+        -- This is useful for the @NetworkLayer@ to know how far we have synced.
+
     , rollbackTo
         :: SlotId -> m ()
         -- ^ Remove all entries of slot ids newer than the argument

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -26,6 +26,7 @@ import Cardano.Pool.DB.Model
     , mCleanPoolProduction
     , mPutPoolProduction
     , mPutStakeDistribution
+    , mReadCursor
     , mReadPoolProduction
     , mReadStakeDistribution
     , mRollbackTo
@@ -60,6 +61,8 @@ newDBLayer = do
 
         , readStakeDistribution =
             readPoolDB db . mReadStakeDistribution
+
+        , readCursor = readPoolDB db . mReadCursor
 
         , rollbackTo =
             void . alterPoolDB (const Nothing) db . mRollbackTo

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -38,6 +38,7 @@ module Cardano.Pool.DB.Model
     , mPutStakeDistribution
     , mReadStakeDistribution
     , mRollbackTo
+    , mReadCursor
     ) where
 
 import Prelude
@@ -48,6 +49,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( fromMaybe )
+import Data.Ord
+    ( Down (..) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -125,6 +128,13 @@ mReadStakeDistribution epoch db@PoolDatabase{distributions} =
     ( Right $ fromMaybe mempty $ Map.lookup epoch distributions
     , db
     )
+
+mReadCursor :: Int -> ModelPoolOp [BlockHeader]
+mReadCursor k db@PoolDatabase{pools} =
+    let allHeaders = foldMap snd $ Map.toList pools
+        sortDesc = L.sortOn (Down . slotId)
+        limit = take k
+    in (Right $ reverse $ limit $ sortDesc allHeaders, db)
 
 mRollbackTo :: SlotId -> ModelPoolOp ()
 mRollbackTo point PoolDatabase{pools, distributions} =

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -150,6 +150,12 @@ newDBLayer logConfig trace fp = do
             deleteWhere [ PoolProductionSlot >. point ]
             deleteWhere [ StakeDistributionEpoch >. epoch ]
 
+
+        , readCursor = \k -> runQuery $ do
+            reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
+                []
+                [Desc PoolProductionSlot, LimitTo k]
+
         , cleanDB = runQuery $
             deleteWhere ([] :: [Filter PoolProduction])
         })


### PR DESCRIPTION
# Issue Number

#713

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added `readCursor` to `Pool.DB` such that we can resume restoration from the node.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
