### PR TITLE
Fix text locale encoding issues on windows

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -57,9 +57,6 @@ module Cardano.CLI
     , verbosityToArgs
     , verbosityToMinSeverity
 
-    -- * Unicode Terminal Helpers
-    , setUtf8Encoding
-
     -- * ANSI Terminal Helpers
     , putErrLn
     , hPutErrLn
@@ -173,8 +170,6 @@ import Fmt
     ( Buildable, pretty )
 import GHC.Generics
     ( Generic )
-import GHC.IO.Encoding
-    ( setLocaleEncoding )
 import GHC.TypeLits
     ( Symbol )
 import Network.HTTP.Client
@@ -244,11 +239,8 @@ import System.IO
     , hPutChar
     , hSetBuffering
     , hSetEcho
-    , hSetEncoding
     , stderr
     , stdin
-    , stdout
-    , utf8
     )
 
 import qualified Cardano.BM.Configuration.Model as CM
@@ -375,9 +367,9 @@ cmdWalletCreate = command "create" $ info (helper <*> cmd) $ mempty
             getLine prompt parser
         wSndFactor <- do
             let prompt =
-                    "(Enter a blank line if you do not wish to use a second \
-                    \factor.)\n\
-                    \Please enter a 9–12 word mnemonic second factor: "
+                    "(Enter a blank line if you do not wish to use a second " <>
+                    "factor.)\n" <>
+                    "Please enter a 9–12 word mnemonic second factor: "
             let parser =
                     optionalE (fromMnemonic @'[9,12] @"generation") . T.words
             getLine prompt parser <&> \case
@@ -837,8 +829,8 @@ paymentOption = optionT $ mempty
     <> long "payment"
     <> metavar "PAYMENT"
     <> help
-        "address to send to and amount to send separated by @\
-        \, e.g. '<amount>@<address>'"
+        ("address to send to and amount to send separated by @" <>
+        ", e.g. '<amount>@<address>'")
 
 -- | [--address-pool-gap=INT], default: 20
 poolGapOption :: Parser AddressPoolGap
@@ -1225,18 +1217,6 @@ withLogging configFile minSeverity action = bracket before after (action . snd)
     after (sb, (_, tr)) = do
         logDebug tr "Logging shutdown."
         shutdown sb
-
-{-------------------------------------------------------------------------------
-                            Unicode Terminal Helpers
--------------------------------------------------------------------------------}
-
--- | Override the system output encoding setting. This is needed because the CLI
--- prints UTF-8 characters regardless of the @LANG@ environment variable.
-setUtf8Encoding :: IO ()
-setUtf8Encoding = do
-    setLocaleEncoding utf8
-    hSetEncoding stdout utf8
-    hSetEncoding stderr utf8
 
 {-------------------------------------------------------------------------------
                             ANSI Terminal Helpers

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -152,6 +152,7 @@ test-suite unit
     , bytestring
     , cardano-crypto
     , cardano-wallet-core
+    , cardano-wallet-launcher
     , cardano-wallet-test-utils
     , cborg
     , containers
@@ -238,6 +239,7 @@ test-suite unit
       Data.Time.TextSpec
       Data.Time.UtilsSpec
       Network.Wai.Middleware.LoggingSpec
+      Spec
 
 benchmark db
   default-language:

--- a/lib/core/test/unit/Main.hs
+++ b/lib/core/test/unit/Main.hs
@@ -1,1 +1,12 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main where
+
+import Cardano.Launcher
+    ( setUtf8Encoding )
+import Prelude
+import qualified Spec
+import Test.Hspec.Runner
+
+main :: IO ()
+main = do
+    setUtf8Encoding
+    hspecWith defaultConfig Spec.spec

--- a/lib/core/test/unit/Spec.hs
+++ b/lib/core/test/unit/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -47,7 +47,6 @@ import Cardano.CLI
     , optionT
     , requireFilePath
     , runCli
-    , setUtf8Encoding
     , setupDirectory
     , stateDirOption
     , verbosityOption
@@ -55,7 +54,7 @@ import Cardano.CLI
     , withLogging
     )
 import Cardano.Launcher
-    ( StdStream (..) )
+    ( StdStream (..), setUtf8Encoding )
 import Cardano.Wallet.Api.Server
     ( HostPreference, Listen (..) )
 import Cardano.Wallet.Jormungandr

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -44,6 +44,7 @@ library
   if os(windows)
     build-depends: Win32
     other-modules: Cardano.Launcher.Windows
+    cpp-options:   -DWINDOWS
   else
     build-depends: unix
     other-modules: Cardano.Launcher.POSIX

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -117,6 +117,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
             (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
             (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."containers" or (buildDepError "containers"))


### PR DESCRIPTION
Relates to #703.

# Overview

- Forces the current windows console into UTF-8 mode.
- UTF-8 is far from standard on windows. But it shouldn't be assumed on any platform.
- This fixes strange characters appearing on windows and test failures with exceptions related to encoding.
