### PR TITLE
Add `reward` field to `ApiWallet` type.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -68,6 +68,7 @@ module Test.Integration.Framework.DSL
     , syncProgress
     , walletId
     , walletName
+    , walletReward
 
     -- * Helpers
     , (</>)
@@ -723,6 +724,15 @@ walletName =
     _get = getWalletName . getApiT . view typed
     _set :: HasType (ApiT WalletName) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletName v) s
+
+walletReward :: HasType (Quantity "lovelace" Natural) s => Lens' s Natural
+walletReward =
+    lens _get _set
+  where
+    _get :: HasType (Quantity "lovelace" Natural) s => s -> Natural
+    _get = fromQuantity @"lovelace" @Natural . view typed
+    _set :: HasType (Quantity "lovelace" Natural) s => (s, Natural) -> s
+    _set (s, v) = set typed (Quantity @"lovelace" @Natural v) s
 
 walletId :: HasType (ApiT WalletId) s => Lens' s Text
 walletId =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -651,9 +651,9 @@ balanceAvailable =
     _get = fromQuantity @"lovelace" . available . getApiT . view typed
     _set :: HasType (ApiT WalletBalance) s => (s, Natural) -> s
     _set (s, v) = set typed initBal s
-        where
-            initBal =
-                (ApiT $ WalletBalance {available = Quantity v, Types.total = Quantity v })
+      where
+        initBal = ApiT $ WalletBalance
+            {available = Quantity v, Types.total = Quantity v}
 
 balanceTotal :: HasType (ApiT WalletBalance) s => Lens' s Natural
 balanceTotal =
@@ -663,9 +663,9 @@ balanceTotal =
     _get = fromQuantity @"lovelace" . Types.total . getApiT . view typed
     _set :: HasType (ApiT WalletBalance) s => (s, Natural) -> s
     _set (s, v) = set typed initBal s
-        where
-            initBal =
-                (ApiT $ WalletBalance {available = Quantity v, Types.total = Quantity v })
+      where
+        initBal = ApiT $ WalletBalance
+            {available = Quantity v, Types.total = Quantity v}
 
 delegation
     :: HasType (ApiT (WalletDelegation (ApiT PoolId))) s
@@ -675,13 +675,11 @@ delegation =
   where
     _get
         :: HasType (ApiT (WalletDelegation (ApiT PoolId))) s
-        => s
-        -> (WalletDelegation (ApiT PoolId))
+        => s -> (WalletDelegation (ApiT PoolId))
     _get = getApiT . view typed
     _set
         :: HasType (ApiT (WalletDelegation (ApiT PoolId))) s
-        => (s, (WalletDelegation (ApiT PoolId)))
-        -> s
+        => (s, (WalletDelegation (ApiT PoolId))) -> s
     _set (s, v) = set typed (ApiT v ) s
 
 feeEstimator
@@ -698,10 +696,15 @@ passphraseLastUpdate
 passphraseLastUpdate =
     lens _get _set
   where
-    _get :: HasType (Maybe (ApiT WalletPassphraseInfo)) s => s -> Maybe Text
+    _get
+        :: HasType (Maybe (ApiT WalletPassphraseInfo)) s
+        => s -> Maybe Text
     _get = fmap (T.pack . show . lastUpdatedAt . getApiT) . view typed
-    _set :: HasType (Maybe (ApiT WalletPassphraseInfo)) s => (s, Maybe Text) -> s
-    _set (s, v) = set typed (ApiT . WalletPassphraseInfo . read . T.unpack <$> v) s
+    _set
+        :: HasType (Maybe (ApiT WalletPassphraseInfo)) s
+        => (s, Maybe Text) -> s
+    _set (s, v) =
+        set typed (ApiT . WalletPassphraseInfo . read . T.unpack <$> v) s
 
 state :: HasField' "state" s (ApiT t) => Lens' s t
 state =
@@ -761,9 +764,13 @@ outputs :: HasType (NonEmpty (AddressAmount t)) s => Lens' s [AddressAmount t]
 outputs =
     lens _get _set
   where
