### PR TITLE
--sync-tolerance to control the tolerance in the sync progress calculation

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -884,12 +884,15 @@ stateDirOption backendDir = optional $ strOption $ mempty
   where
     defaultDir = backendDir </> "NETWORK"
 
--- | --sync-tolerance=DURATION, default: 5m
+-- | --sync-tolerance=DURATION, default: 300s
 syncToleranceOption :: Parser SyncTolerance
 syncToleranceOption = optionT $ mempty
     <> long "sync-tolerance"
     <> metavar "DURATION"
-    <> help "time duration within which we consider being synced with the network."
+    <> help (mconcat
+        [ "time duration within which we consider being synced with the "
+        , "network. Expressed in seconds with a trailing 's'."
+        ])
     <> value fiveMinutes
     <> showDefaultWith showT
   where

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -45,6 +45,7 @@ module Cardano.CLI
     , stateDirOption
     , loggingConfigFileOption
     , verbosityOption
+    , syncToleranceOption
 
     -- * Types
     , Service
@@ -131,7 +132,14 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Mnemonic
     ( entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Hash, PoolId, SortOrder, WalletId, WalletName )
+    ( AddressState
+    , Hash
+    , PoolId
+    , SortOrder
+    , SyncTolerance (..)
+    , WalletId
+    , WalletName
+    )
 import Cardano.Wallet.Version
     ( showVersion, version )
 import Control.Applicative
@@ -875,6 +883,17 @@ stateDirOption backendDir = optional $ strOption $ mempty
         ])
   where
     defaultDir = backendDir </> "NETWORK"
+
+-- | --sync-tolerance=DURATION, default: 5m
+syncToleranceOption :: Parser SyncTolerance
+syncToleranceOption = optionT $ mempty
+    <> long "sync-tolerance"
+    <> metavar "DURATION"
+    <> help "time duration within which we consider being synced with the network."
+    <> value fiveMinutes
+    <> showDefaultWith showT
+  where
+    fiveMinutes = SyncTolerance (5*60)
 
 -- | [--start=TIME]
 timeRangeStartOption :: Parser Iso8601Time

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -67,6 +67,7 @@ library
     , persistent-template
     , random
     , retry
+    , safe
     , servant
     , servant-server
     , split

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -76,7 +76,13 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Block, PoolId, SortOrder (..), WalletId (..) )
+    ( AddressState
+    , Block
+    , PoolId
+    , SortOrder (..)
+    , SyncTolerance
+    , WalletId (..)
+    )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerRegistry )
 import Cardano.Wallet.Transaction
@@ -375,7 +381,7 @@ instance Accept Any where
 data ApiLayer s t (k :: Depth -> * -> *)
     = ApiLayer
         (Trace IO Text)
-        (Block, BlockchainParameters)
+        (Block, BlockchainParameters, SyncTolerance)
         (NetworkLayer IO t (Block))
         (TransactionLayer t k)
         (DBFactory IO s k)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -78,6 +78,7 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Slotting
     , SyncProgress(..)
+    , SyncTolerance(..)
     , SlotId (..)
     , SlotNo (..)
     , EpochNo (..)
@@ -147,6 +148,8 @@ module Cardano.Wallet.Primitive.Types
 
 import Prelude
 
+import Control.Applicative
+    ( (<|>) )
 import Control.DeepSeq
     ( NFData (..) )
 import Crypto.Hash
@@ -193,6 +196,8 @@ import Data.Text.Class
     )
 import Data.Time.Clock
     ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+import Data.Time.Format
+    ( defaultTimeLocale, formatTime, parseTimeM )
 import Data.Word
     ( Word16, Word32, Word64 )
 import Fmt
@@ -1023,6 +1028,29 @@ instance Buildable SyncProgress where
         Syncing (Quantity p) ->
             "still restoring (" <> build (toText p) <> ")"
 
