### PR TITLE
Refactor `(Tx, [TxWitness])` to `SealedTx`

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -185,7 +185,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (LinearFee)
     , Hash (..)
     , Range (..)
-    , SignedTxBinary
+    , SealedTx
     , SlotId (..)
     , SlotParameters (..)
     , SortOrder (..)
@@ -798,7 +798,7 @@ signTx
     -> ArgGenChange s
     -> Passphrase "encryption"
     -> CoinSelection
-    -> ExceptT ErrSignTx IO (Tx, TxMeta, UTCTime, SignedTxBinary)
+    -> ExceptT ErrSignTx IO (Tx, TxMeta, UTCTime, SealedTx)
 signTx ctx wid argGenChange pwd (CoinSelection ins outs chgs) = db & \DBLayer{..} -> do
     withRootKey @_ @s ctx wid pwd ErrSignTxWithRootKey $ \xprv -> do
         mapExceptT atomically $ do
@@ -849,7 +849,7 @@ submitTx
         )
     => ctx
     -> WalletId
-    -> (Tx, TxMeta, SignedTxBinary)
+    -> (Tx, TxMeta, SealedTx)
     -> ExceptT ErrSubmitTx IO ()
 submitTx ctx wid (tx, meta, binary) = db & \DBLayer{..} -> do
     withExceptT ErrSubmitTxNetwork $ postTx nw binary

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -38,7 +38,7 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo
     , Hash (..)
     , PoolId (..)
-    , SignedTxBinary
+    , SealedTx
     , SlotId
     )
 import Control.Concurrent
@@ -114,7 +114,7 @@ data NetworkLayer m target block = NetworkLayer
         -- ^ Get the current network tip from the chain producer
 
     , postTx
-        :: SignedTxBinary -> ExceptT ErrPostTx m ()
+        :: SealedTx -> ExceptT ErrPostTx m ()
         -- ^ Broadcast a transaction to the chain producer
 
     , staticBlockchainParameters

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -38,9 +38,8 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo
     , Hash (..)
     , PoolId (..)
+    , SignedTxBinary
     , SlotId
-    , Tx
-    , TxWitness
     )
 import Control.Concurrent
     ( threadDelay )
@@ -115,7 +114,7 @@ data NetworkLayer m target block = NetworkLayer
         -- ^ Get the current network tip from the chain producer
 
     , postTx
