### PR TITLE
Test that monitorStakePools resumes correctly after being killed

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -71,6 +71,8 @@ import Database.Persist.Sql
     )
 import Database.Persist.Sqlite
     ( SqlPersistT )
+import System.FilePath
+    ( (</>) )
 
 import Cardano.Pool.DB.Sqlite.TH
 
@@ -83,7 +85,7 @@ defaultFilePath
     :: FilePath
     -- ^ The directory in which the .sqlite file will be located.
     -> FilePath
-defaultFilePath = (<> "/stake-pools.sqlite")
+defaultFilePath = (</> "stake-pools.sqlite")
 
 -- | Runs an action with a connection to the SQLite database.
 --

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -199,6 +199,7 @@ test-suite integration
     , exceptions
     , extra
     , filepath
+    , fmt
     , generic-arbitrary
     , generic-lens
     , hspec
@@ -237,6 +238,7 @@ test-suite integration
       Cardano.Faucet
       Cardano.Wallet.Jormungandr.Launch
       Cardano.Wallet.Jormungandr.NetworkSpec
+      Cardano.Pool.MetricsSpec
       Test.Integration.Jormungandr.Scenario.API.StakePools
       Test.Integration.Jormungandr.Scenario.API.Transactions
       Test.Integration.Jormungandr.Scenario.CLI.Launcher

--- a/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+module Cardano.Pool.MetricsSpec where
+
+import Prelude
+
+import Cardano.BM.Configuration.Static
+    ( defaultConfigStdout )
+import Cardano.BM.Trace
+    ( nullTracer )
+import Cardano.Pool.Metrics
+    ( monitorStakePools )
+import Cardano.Wallet.Jormungandr
+    ( toSPBlock )
+import Cardano.Wallet.Jormungandr.Launch
+    ( withConfig )
+import Cardano.Wallet.Jormungandr.Network
+    ( JormungandrBackend (..), withJormungandr, withNetworkLayer )
+import Cardano.Wallet.Primitive.Types
+    ( BlockHeader (..), SlotId )
+import Control.Concurrent
+    ( forkIO, killThread )
+import Control.Exception
+    ( bracket, throwIO )
+import Control.Monad
+    ( void )
+import Data.List
+    ( isPrefixOf, (\\) )
+import Fmt
+    ( pretty )
+import System.FilePath
+    ( (</>) )
+import System.IO.Temp
+    ( withSystemTempDirectory )
+import Test.Hspec
+    ( Spec, around, expectationFailure, it )
+import Test.Integration.Framework.DSL
+    ( eventually )
+
+import qualified Cardano.Pool.DB as Pool
+import qualified Cardano.Pool.DB.Sqlite as Pool
+
+spec :: Spec
+spec = around setup $ do
+    it "a monitorStakePools thread with db, if killed and restarted, catches up\
+        \ with one that stays running" $ \(nl, referenceDB) ->
+        withDB "db.sqlite" $ \db ->
+            withMonitorStakePoolsThread nl db $ \worker -> do
+                eventually $ do
+                    db `shouldContainSameSlotsAs` referenceDB
+                    shouldNotBeEmpty db
+
+                killThread worker
+
+                eventually $
+                    shouldBeBehindBy 3 db referenceDB
+
+                withMonitorStakePoolsThread nl db $ \_ ->
+                    eventually $ db `shouldContainSameSlotsAs` referenceDB
+  where
+    shouldBeBehindBy n db ref = do
+        refSlots <- readSlots ref
+        dbSlots <- readSlots db
+        if length (refSlots \\ dbSlots) >= n
+            && dbSlots `isPrefixOf` refSlots
+            -- NOTE: The isPrefixOf-check is arguably not vital, but also
+            -- expected since the self-node we're testing against shouldn't
+            -- rollback.
+        then return ()
+        else expectationFailure $ mconcat
+            [ "The db with slots:\n    "
+            , pretty dbSlots
+            , "\nshould be behind the reference db containing:\n    "
+            , pretty refSlots
+            , "\nbut isn't."
+            ]
+
+    shouldContainSameSlotsAs db ref = do
+        refSlots <- readSlots ref
+        dbSlots <- readSlots db
+        if dbSlots == refSlots
+        then return ()
+        else expectationFailure $ mconcat
+            [ "The db containing slots:\n    "
+            , pretty dbSlots
+            , "\nshould contain the same slots as the reference db:\n    "
+            , pretty refSlots
+            , "\nbut they are different."
+            ]
+
+    shouldNotBeEmpty db = do
+        dbSlots <- readSlots db
+        if not $ null dbSlots
+        then return ()
+        else expectationFailure "The db shouldn't be empty"
+
+    -- | Intended as "read all pool productions from the db". Oldest first, the
+    -- tip last. In practice only reads the 10000 latest, but in this module we
+    -- expect the dbs to contain ~10 slots, so it doesn't matter.
+    readSlots :: Pool.DBLayer IO -> IO [SlotId]
+    readSlots x = map slotId <$> Pool.readPoolProductionCursor x 10000
+
+    withMonitorStakePoolsThread nl db action = do
+        bracket
+            (forkIO $ void $ monitorStakePools nullTracer nl db)
+            killThread
+            action
+
+    setup cb = withConfig $ \cfg -> do
+        let tr = nullTracer
+        e <- withJormungandr tr cfg $ \cp ->
+            withNetworkLayer tr (UseRunning cp) $ \case
+                Right (_, nl) -> withDB "reference.sqlite" $ \db -> do
+                    let nl' = toSPBlock <$> nl
+                    withMonitorStakePoolsThread nl' db $ \_workerThread ->
+                        cb (nl', db)
+                Left e -> throwIO e
+        either throwIO (\_ -> return ()) e
+
+    withDB name action =
+        withSystemTempDirectory "stake-pool" $ \dir -> do
+            let dbFile = dir </> name
+            cfg <- defaultConfigStdout
+            Pool.withDBLayer cfg nullTracer (Just dbFile) action

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -66,6 +66,7 @@ import Test.Integration.Framework.DSL
     ( Context (..), KnownCommand (..), TxDescription (..), tearDown )
 
 import qualified Cardano.BM.Configuration.Model as CM
+import qualified Cardano.Pool.MetricsSpec as MetricsSpec
 import qualified Cardano.Wallet.Jormungandr.NetworkSpec as NetworkLayer
 import qualified Data.Text as T
 import qualified Test.Integration.Jormungandr.Scenario.API.StakePools as StakePoolsApiJormungandr
@@ -101,6 +102,7 @@ main = withLogging Nothing Info $ \logging -> do
             describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
             describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
+            describe "Stake Pool Metrics" MetricsSpec.spec
 
         describe "API Specifications" $ specWithServer logging $ do
             Addresses.spec

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -175,6 +175,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."exceptions" or (buildDepError "exceptions"))
             (hsPkgs."extra" or (buildDepError "extra"))
             (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."generic-arbitrary" or (buildDepError "generic-arbitrary"))
             (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
             (hsPkgs."hspec" or (buildDepError "hspec"))


### PR DESCRIPTION
# Issue Number

#713 

# Overview

- [x] I added an integration test, testing `monitorStakePools` and `Pool.DB, making sure that if a worker is killed and restarted, it is the same as if it had never been killed.

# Comments


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
