### PR TITLE
Support for legacy UTxO witness in Jörmungandr

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -43,6 +43,10 @@ module Cardano.Wallet.Jormungandr.Binary
     , signData
     , utxoWitness
     , legacyUtxoWitness
+    , TxWitnessTag (..)
+    , putTxWitnessTag
+    , getTxWitnessTag
+    , txWitnessSize
 
     -- * Purification of chain block types
     , convertBlock
@@ -626,7 +630,7 @@ estimateMaxNumberOfInputsParams = EstimateMaxNumberOfInputsParams
     , estBlockHashSize = 32
 
     -- The length of the smallest type of witness.
-    , estTxWitnessSize = txWitnessSize TxWitnessUTxO
+    , estTxWitnessSize = txWitnessSize TxWitnessUTxO + txWitnessTagSize
     }
 
 -- | Jörmungandr distinguish 'fragment id' (what we commonly call 'txId')

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -102,6 +102,15 @@ mkStdTxSpec = do
         -- ^ e01bfb39e3e595fce0b9b19e386a82816e0cef8aa823c75a32bc0f39bcf7c14e
         --   8a03d255df0440b6d0fcf5d5199a582d1df7d858bd7556d4941ebf6223fa66d1
 
+    let (xprvRnd0, pwdRnd0) =
+            xprvRndFromSeed "arbitrary-seed-0"
+        -- ^ 183b26b1127ea29c2f053ee8f9d8c0a90c5251235e0fd2bfda401da318045a4d
+        --   8fe398f1d0898ee4505e6b2546c1ac5c4b201e0833708312489e26142892a4ae
+    let (xprvRnd1, pwdRnd1) =
+            xprvRndFromSeed "arbitrary-seed-1"
+        -- ^ 80330dc0e8382d72313a050add1fdaf8ad3f99f8a0bd56b4a27af497d43d0c53
+        --   acdbfa4f24a8e04aa2298ddc623ebbb4b61fd61f6076d269aa6a30ffb6bb7574
+
     let txin0 = Hash $ unsafeFromHex
             "666984dec4bc0ff1888be97bfe0694a96b35c58d025405ead51d5cc72a3019f4"
     let txin1 = Hash $ unsafeFromHex
@@ -196,6 +205,64 @@ mkStdTxSpec = do
             \080f5ac10474c7f6decbbc35f1620817b15bf1594981c034b7f6a15d0a24ec743d\
             \332f1774eb8733a5d40c"
 
