### PR TITLE
Produce user-friendly CLI error on failure to decode a transaction ID 

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -48,6 +48,7 @@ module Cardano.CLI
 
     -- * Types
     , Service
+    , TxId
     , MnemonicSize (..)
     , Port (..)
 
@@ -1171,6 +1172,7 @@ instance ToText (Port tag) where
 newtype Service = Service Text deriving newtype IsString
 
 newtype TxId = TxId { getTxId :: Hash "Tx" }
+    deriving (Eq, Show)
 
 instance FromText TxId where
     fromText = Bi.first (const err) . fmap TxId . fromText

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -14,6 +14,7 @@ import Prelude
 import Cardano.CLI
     ( MnemonicSize (..)
     , Port (..)
+    , TxId
     , cli
     , cmdAddress
     , cmdMnemonic
@@ -362,6 +363,17 @@ spec = do
     describe "Can perform roundtrip textual encoding & decoding" $ do
         textRoundtrip $ Proxy @(Port "test")
         textRoundtrip $ Proxy @MnemonicSize
+
+    describe "Transaction ID decoding from text" $ do
+
+        it "Should produce a user-friendly error message on failing to \
+            \decode a transaction ID." $ do
+
+            let err = TextDecodingError
+                    "A transaction ID should be a hex-encoded string of 64 \
+                    \characters."
+
+            fromText @TxId "not-a-transaction-id" `shouldBe` Left err
 
     describe "Port decoding from text" $ do
         let err = TextDecodingError

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -1015,7 +1015,8 @@ spec = do
             wid <- emptyWallet' ctx
             (Exit c, Stdout out, Stderr err) <-
                 deleteTransactionViaCLI @t ctx wid tid
-            err `shouldContain` "expected Base16 encoding"
+            err `shouldContain`
+                "should be a hex-encoded string of 64 characters"
             out `shouldBe` ""
             c `shouldBe` ExitFailure 1
 


### PR DESCRIPTION
# Issue Number

#922 

# Overview

This PR:

- [x] Adds a user-friendly error message to the CLI when failing to decode a transaction ID.
- [x] Adds a unit test to verify that this error message is indeed produced when given an invalid transaction ID.