-        :: (Tx, [TxWitness]) -> ExceptT ErrPostTx m ()
+        :: SignedTxBinary -> ExceptT ErrPostTx m ()
         -- ^ Broadcast a transaction to the chain producer
 
     , staticBlockchainParameters

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -43,7 +43,7 @@ module Cardano.Wallet.Primitive.Types
     , Direction(..)
     , TxStatus(..)
     , TxWitness(..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , TransactionInfo (..)
     , FeePolicy (..)
     , txIns
@@ -682,9 +682,9 @@ instance FromText Direction where
 instance ToText Direction where
     toText = toTextFromBoundedEnum SnakeLowerCase
 
--- | @SignedTxBinary@ is a serialised transaction that is ready to be submited
+-- | @SealedTx@ is a serialised transaction that is ready to be submited
 -- to the node.
-newtype SignedTxBinary = SignedTxBinary { getSignedTxBinary :: ByteString }
+newtype SealedTx = SealedTx { getSealedTx :: ByteString }
     deriving stock (Show, Eq, Generic)
     deriving newtype (ByteArrayAccess)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1278,9 +1278,9 @@ class Dom a where
     type DomElem a :: *
     dom :: a -> Set (DomElem a)
 
-newtype Hash (tag :: Symbol) = Hash
-    { getHash :: ByteString
-    } deriving (Show, Generic, Eq, Ord)
+newtype Hash (tag :: Symbol) = Hash { getHash :: ByteString }
+    deriving stock (Show, Generic, Eq, Ord)
+    deriving newtype (ByteArrayAccess)
 
 instance NFData (Hash tag)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -43,6 +43,7 @@ module Cardano.Wallet.Primitive.Types
     , Direction(..)
     , TxStatus(..)
     , TxWitness(..)
+    , SignedTxBinary (..)
     , TransactionInfo (..)
     , FeePolicy (..)
     , txIns
@@ -678,6 +679,11 @@ instance FromText Direction where
 
 instance ToText Direction where
     toText = toTextFromBoundedEnum SnakeLowerCase
+
+-- | @SignedTxBinary@ is a serialised transaction that is ready to be submited
+-- to the node.
+newtype SignedTxBinary = SignedTxBinary { getSignedTxBinary :: ByteString }
+    deriving (Show, Eq, Generic)
 
 -- | @TxWitness@ is proof that transaction inputs are allowed to be spent
 newtype TxWitness = TxWitness { unWitness :: ByteString }

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -160,6 +160,8 @@ import Crypto.Random.Types
     ( MonadRandom )
 import Data.Bifunctor
     ( bimap )
+import Data.ByteArray
+    ( ByteArrayAccess )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
 import Data.ByteString
@@ -683,7 +685,8 @@ instance ToText Direction where
 -- | @SignedTxBinary@ is a serialised transaction that is ready to be submited
 -- to the node.
 newtype SignedTxBinary = SignedTxBinary { getSignedTxBinary :: ByteString }
-    deriving (Show, Eq, Generic)
+    deriving stock (Show, Eq, Generic)
+    deriving newtype (ByteArrayAccess)
 
 -- | @TxWitness@ is proof that transaction inputs are allowed to be spent
 newtype TxWitness = TxWitness { unWitness :: ByteString }

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -43,7 +43,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), Tx (..), TxIn (..), TxOut (..), TxWitness (..) )
+    ( Address (..)
+    , Hash (..)
+    , SignedTxBinary (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxWitness (..)
+    )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity
@@ -60,7 +67,7 @@ data TransactionLayer t k = TransactionLayer
         :: (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
         -> [(TxIn, TxOut)]
         -> [TxOut]
-        -> Either ErrMkStdTx (Tx, [TxWitness])
+        -> Either ErrMkStdTx (Tx, SignedTxBinary)
         -- ^ Construct a standard transaction
         --
         -- " Standard " here refers to the fact that we do not deal with redemption,
@@ -104,7 +111,7 @@ data TransactionLayer t k = TransactionLayer
       -- on its side doesn't support more than 255 inputs or outputs.
 
     , decodeSignedTx
-        :: ByteString -> Either ErrDecodeSignedTx (Tx, [TxWitness])
+        :: ByteString -> Either ErrDecodeSignedTx (Tx, SignedTxBinary)
         -- ^ Decode an externally-signed transaction to the chain producer
     }
 

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Hash (..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
@@ -67,7 +67,7 @@ data TransactionLayer t k = TransactionLayer
         :: (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
         -> [(TxIn, TxOut)]
         -> [TxOut]
-        -> Either ErrMkStdTx (Tx, SignedTxBinary)
+        -> Either ErrMkStdTx (Tx, SealedTx)
         -- ^ Construct a standard transaction
         --
         -- " Standard " here refers to the fact that we do not deal with redemption,
@@ -111,7 +111,7 @@ data TransactionLayer t k = TransactionLayer
       -- on its side doesn't support more than 255 inputs or outputs.
 
     , decodeSignedTx
-        :: ByteString -> Either ErrDecodeSignedTx (Tx, SignedTxBinary)
+        :: ByteString -> Either ErrDecodeSignedTx (Tx, SealedTx)
         -- ^ Decode an externally-signed transaction to the chain producer
     }
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -63,7 +63,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochNo (..)
     , Hash (..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
@@ -433,7 +433,7 @@ dummyTransactionLayer = TransactionLayer
                 (CC.unXPub (getKey $ publicKey xprv) <> sig)
 
         -- (tx1, wit1) == (tx2, wit2) <==> fakebinary1 == fakebinary2
-        let fakeBinary = SignedTxBinary . B8.pack $ show (tx, wit)
+        let fakeBinary = SealedTx . B8.pack $ show (tx, wit)
         return (tx, fakeBinary)
     , estimateSize =
         error "dummyTransactionLayer: estimateSize not implemented"

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -41,7 +41,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , HardDerivation (..)
     , Index
     , Passphrase (..)
-    , WalletKey (..)
     , XPrv
     , publicKey
     )
@@ -64,6 +63,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochNo (..)
     , Hash (..)
+    , SignedTxBinary (..)
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
@@ -351,11 +351,11 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
         let wallet = (wid, wname, DummyState state)
         (WalletLayerFixture _ wl _ _) <- liftIO $ setupFixture wallet
         unsafeRunExceptT $ W.attachPrivateKey wl wid (xprv, pwd)
-        (_,_,_,[witOld]) <- unsafeRunExceptT $ W.signTx @_ @_ @DummyTarget wl wid () pwd selection
+        (_,_,_,txOld) <- unsafeRunExceptT $ W.signTx @_ @_ @DummyTarget wl wid () pwd selection
         unsafeRunExceptT $ W.updateWalletPassphrase wl wid (coerce pwd, newPwd)
-        (_,_,_,[witNew]) <-
+        (_,_,_,txNew) <-
             unsafeRunExceptT $ W.signTx @_ @_ @DummyTarget wl wid () (coerce newPwd) selection
-        witOld `shouldBe` witNew
+        txOld `shouldBe` txNew
   where
     selection = CoinSelection
         [ ( TxIn (Hash "eb4ab6028bd0ac971809d514c92db1") 1
@@ -431,7 +431,10 @@ dummyTransactionLayer = TransactionLayer
             let sig = CC.unXSignature $ CC.sign pwd (getKey xprv) sigData
             return $ TxWitness
                 (CC.unXPub (getKey $ publicKey xprv) <> sig)
-        return (tx, wit)
+
+        -- (tx1, wit1) == (tx2, wit2) <==> fakebinary1 == fakebinary2
+        let fakeBinary = SignedTxBinary . B8.pack $ show (tx, wit)
+        return (tx, fakeBinary)
     , estimateSize =
         error "dummyTransactionLayer: estimateSize not implemented"
     , estimateMaxNumberOfInputs =

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Jormungandr.Api.Types
 import Cardano.Wallet.Jormungandr.Binary
     ( Block )
 import Cardano.Wallet.Primitive.Types
-    ( Tx (..), TxWitness )
+    ( SignedTxBinary (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Servant.API
@@ -87,7 +87,7 @@ type GetTipId
 type PostMessage
     = "api" :> "v0"
     :> "message"
-    :> ReqBody '[JormungandrBinary] (Tx, [TxWitness])
+    :> ReqBody '[JormungandrBinary] SignedTxBinary
     :> Post '[NoContent] NoContent
 
 -- | Retrieve stake distribution

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Jormungandr.Api.Types
 import Cardano.Wallet.Jormungandr.Binary
     ( Block )
 import Cardano.Wallet.Primitive.Types
-    ( SignedTxBinary (..) )
+    ( SealedTx (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Servant.API
@@ -87,7 +87,7 @@ type GetTipId
 type PostMessage
     = "api" :> "v0"
     :> "message"
-    :> ReqBody '[JormungandrBinary] SignedTxBinary
+    :> ReqBody '[JormungandrBinary] SealedTx
     :> Post '[NoContent] NoContent
 
 -- | Retrieve stake distribution

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -70,12 +70,7 @@ import Cardano.Wallet.Network
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
-    , BlockHeader (..)
-    , Hash (..)
-    , SignedTxBinary
-    , SlotLength (..)
-    )
+    ( Block (..), BlockHeader (..), Hash (..), SealedTx, SlotLength (..) )
 import Control.Arrow
     ( left )
 import Control.Exception
@@ -139,7 +134,7 @@ data JormungandrClient m = JormungandrClient
         -> Word
         -> ExceptT ErrGetDescendants m [Hash "BlockHeader"]
     , postMessage
-        :: SignedTxBinary
+        :: SealedTx
         -> ExceptT ErrPostTx m ()
     , getInitialBlockchainParameters
         :: Hash "Genesis"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -73,9 +73,8 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , Hash (..)
+    , SignedTxBinary
     , SlotLength (..)
-    , Tx (..)
-    , TxWitness (..)
     )
 import Control.Arrow
     ( left )
@@ -140,7 +139,7 @@ data JormungandrClient m = JormungandrClient
         -> Word
         -> ExceptT ErrGetDescendants m [Hash "BlockHeader"]
     , postMessage
-        :: (Tx, [TxWitness])
+        :: SignedTxBinary
         -> ExceptT ErrPostTx m ()
     , getInitialBlockchainParameters
         :: Hash "Genesis"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
@@ -33,16 +33,9 @@ module Cardano.Wallet.Jormungandr.Api.Types
 import Prelude
 
 import Cardano.Wallet.Jormungandr.Binary
-    ( Block
-    , FragmentSpec (..)
-    , getBlock
-    , putSignedTx
-    , runGet
-    , runPut
-    , withHeader
-    )
+    ( Block, getBlock, runGet )
 import Cardano.Wallet.Primitive.Types
-    ( EpochNo (..), Hash (..), PoolId (..), ShowFmt (..), Tx (..), TxWitness )
+    ( EpochNo (..), Hash (..), PoolId (..), ShowFmt (..), SignedTxBinary (..) )
 import Control.Applicative
     ( many )
 import Control.Monad
@@ -154,9 +147,8 @@ instance Accept JormungandrBinary where
 instance MimeUnrender JormungandrBinary Block where
     mimeUnrender _ = pure . runGet getBlock
 
-instance MimeRender JormungandrBinary (Tx, [TxWitness]) where
-    mimeRender _ (Tx _ ins outs, wits) =
-        runPut $ withHeader FragmentTransaction $ putSignedTx ins outs wits
+instance MimeRender JormungandrBinary SignedTxBinary where
+    mimeRender _ (SignedTxBinary bytes) = BL.fromStrict bytes
 
 data Hex
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
@@ -35,7 +35,7 @@ import Prelude
 import Cardano.Wallet.Jormungandr.Binary
     ( Block, getBlock, runGet )
 import Cardano.Wallet.Primitive.Types
-    ( EpochNo (..), Hash (..), PoolId (..), ShowFmt (..), SignedTxBinary (..) )
+    ( EpochNo (..), Hash (..), PoolId (..), SealedTx (..), ShowFmt (..) )
 import Control.Applicative
     ( many )
 import Control.Monad
@@ -147,8 +147,8 @@ instance Accept JormungandrBinary where
 instance MimeUnrender JormungandrBinary Block where
     mimeUnrender _ = pure . runGet getBlock
 
-instance MimeRender JormungandrBinary SignedTxBinary where
-    mimeRender _ (SignedTxBinary bytes) = BL.fromStrict bytes
+instance MimeRender JormungandrBinary SealedTx where
+    mimeRender _ (SealedTx bytes) = BL.fromStrict bytes
 
 data Hex
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -41,6 +41,9 @@ module Cardano.Wallet.Jormungandr.Binary
     , putTx
     , putStakeDelegationTx
 
+    -- * Fragment construction
+    , signedTransactionFragment
+
     -- * Transaction witnesses
     , signData
     , utxoWitness
@@ -90,6 +93,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Hash (..)
     , PoolId (..)
+    , SignedTxBinary (..)
     , SlotId (..)
     , SlotNo (..)
     , Tx (..)
@@ -348,6 +352,19 @@ getInitial = label "getInitial" $ do
 {-------------------------------------------------------------------------------
                                 Transactions
 -------------------------------------------------------------------------------}
+
+-- | Glues together a tx, witnesses into a full @SignedTxBinary@.
+--
+-- NOTE: For constructing a tx from scratch this is a rather inconvenient
+-- function. It relies on you already having the txId and the witnesses.
+--
+-- TODO: We should create a more convenient alternative taking only inputs,
+-- outputs and key-lookup function.
+signedTransactionFragment :: Tx -> [TxWitness] -> SignedTxBinary
+signedTransactionFragment (Tx _ ins outs) wits = SignedTxBinary
+    $ BL.toStrict
+    $ runPut
+    $ withHeader FragmentTransaction (putSignedTx ins outs wits)
 
 data AccountType
     = SingleAccount

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -93,7 +93,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Hash (..)
     , PoolId (..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , SlotId (..)
     , SlotNo (..)
     , Tx (..)
@@ -353,15 +353,15 @@ getInitial = label "getInitial" $ do
                                 Transactions
 -------------------------------------------------------------------------------}
 
--- | Glues together a tx, witnesses into a full @SignedTxBinary@.
+-- | Glues together a tx, witnesses into a full @SealedTx@.
 --
 -- NOTE: For constructing a tx from scratch this is a rather inconvenient
 -- function. It relies on you already having the txId and the witnesses.
 --
 -- TODO: We should create a more convenient alternative taking only inputs,
 -- outputs and key-lookup function.
-signedTransactionFragment :: Tx -> [TxWitness] -> SignedTxBinary
-signedTransactionFragment (Tx _ ins outs) wits = SignedTxBinary
+signedTransactionFragment :: Tx -> [TxWitness] -> SealedTx
+signedTransactionFragment (Tx _ ins outs) wits = SealedTx
     $ BL.toStrict
     $ runPut
     $ withHeader FragmentTransaction (putSignedTx ins outs wits)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -103,7 +103,7 @@ newTransactionLayer (Hash block0H) = TransactionLayer
         case runGetOrFail getFragment (BL.fromStrict payload) of
             Left _ -> Left errInvalidPayload
             Right (_,_,msg) -> case msg of
-                Transaction (tx, _) -> return (tx, SignedTxBinary payload)
+                Transaction tx -> return (tx, SignedTxBinary payload)
                 _ -> Left errInvalidPayload
 
     -- NOTE

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), SignedTxBinary (..), Tx (..), TxOut (..), TxWitness (..) )
+    ( Hash (..), SealedTx (..), Tx (..), TxOut (..), TxWitness (..) )
 import Cardano.Wallet.Transaction
     ( ErrDecodeSignedTx (..)
     , ErrMkStdTx (..)
@@ -103,7 +103,7 @@ newTransactionLayer (Hash block0H) = TransactionLayer
         case runGetOrFail getFragment (BL.fromStrict payload) of
             Left _ -> Left errInvalidPayload
             Right (_,_,msg) -> case msg of
-                Transaction tx -> return (tx, SignedTxBinary payload)
+                Transaction tx -> return (tx, SealedTx payload)
                 _ -> Left errInvalidPayload
 
     -- NOTE

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -65,7 +65,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Hash (..)
     , PoolId (..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , SlotId (..)
     , Tx (..)
     , TxIn (..)
@@ -372,7 +372,7 @@ spec = do
                         $ withHeader FragmentTransaction
                         $ putSignedTx inps outs wits
                 let bin = BL.toStrict $ encode signedTx
-                decodeSignedTx tl bin `shouldBe` Right (tx, SignedTxBinary bin)
+                decodeSignedTx tl bin `shouldBe` Right (tx, SealedTx bin)
 
         it "decodeExternalTx throws an exception when binary blob has non-\
             \transaction-type header or is wrongly constructed binary blob" $

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -493,5 +493,5 @@ fixtureExternalTx ctx toSend = do
              )
 
 txToBase :: SignedTxBinary -> Base -> Text
-txToBase (SignedTxBinary bin) base =
-    T.decodeUtf8 $ convertToBase base bin
+txToBase tx base =
+    T.decodeUtf8 $ convertToBase base tx

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -277,10 +277,7 @@ spec = do
        \wrong binary format" $ \ctx -> do
         let toSend = 1 :: Natural
         (ExternalTxFixture _ _ _ bin _) <- fixtureExternalTx ctx toSend
-        let baseOk = Base16
-        let wronglyEncodedSignedTx = T.decodeUtf8 $ convertToBase baseOk bin
-        let payload = NonJson $ BL.fromStrict $
-                (toRawBytes baseOk) wronglyEncodedSignedTx
+        let payload = NonJson $ BL.fromStrict $ ("\NUL\NUL"<>) $ getSealedTx bin
         let headers = Headers [ ("Content-Type", "application/octet-stream") ]
         r <- request @ApiTxId ctx postExternalTxEp headers payload
         verify r

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -37,13 +37,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, mkSeqState )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..)
-    , SignedTxBinary (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxOut (..)
-    , WalletId
-    )
+    ( Coin (..), SealedTx (..), Tx (..), TxIn (..), TxOut (..), WalletId )
 import Cardano.Wallet.Transaction
     ( TransactionLayer (..) )
 import Control.Monad
@@ -399,7 +393,7 @@ data ExternalTxFixture = ExternalTxFixture
     { srcWallet :: ApiWallet
     , dstWallet :: ApiWallet
     , feeMin :: Natural
-    , txBinary :: SignedTxBinary
+    , txBinary :: SealedTx
     , txTx :: Tx
     }
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Primitive.Types
 import Data.Binary.Put
     ( putByteString )
 import Data.ByteArray.Encoding
-    ( Base (Base16, Base64) )
+    ( Base (Base16, Base64), convertToBase )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Proxy
@@ -60,10 +60,11 @@ import Test.Integration.Framework.TestData
     , errMsg403NoPendingAnymore
     )
 import Test.Integration.Jormungandr.Scenario.API.Transactions
-    ( ExternalTxFixture (..), fixtureExternalTx, txToBase )
+    ( ExternalTxFixture (..), fixtureExternalTx )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
 
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -95,7 +96,7 @@ spec = do
         (ExternalTxFixture _ wDest _ bin tx) <-
             fixtureExternalTx @t ctx toSend
         let baseOk = Base16
-        let arg = T.unpack $ txToBase bin baseOk
+        let arg = B8.unpack $ convertToBase baseOk bin
         let expectedTxId = T.decodeUtf8 $ hex . getHash $ txId tx
 
         -- post external transaction
@@ -121,7 +122,7 @@ spec = do
         let toSend = 1 :: Natural
         (ExternalTxFixture _ _ _ bin _) <- fixtureExternalTx @t ctx toSend
         let baseWrong = Base64
-        let argWrong = T.unpack $ txToBase bin baseWrong
+        let argWrong = B8.unpack $ convertToBase baseWrong bin
         -- post external transaction
         (Exit code1, Stdout out1, Stderr err1) <-
             postExternalTransactionViaCLI @t ctx [argWrong]
@@ -140,7 +141,7 @@ spec = do
 
         let wrongTx = addHeader bin
         let baseOk = Base16
-        let arg = T.unpack $ txToBase wrongTx baseOk
+        let arg = B8.unpack $ convertToBase baseOk wrongTx
 
         -- post external transaction
         (Exit code, Stdout out, Stderr err) <-

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
@@ -12,14 +12,10 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiTxId (..), ApiWallet, getApiT )
-import Cardano.Wallet.Jormungandr.Binary
-    ( FragmentSpec (..), runPut, withHeader )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), hex )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), SignedTxBinary (..), Tx (..) )
-import Data.Binary.Put
-    ( putByteString )
+    ( Hash (..), Tx (..) )
 import Data.ByteArray.Encoding
     ( Base (Base16, Base64), convertToBase )
 import Data.Generics.Internal.VL.Lens
