### PR TITLE
Add Jörmungandr binary decoders for legacy funds

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -66,7 +66,7 @@ import Cardano.Wallet.Jormungandr.Transaction
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant
+    ( NetworkDiscriminant (..)
     , NetworkDiscriminantVal
     , PaymentAddress
     , PersistKey
@@ -132,7 +132,6 @@ serveWallet
         , NetworkDiscriminantVal n
         , DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
         , PaymentAddress n ShelleyKey
         )
     => (CM.Configuration, Trace IO Text)
@@ -156,7 +155,7 @@ serveWallet (cfg, tr) databaseDir hostPref listen lj beforeMainLoop = do
         Right (cp, nl) -> do
             let nPort = Port $ baseUrlPort $ _restApi cp
             let (_, bp) = staticBlockchainParameters nl
-            let rndTl = newTransactionLayer @n (getGenesisBlockHash bp)
+            let rndTl = newTransactionLayer @'Mainnet (getGenesisBlockHash bp)
             let seqTl = newTransactionLayer @n (getGenesisBlockHash bp)
             let poolDBPath = Pool.defaultFilePath <$> databaseDir
             Pool.withDBLayer cfg tr poolDBPath $ \db -> do
@@ -170,7 +169,7 @@ serveWallet (cfg, tr) databaseDir hostPref listen lj beforeMainLoop = do
         :: Trace IO Text
         -> Port "node"
         -> BlockchainParameters
