### PR TITLE
Integration tests: logging is shut down when CLI finished

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -159,6 +159,22 @@ spec = do
             --
             -- but in practice, we only have INFO logs on start-up.
 
+        it "LOGGING - Serve shuts down logging correctly" $ \ctx -> do
+            let args =
+                    ["serve"
+                    , "--database"
+                    , "/does-not-exist"
+                    , "--node-port"
+                    , show (ctx ^. typed @(Port "node"))
+                    , "--random-port"
+                    , "--verbose"
+                    , "--genesis-block-hash"
+                    , block0H
+                    ]
+            let process = proc' (commandName @t) args
+            (out, _) <- collectStreams (2, 0) process
+            out `shouldContainT` "Logging shutdown."
+
         describe "LOGGING - Exits nicely on wrong genesis hash" $  do
             let hashes =
                     [ replicate 40 '1'


### PR DESCRIPTION
Relates to #851.

# Overview

Adds integration test case for clean logging shutdown.
