### PR TITLE
Fix the initial sleep delay in the chain following

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -282,6 +282,7 @@ follow nl tr cps yield rollback header =
     delay0 = 1000*1000 -- 1 second
 
     retryDelay :: Int -> Int
+    retryDelay 0 = delay0
     retryDelay delay = min (2*delay) (60 * delay0)
 
     -- | Wait a short delay before querying for blocks again. We also take this


### PR DESCRIPTION

# Issue Number

#1027


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have changed the initial sleep delay from `0` to `1 s`.


# Comments

- Minor downside: we sleep for the initial delay on startup.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
