### PR TITLE
Fix underflow in performance calculation

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -79,21 +79,21 @@ spec = do
                 , expectListItemFieldBetween 0
                     (metrics . blocks) (1, 2)
                 , expectListItemFieldBetween 0
-                    apparentPerformance (0, 1)
+                    apparentPerformance (0.8, 1)
 
                 , expectListItemFieldEqual 1
                     (metrics . stake) 1
                 , expectListItemFieldEqual 1
                     (metrics . blocks) 0
-                , expectListItemFieldBetween 1
-                    apparentPerformance (0, 1)
+                , expectListItemFieldEqual 2
+                    apparentPerformance 0
 
                 , expectListItemFieldEqual 2
                     (metrics . stake) 1
                 , expectListItemFieldEqual 2
                     (metrics . blocks) 0
-                , expectListItemFieldBetween 2
-                    apparentPerformance (0, 1)
+                , expectListItemFieldEqual 2
+                    apparentPerformance 0
                 ]
 
     it "STAKE_POOLS_LIST_02 - May fail on epoch boundaries" $ \ctx -> do


### PR DESCRIPTION
# Issue Number

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed underflow by converting from `EpochNo` to `Int` and back.
- [x] I made integration tests stronger. ⚠️ Does not catch the bug however, as the current epoch is too high. (needs to be 14 or lower to underflow)


# Comments

- Oops.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
