### PR TITLE
nix: Make a separate testing bundle for windows

### DIFF
--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -1,8 +1,7 @@
 ############################################################################
 # Windows release CARDAN~1.ZIP
 #
-# This bundles up the windows build and its dependencies, adds an
-# example self-node configuration, and some .BAT files for launching,
+# This bundles up the windows build and its dependencies,
 # and sets up the Hydra build artifact.
 #
 ############################################################################
@@ -10,59 +9,16 @@
 { pkgs
 , project
 , cardano-wallet-jormungandr
-, tests ? []
-, benchmarks ? []
 }:
 
 let
-  testData = {
-    core = ../lib/core/test/data;
-    jormungandr = ../lib/jormungandr/test/data;
-  };
-
   name = "cardano-wallet-jormungandr-${project.version}-win64";
-  jm-bat = pkgs.writeText "jm.bat" ''
-    jormungandr.exe --config test\data\jormungandr\config.yaml --genesis-block test\data\jormungandr\block0.bin --secret test\data\jormungandr\secret.yaml
-  '';
-  cw-bat = pkgs.writeText "cw.bat" ''
-    cardano-wallet-jormungandr.exe serve --node-port 8080 --genesis-block-hash HASH --database c:\cardano-wallet-jormungandr\wallets
-  '';
-  launch-bat = pkgs.writeText "launch.bat" ''
-    cardano-wallet-jormungandr.exe launch --genesis-block test\data\jormungandr\block0.bin --state-dir c:\cardano-wallet-jormungandr -- --config test\data\jormungandr\config.yaml --secret test\data\jormungandr\secret.yaml
-  '';
 
-in pkgs.runCommand name {
-  nativeBuildInputs = [ pkgs.zip pkgs.jq pkgs.gnused project.jormungandr-cli ];
-  passthru = { inherit tests benchmarks; };
-} ''
-  mkdir -pv jm jm/test/data $out/nix-support
-  cd jm
+in pkgs.runCommand name { buildInputs = [ pkgs.buildPackages.zip ]; } ''
+  mkdir -p $out/nix-support release
+  cd release
 