@@ -132,22 +128,11 @@ spec = do
 
     it "TRANS_EXTERNAL_CREATE_03 - proper single output transaction and \
        \wrong binary format" $ \ctx -> do
-        let toSend = 1 :: Natural
-        (ExternalTxFixture _ _ _ bin _) <- fixtureExternalTx ctx toSend
-
-        let run = SignedTxBinary . BL.toStrict . runPut
-        let putBin (SignedTxBinary bs) = putByteString bs
-        let addHeader = run . (withHeader FragmentTransaction) . putBin
-
-        let wrongTx = addHeader bin
-        let baseOk = Base16
-        let arg = B8.unpack $ convertToBase baseOk wrongTx
-
-        -- post external transaction
-        (Exit code, Stdout out, Stderr err) <-
-            postExternalTransactionViaCLI @t ctx [arg]
+        let invalidArg = "0000"
+        (Exit code, Stdout out, Stderr err)
+            <- postExternalTransactionViaCLI @t ctx [invalidArg]
         err `shouldContain` errMsg400MalformedTxPayload
-        out `shouldBe` ""
+        out `shouldBe` mempty
         code `shouldBe` ExitFailure 1
 
     it "TRANS_DELETE_05 - Cannot forget external tx via CLI" $ \ctx -> do

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -151,7 +151,7 @@ spec = do
                 let decode =
                         unFragment . runGet getFragment
                 tx' <- try' (decode $ encode signedTx)
