### PR TITLE
Fix Arithmetic Underflow in Migration Coin Selection

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -136,10 +136,12 @@ selectCoinsForMigration feeOpts batchSize utxo =
             { change = modifyFirst (c :| cs) (+ diff) }
       where
         diff :: Integer
-        diff = fromIntegral actualFee - fromIntegral requiredFee
+        diff = actualFee - integer requiredFee
           where
-            (Fee requiredFee) = estimateFee feeOpts coinSel
-            actualFee = inputBalance coinSel - changeBalance coinSel
+            (Fee requiredFee) =
+                estimateFee feeOpts coinSel
+            actualFee =
+                integer (inputBalance coinSel) - integer (changeBalance coinSel)
 
     -- | Apply the given function to the first coin of the list. If the
     -- operation makes the 'Coin' smaller than the dust threshold, the coin is
@@ -150,10 +152,10 @@ selectCoinsForMigration feeOpts batchSize utxo =
         | otherwise = (Coin (fromIntegral c')):cs
       where
         c' :: Integer
-        c' = op (fromIntegral c)
+        c' = op (integer c)
 
         threshold :: Integer
-        threshold = fromIntegral (getCoin (dustThreshold feeOpts))
+        threshold = integer (getCoin (dustThreshold feeOpts))
 
     getNextBatch :: State [a] [a]
     getNextBatch = do
@@ -175,3 +177,7 @@ idealBatchSize coinselOpts = fromIntegral (fixPoint 1)
       where
         maxN :: Word8 -> Word8
         maxN = maximumNumberOfInputs coinselOpts
+
+-- | Safe conversion of an integral type to an integer
+integer :: Integral a => a -> Integer
+integer = fromIntegral

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -29,6 +29,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Data.ByteString
     ( ByteString )
+import Data.Function
+    ( (&) )
 import Data.Word
     ( Word8 )
 import Numeric.Natural
@@ -169,9 +171,13 @@ prop_inputsGreaterThanOutputs
     -> UTxO
     -> Property
 prop_inputsGreaterThanOutputs feeOpts batchSize utxo = do
-    let sumCoinSelectionChange = changeBalance <$>
-            selectCoinsForMigration feeOpts batchSize utxo
-    property (balance utxo >= fromIntegral (sum sumCoinSelectionChange))
+    let selections  = selectCoinsForMigration feeOpts batchSize utxo
+    let totalChange = sum (changeBalance <$> selections)
+    let balanceUTxO = balance utxo
+    property (balanceUTxO >= fromIntegral totalChange)
+        & counterexample ("Total change balance: " <> show totalChange)
+        & counterexample ("Total UTxO balance: " <> show balanceUTxO)
+        & counterexample ("Selections: " <> show selections)
 
 -- | Every selected input is unique, i.e. selected only once
 prop_inputsAreUnique

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -112,6 +112,28 @@ spec = do
         it "Every coin selection is well-balanced" $
             property $ withMaxSuccess 1000 prop_wellBalanced
 
+    describe "selectCoinsForMigration regressions" $ do
+        it "regression #1" $ do
+            let feeOpts = FeeOptions
+                    { dustThreshold = Coin 9
+                    , estimateFee = \s -> Fee
+                        $ fromIntegral
+                        $ 5 * (length (inputs s) + length (outputs s))
+                    }
+            let batchSize = 1
+            let utxo = UTxO $ Map.fromList
+                    [ ( TxIn
+                        { inputId = Hash "|\243^\SUBg\242\231\&1\213\203"
+                        , inputIx = 2
+                        }
+                      , TxOut
+                        { address = Address "ADDR03"
+                        , coin = Coin 2
+                        }
+                      )
+                    ]
+            property (prop_inputsGreaterThanOutputs feeOpts batchSize utxo)
+
 {-------------------------------------------------------------------------------
                                   Properties
 -------------------------------------------------------------------------------}


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#908  

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a regression test to capture the failing test case
- [x] I have fixed the arithmetic underflow going on during the fee calculation


# Comments

<!-- Additional comments or screenshots to attach if any -->

Currently re-running all properties with max success = 1M

so far:

```
    No coin selection has outputs
      +++ OK, passed 1000000 tests.
    Every coin in the selection change >= minimum threshold coin
      +++ OK, passed 1000000 tests.
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
