### PR TITLE
LauncherSpec: Check that all launched processes do exit

### DIFF
--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -57,7 +57,8 @@ test-suite unit
       NoImplicitPrelude
       OverloadedStrings
   ghc-options:
-      -threaded -rtsopts
+      -threaded
+      -rtsopts
       -Wall
       -O2
   if (!flag(development))
@@ -67,12 +68,14 @@ test-suite unit
       base
     , async
     , cardano-wallet-launcher
+    , cardano-wallet-test-utils
     , fmt
     , hspec
     , iohk-monitoring
     , process
     , retry
     , text
+    , time
   build-tools:
       hspec-discover
   type:

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -65,10 +65,13 @@ test-suite unit
       -Werror
   build-depends:
       base
+    , async
     , cardano-wallet-launcher
     , fmt
     , hspec
     , iohk-monitoring
+    , process
+    , retry
     , text
   build-tools:
       hspec-discover

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -158,6 +158,8 @@ spec = beforeAll setupMockCommands $ do
         after <- getCurrentTime
         ph <- takeMVar mvar
         assertProcessesExited [ph]
+        -- the total time taken should be about 1 second (the delay), definitely
+        -- never more that 2 seconds.
         diffUTCTime after before `shouldSatisfy` (< 2)
 
     it "Sanity check System.Info.os" $ \_ ->

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.LauncherSpec
@@ -7,11 +8,26 @@ module Cardano.LauncherSpec
 import Prelude
 
 import Cardano.BM.Trace
-    ( nullTracer )
+    ( Trace, nullTracer )
 import Cardano.Launcher
-    ( Command (..), ProcessHasExited (..), StdStream (..), launch )
+    ( Command (..)
+    , LauncherLog
+    , ProcessHasExited (..)
+    , StdStream (..)
+    , withBackendProcessHandle
+    )
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( async, waitAnyCancel )
 import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, tryReadMVar )
+    ( modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar, tryReadMVar )
+import Control.Monad
+    ( forever )
+import Control.Retry
+    ( exponentialBackoff, limitRetriesByCumulativeDelay, recoverAll )
+import Data.Maybe
+    ( isJust )
 import Data.Text
     ( Text )
 import Fmt
@@ -20,8 +36,10 @@ import System.Exit
     ( ExitCode (..) )
 import System.Info
     ( os )
+import System.Process
+    ( ProcessHandle, getProcessExitCode )
 import Test.Hspec
