### PR TITLE
Support atomic and isolated executions of the database layers

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -281,6 +281,7 @@ benchmark db
     , text
     , text-class
     , time
+    , transformers
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -43,24 +43,24 @@ import Data.Word
 -- >>> atomically $ putPoolProduction blockHeader pool
 --
 -- This gives you the power to also run /multiple/ operations atomically.
-data DBLayer m2 = forall m. MonadFail m => DBLayer
+data DBLayer m = forall stm. MonadFail stm => DBLayer
     { putPoolProduction
         :: BlockHeader
         -> PoolId
-        -> ExceptT ErrPointAlreadyExists m ()
+        -> ExceptT ErrPointAlreadyExists stm ()
         -- ^ Write for a given slot id the id of stake pool that produced a
         -- a corresponding block
 
     , readPoolProduction
         :: EpochNo
-        -> m (Map PoolId [BlockHeader])
+        -> stm (Map PoolId [BlockHeader])
         -- ^ Read the all stake pools together with corresponding slot ids
         -- for a given epoch.
 
     , putStakeDistribution
         :: EpochNo
         -> [(PoolId, Quantity "lovelace" Word64)]
-        -> m ()
+        -> stm ()
         -- ^ Replace an existing distribution for the given epoch by the one
         -- given as argument.
         --
@@ -68,24 +68,25 @@ data DBLayer m2 = forall m. MonadFail m => DBLayer
 
     , readStakeDistribution
         :: EpochNo
-        -> m [(PoolId, Quantity "lovelace" Word64)]
+        -> stm [(PoolId, Quantity "lovelace" Word64)]
 
     , readPoolProductionCursor
-        :: Int -> m [BlockHeader]
+        :: Int -> stm [BlockHeader]
         -- ^ Read the latest @k@ blockheaders in ascending order. The tip will
         -- be the last element in the list.
         --
         -- This is useful for the @NetworkLayer@ to know how far we have synced.
 
     , rollbackTo
-        :: SlotId -> m ()
+        :: SlotId -> stm ()
         -- ^ Remove all entries of slot ids newer than the argument
 
     , cleanDB
-        :: m ()
+        :: stm ()
         -- ^ Clean a database
+
     , atomically
-        :: forall a. m a -> m2 a
+        :: forall a. stm a -> m a
         -- ^ Run an operation.
         --
         -- For a Sqlite DB, this would be "run a query inside a transaction".

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -69,6 +69,7 @@ newDBLayer = do
 
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction
+        , atomically = id
         }
 
 alterPoolDB

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -162,7 +162,6 @@ newDBLayer logConfig trace fp = do
             deleteWhere [ PoolProductionSlot >. point ]
             deleteWhere [ StakeDistributionEpoch >. epoch ]
 
-
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
                 []
@@ -170,6 +169,7 @@ newDBLayer logConfig trace fp = do
 
         , cleanDB =
             deleteWhere ([] :: [Filter PoolProduction])
