### PR TITLE
Address Pool work with key/address fingerprints 

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -106,6 +106,9 @@ module Cardano.Wallet
     , ErrListTransactions (..)
     , ErrNetworkUnavailable (..)
     , ErrStartTimeLaterThanEndTime (..)
+
+    -- ** Root Key
+    , withRootKey
     ) where
 
 import Prelude hiding

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -948,7 +948,8 @@ migrateByronWallet rndCtx seqCtx (ApiT rndWid) (ApiT seqWid) migrateData = do
     forM cs $ \selection -> do
         (tx, meta, time, wit) <- liftHandler
             $ withWorkerCtx rndCtx rndWid (throwE . ErrSignTxNoSuchWallet)
-            $ \wrk -> W.signTx wrk rndWid passphrase passphrase selection
+            $ \wrk -> W.withRootKey wrk rndWid passphrase ErrSignTxWithRootKey
+            $ \xprv -> W.signTx wrk rndWid (xprv, passphrase) passphrase selection
         liftHandler
             $ withWorkerCtx rndCtx rndWid (throwE . ErrSubmitTxNoSuchWallet)
             $ \wrk -> W.submitTx wrk rndWid (tx, meta, wit)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -36,8 +36,6 @@ import Prelude
 
 import Cardano.BM.Trace
     ( Trace, appendName, logInfo, logNotice )
-import Cardano.Crypto.Wallet
-    ( XPrv )
 import Cardano.DB.Sqlite
     ( SqliteContext (..)
     , chunkSize
@@ -76,13 +74,17 @@ import Cardano.Wallet.DB.Sqlite.TH
     , unWalletKey
     )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( AddressPoolXPub (..), BlockId (..), TxId (..) )
+    ( BlockId (..), TxId (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), PersistKey (..), WalletKey (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey, nullKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey )
+    ( Depth (..)
+    , PaymentAddress (..)
+    , PersistPrivateKey (..)
+    , PersistPublicKey (..)
+    , SoftDerivation (..)
+    , WalletKey (..)
+    , XPrv
+    , XPub
+    )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.Types
@@ -182,7 +184,7 @@ withDBLayer
         , Show s
         , PersistState s
         , PersistTx t
-        , PersistKey k
+        , PersistPrivateKey (k 'RootK)
         )
     => CM.Configuration
        -- ^ Logging configuration
@@ -207,7 +209,8 @@ mkDBFactory
         , Show s
         , PersistState s
         , PersistTx t
-        , PersistKey k
+        , PersistPrivateKey (k 'RootK)
+        , WalletKey k
         )
     => CM.Configuration
        -- ^ Logging configuration
@@ -246,7 +249,7 @@ mkDBFactory cfg tr mDatabaseDir = case mDatabaseDir of
 -- | Return all wallet databases that match the specified key type within the
 --   specified directory.
 findDatabases
-    :: forall k. PersistKey k
+    :: forall k. WalletKey k
     => Trace IO Text
     -> FilePath
     -> IO [W.WalletId]
@@ -287,7 +290,7 @@ newDBLayer
         , Show s
         , PersistState s
         , PersistTx t
-        , PersistKey k
+        , PersistPrivateKey (k 'RootK)
         )
     => CM.Configuration
        -- ^ Logging configuration
@@ -514,7 +517,7 @@ metadataFromEntity wal = W.WalletMetadata
     }
 
 mkPrivateKeyEntity
