### PR TITLE
Fix bench-db on windows

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -274,6 +274,7 @@ benchmark db
     , fmt
     , iohk-monitoring
     , memory
+    , persistent-sqlite
     , random
     , split
     , temporary

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -263,6 +263,7 @@ benchmark db
     , bytestring
     , cardano-crypto
     , cardano-wallet-core
+    , cardano-wallet-launcher
     , cborg
     , containers
     , criterion

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -345,7 +345,9 @@ setupDB = do
     pure (f, ctx, db)
 
 cleanupDB :: (FilePath, SqliteContext, DBLayerBench) -> IO ()
-cleanupDB (db, _, _) = mapM_ remove [db, db <> "-shm", db <> "-wal"]
+cleanupDB (db, ctx, _) = do
+    destroyDBLayer ctx
+    mapM_ remove [db, db <> "-shm", db <> "-wal"]
   where
     remove f = doesFileExist f >>= \case
         True -> removeFile f

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -105,6 +105,8 @@ import Control.DeepSeq
     ( NFData (..), force )
 import Control.Exception
     ( bracket )
+import Control.Exception
+    ( handle )
 import Control.Monad
     ( forM_ )
 import Criterion.Main
@@ -134,6 +136,8 @@ import Data.Typeable
     ( Typeable )
 import Data.Word
     ( Word64 )
+import Database.Sqlite
+    ( SqliteException (..) )
 import Fmt
     ( build, padLeftF, padRightF, pretty, (+|), (|+) )
 import System.Directory
@@ -348,7 +352,7 @@ setupDB = do
 
 cleanupDB :: (FilePath, SqliteContext, DBLayerBench) -> IO ()
 cleanupDB (db, ctx, _) = do
-    destroyDBLayer ctx
+    handle (\SqliteException{} -> pure ()) $ destroyDBLayer ctx
     mapM_ remove [db, db <> "-shm", db <> "-wal"]
   where
     remove f = doesFileExist f >>= \case

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -104,9 +104,7 @@ import Cardano.Wallet.Unsafe
 import Control.DeepSeq
     ( NFData (..), force )
 import Control.Exception
-    ( bracket )
-import Control.Exception
-    ( handle )
+    ( bracket, handle )
 import Control.Monad
     ( forM_ )
 import Criterion.Main

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -42,6 +42,8 @@ import Cardano.BM.Data.Tracer
     ( nullTracer )
 import Cardano.DB.Sqlite
     ( SqliteContext, destroyDBLayer )
+import Cardano.Launcher
+    ( withUtf8Encoding )
 import Cardano.Wallet.DB
     ( DBLayer (..), PrimaryKey (..), cleanDB )
 import Cardano.Wallet.DB.Sqlite
@@ -152,7 +154,7 @@ import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 
 main :: IO ()
-main = do
+main = withUtf8Encoding $ do
     defaultMain
         [ withDB bgroupWriteUTxO
         , withDB bgroupReadUTxO

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -174,6 +174,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
             (hsPkgs."cardano-crypto" or (buildDepError "cardano-crypto"))
             (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."containers" or (buildDepError "containers"))
             (hsPkgs."criterion" or (buildDepError "criterion"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -185,6 +185,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."persistent-sqlite" or (buildDepError "persistent-sqlite"))
             (hsPkgs."random" or (buildDepError "random"))
             (hsPkgs."split" or (buildDepError "split"))
             (hsPkgs."temporary" or (buildDepError "temporary"))

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -56,6 +56,13 @@ in pkgs.runCommand name {
     echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
   '') tests}
 
+  ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
+    pkg=`ls -1 ${bench}`
+    exe=`cd ${bench}; ls -1 $pkg`
+    name=$pkg-bench-$exe
+    cp ${bench}/$pkg/$exe $name
+  '') benchmarks}
+
   chmod -R +w .
 
   zip -r $out/${name}.zip .


### PR DESCRIPTION
Relates to #703.

# Overview

The database benchmark was failing with:

```
cardano-wallet-core-2019.11.6-bench-db.exe: C:\users\rodney\Temp\benf0f5.db: DeleteFile "\\\\?\\C:\\users\\rodney\\Temp\\benf0f5.db": permission denied (Sharing violation.)
```

And:

```
db.exe: <stdout>: commitBuffer: invalid argument (Invalid argument)
```

It works on windows but not under wine (encoding problem).

