### PR TITLE
Test for #935 - Pending tx should have pendingSince in the list tx response

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -21,6 +21,7 @@ import Cardano.Wallet.Api.Types
     , ApiTxId (..)
     , ApiWallet
     , insertedAt
+    , pendingSince
     , time
     )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -35,6 +36,8 @@ import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.Generics.Product.Typed
     ( HasType )
+import Data.Maybe
+    ( isJust )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -48,7 +51,9 @@ import Network.HTTP.Types.Method
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldSatisfy, xit )
+    ( SpecWith, describe, it, xit )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe, shouldSatisfy )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)
@@ -134,6 +139,34 @@ data TestCase a = TestCase
 
 spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
 spec = do
+    it "Regression #935 -\
+        \ Pending tx should have pendingSince in the list tx response" $ \ctx -> do
+        wSrc <-fixtureWalletWith ctx [5_000_000]
+        wDest <- emptyWallet ctx
+        expectEventually' ctx getWalletEp balanceTotal 5_000_000 wSrc
+
+        let amt = (1 :: Natural)
+        -- post tx
+        r@(_, Right tx) <-
+                postTx ctx (wSrc, postTxEp ,"Secure Passphrase") wDest amt
+        expectFieldEqual status Pending r
+        insertedAt tx `shouldBe` Nothing
+        pendingSince tx `shouldSatisfy` isJust
+
+        -- list txs
+        let q = toQueryString [("order", "ascending")]
+        rTx@(_, Right txs) <-
+                request @([ApiTransaction n]) ctx (listTxEp wSrc q) Default Empty
+        -- there are two txs - first one is the one from the faucet (Incoming)
+        expectListSizeEqual 2 rTx
+        expectListItemFieldEqual 0 direction Incoming rTx
+        expectListItemFieldEqual 0 status InLedger rTx
+        -- we verify second tx (Outgoing) which is still pending
+        expectListItemFieldEqual 1 direction Outgoing rTx
+        expectListItemFieldEqual 1 status Pending rTx
+        insertedAt (txs !! 1) `shouldBe` Nothing
+        pendingSince (txs !! 1) `shouldBe` (pendingSince tx)
+
     it "TRANS_CREATE_01 - Single Output Transaction" $ \ctx -> do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
         let (feeMin, feeMax) = ctx ^. feeEstimator $ TxDescription
@@ -141,7 +174,7 @@ spec = do
                 , nOutputs = 1
                 }
         let amt = (1 :: Natural)
-        r <- postTx ctx (wa, postTxEp) wb amt
+        r <- postTx ctx (wa, postTxEp, "cardano-wallet") wb amt
         verify r
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -1611,7 +1644,7 @@ spec = do
             (wSrc, wDest) <- (,) <$> fWallet ctx <*> emptyWallet ctx
             -- post tx
             let amt = (1 :: Natural)
