### PR TITLE
Forget pending tx endpoint spec update

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -916,12 +916,10 @@ x-responsesPutWalletPassphrase: &responsesPutWalletPassphrase
     description: No Content
 
 x-responsesDeleteTransaction: &responsesDeleteTransaction
-  <<: *responsesErr400
   <<: *responsesErr403
   <<: *responsesErr404
   <<: *responsesErr405
   <<: *responsesErr406
-  <<: *responsesErr415
   204:
     description: No Content
 
@@ -1188,7 +1186,7 @@ paths:
     delete:
       operationId: deleteTransaction
       tags: ["Transactions"]
-      summary: Delete
+      summary: Forget
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
@@ -1264,7 +1262,7 @@ paths:
       tags: ["Byron Wallets"]
       summary: List
       description: |
-        <p align="right">status: <strong>under testing</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
 
         Return a list of known Byron wallets, ordered from oldest to newest.
       responses: *responsesListByronWallets
@@ -1274,7 +1272,7 @@ paths:
       tags: ["Byron Wallets"]
       summary: Restore
       description: |
-        <p align="right">status: <strong>under testing</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
 
         Restore a Byron wallet from a mnemonic sentence.
       parameters:
@@ -1288,7 +1286,7 @@ paths:
       tags: ["Byron Wallets"]
       summary: Get
       description: |
-        <p align="right">status: <strong>under testing</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
 
         Return information about a Byron wallet.
       parameters:
@@ -1300,7 +1298,7 @@ paths:
       tags: ["Byron Wallets"]
       summary: Delete
       description: |
-        <p align="right">status: <strong>under testing</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
 
         Delete a Byron wallet.
       parameters:
@@ -1327,7 +1325,7 @@ paths:
     delete:
       operationId: deleteByronTransaction
       tags: ["Byron Transactions"]
-      summary: Delete
+      summary: Forget
       description: |
         <p align="right">status: <strong>under testing</strong></p>
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -321,12 +321,6 @@ x-transactionStatus: &transactionStatus
     Current transaction status.
 
       ```
-                                  *-------------*
-                                  |             |
-                  *---------------> INVALIDATED |
-                  |               |             |
-              (timeout)           *-------------*
-                  |
              *---------*
              |         |
       -------> PENDING <----------------*
@@ -343,7 +337,6 @@ x-transactionStatus: &transactionStatus
   enum:
     - pending
     - in_ledger
-    - invalidated
 
 x-stakePoolId: &stakePoolId
   <<: *addressId


### PR DESCRIPTION
# Issue Number

#836

# Overview
swagger.yaml update:
 - deleteTransaction summary:  Delete -> Forget
 - update response codes for Tx forget endpoint
 - update status for Byron management nodes

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
