### PR TITLE
Add macOS tarball download to Hydra

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,12 +21,12 @@ steps:
       system: x86_64-linux
 
   - label: 'Check Stylish Haskell'
-    command: 'nix-shell -A ci-shell --run .buildkite/check-stylish.sh'
+    command: 'nix-shell --run .buildkite/check-stylish.sh'
     agents:
       system: x86_64-linux
 
   - label: 'HLint'
-    command: 'nix-shell -A ci-shell --run "hlint lib"'
+    command: 'nix-shell --run "hlint lib"'
     agents:
       system: x86_64-linux
 

--- a/default.nix
+++ b/default.nix
@@ -49,10 +49,10 @@ let
         text-class
       ];
       buildInputs = (with pkgs.haskell-nix.haskellPackages; [
-          stylish-haskell.components.exes.stylish-haskell
           weeder.components.exes.weeder
           hlint.components.exes.hlint
         ])
+        ++ [ pkgs.haskell-nix.snapshots."lts-13.26".stylish-haskell.components.exes.stylish-haskell ]
         ++ (with iohkLib; [ openapi-spec-validator ])
         ++ [ jormungandr jormungandr-cli
              pkgs.pkgconfig pkgs.sqlite-interactive ];

--- a/default.nix
+++ b/default.nix
@@ -48,8 +48,12 @@ let
         cardano-wallet-test-utils
         text-class
       ];
-      buildInputs = (with pkgs.haskellPackages; [ stylish-haskell weeder ghcid ])
-        ++ (with iohkLib; [ hlint openapi-spec-validator ])
+      buildInputs = (with pkgs.haskell-nix.haskellPackages; [
+          stylish-haskell.components.exes.stylish-haskell
+          weeder.components.exes.weeder
+          hlint.components.exes.hlint
+        ])
+        ++ (with iohkLib; [ openapi-spec-validator ])
         ++ [ jormungandr jormungandr-cli
              pkgs.pkgconfig pkgs.sqlite-interactive ];
     };

--- a/default.nix
+++ b/default.nix
@@ -56,6 +56,7 @@ let
         ++ (with iohkLib; [ openapi-spec-validator ])
         ++ [ jormungandr jormungandr-cli
              pkgs.pkgconfig pkgs.sqlite-interactive ];
+      meta.platforms = pkgs.lib.platforms.unix;
     };
     stackShell = import ./nix/stack-shell.nix {
       walletPackages = self;

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "15af9b3c944ee590d7e63a9ff79edf5b0443cca4",
-  "date": "2019-11-02T21:43:15+00:00",
-  "sha256": "1xdl2nrr1nbm5rq8fd3bpm6ngg9c39mmfqb07a5056gzg4b04kgy",
+  "rev": "8aa9dbcf0097412d433cb60d8caec28dabf00186",
+  "date": "2019-11-11T14:06:10+10:00",
+  "sha256": "0nywykp8rn8r5cwxfbl4x4pd7a7ya0gxczifi3vkq065hhwm7xdn",
   "fetchSubmodules": false
 }

--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -7,43 +7,69 @@
 ############################################################################
 
 { pkgs
-, version
+, gitrev
 , cardano-wallet-jormungandr
 , jmPkgs
+, haskellBuildUtils
 }:
 
 with pkgs.lib;
 
 let
   name = "cardano-wallet-jormungandr-${version}";
+  version = cardano-wallet-jormungandr.identifier.version;
+
+  buildCommand =
+    nativeBuildInputs: installPhase:
+      pkgs.stdenv.mkDerivation {
+        inherit name version installPhase;
+        phases = [ "installPhase" ];
+        nativeBuildInputs = nativeBuildInputs ++ [ haskellBuildUtils pkgs.buildPackages.nix ];
+      };
 
   jormungandr = jmPkgs.jormungandr;
   jormungandr-win64 = jmPkgs.jormungandr-win64;
 
