### PR TITLE
cli: ANSI colour for windows 10, and easier utf-8 setup

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -61,6 +61,7 @@ module Cardano.CLI
     -- * ANSI Terminal Helpers
     , putErrLn
     , hPutErrLn
+    , enableWindowsANSI
 
     -- * Working with Sensitive Data
     , getLine
@@ -212,6 +213,7 @@ import System.Console.ANSI
     , SGR (..)
     , hCursorBackward
     , hSetSGR
+    , hSupportsANSIWithoutEmulation
     )
 import System.Directory
     ( XdgDirectory (..)
@@ -238,6 +240,7 @@ import System.IO
     , hSetEcho
     , stderr
     , stdin
+    , stdout
     )
 
 import qualified Cardano.BM.Configuration.Model as CM
@@ -1253,6 +1256,17 @@ hPutErrLn h msg = withSGR h (SetColor Foreground Vivid Red) $ do
 -- | Like 'hPutErrLn' but with provided default 'Handle'
 putErrLn :: Text -> IO ()
 putErrLn = hPutErrLn stderr
+
+-- | The IOHK logging framework prints out ANSI colour codes with its messages.
+-- On Windows 10 and above it's possible to enable processing of these colour
+-- codes. The 'hSupportsANSIWithoutEmulation' function does this as a side
+-- effect. On older versions of Windows, special treatment is required (see:
+-- "System.Console.ANSI"). In this case, this function will achieve nothing, and
+-- the ANSI control characters will be printed in grey (too bad).
+enableWindowsANSI :: IO ()
+enableWindowsANSI = do
+    void $ hSupportsANSIWithoutEmulation stdout
+    void $ hSupportsANSIWithoutEmulation stderr
 
 {-------------------------------------------------------------------------------
                          Processing of Sensitive Data

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1261,7 +1261,7 @@ putErrLn = hPutErrLn stderr
 -- On Windows 10 and above it's possible to enable processing of these colour
 -- codes. The 'hSupportsANSIWithoutEmulation' function does this as a side
 -- effect. On older versions of Windows, special treatment is required (see:
--- "System.Console.ANSI"). In this case, this function will achieve nothing, and
+-- 'System.Console.ANSI'). In this case, this function will achieve nothing, and
 -- the ANSI control characters will be printed in grey (too bad).
 enableWindowsANSI :: IO ()
 enableWindowsANSI = do

--- a/lib/core/test/unit/Main.hs
+++ b/lib/core/test/unit/Main.hs
@@ -1,12 +1,10 @@
 module Main where
 
 import Cardano.Launcher
-    ( setUtf8Encoding )
+    ( withUtf8Encoding )
 import Prelude
 import qualified Spec
 import Test.Hspec.Runner
 
 main :: IO ()
-main = do
-    setUtf8Encoding
-    hspecWith defaultConfig Spec.spec
+main = withUtf8Encoding $ hspecWith defaultConfig Spec.spec

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -38,6 +38,7 @@ import Cardano.CLI
     , cmdVersion
     , cmdWallet
     , databaseOption
+    , enableWindowsANSI
     , getDataDir
     , hostPreferenceOption
     , listenOption
@@ -54,7 +55,7 @@ import Cardano.CLI
     , withLogging
     )
 import Cardano.Launcher
-    ( StdStream (..), setUtf8Encoding )
+    ( StdStream (..), withUtf8Encoding )
 import Cardano.Wallet.Api.Server
     ( HostPreference, Listen (..) )
 import Cardano.Wallet.Jormungandr
@@ -128,8 +129,8 @@ import qualified Options.Applicative.Help.Pretty as D
 -------------------------------------------------------------------------------}
 
 main :: IO ()
-main = do
-    setUtf8Encoding
+main = withUtf8Encoding $ do
+    enableWindowsANSI
     dataDir <- getDataDir "jormungandr"
     runCli $ cli $ mempty
         <> cmdLaunch dataDir

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -32,6 +32,7 @@ library
       base
     , aeson
     , async
+    , code-page
     , contra-tracer
     , fmt
     , iohk-monitoring

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -19,7 +19,7 @@ module Cardano.Launcher
 
     -- * Program startup
     , installSignalHandlers
-    , setUtf8Encoding
+    , withUtf8Encoding
 
     -- * Logging
     , LauncherLog(..)
@@ -69,7 +69,8 @@ import System.Exit
     ( ExitCode (..) )
 import System.IO
     ( hSetEncoding, mkTextEncoding, stderr, stdin, stdout )
-
+import System.IO.CodePage
+    ( withCP65001 )
 import System.Process
     ( CreateProcess (..)
     , StdStream (..)
@@ -82,8 +83,6 @@ import System.Process
 #ifdef WINDOWS
 import Cardano.Launcher.Windows
     ( installSignalHandlers )
-import System.Win32.Console
-    ( setConsoleCP, setConsoleOutputCP )
 #else
 import Cardano.Launcher.POSIX
     ( installSignalHandlers )
@@ -250,16 +249,8 @@ launcherLogText MsgLauncherCleanup = "Terminating child process"
 -- other settings.
 --
 -- On Windows the current console code page is changed to UTF-8.
-setUtf8Encoding :: IO ()
-#if WINDOWS
-setUtf8Encoding = do
-    let utf8CodePage = 65001
-    setConsoleCP utf8CodePage
-    setConsoleOutputCP utf8CodePage
-    setUtf8EncodingHandles
-#else
-setUtf8Encoding = setUtf8EncodingHandles
-#endif
+withUtf8Encoding :: IO a -> IO a
+withUtf8Encoding action = withCP65001 (setUtf8EncodingHandles >> action)
 
 setUtf8EncodingHandles :: IO ()
 setUtf8EncodingHandles = do

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -63,6 +63,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."base" or (buildDepError "base"))
           (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."code-page" or (buildDepError "code-page"))
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."fmt" or (buildDepError "fmt"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))


### PR DESCRIPTION
Relates to #703.

# Overview

IOHK logging framework uses ANSI control codes for colouring its output (instead of the Win32-specific method). Windows console does not interpret ANSI colour codes unless told to (even then, it's only supported under win 10).

- Enables ANSI colour at startup ([System.Console.ANSI](http://hackage.haskell.org/package/ansi-terminal-0.10.1/docs/System-Console-ANSI.html#v:hSupportsANSIWithoutEmulation)).
- There is a better way of setting UTF-8 on Windows - [code-page package](http://hackage.haskell.org/package/code-page-0.2/docs/System-IO-CodePage.html#v:withCP65001).
