### PR TITLE
Can run Windows integration tests under Wine

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # Use pinned Nixpkgs with Haskell.nix overlay
 , pkgs ? import ./nix/nixpkgs-haskell.nix  { inherit system crossSystem config; }
 # Use this git revision for stamping executables
-, gitrev ? iohkLib.commitIdFromGitRepo ./.
+, gitrev ? iohkLib.commitIdFromGitRepo ./.git
 }:
 
 with import ./nix/util.nix { inherit pkgs; };

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -195,6 +195,7 @@ test-suite unit
     , tree-diff
     , unordered-containers
     , yaml
+    , wai
     , warp
   build-tools:
       hspec-discover
@@ -221,6 +222,7 @@ test-suite unit
       Cardano.Wallet.DB.StateMachine
       Cardano.Wallet.DummyTarget.Primitive.Types
       Cardano.Wallet.Network.BlockHeadersSpec
+      Cardano.Wallet.Network.PortsSpec
       Cardano.Wallet.NetworkSpec
       Cardano.Wallet.Primitive.AddressDerivation.ByronSpec
       Cardano.Wallet.Primitive.AddressDerivation.ShelleySpec

--- a/lib/core/src/Cardano/Wallet/Network/Ports.hs
+++ b/lib/core/src/Cardano/Wallet/Network/Ports.hs
@@ -31,6 +31,8 @@ import Control.Monad.IO.Class
     ( liftIO )
 import Control.Retry
     ( RetryPolicyM, retrying )
+import Data.List
+    ( isSubsequenceOf )
 import Data.Streaming.Network
     ( bindRandomPortTCP )
 import Data.Word
@@ -51,7 +53,6 @@ import Network.Socket
     )
 import UnliftIO.Exception
     ( bracket, throwIO, try )
-
 
 -- | Wait until a TCP port is open to connections according to a given retry
 -- policy. Throws an exception if the time out is reached.
@@ -89,10 +90,19 @@ isPortOpen sockAddr = do
     res <- try $ connect sock sockAddr
     case res of
       Right () -> return True
-      Left e ->
-        if (Errno <$> ioe_errno e) == Just eCONNREFUSED
-          then return False
-          else throwIO e
+      Left e
+        | (Errno <$> ioe_errno e) == Just eCONNREFUSED -> pure False
+        | any (`isSubsequenceOf` show e) windowsNetworkError -> pure False
+        | otherwise -> throwIO e
+  where
+    windowsNetworkError :: [String]
+    windowsNetworkError =
+        [ "WSAECONNREFUSED"  -- Connection refused
+        , "WSAEADDRNOTAVAIL" -- Cannot assign requested address
+        , "WSAETIMEDOUT"     -- Connection timed out
+        , "WSAEHOSTUNREACH"  -- Host is unreachable
+        , "WSAEHOSTDOWN"     -- Host is down
+        ]
 
 -- | Creates a `SockAttr` from host IP and port number.
 --

--- a/lib/core/src/Cardano/Wallet/Network/Ports.hs
+++ b/lib/core/src/Cardano/Wallet/Network/Ports.hs
@@ -32,7 +32,7 @@ import Control.Monad.IO.Class
 import Control.Retry
     ( RetryPolicyM, retrying )
 import Data.List
-    ( isSubsequenceOf )
+    ( isInfixOf )
 import Data.Streaming.Network
     ( bindRandomPortTCP )
 import Data.Word
@@ -92,17 +92,8 @@ isPortOpen sockAddr = do
       Right () -> return True
       Left e
         | (Errno <$> ioe_errno e) == Just eCONNREFUSED -> pure False
-        | any (`isSubsequenceOf` show e) windowsNetworkError -> pure False
+        | "WSAECONNREFUSED" `isInfixOf` show e -> pure False
         | otherwise -> throwIO e
-  where
-    windowsNetworkError :: [String]
-    windowsNetworkError =
-        [ "WSAECONNREFUSED"  -- Connection refused
-        , "WSAEADDRNOTAVAIL" -- Cannot assign requested address
-        , "WSAETIMEDOUT"     -- Connection timed out
-        , "WSAEHOSTUNREACH"  -- Host is unreachable
-        , "WSAEHOSTDOWN"     -- Host is down
-        ]
 
 -- | Creates a `SockAttr` from host IP and port number.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Network/PortsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Network/PortsSpec.hs
@@ -1,0 +1,31 @@
+module Cardano.Wallet.Network.PortsSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Network.Ports
+    ( getRandomPort, isPortOpen, simpleSockAddr )
+import Network.HTTP.Types
+    ( status200 )
+import Network.Wai
+    ( responseLBS )
+import Network.Wai.Handler.Warp
+    ( withApplication )
+import Test.Hspec
+    ( Spec, describe, it, shouldReturn )
+
+spec :: Spec
+spec = describe "Cardano.Wallet.Network.Ports" $ do
+    it "isPortOpen detects an available port" $ do
+        port <- getRandomPort
+        isPortOpen (localhost port) `shouldReturn` False
+
+    it "isPortOpen detects a port in use" $ do
+        let app = \_req respond -> respond $ responseLBS status200 [] ""
+        withApplication (pure app) $ \port ->
+            isPortOpen (localhost (fromIntegral port)) `shouldReturn` True
+            
+  where
+    localhost = simpleSockAddr (127,0,0,1)
+     

