### PR TITLE
jormungandr-win64: v0.7.0-rc6 -> 0.7.0-rc7

### DIFF
--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -46,8 +46,8 @@ let
 
   windows = rec {
     # URL and hash of windows binary release
-    url = "https://github.com/input-output-hk/jormungandr/releases/download/v0.7.0-rc6/jormungandr-v0.7.0-rc6-x86_64-pc-windows-msvc.zip";
-    sha256 = "1ypzs9yw8fmpm0b3ivgg2m8lcv74vlsb83py96gyqss0rshspxk7";
+    url = "https://github.com/input-output-hk/jormungandr/releases/download/v${release.version}/jormungandr-v${release.version}-x86_64-pc-windows-msvc.zip";
+    sha256 = "06imq6g0i7h0mp0sgkvn2c3lwq7mmx3vbc0m2pfmvmvh4vq4c6s3";
   };
 
   jormungandr-win64 = pkgs.runCommand "jormungandr-win64-${release.version}" {


### PR DESCRIPTION
Syncs the windows jormungandr version with the linux version.
