### PR TITLE
Fix DaedalusIPC race-condition when sending 'Started' too quickly

### DIFF
--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -91,7 +91,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Concurrent
-    ( forkFinally, threadDelay )
+    ( forkFinally )
 import Control.Concurrent.Async
     ( race )
 import Control.DeepSeq
@@ -160,14 +160,7 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
         Left e -> handleApiServerStartupError e
         Right (wPort, socket) -> either (const ExitSuccess) id <$> do
             let tracerIPC = appendName "daedalus-ipc" tr
-            -- FIXME
-            -- There's an ugly pause of 1s here for lack of a better fix. There
-            -- seem to be a race-condition on Daedalus' side which isn't able to
-            -- pick up the 'Started' message if we send it too quickly...
-            -- There shouldn't be any issue for us to resend the 'Started'
-            -- message multiple time if we haven't received 'QueryPort' after a
-            -- while and that would be a better way to fix this!
-            race (threadDelay oneSecond *> daedalusIPC tracerIPC wPort) $ do
+            race (daedalusIPC tracerIPC wPort) $ do
                 withNetworkLayer tr lj $ \case
                     Left e -> handleNetworkStartupError e
                     Right (cp, nl) -> do
@@ -319,10 +312,6 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
 --------------------------------------------------------------------------------
 -- Exported Utilities
 --------------------------------------------------------------------------------
-
--- | One second in micro seconds
-oneSecond :: Int
-oneSecond = 1000 * 1000
 
 -- | Covert a raw block to one that the "Cardano.Pool.Metrics" module accepts.
 toSPBlock :: J.Block -> Pool.Block

--- a/lib/jormungandr/test/integration/js/mock-daedalus.js
+++ b/lib/jormungandr/test/integration/js/mock-daedalus.js
@@ -35,34 +35,42 @@ function main() {
     process.exit(4);
   });
 
-  proc.on("message", function(msg) {
-    console.log("JS: message received", msg);
-    // See CardanoNode.js in Daedalus for the message types in use.
-    if (msg.Started) {
-      console.log("JS: sending a bogus message");
-      proc.send("hello");
-    } else if (msg.ParseError && msg.ParseError.match(/encountered String/)) {
-      console.log("JS: sending QueryPort");
-      proc.send({ QueryPort: [] });
-    } else if (msg.ParseError) {
-      console.log("JS: i did not expect that");
-      process.exit(5);
-    } else if (msg.ReplyPort) {
-      http.get({
-        hostname: "localhost",
-        port: msg.ReplyPort,
-        path: "/v2/wallets",
-        agent: false
-      }, (res) => {
-        console.log("JS: response from wallet: " + res.statusCode);
-        res.resume();
-        res.on("end", () => {
-          console.log("JS: request response from wallet finished, exiting.");
-          process.exit(0);
+
+  const installHandler = () => {
+    proc.on("message", function(msg) {
+      console.log("JS: message received", msg);
+      // See CardanoNode.js in Daedalus for the message types in use.
+      if (msg.Started) {
+        console.log("JS: sending a bogus message");
+        proc.send("hello");
+      } else if (msg.ParseError && msg.ParseError.match(/encountered String/)) {
+        console.log("JS: sending QueryPort");
+        proc.send({ QueryPort: [] });
+      } else if (msg.ParseError) {
+        console.log("JS: i did not expect that");
+        process.exit(5);
+      } else if (msg.ReplyPort) {
+        http.get({
+          hostname: "localhost",
+          port: msg.ReplyPort,
+          path: "/v2/wallets",
+          agent: false
+        }, (res) => {
+          console.log("JS: response from wallet: " + res.statusCode);
+          res.resume();
+          res.on("end", () => {
+            console.log("JS: request response from wallet finished, exiting.");
+            process.exit(0);
+          });
         });
-      });
-    }
-  });
+      }
+    });
+  };
+
+  // NOTE
+  // We artifically install the handler after a certain delay (2s), to simulate the race
+  // condition that could actually happen in practice.
+  setTimeout(installHandler, 2000);
 }
 
 main();


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1036 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have artificially reproduced the issue in our mock-daedalus and saw it fails (wait infinitely)
- [x] I have added some retry logic to re-send `Started` every second if Daedalus has shown any sign of life.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
