### PR TITLE
Don't store wallet syncProgress in DB

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -581,9 +581,12 @@ restoreBlocks ctx wid blocks nodeTip = do
         DB.prune db (PrimaryKey wid)
         DB.putTxHistory db (PrimaryKey wid) txs
 
+
         liftIO $ do
+            progress <- walletSyncProgress (NE.last cps)
             logInfo tr $
                 pretty meta
+            logInfo tr $ "syncProgress: " <> pretty progress
             logInfo tr $ "discovered "
                 <> pretty (length txs) <> " new transaction(s)"
             logInfo tr $ "local tip: "

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -70,6 +70,7 @@ module Cardano.Wallet
     , restoreWallet
     , updateWallet
     , updateWalletPassphrase
+    , walletSyncProgress
     , ErrWalletAlreadyExists (..)
     , ErrNoSuchWallet (..)
     , ErrListUTxOStatistics (..)
@@ -416,7 +417,6 @@ createWallet ctx wid wname s = do
             { name = wname
             , creationTime = now
             , passphraseInfo = Nothing
-            , status = Syncing minBound
             , delegation = NotDelegating
             }
     DB.createWallet db (PrimaryKey wid) cp meta hist $> wid
@@ -437,6 +437,12 @@ readWallet ctx wid = (,,)
    <$> readWalletCheckpoint @ctx @s @t @k ctx wid
    <*> readWalletMeta @ctx @s @t @k ctx wid
    <*> lift (pendingTxHistory @ctx @s @t @k ctx wid)
+
+walletSyncProgress :: Wallet s t -> IO SyncProgress
+walletSyncProgress w = do
+    let bp = blockchainParameters w
+    let h = currentTip w
+    syncProgressRelativeToTime (slotParams bp) h <$> getCurrentTime
 
 -- | Retrieve a wallet's most recent checkpoint
 readWalletCheckpoint
@@ -567,7 +573,6 @@ restoreBlocks ctx wid blocks nodeTip = do
         let k = bp ^. #getEpochStability
         let localTip = currentTip $ NE.last cps
 
-        meta' <- liftIO $ calculateMetadata bp localTip meta
         let unstable = sparseCheckpoints k (nodeTip ^. #blockHeight)
         forM_ (NE.init cps) $ \cp -> do
             let (Quantity h) = currentTip cp ^. #blockHeight
@@ -575,11 +580,10 @@ restoreBlocks ctx wid blocks nodeTip = do
         makeCheckpoint (NE.last cps)
         DB.prune db (PrimaryKey wid)
         DB.putTxHistory db (PrimaryKey wid) txs
-        DB.putWalletMeta db (PrimaryKey wid) meta'
 
         liftIO $ do
             logInfo tr $
-                pretty meta'
+                pretty meta
             logInfo tr $ "discovered "
                 <> pretty (length txs) <> " new transaction(s)"
             logInfo tr $ "local tip: "
@@ -597,16 +601,6 @@ restoreBlocks ctx wid blocks nodeTip = do
         liftIO $ logInfo tr $
             "Creating checkpoint at " <> pretty (currentTip cp)
         DB.putCheckpoint db (PrimaryKey wid) cp
-
-    calculateMetadata
-        :: BlockchainParameters
-        -> BlockHeader
-        -> WalletMetadata
-        -> IO WalletMetadata
-    calculateMetadata bp h meta = do
-        p <- syncProgressRelativeToTime (slotParams bp) h <$> getCurrentTime
-        pure (meta { status = p } :: WalletMetadata)
-
 
 -- | Remove an existing wallet. Note that there's no particular work to
 -- be done regarding the restoration worker as it will simply terminate

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -484,7 +484,6 @@ mkWalletEntity wid meta = Wallet
     , walCreationTime = meta ^. #creationTime
     , walPassphraseLastUpdatedAt =
         W.lastUpdatedAt <$> meta ^. #passphraseInfo
-    , walStatus = meta ^. #status
     , walDelegation = delegationToPoolId $ meta ^. #delegation
     }
 
@@ -494,7 +493,6 @@ mkWalletMetadataUpdate meta =
     , WalCreationTime =. meta ^. #creationTime
     , WalPassphraseLastUpdatedAt =.
         W.lastUpdatedAt <$> meta ^. #passphraseInfo
