### PR TITLE
Byron migration integration tests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -913,8 +913,10 @@ fixtureByronWallet ctx = do
             } |]
     (_, w) <- unsafeRequest @ApiByronWallet ctx postByronWalletEp payload
     race (threadDelay sixtySeconds) (checkBalance w) >>= \case
-        Left _ -> fail "fixtureByronWallet: waited too long for initial transaction"
-        Right a -> return a
+        Left _ ->
+            fail "fixtureByronWallet: waited too long for initial transaction"
+        Right a ->
+            return a
   where
     sixtySeconds = 60*oneSecond
     checkBalance w = do
@@ -1148,7 +1150,8 @@ listByronTxEp w query =
 migrateByronWalletEp :: ApiByronWallet -> ApiWallet -> (Method, Text)
 migrateByronWalletEp wSrc wDest =
     ( "POST"
-    , "v2/byron-wallets/" <> wSrc ^. walletId <> "/migrations/" <> wDest ^. walletId
+    , "v2/byron-wallets/" <>
+        wSrc ^. walletId <> "/migrations/" <> wDest ^. walletId
     )
 
 calculateByronMigrationCostEp :: ApiByronWallet -> (Method, Text)

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -29,6 +29,7 @@ module Test.Integration.Framework.DSL
     , expectErrorMessage
     , expectFieldEqual
     , expectFieldNotEqual
+    , expectFieldSatisfy
     , expectFieldBetween
     , expectListItemFieldBetween
     , expectListItemFieldEqual
@@ -380,6 +381,20 @@ expectFieldBetween getter (aMin, aMax) (_, res) = case res of
                 "expected " <> show a <> " <= " <> show aMax
             _ ->
                 return ()
+
+expectFieldSatisfy
+    :: (MonadIO m, MonadFail m, Show a)
+    => Lens' s a
+    -> (a -> Bool)
+    -> (HTTP.Status, Either RequestException s)
+    -> m ()
+expectFieldSatisfy getter predicate (_, res) = case res of
+    Left e  -> wantedSuccessButError e
+    Right s ->
+        let a = view getter s in
+        if predicate a
+            then return ()
+            else fail $ "predicate failed for: " <> show a
 
 expectFieldNotEqual
     :: (MonadIO m, MonadFail m, Show a, Eq a)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -159,22 +159,23 @@ spec = do
             rg <- request @ApiWallet ctx (getByronWalletEp w) headers Empty
             verify rg expec
 
-    it "BYRON_LIST_01 - Byron Wallets are listed from oldest to newest" $ \ctx -> do
-        m1 <- genMnemonics
-        m2 <- genMnemonics
-        m3 <- genMnemonics
-        _ <- emptyByronWalletWith ctx ("b1", m1, "Secure Passphrase")
-        _ <- emptyByronWalletWith ctx ("b2", m2, "Secure Passphrase")
-        _ <- emptyByronWalletWith ctx ("b3", m3, "Secure Passphrase")
+    it "BYRON_LIST_01 - Byron Wallets are listed from oldest to newest" $
+        \ctx -> do
+            m1 <- genMnemonics
+            m2 <- genMnemonics
+            m3 <- genMnemonics
+            _ <- emptyByronWalletWith ctx ("b1", m1, "Secure Passphrase")
+            _ <- emptyByronWalletWith ctx ("b2", m2, "Secure Passphrase")
+            _ <- emptyByronWalletWith ctx ("b3", m3, "Secure Passphrase")
 
