### PR TITLE
Implement chain follower for the stake pool metrics

### DIFF
--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -73,7 +73,7 @@ import qualified Data.Map.Strict as Map
 
 data Block = Block
     { header :: BlockHeader
-    , producer :: Maybe PoolId
+    , producer :: PoolId
     } deriving (Eq, Show, Generic)
 
 data ErrMetricsWorker

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -105,6 +105,8 @@ worker nl db tr = do
         handleResult = \case
             Left ErrMetricsWorkerTipTooVolatile
                 -> Retry
+            Left e@ErrMetricsWorkerDataInconsistencyDuplicateBlock
+                -> ExitWith e
             Left e
                 -> ExitWith e
                 -- TODO: Make all cases explicit here.

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -19,10 +19,6 @@ module Cardano.Pool.Metrics
     , ErrMetricsInconsistency (..)
 
     , worker
-
-    -- * Helper
-    , withinSameTip
-    , ErrWithinSameTip (..)
     )
     where
 
@@ -39,17 +35,13 @@ import Cardano.Wallet.Network
     , staticBlockchainParameters
     )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), PoolId (..), SlotId (..) )
+    ( BlockHeader (..), EpochNo, PoolId (..), SlotId (..) )
 import Control.Monad
     ( forM_, unless )
 import Control.Monad.IO.Class
-    ( MonadIO, liftIO )
+    ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT, throwE, withExceptT )
-import Control.Retry
-    ( RetryPolicyM, limitRetries, retrying )
-import Data.Either
-    ( isLeft )
 import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.List.NonEmpty
@@ -124,7 +116,17 @@ worker nl db tr = do
         -> BlockHeader
         -> ExceptT ErrMetricsWorker IO ()
     advance blocks nodeTip = do
-        -- Get a stake distribution and next batch of blocks such that we know
+        distr <- stakeDistributionConsistentWithTip nodeTip
+        liftIO $ uncurry (putStakeDistribution db) distr
+
+        forM_ blocks $ \block ->
+            -- TODO: We might want to batch the insertion to the DB.
+            -- TODO: What do we do if the production already exists?!
+            withExceptT
+                (const ErrMetricsWorkerDataInconsistencyDuplicateBlock)
+                $ putPoolProduction db (header block) (producer block)
+      where
+        -- | Get a stake distribution and next batch of blocks such that we know
         -- they are from the same chain.
         --
         -- Assumtion: We don't expect the node to switch from tip A to tip B,
@@ -133,26 +135,20 @@ worker nl db tr = do
         -- If the tip is still the same after we have fetched the stake
         -- distribution, we conclude that the stake-distrubtion is from the same
         -- chain as the tip.
-        consistentDistr <- withinSameTip (limitRetries 3) liftE getTip $ \nodeTip2 -> do
-            distr <- withExceptT (const ErrMetricsWorkerStakeDistributionUnavailable)
+        stakeDistributionConsistentWithTip
+            :: BlockHeader
+            -> ExceptT ErrMetricsWorker IO
+                (EpochNo, [(PoolId, Quantity "lovelace" Word64)])
+        stakeDistributionConsistentWithTip tip = do
+            (e, distr) <- withExceptT
+                (const ErrMetricsWorkerStakeDistributionUnavailable)
                 $ stakeDistribution nl
-            unless (nodeTip == nodeTip2) $
+            tipAfter <- getTip
+            unless (tip == tipAfter) $
                 -- The tip has changed. We cannot guarantee that the blocks and
                 -- the stake-distribution are on the same chain.
                 throwE ErrMetricsWorkerTipTooVolatile
-            return (fst distr, Map.toList $ snd distr)
-
-        liftIO $ uncurry (putStakeDistribution db) consistentDistr
-
-        forM_ blocks $ \block ->
-            -- TODO: We might want to batch the insertion to the DB.
-            -- TODO: What do we do if the production already exists?!
-            withExceptT
-                (const ErrMetricsWorkerDataInconsistencyDuplicateBlock)
-                $ putPoolProduction db (header block) (producer block)
-          where
-            liftE ErrWithinSameTipMaxRetries =
-                throwE ErrMetricsWorkerTipTooVolatile
+            return (e, Map.toList distr)
 
     rollback :: SlotId -> IO (FollowAction ErrMetricsWorker)
     rollback point = do