-    :: PersistKey k
+    :: PersistPrivateKey (k 'RootK)
     => W.WalletId
     -> (k 'RootK XPrv, W.Hash "encryption")
     -> PrivateKey
@@ -527,10 +530,11 @@ mkPrivateKeyEntity wid kh = PrivateKey
     (root, hash) = serializeXPrv kh
 
 privateKeyFromEntity
-    :: PersistKey k
+    :: PersistPrivateKey (k 'RootK)
     => PrivateKey
-    -> Either String (k 'RootK XPrv, W.Hash "encryption")
-privateKeyFromEntity (PrivateKey _ k h) = deserializeXPrv (k, h)
+    -> (k 'RootK XPrv, W.Hash "encryption")
+privateKeyFromEntity (PrivateKey _ k h) =
+    unsafeDeserializeXPrv (k, h)
 
 mkCheckpointEntity
     :: forall s t. ()
@@ -855,13 +859,12 @@ deletePendingTx wid tid = deleteWhere
     [TxMetaWalletId ==. wid, TxMetaTxId ==. tid, TxMetaStatus ==. W.Pending ]
 
 selectPrivateKey
-    :: (MonadIO m, PersistKey k)
+    :: (MonadIO m, PersistPrivateKey (k 'RootK))
     => W.WalletId
     -> SqlPersistT m (Maybe (k 'RootK XPrv, W.Hash "encryption"))
-selectPrivateKey wid =
-    let keys = selectFirst [PrivateKeyWalletId ==. wid] []
-        toMaybe = either (const Nothing) Just
-    in (>>= toMaybe . privateKeyFromEntity . entityVal) <$> keys
+selectPrivateKey wid = do
+    keys <- selectFirst [PrivateKeyWalletId ==. wid] []
+    pure $ (privateKeyFromEntity . entityVal) <$> keys
 
 -- | Find the nearest 'Checkpoint' that is either at the given point or before.
 findNearestPoint
@@ -919,7 +922,12 @@ class DefineTx t => PersistTx t where
                           Sequential address discovery
 -------------------------------------------------------------------------------}
 
-instance W.PaymentAddress t ShelleyKey => PersistState (Seq.SeqState t) where
+instance
+    ( Eq (k 'AccountK XPub)
+    , PersistPublicKey (k 'AccountK)
+    , PaymentAddress n k
+    , SoftDerivation k
+    ) => PersistState (Seq.SeqState n k) where
     insertState (wid, sl) st = do
         let (intPool, extPool) = (Seq.internalPool st, Seq.externalPool st)
         let (xpub, _) = W.invariant
@@ -928,9 +936,7 @@ instance W.PaymentAddress t ShelleyKey => PersistState (Seq.SeqState t) where
                 (uncurry (==))
         let eGap = Seq.gap extPool
         let iGap = Seq.gap intPool
-        repsert
-            (SeqStateKey wid)
-            (SeqState wid eGap iGap (AddressPoolXPub xpub))
+        repsert (SeqStateKey wid) (SeqState wid eGap iGap (serializeXPub xpub))
         insertAddressPool wid sl intPool
         insertAddressPool wid sl extPool
         deleteWhere [SeqStatePendingWalletId ==. wid]
@@ -940,17 +946,18 @@ instance W.PaymentAddress t ShelleyKey => PersistState (Seq.SeqState t) where
 
     selectState (wid, sl) = runMaybeT $ do
         st <- MaybeT $ selectFirst [SeqStateWalletId ==. wid] []
-        let SeqState _ eGap iGap xPub = entityVal st
-        intPool <- lift $ selectAddressPool wid sl iGap xPub
-        extPool <- lift $ selectAddressPool wid sl eGap xPub
+        let SeqState _ eGap iGap bytes = entityVal st
+        let xpub = unsafeDeserializeXPub bytes
+        intPool <- lift $ selectAddressPool wid sl iGap xpub
+        extPool <- lift $ selectAddressPool wid sl eGap xpub
         pendingChangeIxs <- lift $ selectSeqStatePendingIxs wid
         pure $ Seq.SeqState intPool extPool pendingChangeIxs
 
 insertAddressPool
-    :: forall t c. (Typeable c)
+    :: forall n k c. (PaymentAddress n k, Typeable c)
     => W.WalletId
     -> W.SlotId
-    -> Seq.AddressPool t c
+    -> Seq.AddressPool n c k
     -> SqlPersistT IO ()
 insertAddressPool wid sl pool =
     void $ dbChunked insertMany_
@@ -959,13 +966,17 @@ insertAddressPool wid sl pool =
         ]
 
 selectAddressPool
-    :: forall t c. (W.PaymentAddress t ShelleyKey, Typeable c)
+    :: forall n k c.
+        ( Typeable c
+        , PaymentAddress n k
+        , SoftDerivation k
+        )
     => W.WalletId
     -> W.SlotId
     -> Seq.AddressPoolGap
-    -> AddressPoolXPub
-    -> SqlPersistT IO (Seq.AddressPool t c)
-selectAddressPool wid sl gap (AddressPoolXPub xpub) = do
+    -> k 'AccountK XPub
+    -> SqlPersistT IO (Seq.AddressPool n c k)
+selectAddressPool wid sl gap xpub = do
     addrs <- fmap entityVal <$> selectList
         [ SeqStateAddressWalletId ==. wid
         , SeqStateAddressSlot ==. sl
@@ -975,9 +986,9 @@ selectAddressPool wid sl gap (AddressPoolXPub xpub) = do
   where
     addressPoolFromEntity
         :: [SeqStateAddress]
-        -> Seq.AddressPool t c
+        -> Seq.AddressPool n c k
     addressPoolFromEntity addrs =
-        Seq.mkAddressPool @t @c xpub gap (map seqStateAddressAddress addrs)
+        Seq.mkAddressPool @n @c @k xpub gap (map seqStateAddressAddress addrs)
 
 mkSeqStatePendingIxs :: W.WalletId -> Seq.PendingIxs -> [SeqStatePendingIx]
 mkSeqStatePendingIxs wid =
@@ -1019,7 +1030,15 @@ instance PersistState (Rnd.RndState t) where
         let (RndState _ ix gen) = entityVal st
         addresses <- lift $ selectRndStateAddresses wid sl
         pendingAddresses <- lift $ selectRndStatePending wid
-        rndKey <- lift $ selectRndStateKey wid
+        rndKey <- lift (selectPrivateKey wid >>= \case
+            Just (key, _passphrase) ->
+                pure key
+            Nothing -> fail
+                "selectState: attempted to read random state before the key \
+                \was stored in the database! This is unlikely to happen as it \
+                \requires a concurrent read request to be made while a wallet \
+                \is being created!?"
+            )
         pure $ Rnd.RndState
             { rndKey = rndKey
             , accountIndex = W.Index ix
@@ -1075,8 +1094,3 @@ selectRndStatePending wid = do
   where
     assocFromEntity (RndStatePendingAddress _ accIx addrIx addr) =
         ((W.Index accIx, W.Index addrIx), addr)
-
--- | Gets the wallet root key to put in RndState. If there is none yet, just
--- return a placeholder.
-selectRndStateKey :: W.WalletId -> SqlPersistT IO (ByronKey 'RootK XPrv)
-selectRndStateKey wid = maybe nullKey fst <$> selectPrivateKey wid

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -25,7 +25,7 @@ module Cardano.Wallet.DB.Sqlite.TH where
 import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Types
-    ( AddressPoolXPub, BlockId, TxId, sqlSettings' )
+    ( BlockId, TxId, sqlSettings' )
 import Data.Text
     ( Text )
 import Data.Time.Clock
@@ -43,7 +43,7 @@ import Numeric.Natural
 import System.Random
     ( StdGen )
 
-import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as W
+import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteString.Char8 as B8
@@ -170,7 +170,7 @@ SeqState
     seqStateWalletId        W.WalletId        sql=wallet_id
     seqStateExternalGap     W.AddressPoolGap  sql=external_gap
     seqStateInternalGap     W.AddressPoolGap  sql=internal_gap
-    seqStateAccountXPub     AddressPoolXPub   sql=account_xpub
+    seqStateAccountXPub     B8.ByteString     sql=account_xpub
 
     Primary seqStateWalletId
     Foreign Wallet seq_state seqStateWalletId ! ON DELETE CASCADE

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -25,7 +25,7 @@ module Cardano.Wallet.DB.Sqlite.TH where
 import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Types
-    ( BlockId, TxId, sqlSettings' )
+    ( BlockId, HDPassphrase, TxId, sqlSettings' )
 import Data.Text
     ( Text )
 import Data.Time.Clock
@@ -209,6 +209,7 @@ RndState
     rndStateWalletId        W.WalletId        sql=wallet_id
     rndStateAccountIndex    Word32            sql=account_ix
     rndStateGen             StdGen            sql=gen
+    rndStateHdPassphrase    HDPassphrase      sql=hd_passphrase
 
     Primary rndStateWalletId
     Foreign Wallet rnd_state rndStateWalletId ! ON DELETE CASCADE

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -20,12 +20,8 @@ module Cardano.Wallet.DB.Sqlite.Types where
 
 import Prelude
 
-import Cardano.Crypto.Wallet
-    ( XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ChangeChain, ShelleyKey, deserializeXPubSeq, serializeXPubSeq )
+    ( ChangeChain (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), getAddressPoolGap, mkAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
@@ -93,7 +89,6 @@ import Web.HttpApiData
 import Web.PathPieces
     ( PathPiece (..) )
 
-import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 
 ----------------------------------------------------------------------------
@@ -357,23 +352,6 @@ instance PersistField AddressPoolGap where
 
 instance PersistFieldSql AddressPoolGap where
     sqlType _ = sqlType (Proxy @Word8)
-
-----------------------------------------------------------------------------
--- XPub for sequential address discovery
-
-newtype AddressPoolXPub = AddressPoolXPub
-    { getAddressPoolXPub :: ShelleyKey 'AccountK XPub }
-    deriving (Show, Eq, Generic)
-
-instance PersistField AddressPoolXPub where
-    toPersistValue = toPersistValue . serializeXPubSeq . getAddressPoolXPub
-    fromPersistValue pv = fromPersistValue >=> deserializeXPub' $ pv
-      where
-        deserializeXPub' = bimap msg AddressPoolXPub . deserializeXPubSeq
-        msg e = T.pack $ "not a valid XPub: " <> show pv <> ": " <> e
-
-instance PersistFieldSql AddressPoolXPub where
-    sqlType _ = sqlType (Proxy @B8.ByteString)
 
 ----------------------------------------------------------------------------
 -- ChangeChain

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -575,13 +575,20 @@ class WalletKey key => PersistKey (key :: Depth -> * -> *) where
         -> Either String (key 'RootK XPrv, Hash "encryption")
 
 -- | Access constituants of an address.
-class InspectAddress (key :: Depth -> * -> *) where
+class
+    ( Ord (KeyFingerprint "payment" key)
+    , Ord (KeyFingerprint "delegation" key)
+    ) => InspectAddress (key :: Depth -> * -> *) where
     type KeyFingerprint (s :: Symbol) key :: *
         -- | Something that uniquely identifies a public key. Typically,
         -- a hash of that key or the key itself.
 
     paymentKeyFingerprint
         :: Address
+        -> KeyFingerprint "payment" key
+
+    paymentKeyFingerprint'
+        :: key 'AddressK XPub
         -> KeyFingerprint "payment" key
 
     delegationKeyFingerprint

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -56,7 +56,8 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , DelegationAddress(..)
     , WalletKey(..)
     , PersistKey(..)
-    , InspectAddress(..)
+    , MkKeyFingerprint(..)
+    , KeyFingerprint(..)
     , dummyAddress
 
     -- * Passphrase
@@ -574,23 +575,19 @@ class WalletKey key => PersistKey (key :: Depth -> * -> *) where
         :: (ByteString, ByteString)
         -> Either String (key 'RootK XPrv, Hash "encryption")
 
--- | Access constituants of an address.
-class
-    ( Ord (KeyFingerprint "payment" key)
-    , Ord (KeyFingerprint "delegation" key)
-    ) => InspectAddress (key :: Depth -> * -> *) where
-    type KeyFingerprint (s :: Symbol) key :: *
-        -- | Something that uniquely identifies a public key. Typically,
-        -- a hash of that key or the key itself.
+-- | Something that uniquely identifies a public key. Typically,
+-- a hash of that key or the key itself.
+newtype KeyFingerprint (s :: Symbol) key = KeyFingerprint ByteString
+    deriving (Generic, Show, Eq, Ord)
 
+instance NFData (KeyFingerprint s key)
+
+-- | Produce 'KeyFingerprint' for existing types.
+class MkKeyFingerprint (key :: Depth -> * -> *) from where
     paymentKeyFingerprint
-        :: Address
-        -> KeyFingerprint "payment" key
-
-    paymentKeyFingerprint'
-        :: key 'AddressK XPub
+        :: from
         -> KeyFingerprint "payment" key
 
     delegationKeyFingerprint
-        :: Address
+        :: from
         -> Maybe (KeyFingerprint "delegation" key)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -492,9 +492,9 @@ class WalletKey key => PersistKey (key :: Depth -> * -> *) where
 
 -- | Access constituants of an address.
 class InspectAddress (key :: Depth -> * -> *) where
-    -- | Something that uniquely identifies a public key. Typically,
-    -- a hash of that key or the key itself.
     type KeyFingerprint (s :: Symbol) key :: *
+        -- | Something that uniquely identifies a public key. Typically,
+        -- a hash of that key or the key itself.
 
     paymentKeyFingerprint
         :: Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -617,7 +617,21 @@ newtype KeyFingerprint (s :: Symbol) key = KeyFingerprint ByteString
 
 instance NFData (KeyFingerprint s key)
 
--- | Produce 'KeyFingerprint' for existing types.
+-- | Produce 'KeyFingerprint' for existing types. A fingerprint here uniquely
+-- identifies part of an address. It can refer to either the payment key or, if
+-- any, the delegation key of an address.
+--
+-- The fingerprint obeys the following rules:
+--
+-- - If two addresses are the same, then they have the same fingerprints
+-- - It is possible to lift the fingerprint back into an address
+--
+-- This second rule pretty much fixes what can be chosen as a fingerprint for
+-- various key types:
+--
+-- 1. For 'ByronKey', it can only be the address itself!
+-- 2. For 'ShelleyKey', then the "payment" fingerprint refers to the payment key
+--    within a single or grouped address.
 class MkKeyFingerprint (key :: Depth -> * -> *) where
     paymentKeyFingerprint
         :: Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -378,8 +378,8 @@ instance MkKeyFingerprint ShelleyKey where
         | len == addrSingleSize || len == addrGroupedSize =
             KeyFingerprint $ BS.take publicKeySize $ BS.drop 1 bytes
         | otherwise = error $ unwords
-            [ "InspectAddress.getPaymentKey was given an invalid 'ShelleyKey'"
-            , "of"
+            [ "MkKeyFingerprint.paymentKeyFingerprint was given an invalid"
+            , "'ShelleyKey' of"
             , show len
             , "bytes!"
             ]
@@ -392,19 +392,13 @@ instance MkKeyFingerprint ShelleyKey where
         | len == addrGroupedSize =
             Just $ KeyFingerprint $ BS.drop addrSingleSize bytes
         | otherwise = error $ unwords
-            [ "InspectAddress.getDelegationKey was given an invalid 'ShelleyKey'"
-            , "of"
+            [ "MkKeyFingerprint.delegationKeyFingerprint was given an invalid"
+            , "'ShelleyKey' of"
             , show len
             , "bytes!"
             ]
       where
         len = BS.length bytes
-
--- instance MkKeyFingerprint ShelleyKey (ShelleyKey 'AddressK XPub) where
---     paymentKeyFingerprint (ShelleyKey (XPub bytes _chainCode)) =
---         KeyFingerprint bytes
---     delegationKeyFingerprint (ShelleyKey (XPub bytes _chainCode)) =
---         Just $ KeyFingerprint bytes
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -384,6 +384,9 @@ instance InspectAddress ShelleyKey where
       where
         len = BS.length bytes
 
+    paymentKeyFingerprint' (ShelleyKey (XPub bytes _chainCode)) =
+        bytes
+
     type KeyFingerprint "delegation" ShelleyKey = ByteString
     delegationKeyFingerprint (Address bytes)
         | len == addrSingleSize =

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -379,9 +379,9 @@ instance MkKeyFingerprint ShelleyKey where
             KeyFingerprint $ BS.take publicKeySize $ BS.drop 1 bytes
         | otherwise = error $ unwords
             [ "InspectAddress.getPaymentKey was given an invalid 'ShelleyKey'"
-            , " of "
+            , "of"
             , show len
-            , " bytes!"
+            , "bytes!"
             ]
       where
         len = BS.length bytes
@@ -393,9 +393,9 @@ instance MkKeyFingerprint ShelleyKey where
             Just $ KeyFingerprint $ BS.drop addrSingleSize bytes
         | otherwise = error $ unwords
             [ "InspectAddress.getDelegationKey was given an invalid 'ShelleyKey'"
-            , " of "
+            , "of"
             , show len
-            , " bytes!"
+            , "bytes!"
             ]
       where
         len = BS.length bytes

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , IsOwned(..)
     , GenChange(..)
     , CompareDiscovery(..)
+    , KnownAddresses(..)
     , EncodeAddress(..)
     , DecodeAddress(..)
     ) where
@@ -143,6 +144,16 @@ class CompareDiscovery s where
         -> Address
         -> Address
         -> Ordering
+
+-- | Extract the list of all known addresses.
+--
+-- NOTE: Change addresses aren't considered "known" until they've been used. The
+-- rationale is that, we don't want users or consumers of the wallet to be using
+-- change addresses prematurely.
+class KnownAddresses s where
+    knownAddresses
+        :: s
+        -> [Address]
 
 -- | An abstract class to allow encoding of addresses depending on the target
 -- backend used.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -145,16 +145,6 @@ class CompareDiscovery s where
         -> Address
         -> Ordering
 
--- | Extract the list of all known addresses.
---
--- NOTE: Change addresses aren't considered "known" until they've been used. The
--- rationale is that, we don't want users or consumers of the wallet to be using
--- change addresses prematurely.
-class KnownAddresses s where
-    knownAddresses
-        :: s
-        -> [Address]
-
 -- | An abstract class to allow encoding of addresses depending on the target
 -- backend used.
 class EncodeAddress (n :: NetworkDiscriminant) where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -25,7 +25,6 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , IsOwned(..)
     , GenChange(..)
     , CompareDiscovery(..)
-    , KnownAddresses(..)
     , EncodeAddress(..)
     , DecodeAddress(..)
     ) where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -226,3 +226,6 @@ deriveRndStateAddress st passphrase path =
 -- derivation scheme won't be ordered in any particular order.
 instance CompareDiscovery (RndState n) where
     compareDiscovery _ _ _ = EQ
+
+instance KnownAddresses (RndState n) where
+    knownAddresses s = Map.elems (addresses s)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -103,9 +102,9 @@ instance Show (RndState network) where
         p x = "(" ++ show x ++ ")"
 
 instance Buildable (RndState network) where
-    build (RndState _ ix addrs pending gen) = "RndState:\n"
+    build (RndState _ ix addrs pending g) = "RndState:\n"
         <> indentF 4 ("Account ix:       " <> build ix)
-        <> indentF 4 ("Random Generator: " <> build (show gen))
+        <> indentF 4 ("Random Generator: " <> build (show g))
         <> indentF 4 ("Known addresses:  " <> blockMapF' tupleF build addrs)
         <> indentF 4 ("Change addresses: " <> blockMapF' tupleF build pending)
 
@@ -181,12 +180,12 @@ findUnusedPath
     -> Index 'Hardened 'AccountK
     -> Set DerivationPath
     -> (DerivationPath, StdGen)
-findUnusedPath gen accIx used
+findUnusedPath g accIx used
     | Set.notMember path used = (path, gen')
     | otherwise = findUnusedPath gen' accIx used
   where
     path = (accIx, addrIx)
-    (addrIx, gen') = randomIndex gen
+    (addrIx, gen') = randomIndex g
 
 randomIndex
     :: forall ix g. (RandomGen g, ix ~ Index 'Hardened 'AddressK)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -226,6 +226,3 @@ deriveRndStateAddress st passphrase path =
 -- derivation scheme won't be ordered in any particular order.
 instance CompareDiscovery (RndState n) where
     compareDiscovery _ _ _ = EQ
-
-instance KnownAddresses (RndState n) where
-    knownAddresses s = Map.elems (addresses s)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -75,8 +75,8 @@ import qualified Data.Set as Set
 
 -- | HD random address discovery state and key material for AD.
 data RndState (network :: NetworkDiscriminant) = RndState
-    { rndKey :: ByronKey 'RootK XPrv
-    -- ^ The wallet root key.
+    { hdPassphrase :: Passphrase "addr-derivation-payload"
+    -- ^ The HD derivation passphrase
     , accountIndex :: Index 'Hardened 'AccountK
     -- ^ The account index used for address _generation_ in this wallet. Note
     -- that addresses will be _discovered_ from any and all account indices,
@@ -116,21 +116,21 @@ type DerivationPath = (Index 'Hardened 'AccountK, Index 'Hardened 'AddressK)
 -- as a Byron HD random address, and where the wallet key can be used to decrypt
 -- the address derivation path.
 instance IsOurs (RndState n) where
-    isOurs addr st@(RndState{rndKey}) =
+    isOurs addr st =
         (isJust path, maybe id (addDiscoveredAddress addr) path st)
       where
-        path = addressToPath addr rndKey
+        path = addressToPath addr (hdPassphrase st)
 
 instance IsOwned (RndState n) ByronKey where
-    isOwned (st@RndState{rndKey}) (_,pwd) addr =
-        (, pwd) . deriveAddressKeyFromPath st pwd <$> addressToPath addr rndKey
+    isOwned st (key, pwd) addr =
+        (, pwd) . deriveAddressKeyFromPath key pwd
+            <$> addressToPath addr (hdPassphrase st)
 
 addressToPath
     :: Address
-    -> ByronKey 'RootK XPrv
+    -> Passphrase "addr-derivation-payload"
     -> Maybe DerivationPath
-addressToPath (Address addr) key = do
-    let pwd = payloadPassphrase key
+addressToPath (Address addr) pwd = do
     payload <- deserialiseCbor decodeAddressPayload addr
     join $ deserialiseCbor (decodeAddressDerivationPath pwd) payload
 
@@ -138,7 +138,7 @@ addressToPath (Address addr) key = do
 -- seed.
 mkRndState :: ByronKey 'RootK XPrv -> Int -> RndState n
 mkRndState key seed = RndState
-    { rndKey = key
+    { hdPassphrase = payloadPassphrase key
     , accountIndex = minBound
     , addresses = mempty
     , pendingAddresses = mempty
@@ -155,10 +155,10 @@ addDiscoveredAddress addr path st =
        , pendingAddresses = Map.delete path (pendingAddresses st) }
 
 instance PaymentAddress n ByronKey => GenChange (RndState n) where
-    type ArgGenChange (RndState n) = Passphrase "encryption"
-    genChange pwd st = (address, st')
+    type ArgGenChange (RndState n) = (ByronKey 'RootK XPrv, Passphrase "encryption")
+    genChange (rootXPrv, pwd) st = (address, st')
       where
-        address = deriveRndStateAddress @n st pwd path
+        address = deriveRndStateAddress @n rootXPrv pwd path
         (path, gen') = findUnusedPath (gen st) (accountIndex st)
             (unavailablePaths st)
         st' = st
@@ -200,24 +200,24 @@ randomIndex g = (Index ix, g')
 -- | Use the key material in 'RndState' to derive a change address for a given
 -- derivation path.
 deriveAddressKeyFromPath
-    :: RndState n
+    :: ByronKey 'RootK XPrv
     -> Passphrase "encryption"
     -> DerivationPath
     -> ByronKey 'AddressK XPrv
-deriveAddressKeyFromPath st passphrase (accIx, addrIx) = addrXPrv
+deriveAddressKeyFromPath rootXPrv passphrase (accIx, addrIx) = addrXPrv
   where
-    accXPrv = deriveAccountPrivateKey passphrase (rndKey st) accIx
+    accXPrv = deriveAccountPrivateKey passphrase rootXPrv accIx
     addrXPrv = deriveAddressPrivateKey passphrase accXPrv addrIx
 
 -- | Use the key material in 'RndState' to derive a change address.
 deriveRndStateAddress
     :: forall n. (PaymentAddress n ByronKey)
-    => RndState n
+    => ByronKey 'RootK XPrv
     -> Passphrase "encryption"
     -> DerivationPath
     -> Address
-deriveRndStateAddress st passphrase path =
-    paymentAddress @n $ publicKey $ deriveAddressKeyFromPath st passphrase path
+deriveRndStateAddress k passphrase path =
+    paymentAddress @n $ publicKey $ deriveAddressKeyFromPath k passphrase path
 
 -- Unlike sequential derivation, we can't derive an order from the index only
 -- (they are randomly generated), nor anything else in the address itself.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -33,7 +33,13 @@ module Cardano.Wallet.Transaction
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Passphrase, PaymentAddress (..), XPrv, dummyAddress )
+    ( Depth (..)
+    , Passphrase
+    , PaymentAddress (..)
+    , WalletKey
+    , XPrv
+    , dummyAddress
+    )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
@@ -141,7 +147,10 @@ data EstimateMaxNumberOfInputsParams t = EstimateMaxNumberOfInputsParams
 -- All the values used are the smaller ones. For example, the shortest adress
 -- type and shortest witness type are chosen to use for the estimate.
 estimateMaxNumberOfInputsBase
-    :: forall t n k. (PaymentAddress n k)
+    :: forall t n k.
+        ( PaymentAddress n k
+        , WalletKey k
+        )
     => EstimateMaxNumberOfInputsParams t
     -- ^ Backend-specific variables used in the estimation
     -> Quantity "byte" Word16

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -478,7 +478,7 @@ benchPutSeqState numCheckpoints numAddrs db =
 
 mkPool
     :: forall t c. (PaymentAddress t ShelleyKey, Typeable c)
-    => Int -> Int -> AddressPool t c
+    => Int -> Int -> AddressPool t c ShelleyKey
 mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
   where
     addrs =
@@ -564,8 +564,8 @@ benchDiskSize action = bracket setupDB cleanupDB $ \(f, ctx, db) -> do
 ----------------------------------------------------------------------------
 -- Mock data to use for benchmarks
 
-type DBLayerBench = DBLayer IO (SeqState 'Testnet) DummyTarget ShelleyKey
-type WalletBench = Wallet (SeqState 'Testnet) DummyTarget
+type DBLayerBench = DBLayer IO (SeqState 'Testnet ShelleyKey) DummyTarget ShelleyKey
+type WalletBench = Wallet (SeqState 'Testnet ShelleyKey) DummyTarget
 
 instance NFData (DBLayer m s t k) where
     rnf _ = ()
@@ -576,7 +576,7 @@ instance NFData SqliteContext where
 testCp :: WalletBench
 testCp = snd $ initWallet block0 genesisParameters initDummyState
 
-initDummyState :: SeqState 'Testnet
+initDummyState :: SeqState 'Testnet ShelleyKey
 initDummyState =
     mkSeqState (xprv, mempty) defaultAddressPoolGap
   where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -463,13 +463,11 @@ instance Arbitrary (RndState 'Testnet) where
         | (ix', addrs', pending') <- shrink (ix, addrs, pending)
         ]
     arbitrary = RndState
-        <$> pure (Rnd.generateKeyFromSeed seed mempty)
+        <$> pure (Passphrase "passphrase")
         <*> pure minBound
         <*> arbitrary
         <*> (pure mempty) -- FIXME: see comment on 'Arbitrary Seq.PendingIxs'
         <*> pure (mkStdGen 42)
-      where
-        seed = Passphrase $ BA.convert $ BS.replicate 32 0
 
 instance Arbitrary (ByronKey 'RootK XPrv) where
     shrink _ = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -51,7 +51,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey (..), unsafeGenerateKeyFromSeed )
+    ( ShelleyKey (..), addrSingleSize, unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
@@ -141,7 +141,6 @@ import Test.QuickCheck
     , generate
     , genericShrink
     , liftArbitrary
-    , oneof
     , scale
     , shrinkList
     , vectorOf
@@ -379,18 +378,7 @@ instance Arbitrary UTxO where
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Address where
-    arbitrary = oneof
-        [ pure $ Address "ADDR01"
-        , pure $ Address "ADDR02"
-        , pure $ Address "ADDR03"
-        , pure $ Address "ADDR04"
-        , pure $ Address "ADDR05"
-        , pure $ Address "ADDR06"
-        , pure $ Address "ADDR07"
-        , pure $ Address "ADDR08"
-        , pure $ Address "ADDR09"
-        , pure $ Address "ADDR10"
-        ]
+    arbitrary = Address . B8.pack <$> vectorOf addrSingleSize arbitrary
 
 instance Arbitrary (Index 'Soft 'AddressK) where
     shrink _ = []
@@ -408,7 +396,7 @@ instance Arbitrary (Index 'Hardened 'AddressK) where
                               Sequential State
 -------------------------------------------------------------------------------}
 
-instance Arbitrary (SeqState 'Testnet) where
+instance Arbitrary (SeqState 'Testnet ShelleyKey) where
     shrink (SeqState intPool extPool ixs) =
         (\(i, e, x) -> SeqState i e x) <$> shrink (intPool, extPool, ixs)
     arbitrary = do
@@ -439,7 +427,7 @@ instance Arbitrary (ShelleyKey 'RootK XPrv) where
 instance Arbitrary (Seq.PendingIxs) where
     arbitrary = pure Seq.emptyPendingIxs
 
-instance Typeable chain => Arbitrary (AddressPool 'Testnet chain) where
+instance Typeable chain => Arbitrary (AddressPool 'Testnet chain ShelleyKey) where
     arbitrary = pure $ mkAddressPool arbitrarySeqAccount minBound mempty
 
 -- Properties are quite heavy on the generation of values, although for
@@ -508,7 +496,7 @@ rootKeysRnd = unsafePerformIO $ generate (vectorOf 10 genRootKeysRnd)
 
 deriving instance Arbitrary a => Arbitrary (ShowFmt a)
 
-deriving instance Eq (SeqState 'Testnet)
+deriving instance Eq (SeqState 'Testnet ShelleyKey)
 
 -- Necessary unsound Show instance for QuickCheck failure reporting
 instance Show XPrv where

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -19,6 +19,8 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -35,7 +37,7 @@ import Test.QuickCheck
 import qualified Cardano.Wallet.DB.MVar as MVar
 
 spec :: Spec
-spec = withDB @(SeqState 'Testnet) MVar.newDBLayer $
+spec = withDB @(SeqState 'Testnet ShelleyKey) MVar.newDBLayer $
     describe "MVar" properties
 
 newtype DummyStateMVar = DummyStateMVar Int

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -70,7 +70,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PersistKey
+    , PersistPrivateKey
     , encryptPassphrase
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -266,7 +266,7 @@ simpleSpec cp = do
 -------------------------------------------------------------------------------}
 
 loggingSpec :: Spec
-loggingSpec = withLoggingDB @(SeqState 'Testnet) @DummyTarget @ShelleyKey $ do
+loggingSpec = withLoggingDB @(SeqState 'Testnet ShelleyKey) @DummyTarget @ShelleyKey $ do
     describe "Sqlite query logging" $ do
         it "should log queries at DEBUG level" $ \(getLogs, db) -> do
             unsafeRunExceptT $ createWallet db testPk testCpSeq testMetadata mempty
@@ -293,12 +293,24 @@ loggingSpec = withLoggingDB @(SeqState 'Testnet) @DummyTarget @ShelleyKey $ do
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.
 newMemoryDBLayer
-    :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t, PersistKey k)
+    :: ( IsOurs s
+       , NFData s
+       , Show s
+       , PersistState s
+       , PersistTx t
+       , PersistPrivateKey (k 'RootK)
+       )
     => IO (DBLayer IO s t k)
 newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
 newMemoryDBLayer'
-    :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t, PersistKey k)
+    :: ( IsOurs s
+       , NFData s
+       , Show s
+       , PersistState s
+       , PersistTx t
+       , PersistPrivateKey (k 'RootK)
+       )
     => IO (TVar [LogObject Text], (SqliteContext, DBLayer IO s t k))
 newMemoryDBLayer' = do
     logConfig <- testingLogConfig
@@ -339,7 +351,13 @@ testingLogConfig = do
     pure logConfig
 
 withLoggingDB
-    :: (IsOurs s, NFData s, Show s, PersistState s, PersistTx t, PersistKey k)
+    :: ( IsOurs s
+       , NFData s
+       , Show s
+       , PersistState s
+       , PersistTx t
+       , PersistPrivateKey (k 'RootK)
+       )
     => SpecWith (IO [LogObject Text], DBLayer IO s t k)
     -> Spec
 withLoggingDB = beforeAll newMemoryDBLayer' . beforeWith clean
@@ -372,7 +390,7 @@ shouldHaveLog msgs (sev, str) = unless (any match msgs) $
                                 File Mode Spec
 -------------------------------------------------------------------------------}
 
-type TestDBSeq = DBLayer IO (SeqState 'Testnet) DummyTarget ShelleyKey
+type TestDBSeq = DBLayer IO (SeqState 'Testnet ShelleyKey) DummyTarget ShelleyKey
 type TestDBRnd = DBLayer IO (RndState 'Testnet) DummyTarget ByronKey
 
 fileModeSpec :: Spec
@@ -381,7 +399,7 @@ fileModeSpec =  do
         it "Opening and closing of db works" $ do
             replicateM_ 25 $ do
                 db <- Just <$> temporaryDBFile
-                (ctx, _) <- newDBLayer' @(SeqState 'Testnet) @DummyTarget db
+                (ctx, _) <- newDBLayer' @(SeqState 'Testnet ShelleyKey) @DummyTarget db
                 destroyDBLayer ctx
 
     describe "Sqlite database file" $ do
@@ -455,7 +473,7 @@ fileModeSpec =  do
 
     describe "random operation chunks property" $ do
         it "realize a random batch of operations upon one db open"
-            (property $ prop_randomOpChunks @(SeqState 'Testnet) @DummyTarget)
+            (property $ prop_randomOpChunks @(SeqState 'Testnet ShelleyKey) @DummyTarget)
 
 -- This property checks that executing series of wallet operations in a single
 -- SQLite session has the same effect as executing the same operations over
@@ -511,7 +529,7 @@ prop_randomOpChunks (KeyValPairs pairs) =
 testOpeningCleaning
     :: (Show s, Eq s)
     => FilePath
-    -> (DBLayer IO (SeqState 'Testnet) DummyTarget ShelleyKey -> IO s)
+    -> (DBLayer IO (SeqState 'Testnet ShelleyKey) DummyTarget ShelleyKey -> IO s)
     -> s
     -> s
     -> Expectation
@@ -528,7 +546,7 @@ testOpeningCleaning filepath call expectedAfterOpen expectedAfterClean = do
 
 -- | Run a test action inside withDBLayer, then check assertions.
 withTestDBFile
-    :: (DBLayer IO (SeqState 'Testnet) DummyTarget ShelleyKey -> IO ())
+    :: (DBLayer IO (SeqState 'Testnet ShelleyKey) DummyTarget ShelleyKey -> IO ())
     -> (FilePath -> IO a)
     -> IO a
 withTestDBFile action expectations = do
@@ -591,10 +609,10 @@ cutRandomly = iter []
                                    Test data
 -------------------------------------------------------------------------------}
 
-testCp :: Wallet (SeqState 'Testnet) DummyTarget
+testCp :: Wallet (SeqState 'Testnet ShelleyKey) DummyTarget
 testCp = snd $ initWallet block0 genesisParameters initDummyState
   where
-    initDummyState :: SeqState 'Testnet
+    initDummyState :: SeqState 'Testnet ShelleyKey
     initDummyState = mkSeqState (xprv, mempty) defaultAddressPoolGap
       where
         bytes = entropyToBytes <$> unsafePerformIO $ genEntropy @(EntropySize 15)
@@ -640,10 +658,10 @@ class GenerateTestKey (key :: Depth -> * -> *) where
                            Test data - Sequential AD
 -------------------------------------------------------------------------------}
 
-testCpSeq :: Wallet (SeqState 'Testnet) DummyTarget
+testCpSeq :: Wallet (SeqState 'Testnet ShelleyKey) DummyTarget
 testCpSeq = snd $ initWallet block0 genesisParameters initDummyStateSeq
 
-initDummyStateSeq :: SeqState 'Testnet
+initDummyStateSeq :: SeqState 'Testnet ShelleyKey
 initDummyStateSeq = mkSeqState (xprv, mempty) defaultAddressPoolGap
   where
       bytes = entropyToBytes <$> unsafePerformIO $ genEntropy @(EntropySize 15)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
@@ -56,6 +56,7 @@ import Test.QuickCheck
     , elements
     , expectFailure
     , property
+    , suchThat
     , vectorOf
     , (===)
     , (==>)
@@ -216,5 +217,6 @@ instance Arbitrary GroupedAddress where
 newtype InvalidAddress = InvalidAddress Address deriving (Eq, Show)
 
 instance Arbitrary InvalidAddress where
-    arbitrary = InvalidAddress . Address . BS.pack
-        <$> vectorOf (addrSingleSize + addrGroupedSize) arbitrary
+    arbitrary = InvalidAddress . Address . BS.pack <$> do
+        n <- suchThat (choose (1, 100)) (`notElem` [addrSingleSize, addrGroupedSize])
+        vectorOf n arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -25,6 +25,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Passphrase (..)
     , PaymentAddress (..)
     , WalletKey (..)
+    , XPrv
     , fromMnemonic
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -194,7 +195,7 @@ checkIsOurs GoldenTest{..} = do
     fst (isOurs addr' rndState) `shouldBe` expected
   where
     Right addr' = Address <$> convertFromBase Base16 addr
-    rndState = rndStateFromMnem arbitraryMnemonic
+    (_, rndState) = rndStateFromMnem arbitraryMnemonic
 
 checkIsOwned :: GoldenTest -> Expectation
 checkIsOwned GoldenTest{..} = do
@@ -202,15 +203,15 @@ checkIsOwned GoldenTest{..} = do
   where
     pwd = Passphrase ""
     Right addr' = Address <$> convertFromBase Base16 addr
-    st@RndState{rndKey} = rndStateFromMnem arbitraryMnemonic
+    (rndKey, st) = rndStateFromMnem arbitraryMnemonic
     accXPrv = deriveAccountPrivateKey pwd rndKey (Index accIndex)
     addrXPrv = deriveAddressPrivateKey pwd accXPrv (Index addrIndex)
     expectation = if expected then
         Just (addrXPrv, pwd)
         else Nothing
 
-rndStateFromMnem :: [Text] -> RndState 'Testnet
-rndStateFromMnem mnem = mkRndState @'Testnet rootXPrv 0
+rndStateFromMnem :: [Text] -> (ByronKey 'RootK XPrv, RndState 'Testnet)
+rndStateFromMnem mnem = (rootXPrv, mkRndState @'Testnet rootXPrv 0)
   where
     rootXPrv = generateKeyFromSeed (Passphrase seed) (Passphrase "")
     Right (Passphrase seed) = fromMnemonic @'[12] mnem
@@ -232,7 +233,11 @@ propSpec = describe "Random Address Discovery Properties" $ do
 
 -- | A pair of random address discovery state, and the encryption passphrase for
 -- the RndState root key.
-data Rnd = Rnd (RndState 'Testnet) (Passphrase "encryption")
+data Rnd = Rnd
+    (RndState 'Testnet)
+    (ByronKey 'RootK XPrv)
+    (Passphrase "encryption")
+    deriving Show
 
 prop_derivedKeysAreOurs
     :: Rnd
@@ -240,7 +245,7 @@ prop_derivedKeysAreOurs
     -> Index 'Hardened 'AddressK
     -> Property
 prop_derivedKeysAreOurs
-    (Rnd st@(RndState rk accIx _ _ _) pwd) (Rnd st' _) addrIx =
+    (Rnd st@(RndState _ accIx _ _ _) rk pwd) (Rnd st' _ _) addrIx =
     fst (isOurs addr st) .&&. not (fst (isOurs addr st'))
   where
     addr = paymentAddress @'Testnet addrKey
@@ -253,10 +258,10 @@ prop_derivedKeysAreOwned
     -> Index 'Hardened 'AddressK
     -> Property
 prop_derivedKeysAreOwned
-    (Rnd st@(RndState rk accIx _ _ _) pwd)
-    (Rnd st'@(RndState rk' _ _ _ _) pwd')
+    (Rnd st@(RndState _ accIx _ _ _) rk pwd)
+    (Rnd st' rk' pwd')
     addrIx =
-    isOwned st (rndKey st, pwd) addr === Just (addrKeyPrv, pwd)
+    isOwned st (rk, pwd) addr === Just (addrKeyPrv, pwd)
     .&&.
     isOwned st' (rk', pwd') addr === Nothing
   where
@@ -269,17 +274,17 @@ prop_changeAddressesBelongToUs
     -> Rnd
     -> Property
 prop_changeAddressesBelongToUs
-    (Rnd st pwd)
-    (Rnd st' _) =
+    (Rnd st rk pwd)
+    (Rnd st' _ _) =
     fst (isOurs addr st) .&&. not (fst (isOurs addr st'))
   where
-    (addr, _) = genChange pwd st
+    (addr, _) = genChange (rk, pwd) st
 
 prop_forbiddenAddreses
     :: Rnd
     -> Index 'Hardened 'AddressK
     -> Property
-prop_forbiddenAddreses (Rnd st@(RndState rk accIx _ _ _) pwd) addrIx = conjoin
+prop_forbiddenAddreses (Rnd st@(RndState _ accIx _ _ _) rk pwd) addrIx = conjoin
     [ (Set.notMember addr (forbidden st))
     , (Set.member addr (forbidden isOursSt))
     , (Set.notMember changeAddr (forbidden isOursSt))
@@ -289,7 +294,7 @@ prop_forbiddenAddreses (Rnd st@(RndState rk accIx _ _ _) pwd) addrIx = conjoin
     ]
   where
     (_ours, isOursSt) = isOurs addr st
-    (changeAddr, changeSt) = genChange pwd isOursSt
+    (changeAddr, changeSt) = genChange (rk, pwd) isOursSt
 
     forbidden s = Set.fromList $ Map.elems $ addresses s <> pendingAddresses s
 
@@ -303,10 +308,7 @@ prop_forbiddenAddreses (Rnd st@(RndState rk accIx _ _ _) pwd) addrIx = conjoin
 
 instance Eq (RndState t) where
     (RndState k1 accIx1 _ _ _) == (RndState k2 accIx2 _ _ _)
-        = getKey k1 == getKey k2 && accIx1 == accIx2
-
-instance Show Rnd where
-    show (Rnd (RndState a _ _ _ _) _) = show (getKey a)
+        = k1 == k2 && accIx1 == accIx2
 
 instance Arbitrary Rnd where
     shrink _ = []  -- no shrinking
@@ -314,7 +316,7 @@ instance Arbitrary Rnd where
         s <- genPassphrase @"seed" (16, 32)
         e <- genPassphrase @"encryption" (0, 16)
         let key = generateKeyFromSeed s e
-        pure $ Rnd (mkRndState key 0) e
+        pure $ Rnd (mkRndState key 0) key e
       where
         genPassphrase :: (Int, Int) -> Gen (Passphrase purpose)
         genPassphrase range = do

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -33,9 +33,11 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, Tx (..), block0, genesisParameters )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( ChangeChain (..)
+    , Depth (..)
     , DerivationType (..)
     , ErrWrongPassphrase (..)
+    , HardDerivation (..)
     , Index
     , Passphrase (..)
     , WalletKey (..)
@@ -43,12 +45,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ChangeChain (..)
-    , ShelleyKey (..)
-    , deriveAccountPrivateKey
-    , deriveAddressPrivateKey
-    , generateKeyFromSeed
-    )
+    ( ShelleyKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GenChange (..)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -74,6 +74,7 @@ newTransactionLayer
         ( t ~ Jormungandr
         , PaymentAddress n k
         , MkTxWitness k
+        , WalletKey k
         )
     => Hash "Genesis"
     -> TransactionLayer t k


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#901 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have created an interface for performing hard and soft key derivation on keys 
- [x] I have temporarily removed 'KnownAddresses' interface, to be replaced with a DB call
- [x] I have updated `AddressPool` and `SeqState` to no longer require a `ShelleyKey` nor `Address`, but instead, use an abstract `key` type and track `KeyFingerprint` (which can be obtained from both Shelley and Byron keys).
- [x] I have revised how keys get serialized / unserialize to the database to have cleaner interfaces

# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: base is `KtorZ/900/inspect-address-tests` :warning: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