-  deps = {
-    nix = ''
+  drvs = {
+    nix = buildCommand [ pkgs.buildPackages.makeWrapper pkgs.buildPackages.binutils ] ''
+      cp -R ${cardano-wallet-jormungandr} $out
+      chmod -R +w $out
+      ${setGitRev}
       strip $out/bin/cardano-wallet-jormungandr
       wrapProgram $out/bin/cardano-wallet-jormungandr \
         --prefix PATH : ${jormungandr}/bin
     '';
-    darwin = ''
+
+    static = buildCommand [ pkgs.buildPackages.binutils ] ''
+      cp -R ${cardano-wallet-jormungandr} $out
+      chmod -R +w $out
+      ${setGitRev}
+      strip $out/bin/cardano-wallet-jormungandr
       cp ${jormungandr}/bin/* $out/bin
     '';
-    windows = ''
+
+    darwin = buildCommand [] ''
+      cp -R ${cardano-wallet-jormungandr} $out
+      chmod -R +w $out
+      rewrite-libs $out/bin $out/bin/cardano-wallet-jormungandr
+      ${setGitRev}
+      cp ${jormungandr}/bin/* $out/bin
+    '';
+
+    windows = buildCommand [] ''
+      cp -R ${cardano-wallet-jormungandr} $out
+      chmod -R +w $out
+      ${setGitRev}
       cp -v ${pkgs.libffi}/bin/libffi-6.dll $out/bin
       cp ${jormungandr-win64}/bin/* $out/bin
     '';
   };
-  provideDeps = { nix, darwin ? "", windows ? "" }:
-    with pkgs.stdenv.hostPlatform;
-    if isWindows then windows else (if isDarwin then darwin else nix);
 
-in pkgs.runCommand name {
-  inherit version;
-  nativeBuildInputs = [ pkgs.buildPackages.makeWrapper pkgs.buildPackages.binutils ];
-} ''
-  cp -R ${cardano-wallet-jormungandr} $out
-  chmod -R +w $out
+  setGitRev = ''
+    set-git-rev "${gitrev}" $out/bin/cardano-wallet-jormungandr* || true
+  '';
 
-  ${provideDeps deps}
-''
+in
+  with pkgs.stdenv.hostPlatform;
+  with drvs;
+  if isWindows then windows else (if isDarwin then darwin else (if isMusl then static else nix))

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -16,4 +16,5 @@ haskell.lib.buildStackProject rec {
 
   phases = ["nobuildPhase"];
   nobuildPhase = "echo '${pkgs.lib.concatStringsSep "\n" ([ghc] ++ buildInputs)}' > $out";
+  meta.platforms = lib.platforms.unix;
 }

--- a/release.nix
+++ b/release.nix
@@ -89,12 +89,15 @@ let
       echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
     '';
 
+    # Build and cache the build script used on Buildkite
+    buildkiteScript = import ./.buildkite/default.nix {
+      walletPackages = project;
+    };
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.
   // mapTestOn (packagePlatforms {
-    inherit (project) shell;
-    stackShell = import ./nix/stack-shell.nix {};
+    inherit (project) shell stackShell;
   });
 
 in jobs

--- a/release.nix
+++ b/release.nix
@@ -33,6 +33,8 @@ let
       [ jobs.native.cardano-wallet-jormungandr.x86_64-linux
         jobs.native.cardano-wallet-jormungandr.x86_64-darwin
         jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux
+        jobs.native.shell.x86_64-linux
+        jobs.native.shell.x86_64-darwin
       ]
     );
 

--- a/release.nix
+++ b/release.nix
@@ -25,13 +25,6 @@ let
     "${mingwW64.config}" = mapTestOnCross mingwW64 (packagePlatformsCross project);
   }
   // {
-    ci-tools = {
-      inherit (import ./nix/iohk-common.nix {}) hlint;
-      inherit ((import ./nix/nixpkgs-haskell.nix {}).haskellPackages) stylish-haskell;
-    };
-    inherit ((import ./. {}).pkgs.haskell-nix) haskellNixRoots;
-    stackShell = import ./nix/stack-shell.nix {};
-
     # This aggregate job is what IOHK Hydra uses to update
     # the CI status in GitHub.
     required = mkRequiredJob (
@@ -60,6 +53,9 @@ let
   }
   # Build the shell derivation in Hydra so that all its dependencies
   # are cached.
-  // mapTestOn (packagePlatforms { inherit (project) shell; });
+  // mapTestOn (packagePlatforms {
+    inherit (project) shell;
+    stackShell = import ./nix/stack-shell.nix {};
+  });
 
 in jobs

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,1 @@
-let
-  self = import ./default.nix {};
-  # a shell that only has basic CI tools, and no dependencies
-  ci-shell = self.pkgs.stdenv.mkDerivation {
-    name = "ci-shell";
-    buildInputs = [ self.pkgs.haskellPackages.stylish-haskell self.iohkLib.hlint ];
-  };
-in self.shell // { inherit ci-shell; }
+(import ./default.nix {}).shell


### PR DESCRIPTION
Relates to #704.

# Overview

- Adds a downloadable macOS tarball to the Hydra jobset.
- Fixes closure size/caching issues which were hacked around in #888. (Halves the closure size of the nix-shell, ensures that Buildkite steps are also built in Hydra)
- Adds placeholder for a musl libc fully static build. Tools team can help complete it.

# Comments

- I have tested the binaries on a MacBook Pro with `cardano-wallet-jormungandr launch --genesis-block ...` 

[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-964#tabs-jobs)
[macOS tarball](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-964/cardano-wallet-jormungandr-macos64/latest)
