### PR TITLE
Fix DaedalusIPC startup issue on Windows

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -81,8 +81,10 @@ spec = do
             threadDelay oneSecond
 
     describe "DaedalusIPC [SERIAL]" $ do
+        let scriptPath = "test" </> "integration" </> "js" </> "mock-daedalus.js"
         let defaultArgs nodePort =
-                [ commandName @t
+                [ scriptPath
+                , commandName @t
                 , "serve"
                 , "--node-port"
                 , show nodePort
@@ -90,19 +92,17 @@ spec = do
                 , block0H
                 ]
 
-        let filepath = "test" </> "integration" </> "js" </> "mock-daedalus.js"
-
         it "Should reply with the port --random" $ \ctx -> do
             let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
                     ++ ["--random-port"]
-            (_, _, _, ph) <- createProcess (proc filepath scriptArgs)
+            (_, _, _, ph) <- createProcess (proc "node" scriptArgs)
             waitForProcess ph `shouldReturn` ExitSuccess
 
         it "Should reply with the port --random" $ \ctx -> do
             walletPort <- findPort
             let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
                     ++ ["--port", show walletPort]
-            (_, _, _, ph) <- createProcess (proc filepath scriptArgs)
+            (_, _, _, ph) <- createProcess (proc "node" scriptArgs)
             waitForProcess ph `shouldReturn` ExitSuccess
 
     describe "LOGGING - cardano-wallet serve logging [SERIAL]" $ do

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -82,27 +82,34 @@ spec = do
 
     describe "DaedalusIPC [SERIAL]" $ do
         let scriptPath = "test" </> "integration" </> "js" </> "mock-daedalus.js"
-        let defaultArgs nodePort =
+        let mockProc testCase nodePort extra = proc "node" $
                 [ scriptPath
+                , testCase
                 , commandName @t
                 , "serve"
                 , "--node-port"
                 , show nodePort
                 , "--genesis-block-hash"
                 , block0H
-                ]
+                ] ++ extra
 
         it "Should reply with the port --random" $ \ctx -> do
-            let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
-                    ++ ["--random-port"]
-            (_, _, _, ph) <- createProcess (proc "node" scriptArgs)
+            let script = mockProc "test1" (ctx ^. typed @(Port "node"))
+                    ["--random-port"]
+            (_, _, _, ph) <- createProcess script
             waitForProcess ph `shouldReturn` ExitSuccess
 
-        it "Should reply with the port --random" $ \ctx -> do
+        it "Should reply with the port --port" $ \ctx -> do
             walletPort <- findPort
-            let scriptArgs = defaultArgs (ctx ^. typed @(Port "node"))
-                    ++ ["--port", show walletPort]
-            (_, _, _, ph) <- createProcess (proc "node" scriptArgs)
+            let script = mockProc "test1" (ctx ^. typed @(Port "node"))
+                    ["--port", show walletPort]
+            (_, _, _, ph) <- createProcess script
+            waitForProcess ph `shouldReturn` ExitSuccess
+
+        it "Regression test for #1036" $ \ctx -> do
+            let script = mockProc "test2" (ctx ^. typed @(Port "node"))
+                    ["--random-port"]
+            (_, _, _, ph) <- createProcess script
             waitForProcess ph `shouldReturn` ExitSuccess
 
     describe "LOGGING - cardano-wallet serve logging [SERIAL]" $ do

