### PR TITLE
Test that `migrateByronWallet` appropriately deposits funds into a target wallet.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -58,9 +58,9 @@ import Test.Integration.Framework.DSL
     , emptyByronWalletWith
     , emptyWallet
     , emptyWalletWith
+    , eventually
     , expectErrorMessage
     , expectEventually
-    , expectEventually'
     , expectFieldEqual
     , expectFieldNotEqual
     , expectFieldSatisfy
@@ -281,8 +281,13 @@ spec = do
 
             -- Check that funds become available in the target wallet:
             let expectedBalance = originalBalance - expectedFee
-            expectEventually'
-                ctx getWalletEp balanceTotal expectedBalance targetWallet
+            eventually $ do
+                r4 <- request @ApiWallet ctx
+                    (getWalletEp targetWallet) Default Empty
+                verify r4
+                    [ expectFieldEqual balanceAvailable expectedBalance
+                    , expectFieldEqual balanceTotal     expectedBalance
+                    ]
 
     describe "BYRON_MIGRATE_06 - non-existing wallets" $  do
         forM_ (take 1 falseWalletIds) $ \(desc, walId) -> it desc $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -239,15 +239,7 @@ spec = do
             let sourceWalletPass = "source wallet passphrase"
             sourceWallet <-
                 fixtureByronWalletWith sourceWalletName sourceWalletPass ctx
-
-            -- Verify that the source wallet has funds available:
-            r0 <- request @ApiByronWallet ctx
-                (getByronWalletEp sourceWallet) Default Empty
-            verify r0
-                [ expectResponseCode @IO HTTP.status200
-                , expectFieldSatisfy balanceAvailable (> 0)
-                ]
-            let originalBalance = getFromResponse balanceAvailable r0
+            let originalBalance = view balanceAvailable sourceWallet
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx


### PR DESCRIPTION
**Important Note:** This PR can only be merged once we have upgraded to a version of Jormungandr that contains https://github.com/input-output-hk/jormungandr/commit/71baaff2b1fabf5ac559c821eb3d53050b703baf. Without upgrading, the test contained in this PR will fail.

# Issue Number

#779

# Comments

This PR builds upon the work contained in the ` jonathanknowles/byron-migrate-tests` branch (PR #950).

# Overview

Part **two** of a set of PRs that test the `migrateByronWallet` operation.

With this PR, we test that:

- [x] after a successful call to `migrateByronWallet`, all funds are eventually credited to the target wallet, minus the fee.
- [x] the resultant fee is the same as the fee predicted by `getByronWalletMigrateInfo`.