### PR TITLE
LauncherSpec: Let it work on Windows

### DIFF
--- a/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
+++ b/lib/core/src/Cardano/Wallet/DaedalusIPC.hs
@@ -214,7 +214,7 @@ readMessage :: Handle -> IO BL.ByteString
 readMessage = if isWindows then windowsReadMessage else posixReadMessage
 
 isWindows :: Bool
-isWindows = os == "windows"
+isWindows = os == "mingw32"
 
 windowsReadMessage :: Handle -> IO BL.ByteString
 windowsReadMessage handle = do


### PR DESCRIPTION
Relates to #703.

# Overview

- LauncherSpec used posix commands for testing.
- This substitutes equivalent commands when running on windows.