-    _get :: HasType (NonEmpty (AddressAmount t)) s => s -> [AddressAmount t]
+    _get
+        :: HasType (NonEmpty (AddressAmount t)) s
+        => s -> [AddressAmount t]
     _get = NE.toList . view typed
-    _set :: HasType (NonEmpty (AddressAmount t)) s => (s, [AddressAmount t]) -> s
+    _set
+        :: HasType (NonEmpty (AddressAmount t)) s
+        => (s, [AddressAmount t]) -> s
     _set (s, v) = set typed (NE.fromList v) s
 
 status :: HasType (ApiT TxStatus) s => Lens' s TxStatus

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -132,7 +132,8 @@ spec = do
             , expectFieldEqual balanceTotal 0
             , expectEventually ctx getWalletEp state Ready
             , expectFieldEqual delegation (NotDelegating)
-            , expectFieldEqual walletId "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
+            , expectFieldEqual walletId
+                "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
             , expectFieldNotEqual passphraseLastUpdate Nothing
             ]
 
@@ -815,7 +816,8 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default simplePayload
         let walId = getFromResponse walletId r
 
-        rg <- request @ApiWallet ctx ("GET", "v2/wallets" </> walId) Default Empty
+        rg <- request
+            @ApiWallet ctx ("GET", "v2/wallets" </> walId) Default Empty
         verify rg
             [ expectResponseCode @IO HTTP.status200
             , expectFieldEqual walletName "Secure Wallet"
@@ -890,7 +892,8 @@ spec = do
             , expectListItemFieldEqual 0 balanceAvailable 0
             , expectListItemFieldEqual 0 balanceTotal 0
             , expectListItemFieldEqual 0 delegation (NotDelegating)
-            , expectListItemFieldEqual 0 walletId "dfe87fcf0560fb57937a6468ea51e860672fad79"
+            , expectListItemFieldEqual 0 walletId
+                "dfe87fcf0560fb57937a6468ea51e860672fad79"
             ]
 
     it "WALLETS_LIST_01 - Wallets are listed from oldest to newest" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -893,6 +893,7 @@ spec = do
             , expectListItemFieldEqual 0 addressPoolGap 20
             , expectListItemFieldEqual 0 balanceAvailable 0
             , expectListItemFieldEqual 0 balanceTotal 0
+            , expectListItemFieldEqual 0 walletReward 0
             , expectListItemFieldEqual 0 delegation (NotDelegating)
             , expectListItemFieldEqual 0 walletId
                 "dfe87fcf0560fb57937a6468ea51e860672fad79"

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -66,6 +66,7 @@ import Test.Integration.Framework.DSL
     , verify
     , walletId
     , walletName
+    , walletReward
     , (</>)
     )
 import Test.Integration.Framework.TestData
@@ -130,6 +131,7 @@ spec = do
             , expectFieldEqual addressPoolGap 30
             , expectFieldEqual balanceAvailable 0
             , expectFieldEqual balanceTotal 0
+            , expectFieldEqual walletReward 0
             , expectEventually ctx getWalletEp state Ready
             , expectFieldEqual delegation (NotDelegating)
             , expectFieldEqual walletId

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -812,7 +812,7 @@ spec = do
             expectResponseCode @IO HTTP.status405 r
             expectErrorMessage errMsg405 r
 
-    it "WALLETS_GET_01 - can get wallet detals" $ \ctx -> do
+    it "WALLETS_GET_01 - can get wallet details" $ \ctx -> do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default simplePayload
         let walId = getFromResponse walletId r
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1151,6 +1151,7 @@ mkApiWallet wid wallet meta progress pending = ApiWallet
     , id = ApiT wid
     , name = ApiT $ meta ^. #name
     , passphrase = ApiT <$> meta ^. #passphraseInfo
+    , reward = Quantity 0
     , state = ApiT progress
     , tip = getWalletTip wallet
     }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -184,6 +184,7 @@ data ApiWallet = ApiWallet
     , delegation :: !(ApiT (WalletDelegation (ApiT PoolId)))
     , name :: !(ApiT WalletName)
     , passphrase :: !(Maybe (ApiT WalletPassphraseInfo))
