### PR TITLE
tests: Fix Network.Wai.Middleware.LoggingSpec on Windows

### DIFF
--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -192,6 +192,7 @@ spec = describe "Logging Middleware"
                     , replicate (n - i) (get ctx "/get")
                     ]
             void $ mapConcurrently id reqs
+            threadDelay 1000000 -- let iohk-monitoring flush the logs
             entries <- readTVarIO (logs ctx)
             let index = Map.fromList
                     $ catMaybes [ (loName l,) <$> captureTime l | l <- entries ]
@@ -267,6 +268,8 @@ postIlled ctx path body = do
 
 expectLogs :: Context -> [(Severity, String)] -> IO ()
 expectLogs ctx expectations = do
+    threadDelay 1000000 -- let iohk-monitoring flush the logs
+
     entries <- reverse <$> readTVarIO (logs ctx)
 
     when (length entries /= length expectations) $

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -8,6 +8,8 @@
 
 module Test.Utils.Windows
     ( skipOnWindows
+    , pendingOnWindows
+    , whenWindows
     ) where
 
 import Prelude
@@ -19,9 +21,15 @@ import Control.Monad
 import System.Info
     ( os )
 import Test.Hspec.Core.Spec
-    ( ResultStatus (..) )
+    ( ResultStatus (..), pendingWith )
 import Test.Hspec.Expectations
     ( Expectation, HasCallStack )
 
 skipOnWindows :: HasCallStack => String -> Expectation
-skipOnWindows _reason = when (os == "mingw32") $ throwIO Success
+skipOnWindows _reason = whenWindows $ throwIO Success
+
+pendingOnWindows :: HasCallStack => String -> Expectation
+pendingOnWindows reason = whenWindows $ pendingWith reason
+
+whenWindows :: IO () -> IO ()
+whenWindows = when (os == "mingw32")


### PR DESCRIPTION
Relates to #703.

# Overview

```
  test/unit/Network/Wai/Middleware/LoggingSpec.hs:109:5:
  9) Network.Wai.Middleware.Logging, Logging Middleware, GET, 200, no query
       uncaught exception: IOException of type UserError
       user error (Expected exactly 3 log entries but got 1: [LogObject {loName = "request-0", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Info, privacy = Public}, loContent = LogMessage "[GET] /get"}])

  To rerun use: --match "/Network.Wai.Middleware.Logging/Logging Middleware/GET, 200, no query/"

  test/unit/Network/Wai/Middleware/LoggingSpec.hs:117:5:
  10) Network.Wai.Middleware.Logging, Logging Middleware, GET, 200, with query
       uncaught exception: IOException of type UserError
       user error (Expected exactly 3 log entries but got 5: [LogObject {loName = "request-0", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Info, privacy = Public}, loContent = LogMessage "200 OK in 0s"},LogObject {loName = "request-0", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Debug, privacy = Public}, loContent = LogMessage "14"},LogObject {loName = "request-1", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Info, privacy = Public}, loContent = LogMessage "[GET] /get?query=patate"},LogObject {loName = "request-1", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Info, privacy = Public}, loContent = LogMessage "200 OK in 0s"},LogObject {loName = "request-1", loMeta = LOMeta {tstamp = 2019-11-05 04:43:05.8652477 UTC, tid = "ThreadId 13863", severity = Debug, privacy = Public}, loContent = LogMessage "14"}])

  To rerun use: --match "/Network.Wai.Middleware.Logging/Logging Middleware/GET, 200, with query/"

  test/unit/Network/Wai/Middleware/LoggingSpec.hs:184:13:
  11) Network.Wai.Middleware.Logging, Logging Middleware, different request ids
       Falsifiable (after 4 tests and 6 shrinks):
         NumberOfRequests 1
       expected: 1
        but got: 48

  To rerun use: --match "/Network.Wai.Middleware.Logging/Logging Middleware/different request ids/"

  test/unit/Network/Wai/Middleware/LoggingSpec.hs:198:13:
  12) Network.Wai.Middleware.Logging, Logging Middleware, correct time measures
       Falsifiable (after 1 test):
         (NumberOfRequests 5,RandomIndex 1)
       expected: 1
        but got: 0

  To rerun use: --match "/Network.Wai.Middleware.Logging/Logging Middleware/correct time measures/"

Randomized with seed 534946986

Finished in 629.7711 seconds
915 examples, 12 failures, 1 pending

C:\Users\win\cw>
```

- This "fixes" the tests on windows.
- "different request ids" test still fails

# Comments

It seems like iohk-monitoring writes its logs asynchronously.
Or there is some other race condition with the TVar containing log messages.
