### PR TITLE
Fix SlotNo Word16 Overflow

### DIFF
--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -86,7 +86,7 @@ import Data.Either.Extra
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
-    ( Word16, Word64, Word8 )
+    ( Word32, Word64, Word8 )
 import Debug.Trace
     ( traceShow )
 
@@ -374,7 +374,7 @@ decodeMainBlockHeader = do
         , parentHeaderHash = previous
         }
 
-decodeMainConsensusData :: CBOR.Decoder s ((Word64, Word16), Word64)
+decodeMainConsensusData :: CBOR.Decoder s ((Word64, Word32), Word64)
 decodeMainConsensusData = do
     _ <- CBOR.decodeListLenCanonicalOf 4
     slot <- decodeSlotId
@@ -472,11 +472,11 @@ decodeSharesProof = do
     _ <- CBOR.decodeBytes -- Vss Certificates Hash
     return ()
 
-decodeSlotId :: CBOR.Decoder s (Word64, Word16)
+decodeSlotId :: CBOR.Decoder s (Word64, Word32)
 decodeSlotId = do
     _ <- CBOR.decodeListLenCanonicalOf 2
     epoch <- CBOR.decodeWord64
-    slot <- CBOR.decodeWord16
+    slot <- fromIntegral <$> CBOR.decodeWord16
     return (epoch, slot)
 
 decodeSoftwareVersion :: CBOR.Decoder s ()

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -134,7 +134,7 @@ Checkpoint
     checkpointGenesisStart   UTCTime      sql=genesis_start
     checkpointFeePolicy      W.FeePolicy  sql=fee_policy
     checkpointSlotLength     Word64       sql=slot_length
-    checkpointEpochLength    Word16       sql=epoch_length
+    checkpointEpochLength    Word32       sql=epoch_length
     checkpointTxMaxSize      Word16       sql=tx_max_size
     checkpointEpochStability Word32       sql=epoch_stability
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -77,7 +77,7 @@ import Data.Text.Class
     , getTextDecodingError
     )
 import Data.Word
-    ( Word16, Word64, Word8 )
+    ( Word64, Word8 )
 import Database.Persist.Sqlite
     ( PersistField (..), PersistFieldSql (..), PersistValue )
 import Database.Persist.TH
@@ -258,9 +258,9 @@ instance PersistFieldSql SlotId where
 -- | As a short-to-medium term solution of persisting 'SlotId', we use
 -- 'flatSlot' with an artificial epochLength. I.e. /not the same epochLength as
 -- the blockchain/. This is just for the sake of storing the 64 bit epoch and
--- the 16 bit slot inside a single 64-bit field.
+-- the 32-bit slot inside a single 64-bit field.
 artificialEpochLength :: EpochLength
-artificialEpochLength = EpochLength $ fromIntegral (maxBound :: Word16)
+artificialEpochLength = EpochLength maxBound
 
 instance PersistField SlotId where
     toPersistValue = toPersistValue . flatSlot artificialEpochLength

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -492,6 +492,8 @@ instance MonadRandom ((->) (Passphrase "salt")) where
 data NetworkDiscriminant = Mainnet | Testnet
     deriving (Generic, Show, Eq, Bounded, Enum)
 
+instance NFData NetworkDiscriminant
+
 instance FromText NetworkDiscriminant where
     fromText = fromTextToBoundedEnum SnakeLowerCase
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -681,7 +681,9 @@ instance ToText Direction where
 
 -- | @TxWitness@ is proof that transaction inputs are allowed to be spent
 newtype TxWitness = TxWitness { unWitness :: ByteString }
-    deriving (Show, Eq, Ord)
+    deriving (Generic, Show, Eq, Ord)
+
+instance NFData TxWitness
 
 -- | True if the given tuple refers to a pending transaction
 isPending :: TxMeta -> Bool
@@ -1250,7 +1252,9 @@ newtype ProtocolMagic = ProtocolMagic Int32
 -- | Also known as a staking key, chimeric account is used in group-type address
 -- for staking purposes. It is a public key of the account address
 newtype ChimericAccount = ChimericAccount ByteString