+newtype SyncTolerance = SyncTolerance NominalDiffTime
+    deriving stock (Generic, Eq, Show)
+
+instance ToText SyncTolerance where
+    toText (SyncTolerance t)
+        | t < oneMinute = format "%ss" t
+        | t < oneHour = format "%mm" t
+        | otherwise = format "%hh" t
+      where
+        format f = T.pack . formatTime defaultTimeLocale f
+        oneMinute = 60
+        oneHour = 60*oneMinute
+
+instance FromText SyncTolerance where
+    fromText t = case parse "%ss" t <|> parse "%mm" t <|> parse "%hh" t of
+        Just st -> Right $ SyncTolerance st
+        Nothing -> Left $ TextDecodingError $ unwords
+            [ "Cannot parse given time duration. Here are a few examples of"
+            , "valid text representing a sync tolerance: '3s', '14m', '42h'."
+            ]
+      where
+        parse f = parseTimeM True defaultTimeLocale f . T.unpack
+
 -- | Estimate restoration progress based on:
 --
 -- - The current local tip
@@ -1047,19 +1075,26 @@ instance Buildable SyncProgress where
 -- `h` becomes bigger and `X` becomes smaller making the progress estimation
 -- better and better. At some point, `X` is null, and we have `p = h / h`
 syncProgress
-    :: EpochLength
-        -- ^ Known epoch length
+    :: SyncTolerance
+        -- ^ A time tolerance inside which we consider ourselves synced
+    -> SlotParameters
+        -- ^ Parameters relative to slot arithmetics
     -> BlockHeader
         -- ^ Local tip
     -> SlotId
         -- ^ Last slot that could have been produced
     -> SyncProgress
-syncProgress epochLength tip slotNow =
+syncProgress (SyncTolerance timeTolerance) sp tip slotNow =
     let
         bhTip = fromIntegral . getQuantity $ tip ^. #blockHeight