+    describe "mkStdTx (legacy) 'Mainnet" $ do
+        let tl = newTransactionLayer @'Mainnet block0
+        let addrRnd0 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprvRnd0)
+        -- ^ DdzFFzCqrhsyySN2fbNnZf4kh2gg9t4mZzcnCiiw1EFG4ynvCGi35qgdUPh1DJp5Z28SVQxsxfNn7CaRB6DbvvvXZzdtMJ4ML2RrXvrG
+        let addrRnd1 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprvRnd1)
+        -- ^ DdzFFzCqrhsrqGWaofA6TmXeChoV5YGk8GyvLE2DCyTib8YpQn4qxsomw4oagtcpa321iQynEtT2D31xG5XGLSWTLHe9CZz26CwZZBQf
+        let addr0 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprv0)
+        -- ^ ca1qvk32hg8rppc0wn0lzpkq996pd3xkxqguel8tharwrpdch6czu2luh3truq
+        let addr1 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprv1)
+        -- ^ ca1qwedmnalvvgqqgt2dczppejvyrn2lydmk2pxya4dd076wal8v6eykzfapdx
+        let addr2 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprv2)
+        -- ^ ca1qvp2m296efkn4zy63y769x4g52g5vrt7e9dnvszt7z2vrfe0ya66vznknfn
+
+        let keystore = mkKeystore
+                [ (addrRnd0, (xprvRnd0, pwdRnd0))
+                , (addrRnd1, (xprvRnd1, pwdRnd1))
+                ]
+
+        -- See 'Mainnet description
+        goldenTestStdTx tl keystore
+            [ (TxIn txin0 0, TxOut addrRnd0 (Coin 10000)) ]
+            [ TxOut addr1 (Coin 14)
+            , TxOut addr2 (Coin 9986)
+            ]
+            "00ff020102000000000000002710666984dec4bc0ff1888be97bfe0694a96b35c5\
+            \8d025405ead51d5cc72a3019f403b2ddcfbf631000216a6e0410e64c20e6af91bb\
+            \b2826276ad6bfda777e766b24b000000000000000e0302ada8baca6d3a889a893d\
+            \a29aa8a291460d7ec95b36404bf094c1a72f2775a6000000000000270200260e3f\
+            \0867d341caf86f9b7bd9689f1b21f04dad05711ea3594cc441f159a723537824ae\
+            \e5526bd50c6cc32113911bd591e3a3601326513ed88151ce8dbdfa488754e00ab7\
+            \e4f1e8d7534cd654b82b3eab841bb387113e46f9902519a94f9296b83a5fb99793\
+            \4c1cba5ccefc42e55b59c70752b356a77307f1a32e686a42970c"
+
+        -- See 'Mainnet description
+        goldenTestStdTx tl keystore
+            [ (TxIn txin0 0, TxOut addrRnd0 (Coin 10000))
+            , (TxIn txin1 1, TxOut addrRnd1 (Coin 999999999))
+            ]
+            [ TxOut addr0 (Coin 99999)
+            , TxOut addr1 (Coin 42)
+            , TxOut addr2 (Coin 1337)
+            ]
+            "01d2020203000000000000002710666984dec4bc0ff1888be97bfe0694a96b35c5\
+            \8d025405ead51d5cc72a3019f401000000003b9ac9ff1323856bc91c49e928f6f3\
+            \0f4e8d665d53eb4ab6028bd0ac971809d514c92db1032d155d07184387ba6ff883\
+            \6014ba0b626b1808e67e75dfa370c2dc5f581715fe000000000001869f03b2ddcf\
+            \bf631000216a6e0410e64c20e6af91bbb2826276ad6bfda777e766b24b00000000\
+            \0000002a0302ada8baca6d3a889a893da29aa8a291460d7ec95b36404bf094c1a7\
+            \2f2775a6000000000000053900260e3f0867d341caf86f9b7bd9689f1b21f04dad\
+            \05711ea3594cc441f159a723537824aee5526bd50c6cc32113911bd591e3a36013\
+            \26513ed88151ce8dbdfa4817c80704772729b5c0b2583abe0a3e675e2227879a74\
+            \52882ba9733baa03bfb9ec2ff75e086fdf8f8fd89c2c3ef9b9c4052e7096dd9fc1\
+            \2fc22541394a0b3d0d000205b66108c02e4d6dbc4c70adaa27d22ea2adeffe0de0\
+            \09c099ac230b520917d2c23ec4bf897f4fd236c676988b62877259f81bd9f08d43\
+            \55d5fe6b96cda06db052067dafcc5b525efe2bd9d03d21c356aa1b82887126a218\
+            \5231c749a117d70641583fe739d6b59fab049028ad68cbe935910251eb4aacb803\
+            \5353e609e400"
+
     describe "mkStdTx 'Testnet" $ do
         let tl = newTransactionLayer @'Testnet block0
         let keyToAddress' = keyToAddress @(Jormungandr 'Testnet)
@@ -247,6 +314,65 @@ mkStdTxSpec = do
             \d6bd5c813d6f3f454f4935b009eabbac1ffd768a07e37773e5b568e8c76c57e53d\
             \a6b26d3da9f466b78200"
 
