### PR TITLE
Remove length invariant from `Cardano.Wallet.Jormungandr.Binary.putAddress`.

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -561,22 +561,7 @@ getAddress = do
     kindValue = (.&. 0b01111111)
 
 putAddress :: Address -> Put
-putAddress addr@(Address bs)
-    | hasCorrectLength = putByteString bs
-    | otherwise = fail
-        $ "Address has unexpected length "
-        ++ show len ++ ": " ++ show addr
-  where
-    hasCorrectLength = len == addrLenSingle || len == addrLenGrouped
-    len = fromIntegral $ BS.length bs
-
--- Serialized length in bytes of a bootstrap or account address (Single Address)
-addrLenSingle :: Int
-addrLenSingle = 33
-
--- Serialized length in bytes of a delegation address (Grouped Address)
-addrLenGrouped :: Int
-addrLenGrouped = 65
+putAddress (Address bs) = putByteString bs
 
 singleAddressFromKey :: forall n. KnownNetwork n => Proxy n -> XPub -> Address
 singleAddressFromKey _ xPub = Address $ BL.toStrict $ runPut $ do

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -305,11 +305,6 @@ spec = do
             let tx = (Tx (fragmentId [] outs []) [] outs, [])
             runExceptT (postTx nw tx) `shouldReturn` Right ()
 
-        it "throws when addresses and hashes have wrong length" $ \(nw, _) -> do
-            let out = TxOut (Address "<not an address>") (Coin 1227362560)
-            let tx = (Tx (fragmentId [] [out] []) [] [out], [])
-            runExceptT (postTx nw tx) `shouldThrow` anyException
-
         it "encoder throws an exception if tx is invalid (eg too many inputs)" $
             \(nw, _) -> do
             let inps = replicate 300 (head $ inputs txNonEmpty)

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -293,12 +293,6 @@ spec = do
             evaluate (singleAddressFromKey testnet (XPub "\148" cc))
                 `shouldThrow` userException msg
 
-        it "throws when encoding an address of invalid length" $ do
-            let msg = "Address has unexpected length 1: \
-                \Address {unAddress = \"0\"}"
-            evaluate (runPut $ putAddress $ Address "0")
-                `shouldThrow` userException msg
-
         it "decode (encode address) === address" $ property $
             \addr -> monadicIO $ liftIO $ do
                 let encode = runPut . putAddress


### PR DESCRIPTION
This invariant is no longer appropriate.

# Issue Number

None. Discovered while working on integration tests for #778.

# Overview

This PR:

- [x] removes the length invariant from `Cardano.Wallet.Jormungandr.Binary.putAddress`.
- [x] fixes any tests that attempt to provoke this invariant.