@@ -218,43 +214,3 @@ combineMetrics =
             (Quantity "lovelace" Word64, Quantity "block" Natural)
     stakeAndActivity =
         zipWithMatched (\_k stake productions -> (stake, productions))
-
--- | Runs an action by making sure that the network header hasn't changed before
--- and after the action. This is useful in order to combine data from different
--- sources and make sure that all data retrieval and computations happens on a
--- same version.
---
--- The action __must__ be retry-able (i.e. read-only) for it will be retried if
--- the tip has changed before and after the call.
-withinSameTip
-    :: forall m header a. (MonadIO m, Eq header)
-    => RetryPolicyM m
-        -- ^ Retrying policy to command what to do in case the action wasn't
-        -- executed within the same tip.
-    -> (ErrWithinSameTip -> m a)
-        -- ^ On failure
-    -> m header
-        -- ^ A getter for that header.
-    -> (header -> m a)
-        -- ^ The action to run
-    -> m a
-withinSameTip policy liftE getTip action = do
-    let shouldRetry = const (pure . isLeft)
-    res <- retrying policy shouldRetry (const trial)
-    case res of
-        Left e -> liftE e
-        Right r -> return r
-  where
-    trial :: m (Either ErrWithinSameTip a)
-    trial = do
-        start <- getTip
-        a <- action start
-        end <- getTip
-        pure $ if (start /= end)
-            then Left ErrWithinSameTipMaxRetries
-            else Right a
-
-data ErrWithinSameTip
-    = ErrWithinSameTipMaxRetries
-        -- ^ Retried too many times
-    deriving (Generic, Show, Eq)

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -14,9 +14,12 @@
 -- - "Cardano.Pool.DB" - which can persist the metrics
 -- - "Cardano.Wallet.Api.Server" - which presents the results in an endpoint
 module Cardano.Pool.Metrics
-    ( activityForEpoch
+    ( Block (..)
+    , activityForEpoch
     , combineMetrics
     , ErrMetricsInconsistency (..)
+
+    , worker
 
     -- * Helper
     , withinSameTip
@@ -29,20 +32,40 @@ module Cardano.Pool.Metrics
 
 import Prelude
 
+import Cardano.BM.Trace
+    ( Trace )
+import Cardano.Pool.DB
+    ( DBLayer (..) )
+import Cardano.Wallet.Network
+    ( FollowAction (..)
+    , NetworkLayer (networkTip, stakeDistribution)
+    , follow
+    , staticBlockchainParameters
+    )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..), EpochNo (..), PoolId (..), SlotId (..) )
+import Control.Monad
+    ( forM_, unless )
 import Control.Monad.IO.Class
-    ( MonadIO )
+    ( MonadIO, liftIO )
+import Control.Monad.Trans.Except
+    ( ExceptT, runExceptT, throwE, withExceptT )
 import Control.Retry
-    ( RetryPolicyM, retrying )
+    ( RetryPolicyM, limitRetries, retrying )
 import Data.Either
     ( isLeft )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import Data.Map.Merge.Strict
     ( WhenMatched, WhenMissing, mergeA, traverseMissing, zipWithMatched )
 import Data.Map.Strict
     ( Map )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -53,6 +76,97 @@ import Numeric.Natural
     ( Natural )
 
 import qualified Data.Map.Strict as Map