+    describe "mkStdTx (legacy) 'Testnet" $ do
+        let tl = newTransactionLayer @'Testnet block0
+
+        let addrRnd0 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprvRnd0)
+        -- ^ DdzFFzCqrhsyySN2fbNnZf4kh2gg9t4mZzcnCiiw1EFG4ynvCGi35qgdUPh1DJp5Z28SVQxsxfNn7CaRB6DbvvvXZzdtMJ4ML2RrXvrG
+        let addrRnd1 = keyToAddress @(Jormungandr 'Mainnet) (publicKey xprvRnd1)
+        -- ^ DdzFFzCqrhsrqGWaofA6TmXeChoV5YGk8GyvLE2DCyTib8YpQn4qxsomw4oagtcpa321iQynEtT2D31xG5XGLSWTLHe9CZz26CwZZBQf
+        let addr0 = keyToAddress @(Jormungandr 'Testnet) (publicKey xprv0)
+        -- ^ ta1svk32hg8rppc0wn0lzpkq996pd3xkxqguel8tharwrpdch6czu2luue5k36
+        let addr1 = keyToAddress @(Jormungandr 'Testnet) (publicKey xprv1)
+        -- ^ ta1swedmnalvvgqqgt2dczppejvyrn2lydmk2pxya4dd076wal8v6eykfpz5qu
+        let addr2 = keyToAddress @(Jormungandr 'Testnet) (publicKey xprv2)
+        -- ^ ta1svp2m296efkn4zy63y769x4g52g5vrt7e9dnvszt7z2vrfe0ya66vfmfxyf
+
+        let keystore = mkKeystore
+                [ (addrRnd0, (xprvRnd0, pwdRnd0))
+                , (addrRnd1, (xprvRnd1, pwdRnd1))
+                ]
+
+        -- See 'Mainnet description
+        goldenTestStdTx tl keystore
+            [ (TxIn txin0 0, TxOut addrRnd0 (Coin 10000)) ]
+            [ TxOut addr1 (Coin 14)
+            , TxOut addr2 (Coin 9986)
+            ]
+            "00ff020102000000000000002710666984dec4bc0ff1888be97bfe0694a96b35c5\
+            \8d025405ead51d5cc72a3019f483b2ddcfbf631000216a6e0410e64c20e6af91bb\
+            \b2826276ad6bfda777e766b24b000000000000000e8302ada8baca6d3a889a893d\
+            \a29aa8a291460d7ec95b36404bf094c1a72f2775a6000000000000270200260e3f\
+            \0867d341caf86f9b7bd9689f1b21f04dad05711ea3594cc441f159a723537824ae\
+            \e5526bd50c6cc32113911bd591e3a3601326513ed88151ce8dbdfa486fb2c7b4bf\
+            \45910e1a07f26209654a00541d918a49f0339bb820da724f165df1c647ccfc6e5c\
+            \de86dd31e154b7cc6beef06d561359a2d102f8b3de15b5990007"
+
+        -- See 'Mainnet description
+        goldenTestStdTx tl keystore
+            [ (TxIn txin0 0, TxOut addrRnd0 (Coin 10000))
+            , (TxIn txin1 1, TxOut addrRnd1 (Coin 999999999))
+            ]
+            [ TxOut addr0 (Coin 99999)
+            , TxOut addr1 (Coin 42)
+            , TxOut addr2 (Coin 1337)
+            ]
+            "01d2020203000000000000002710666984dec4bc0ff1888be97bfe0694a96b35c5\
+            \8d025405ead51d5cc72a3019f401000000003b9ac9ff1323856bc91c49e928f6f3\
+            \0f4e8d665d53eb4ab6028bd0ac971809d514c92db1832d155d07184387ba6ff883\
+            \6014ba0b626b1808e67e75dfa370c2dc5f581715fe000000000001869f83b2ddcf\
+            \bf631000216a6e0410e64c20e6af91bbb2826276ad6bfda777e766b24b00000000\
+            \0000002a8302ada8baca6d3a889a893da29aa8a291460d7ec95b36404bf094c1a7\
+            \2f2775a6000000000000053900260e3f0867d341caf86f9b7bd9689f1b21f04dad\
+            \05711ea3594cc441f159a723537824aee5526bd50c6cc32113911bd591e3a36013\
+            \26513ed88151ce8dbdfa48b1c5041340c009641039e1dcdf436ecc2e7f219d3dd3\
+            \aa93b5841662b45e04e8232050f3c42cb64ca45219deb841ecef026488fbf0d653\
+            \2589c4e50fd7a11d00000205b66108c02e4d6dbc4c70adaa27d22ea2adeffe0de0\
+            \09c099ac230b520917d2c23ec4bf897f4fd236c676988b62877259f81bd9f08d43\
+            \55d5fe6b96cda06db22f7d78f0ff0ec3a7c7fbc3da777a6aea6aeddd8ffef0beb8\
+            \0afd3ba2dd9972585ae74b5876cca3301cee381daf5f9e10b5f8da2f2b9eabba26\
+            \bc5c0f01b803"
+
     describe "mkStdTx unknown input" $ do
         unknownInputTest (Proxy @'Mainnet) block0
         unknownInputTest (Proxy @'Testnet) block0
@@ -260,7 +386,7 @@ mkStdTxSpec = do
         tooNumerousOutsTest (Proxy @'Testnet) block0
 
 goldenTestStdTx
-    :: forall t n k. (t ~ Jormungandr n, KnownNetwork n)
+    :: forall t n k. (t ~ Jormungandr n)
     => TransactionLayer t k
     -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
     -> [(TxIn, TxOut)]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#779 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have extended `mkStdTx` so that it would properly handle transactions coming from a `RndKey` and construct `legacy-utxo` witnesses for it.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Jörmungandr doesn't implement creating legacy utxo witnesses from jcli ... 

[jcli/src/jcli_app/transaction/mk_witness.rs](https://github.com/input-output-hk/jormungandr/blob/master/jcli/src/jcli_app/transaction/mk_witness.rs#L78-L82)
```rust
            WitnessType::OldUTxO => {
                // TODO unimplemented!()
                let _secret_key: SecretKey<Ed25519Bip32> = self.secret()?;
                Err(Error::MakeWitnessLegacyUtxoUnsupported)?;
                unimplemented!()
            }
``` 

so I had to construct them by hand according to:

- The format defined in [chain-impl-mockchain#witnesses](https://github.com/input-output-hk/chain-libs/blob/incentive/chain-impl-mockchain/doc/format.md#witnesses)

- The format from the source (double checking it matches the doc..) [chain-impl-mockchain/src/transaction/witness.rs](https://github.com/input-output-hk/chain-libs/blob/incentive/chain-impl-mockchain/src/transaction/witness.rs#L173-L176)

It'd be nice to review our golden if / when the constructor for the witness type gets updated.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