-        rl <- request @[ApiByronWallet] ctx listByronWalletEp Default Empty
-        verify rl
-            [ expectResponseCode @IO HTTP.status200
-            , expectListSizeEqual 3
-            , expectListItemFieldEqual 0 walletName "b1"
-            , expectListItemFieldEqual 1 walletName "b2"
-            , expectListItemFieldEqual 2 walletName "b3"
-            ]
+            rl <- request @[ApiByronWallet] ctx listByronWalletEp Default Empty
+            verify rl
+                [ expectResponseCode @IO HTTP.status200
+                , expectListSizeEqual 3
+                , expectListItemFieldEqual 0 walletName "b1"
+                , expectListItemFieldEqual 1 walletName "b2"
+                , expectListItemFieldEqual 2 walletName "b3"
+                ]
 
     it "BYRON_LIST_02,03 -\
         \ Byron wallets listed only via Byron endpoints \\\
@@ -280,7 +281,8 @@ spec = do
         forM_ (getHeaderCases HTTP.status204)
             $ \(title, headers, expectations) -> it title $ \ctx -> do
             w <- emptyByronWallet ctx
-            rl <- request @ApiByronWallet ctx (deleteByronWalletEp w) headers Empty
+            rl <- request
+                @ApiByronWallet ctx (deleteByronWalletEp w) headers Empty
             verify rl expectations
 
     it "BYRON_RESTORE_01, GET_01, LIST_01 - Restore a wallet" $ \ctx -> do
@@ -315,13 +317,17 @@ spec = do
             , expectListItemFieldEqual 0 balanceTotal 0
             ]
 
-    it "BYRON_RESTORE_02 - One can restore previously deleted wallet" $ \ctx -> do
-        m <- genMnemonics
-        w <- emptyByronWalletWith ctx ("Byron Wallet", m, "Secure Passphrase")
-        rd <- request @ApiByronWallet ctx (deleteByronWalletEp w) Default Empty
-        expectResponseCode @IO HTTP.status204 rd
-        wr <- emptyByronWalletWith ctx ("Byron Wallet2", m, "Secure Pa33phrase")
-        w ^. walletId `shouldBe` wr ^. walletId
+    it "BYRON_RESTORE_02 - One can restore previously deleted wallet" $
+        \ctx -> do
+            m <- genMnemonics
+            w <- emptyByronWalletWith
+                ctx ("Byron Wallet", m, "Secure Passphrase")
+            rd <- request
+                @ApiByronWallet ctx (deleteByronWalletEp w) Default Empty
+            expectResponseCode @IO HTTP.status204 rd
+            wr <- emptyByronWalletWith
+                ctx ("Byron Wallet2", m, "Secure Pa33phrase")
+            w ^. walletId `shouldBe` wr ^. walletId
 
     it "BYRON_RESTORE_03 - Cannot restore wallet that exists" $ \ctx -> do
         mnemonic <- genMnemonics
@@ -446,13 +452,15 @@ spec = do
                     } |]
             r <- request @ApiByronWallet ctx postByronWalletEp Default payload
             expectResponseCode @IO HTTP.status400 r
