### PR TITLE
Update stylish-haskell to latest (v0.9.4.4)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ let
           weeder.components.exes.weeder
           hlint.components.exes.hlint
         ])
-        ++ [ pkgs.haskell-nix.snapshots."lts-13.26".stylish-haskell.components.exes.stylish-haskell ]
+        ++ [(pkgs.callPackage ./nix/stylish-haskell.nix {})]
         ++ (with iohkLib; [ openapi-spec-validator ])
         ++ [ jormungandr jormungandr-cli
              pkgs.pkgconfig pkgs.sqlite-interactive ];

--- a/nix/stylish-haskell.nix
+++ b/nix/stylish-haskell.nix
@@ -1,0 +1,21 @@
+{ lib, runCommand, fetchFromGitHub, haskell-nix }:
+
+let
+  src = fetchFromGitHub {
+    owner = "jaspervdj";
+    repo = "stylish-haskell";
+    rev = "9958a5253a9498c29508895450c4ac47542d5f2a";
+    sha256 = "1lc2q15qdhv7xnawdqbrxcdhmy4m7h9v6z1sg4qpyvhf93b43bix";
+  };
+
+  pkgSet = haskell-nix.mkStackPkgSet {
+    stack-pkgs = (haskell-nix.importAndFilterProject (haskell-nix.callStackToNix {
+      inherit src;
+    })).pkgs;
+    pkg-def-extras = [];
+    modules = [];
+  };
+
+  packages = pkgSet.config.hsPkgs;
+in
+  packages.stylish-haskell.components.exes.stylish-haskell


### PR DESCRIPTION
Updates stylish-haskell to the latest.

I mistakenly thought that the latest version in a Stackage LTS would be recent and downgraded it before.

To test:

```
nix-shell --run "stylish-haskell --version"
```
