### PR TITLE
Review responsibility of getMessage vs getTransaction in Jörmungandr.Binary

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -349,7 +349,7 @@ getTransaction tid = label "getTransaction" $ do
         let len = txWitnessSize tag + txWitnessTagSize
         -- NOTE: Regardless of the type of witness, we decode it as a
         -- @TxWitness@.
-        TxWitness <$> isolate len (getByteString len)
+        TxWitness <$> getByteString len
 
     getTokenTransfer :: Get ([(TxIn, Coin)], [TxOut])
     getTokenTransfer = label "getTokenTransfer" $ do


### PR DESCRIPTION
# Issue Number

# Problem

```haskell
getTransaction :: Int -> Get (Tx, [TxWitness])
getTransaction n = label "getTransaction" $ do
    bytes <- lookAhead (getLazyByteString $ fromIntegral n)
    let tag = runPut (putWord8 (messageTypeTag MsgTypeTransaction))
    let tid = Hash . blake2b256 . BL.toStrict $ (tag <> bytes)
```

- We have to be passed the size of the message `n` (and what `n` is exactly, is only clear from looking at the call-site)
- We have to awkwardly `runPut` and prepend the tag that `getTransaction` otherwise never would see

# Overview / Solution

- [x] I moved the hash computation to `getMessage`, before the msgTag is parsed.
- [x] This `msgHash` is lazily computed, and is not evaluated when decoding messages that doesn't need it (e.g. `Initial`).

# Comments

- I checked the laziness by inserting a `trace` and running `stack test cardano-wallet-jormungandr:unit --ta '--match "should decode a genesis block (Mainnet)"', which only decodes an `Initial`-message, and observed the absence of trace-output.

### Potential further work:
- I originally envisioned an exported `putMessage :: Message -> Put`. I wonder if it actually wouldn't make sense to remove `MessageType` completely in favour of that. This PR removes one use of `MessageType`.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