+
+data Block = Block
+    { header :: BlockHeader
+    , producer :: Maybe PoolId
+    } deriving (Eq, Show, Generic)
+
+data ErrMetricsWorker
+    = ErrMetricsWorkerTipTooVolatile
+    | ErrMetricsWorkerStakeDistributionUnavailable
+    | ErrMetricsWorkerDataInconsistencyBlockWithoutProducer
+    | ErrMetricsWorkerDataInconsistencyDuplicateBlock
+    | ErrMetricsWorkerTipIsUnreachable
+    deriving (Show, Eq)
+
+-- | @worker@ follows the chain and puts pool productions and stake
+-- distributions to a @DBLayer@, such that the data in the @DB@ always is
+-- consistent.
+--
+-- The pool productions and stake distrubtions in the DB can /never/ be from
+-- different forks.
+worker
+    :: NetworkLayer IO t Block
+    -> DBLayer IO
+    -> Trace IO Text
+    -> IO ()
+worker nl db tr = do
+    -- Read the k latest headers the DB knows about
+    let (_block0, bp) = staticBlockchainParameters nl
+    let k = fromIntegral . getQuantity . view #getEpochStability $ bp
+    knownHeaders <- readCursor db k
+
+    follow nl tr knownHeaders advance' rollback header
+  where
+
+    advance'
+        :: NonEmpty Block
+        -> BlockHeader
+        -> IO (FollowAction ErrMetricsWorker)
+    advance' bs h = handleResult <$> runExceptT (advance bs h)
+      where
+        handleResult = \case
+            Left ErrMetricsWorkerTipTooVolatile
+                -> Retry
+            Left e
+                -> ExitWith e
+                -- TODO: Make all cases explicit here.
+            Right ()
+                -> Continue
+
+    advance
+        :: NonEmpty Block
+        -> BlockHeader
+        -> ExceptT ErrMetricsWorker IO ()
+    advance blocks nodeTip = do
+        -- Get a stake distribution and next batch of blocks such that we know
+        -- they are from the same chain.
+        --
+        -- Assumtion: We don't expect the node to switch from tip A to tip B,
+        -- and back to tip A.
+        --
+        -- If the tip is still the same after we have fetched the stake
+        -- distribution, we conclude that the stake-distrubtion is from the same
+        -- chain as the tip.
+        consistentDistr <- withinSameTip (limitRetries 3) liftE getTip $ \nodeTip2 -> do
+            distr <- withExceptT (const ErrMetricsWorkerStakeDistributionUnavailable)
+                $ stakeDistribution nl
+            unless (nodeTip == nodeTip2) $
+                -- The tip has changed. We cannot guarantee that the blocks and
+                -- the stake-distribution are on the same chain.
+                throwE ErrMetricsWorkerTipTooVolatile
+            return (fst distr, Map.toList $ snd distr)
+
+        liftIO $ uncurry (putStakeDistribution db) consistentDistr
+
+        forM_ blocks $ \block ->
+            -- TODO: We might want to batch the insertion to the DB.
+            -- TODO: What do we do if the production already exists?!
+            withExceptT
+                (const ErrMetricsWorkerDataInconsistencyDuplicateBlock)
+                $ putPoolProduction db (header block) (producer block)
+          where
+            liftE ErrWithinSameTipMaxRetries =
+                throwE ErrMetricsWorkerTipTooVolatile
+
+    rollback :: SlotId -> IO (FollowAction ErrMetricsWorker)
+    rollback point = do
+        liftIO $ rollbackTo db point
+        return Continue
+
+    getTip = withExceptT (const ErrMetricsWorkerTipIsUnreachable) $
+        networkTip nl
 
 -- | For a given epoch, and state, this function returns /how many/ blocks
 -- each pool produced.
@@ -185,14 +299,13 @@ instance Buildable State where
             (\(k,v) -> fmt (""+|k|+": "+|length v|+"") )
             (Map.toList m)
 
-applyBlock :: (BlockHeader, PoolId) -> State -> State
-applyBlock (newTip, poolId) (State _prevTip prevMap) =
-        State newTip (Map.alter alter poolId prevMap)
+applyBlock :: Block -> State -> State
+applyBlock (Block newTip mpoolId) s@(State _prevTip prevMap) =
+    case mpoolId of
+        Just pool -> State newTip (Map.alter alter pool prevMap)
+        Nothing -> s
   where
     slot = slotId newTip
     alter = \case
         Nothing -> Just [slot]
         Just slots -> Just (slot:slots)
-
-
-

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -50,6 +50,8 @@ import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Except
     ( runExceptT, throwE, withExceptT )
+import Data.Functor
+    ( (<&>) )
 import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.List.NonEmpty
@@ -69,6 +71,7 @@ import GHC.Generics
 import Numeric.Natural
     ( Natural )
 
+import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map.Strict as Map
 
 data Block = Block