-                if tx' == Right signedTx
+                if tx' == Right (fst signedTx)
                 then return ()
                 else expectationFailure $
                     "tx /= decode (encode tx) == " ++ show tx'
@@ -167,18 +167,18 @@ spec = do
                 let decode =
                         getStakeDelegationTxFragment . runGet getFragment
                 tx' <- try' (decode encode)
-                if tx' == Right (poolId, accId, tx, wits)
+                if tx' == Right (poolId, accId, tx)
                 then return ()
                 else expectationFailure $
                     "tx /= decode (encode tx) == " ++ show tx'
   where
-    unFragment :: Fragment -> (Tx, [TxWitness])
+    unFragment :: Fragment -> Tx
     unFragment m = case m of
         Transaction stx -> stx
         _ -> error "expected a Transaction message"
 
     getStakeDelegationTxFragment
-        :: Fragment -> (PoolId, ChimericAccount, Tx, [TxWitness])
+        :: Fragment -> (PoolId, ChimericAccount, Tx)
     getStakeDelegationTxFragment m = case m of
         StakeDelegation stx -> stx
         _ -> error "expected a Transaction message"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -38,7 +38,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
     , Hash (..)
-    , SignedTxBinary (..)
+    , SealedTx (..)
     , TxIn (..)
     , TxOut (..)
     )
