### PR TITLE
Add Docker image to Buildkite

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -1,0 +1,62 @@
+# This script will load nix-built docker images of cardano-wallet
+# into the Docker daemon (must be running), and then push to the
+# Docker Hub. Credentials for the hub must already be installed with
+# "docker login".
+
+{ walletPackages ?  import ../default.nix {}
+, pkgs ? walletPackages.pkgs
+
+# Build system's Nixpkgs. We use this so that we have the same docker
+# version as the docker daemon.
+, hostPkgs ? import <nixpkgs> {}
+
+# Dockerhub repository for image tagging.
+, dockerHubRepoName ? null
+}:
+
+with hostPkgs;
+with hostPkgs.lib;
+
+let
+  images = map impureCreated [
+    walletPackages.dockerImage
+  ];
+
+  # Override Docker image, setting its creation date to the current time rather than the unix epoch.
+  impureCreated = image: image.overrideAttrs (oldAttrs: { created = "now"; }) // { inherit (image) version; };
+
+in
+  writeScript "docker-build-push" (''
+    #!${runtimeShell}
+
+    set -euo pipefail
+
+    export PATH=${lib.makeBinPath [ docker gnused ]}
+
+    ${if dockerHubRepoName == null then ''
+    reponame=cardano-wallet
+    username="$(docker info | sed '/Username:/!d;s/.* //')"
+    fullrepo="$username/$reponame"
+    '' else ''
+    fullrepo="${dockerHubRepoName}"
+    ''}
+
+  '' + concatMapStringsSep "\n" (image: ''
+    branch="''${BUILDKITE_BRANCH:-}"
+    tag="''${BUILDKITE_TAG:-}"
+    if [[ -n "$tag" ]] || [[ "$branch" = "rvl/923/docker" ]]; then
+      tag="${image.imageTag}"
+    elif [[ "$branch" = master ]]; then
+      tag="$(echo ${image.imageTag} | sed -e s/${image.version}/''${BUILDKITE_COMMIT:-dev}/)"
+    else
+      echo "Not pushing docker image because this is not a master branch or tag build."
+      exit 0
+    fi
+    echo "Loading ${image}"
+    tagged="$fullrepo:$tag"
+    docker load -i "${image}"
+    if [ "$tagged" != "${image.imageName}:${image.imageTag}" ]; then
+      docker tag "${image.imageName}:${image.imageTag}" "$tagged"
+    fi
+    docker push "$tagged"
+  '') images)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -34,3 +34,10 @@ steps:
     command: 'nix-shell --run "openapi-spec-validator --schema 2.0 specifications/api/swagger.yaml"'
     agents:
       system: x86_64-linux
+
+  - label: 'Docker Image'
+    command:
+      - "nix-build .buildkite/docker-build-push.nix --argstr dockerHubRepoName inputoutput/cardano-wallet -o docker-build-push"
+      - "./docker-build-push"
+    agents:
+      system: x86_64-linux

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,10 @@ let
     tests = collectComponents "tests" isCardanoWallet haskellPackages;
     benchmarks = collectComponents "benchmarks" isCardanoWallet haskellPackages;
 
+    dockerImage = pkgs.callPackage ./nix/docker.nix {
+      inherit (self) cardano-wallet-jormungandr;
+    };
+
     shell = haskellPackages.shellFor {
       name = "cardano-wallet-shell";
       packages = ps: with ps; [

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -1,0 +1,55 @@
+############################################################################
+# Docker image builder
+#
+# To test it out, use:
+#
+#   docker load -i $(nix-build -A dockerImage --no-out-link)
+#   docker run cardano-wallet-jormungandr
+#
+############################################################################
+
+{ runtimeShell, writeScriptBin, runCommand, dockerTools
+
+# The main contents of the image.
+, cardano-wallet-jormungandr
+
+# Other things to include in the image.
+, glibcLocales, iana-etc, bashInteractive, coreutils, utillinux, iproute, iputils, curl, socat
+
+# Used to generate the docker image names
+, repoName ? "inputoutput/cardano-wallet"
+}:
+
+let
+  defaultPort = "8090";
+
+  startScript = writeScriptBin "start-cardano-wallet-jormungandr" ''
+    #!${runtimeShell}
+    set -euo pipefail
+    export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
+    exec ${cardano-wallet-jormungandr}/bin/cardano-wallet-jormungandr "$@"
+  '';
+
+  # Layer of tools which aren't going to change much between versions.
+  baseImage = dockerTools.buildImage {
+    name = "${repoName}-env";
+    contents = [ iana-etc bashInteractive coreutils utillinux iproute iputils curl socat ];
+  };
+
+in
+  dockerTools.buildImage {
+    name = repoName;
+    tag = "${cardano-wallet-jormungandr.version}-jormungandr";
+    fromImage = baseImage;
+    contents = [
+      cardano-wallet-jormungandr
+      startScript
+    ];
+    config = {
+      EntryPoint = [ "start-cardano-wallet-jormungandr" ];
+      # Cmd = [ "--port" defaultPort ];
+      ExposedPorts = {
+        "${defaultPort}/tcp" = {}; # wallet api
+      };
+    };
+  } // { inherit (cardano-wallet-jormungandr) version; }

--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -45,7 +45,6 @@ let
       chmod -R +w $out
       ${setGitRev}
       strip $out/bin/cardano-wallet-jormungandr
-      cp ${jormungandr}/bin/* $out/bin
     '';
 
     darwin = buildCommand [] ''


### PR DESCRIPTION
Relates to #923.

# Overview

Docker lets users run software images which are completely self-contained.
Docker Hub is a public repository from which users can pull images.
 
- Adds a Docker image build for cardano-wallet-jormungandr.
- Adds a Buildkite script for uploading to docker hub.

# Comments

- [x] Needs a [cardano-wallet](https://hub.docker.com/repository/docker/inputoutput/cardano-wallet) repository created on Docker hub.
- [x] Needs to have docker hub credentials installed on buildkite agents ⇒ input-output-hk/iohk-ops#702.