-    deriving (Show, Eq)
+    deriving (Generic, Show, Eq)
+
+instance NFData ChimericAccount
 
 {-------------------------------------------------------------------------------
                                Polymorphic Types

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -196,7 +196,7 @@ import Data.Text.Class
 import Data.Time.Clock
     ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
 import Data.Word
-    ( Word16, Word32, Word64 )
+    ( Word32, Word64 )
 import Fmt
     ( Buildable (..)
     , blockListF
@@ -985,7 +985,7 @@ data SlotId = SlotId
   , slotNumber :: !SlotNo
   } deriving stock (Show, Read, Eq, Ord, Generic)
 
-newtype SlotNo = SlotNo { unSlotNo :: Word16 }
+newtype SlotNo = SlotNo { unSlotNo :: Word32 }
     deriving stock (Show, Read, Eq, Ord, Generic)
     deriving newtype (Num, Buildable, NFData, Enum)
 
@@ -1227,7 +1227,7 @@ newtype SlotLength = SlotLength NominalDiffTime
 instance NFData SlotLength
 
 -- | Number of slots in a single epoch
-newtype EpochLength = EpochLength Word16
+newtype EpochLength = EpochLength Word32
     deriving (Show, Eq, Generic)
 
 instance NFData EpochLength

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -135,6 +135,7 @@ test-suite unit
     , cardano-wallet-core-integration
     , cardano-wallet-jormungandr
     , containers
+    , deepseq
     , directory
     , filepath
     , fmt

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -91,6 +91,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , PoolId (..)
     , SlotId (..)
+    , SlotNo (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
@@ -202,7 +203,7 @@ getBlockHeader = label "getBlockHeader" $ do
         version <- getWord16be
         contentSize <- getWord32be
         slotEpoch <- fromIntegral <$> getWord32be
-        slotId <- toEnum . fromEnum <$> getWord32be
+        slotNo <- SlotNo <$> getWord32be
         chainLength <- getWord32be
         contentHash <- Hash <$> getByteString 32 -- or 256 bits
         parentHeaderHash <- Hash <$> getByteString 32
@@ -233,7 +234,7 @@ getBlockHeader = label "getBlockHeader" $ do
         return $ BlockHeader
             { version
             , contentSize
-            , slot = SlotId { epochNumber = slotEpoch, slotNumber = slotId }
+            , slot = SlotId { epochNumber = slotEpoch, slotNumber = slotNo }
             , chainLength
             , contentHash
             , parentHeaderHash
@@ -595,7 +596,7 @@ getConfigParam = label "getConfigParam" $ do
         2 -> Block0Date . W.StartTime . posixSecondsToUTCTime . fromIntegral
             <$> getWord64be
         3 -> Consensus <$> getConsensusVersion
-        4 -> SlotsPerEpoch . W.EpochLength . fromIntegral  <$> getWord32be
+        4 -> SlotsPerEpoch . W.EpochLength <$> getWord32be
         5 -> SlotDuration . secondsToNominalDiffTime <$> getWord8
         6 -> EpochStabilityDepth . Quantity <$> getWord32be
         8 -> ConsensusGenesisPraosParamF <$> getMilli

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -97,6 +98,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Transaction
     ( EstimateMaxNumberOfInputsParams (..) )
+import Control.DeepSeq
+    ( NFData )
 import Control.Monad
     ( replicateM, unless )
 import Control.Monad.Loops
@@ -145,6 +148,8 @@ import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime )
 import Data.Word
     ( Word16, Word32, Word64, Word8 )
+import GHC.Generics
+    ( Generic )
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.ByteArray as BA
@@ -177,12 +182,16 @@ data BlockHeader = BlockHeader
     , producedBy :: Maybe PoolId
         -- ^ Will contain the VRFPubKey of the stake pool for non-genesis
         -- Genesis/Praos blocks.
-    } deriving (Show, Eq)
+    } deriving (Show, Eq, Generic)
+
+instance NFData BlockHeader
 
 data Block = Block
     { header :: BlockHeader
     , messages :: [Message]
-    } deriving (Eq, Show)
+    } deriving (Show, Eq, Generic)
+
+instance NFData Block
 
 getBlockHeader :: Get BlockHeader
 getBlockHeader = label "getBlockHeader" $ do
@@ -263,7 +272,9 @@ data Message
     -- ^ A signed transaction with stake pool delegation
     | UnimplementedMessage Int
     -- Messages not yet supported go there.
-    deriving (Eq, Show)
+    deriving (Generic, Eq, Show)
+
+instance NFData Message
 
 data MessageType
     = MsgTypeInitial
@@ -564,7 +575,9 @@ data ConfigParam
     -- ^ Maximum number of seconds per update for KES keys known by the system
     -- after start time.
     | UnimplementedConfigParam  Word16
-    deriving (Eq, Show)
+    deriving (Generic, Eq, Show)
+
+instance NFData ConfigParam
 
 getConfigParam :: Get ConfigParam
 getConfigParam = label "getConfigParam" $ do
@@ -611,13 +624,19 @@ getConfigParam = label "getConfigParam" $ do
 -- | Used to represent (>= 0) rational numbers as (>= 0) integers, by just
 -- multiplying by 1000. For instance: '3.141592' is represented as 'Milli 3142'.
 newtype Milli = Milli Word64
-    deriving (Eq, Show)
+    deriving (Generic, Eq, Show)
+
+instance NFData Milli
 
 newtype LeaderId = LeaderId ByteString
-    deriving (Eq, Show)
+    deriving (Generic, Eq, Show)
+
+instance NFData LeaderId
 
 data ConsensusVersion = BFT | GenesisPraos
-    deriving (Eq, Show)
+    deriving (Generic, Eq, Show)
+
+instance NFData ConsensusVersion
 
 getConsensusVersion :: Get ConsensusVersion
 getConsensusVersion = label "getConsensusVersion" $ getWord16be >>= \case

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -133,6 +133,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cardano-wallet-core-integration" or (buildDepError "cardano-wallet-core-integration"))
             (hsPkgs."cardano-wallet-jormungandr" or (buildDepError "cardano-wallet-jormungandr"))
             (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."deepseq" or (buildDepError "deepseq"))
             (hsPkgs."directory" or (buildDepError "directory"))
             (hsPkgs."filepath" or (buildDepError "filepath"))
             (hsPkgs."fmt" or (buildDepError "fmt"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1025 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a regression test and... didn't saw it fail until I forced the evaluation to WHNF :'( (alternatively, could have added a bang `!` on the BlockHeader field, but I thought we might as well check everything!)

- [x] I have fixed the slot no to be `Word16`

# Comments

<!-- Additional comments or screenshots to attach if any -->

We still use this `flatSlot` to store the slot id into the database. This means that in practice, the `Epoch` can't be greater than `2^32 = 4294967296`, which, if we had a new epoch every seconds which still give us `3268` years to find a better solution to this problem.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
