### PR TITLE
reduce network exponential backoff maximum cap to 10s

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -58,11 +58,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Control.Retry
-    ( RetryPolicyM
-    , exponentialBackoff
-    , limitRetriesByCumulativeDelay
-    , retrying
-    )
+    ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay, retrying )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map
@@ -207,7 +203,7 @@ waitForNetwork getStatus policy = do
 -- for no longer than a minute.
 defaultRetryPolicy :: Monad m => RetryPolicyM m
 defaultRetryPolicy =
-    limitRetriesByCumulativeDelay (3600 * second) (exponentialBackoff 10000)
+    limitRetriesByCumulativeDelay (3600 * second) (constantDelay second)
   where
     second = 1000*1000
 
@@ -279,11 +275,11 @@ follow nl tr cps yield rollback header =
     sleep 0 (initCursor nl cps)
   where
     delay0 :: Int
-    delay0 = 1000*1000 -- 1 second
+    delay0 = 500*1000 -- 500ms
 
     retryDelay :: Int -> Int
     retryDelay 0 = delay0
-    retryDelay delay = min (2*delay) (60 * delay0)
+    retryDelay delay = min (2*delay) (10 * delay0)
 
     -- | Wait a short delay before querying for blocks again. We also take this
     -- opportunity to refresh the chain tip as it has probably increased in

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -73,7 +73,7 @@ followSpec =
                 (follow mockNetworkLayer tr [] advance rollback getHeader)
             errors <- mapMaybe (unMsg . loContent) <$> readTVarIO tvar
             case length errors of
-                x | x == 4 -> return ()
+                x | x == 5 -> return ()
                   | otherwise -> expectationFailure
                         $ "we expected 4 errors to be logged, not " ++ show x
   where


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have reduced the maximum delay in the exponential backoff retry logic in the network follower and logic for waiting for the nodes. 

# Comments

<!-- Additional comments or screenshots to attach if any -->

Right now, when Daedalus is starting, it'll wait for our API to be ready and show a splash screen until it gets ready. We start our API once we know Jörmungandr is up and we check that by making http requests to Jörmugandr. So far, we've been using an exponential backoff, uncapped. Jörmungandr typically takes 30 to 40 seconds to start, which means that, initially we would be trying after 500ms, 1s, 2s, 4s, 8s, 16s, 32s, 64s etc ...
As a consequence, if Jörmungandr starts after let's say 40s, we only get to retry after more than 20s. If it takes a minute, we'll not retry before another minute! Etc ..

So instead, I've switched to using a constant delay, to make the whole thing more reactive. We poll every second and it's a local node, so there's no particular issue with that.
Also, in the chain follower, I've reduced the maximum retry delay to be 10s for roughly the same reason. It was 60s before which gives us a quite poor reactivity.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
