### PR TITLE
Property tests for 'InspectAddress' on Shelley keys / addresses

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -492,7 +492,14 @@ class WalletKey key => PersistKey (key :: Depth -> * -> *) where
 
 -- | Access constituants of an address.
 class InspectAddress (key :: Depth -> * -> *) where
-    type SpendingKey key :: *
-    type DelegationKey key :: *
-    getSpendingKey :: Address -> SpendingKey key
-    getDelegationKey :: Address -> Maybe (DelegationKey key)
+    -- | Something that uniquely identifies a public key. Typically,
+    -- a hash of that key or the key itself.
+    type KeyFingerprint (s :: Symbol) key :: *
+
+    paymentKeyFingerprint
+        :: Address
+        -> KeyFingerprint "payment" key
+
+    delegationKeyFingerprint
+        :: Address
+        -> Maybe (KeyFingerprint "delegation" key)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#900

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have slightly reviewed the interface of 'InspectAddress' to makes it clearer
- [x] I have reviewed the exports for the `AddressDerivation.Shelley` module
- [x] I have added three properties to check the behavior of 'InspectAddress' 

# Comments

<!-- Additional comments or screenshots to attach if any -->

```
  InspectAddress
    Single addresses have a payment key but no delegation key
      +++ OK, passed 100 tests.
    Grouped addresses have a payment key and a delegation key
      +++ OK, passed 100 tests.
    Inspecting Invalid addresses throws
      +++ OK, passed 100 tests.
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
