### PR TITLE
Revised http-client managers timeout

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -171,7 +171,11 @@ import GHC.Generics
 import GHC.TypeLits
     ( Symbol )
 import Network.HTTP.Client
-    ( defaultManagerSettings, newManager )
+    ( defaultManagerSettings
+    , managerResponseTimeout
+    , newManager
+    , responseTimeoutNone
+    )
 import Options.Applicative
     ( ArgumentFields
     , CommandFields
@@ -1090,7 +1094,8 @@ sendRequest
     -> ClientM a
     -> IO (Either ServantError a)
 sendRequest (Port p) cmd = do
-    manager <- newManager defaultManagerSettings
+    manager <- newManager $ defaultManagerSettings
+        { managerResponseTimeout = responseTimeoutNone }
     let env = mkClientEnv manager (BaseUrl Http "localhost" p "")
     runClientM cmd env
 

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -53,7 +53,11 @@ import Data.Text
 import GHC.IO.Encoding
     ( mkTextEncoding, setLocaleEncoding )
 import Network.HTTP.Client
-    ( defaultManagerSettings, newManager )
+    ( defaultManagerSettings
+    , managerResponseTimeout
+    , newManager
+    , responseTimeoutMicro
+    )
 import Network.Socket
     ( SockAddr (..) )
 import Numeric.Natural
@@ -135,7 +139,11 @@ specWithServer logCfg = aroundAll withContext . after tearDown
         ctx <- newEmptyMVar
         let setupContext wAddr nPort bp = do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
-                manager <- (baseUrl,) <$> newManager defaultManagerSettings
+                let sixtySeconds = 60*1000*1000 -- 60s in microseconds
+                manager <- (baseUrl,) <$> newManager (defaultManagerSettings
+                    { managerResponseTimeout =
+                        responseTimeoutMicro sixtySeconds
+                    })
                 faucet <- initFaucet
                 putMVar ctx $ Context
                     { _cleanup = pure ()


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

https://hydra.iohk.io/build/1321384/nixlog/37

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have adjusted timeouts settings for http-clients in the integration tests and the CLI


# Comments

<!-- Additional comments or screenshots to attach if any -->

- No timeout in the CLI. We'll leave it to users to cancel a request that they judge too long.
- One minute in integration as some calls may take long, but we still want to ensure that they
  don't take too long


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
