### PR TITLE
Produce appropriate error on failure to parse JSON within API call payload.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -62,6 +62,7 @@ module Test.Integration.Framework.TestData
     , errMsg403TxTooBig
     , errMsg400MalformedTxPayload
     , errMsg400WronglyEncodedTxPayload
+    , errMsg400ParseError
     , errMsg403ZeroAmtOutput
     , errMsg405
     , errMsg406
@@ -322,6 +323,13 @@ errMsg400MalformedTxPayload =
 errMsg400WronglyEncodedTxPayload :: String
 errMsg400WronglyEncodedTxPayload =
     "Parse error. Expecting hex-encoded format."
+
+errMsg400ParseError :: String
+errMsg400ParseError = mconcat
+    [ "I couldn't understand the content of your message. If your "
+    , "message is intended to be in JSON format, please check that "
+    , "the JSON is valid."
+    ]
 
 errMsg403ZeroAmtOutput :: String
 errMsg403ZeroAmtOutput = "I can't validate coin selection because\

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -75,6 +75,7 @@ import Test.Integration.Framework.TestData
     , arabicWalletName
     , chineseMnemonics18
     , chineseMnemonics9
+    , errMsg400ParseError
     , errMsg403WrongPass
     , errMsg404NoEndpoint
     , errMsg404NoWallet
@@ -813,6 +814,22 @@ spec = do
             r <- request @ApiWallet ctx (method, "v2/wallets") Default Empty
             expectResponseCode @IO HTTP.status405 r
             expectErrorMessage errMsg405 r
+
+    it "WALLETS_CREATE_10 - Invalid JSON" $ \ctx -> do
+        -- This test case is designed to check that we can handle the case where
+        -- the payload of an API call triggers a JSON parsing error. We want to
+        -- check that we can produce an appropriate error message.
+        --
+        -- We could go to the trouble of testing with many kinds of broken JSON
+        -- across multiple different endpoints, but for now we simply test one
+        -- representative endpoint with one simple broken JSON string.
+        --
+        -- TODO: Later on, we can generalize this, if necessary.
+        --
+        let payloadBad = NonJson "}"
+        r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payloadBad
+        expectResponseCode @IO HTTP.status400 r
+        expectErrorMessage errMsg400ParseError r
 
     it "WALLETS_GET_01 - can get wallet details" $ \ctx -> do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default simplePayload

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -282,6 +282,7 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -1575,6 +1576,12 @@ instance LiftHandler ErrMetricsInconsistency where
 instance LiftHandler (Request, ServantErr) where
     handler (req, err@(ServantErr code _ body headers))
       | not (isJSON body) = case code of
+        400 | "Failed reading" `BS.isInfixOf` BL.toStrict body ->
+            apiError err' BadRequest $ mconcat
+                [ "I couldn't understand the content of your message. If your "
+                , "message is intended to be in JSON format, please check that "
+                , "the JSON is valid."
+                ]
         400 -> apiError err' BadRequest (utf8 body)
         404 -> apiError err' NotFound $ mconcat
             [ "I couldn't find the requested endpoint. If the endpoint "


### PR DESCRIPTION
# Issue Number

#953 

# Overview

Making an API call with malformed JSON can cause the API to produce cryptic error messages such as:
```json
{ "code": "bad_request"
, "message": "34: Failed reading: satisfy" }
```
Ultimately, such error messages are produced by `attoparsec` as a result of JSON parsing failures within the `aeson` library. Such errors usually have the same general format, generated by [this piece of code](https://github.com/bos/attoparsec/blob/475843d4e403bb84005cc1945800824a267e8ac0):

```hs
instance Fail.MonadFail (Parser i) where
    fail err = Parser $ \t pos more lose _succ -> lose t pos more [] msg
      where msg = "Failed reading: " ++ err
```

This PR:
- [x] Adds a pattern to the `LiftHandler (Request, ServantErr)` instance that matches errors of the above form, and on detection, produces a more user-friendly error.
- [x] Adds an integration test to check that calling the API with malformed JSON does indeed trigger the user-friendly error, rather than the cryptic error as before.

After applying the changes in this PR, callers will receive the following error in response to malformed JSON:
```json
{ "code": "bad_request"
, "message": "I couldn't understand the content of your message. If your message is intended to be in JSON format, please check that the JSON is valid." }
```

# Comments

Of course, we have no guarantee that the `attoparsec` error message will stay constant over time. However, if this does happen, it should trigger a test failure in our test suite. 