--- a/lib/jormungandr/test/integration/js/mock-daedalus.js
+++ b/lib/jormungandr/test/integration/js/mock-daedalus.js
@@ -7,11 +7,74 @@ const child_process = require("child_process");
 const http = require('http');
 
 function main() {
-  // prevent coverage reports from clobbering each other
-  process.env.HPCTIXFILE = "nodejs.tix";
+  const testName = process.argv[2];
+  const cmd = process.argv[3];
+  const args = process.argv.slice(4);
 
-  let args = process.argv.slice(3);
-  const proc = child_process.spawn(process.argv[2], args,
+  const tests = {
+    test1: function() {
+      // test the different message types in sequence
+      proc.on("message", function(msg) {
+        console.log("JS: message received", msg);
+        // See CardanoNode.js in Daedalus for the message types in use.
+        if (msg.Started) {
+          console.log("JS: sending a bogus message");
+          proc.send("hello");
+        } else if (msg.ParseError && msg.ParseError.match(/encountered String/)) {
+          console.log("JS: sending QueryPort");
+          proc.send({ QueryPort: [] });
+        } else if (msg.ParseError) {
+          console.log("JS: i did not expect that");
+          process.exit(5);
+        } else if (msg.ReplyPort) {
+          http.get({
+            hostname: "localhost",
+            port: msg.ReplyPort,
+            path: "/v2/wallets",
+            agent: false
+          }, (res) => {
+            console.log("JS: response from wallet: " + res.statusCode);
+            res.resume();
+            res.on("end", () => {
+              console.log("JS: request response from wallet finished, exiting.");
+              process.exit(0);
+            });
+          });
+        }
+      });
+    },
+    test2: function() {
+      // regression test for #1036
+      proc.send({ QueryPort: [] });
+      proc.on("message", function(msg) {
+        console.log("JS: message received", msg);
+        if (msg.ReplyPort) {
+          http.get({
+            hostname: "localhost",
+            port: msg.ReplyPort,
+            path: "/v2/wallets",
+            agent: false
+          }, (res) => {
+            console.log("JS: response from wallet: " + res.statusCode);
+            res.resume();
+            res.on("end", () => {
+              console.log("JS: request response from wallet finished, exiting.");
+              process.exit(0);
+            });
+          });
+        }
+      });
+    }
+  };
+
+  const test = tests[testName];
+
+  if (!cmd || !test) {
+    console.log("usage: node mock-daedalus.js (test1|test2) command [args]");
+    process.exit(10);
+  }
+
+  const proc = child_process.spawn(cmd, args,
     { stdio: ["ignore", "inherit", "inherit", "ipc"] }
   );
 
@@ -35,42 +98,7 @@ function main() {
     process.exit(4);
   });
 
-
-  const installHandler = () => {
-    proc.on("message", function(msg) {
-      console.log("JS: message received", msg);
-      // See CardanoNode.js in Daedalus for the message types in use.
-      if (msg.Started) {
-        console.log("JS: sending a bogus message");
-        proc.send("hello");
-      } else if (msg.ParseError && msg.ParseError.match(/encountered String/)) {
-        console.log("JS: sending QueryPort");
-        proc.send({ QueryPort: [] });
-      } else if (msg.ParseError) {
-        console.log("JS: i did not expect that");
-        process.exit(5);
-      } else if (msg.ReplyPort) {
-        http.get({
-          hostname: "localhost",
-          port: msg.ReplyPort,
-          path: "/v2/wallets",
-          agent: false
-        }, (res) => {
-          console.log("JS: response from wallet: " + res.statusCode);
-          res.resume();
-          res.on("end", () => {
-            console.log("JS: request response from wallet finished, exiting.");
-            process.exit(0);
-          });
-        });
-      }
-    });
-  };
-
-  // NOTE
-  // We artifically install the handler after a certain delay (2s), to simulate the race
-  // condition that could actually happen in practice.
-  setTimeout(installHandler, 2000);
+  test();
 }
 
 main();

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -31,6 +31,11 @@ let
     cardano-wallet-jormungandr.exe launch --genesis-block test\data\jormungandr\block0.bin --state-dir c:\cardano-wallet-jormungandr -- --config test\data\jormungandr\config.yaml --secret test\data\jormungandr\secret.yaml
   '';
 
+  nodejs = pkgs.fetchzip {
+    url = https://nodejs.org/dist/v12.13.0/node-v12.13.0-win-x64.zip;
+    sha256 = "1jd41idj1l0sa7pifsdhw0i0a0xll7qm8jif98zxl2ablrhninys";
+  };
+
 in pkgs.runCommand name {
   nativeBuildInputs = [ pkgs.zip pkgs.gnused project.jormungandr-cli ];
   passthru = { inherit tests benchmarks; };
@@ -39,6 +44,7 @@ in pkgs.runCommand name {
   cd jm
 
   cp -v ${cardano-wallet-jormungandr}/bin/* .
+  cp -v ${nodejs}/node.exe .
   cp -Rv --no-preserve=mode ${testData.core}/* ${testData.jormungandr}/* test/data
   cp -v ${jm-bat} jm.bat
   hash="$(jcli genesis hash --input test/data/jormungandr/block0.bin)"


### PR DESCRIPTION
Relates to #1036 

# Overview

It's not possible to concurrently read and write to Windows named pipes. One of the operations will block until the other completes.

The order which this happens in determines whether or not Daedalus receives a `ReplyPort` message on Windows.
 
This PR changes `daedalusIPC` to run sends and receives sequentially. It will fix some of the "Waiting for network..." backend connection issues on Daedalus Windows.

# Comments

- [x] Tested in Daedalus on Windows
- [x] Tested in Daedalus on Linux

Later - We should simplify the message scheme so that there is a single message `WalletApiPort <int>`, and no unnecessary request/response.