--- a/lib/core/test/unit/Cardano/Wallet/Network/PortsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Network/PortsSpec.hs
@@ -22,10 +22,10 @@ spec = describe "Cardano.Wallet.Network.Ports" $ do
         isPortOpen (localhost port) `shouldReturn` False
 
     it "isPortOpen detects a port in use" $ do
-        let app = \_req respond -> respond $ responseLBS status200 [] ""
+        let app _req respond = respond $ responseLBS status200 [] ""
         withApplication (pure app) $ \port ->
             isPortOpen (localhost (fromIntegral port)) `shouldReturn` True
-            
+
   where
     localhost = simpleSockAddr (127,0,0,1)
-     
+

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -22,6 +22,8 @@ import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
+import Cardano.Launcher
+    ( withUtf8Encoding )
 import Cardano.Wallet.Api.Server
     ( Listen (..) )
 import Cardano.Wallet.Jormungandr
@@ -52,8 +54,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Text
     ( Text )
-import GHC.IO.Encoding
-    ( mkTextEncoding, setLocaleEncoding )
 import Network.HTTP.Client
     ( defaultManagerSettings
     , managerResponseTimeout
@@ -100,8 +100,7 @@ instance KnownCommand Jormungandr where
     commandName = "cardano-wallet-jormungandr"
 
 main :: forall t. (t ~ Jormungandr) => IO ()
-main = withLogging Nothing Info $ \logging -> do
-    setUtf8LenientCodecs
+main = withUtf8Encoding $ withLogging Nothing Info $ \logging ->
     hspec $ do
         describe "No backend required" $ do
             describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec
@@ -162,11 +161,6 @@ specWithServer logCfg = aroundAll withContext . after tearDown
     withServer setup = withConfig $ \jmCfg ->
         serveWallet @'Testnet logCfg (SyncTolerance 10) Nothing "127.0.0.1"
             ListenOnRandomPort (Launch jmCfg) setup
-
--- | Set a utf8 text encoding that doesn't crash when non-utf8 bytes are
--- encountered.
-setUtf8LenientCodecs :: IO ()
-setUtf8LenientCodecs = mkTextEncoding "UTF-8//IGNORE" >>= setLocaleEncoding
 
 sockAddrPort :: SockAddr -> Port a
 sockAddrPort addr = Port . fromIntegral $ case addr of

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -21,9 +21,7 @@ import Cardano.CLI
 import Cardano.Faucet
     ( initFaucet )
 import Cardano.Launcher
-    ( ProcessHasExited (..) )
-import Cardano.Launcher
-    ( withUtf8Encoding )
+    ( ProcessHasExited (..), withUtf8Encoding )
 import Cardano.Wallet.Api.Server
     ( Listen (..) )
 import Cardano.Wallet.Jormungandr

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -160,6 +160,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
             (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             (hsPkgs."yaml" or (buildDepError "yaml"))
+            (hsPkgs."wai" or (buildDepError "wai"))
             (hsPkgs."warp" or (buildDepError "warp"))
             ];
           build-tools = [

--- a/nix/haskell-nix-src.json
+++ b/nix/haskell-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "7d96b156c53bc86f3ad79d8588575ee0dc774f3c",
-  "date": "2019-11-11T01:01:30+13:00",
-  "sha256": "1nnjz2a0m97sjjq99zixgar7lf4vx1mkjhd80ngx1a7q87f28sa7",
+  "rev": "ef4b453f8d4589cefbab750bcf551e338e8cba91",
+  "date": "2019-11-13T21:57:38+13:00",
+  "sha256": "0qv7k33rfp5791ghqk4l3w8my7arvy486ym3avnqvs5dix6x9czv",
   "fetchSubmodules": false
 }

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -49,7 +49,7 @@ in pkgs.runCommand name {
 
   ${pkgs.lib.concatMapStringsSep "\n" (test: ''
     pkg=`ls -1 ${test}`
-    exe=`cd ${test}; ls -1 $pkg`
+    exe=`cd ${test}/$pkg; ls -1 *.exe`
     name=$pkg-test-$exe
     cp ${test}/$pkg/$exe $name
     echo $name >> tests.bat
@@ -58,7 +58,7 @@ in pkgs.runCommand name {
 
   ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
     pkg=`ls -1 ${bench}`
-    exe=`cd ${bench}; ls -1 $pkg`
+    exe=`cd ${bench}/$pkg; ls -1 *.exe`
     name=$pkg-bench-$exe
     cp ${bench}/$pkg/$exe $name
   '') benchmarks}


### PR DESCRIPTION
Relates to #703.

# Overview

- [ ] It's possible to execute `cardano-wallet-jormungandr:test:integration` under Wine.

# Comments

The tests run on Windows but there is something weird going on with Wine.

![2019-11-12-14-30-53-wine-integration-tests](https://user-images.githubusercontent.com/1019641/68679174-19e1db00-05ab-11ea-9c62-8a30e2807f77.png)

To build and run the tests under wine, use:
```
wine $(nix-build release.nix -A x86_64-pc-mingw32.tests.cardano-wallet-jormungandr.integration.x86_64-linux -o integration-windows)/cardano-wallet-jormungandr-2019.11.7/integration.exe
```
