### PR TITLE
Extend `Block` type to contain delegation certificate registrations.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1311,7 +1311,7 @@ newtype ProtocolMagic = ProtocolMagic Int32
 -- | Also known as a staking key, chimeric account is used in group-type address
 -- for staking purposes. It is a public key of the account address
 newtype ChimericAccount = ChimericAccount ByteString
-    deriving (Generic, Show, Eq)
+    deriving (Generic, Show, Eq, Ord)
 
 instance NFData ChimericAccount
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -527,12 +527,14 @@ data Block = Block
         :: !BlockHeader
     , transactions
         :: ![Tx]
+    , delegations
+        :: ![(ChimericAccount, PoolId)]
     } deriving (Show, Eq, Ord, Generic)
 
 instance NFData Block
 
 instance Buildable (Block) where
-    build (Block h txs) = mempty
+    build (Block h txs _) = mempty
         <> build h
         <> if null txs then " ∅" else "\n" <> indentF 4 (blockListF txs)
 

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -64,6 +64,7 @@ block0 = Block
         , parentHeaderHash = coerce genesisHash
         }
     , transactions = []
+    , delegations = []
     }
 
 genesisParameters  :: BlockchainParameters

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -231,18 +231,23 @@ instance Arbitrary MockChain where
         n0 <- choose (1, 10)
         slot0 <- arbitrary
         height0 <- fromIntegral <$> choose (0, flatSlot epochLength slot0)
-        blocks <- sequence $ flip unfoldr (slot0, height0, n0) $ \(slot, height, n) ->
-            if n <= (0 :: Int)
-                then Nothing
-                else Just
-                    ( genBlock slot height
-                    , (slotSucc sp slot, height + 1, n - 1)
-                    )
+        blocks <- sequence $ flip unfoldr (slot0, height0, n0) $
+            \(slot, height, n) ->
+                if n <= (0 :: Int)
+                    then Nothing
+                    else Just
+                        ( genBlock slot height
+                        , (slotSucc sp slot, height + 1, n - 1)
+                        )
         return (MockChain blocks)
       where
         genBlock :: SlotId -> Word32 -> Gen Block
         genBlock slot height = do
-            let h = BlockHeader slot (Quantity height) (mockHash slot) (mockHash slot)
+            let h = BlockHeader
+                    slot
+                    (Quantity height)
+                    (mockHash slot)
+                    (mockHash slot)
             Block h <$> (choose (1, 10) >>= \k -> vectorOf k arbitrary)
 
         epochLength :: EpochLength

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -226,7 +226,8 @@ instance Arbitrary MockChain where
         , not (null chain')
         ]
       where
-        shrinkBlock (Block h txs) = Block h <$> shrinkList shrink txs
+        shrinkBlock (Block h txs _) =
+            Block h <$> shrinkList shrink txs <*> pure []
     arbitrary = do
         n0 <- choose (1, 10)
         slot0 <- arbitrary
@@ -248,7 +249,9 @@ instance Arbitrary MockChain where
                     (Quantity height)
                     (mockHash slot)
                     (mockHash slot)
-            Block h <$> (choose (1, 10) >>= \k -> vectorOf k arbitrary)
+            Block h
+                <$> (choose (1, 10) >>= \k -> vectorOf k arbitrary)
+                <*> pure []
 
         epochLength :: EpochLength
         epochLength = genesisParameters ^. #getEpochLength

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -368,6 +368,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -416,6 +417,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -464,6 +466,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -493,6 +496,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -502,6 +506,7 @@ blockchain =
             , parentHeaderHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -531,6 +536,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -559,6 +565,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -588,6 +595,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -597,6 +605,7 @@ blockchain =
               , parentHeaderHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
               }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -630,6 +639,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -639,6 +649,7 @@ blockchain =
             , parentHeaderHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -648,6 +659,7 @@ blockchain =
             , parentHeaderHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -657,6 +669,7 @@ blockchain =
             , parentHeaderHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -666,6 +679,7 @@ blockchain =
             , parentHeaderHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -714,6 +728,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -762,6 +777,7 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -771,6 +787,7 @@ blockchain =
             , parentHeaderHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
             }
         , transactions = []
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -779,6 +796,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
             }
+        , delegations = []
         , transactions = []
         }
     , Block
@@ -788,6 +806,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
             }
+        , delegations = []
         , transactions = []
         }
     , Block
@@ -797,6 +816,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
             }
+        , delegations = []
         , transactions = []
         }
     , Block
@@ -806,6 +826,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
             }
+        , delegations = []
         , transactions = []
         }
     , Block
@@ -815,6 +836,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
             }
+        , delegations = []
         , transactions = []
         }
     , Block
@@ -864,6 +886,7 @@ blockchain =
                       ]
                 }
             ]