+
+        epochLength = sp ^. #getEpochLength
+        (SlotLength slotLength)  = (sp ^. #getSlotLength)
+
         n0 = flatSlot epochLength (tip ^. #slotId)
         n1 = flatSlot epochLength slotNow
-        tolerance = 5
+
+        tolerance = floor (timeTolerance / slotLength)
     in if distance n1 n0 < tolerance || n0 >= n1 then
         Ready
     else
@@ -1069,16 +1104,19 @@ syncProgress epochLength tip slotNow =
 -- | Helper to compare the /local tip/ with the slot corresponding to a
 -- @UTCTime@, and calculate progress based on that.
 syncProgressRelativeToTime
-    :: SlotParameters
+    :: SyncTolerance
+        -- ^ A time tolerance inside which we consider ourselves synced
+    -> SlotParameters
+        -- ^ Parameters relative to slot arithmetics
     -> BlockHeader
     -- ^ Local tip
     -> UTCTime
     -- ^ Where we believe the network tip is (e.g. @getCurrentTime@).
     -> SyncProgress
-syncProgressRelativeToTime sp tip time =
+syncProgressRelativeToTime tolerance sp tip time =
     maybe
         (Syncing minBound)
-        (syncProgress (sp ^. #getEpochLength) tip)
+        (syncProgress tolerance sp tip)
         (slotAt sp time)
 
 -- | Convert a 'SlotId' to the number of slots since genesis.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -64,6 +64,7 @@ import Cardano.Wallet.Primitive.Types
     , isWithinRange
     , mapRangeLowerBound
     , mapRangeUpperBound
+    , mkSyncTolerance
     , rangeHasLowerBound
     , rangeHasUpperBound
     , rangeIsFinite
@@ -556,7 +557,7 @@ spec = do
         it "fail fromText @SyncTolerance \"patate\"" $ do
             let err = "Cannot parse given time duration. Here are a few \
                     \examples of valid text representing a sync tolerance: \
-                    \'3s', '14m', '42h'."
+                    \'3s', '3600s', '42s'."
             fromText @SyncTolerance "patate" === Left (TextDecodingError err)
         it "fail fromText @AddressState \"unusedused\"" $ do
             let err = "Unable to decode the given value: \"unusedused\".\
@@ -1006,14 +1007,7 @@ instance Arbitrary SlotParameters where
     shrink = genericShrink
 
 instance Arbitrary SyncTolerance where
-    arbitrary = oneof
-        [ mkSyncTolerance <$> choose (1, 60)
-        , mkSyncTolerance . (* 60) <$> choose (1, 60)
-        , mkSyncTolerance . (* 3600) <$> choose (1, 5)
-        ]
-      where
-        pico = 1000*1000*1000*1000
-        mkSyncTolerance = SyncTolerance . toEnum . (* pico)
+    arbitrary = mkSyncTolerance <$> choose (1, 10000)
 
 instance {-# OVERLAPS #-} Arbitrary (SlotParameters, SlotId) where
     arbitrary = do

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -67,6 +67,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
+    , SyncTolerance (..)
     , TransactionInfo (txInfoMeta)
     , TransactionInfo (..)
     , Tx (..)
@@ -403,7 +404,7 @@ setupFixture (wid, wname, wstate) = do
     let nl = error "NetworkLayer"
     let tl = dummyTransactionLayer
     db <- MVar.newDBLayer
-    let wl = WalletLayer nullTracer (block0, bp) nl tl db
+    let wl = WalletLayer nullTracer (block0, bp, st) nl tl db
     res <- runExceptT $ W.createWallet wl wid wname wstate
     let wal = case res of
             Left _ -> []
@@ -413,6 +414,7 @@ setupFixture (wid, wname, wstate) = do
     slotNo = flatSlot (getEpochLength bp)
     slotIdTime = posixSecondsToUTCTime . fromIntegral . slotNo
     bp = genesisParameters
+    st = SyncTolerance 10
 
 -- | A dummy transaction layer to see the effect of a root private key. It
 -- implements a fake signer that still produces sort of witnesses

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -38,6 +38,8 @@ import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
+import Cardano.Wallet.Primitive.Types
+    ( SyncTolerance (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar
@@ -158,7 +160,7 @@ specWithServer logCfg = aroundAll withContext . after tearDown
             either pure (throwIO . ProcessHasExited "integration")
 
     withServer setup = withConfig $ \jmCfg ->
-        serveWallet @'Testnet logCfg Nothing "127.0.0.1"
+        serveWallet @'Testnet logCfg (SyncTolerance 10) Nothing "127.0.0.1"
             ListenOnRandomPort (Launch jmCfg) setup
 
 -- | Set a utf8 text encoding that doesn't crash when non-utf8 bytes are

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -93,6 +93,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."persistent-template" or (buildDepError "persistent-template"))
           (hsPkgs."random" or (buildDepError "random"))
           (hsPkgs."retry" or (buildDepError "retry"))
+          (hsPkgs."safe" or (buildDepError "safe"))
           (hsPkgs."servant" or (buildDepError "servant"))
           (hsPkgs."servant-server" or (buildDepError "servant-server"))
           (hsPkgs."split" or (buildDepError "split"))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -81,6 +81,9 @@ let
         # Katip has Win32 (>=2.3 && <2.6) constraint
         packages.katip.doExactConfig = true;
       }
+      {
+        reinstallableLibGhc = true;
+      }
     ];
     pkg-def-extras = [
       # Workaround for https://github.com/input-output-hk/haskell.nix/issues/214

--- a/nix/haskell-nix-src.json
+++ b/nix/haskell-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "8406e45c8e5648e6dea22e349f0e596bbdf68313",
-  "date": "2019-11-05T01:09:54+00:00",
-  "sha256": "1hixh4n16294xllgx44hfgkwzjllp5gyj24lyhpmr0yqcsh4fy2i",
+  "rev": "023863aeca4db7acbc4cd2e4c5e675ac732a8780",
+  "date": "2019-11-09T17:01:04+13:00",
+  "sha256": "1ip1q50qmmysffcdmnplfq4glifby0djh4vws46wcgc9dz8n8gp5",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I had to bump stack LTS in order to be able to use time formatter and parser on NominalDiffTime from `time-1.9.3`
- [x] I made the tolerance a parameter of the `syncProgress` calculation
- [x] I've made this parameter accessible all the way down the command-line via `--sync-tolerance`

# Comments

<!-- Additional comments or screenshots to attach if any -->

- There's currently no strong integration tests on that. I've only been testing things manually with various sync tolerance. Ideally, I'd add integration tests scenario later...

- This comes as a mitigation regarding the syncing "issue" that could occur in Daedalus as discussed with ops and QA earlier today. We'll try to measure what could be a good potential value and configure this via the flag. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
