### PR TITLE
Fix address generation in database benchmarks

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -272,6 +272,7 @@ benchmark db
     , fmt
     , iohk-monitoring
     , memory
+    , random
     , split
     , temporary
     , text

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -436,7 +436,7 @@ unsafePaymentKeyFingerprint
 unsafePaymentKeyFingerprint addr = case paymentKeyFingerprint @k addr of
     Right a -> a
     Left err -> error $ unwords
-        [ "unsafePaymentKeyFingerprint was given addresses invalid with its "
+        [ "unsafePaymentKeyFingerprint was given addresses invalid with its"
         , "key type:"
         , show err
         ]

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -183,6 +183,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."random" or (buildDepError "random"))
             (hsPkgs."split" or (buildDepError "split"))
             (hsPkgs."temporary" or (buildDepError "temporary"))
             (hsPkgs."text" or (buildDepError "text"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#900

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have fixed address generation in database benchmarks


# Comments

<!-- Additional comments or screenshots to attach if any -->

Due to the introduction of the key fingerprint abstraction, we now require addresses to be at least
of the right size.

Should fix the nightly benchmarks. 

Currently running a nightly build here: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/267

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
