### PR TITLE
Fix range tests by generating non-singleton ranges directly.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -840,15 +840,10 @@ instance Arbitrary Coin where
     arbitrary = Coin <$> choose (0, 3)
 
 instance (Arbitrary a, Ord a) => Arbitrary (Range a) where
-    arbitrary = fmap makeRangeValid $
-        Range
-            <$> arbitrary
-            <*> arbitrary
-    shrink (Range p q) = makeRangeValid <$>
-        [ Range u v
-        | u <- shrink p
-        , v <- shrink q
-        ]
+    arbitrary =
+        makeRangeValid . uncurry Range <$> arbitrary
+    shrink (Range p q) =
+        makeRangeValid . uncurry Range <$> shrink (p, q)
 
 -- Ensures that the start of a range is not greater than its end.
 makeRangeValid :: Ord a => Range a -> Range a

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -219,15 +219,13 @@ spec = do
 
         it "arbitrary non-singleton ranges are valid" $
             withMaxSuccess 1000 $ property $ \(nsr :: NonSingletonRange Int) ->
-                let isValidNonSingleton r =
+                let isValidNonSingleton (NonSingletonRange r) =
                         rangeIsValid r && not (rangeIsSingleton r) in
                 checkCoverage $
                 cover 10 (rangeIsFinite (getNonSingletonRange nsr))
                     "finite range" $
-                isValidNonSingleton (getNonSingletonRange nsr) .&&.
-                    all
-                        (isValidNonSingleton . getNonSingletonRange)
-                        (shrink nsr)
+                isValidNonSingleton nsr .&&.
+                    all isValidNonSingleton (shrink nsr)
 
         it "functions is{Before,Within,After}Range are mutually exclusive" $
             withMaxSuccess 1000 $ property $ \(a :: Integer) r ->

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -306,8 +306,8 @@ spec = do
                 r `isSubrangeOf` wholeRange
 
         it "Range (succ a) b `isSubrangeOf` Range a b" $
-            withMaxSuccess 1000 $ property $ \r@(Range a b :: Range Int) ->
-                not (rangeIsSingleton r) ==>
+            withMaxSuccess 1000 $ property $ \nsr ->
+                let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $
@@ -315,8 +315,8 @@ spec = do
                 Range (succ <$> a) b `isSubrangeOf` Range a b
 
         it "Range a (pred b) `isSubrangeOf` Range a b" $
-            withMaxSuccess 1000 $ property $ \r@(Range a b :: Range Int) ->
-                not (rangeIsSingleton r) ==>
+            withMaxSuccess 1000 $ property $ \nsr ->
+                let r@(Range a b :: Range Int) = getNonSingletonRange nsr in
                 checkCoverage $
                 cover 10 (rangeHasLowerBound r) "has lower bound" $
                 cover 10 (rangeHasUpperBound r) "has upper bound" $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -876,9 +876,8 @@ instance (Arbitrary a, Ord a) => Arbitrary (NonSingletonRange a) where
         ranges <- infiniteList
         pure $ head $ catMaybes $
             makeNonSingletonRangeValid . NonSingletonRange <$> ranges
-    shrink (NonSingletonRange (Range x y)) = catMaybes $
-        makeNonSingletonRangeValid . NonSingletonRange . uncurry Range
-            <$> shrink (x, y)
+    shrink (NonSingletonRange r) = catMaybes $
+        makeNonSingletonRangeValid . NonSingletonRange <$> shrink r
 
 -- Ensures that a range is not a singleton range.
 makeNonSingletonRangeValid


### PR DESCRIPTION
# Issue Number

#917

# Overview

This PR:

- [x] Adds a `NonSingletonRange` type and associated `Arbitrary` instance. Generated ranges of this type are always expected to contain than one value.
- [x] Adds tests to demonstrate that the generator and shrinker for `NonSingletonRange` always produces non-singleton ranges.
- [x] Uses the `NonSingletonRange` type to replace the preconditions for the `isSubrange` tests.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
