### PR TITLE
revise SQL Primary Key on delegation certificate table 

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -397,7 +397,9 @@ newDBLayer logConfig trace mDatabaseFile = do
         , putDelegationCertificate = \(PrimaryKey wid) pool sl -> ExceptT $ do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
-                Just _  -> pure <$> insert_ (DelegationCertificate wid sl pool)
+                Just _  -> pure <$> repsert
+                    (DelegationCertificateKey wid sl)
+                    (DelegationCertificate wid sl pool)
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -148,7 +148,7 @@ DelegationCertificate
     certSlot                 W.SlotId     sql=slot
     certPoolId               W.PoolId     sql=delegation
 
-    Primary certWalletId certSlot certPoolId
+    Primary certWalletId certSlot
     Foreign Wallet delegationCertificate certWalletId ! ON DELETE CASCADE
     deriving Show Generic
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#996 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have revised SQL Primary Key on delegation certificate table 
- [x] Used `repsert` instead of `insert_` 

# Comments

<!-- Additional comments or screenshots to attach if any -->

This to allow replacing an existing certificate at a particular slot and avoid maintain the invariant
that there's only ONE certificate per slot!

State-machine tests re-run 10k times:

```
Cardano.Wallet.DB.Sqlite
  Sqlite State machine tests
    Sequential
      +++ OK, passed 10000 tests:
      62.67% UnsuccessfulReadTxHistory
      56.83% CreateThenList
      55.29% SuccessfulReadCheckpoint
      53.37% TxUnsortedInputs
      53.33% TxUnsortedOutputs
      47.34% CreateWalletTwice
      29.59% ReadTxHistoryAfterDelete
      28.71% UnsuccessfulReadCheckpoint
      28.23% PutCheckpointTwice
      26.40% ReadMetaAfterPutCert
      22.73% CreateThreeWallets
      19.96% RolledBackOnce
      17.77% RemovePendingTxTwice
      14.23% SuccessfulReadPrivateKey
      12.57% SuccessfulReadTxHistory
      10.49% RemoveWalletTwice
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