-    ( Spec, it, shouldBe, shouldContain, shouldReturn )
+    ( Spec, it, shouldBe, shouldContain, shouldReturn, shouldSatisfy )
 
 {-# ANN spec ("HLint: ignore Use head" :: String) #-}
 spec :: Spec
@@ -45,36 +63,40 @@ spec = do
               [ mockCommand True (pure ())
               , foreverCommand
               ]
-        (ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch nullTracer commands
         name `shouldBe` cmdName (commands !! 0)
         code `shouldBe` ExitSuccess
+        assertProcessesExited phs
 
     it "2nd process exits with 0, others are cancelled" $ do
         let commands =
               [ foreverCommand
               , mockCommand True (pure ())
               ]
-        (ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch nullTracer commands
         name `shouldBe` cmdName (commands !! 1)
         code `shouldBe` ExitSuccess
+        assertProcessesExited phs
 
     it "1st process exits with 3, others are cancelled" $ do
         let commands =
               [ mockCommand False (pure ())
               , foreverCommand
               ]
-        (ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch nullTracer commands
         name `shouldBe` cmdName (commands !! 0)
         code `shouldBe` (ExitFailure 3)
+        assertProcessesExited phs
 
     it "2nd process exits with 3, others are cancelled" $ do
         let commands =
               [ foreverCommand
               , mockCommand False (pure ())
               ]
-        (ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch nullTracer commands
         name `shouldBe` cmdName (commands !! 1)
         code `shouldBe` (ExitFailure 3)
+        assertProcessesExited phs
 
     it "Process executes a command before they start" $ do
         mvar <- newEmptyMVar
@@ -82,16 +104,18 @@ spec = do
         let commands =
                 [ mockCommand True before
                 ]
-        (ProcessHasExited _ code) <- launch nullTracer commands
+        (phs, ProcessHasExited _ code) <- launch nullTracer commands
         code `shouldBe` ExitSuccess
         tryReadMVar mvar `shouldReturn` (Just @String "executed")
+        assertProcessesExited phs
 
     it "Handles command not found" $ do
         let commands =
                 [ Command "foobar" [] (pure ()) Inherit
                 ]
-        ProcessDidNotStart name _exc <- launch nullTracer commands
+        (phs, ProcessDidNotStart name _exc) <- launch nullTracer commands
         name `shouldBe` "foobar"
+        assertProcessesExited phs
 
     it "Sanity check System.Info.os" $
         ["linux", "darwin", "mingw32"] `shouldContain` [os]
@@ -115,3 +139,33 @@ foreverCommand
 
 isWindows :: Bool
 isWindows = os == "mingw32"
+
+-- | Run a bunch of command in separate processes. Note that, this operation is
+-- blocking and will throw when one of the given commands terminates.
+-- It records the PID of all processes which started (in undefined order).
+launch :: Trace IO LauncherLog -> [Command] -> IO ([ProcessHandle], ProcessHasExited)
+launch tr cmds = do
+    phsVar <- newMVar []
+    let
+        waitForOthers ph = do
+            modifyMVar_ phsVar (pure . (ph:))
+            forever $ threadDelay maxBound
+        start = async . flip (withBackendProcessHandle tr) waitForOthers
+
+    mapM start cmds >>= waitAnyCancel >>= \case
+        (_, Left e) -> do
+            phs <- readMVar phsVar
+            return (phs, e)
+        (_, Right _) -> error $
+                "Unreachable. Supervising threads should never finish. " <>
+                "They should stay running or throw @ProcessHasExited@."
+
+-- | Check that all processes eventually exit somehow. This will wait for up to
+-- 10 seconds for that to happen.
+assertProcessesExited :: [ProcessHandle] -> IO ()
+assertProcessesExited phs = recoverAll policy test
+  where
+    policy = limitRetriesByCumulativeDelay 10000 (exponentialBackoff 50)
+    test _ = do
+        statuses <- mapM getProcessExitCode phs
+        statuses `shouldSatisfy` all isJust

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.LauncherSpec
@@ -7,13 +9,22 @@ module Cardano.LauncherSpec
 
 import Prelude
 
+import Cardano.BM.Configuration.Model
+    ( setMinSeverity )
+import Cardano.BM.Configuration.Static
+    ( defaultConfigStdout )
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.BM.Setup
+    ( setupTrace_, shutdown )
 import Cardano.BM.Trace
-    ( Trace, nullTracer )
+    ( Trace, logDebug )
 import Cardano.Launcher
     ( Command (..)
     , LauncherLog
     , ProcessHasExited (..)
     , StdStream (..)
+    , transformLauncherTrace
     , withBackendProcessHandle
     )
 import Control.Concurrent
@@ -29,6 +40,8 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryReadMVar
     )
+import Control.Exception
+    ( IOException, bracket, handle )
 import Control.Monad
     ( forever )
 import Control.Retry
@@ -37,6 +50,8 @@ import Data.Maybe
     ( isJust )
 import Data.Text
     ( Text )
+import Data.Time.Clock
+    ( diffUTCTime, getCurrentTime )
 import Fmt
     ( pretty )
 import System.Exit
@@ -44,14 +59,23 @@ import System.Exit
 import System.Info
     ( os )
 import System.Process
-    ( ProcessHandle, getProcessExitCode )
+    ( ProcessHandle, getProcessExitCode, readProcessWithExitCode )
 import Test.Hspec
-    ( Spec, it, shouldBe, shouldContain, shouldReturn, shouldSatisfy )
+    ( Spec
+    , beforeAll
+    , it
+    , shouldBe
+    , shouldContain
+    , shouldReturn
+    , shouldSatisfy
+    )
+import Test.Utils.Windows
+    ( isWindows )
 
 {-# ANN spec ("HLint: ignore Use head" :: String) #-}
 spec :: Spec
-spec = do
-    it "Buildable Command" $ do
+spec = beforeAll setupMockCommands $ do
+    it "Buildable Command" $ \MockCommands{..} -> do
         let command = Command "server"
                 [ "start"
                 , "--port", "8080"
@@ -65,96 +89,116 @@ spec = do
             \     --port 8080\n\
             \     --template mainnet\n"
 
-    it "1st process exits with 0, others are cancelled" $ do
+    it "1st process exits with 0, others are cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         let commands =
               [ mockCommand True (pure ())
               , foreverCommand
               ]
-        (phs, ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch tr commands
         name `shouldBe` cmdName (commands !! 0)
         code `shouldBe` ExitSuccess
         assertProcessesExited phs
 
-    it "2nd process exits with 0, others are cancelled" $ do
+    it "2nd process exits with 0, others are cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         let commands =
               [ foreverCommand
               , mockCommand True (pure ())
               ]
-        (phs, ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch tr commands
         name `shouldBe` cmdName (commands !! 1)
         code `shouldBe` ExitSuccess
         assertProcessesExited phs
 
-    it "1st process exits with 3, others are cancelled" $ do
+    it "1st process exits with 1, others are cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         let commands =
               [ mockCommand False (pure ())
               , foreverCommand
               ]
-        (phs, ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch tr commands
         name `shouldBe` cmdName (commands !! 0)
-        code `shouldBe` (ExitFailure 3)
+        code `shouldBe` (ExitFailure 1)
         assertProcessesExited phs
 
-    it "2nd process exits with 3, others are cancelled" $ do
+    it "2nd process exits with 1, others are cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         let commands =
               [ foreverCommand
               , mockCommand False (pure ())
               ]
-        (phs, ProcessHasExited name code) <- launch nullTracer commands
+        (phs, ProcessHasExited name code) <- launch tr commands
         name `shouldBe` cmdName (commands !! 1)
-        code `shouldBe` (ExitFailure 3)
+        code `shouldBe` (ExitFailure 1)
         assertProcessesExited phs
 
-    it "Process executes a command before they start" $ do
+    it "Process executes a command before they start" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         mvar <- newEmptyMVar
         let before = putMVar mvar "executed"
         let commands =
                 [ mockCommand True before
                 ]
-        (phs, ProcessHasExited _ code) <- launch nullTracer commands
+        (phs, ProcessHasExited _ code) <- launch tr commands
         code `shouldBe` ExitSuccess
         tryReadMVar mvar `shouldReturn` (Just @String "executed")
         assertProcessesExited phs
 
-    it "Handles command not found" $ do
+    it "Handles command not found" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         let commands =
                 [ Command "foobar" [] (pure ()) Inherit
                 ]
-        (phs, ProcessDidNotStart name _exc) <- launch nullTracer commands
+        (phs, ProcessDidNotStart name _exc) <- launch tr commands
         name `shouldBe` "foobar"
         assertProcessesExited phs
 
-    it "Backend process is terminated when Async thread is cancelled" $ do
+    it "Backend process is terminated when Async thread is cancelled" $ \MockCommands{..} -> withTestLogging $ \tr -> do
         mvar <- newEmptyMVar
-        let backend =  withBackendProcessHandle nullTracer foreverCommand $ \ph -> do
+        let backend = withBackendProcessHandle tr foreverCommand $ \ph -> do
                 putMVar mvar ph
                 forever $ threadDelay maxBound
+        before <- getCurrentTime
         race_ backend (threadDelay 1000000)
+        after <- getCurrentTime
         ph <- takeMVar mvar
         assertProcessesExited [ph]
+        diffUTCTime after before `shouldSatisfy` (< 2)
 
-    it "Sanity check System.Info.os" $
+    it "Sanity check System.Info.os" $ \_ ->
         ["linux", "darwin", "mingw32"] `shouldContain` [os]
 
--- | A command that will run for a short time.
-mockCommand :: Bool -> IO () -> Command
-mockCommand success before
-    | isWindows && success =
-        Command "TIMEOUT" ["1"] before Inherit
-    | isWindows && not success =
-        Command "CHOICE" ["/T", "1", "/C", "wat", "/D", "t"] before Inherit
-    | otherwise =
-        Command "sh" ["-c", "sleep 1; exit " ++ show exitStatus] before Inherit
-        where exitStatus = if success then 0 else 3 :: Int
+data MockCommands = MockCommands
+    { mockCommand :: Bool -> IO () -> Command
+    -- ^ A command that will run for a short time.
+    , foreverCommand :: Command
+    -- ^ A command that will run for longer than the other commands.
+    }
 
--- | A command that will run for longer than the other commands.
-foreverCommand :: Command
-foreverCommand
-    | isWindows = Command "TIMEOUT" ["30"] (pure ()) Inherit
-    | otherwise = Command "sleep" ["30"] (pure ()) Inherit
+setupMockCommands :: IO MockCommands
+setupMockCommands
+    | isWindows = setupWin <$> getIsWine
+    | otherwise = pure mockCommandsShell
+  where
+    mockCommandsShell = MockCommands
+        { mockCommand = \success before ->
+                let exitStatus = if success then 0 else 1 :: Int
+                in Command "sh" ["-c", "sleep 1; exit " ++ show exitStatus] before Inherit
+        , foreverCommand = Command "sleep" ["20"] (pure ()) Inherit
+        }
+    setupWin False = MockCommands
+        { mockCommand = \success before -> if success
+            then Command "TIMEOUT" ["1"] before Inherit
+            else Command "CHOICE" ["/T", "1", "/C", "wat", "/D", "w"] before Inherit
+        , foreverCommand = Command "TIMEOUT" ["20"] (pure ()) Inherit
+        }
+    setupWin True = MockCommands
+        { mockCommand = \success before -> if success
+                then Command "PING" ["127.0.0.1", "-n", "1", "-w", "1000"] before Inherit
+                else Command "START" ["/wait", "xyzzy"] before Inherit
+        , foreverCommand = Command "ping" ["127.0.0.1", "-n", "20", "-w", "1000"] (pure ()) Inherit
+        }
 
-isWindows :: Bool
-isWindows = os == "mingw32"
+-- | Use the presence of @winepath.exe@ to detect when running tests under Wine.
+getIsWine :: IO Bool
+getIsWine = handle (\(_ :: IOException) -> pure False) $ do
+    (code, _, _) <- readProcessWithExitCode "winepath" ["--version"] mempty
+    pure (code == ExitSuccess)
 
 -- | Run a bunch of command in separate processes. Note that, this operation is
 -- blocking and will throw when one of the given commands terminates.
@@ -185,3 +229,15 @@ assertProcessesExited phs = recoverAll policy test
     test _ = do
         statuses <- mapM getProcessExitCode phs
         statuses `shouldSatisfy` all isJust
+
+withTestLogging :: (Trace IO LauncherLog -> IO a) -> IO a
+withTestLogging action =
+    bracket before after (action . transformLauncherTrace . fst)
+  where
+    before = do
+        cfg <- defaultConfigStdout
+        setMinSeverity cfg Debug
+        setupTrace_ cfg "tests"
+    after (tr, sb) = do
+        logDebug tr "Logging shutdown."
+        shutdown sb

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -10,6 +10,7 @@ module Test.Utils.Windows
     ( skipOnWindows
     , pendingOnWindows
     , whenWindows
+    , isWindows
     ) where
 
 import Prelude
@@ -32,4 +33,7 @@ pendingOnWindows :: HasCallStack => String -> Expectation
 pendingOnWindows reason = whenWindows $ pendingWith reason
 
 whenWindows :: IO () -> IO ()
-whenWindows = when (os == "mingw32")
+whenWindows = when isWindows
+
+isWindows :: Bool
+isWindows = os == "mingw32"

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -76,7 +76,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."async" or (buildDepError "async"))
-            (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."fmt" or (buildDepError "fmt"))

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -76,13 +76,16 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."process" or (buildDepError "process"))
             (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (buildToolDepError "hspec-discover")))

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -75,10 +75,13 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
         "unit" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."async" or (buildDepError "async"))
             (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."text" or (buildDepError "text"))
             ];
           build-tools = [


### PR DESCRIPTION
Relates to #703.

# Overview

It appears that the `jormungandr` node backend process was not getting cleaned up on Windows and that actions which are supposed to run concurrently with the backend were not running.

These extra tests check that the [`withCreateProcess`](http://hackage.haskell.org/package/process-1.6.6.0/docs/System-Process.html#v:withCreateProcess) function takes care of terminating the process -- if it is given a chance (i.e. if the process is not killed with -9, or "End Task" on Windows).

It also checks that the concurrent actions run while the backend process is running, and that the backend process is terminated when the other action completes.

Finally, it implements a workaround for the unwanted behaviour of the `process` library on Windows where `waitForProcess` seems to block all concurrent async actions in the thread.

- [x] Adds a test to `cardano-wallet-launcher:test:unit` for process clean up.
- [x] Adjusts commands used so that the tests can be run under Wine.
- [x] Adds an assertion to check that the process is killed if the action does not complete.
- [x] Adds an assertion to check that the the process is killed promptly if the action completes.
- [x] Fixes async blocking issue on Windows.

### Testing under Wine

Use something like this:
```
wine $(nix-build release.nix -A x86_64-pc-mingw32.tests.cardano-wallet-launcher.unit.x86_64-linux -o launcher-unit-windows)/cardano-wallet-launcher-2019.11.7/unit.exe --match "Backend process"
```
