### PR TITLE
wip: Add TransactionLayer.mkCertificateTx

### DIFF
--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -43,7 +43,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), Tx (..), TxIn (..), TxOut (..), TxWitness (..) )
+    ( Address (..)
+    , Hash (..)
+    , PoolId
+    , Tx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxWitness (..)
+    )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity
@@ -68,6 +75,19 @@ data TransactionLayer t k = TransactionLayer
         --
         -- This expects as a first argument a mean to compute or lookup private
         -- key corresponding to a particular address.
+
+    , mkCertificateTx
+        :: (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+        -> (PoolId, k 'AddressK XPrv)
+        -> [(TxIn, TxOut)]
+        -> [TxOut]
+        -> Either ErrMkStdTx (ByteString, (Tx, [TxWitness]))
+        -- ^ Construct a transaction for registering a stake pool with a certificate.
+        --
+        -- The certificate is a combination of the node public key ('PoolId'),
+        -- and the public key of the reward account. (Note that this is an
+        -- address key and HD account keys are something different)
+
 
     , estimateSize :: CoinSelection -> Quantity "byte" Int
         -- ^ Estimate the size of a 'CoinSelection', in bytes. This operation is

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -432,6 +432,8 @@ dummyTransactionLayer = TransactionLayer
             return $ TxWitness
                 (CC.unXPub (getKey $ publicKey xprv) <> sig)
         return (tx, wit)
+    , mkCertificateTx =
+        error "dummyTransactionLayer: mkCertificateTx not implemented"
     , estimateSize =
         error "dummyTransactionLayer: estimateSize not implemented"
     , estimateMaxNumberOfInputs =

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -49,6 +49,8 @@ import Data.Binary.Get
     ( getByteString )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -181,7 +183,13 @@ instance MimeUnrender JormungandrBinary Block where
 
 instance MimeRender JormungandrBinary (Tx, [TxWitness]) where
     mimeRender _ (Tx _ ins outs, wits) =
-        runPut $ withHeader MsgTypeTransaction $ putSignedTx ins outs wits
+        runPut $ withHeader MsgTypeTransaction $
+            putSignedTx mempty ins outs wits
+
+instance MimeRender JormungandrBinary (ByteString, (Tx, [TxWitness])) where
+    mimeRender _ (payload, (Tx _ ins outs, wits)) =
+        runPut $ withHeader MsgTypeDelegation $
+            putSignedTx payload ins outs wits
 
 data Hex
 


### PR DESCRIPTION
Relates to #893.

# Overview

- Implements `mkCertificateTx` for the jormungandr TransactionLayer
- Golden test case

# Comments

- This is blocked on delegation certificate signing, etc. being implemented in jormungandr.
- Still working out how to assemble the certificate to use in the test transaction.
- Need to adjust `Tx` type and Binary module so that the result of `mkCertificateTx` can be serialized.