@@ -437,7 +437,7 @@ goldenTestStdTx
     -> SpecWith ()
 goldenTestStdTx tl keystore inps outs bytes' = it title $ do
     let tx = mkStdTx tl keystore inps outs
-    let bytes = hex . getSignedTxBinary . snd <$> tx
+    let bytes = hex . getSealedTx . snd <$> tx
     bytes `shouldBe` Right bytes'
   where
     title = "golden test mkStdTx: " <> show inps <> show outs

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -13,8 +13,6 @@ module Cardano.Wallet.Jormungandr.TransactionSpec
 
 import Prelude
 
-import Cardano.Wallet.Jormungandr.Binary
-    ( FragmentSpec (..), putSignedTx, runPut, withHeader )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Transaction
@@ -37,7 +35,13 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), Hash (..), Tx (..), TxIn (..), TxOut (..) )
+    ( Address (..)
+    , Coin (..)
+    , Hash (..)
+    , SignedTxBinary (..)
+    , TxIn (..)
+    , TxOut (..)
+    )
 import Cardano.Wallet.Transaction
     ( ErrMkStdTx (..), TransactionLayer (..) )
 import Cardano.Wallet.TransactionSpecShared
@@ -60,7 +64,6 @@ import Test.QuickCheck
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
 import qualified Data.ByteArray as BA
-import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
@@ -434,13 +437,7 @@ goldenTestStdTx
     -> SpecWith ()
 goldenTestStdTx tl keystore inps outs bytes' = it title $ do
     let tx = mkStdTx tl keystore inps outs
-    let bytes = fmap
-            (\(Tx _ i o, w) -> hex
-                $ BL.toStrict
-                $ runPut
-                $ withHeader FragmentTransaction
-                $ putSignedTx i o w)
-            tx
+    let bytes = hex . getSignedTxBinary . snd <$> tx
     bytes `shouldBe` Right bytes'
   where
     title = "golden test mkStdTx: " <> show inps <> show outs


### PR DESCRIPTION
# Issue Number

Intended to aid #893, and #1021 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] We don't need to deal with the intermediary `(Tx, [TxWitness])` before serialising that to binary. By serialising to binary early on, we won't need to pass around a `(payload, tx, wits, auth)` to serialise certificate txs.

# Comments

- Think there is still low-hanging fruit for improving tx-construction in tests which I'm leaving alone here
- https://input-output-rnd.slack.com/archives/GBT05825V/p1573652690032900

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
