### PR TITLE
Wait an hour for the Jormungandr REST API to start

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -212,7 +212,7 @@ waitForNetwork nw policy = do
 -- for no longer than a minute.
 defaultRetryPolicy :: Monad m => RetryPolicyM m
 defaultRetryPolicy =
-    limitRetriesByCumulativeDelay (60 * second) (exponentialBackoff 10000)
+    limitRetriesByCumulativeDelay (3600 * second) (exponentialBackoff 10000)
   where
     second = 1000*1000
 


### PR DESCRIPTION
Relates to #832.

# Overview

Until the startup order is fixed in Jörmungandr (should be in 0.7.x), we need to wait quite a while for it to do stuff before we can fetch the genesis block.

# Comments

This unblocks integration of cardano-wallet-jormungandr into the Daedalus installer.
