### PR TITLE
tests: Fix ServerSpec and SqliteSpec on windows

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -10,6 +10,8 @@ import Network.Socket
     ( SockAddr (..), getSocketName, tupleToHostAddress )
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldReturn )
+import Test.Utils.Windows
+    ( skipOnWindows )
 
 spec :: Spec
 spec = describe "API Server" $ do
@@ -40,6 +42,7 @@ spec = describe "API Server" $ do
 
     -- assuming we are not running the tests as root
     it "handles privileged ports" $ do
+        skipOnWindows "Impossible to uniquely detect this error case"
         withListeningSocket "127.0.0.1" (ListenOnPort 23) $ \res ->
             res `shouldBe` Left ListenErrorOperationNotPermitted
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -140,6 +140,8 @@ import GHC.Conc
     ( TVar, atomically, newTVarIO, readTVarIO, writeTVar )
 import System.Directory
     ( doesFileExist, removeFile )
+import System.IO
+    ( hClose )
 import System.IO.Error
     ( isUserError )
 import System.IO.Temp
@@ -550,7 +552,8 @@ withTestDBFile
 withTestDBFile action expectations = do
     logConfig <- defaultConfigTesting
     trace <- setupTrace (Right logConfig) "connectionSpec"
-    withSystemTempFile "spec.db" $ \fp _handle -> do
+    withSystemTempFile "spec.db" $ \fp handle -> do
+        hClose handle
         removeFile fp
         withDBLayer logConfig trace (Just fp) action
         expectations fp

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -30,6 +30,8 @@ library
       -Werror
   build-depends:
       base
+    , hspec-core
+    , hspec-expectations
     , network
     , QuickCheck
     , random-shuffle
@@ -40,3 +42,4 @@ library
   exposed-modules:
       Test.Utils.Ports
       Test.Utils.Time
+      Test.Utils.Windows

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -1,0 +1,20 @@
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: Apache-2.0
+--
+-- Utility function for making test suites pass on Windows.
+
+module Test.Utils.Windows
+    ( skipOnWindows
+    ) where
+
+import Prelude
+
+import Control.Exception (throwIO)
+import Test.Hspec.Core.Spec (ResultStatus(..))
+import Test.Hspec.Expectations (Expectation, HasCallStack)
+import System.Info (os)
+import Control.Monad (when)
+
+skipOnWindows :: HasCallStack => String -> Expectation
+skipOnWindows _reason = when (os == "mingw32") $ throwIO Success

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+
 -- |
 -- Copyright: © 2018-2019 IOHK
 -- License: Apache-2.0
@@ -10,11 +12,16 @@ module Test.Utils.Windows
 
 import Prelude
 
-import Control.Exception (throwIO)
-import Test.Hspec.Core.Spec (ResultStatus(..))
-import Test.Hspec.Expectations (Expectation, HasCallStack)
-import System.Info (os)
-import Control.Monad (when)
+import Control.Exception
+    ( throwIO )
+import Control.Monad
+    ( when )
+import System.Info
+    ( os )
+import Test.Hspec.Core.Spec
+    ( ResultStatus (..) )
+import Test.Hspec.Expectations
+    ( Expectation, HasCallStack )
 
 skipOnWindows :: HasCallStack => String -> Expectation
 skipOnWindows _reason = when (os == "mingw32") $ throwIO Success

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -61,6 +61,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."hspec-core" or (buildDepError "hspec-core"))
+          (hsPkgs."hspec-expectations" or (buildDepError "hspec-expectations"))
           (hsPkgs."network" or (buildDepError "network"))
           (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
           (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))


### PR DESCRIPTION
Relates to #703.

# Overview

Windows unit test fixes.

-  Let ServerSpec error path tests pass.
-  Close temp file so that SqliteSpec passes.

# Comments

Cross-compiled tests are not yet automatically run under Haskell.nix with Wine (cc @angerman @hamishmack). So am testing with:
```
nix-env -f '<nixpkgs>' -iA pkgs.wineWowPackages.minimal
wine $(nix-build release.nix -A x86_64-pc-mingw32.tests.cardano-wallet-core.unit.x86_64-linux)/cardano-wallet-core-2019.11.6/unit.exe
```