+        , delegations = []
         }
     , Block
         { header = BlockHeader
@@ -893,5 +916,6 @@ blockchain =
                     ]
                 }
             ]
+        , delegations = []
         }
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -596,7 +596,7 @@ blockchain =
               , headerHash = Hash "unused"
               , parentHeaderHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
               }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -638,7 +638,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -647,7 +647,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -656,7 +656,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -665,7 +665,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -770,7 +770,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -779,7 +779,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -788,7 +788,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -797,7 +797,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -806,7 +806,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader
@@ -815,7 +815,7 @@ blockchain =
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
             }
-        , transactions =  []
+        , transactions = []
         }
     , Block
         { header = BlockHeader

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -1073,10 +1073,10 @@ instance Arbitrary SlotId where
         return (SlotId (unsafeEpochNo ep) (SlotNo sl))
 
 instance Arbitrary Block where
-    shrink (Block h txs) = Block h <$> shrink txs
+    shrink (Block h txs _) = Block h <$> shrink txs <*> pure []
     arbitrary = do
         txs <- choose (0, 500) >>= flip vectorOf arbitrary
-        Block <$> arbitrary <*> pure txs
+        Block <$> arbitrary <*> pure txs <*> pure []
 
 instance Arbitrary WalletId where
     shrink _ = []

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -322,7 +322,7 @@ getFragment :: Get Fragment
 getFragment = label "getFragment" $ do
     size <- fromIntegral <$> getWord16be
 
-    -- We lazily compute the fragment-id, using lookAHead, before calling the
+    -- We lazily compute the fragment-id, using look-ahead, before calling the
     -- specialized decoders.
     --
     -- The fragment-id is needed, for instance, to construct a @Tx@, where it

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -823,8 +823,15 @@ signData inps outs =
 -- | Convert the Jörmungandr binary format block into a simpler Wallet block.
 convertBlock :: Block -> W.Block
 convertBlock (Block h msgs) =
-    W.Block (convertBlockHeader h) transactions []
+    W.Block (convertBlockHeader h) transactions delegations
   where
+    delegations :: [(ChimericAccount, PoolId)]
+    delegations = msgs >>= \case
+        Initial _ -> []
+        Transaction _ -> []
+        StakeDelegation (poolId, accountId, _tx) ->
+            return (accountId, poolId)
+        UnimplementedFragment _ -> []
     transactions :: [Tx]
     transactions = msgs >>= \case
         Initial _ -> []

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -823,7 +823,7 @@ signData inps outs =
 -- | Convert the Jörmungandr binary format block into a simpler Wallet block.
 convertBlock :: Block -> W.Block
 convertBlock (Block h msgs) =
-    W.Block (convertBlockHeader h) coerceFragments
+    W.Block (convertBlockHeader h) coerceFragments []
   where
     coerceFragments = msgs >>= \case
         Initial _ -> []

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -823,12 +823,13 @@ signData inps outs =
 -- | Convert the Jörmungandr binary format block into a simpler Wallet block.
 convertBlock :: Block -> W.Block
 convertBlock (Block h msgs) =
-    W.Block (convertBlockHeader h) coerceFragments []
+    W.Block (convertBlockHeader h) transactions []
   where
-    coerceFragments = msgs >>= \case
+    transactions :: [Tx]
+    transactions = msgs >>= \case
         Initial _ -> []
         Transaction tx -> return tx
-        StakeDelegation (_poolId, _xpub, tx) -> return tx
+        StakeDelegation (_poolId, _accountId, tx) -> return tx
         UnimplementedFragment _ -> []
 
 -- | Convert the Jörmungandr binary format header into a simpler Wallet header.

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -318,6 +318,9 @@ getTxWitnessTag = getWord8 >>= \case
     other -> fail $ "Invalid witness type: " ++ show other
 
 -- | Decode a fragment (header + contents).
+--
+-- Corresponds to FRAGMENT in the specification.
+--
 getFragment :: Get Fragment
 getFragment = label "getFragment" $ do
     size <- fromIntegral <$> getWord16be

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -414,6 +414,8 @@ stakeDelegationTypeTag = \case
 
 -- | Decode the contents of a @Transaction@-fragment carrying a delegation cert.
 --
+-- Corresponds to STAKE-DELEGATION in the specification.
+--
 -- Returns 'Nothing' for unsupported stake delegation types: DLG-NONE & DLG-RATIO
 getStakeDelegation
     :: Hash "Tx"


### PR DESCRIPTION
# Issue Number

#898 

# Overview

I have:

- [x] Extended the Jörmungandr `Block` type to contain stake delegations.
- [x] Adjusted the `convertBlock` function to populate the `delegations` field when converting from a Jörmungandr block to Wallet-layer block.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