-    , WalStatus =. meta ^. #status
     , WalDelegation =. delegationToPoolId (meta ^. #delegation)
     ]
 
@@ -512,7 +510,6 @@ metadataFromEntity wal = W.WalletMetadata
     , creationTime = walCreationTime wal
     , passphraseInfo = W.WalletPassphraseInfo <$>
         walPassphraseLastUpdatedAt wal
-    , status = walStatus wal
     , delegation = delegationFromPoolId (walDelegation wal)
     }
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -61,7 +61,6 @@ Wallet
     walCreationTime       UTCTime        sql=creation_time
     walName               Text           sql=name
     walPassphraseLastUpdatedAt  UTCTime Maybe  sql=passphrase_last_updated_at
-    walStatus             W.SyncProgress sql=status
     walDelegation         W.PoolId Maybe sql=delegation
 
     Primary walId

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -237,8 +237,6 @@ data WalletMetadata = WalletMetadata
         :: !UTCTime
     , passphraseInfo
         :: !(Maybe WalletPassphraseInfo)
-    , status
-        :: !SyncProgress
     , delegation
         :: !(WalletDelegation PoolId)
     } deriving (Eq, Show, Generic)
@@ -246,8 +244,8 @@ data WalletMetadata = WalletMetadata
 instance NFData WalletMetadata
 
 instance Buildable WalletMetadata where
-    build (WalletMetadata wName wTime _ wStatus wDelegation) = mempty
-        <> build wName <> " (" <> build wStatus <> "), "
+    build (WalletMetadata wName wTime _ wDelegation) = mempty
+        <> build wName <> ", "
         <> "created at " <> build wTime <> ", "
         <> build wDelegation
 

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (unSlotNo)
     , SortOrder (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -588,7 +587,6 @@ testMetadata :: WalletMetadata
 testMetadata = WalletMetadata
     { name = WalletName "test wallet"
     , passphraseInfo = Nothing
-    , status = Ready
     , delegation = NotDelegating
     , creationTime = systemToUTCTime (MkSystemTime 0 0)
     }

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -80,7 +80,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , SlotParameters (..)
     , SortOrder (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
@@ -115,7 +114,7 @@ import Data.Generics.Labels
 import Data.List
     ( unfoldr )
 import Data.Quantity
-    ( Percentage, Quantity (..), mkPercentage )
+    ( Quantity (..) )
 import Data.Text.Class
     ( toText )
 import Data.Typeable
@@ -145,7 +144,6 @@ import Test.QuickCheck
     , oneof
     , scale
     , shrinkList
-    , suchThat
     , vectorOf
     )
 import Test.Utils.Time
@@ -292,13 +290,7 @@ instance Arbitrary WalletMetadata where
         <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
         <*> genUniformTime
         <*> (fmap WalletPassphraseInfo <$> liftArbitrary genUniformTime)
-        <*> oneof [pure Ready, Syncing . Quantity <$> genPercentage]
         <*> pure NotDelegating
-      where
-        genPercentage :: Gen Percentage
-        genPercentage = do
-            let (Right upperBound) = mkPercentage @Int 100
-            arbitraryBoundedEnum `suchThat` (/= upperBound)
 
 {-------------------------------------------------------------------------------
                                    Blocks

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -94,7 +94,6 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , SlotId (..)
     , SortOrder (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxMeta (TxMeta)
     , TxOut (..)
@@ -606,7 +605,6 @@ testMetadata = WalletMetadata
     { name = WalletName "test wallet"
     , creationTime = unsafePerformIO getCurrentTime
     , passphraseInfo = Nothing
-    , status = Ready
     , delegation = NotDelegating
     }
 


### PR DESCRIPTION
# Issue Number

#921 


# Overview

- [x] I have removed `SyncProgress` from `WalletMeta` and the DB. It is now calculated by `Api.Server` when listing wallets. This way, the progress is always relative to the (most recent) current time.
- [x] TODO: Make tests compile

# Comments

<!-- Additional comments or screenshots to attach if any -->


- Oh, right, there are tests that need to compile too 🙃 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