@@ -98,10 +101,11 @@ monitorStakePools nl db tr = do
   where
     initCursor :: IO [BlockHeader]
     initCursor = do
-        let (_block0, bp) = staticBlockchainParameters nl
+        let (block0, bp) = staticBlockchainParameters nl
         let k = fromIntegral . getQuantity . view #getEpochStability $ bp
-        readCursor db k
-
+        readCursor db k <&> \case
+            [] -> [W.header block0]
+            xs -> xs
     backward
         :: SlotId
         -> IO (FollowAction ErrMonitorStakePools)

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -10,7 +10,7 @@ module Cardano.Pool.MetricsSpec (spec) where
 import Prelude
 
 import Cardano.Pool.Metrics
-    ( Block (..), State (..), applyBlock, combineMetrics, withinSameTip )
+    ( Block (..), combineMetrics, withinSameTip )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , EpochLength (..)
@@ -74,18 +74,6 @@ spec = do
             (property prop_withinSameTipMaxRetries)
 
     describe "Counting how many blocks each pool produced" $ do
-        describe "State" $ do
-            it "stores the last applied blockHeader"
-                $ property $ \s b@(Block h _) -> do
-                tip (applyBlock b s) `shouldBe` h
-
-            it "counts every block it applies (total activity increases by 1\
-               \when a block is applied"
-                $ property $ \s block -> do
-                let s' = applyBlock block s
-                let count = Map.foldl (\r l -> r + (length l)) 0 . activity
-                count s' === (count s + 1)
-
         describe "combineMetrics" $ do
             it "pools with no entry for productions are included" $
                 property $ \stakeDistr -> do
@@ -163,10 +151,6 @@ instance Arbitrary BlockHeader where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-    shrink = genericShrink
-
-instance Arbitrary State where
-    arbitrary = genericArbitrary
     shrink = genericShrink
 
 instance Arbitrary SlotId where

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -10,7 +10,7 @@ module Cardano.Pool.MetricsSpec (spec) where
 import Prelude
 
 import Cardano.Pool.Metrics
-    ( State (..), applyBlock, combineMetrics, withinSameTip )
+    ( Block (..), State (..), applyBlock, combineMetrics, withinSameTip )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , EpochLength (..)
@@ -76,8 +76,8 @@ spec = do
     describe "Counting how many blocks each pool produced" $ do
         describe "State" $ do
             it "stores the last applied blockHeader"
-                $ property $ \s b@(header,_) -> do
-                tip (applyBlock b s) `shouldBe` header
+                $ property $ \s b@(Block h _) -> do
+                tip (applyBlock b s) `shouldBe` h
 
             it "counts every block it applies (total activity increases by 1\
                \when a block is applied"
@@ -184,6 +184,10 @@ instance Arbitrary (Hash tag) where
     shrink x = [zeros | x /= zeros]
       where
         zeros = Hash $ BS.pack $ replicate 32 0
+
+instance Arbitrary Block where
+     arbitrary = genericArbitrary
+     shrink = genericShrink
 
 instance Arbitrary (Quantity "block" Word32) where
      arbitrary = Quantity . fromIntegral <$> (arbitrary @Word)

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -10,7 +10,7 @@ module Cardano.Pool.MetricsSpec (spec) where
 import Prelude
 
 import Cardano.Pool.Metrics
-    ( Block (..), combineMetrics, withinSameTip )
+    ( Block (..), combineMetrics )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , EpochLength (..)
@@ -20,16 +20,6 @@ import Cardano.Wallet.Primitive.Types
     , flatSlot
     , fromFlatSlot
     )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, newMVar, readMVar )