-        -> ApiLayer (RndState n) t ByronKey
+        -> ApiLayer (RndState 'Mainnet) t ByronKey
         -> ApiLayer (SeqState n) t ShelleyKey
         -> StakePoolLayer IO
         -> IO ExitCode

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -395,7 +395,7 @@ getLegacyTransaction size = do
         coin <- Coin <$> getWord64be
         addr <- getLegacyAddress
         pure (TxOut addr coin)
-    let inps = pure (error "TODO: getLegacyTransaction inputs?")
+    let inps = mempty
     pure (Tx tid inps outs)
 
 putSignedTx :: [(TxIn, Coin)] -> [TxOut] -> [TxWitness] -> Put

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -250,6 +250,7 @@ data Message
 
 data MessageType
     = MsgTypeInitial
+    | MsgTypeLegacyUTxO
     | MsgTypeTransaction
 
 data TxWitnessTag
@@ -292,16 +293,17 @@ getMessage = label "getMessage" $ do
     let unimpl = skip remaining >> return (UnimplementedMessage msgType)
     isolate remaining $ case msgType of
         0 -> Initial <$> getInitial
-        1 -> unimpl
+        1 -> Transaction . (,[]) <$> getLegacyTransaction remaining
         2 -> Transaction <$> getTransaction fragId
-        3 -> unimpl
-        4 -> unimpl
-        5 -> unimpl
+        3 -> unimpl -- Certificate
+        4 -> unimpl -- UpdateProposal
+        5 -> unimpl -- UpdateVote
         other -> fail $ "Unexpected content type tag " ++ show other
 
 messageTypeTag :: MessageType -> Word8
 messageTypeTag = \case
     MsgTypeInitial -> 0
+    MsgTypeLegacyUTxO -> 1
     MsgTypeTransaction -> 2
 
 -- | Decode the contents of a @Initial@-message.
@@ -309,7 +311,6 @@ getInitial :: Get [ConfigParam]
 getInitial = label "getInitial" $ do
     len <- fromIntegral <$> getWord16be
     replicateM len getConfigParam
-
 
 {-------------------------------------------------------------------------------
                                 Transactions
@@ -373,6 +374,28 @@ getTransaction tid = label "getTransaction" $ do
             addr <- getAddress
             value <- Coin <$> getWord64be
             return $ TxOut addr value
+
+--
+-- @
+-- FRAGMENT-ID = H(TYPE | CONTENT)
+-- CONTENT = #OUTPUTS (1 byte) | OUTPUT-1 | .. | OUTPUT-N
+-- OUTPUT = VALUE (8 bytes) | ADDR-SIZE (2 bytes) | ADDR (ADDR-SIZE bytes)
+-- TYPE = 1
+--
+-- H = blake2b_256
+-- @
+getLegacyTransaction :: Int -> Get Tx
+getLegacyTransaction size = do
+    bytes <- lookAhead (getLazyByteString $ fromIntegral size)
+    let tag = runPut (putWord8 (messageTypeTag MsgTypeLegacyUTxO))
+    let tid = Hash . blake2b256 . BL.toStrict $ (tag <> bytes)
+    n <- fromIntegral <$> getWord8
+    outs <- replicateM n $ do
+        coin <- Coin <$> getWord64be
+        addr <- getLegacyAddress
+        pure (TxOut addr coin)
+    let inps = pure (error "TODO: getLegacyTransaction inputs?")
+    pure (Tx tid inps outs)
 
 putSignedTx :: [(TxIn, Coin)] -> [TxOut] -> [TxWitness] -> Put
 putSignedTx inputs outputs witnesses = do
@@ -549,6 +572,11 @@ getAddress = do
   where
     kindValue :: Word8 -> Word8
     kindValue = (.&. 0b01111111)
+
+getLegacyAddress :: Get Address
+getLegacyAddress = do
+    size <- fromIntegral <$> getWord16be
+    Address <$> getByteString size
 
 putAddress :: Address -> Put
 putAddress (Address bs) = putByteString bs

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -191,9 +191,9 @@ getBlockHeader = label "getBlockHeader" $ do
         -- 2. BFT
         -- 3. Praos / Genesis
         --
-        -- We could make sure we get the right kind of proof, but we don't need to.
-        -- Just checking that the length is not totally wrong, is much simpler
-        -- and gives us sanity about the binary format being correct.
+        -- We could make sure we get the right kind of proof, but we don't need
+        -- to.  Just checking that the length is not totally wrong is much
+        -- simpler and gives us sanity about the binary format being correct.
         read' <- fromIntegral <$> bytesRead
         let remaining = size - read'
         producedBy <- case remaining of
@@ -206,7 +206,8 @@ getBlockHeader = label "getBlockHeader" $ do
             612 ->
                 -- Praos/Genesis
                 Just . PoolId <$> getByteString 32 <* skip (remaining - 32)
-            _ -> fail $ "BlockHeader proof has unexpected size " <> (show remaining)
+            _ -> fail $
+                "BlockHeader proof has unexpected size " <> (show remaining)
         return $ BlockHeader
             { version
             , contentSize
@@ -411,9 +412,13 @@ putSignedTx inputs outputs witnesses = do
 putTx :: [(TxIn, Coin)] -> [TxOut] -> Put
 putTx inputs outputs = do
     unless (length inputs <= fromIntegral (maxBound :: Word8)) $
-        fail ("number of inputs cannot be greater than " ++ show maxNumberOfInputs)
+        fail $
+            "number of inputs cannot be greater than " ++
+            show maxNumberOfInputs
     unless (length outputs <= fromIntegral (maxBound :: Word8)) $
-        fail ("number of outputs cannot be greater than " ++ show maxNumberOfOutputs)
+        fail $
+            "number of outputs cannot be greater than " ++
+            show maxNumberOfOutputs
     putWord8 $ toEnum $ length inputs
     putWord8 $ toEnum $ length outputs
     mapM_ putInput inputs
@@ -482,7 +487,8 @@ getConfigParam = label "getConfigParam" $ do
     let len = fromIntegral $ taglen .&. (63) -- 0b111111
     isolate len $ case tag of
         1 -> Discrimination <$> getNetworkDiscriminant
-        2 -> Block0Date . W.StartTime . posixSecondsToUTCTime . fromIntegral <$> getWord64be
+        2 -> Block0Date . W.StartTime . posixSecondsToUTCTime . fromIntegral
+            <$> getWord64be
         3 -> Consensus <$> getConsensusVersion
         4 -> SlotsPerEpoch . W.EpochLength . fromIntegral  <$> getWord32be
         5 -> SlotDuration . secondsToNominalDiffTime <$> getWord8


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#779 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have force the legacy API to use only 'Mainnet discrimination (even on the Testnet!). Addresses in the genesis file will be Mainnet addresses, so we need the ability to recognize them even if running on testnet.

- [x] I have started a first implementation of binary decoder for the legacy funds. The format for legacy funds is different from the format used for standard genesis fund. The message payload contains only a list of txout (address, value) with no associated inputs? It is still unclear to me what these inputs should be and how we could realistically handle these legacy funds