### PR TITLE
Make sure application exits when Daedalus IPC channel closes

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -37,7 +37,7 @@ import System.Process
     , withCreateProcess
     )
 import Test.Hspec
-    ( SpecWith, describe, it, pendingWith, runIO )
+    ( SpecWith, describe, it, runIO )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain, shouldReturn )
 import Test.Integration.Framework.DSL
@@ -86,14 +86,12 @@ spec = do
         let filepath = "test/integration/js/mock-daedalus.js"
 
         it "Should reply with the port --random" $ \ctx -> do
-            pendingWith "Seems to cause some sort of race condition with --coverage"
             let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
                     ++ ["--random-port"]
             (_, _, _, ph) <- createProcess (proc filepath scriptArgs)
             waitForProcess ph `shouldReturn` ExitSuccess
 
         it "Should reply with the port --random" $ \ctx -> do
-            pendingWith "Seems to cause some sort of race condition with --coverage"
             walletPort <- findPort
             let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
                     ++ ["--port", show walletPort]

--- a/lib/jormungandr/test/integration/js/mock-daedalus.js
+++ b/lib/jormungandr/test/integration/js/mock-daedalus.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 
-// This runs cardano-wallet-launcher in the same way that Daedalus would.
-// It needs node, cardano-wallet, and cardano-wallet-launcher on the PATH to run.
+// This runs cardano-wallet in the same way that Daedalus would.
+// It needs node and cardano-wallet on the PATH to run.
 
 const child_process = require("child_process");
 const http = require('http');
 
 function main() {
+  // prevent coverage reports from clobbering each other
+  process.env.HPCTIXFILE = "nodejs.tix";
+
   let args = process.argv.slice(3);
   const proc = child_process.spawn(process.argv[2], args,
     { stdio: ["ignore", "inherit", "inherit", "ipc"] }


### PR DESCRIPTION
# Issue Number

TBA

# Overview

The wallet was failing to exit in time if the DaedalusIPC channel was disconnected during jormungandr's bootstrap phase. This was because it was waiting for bootstrap to complete before exiting.

- This change makes the wallet exit as soon as the DaedalusIPC channel is closed.

# Comments

- I have undisabled the integration test for DaedalusIPC and added a patch that should hopefully prevent the random test failures due to HPC.