-  cp -v ${cardano-wallet-jormungandr}/bin/* .
-  cp -Rv --no-preserve=mode ${testData.core}/* ${testData.jormungandr}/* test/data
-  cp -v ${jm-bat} jm.bat
-  hash="$(jcli genesis hash --input test/data/jormungandr/block0.bin)"
-  sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat
-  sed -e "s/HASH/$hash/" ${launch-bat} > launch.bat
-  sed -e 's/storage:.*/storage: "c:\\cardano-wallet-jormungandr\\chain"/' \
-      ${testData.jormungandr}/jormungandr/config.yaml > config.yaml
-
-  ${pkgs.lib.concatMapStringsSep "\n" (test: ''
-    pkg=`ls -1 ${test}`
-    exe=`cd ${test}; ls -1 $pkg`
-    name=$pkg-test-$exe
-    cp ${test}/$pkg/$exe $name
-    echo $name >> tests.bat
-    echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
-  '') tests}
-
-  ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
-    pkg=`ls -1 ${bench}`
-    exe=`cd ${bench}; ls -1 $pkg`
-    name=$pkg-bench-$exe
-    cp ${bench}/$pkg/$exe $name
-  '') benchmarks}
-
+  cp ${cardano-wallet-jormungandr}/bin/* .
   chmod -R +w .
 
   zip -r $out/${name}.zip .

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -1,0 +1,70 @@
+############################################################################
+# Windows testing bundle
+#
+# This bundles up the windows build and its dependencies, adds an
+# example self-node configuration, and some .BAT files for launching,
+# and sets up the Hydra build artifact.
+#
+############################################################################
+
+{ pkgs
+, project
+, cardano-wallet-jormungandr
+, tests ? []
+, benchmarks ? []
+}:
+
+let
+  testData = {
+    core = ../lib/core/test/data;
+    jormungandr = ../lib/jormungandr/test/data;
+  };
+
+  name = "cardano-wallet-jormungandr-${project.version}-tests-win64";
+  jm-bat = pkgs.writeText "jm.bat" ''
+    jormungandr.exe --config test\data\jormungandr\config.yaml --genesis-block test\data\jormungandr\block0.bin --secret test\data\jormungandr\secret.yaml
+  '';
+  cw-bat = pkgs.writeText "cw.bat" ''
+    cardano-wallet-jormungandr.exe serve --node-port 8080 --genesis-block-hash HASH --database c:\cardano-wallet-jormungandr\wallets
+  '';
+  launch-bat = pkgs.writeText "launch.bat" ''
+    cardano-wallet-jormungandr.exe launch --genesis-block test\data\jormungandr\block0.bin --state-dir c:\cardano-wallet-jormungandr -- --config test\data\jormungandr\config.yaml --secret test\data\jormungandr\secret.yaml
+  '';
+
+in pkgs.runCommand name {
+  nativeBuildInputs = [ pkgs.zip pkgs.gnused project.jormungandr-cli ];
+  passthru = { inherit tests benchmarks; };
+} ''
+  mkdir -pv jm jm/test/data $out/nix-support
+  cd jm
+
+  cp -v ${cardano-wallet-jormungandr}/bin/* .
+  cp -Rv --no-preserve=mode ${testData.core}/* ${testData.jormungandr}/* test/data
+  cp -v ${jm-bat} jm.bat
+  hash="$(jcli genesis hash --input test/data/jormungandr/block0.bin)"
+  sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat
+  sed -e "s/HASH/$hash/" ${launch-bat} > launch.bat
+  sed -e 's/storage:.*/storage: "c:\\cardano-wallet-jormungandr\\chain"/' \
+      ${testData.jormungandr}/jormungandr/config.yaml > config.yaml
+
+  ${pkgs.lib.concatMapStringsSep "\n" (test: ''
+    pkg=`ls -1 ${test}`
+    exe=`cd ${test}; ls -1 $pkg`
+    name=$pkg-test-$exe
+    cp ${test}/$pkg/$exe $name
+    echo $name >> tests.bat
+    echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
+  '') tests}
+
+  ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
+    pkg=`ls -1 ${bench}`
+    exe=`cd ${bench}; ls -1 $pkg`
+    name=$pkg-bench-$exe
+    cp ${bench}/$pkg/$exe $name
+  '') benchmarks}
+
+  chmod -R +w .
+
+  zip -r $out/${name}.zip .
+  echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
+''

--- a/release.nix
+++ b/release.nix
@@ -51,14 +51,21 @@ let
       windows = x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
     };
 
-    # This is used for testing the build on windows.
+    # Windows release ZIP archive
     cardano-wallet-jormungandr-win64 = import ./nix/windows-release.nix {
+      inherit pkgs project;
+      cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+    };
+
+    # This is used for testing the build on windows.
+    cardano-wallet-jormungandr-tests-win64 = import ./nix/windows-testing-bundle.nix {
       inherit pkgs project;
       cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
       tests = collectTests jobs.x86_64-pc-mingw32.tests;
       benchmarks = collectTests jobs.x86_64-pc-mingw32.benchmarks;
     };
 
+    # Fully-static linux binary (placeholder - does not build)
     cardano-wallet-jormungandr-linux64 = let
       name = "cardano-wallet-jormungandr-${project.version}";
       tarname = "${name}-linux64.tar.gz";


### PR DESCRIPTION
Relates to #703.

# Overview

- Moves the test executables and test data out of the windows release zip and into a separate archive.

# Comments

- [release job](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1015/cardano-wallet-jormungandr-win64/latest)
- [testing bundle job](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1015/cardano-wallet-jormungandr-tests-win64/latest)