-import Control.Monad.IO.Class
-    ( MonadIO, liftIO )
-import Control.Monad.Trans.Except
-    ( runExceptT, throwE )
-import Control.Retry
-    ( limitRetries )
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -41,38 +31,20 @@ import Test.Hspec
 import Test.QuickCheck
     ( Arbitrary (..)
     , InfiniteList (..)
-    , NonNegative (..)
-    , Property
-    , Small (..)
     , checkCoverage
     , cover
-    , expectFailure
-    , frequency
-    , label
     , property
-    , vectorOf
     , withMaxSuccess
     , (===)
-    , (==>)
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
-import Test.QuickCheck.Monadic
-    ( assert, monadicIO, monitor, run )
 
 import qualified Data.ByteString as BS
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 
 spec :: Spec
 spec = do
-    describe "withinSameTip" $ do
-        it "Retry the action and eventually get a result"
-            (property prop_withinSameTipEventually)
-
-        it "Does not retry more than necessary"
-            (property prop_withinSameTipMaxRetries)
-
     describe "Counting how many blocks each pool produced" $ do
         describe "combineMetrics" $ do
             it "pools with no entry for productions are included" $
@@ -98,52 +70,6 @@ spec = do
                                 aPoolWithoutStakeProduced === True
                             Right x ->
                                 Map.map fst x === stakeDistr
-
-{-------------------------------------------------------------------------------
-                                withinSameTip
--------------------------------------------------------------------------------}
-
-data WithinSameTip header =
-    WithinSameTip (NonEmpty header) Int
-    deriving Show
-
-prop_withinSameTipEventually
-    :: WithinSameTip Char
-    -> Property
-prop_withinSameTipEventually (WithinSameTip source maxRetry) = monadicIO $ do
-    retries <- run $ newMVar (0 :: Int)
-    getNetworkTip <- run (mkNetworkTipGetter <$> newMVar source)
-    let action _ = liftIO $ modifyMVar retries $ \n -> pure (n+1, ())
-    let policy = limitRetries maxRetry
-    result <- run $ runExceptT $ withinSameTip policy throwE getNetworkTip action
-    run (readMVar retries) >>= monitor . label . ("retry="<>) . show
-    assert (result == Right ())
-
-prop_withinSameTipMaxRetries
-    :: WithinSameTip Char
-    -> Property
-prop_withinSameTipMaxRetries (WithinSameTip source maxRetry) =
-    maxRetry > 0 ==> expectFailure $ monadicIO $ do
-        getNetworkTip <- run (mkNetworkTipGetter <$> newMVar source)
-        let action _ = pure ()
-        let policy = limitRetries (maxRetry - 1)
-        result <- run $ runExceptT $ withinSameTip policy throwE getNetworkTip action
-        assert (result == Right ())
-
-mkNetworkTipGetter
-    :: MonadIO m => MVar (NonEmpty header) -> m header
-mkNetworkTipGetter = liftIO . flip modifyMVar (\headers -> case headers of
-    (h :| []) -> pure (headers, h)
-    (h :| q)  -> pure (NE.fromList q, h))
-
-instance Arbitrary (WithinSameTip Char) where
-    arbitrary = do
-        NonNegative (Small maxRetry) <- arbitrary
-        headers <- vectorOf (2*maxRetry) genTip
-        h0 <- genTip
-        pure $ WithinSameTip (h0 :| headers) maxRetry
-      where
-        genTip = frequency [(5, pure 'a'), (5, pure 'b')]
 
 instance Arbitrary BlockHeader where
     arbitrary = BlockHeader

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -332,8 +332,9 @@ mockNetworkLayer logLine = do
     let jm = mockJormungandrClient logLine
     Quantity k <- gets mockNodeK
     st <- newMVar emptyBlockHeaders
-    Right g0 <- runExceptT $ getInitialBlockchainParameters jm genesisHash
-    pure $ fromJBlock <$> mkRawNetworkLayer g0 (fromIntegral k) st jm
+    Right (b0,bp) <- runExceptT $ getInitialBlockchainParameters jm genesisHash
+    let b0' = J.convertBlock b0
+    pure $ fromJBlock <$> mkRawNetworkLayer (b0', bp) (fromIntegral k) st jm
 
 -- | A network layer which returns mock blocks and mutates its state according
 -- to the generated operations.


### PR DESCRIPTION
# Issue Number

#713 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I added a simple `worker` that uses existing functionality to collect, merge and write stake-pool metrics to the DB.
- [x] Added a proper `Block`-type instead of `(BlockHeader, Maybe PoolId)` 

# Comments

- Note: I'm too uncomfortable with the `WorkerRegistry`, so I'm not using it now. 
- Testing: 🤔 Maybe:
    - killing the worker and re-restarting doesn't affect the results (using a mock network layer)



<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
