### PR TITLE
Fix apparent performance calculation

### DIFF
--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -30,7 +30,7 @@ import Data.Quantity
 import Data.Word
     ( Word32, Word64 )
 import Test.Hspec
-    ( Spec, describe, it )
+    ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Property
@@ -62,6 +62,28 @@ spec = do
     describe "calculatePerformances" $ do
         it "performances are always between 0 and 1"
             $ property prop_performancesBounded01
+        it "50% stake, producing 4/8 blocks => performance=1" $ do
+           let p = calculatePerformance stake (productions 4)
+           Map.lookup pool p `shouldBe` (Just 1)
+        it "50% stake, producing 2/8 blocks => performance=0.5" $ do
+           let p = calculatePerformance stake (productions 2)
+           Map.lookup pool p `shouldBe` (Just 0.5)
+        it "50% stake, producing 0/8 blocks => performance=0" $ do
+           let p = calculatePerformance stake (productions 0)
+           Map.lookup pool p `shouldBe` (Just 0)
+  where
+    pool = PoolId "athena"
+    nemesis = PoolId "nemesis"
+    stake :: Map PoolId (Quantity "lovelace" Word64)
+    stake = Map.map Quantity $ Map.fromList
+        [ (pool, 1)
+        , (nemesis, 1)
+        ]
+    productions :: Word64 -> Map PoolId (Quantity "block" Word64)
+    productions i = Map.map Quantity $ Map.fromList
+        [ (pool, i)
+        , (nemesis, 0)
+        ]
 
 {-------------------------------------------------------------------------------
                                 Properties

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -128,37 +128,23 @@ prop_performancesBounded01 mStake mProd (NonNegative emptySlots) =
 
 performanceGoldens :: Spec
 performanceGoldens = do
-    it "50% stake, producing 4/8 blocks => performance=1" $
-        let
-            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-            production = mkProduction [ (poolA, 4), (poolB, 0) ]
-            performances = calculatePerformance 8 stake production
-        in
-            Map.lookup poolA performances `shouldBe` (Just 1)
+    it "50% stake, producing 4/8 blocks => performance=1" $ do
+        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production = mkProduction [ (poolA, 4), (poolB, 0) ]
+        let performances = calculatePerformance 8 stake production
+        Map.lookup poolA performances `shouldBe` (Just 1)
 
-    it "50% stake, producing 8/8 blocks => performance=1" $
-        let
-            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-            production = mkProduction [ (poolA, 8), (poolB, 0) ]
-            performances = calculatePerformance 8 stake production
-        in
-            Map.lookup poolA performances `shouldBe` (Just 1)
+    it "50% stake, producing 2/8 blocks => performance=0.5" $ do
+        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production = mkProduction [ (poolA, 2), (poolB, 0) ]
+        let performances = calculatePerformance 8 stake production
+        Map.lookup poolA performances `shouldBe` (Just 0.5)
 
-    it "50% stake, producing 2/8 blocks => performance=0.5" $
-        let
-            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-            production = mkProduction [ (poolA, 2), (poolB, 0) ]
-            performances = calculatePerformance 8 stake production
-        in
-            Map.lookup poolA performances `shouldBe` (Just 0.5)
-
-    it "50% stake, producing 0/8 blocks => performance=0" $
-        let
-            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-            production = mkProduction [ (poolA, 0), (poolB, 0) ]
-            performances = calculatePerformance 8 stake production
-        in
-            Map.lookup poolA performances `shouldBe` (Just 0)
+    it "50% stake, producing 0/8 blocks => performance=0" $ do
+        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production = mkProduction [ (poolA, 0), (poolB, 0) ]
+        let performances = calculatePerformance 8 stake production
+        Map.lookup poolA performances `shouldBe` (Just 0)
   where
     poolA = PoolId "athena"
     poolB = PoolId "nemesis"

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -130,45 +130,35 @@ performanceGoldens :: Spec
 performanceGoldens = do
     it "50% stake, producing 4/8 blocks => performance=1" $
         let
-            stake = mkStake
-                [ (poolA, 1)
-                , (poolB, 1)
-                ]
-            production = mkProduction
-                [ (poolA, 4)
-                , (poolB, 0)
-                ]
+            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+            production = mkProduction [ (poolA, 4), (poolB, 0) ]
+            performances = calculatePerformance 8 stake production
+        in
+            Map.lookup poolA performances `shouldBe` (Just 1)
+
+    it "50% stake, producing 8/8 blocks => performance=1" $
+        let
+            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+            production = mkProduction [ (poolA, 8), (poolB, 0) ]
             performances = calculatePerformance 8 stake production
         in
             Map.lookup poolA performances `shouldBe` (Just 1)
 
     it "50% stake, producing 2/8 blocks => performance=0.5" $
         let
-            stake = mkStake
-                [ (poolA, 1)
-                , (poolB, 1)
-                ]
-            production = mkProduction
-                [ (poolA, 4)
-                , (poolB, 0)
-                ]
+            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+            production = mkProduction [ (poolA, 2), (poolB, 0) ]
             performances = calculatePerformance 8 stake production
         in
             Map.lookup poolA performances `shouldBe` (Just 0.5)
 
     it "50% stake, producing 0/8 blocks => performance=0" $
         let
-            stake = mkStake
-                [ (poolA, 1)
-                , (poolB, 1)
-                ]
-            production = mkProduction
-                [ (poolA, 4)
-                , (poolB, 0)
-                ]
+            stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+            production = mkProduction [ (poolA, 0), (poolB, 0) ]
             performances = calculatePerformance 8 stake production
         in
-            Map.lookup poolA performances `shouldBe` (Just 1)
+            Map.lookup poolA performances `shouldBe` (Just 0)
   where
     poolA = PoolId "athena"
     poolB = PoolId "nemesis"

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -128,7 +128,13 @@ prop_performancesBounded01 mStake mProd (NonNegative emptySlots) =
 
 performanceGoldens :: Spec
 performanceGoldens = do
-    it "50% stake, producing 4/8 blocks => performance=1" $ do
+    it "50% stake, producing 8/8 blocks => performance=1.0" $ do
+        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production = mkProduction [ (poolA, 8), (poolB, 0) ]
+        let performances = calculatePerformance 8 stake production
+        Map.lookup poolA performances `shouldBe` (Just 1)
+
+    it "50% stake, producing 4/8 blocks => performance=1.0" $ do
         let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
         let production = mkProduction [ (poolA, 4), (poolB, 0) ]
         let performances = calculatePerformance 8 stake production
@@ -140,7 +146,7 @@ performanceGoldens = do
         let performances = calculatePerformance 8 stake production
         Map.lookup poolA performances `shouldBe` (Just 0.5)
 
-    it "50% stake, producing 0/8 blocks => performance=0" $ do
+    it "50% stake, producing 0/8 blocks => performance=0.0" $ do
         let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
         let production = mkProduction [ (poolA, 0), (poolB, 0) ]
         let performances = calculatePerformance 8 stake production
@@ -199,9 +205,8 @@ instance Arbitrary Lovelace where
     arbitrary = do
         n <- choose (0, 100)
         Lovelace <$> frequency
-            [ (50, return n)
-            , (25, return $ minLovelace - n)
-            , (25, choose (minLovelace, maxLovelace))
+            [ (8, return n)
+            , (2, choose (minLovelace, maxLovelace))
             ]
       where
         minLovelace = fromIntegral . getCoin $ minBound @Coin


### PR DESCRIPTION
# Issue Number

Should probably be a bug.

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I fixed the way we calculate `S (number of slots in the epoch)`. 


# Comments

## Comparison

Setup:
```bash
jormungandr --genesis-block-hash 6a40cf890d84981353457fcab6c892af57ee3c3286b33b530cd46b1af5b0e3a7 \
    --rest-listen 127.0.0.1:8080 \
    --storage /Users/Johannes/.local/share/cardano-wallet/jormungandr/testnet/chain \
    --config ../testnet.yml

cardano-wallet-jormungandr serve --genesis-block-hash 6a40cf890d84981353457fcab6c892af57ee3c3286b33b530cd46b1af5b0e3a7 --node-port 8080
```

### Previously (uncapped)

Using the first commit to show the uncapped apparent performances.

```bash
cardano-wallet-jormungandr stake-pool list | jq '.[] | "\(.metrics.controlled_stake.quantity),\(.metrics.produced_blocks.quantity) \(.apparent_performance)"' | tr -d '"'
Ok.
10000000000000,2 2.2908997271066665
10000000000000,2 2.2908997271066665
10000000000000,1 1.1454498635533332
10000000000000,1 1.1454498635533332
799999987900,0 0
10000000000000,0 0
8039991840700,0 0
9886999984600,0 0
```

### Now (uncapped)

```bash
cardano-wallet-jormungandr stake-pool list | jq '.[] | "\(.metrics.controlled_stake.quantity),\(.metrics.produced_blocks.quantity) \(.apparent_performance)"' | tr -d '"'
Ok.
10000000000000,2 0.19636283375199998
10000000000000,2 0.19636283375199998
10000000000000,1 0.09818141687599999
10000000000000,1 0.09818141687599999
799999987900,0 0
10000000000000,0 0
8039991840700,0 0
9886999984600,0 0
```



<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
