### PR TITLE
Correct `ToText` and `FromText` instances for `FeePolicy`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -697,8 +697,8 @@ data TransactionInfo = TransactionInfo
     -- ^ Creation time of the block including this transaction.
     } deriving (Show, Eq, Ord)
 
--- | A linear equation a free variable `x`. Represents the @\s -> a + b*s@
--- function where @s@ can be the transaction size in bytes or, a number of
+-- | A linear equation of a free variable `x`. Represents the @\x -> a + b*x@
+-- function where @x@ can be the transaction size in bytes or, a number of
 -- inputs + outputs.
 --
 -- @a@ and @b@ are constant coefficients.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -710,15 +710,17 @@ instance NFData FeePolicy
 
 instance ToText FeePolicy where
     toText (LinearFee (Quantity a) (Quantity b)) =
-        toText a <> "x + " <> toText b
+        toText a <> " + " <> toText b <> "x"
 
 instance FromText FeePolicy where
-    fromText txt = case T.splitOn "x + " txt of
-        [a, b] -> LinearFee
+    fromText txt = case T.splitOn " + " txt of
+        [a, b] | T.takeEnd 1 b == "x" -> LinearFee
             <$> fmap Quantity (fromText a)
-            <*> fmap Quantity (fromText b)
+            <*> fmap Quantity (fromText (T.dropEnd 1 b))
         _ ->
-            Left $ TextDecodingError "not a linear equation"
+            Left $ TextDecodingError
+                "Unable to decode FeePolicy: \
+                \Linear equation not in expected format: a + bx"
 
 {-------------------------------------------------------------------------------
                                     Address

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -32,6 +32,7 @@ import Cardano.Wallet.Primitive.Types
     , Dom (..)
     , EpochLength (..)
     , EpochNo (..)
+    , FeePolicy (..)
     , Hash (..)
     , HistogramBar (..)
     , Range (..)
@@ -109,7 +110,7 @@ import Data.Set
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( TextDecodingError (..), fromText )
+    ( TextDecodingError (..), fromText, toText )
 import Data.Time
     ( UTCTime )
 import Data.Time.Utils
@@ -168,6 +169,20 @@ spec = do
         textRoundtrip $ Proxy @WalletId
         textRoundtrip $ Proxy @(Hash "Genesis")
         textRoundtrip $ Proxy @(Hash "Tx")
+
+        it "FeePolicy" $ property $ withMaxSuccess 10000 $
+            \fp@(LinearFee (Quantity a) (Quantity b)) ->
+                -- We have to be a little careful here, as small errors can
+                -- occur when encoding and decoding floating point numbers to
+                -- and from text. Rather than requiring absolute equality, we
+                -- instead require that the decoded values are close enough to
+                -- the original values, allowing for a small margin of error.
+                let Right (LinearFee (Quantity a') (Quantity b')) =
+                        fromText (toText fp) in
+                let epsilon = 1e-6 in
+                (abs (a - a') `shouldSatisfy` (< epsilon))
+                    .&&.
+                    (abs (b - b') `shouldSatisfy` (< epsilon))
 
     describe "Buildable" $ do
         it "WalletId" $ do
@@ -791,6 +806,16 @@ deriving instance Arbitrary a => Arbitrary (ShowFmt a)
 instance Arbitrary Direction where
     arbitrary = arbitraryBoundedEnum
     shrink = genericShrink
+
+instance Arbitrary FeePolicy where
+    arbitrary = do
+        NonNegative a <- arbitrary
+        NonNegative b <- arbitrary
+        return $ LinearFee (Quantity a) (Quantity b)
+    shrink (LinearFee (Quantity a) (Quantity b)) =
+        f <$> shrink (a, b)
+      where
+        f (x, y) = LinearFee (Quantity x) (Quantity y)
 
 instance Arbitrary (Hash "Genesis") where
     arbitrary = Hash . BS.pack <$> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -90,7 +90,7 @@ import Cardano.Wallet.Primitive.Types
 import Control.DeepSeq
     ( deepseq )
 import Control.Monad
-    ( replicateM )
+    ( forM_, replicateM )
 import Crypto.Hash
     ( hash )
 import Data.ByteString
@@ -578,6 +578,21 @@ spec = do
             let err = "Unable to decode (Hash \"Genesis\"): \
                       \expected Base16 encoding"
             fromText @(Hash "Genesis") "----" === Left (TextDecodingError err)
+        let invalidFeePolicyTexts =
+                [ "1"
+                , "1x"
+                , "1 + 1"
+                , "1x + 1"
+                , "1+1x"
+                , "1 +1x"
+                , "1+ 1x"
+                ]
+        forM_ invalidFeePolicyTexts $ \policyText ->
+            it ("fail fromText @FeePolicy " <> show policyText) $ do
+                let err =
+                        "Unable to decode FeePolicy: \
+                        \Linear equation not in expected format: a + bx"
+                fromText @FeePolicy policyText === Left (TextDecodingError err)
 
     describe "Lemma 2.1 - Properties of UTxO operations" $ do
         it "2.1.1) ins⊲ u ⊆ u"


### PR DESCRIPTION
# Issue Number

None. Tangentially related to #882.

# Overview

This PR:

- [x] Changes the `ToText` instance for `FeePolicy` so that it outputs text of the form `a + bx` rather than `ax + b`. This matches the way in which `LinearFee` is used within the codebase, where the first parameter `a` is treated as a constant, and the second parameter `b` is a coefficient to be multiplied by a free variable `x`.
- [x] Changes the `FromText` instance to match to the `ToText` instance.
- [x] Adds an `Arbitrary` instance for `FeePolicy`.
- [x] Adds a roundtrip textual encoding / decoding property test for `FeePolicy`.
- [x] Adds negative textual decoding tests for `FeePolicy`.