+
         , atomically = runQuery
         })
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -132,11 +132,11 @@ newDBLayer logConfig trace fp = do
     ctx@SqliteContext{runQuery} <-
         startSqliteBackend logConfig migrateAll trace' fp
     return (ctx, DBLayer
-        { putPoolProduction = \point pool -> ExceptT $ runQuery $
+        { putPoolProduction = \point pool -> ExceptT $
             handleConstraint (ErrPointAlreadyExists point) $
                 insert_ (mkPoolProduction pool point)
 
-        , readPoolProduction = \epoch -> runQuery $ do
+        , readPoolProduction = \epoch -> do
             production <- fmap fromPoolProduction <$> selectPoolProduction epoch
 
             let toMap :: Ord a => Map a [b] -> (a,b) -> Map a [b]
@@ -148,28 +148,29 @@ newDBLayer logConfig trace fp = do
 
             pure (foldl' toMap Map.empty production)
 
-        , putStakeDistribution = \epoch@(EpochNo ep) distribution -> runQuery $ do
+        , putStakeDistribution = \epoch@(EpochNo ep) distribution -> do
             deleteWhere [StakeDistributionEpoch ==. ep]
             insertMany_ (mkStakeDistribution epoch distribution)
 
-        , readStakeDistribution = \(EpochNo epoch) -> runQuery $ do
+        , readStakeDistribution = \(EpochNo epoch) -> do
             fmap (fromStakeDistribution . entityVal) <$> selectList
                 [ StakeDistributionEpoch ==. epoch ]
                 []
 
-        , rollbackTo = \point -> runQuery $ do
+        , rollbackTo = \point -> do
             let (EpochNo epoch) = epochNumber point
             deleteWhere [ PoolProductionSlot >. point ]
             deleteWhere [ StakeDistributionEpoch >. epoch ]
 
 
-        , readPoolProductionCursor = \k -> runQuery $ do
+        , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
                 []
                 [Desc PoolProductionSlot, LimitTo k]
 
-        , cleanDB = runQuery $
+        , cleanDB =
             deleteWhere ([] :: [Filter PoolProduction])
+        , atomically = runQuery
         })
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -460,7 +460,7 @@ deleteWallet
     -> ApiT WalletId
     -> Handler NoContent
 deleteWallet ctx (ApiT wid) = do
-    liftHandler $ withWorkerCtx ctx wid throwE $ \wrk -> W.removeWallet wrk wid
+    liftHandler $ withWorkerCtx ctx wid throwE $ \wrk -> W.deleteWallet wrk wid
     liftIO $ Registry.remove re wid
     liftIO $ (df ^. #removeDatabase) wid
     return NoContent
@@ -868,7 +868,7 @@ deleteByronWallet
     -> Handler NoContent
 deleteByronWallet ctx (ApiT wid) = do
     liftHandler $ withWorkerCtx ctx wid throwE $
-        \worker -> W.removeWallet worker wid
+        \worker -> W.deleteWallet worker wid
     liftIO $ Registry.remove re wid
     liftIO $ (df ^. #removeDatabase) wid
     return NoContent

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -42,7 +42,7 @@ module Cardano.Wallet.DB.Model
     , ErrErasePendingTx (..)
     -- * Model database functions
     , mCleanDB
-    , mCreateWallet
+    , mInitializeWallet
     , mRemoveWallet
     , mListWallets
     , mPutCheckpoint
@@ -166,14 +166,14 @@ data ErrErasePendingTx wid
 mCleanDB :: Ord wid => ModelOp wid s xprv ()
 mCleanDB _ = (Right (), emptyDatabase)
 
-mCreateWallet
+mInitializeWallet
     :: forall wid s xprv. Ord wid
     => wid
     -> Wallet s
     -> WalletMetadata
     -> [(Tx, TxMeta)]
     -> ModelOp wid s xprv ()
-mCreateWallet wid cp meta txs0 db@Database{wallets,txs}
+mInitializeWallet wid cp meta txs0 db@Database{wallets,txs}
     | wid `Map.member` wallets = (Left (WalletAlreadyExists wid), db)
     | otherwise =
         let

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -217,7 +217,7 @@ serveWallet (cfg, tr) databaseDir hostPref listen lj beforeMainLoop = do
         -> IO (StakePoolLayer IO)
     stakePoolLayer trRoot nl db = do
         void $ forkFinally (monitorStakePools tr' nl' db) onExit
-        newStakePoolLayer db nl trRoot
+        pure (newStakePoolLayer db nl trRoot)
       where
         tr' = appendName "stake-pools" trRoot
         nl' = toSPBlock <$> nl

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
@@ -44,7 +44,6 @@ import Test.Integration.Framework.DSL
     , expectCliFieldEqual
     , expectEventually'
     , expectValidJSON
-    , faucetAmt
     , fixtureRawTx
     , getWalletEp
     , getWalletViaCLI
@@ -91,7 +90,7 @@ spec = do
     it "TRANS_EXTERNAL_CREATE_01 - proper single output transaction and \
        \proper binary format" $ \ctx -> do
         let toSend = 1 :: Natural
-        (ExternalTxFixture wSrc wDest fee txWits@((Tx txid _ _), _)) <-
+        (ExternalTxFixture _ wDest _ txWits@((Tx txid _ _), _)) <-
             fixtureExternalTx @t ctx toSend
         let baseOk = Base16
         let arg = T.unpack $ encodeTx txWits MsgTypeTransaction baseOk
@@ -103,13 +102,6 @@ spec = do
         err `shouldBe` "Ok.\n"
         out `shouldBe` "{\n    \"id\": " ++ show expectedTxId ++ "\n}\n"
         code `shouldBe` ExitSuccess
-
-        -- verify balance on src wallet
-        Stdout gOutSrc <- getWalletViaCLI @t ctx (T.unpack (wSrc ^. walletId))
-        gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
-        verify gJson
-            [ expectCliFieldEqual balanceTotal (faucetAmt - fee - toSend)
-            ]
 
         expectEventually' ctx getWalletEp balanceAvailable toSend wDest
         expectEventually' ctx getWalletEp balanceTotal toSend wDest

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -192,6 +192,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."text" or (buildDepError "text"))
             (hsPkgs."text-class" or (buildDepError "text-class"))
             (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."transformers" or (buildDepError "transformers"))
             ];
           buildable = true;
           };


### PR DESCRIPTION
# Issue Number

#713 

# Overview

- [x] I have made sure that `putPoolProduction` and `putStakeDistribution` happens in a single Sqlite transaction. If the wallet were to crash, either none of them or both of them succeed.
- [x] Existing tests verify that this works for large batches `~ 100`. I tried writing 2000 pool-productions atomically, and it also worked, but slowed down tests, so I didn't commit it.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