+    , reward :: !(Quantity "lovelace" Natural)
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
     } deriving (Eq, Generic, Show)

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
@@ -20,17 +20,21 @@
                 }
             },
             "name": "-@y'-Q%>(YrW-8hx< i7i<b𤻛Z`~`BDha 嬉",
+            "reward": {
+                "quantity": 60,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "13568607f83d45b9e129c681d29595bb997d59f8",
             "tip": {
                 "height": {
-                    "quantity": 5255,
+                    "quantity": 7861,
                     "unit": "block"
                 },
-                "epoch_number": 15423399,
-                "slot_number": 6259
+                "epoch_number": 4939939,
+                "slot_number": 5255
             }
         },
         {
@@ -39,11 +43,7 @@
             },
             "address_pool_gap": 79,
             "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 16,
-                    "unit": "percent"
-                }
+                "status": "ready"
             },
             "balance": {
                 "total": {
@@ -56,6 +56,10 @@
                 }
             },
             "name": ":9U5$P!x'5\"GZ7_ErUv\"6K~;qoF<k\\SCEv.KAr.f\"R7%/Lv<qeeDQabaVDFZW(6W.-lh{Z?nMpTok}!.(zb8M>-kQ0P,N*8!&",
+            "reward": {
+                "quantity": 41,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "delegating",
                 "target": "26e57a6f0e0219a6ce5d83c10f9e60483c0e5701f610da8b80361dfe1c7d91e7"
@@ -63,21 +67,17 @@
             "id": "83c532e66ef21d86c3a011107594b450e1e9acd3",
             "tip": {
                 "height": {
-                    "quantity": 18206,
+                    "quantity": 20533,
                     "unit": "block"
                 },
-                "epoch_number": 806156,
-                "slot_number": 30231
+                "epoch_number": 4882593,
+                "slot_number": 18206
             }
         },
         {
             "address_pool_gap": 87,
             "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 16,
-                    "unit": "percent"
-                }
+                "status": "ready"
             },
             "balance": {
                 "total": {
@@ -90,17 +90,21 @@
                 }
             },
             "name": "uI0L*mWOg Hi2gp9;TY cBT𩈥2\"G4{{#!4huI3d~W*,.J6{=P+?J.@𥿼(~&0 ,q`x@𣴜AMs17=n.7V&31P#Lp_aL`$J&sdKsjUZyWF<~;g:q.F<}81rq*DZRC!Ygf+k;?@E#=<`0%`?Tc<}|o/G/-=@UU{43)b/dngd=b``X)MO`)7-5Ck\\𦥽@EUN/𢀙_^r~>.k/<:j7nn847?UN>\\(.V8",
+            "reward": {
+                "quantity": 245,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "ee36a20a42ec87c88c0f6fd25c4e02b7b3cc3049",
             "tip": {
                 "height": {
-                    "quantity": 18710,
+                    "quantity": 28903,
                     "unit": "block"
                 },
-                "epoch_number": 8195063,
-                "slot_number": 7646
+                "epoch_number": 2437740,
+                "slot_number": 18710
             }
         },
         {
@@ -109,11 +113,7 @@
             },
             "address_pool_gap": 55,
             "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 83,
-                    "unit": "percent"
-                }
+                "status": "ready"
             },
             "balance": {
                 "total": {
@@ -126,6 +126,10 @@
                 }
             },
             "name": "]c\\\"N'q컋XDH32?氛]/rU ]9|JJ^*=T,~{s\\fF!PJIC\"K9Dops:)7}3]@0FY𢦀\"Z>T{53t E\"S9O𤃰tFw8q<+Gt_ yahlx@Z𣯥\"4XaZ]&Tm6f_aJ<o=.`G%xj@P_'F'h4",