-            expectErrorMessage "Invalid number of words: 12 words are expected" r
+            expectErrorMessage
+                "Invalid number of words: 12 words are expected" r
 
     describe "BYRON_RESTORE_05 - Faulty mnemonics" $ do
         let matrix =
              [ ( "[] as mnemonic_sentence -> fail", []
                , [ expectResponseCode @IO HTTP.status400
-                 , expectErrorMessage "Invalid number of words: 12 words are expected"
+                 , expectErrorMessage
+                    "Invalid number of words: 12 words are expected"
                  ]
                )
              , ( "specMnemonicSentence -> fail", specMnemonicByron
@@ -481,14 +489,16 @@ spec = do
 
              ]
 
-        forM_ matrix $ \(title, mnemonics, expectations) -> it title $ \ctx -> do
-            let payload = Json [json| {
-                    "name": "Byron Wallet bye bye",
-                    "mnemonic_sentence": #{mnemonics},
-                    "passphrase": "Secure Passphrase"
-                    } |]
-            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
-            verify r expectations
+        forM_ matrix $ \(title, mnemonics, expectations) -> it title $
+            \ctx -> do
+                let payload = Json [json| {
+                        "name": "Byron Wallet bye bye",
+                        "mnemonic_sentence": #{mnemonics},
+                        "passphrase": "Secure Passphrase"
+                        } |]
+                r <- request
+                    @ApiByronWallet ctx postByronWalletEp Default payload
+                verify r expectations
 
     it "BYRON_RESTORE_05 - String as mnemonic_sentence -> fail" $ \ctx -> do
         let payload = Json [json| {
@@ -571,14 +581,16 @@ spec = do
                   , [ expectResponseCode @IO HTTP.status202 ]
                   )
                 ]
-        forM_ matrix $ \(title, passphrase, expectations) -> it title $ \ctx -> do
-            let payload = Json [json| {
-                    "name": "Secure Wallet",
-                    "mnemonic_sentence": #{mnemonics12},
-                    "passphrase": #{passphrase}
-                    } |]
-            r <- request @ApiByronWallet ctx postByronWalletEp Default payload
-            verify r expectations
+        forM_ matrix $ \(title, passphrase, expectations) -> it title $
+            \ctx -> do
+                let payload = Json [json| {
+                        "name": "Secure Wallet",
+                        "mnemonic_sentence": #{mnemonics12},
+                        "passphrase": #{passphrase}
+                        } |]
+                r <- request
+                    @ApiByronWallet ctx postByronWalletEp Default payload
+                verify r expectations
 
     it "BYRON_RESTORE_06 - [] as passphrase -> fail" $ \ctx -> do
         let payload = Json [json| {
@@ -675,7 +687,8 @@ spec = do
         \ v2/byron-wallets - Methods Not Allowed" $ do
         let matrix = ["PUT", "DELETE", "CONNECT", "TRACE", "OPTIONS"]
         forM_ matrix $ \method -> it (show method) $ \ctx -> do
-            r <- request @ApiByronWallet ctx (method, "v2/byron-wallets") Default Empty
+            r <- request
+                @ApiByronWallet ctx (method, "v2/byron-wallets") Default Empty
             expectResponseCode @IO HTTP.status405 r
             expectErrorMessage errMsg405 r
  where

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -120,7 +120,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.Network
     ( ErrNetworkTip (..), ErrNetworkUnavailable (..), NetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant
+    ( NetworkDiscriminant (..)
     , PaymentAddress (..)
     , WalletKey (..)
     , digest
@@ -302,13 +302,12 @@ start
         , DefineTx t
         , DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
         , PaymentAddress n ShelleyKey
         )
     => Warp.Settings
     -> Trace IO Text
     -> Socket
-    -> ApiLayer (RndState n) t ByronKey
+    -> ApiLayer (RndState 'Mainnet) t ByronKey
     -> ApiLayer (SeqState n ShelleyKey) t ShelleyKey
     -> StakePoolLayer IO
     -> IO ()
@@ -850,10 +849,9 @@ compatibilityApiServer
     :: forall t n.
         ( Buildable (ErrValidateSelection t)
         , DefineTx t
-        , PaymentAddress n ByronKey
         , PaymentAddress n ShelleyKey
         )
-    => ApiLayer (RndState n) t ByronKey
+    => ApiLayer (RndState 'Mainnet) t ByronKey
     -> ApiLayer (SeqState n ShelleyKey) t ShelleyKey
     -> Server (CompatibilityApi n)
 compatibilityApiServer rndCtx seqCtx =
@@ -867,7 +865,7 @@ compatibilityApiServer rndCtx seqCtx =
     :<|> deleteByronTransaction rndCtx
 
 deleteByronWallet
-    :: forall s t k n. (s ~ RndState n)
+    :: forall s t k. (s ~ RndState 'Mainnet)
     => ApiLayer s t k
     -> ApiT WalletId
     -> Handler NoContent
@@ -882,17 +880,17 @@ deleteByronWallet ctx (ApiT wid) = do
     df = ctx ^. dbFactory @s @t @k
 
 getByronWallet
-    :: forall t n k. DefineTx t
-    => ApiLayer (RndState n) t k
+    :: forall t k. DefineTx t
+    => ApiLayer (RndState 'Mainnet) t k
     -> ApiT WalletId
     -> Handler ApiByronWallet
 getByronWallet ctx wid =
     fst <$> getWalletWithCreationTime mkApiByronWallet ctx wid
 
 getByronWalletMigrationInfo
-    :: forall ctx s t k n.
+    :: forall ctx s t k.
        ( DefineTx t
-       , s ~ RndState n
+       , s ~ RndState 'Mainnet
        , ctx ~ ApiLayer s t k )
     => ApiLayer s t k
         -- ^ Source wallet context (Byron)
@@ -922,10 +920,9 @@ getByronWalletMigrationInfo ctx (ApiT wid) =
 migrateByronWallet
     :: forall t n.
        ( DefineTx t
-       , PaymentAddress n ByronKey
        , PaymentAddress n ShelleyKey
        )
-    => ApiLayer (RndState n) t ByronKey
+    => ApiLayer (RndState 'Mainnet) t ByronKey
         -- ^ Source wallet context (Byron)
     -> ApiLayer (SeqState n ShelleyKey) t ShelleyKey
         -- ^ Target wallet context (Shelley)
@@ -963,7 +960,7 @@ migrateByronWallet rndCtx seqCtx (ApiT rndWid) (ApiT seqWid) migrateData = do
     passphrase = getApiT $ migrateData ^. #passphrase
 
 listByronWallets
-    :: forall s t k n. (DefineTx t, s ~ RndState n)
+    :: forall s t k. (DefineTx t, s ~ RndState 'Mainnet)
     => ApiLayer s t k
     -> Handler [ApiByronWallet]
 listByronWallets ctx = do
@@ -974,8 +971,8 @@ listByronWallets ctx = do
     re = ctx ^. workerRegistry @s @t @k
 
 postByronWallet
-    :: forall t n. (DefineTx t, PaymentAddress n ByronKey)
-    => ApiLayer (RndState n) t ByronKey
+    :: forall t. (DefineTx t)
+    => ApiLayer (RndState 'Mainnet) t ByronKey
     -> ByronWalletPostData
     -> Handler ApiByronWallet
 postByronWallet ctx body = do
@@ -1009,8 +1006,8 @@ listByronTransactions =
     listTransactions
 
 deleteByronTransaction
-    :: forall ctx s t k n.
-        ( s ~ RndState n
+    :: forall ctx s t k.
+        ( s ~ RndState 'Mainnet
         , ctx ~ ApiLayer s t k
         , DefineTx t
         )
@@ -1159,8 +1156,13 @@ mkApiWallet wid wallet meta progress pending = ApiWallet
     }
 
 mkApiByronWallet
-    :: forall s t n. (DefineTx t, s ~ RndState n)
-    => WalletId -> Wallet s t -> WalletMetadata -> SyncProgress -> Set (Tx t) -> ApiByronWallet
+    :: forall s t. (DefineTx t, s ~ RndState 'Mainnet)
+    => WalletId
+    -> Wallet s t
+    -> WalletMetadata
+    -> SyncProgress
+    -> Set (Tx t)
+    -> ApiByronWallet
 mkApiByronWallet wid wallet meta progress pending = ApiByronWallet
     { balance = getWalletBalance wallet pending
     , id = ApiT wid

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -60,6 +60,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , PersistPrivateKey(..)
     , PersistPublicKey(..)
     , MkKeyFingerprint(..)
+    , ErrMkKeyFingerprint(..)
     , KeyFingerprint(..)
     , dummyAddress
 
@@ -635,11 +636,18 @@ instance NFData (KeyFingerprint s key)
 class MkKeyFingerprint (key :: Depth -> * -> *) where
     paymentKeyFingerprint
         :: Address
-        -> KeyFingerprint "payment" key
+        -> Either
+            (ErrMkKeyFingerprint key)
+            (KeyFingerprint "payment" key)
 
     delegationKeyFingerprint
         :: Address
-        -> Maybe (KeyFingerprint "delegation" key)
+        -> Either
+            (ErrMkKeyFingerprint key)
+            (Maybe (KeyFingerprint "delegation" key))
+
+data ErrMkKeyFingerprint key
+    = ErrInvalidAddress Address (Proxy key) deriving (Show, Eq)
 
 {-------------------------------------------------------------------------------
                                 Helpers

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -61,6 +61,7 @@ import Cardano.Crypto.Wallet
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
+    , ErrMkKeyFingerprint (..)
     , Index (..)
     , KeyFingerprint (..)
     , MkKeyFingerprint (..)
@@ -84,6 +85,8 @@ import Data.ByteArray
     ( ScrubbedBytes )
 import Data.ByteString
     ( ByteString )
+import Data.Proxy
+    ( Proxy (..) )
 import GHC.Generics
     ( Generic )
 
@@ -166,8 +169,14 @@ instance PaymentAddress 'Mainnet ByronKey where
         Address bytes
 
 instance MkKeyFingerprint ByronKey where
-    paymentKeyFingerprint (Address bytes) = KeyFingerprint bytes
-    delegationKeyFingerprint _ = Nothing
+    paymentKeyFingerprint addr@(Address bytes) =
+        case decodeLegacyAddress bytes of
+            Just _  -> Right $ KeyFingerprint bytes
+            Nothing -> Left $ ErrInvalidAddress addr (Proxy @ByronKey)
+    delegationKeyFingerprint addr@(Address bytes) =
+        case decodeLegacyAddress bytes of
+            Just _  -> Right Nothing
+            Nothing -> Left $ ErrInvalidAddress addr (Proxy @ByronKey)
 
 {-------------------------------------------------------------------------------
                             Encoding / Decoding

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -85,6 +85,10 @@ spec = do
             (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
         it "sort (shuffled xs) == sort xs"
             (checkCoverageWith lowerConfidence prop_shufflePreserveElements)
+        it "UTxO toList order deterministic" $
+            checkCoverageWith
+                lowerConfidence
+                prop_utxoToListOrderDeterministic
   where
     lowerConfidence :: Confidence
     lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
@@ -114,6 +118,16 @@ prop_shufflePreserveElements
 prop_shufflePreserveElements xs = monadicIO $ liftIO $ do
     xs' <- shuffle xs
     return $ cover 90 (not $ null xs) "non-empty" (L.sort xs == L.sort xs')
+
+prop_utxoToListOrderDeterministic
+    :: UTxO
+    -> Property
+prop_utxoToListOrderDeterministic u = monadicIO $ liftIO $ do
+    let list0 = Map.toList $ getUTxO u
+    list1 <- shuffle list0
+    return $
+        cover 90 (list0 /= list1) "shuffled" $
+        list0 == Map.toList (Map.fromList list1)
 
 {-------------------------------------------------------------------------------
                          Coin Selection - Unit Tests

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -39,8 +39,6 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , UTxO (..)
     )
-import Control.Monad.IO.Class
-    ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Data.List.NonEmpty
@@ -75,6 +73,7 @@ import qualified Data.ByteString as BS
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import qualified Test.QuickCheck.Monadic as QC
 
 spec :: Spec
 spec = do
@@ -100,14 +99,14 @@ spec = do
 prop_shuffleCanShuffle
     :: NonEmptyList Int
     -> Property
-prop_shuffleCanShuffle (NonEmpty xs) = monadicIO $ liftIO $ do
+prop_shuffleCanShuffle (NonEmpty xs) = monadicIO $ QC.run $ do
     xs' <- shuffle xs
     return $ cover 90 (xs /= xs') "shuffled" ()
 
 prop_shuffleNotDeterministic
     :: NonEmptyList Int
     -> Property
-prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ liftIO $ do
+prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ QC.run $ do
     xs1 <- shuffle xs
     xs2 <- shuffle xs
     return $ cover 90 (xs1 /= xs2) "not deterministic" ()
@@ -115,14 +114,14 @@ prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ liftIO $ do
 prop_shufflePreserveElements
     :: [Int]
     -> Property
-prop_shufflePreserveElements xs = monadicIO $ liftIO $ do
+prop_shufflePreserveElements xs = monadicIO $ QC.run $ do
     xs' <- shuffle xs
     return $ cover 90 (not $ null xs) "non-empty" (L.sort xs == L.sort xs')
 
 prop_utxoToListOrderDeterministic
     :: UTxO
     -> Property
-prop_utxoToListOrderDeterministic u = monadicIO $ liftIO $ do
+prop_utxoToListOrderDeterministic u = monadicIO $ QC.run $ do
     let list0 = Map.toList $ getUTxO u
     list1 <- shuffle list0
     return $

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
-    , NetworkDiscriminant
+    , NetworkDiscriminant (..)
     , NetworkDiscriminantVal
     , PaymentAddress
     , PersistPrivateKey
@@ -134,7 +134,6 @@ serveWallet
         , NetworkDiscriminantVal n
         , DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
         , PaymentAddress n ShelleyKey
         )
     => (CM.Configuration, Trace IO Text)
@@ -158,7 +157,7 @@ serveWallet (cfg, tr) databaseDir hostPref listen lj beforeMainLoop = do
         Right (cp, nl) -> do
             let nPort = Port $ baseUrlPort $ _restApi cp
             let (_, bp) = staticBlockchainParameters nl
-            let rndTl = newTransactionLayer @n (getGenesisBlockHash bp)
+            let rndTl = newTransactionLayer @'Mainnet (getGenesisBlockHash bp)
             let seqTl = newTransactionLayer @n (getGenesisBlockHash bp)
             let poolDBPath = Pool.defaultFilePath <$> databaseDir
             Pool.withDBLayer cfg tr poolDBPath $ \db -> do
@@ -172,7 +171,7 @@ serveWallet (cfg, tr) databaseDir hostPref listen lj beforeMainLoop = do
         :: Trace IO Text
         -> Port "node"
         -> BlockchainParameters
-        -> ApiLayer (RndState n) t ByronKey
+        -> ApiLayer (RndState 'Mainnet) t ByronKey
         -> ApiLayer (SeqState n ShelleyKey) t ShelleyKey
         -> StakePoolLayer IO
         -> IO ExitCode

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -438,7 +438,7 @@ getLegacyTransaction size = do
         coin <- Coin <$> getWord64be
         addr <- getLegacyAddress
         pure (TxOut addr coin)
-    let inps = pure (error "TODO: getLegacyTransaction inputs?")
+    let inps = mempty
     pure (Tx tid inps outs)
 
 putSignedTx :: [(TxIn, Coin)] -> [TxOut] -> [TxWitness] -> Put

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -194,9 +194,9 @@ getBlockHeader = label "getBlockHeader" $ do
         -- 2. BFT
         -- 3. Praos / Genesis
         --
-        -- We could make sure we get the right kind of proof, but we don't need to.
-        -- Just checking that the length is not totally wrong, is much simpler
-        -- and gives us sanity about the binary format being correct.
+        -- We could make sure we get the right kind of proof, but we don't need
+        -- to.  Just checking that the length is not totally wrong is much
+        -- simpler and gives us sanity about the binary format being correct.
         read' <- fromIntegral <$> bytesRead
         let remaining = size - read'
         producedBy <- case remaining of
@@ -209,7 +209,8 @@ getBlockHeader = label "getBlockHeader" $ do
             612 ->
                 -- Praos/Genesis
                 Just . PoolId <$> getByteString 32 <* skip (remaining - 32)
-            _ -> fail $ "BlockHeader proof has unexpected size " <> (show remaining)
+            _ -> fail $
+                "BlockHeader proof has unexpected size " <> (show remaining)
         return $ BlockHeader
             { version
             , contentSize
@@ -430,9 +431,13 @@ putSignedTx inputs outputs witnesses = do
 putTx :: [(TxIn, Coin)] -> [TxOut] -> Put
 putTx inputs outputs = do
     unless (length inputs <= fromIntegral (maxBound :: Word8)) $
-        fail ("number of inputs cannot be greater than " ++ show maxNumberOfInputs)
+        fail $
+            "number of inputs cannot be greater than " ++
+            show maxNumberOfInputs
     unless (length outputs <= fromIntegral (maxBound :: Word8)) $
-        fail ("number of outputs cannot be greater than " ++ show maxNumberOfOutputs)
+        fail $
+            "number of outputs cannot be greater than " ++
+            show maxNumberOfOutputs
     putWord8 $ toEnum $ length inputs
     putWord8 $ toEnum $ length outputs
     mapM_ putInput inputs
@@ -501,7 +506,8 @@ getConfigParam = label "getConfigParam" $ do
     let len = fromIntegral $ taglen .&. (63) -- 0b111111
     isolate len $ case tag of
         1 -> Discrimination <$> getNetworkDiscriminant
-        2 -> Block0Date . W.StartTime . posixSecondsToUTCTime . fromIntegral <$> getWord64be
+        2 -> Block0Date . W.StartTime . posixSecondsToUTCTime . fromIntegral
+            <$> getWord64be
         3 -> Consensus <$> getConsensusVersion
         4 -> SlotsPerEpoch . W.EpochLength . fromIntegral  <$> getWord32be
         5 -> SlotDuration . secondsToNominalDiffTime <$> getWord8

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -167,21 +167,21 @@ spec = do
                             ]
                         }, [])
                     , UnimplementedMessage 5
-                    , TransactionWithDelegation (
-                            PoolId (unsafeFromHex
-                                    "a09ae0da1e618eeb09e7b78d73e265af18f8\
-                                    \7d4d5320386ebf0235f54ecd0347")
-                            , ChimericAccount (unsafeFromHex
-                                    "877fbb2283ba1ed56d835fb8cd66694a840\
-                                    \360e69c690a04aeef39629cdd804f")
-                            , Tx
-                              { txid = Hash $ unsafeFromHex
-                                  "4ab1923eb7e84ab2ac73769ff863138cce3a7\
-                                  \1ba9f4d2533a007d36496aa58c9"
-                              , inputs = []
-                              , outputs = []
-                              }
-                            , []
+                    , StakeDelegation
+                        ( PoolId $ unsafeFromHex
+                            "a09ae0da1e618eeb09e7b78d73e265af18f8\
+                            \7d4d5320386ebf0235f54ecd0347"
+                        , ChimericAccount $ unsafeFromHex
+                            "877fbb2283ba1ed56d835fb8cd66694a840\
+                            \360e69c690a04aeef39629cdd804f"
+                        , Tx
+                            { txid = Hash $ unsafeFromHex
+                              "4ab1923eb7e84ab2ac73769ff863138cce3a7\
+                              \1ba9f4d2533a007d36496aa58c9"
+                            , inputs = []
+                            , outputs = []
+                            }
+                        , []
                         )
                     ]
             unsafeDecodeHex getBlock bytes `shouldBe` block
@@ -320,7 +320,7 @@ spec = do
 
     getStakeDelegationTxMessage :: Message -> (PoolId, ChimericAccount, Tx, [TxWitness])
     getStakeDelegationTxMessage m = case m of
-        TransactionWithDelegation stx -> stx
+        StakeDelegation stx -> stx
         _ -> error "expected a Transaction message"
 
     try' :: a -> IO (Either String a)


### PR DESCRIPTION
# Issue Number

#778 
#779 

# Overview

This PR adds integration tests to verify that:

- [x] Calculating the migration cost of an empty wallet (with [`getByronWalletMigrateInfo`](https://github.com/input-output-hk/cardano-wallet/issues/778)) returns a value of `0`.
- [x] Migrating an empty wallet (with the [`migrateByronWallet`](https://github.com/input-output-hk/cardano-wallet/issues/779) endpoint) should not generate any transactions.
- [x] The actual cost incurred by a migration (with the [`migrateByronWallet`](https://github.com/input-output-hk/cardano-wallet/issues/779) endpoint) **exactly** matches the cost returned by the [`getByronWalletMigrateInfo`](https://github.com/input-output-hk/cardano-wallet/issues/778) endpoint.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