-            rMkTx <- postTx ctx (wSrc, postTxEndp) wDest amt
+            rMkTx <- postTx ctx (wSrc, postTxEndp, "cardano-wallet") wDest amt
             let txId = getFromResponse #id rMkTx
             verify rMkTx
                 [ expectSuccess
@@ -1673,7 +1706,7 @@ spec = do
             (wSrc, wDest) <- (,) <$> fWallet ctx <*> emptyWallet ctx
 
             -- post transaction
-            rTx <- postTx ctx (wSrc, postTxEndp) wDest (1 :: Natural)
+            rTx <- postTx ctx (wSrc, postTxEndp, "cardano-wallet") wDest (1 :: Natural)
             let txId = getFromResponse #id rTx
 
             -- Wait for the transaction to be accepted
@@ -1738,7 +1771,7 @@ spec = do
         it resource $ \ctx -> do
             -- post tx
             (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
-            rMkTx <- postTx ctx (wSrc, postTxEp) wDest (1 :: Natural)
+            rMkTx <- postTx ctx (wSrc, postTxEp, "cardano-wallet") wDest (1 :: Natural)
 
             -- try to forget from different wallet
             wDifferent <- eWallet ctx
@@ -1778,11 +1811,11 @@ spec = do
 
     postTx
         :: Context t
-        -> (wal, wal -> (Method, Text))
+        -> (wal, wal -> (Method, Text), Text)
         -> ApiWallet
         -> Natural
         -> IO (HTTP.Status, Either RequestException (ApiTransaction n))
-    postTx ctx (wSrc, postTxEndp) wDest amt = do
+    postTx ctx (wSrc, postTxEndp, pass) wDest amt = do
         addrs <- listAddresses ctx wDest
         let destination = (addrs !! 1) ^. #id
         let payload = Json [json|{
@@ -1793,7 +1826,7 @@ spec = do
                         "unit": "lovelace"
                     }
                 }],
-                "passphrase": "cardano-wallet"
+                "passphrase": #{pass}
             }|]
         r <- request @(ApiTransaction n) ctx (postTxEndp wSrc) Default payload
         expectResponseCode HTTP.status202 r

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -162,6 +162,7 @@ import Cardano.Wallet.Primitive.Types
     , TransactionInfo (TransactionInfo)
     , TxIn
     , TxOut (..)
+    , TxStatus (..)
     , UTxOStatistics (..)
     , WalletId (..)
     , WalletMetadata (..)
@@ -725,7 +726,10 @@ listTransactions ctx (ApiT wid) mStart mEnd mOrder = do
     mkApiTransactionFromInfo (TransactionInfo txid ins outs meta depth txtime) =
         apiTx { depth  }
       where
-        apiTx = mkApiTransaction txid ins outs (meta, txtime) #insertedAt
+        apiTx = mkApiTransaction txid ins outs (meta, txtime) $
+            case meta ^. #status of
+                Pending  -> #pendingSince
+                InLedger -> #insertedAt
 
 postTransactionFee
     :: forall ctx s t n k.
@@ -933,7 +937,6 @@ migrateByronWallet
     -> ApiWalletPassphrase
     -> Handler [ApiTransaction n]
 migrateByronWallet rndCtx seqCtx (ApiT rndWid) (ApiT seqWid) migrateData = do
-
     -- FIXME
     -- Better error handling here to inform users if they messed up with the
     -- wallet ids.

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -52,7 +52,6 @@ module Cardano.Wallet.Primitive.Model
 
     -- * Auxiliary
     , slotParams
-
     ) where
 
 import Prelude

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -350,9 +350,9 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
         let wallet = (wid, wname, DummyState state)
         (WalletLayerFixture _ wl _ _) <- liftIO $ setupFixture wallet
         unsafeRunExceptT $ W.attachPrivateKey wl wid (xprv, pwd)
-        (_,_,[witOld]) <- unsafeRunExceptT $ W.signTx wl wid () pwd selection
+        (_,_,_,[witOld]) <- unsafeRunExceptT $ W.signTx wl wid () pwd selection
         unsafeRunExceptT $ W.updateWalletPassphrase wl wid (coerce pwd, newPwd)
-        (_,_,[witNew]) <-
+        (_,_,_,[witNew]) <-
             unsafeRunExceptT $ W.signTx wl wid () (coerce newPwd) selection
         witOld `shouldBe` witNew
   where


### PR DESCRIPTION

# Issue Number

#935

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added test for #935 regression. The test should fail now.
- [x] Fixed field assignation to correctly set `pendingSince` on pending tx and `insertedAt` on other transactions (see https://github.com/input-output-hk/cardano-wallet/pull/936/commits/f9b0ae349a9edf674757164e50c8a4497a59fdf6)
- [x] Fixed clock time reference when creating transactions to actually match the time used when listing transactions (i.e. the start of the corresponding slot) and not the _current clock time_ (see https://github.com/input-output-hk/cardano-wallet/pull/936/commits/f6b2f0f8b6569c7708c8a86893b321b99ec419c5)

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