+            "reward": {
+                "quantity": 113,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "delegating",
                 "target": "cf2c98d2f6f9132374af42f874a719b5bf4bd6e1baae34d0e120b87255479a78"
@@ -133,11 +137,11 @@
             "id": "aa2d01c254433274bc6c058785c245388d39544b",
             "tip": {
                 "height": {
-                    "quantity": 25383,
+                    "quantity": 20514,
                     "unit": "block"
                 },
-                "epoch_number": 16044776,
-                "slot_number": 11673
+                "epoch_number": 5464559,
+                "slot_number": 25383
             }
         },
         {
@@ -159,17 +163,21 @@
                 }
             },
             "name": "𡞁颂pT1w00笿=L#Kcl?8#V<f/IꉽKft_Pjo+@e1m@=apj*Yqo-{CjbꯓWelY7r/^J 7YFUsx=:🐔E7𧔂ahO5XstP%[;n𤶛ZN=d!C-t*iMcXj;;=/8mgPTiBR?')5sKESXR+!H`YhMT6J(yVP1{`}IU(g9]Q:.%'ejMy",
+            "reward": {
+                "quantity": 220,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "6a73947d12383f48ce0cccedbe72a4872546dc9e",
             "tip": {
                 "height": {
-                    "quantity": 20982,
+                    "quantity": 16588,
                     "unit": "block"
                 },
-                "epoch_number": 3705584,
-                "slot_number": 6373
+                "epoch_number": 1639521,
+                "slot_number": 20982
             }
         },
         {
@@ -188,17 +196,21 @@
                 }
             },
             "name": ";}~h[eU!5Z#>;;.\\2q}hwKSREgTEYH2+m:\\nYzBNgI`JLf[0Vm;>W>S𡑝Bq6j`xi7>Isiv🝛Z'mq%1sl2A#%}4?g]vY{L\"BW𨫅HDiZ',%+^dm|.g5SABKJ-쵺",
+            "reward": {
+                "quantity": 32,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "f5edcd4a6e0d4bade73b44c8f75784c3d00ed94a",
             "tip": {
                 "height": {
-                    "quantity": 25537,
+                    "quantity": 11604,
                     "unit": "block"
                 },
-                "epoch_number": 14431091,
-                "slot_number": 5014
+                "epoch_number": 12314681,
+                "slot_number": 25537
             }
         },
         {
@@ -207,7 +219,11 @@
             },
             "address_pool_gap": 85,
             "state": {
-                "status": "ready"
+                "status": "syncing",
+                "progress": {
+                    "quantity": 60,
+                    "unit": "percent"
+                }
             },
             "balance": {
                 "total": {
@@ -220,17 +236,21 @@
                 }
             },
             "name": "Ut^e=m*,/A%<28O3𤶠b_A}qG<7^M#Ki\"#dZ4A/_g!s{$b@3R5j=斨^(q𠗕iFQzW-}gahy?PX.{MX>(1~Hnk{qz&U;|]RFt5PM턔necr[fZ\\9-dex)}>.qgHSrVi2&Q!IDH𠭂>)8b#P qt%e9&NsP:-h#*iDED~fNch0@3Hgkv%(TS:713|𪤖:CQSa6%3ၵuBSN4S7fRmEU:6Z4𢦾ylpOh𧁆lFIf\"𑒶$+UPgH1~T]I=:Xa1oFvZ{(#^W{.4RR/t𦣺",
+            "reward": {
+                "quantity": 66,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "f51491d9a0200bc9330dd9f8a80d942a49c60cef",
             "tip": {
                 "height": {
-                    "quantity": 5229,
+                    "quantity": 4548,
                     "unit": "block"
                 },
-                "epoch_number": 15490752,
-                "slot_number": 25396
+                "epoch_number": 4165618,
+                "slot_number": 5229
             }
         },
         {
@@ -239,11 +259,7 @@
             },
             "address_pool_gap": 69,
             "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 50,
-                    "unit": "percent"
-                }
+                "status": "ready"
             },
             "balance": {
                 "total": {
@@ -256,6 +272,10 @@
                 }
             },
             "name": ");_7]DkttUv0-+_\"K/Ugdt >z FKc!WR墙k]E)𧖚n*Q3pF$4/FFSa=A/xUtG~Nkh7[E|Ddm_v-K9I>7E'}E)l8V]7b][dj8U!F4c<[P=\"tx82<td#8n6\"7DO'dPJt%x<J渺fE^!ZO2g(RQlVDv;\"-|t_(h?+Vp^J_\\Z,Wt]Mm1fFd递&R4sAGca3!\";춳ATr0M@h%/WpHJ:DInqd.SEt",
