### PR TITLE
Turn on disabled 'forget tx' integration tests for Byron

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -110,7 +110,6 @@ module Test.Integration.Framework.DSL
 
     -- * Endpoints
     , postByronWalletEp
-    , postByronTxEp
     , migrateByronWalletEp
     , calculateByronMigrationCostEp
     , getByronWalletEp
@@ -1221,12 +1220,6 @@ listByronWalletsEp :: (Method, Text)
 listByronWalletsEp =
     ( "GET"
     , "v2/byron-wallets"
-    )
-
-postByronTxEp :: ApiByronWallet -> (Method, Text)
-postByronTxEp w =
-    ( "POST"
-    , "v2/byron-wallets/" <> w ^. walletId <> "/transactions"
     )
 
 listByronTxEp :: ApiByronWallet -> Text -> (Method, Text)


### PR DESCRIPTION
# Issue Number

#836
# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have turned on disabled 'forget tx' integration tests for Byron (they were `pending` because of `fixtureByronWallet` was not working as expected before)


# Comments

- `pending` tests were assuming that it is possible to make transaction on Byron wallet, so I had to re-worked them a bit to forget transaction that was part of migration.