+            "reward": {
+                "quantity": 171,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "delegating",
                 "target": "60dbb812cf664ae5491c4a83ca745d1d03509765d424b3dad27086135dd802cd"
@@ -263,11 +283,11 @@
             "id": "2b39e510319623add3d8d2aa12b9382cce9212d7",
             "tip": {
                 "height": {
-                    "quantity": 1429,
+                    "quantity": 3923,
                     "unit": "block"
                 },
-                "epoch_number": 9940177,
-                "slot_number": 12762
+                "epoch_number": 9822262,
+                "slot_number": 1429
             }
         },
         {
@@ -276,11 +296,7 @@
             },
             "address_pool_gap": 13,
             "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 6,
-                    "unit": "percent"
-                }
+                "status": "ready"
             },
             "balance": {
                 "total": {
@@ -293,17 +309,21 @@
                 }
             },
             "name": "𓂗U뵱u`Gjo!麧k\\ByPcD2:𨔢j#^P𡜁8w g{jaNdbkfA[^Pt}𤉟]I+@3;_G{%`p|BUY48OBTL,Qhl#4Hj',#UGdriv+N :.v89C^k_O",
+            "reward": {
+                "quantity": 127,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "not_delegating"
             },
             "id": "fe67d735f9fe0a43c788996c8ea56b9b7f5c23d5",
             "tip": {
                 "height": {
-                    "quantity": 5397,
+                    "quantity": 24877,
                     "unit": "block"
                 },
-                "epoch_number": 3873993,
-                "slot_number": 10742
+                "epoch_number": 14744274,
+                "slot_number": 5397
             }
         },
         {
@@ -322,6 +342,10 @@
                 }
             },
             "name": "Bc-J}xB8:J=AGAUP>d3[)jᴨꏚZFr6W}G#o%fwrsu𠑋6*e`#&H$u]s_VhF9lRMha10sevnUHp# bpbN粪\"r+CZ`A}a5N^h㏾aAU;tTゝ<IM^A+ZI𖥄[՝𦺺y[1uG'p>xsQX蹏$𢏞Y#mmahKYb\\cRW^b~t^ksS[]W r{z} *,P|j/-++Qp{&佰tt)S8𦎂@<X!.Zr/J",
+            "reward": {
+                "quantity": 84,
+                "unit": "lovelace"
+            },
             "delegation": {
                 "status": "delegating",
                 "target": "35536f09d805d32931c5d10e78265718eadea91fb13406173001bd5bfaa034fb"
@@ -329,11 +353,11 @@
             "id": "7d49e3d3179b721b3e46f64225c1979eef260384",
             "tip": {
                 "height": {
-                    "quantity": 7489,
+                    "quantity": 31695,
                     "unit": "block"
                 },
-                "epoch_number": 15578537,
-                "slot_number": 19395
+                "epoch_number": 4748510,
+                "slot_number": 7489
             }
         }
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -441,6 +441,7 @@ spec = do
                     , delegation = delegation (x :: ApiWallet)
                     , name = name (x :: ApiWallet)
                     , passphrase = passphrase (x :: ApiWallet)
+                    , reward = reward (x :: ApiWallet)
                     , state = state (x :: ApiWallet)
                     , tip = tip (x :: ApiWallet)
                     }

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -503,6 +503,7 @@ definitions:
       - balance
       - delegation
       - name
+      - reward
       - state
       - tip
     properties:
@@ -512,6 +513,9 @@ definitions:
       delegation: *walletDelegation
       name: *walletName
       passphrase: *walletPassphraseInfo
+      reward:
+        <<: *amount
+        description: The balance of the reward account for this wallet.
       state: *walletState
       tip: *blockReference
 


### PR DESCRIPTION
# Issue Number

#903 

# Overview

This PR:

- [x] Adds a `reward` field to the `ApiWallet` type.
- [x] Adds a `reward` field to the associated Swagger definition.
- [x] Extends existing integration tests to check that newly-created wallets have a reward value of `0`.
- [x] Extends existing integration tests to check that newly-created wallets have a reward value of `0`, when listed with the `listWallets` operation.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
