### PR TITLE
Scan stake pool registrations during wallet restoration.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -650,8 +650,8 @@ listAddresses
     -> ExceptT ErrNoSuchWallet IO [(Address, AddressState)]
 listAddresses ctx wid = db & \DBLayer{..} -> do
     (s, txs) <- mapExceptT atomically $ (,)
-        <$> (getState <$> withNoSuchWallet wid (readCheckpoint $ PrimaryKey wid))
-        <*> lift (readTxHistory (PrimaryKey wid) Descending wholeRange Nothing)
+        <$> (getState <$> withNoSuchWallet wid (readCheckpoint primaryKey))
+        <*> lift (readTxHistory primaryKey Descending wholeRange Nothing)
     let maybeIsOurs (TxOut a _) = if fst (isOurs a s)
             then normalize (rewardAccountKey s)  a
             else Nothing
@@ -674,6 +674,7 @@ listAddresses ctx wid = db & \DBLayer{..} -> do
     normalize rewardAccount addr = do
         fingerprint <- eitherToMaybe (paymentKeyFingerprint addr)
         pure $ liftDelegationAddress @n fingerprint rewardAccount
+    primaryKey = PrimaryKey wid
 
 {-------------------------------------------------------------------------------
                                   Transaction

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -962,8 +962,6 @@ signDelegation ctx wid argGenChange pwd coinSel poolId = db & \DBLayer{..} -> do
             withExceptT ErrSignDelegationNoSuchWallet $
                 putCheckpoint (PrimaryKey wid) (updateState s' cp)
 
-            -- TODO
-            -- Pre-compute this and store it with the wallet static metadata.
             let rewardAccount = deriveRewardAccount @k pwd xprv
             let keyFrom = isOwned (getState cp) (xprv, pwd)
             (tx, sealedTx) <- withExceptT ErrSignDelegationMkTx $ ExceptT $ pure $

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -571,8 +571,8 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
         <$> withNoSuchWallet wid (readCheckpoint $ PrimaryKey wid)
         <*> withNoSuchWallet wid (readWalletMeta $ PrimaryKey wid)
     let bp = blockchainParameters cp
-    let (txs0, cps) = NE.unzip $ applyBlocks @s blocks cp
-    let txs = fold txs0
+    let (filteredBlocks, cps) = NE.unzip $ applyBlocks @s blocks cp
+    let txs = fold $ view #transactions <$> filteredBlocks
     let k = bp ^. #getEpochStability
     let localTip = currentTip $ NE.last cps
 

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -171,13 +171,13 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Binds a stake pool id to a wallet. This will have an influence on
         -- the wallet metadata: the last known certificate will indicate to
-        -- which pool a wallet is currently delegating to.
+        -- which pool a wallet is currently delegating.
         --
         -- This is done separately from 'putWalletMeta' because certificate
-        -- declaration are:
+        -- declarations are:
         --
-        -- 1. Stored on-chain
-        -- 2. Affected by rollbacks (or said differently, tight to a 'SlotId')
+        -- 1. Stored on-chain.
+        -- 2. Affected by rollbacks (or said differently, tied to a 'SlotId').
 
     , putTxHistory
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -41,7 +41,9 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , SoftDerivation (..)
 
     -- * Delegation
+    , ChimericAccount (..)
     , deriveRewardAccount
+    , toChimericAccount
 
     -- * Primitive Crypto Types
     , XPub (..)
@@ -98,7 +100,7 @@ import Cardano.Wallet.Primitive.Mnemonic
     , mnemonicToEntropy
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..) )
+    ( Address (..), ChimericAccount (..), Hash (..) )
 import Control.Arrow
     ( left )
 import Control.DeepSeq
@@ -322,6 +324,15 @@ deriveRewardAccount
 deriveRewardAccount pwd rootPrv =
     let accPrv = deriveAccountPrivateKey pwd rootPrv minBound
     in deriveAddressPrivateKey pwd accPrv MutableAccount minBound
+
+-- | Construct a 'ChimericAccount' by extracting the public key from the
+-- extended public key.
+toChimericAccount
+    :: WalletKey k
+    => k 'AddressK XPub
+    -> ChimericAccount
+toChimericAccount =
+    ChimericAccount . BS.take 32 . unXPub . getRawKey
 
 {-------------------------------------------------------------------------------
                                  Passphrases

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -74,6 +74,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , SoftDerivation (..)
     , WalletKey (..)
     , deriveRewardAccount
+    , xpubPublicKey
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
@@ -83,7 +84,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address, ChimericAccount, invariant )
+    ( Address, ChimericAccount (..), invariant )
 import Control.Applicative
     ( (<|>) )
 import Control.DeepSeq
@@ -532,9 +533,11 @@ instance
         in
             (ixs' `deepseq` ours `deepseq` ours, SeqState s1' s2' ixs' rpk)
 
-instance IsOurs (SeqState n k) ChimericAccount where
-    -- TODO: Add support for identifying a 'ChimericAccount' here.
-    isOurs _account state = (False, state)
+instance WalletKey k => IsOurs (SeqState n k) ChimericAccount where
+    isOurs (ChimericAccount account) state =
+        (account == ourAccount, state)
+      where
+        ourAccount = xpubPublicKey $ getRawKey $ rewardAccountKey state
 
 instance
     ( SoftDerivation k

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -61,6 +61,7 @@ import Cardano.Crypto.Wallet
     ( XPrv, XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..)
+    , ChimericAccount (..)
     , DelegationAddress (..)
     , Depth (..)
     , DerivationType (..)
@@ -74,7 +75,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , SoftDerivation (..)
     , WalletKey (..)
     , deriveRewardAccount
-    , xpubPublicKey
+    , toChimericAccount
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
@@ -84,7 +85,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address, ChimericAccount (..), invariant )
+    ( Address, invariant )
 import Control.Applicative
     ( (<|>) )
 import Control.DeepSeq
@@ -534,10 +535,10 @@ instance
             (ixs' `deepseq` ours `deepseq` ours, SeqState s1' s2' ixs' rpk)
 
 instance WalletKey k => IsOurs (SeqState n k) ChimericAccount where
-    isOurs (ChimericAccount account) state =
+    isOurs account state =
         (account == ourAccount, state)
       where
-        ourAccount = xpubPublicKey $ getRawKey $ rewardAccountKey state
+        ourAccount = toChimericAccount $ rewardAccountKey state
 
 instance
     ( SoftDerivation k

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -70,6 +70,7 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , FeePolicy (..)
     , Hash (..)
+    , PoolId (..)
     , SlotLength (..)
     , SlotParameters (SlotParameters)
     , StartTime (..)
@@ -280,8 +281,12 @@ updateState s (Wallet u tip _ bp) = Wallet u tip s bp
 
 -- | Represents the subset of data from a single block that are relevant to a
 --   particular wallet, discovered when applying a block to that wallet.
-newtype FilteredBlock = FilteredBlock
-    { transactions :: [(Tx, TxMeta)]
+data FilteredBlock = FilteredBlock
+    { delegations :: ![PoolId]
+        -- ^ Stake delegations made on behalf of the wallet, listed in order of
+        -- discovery. If the list contains more than element, those that appear
+        -- later in the list supercede those that appear earlier on.
+    , transactions :: ![(Tx, TxMeta)]
         -- ^ The set of transactions that affect the wallet.
     } deriving (Generic, Show, Eq)
 
@@ -298,7 +303,9 @@ applyBlock
     -> (FilteredBlock, Wallet s)
 applyBlock !b (Wallet !u _ s bp) =
     ( FilteredBlock
-        { transactions = txs }
+        { delegations = []
+        , transactions = txs
+        }
     , Wallet u' (b ^. #header) s' bp
     )
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -417,7 +417,7 @@ prefilterBlock b u0 = runState $ do
     applyTx
         :: IsOurs s Address
         => ([(Tx, TxMeta)], UTxO)
-        ->Tx
+        -> Tx
         -> State s ([(Tx, TxMeta)], UTxO)
     applyTx (!txs, !u) tx = do
         ourU <- state $ utxoOurs tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -277,9 +277,9 @@ updateState
     -> Wallet s
 updateState s (Wallet u tip _ bp) = Wallet u tip s bp
 
--- | Apply Block is the primary way of making the wallet evolve. It returns the
--- updated wallet state, as well as a set of all transactions belonging to the
--- wallet discovered while applying the block.
+-- | Apply a single block to the wallet. This is the primary way of making a
+-- wallet evolve. It returns the updated wallet state, as well as a set of all
+-- transactions belonging to the wallet discovered while applying the block.
 applyBlock
     :: Block
     -> Wallet s
@@ -386,16 +386,16 @@ blockchainParameters (Wallet _ _ _ bp) = bp
 -- linked to the wallet by their inputs.
 --
 -- In order to identify transactions that are ours, we do therefore look for
--- known inputs and known outputs. However, we can't naievely look at the domain
+-- known inputs and known outputs. However, we can't naively look at the domain
 -- of the utxo constructed from all outputs that are ours (as the specification
 -- would suggest) because some transactions may use outputs of a previous
--- transaction within the same block as an input. Therefore, Looking solely at
+-- transaction within the same block as an input. Therefore, looking solely at
 -- the final 'dom (UTxO ⊳ oursOuts)', we would be missing all intermediate txs
 -- that happen from _within_ the block itself.
 --
--- As a consequence, we do have to traverse the block, and look at transaction
+-- As a consequence, we do have to traverse the block, and look at transactions
 -- in order, starting from the known inputs that can be spent (from the previous
--- UTxO) and, collect resolved tx outputs that are ours as we apply transactions.
+-- UTxO) and collect resolved tx outputs that are ours as we apply transactions.
 prefilterBlock
     :: (IsOurs s Address)
     => Block

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -285,12 +285,11 @@ applyBlock
     -> Wallet s
     -> ([(Tx, TxMeta)], Wallet s)
 applyBlock !b (Wallet !u _ s bp) =
-    let
-        ((txs, u'), s') = prefilterBlock b u s
-    in
-        ( txs
-        , Wallet u' (b ^. #header) s' bp
-        )
+    ( txs
+    , Wallet u' (b ^. #header) s' bp
+    )
+  where
+    ((txs, u'), s') = prefilterBlock b u s
 
 -- | Apply multiple blocks in sequence to an existing wallet, returning a list
 --   of intermediate wallet states.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -55,9 +55,8 @@ module Cardano.Wallet.Primitive.Types
     , Address (..)
     , AddressState (..)
 
-    -- * Accounts
+    -- * Delegation
     , ChimericAccount (..)
-    , chimericAccountFromXPub
 
     -- * Coin
     , Coin (..)
@@ -230,7 +229,6 @@ import Numeric.Natural
 import Safe
     ( readMay )
 
-import qualified Cardano.Crypto.Wallet as CC
 import qualified Control.Foldl as F
 import qualified Data.ByteString as BS
 import qualified Data.Char as C
@@ -1318,15 +1316,11 @@ newtype ProtocolMagic = ProtocolMagic Int32
 {-------------------------------------------------------------------------------
                                 Accounts
 -------------------------------------------------------------------------------}
+
 -- | Also known as a staking key, chimeric account is used in group-type address
 -- for staking purposes. It is a public key of the account address
 newtype ChimericAccount = ChimericAccount { unChimericAccount :: ByteString }
     deriving (Generic, Show, Eq, Ord)
-
--- | Construct a 'ChimericAccount' by extracting the public key from the
--- extended public key.
-chimericAccountFromXPub :: CC.XPub -> ChimericAccount
-chimericAccountFromXPub = ChimericAccount . BS.take 32 . CC.unXPub
 
 instance NFData ChimericAccount
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -175,9 +175,9 @@ prop_applyBlockTxHistoryIncoming s =
   where
     (_, cp0) = initWallet @_ block0 genesisParameters s
     bs = NE.fromList blockchain
-    filteredBlocks_cps = applyBlocks bs cp0
-    txs = fold $ (view #transactions . fst) <$> filteredBlocks_cps
-    s' = getState $ NE.last $ snd <$> filteredBlocks_cps
+    (filteredBlocks, cps) = NE.unzip $ applyBlocks bs cp0
+    txs = fold $ (view #transactions) <$> filteredBlocks
+    s' = getState $ NE.last cps
     isIncoming (_, m) = direction m == Incoming
     outs = Set.fromList . concatMap (map address . outputs . fst)
     overlaps a b

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -60,6 +60,10 @@ import Control.Monad.Trans.State.Strict
     ( State, evalState, runState, state )
 import Data.Foldable
     ( fold )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
 import Data.Maybe
     ( catMaybes )
 import Data.Quantity
@@ -171,9 +175,9 @@ prop_applyBlockTxHistoryIncoming s =
   where
     (_, cp0) = initWallet @_ block0 genesisParameters s
     bs = NE.fromList blockchain
-    txs_cps = applyBlocks bs cp0
-    txs = fold $ fst <$> txs_cps
-    s' = getState $ NE.last $ snd <$> txs_cps
+    filteredBlocks_cps = applyBlocks bs cp0
+    txs = fold $ (view #transactions . fst) <$> filteredBlocks_cps
+    s' = getState $ NE.last $ snd <$> filteredBlocks_cps
     isIncoming (_, m) = direction m == Incoming
     outs = Set.fromList . concatMap (map address . outputs . fst)
     overlaps a b

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -159,7 +159,8 @@ serveWallet
     -> (SockAddr -> Port "node" -> BlockchainParameters -> IO ())
     -- ^ Callback to run before the main loop
     -> IO ExitCode
-serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop = do
+serveWallet
+        (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop = do
     installSignalHandlers tr
     logInfo tr "Wallet backend server starting..."
     logInfo tr $ "Node is Jörmungandr on " <> toText (networkDiscriminantVal @n)
@@ -217,7 +218,8 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
     apiLayer tracer tl nl = do
         let (block0, bp) = staticBlockchainParameters nl
         wallets <- maybe (pure []) (Sqlite.findDatabases @k tr) databaseDir
-        Server.newApiLayer tracer (block0, bp, sTolerance) nl' tl dbFactory wallets
+        Server.newApiLayer
+            tracer (block0, bp, sTolerance) nl' tl dbFactory wallets
       where
         nl' = toWLBlock <$> nl
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Jormungandr.Binary
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth, WalletKey (..) )
+    ( Depth, WalletKey (..), toChimericAccount )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
@@ -39,7 +39,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), SealedTx (..), Tx (..), TxOut (..), chimericAccountFromXPub )
+    ( Hash (..), SealedTx (..), Tx (..), TxOut (..) )
 import Cardano.Wallet.Transaction
     ( ErrDecodeSignedTx (..)
     , ErrMkTx (..)
@@ -74,8 +74,7 @@ newTransactionLayer block0H = TransactionLayer
     { mkStdTx = mkFragment $ MkFragmentSimpleTransaction (txWitnessTagFor @k)
 
     , mkDelegationCertTx = \pool accXPrv ->
-        let
-            acc = chimericAccountFromXPub . getRawKey . publicKey . fst $ accXPrv
+        let acc = toChimericAccount . publicKey . fst $ accXPrv
         in mkFragment $ MkFragmentStakeDelegation
                     (txWitnessTagFor @k)
                     (DlgFull pool)


### PR DESCRIPTION
# Issue Number

#899 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

I have:

- [x] Provided an implementation of `IsOurs (SeqState n k) ChimericAccount`.
- [x] Adjusted the return type of `applyBlock` so that it references any stake delegation that has occurred on behalf of the specified wallet.
- [x] Adjusted the definition of `restoreBlocks` so that it correctly processes the registrations returned by `applyBlocks`.
- [x] Adjusted the definition of `applyBlock` to identify delegations relevant to the specified wallet, and return the final registration as part of `FilteredBlock`.
- [x] Added tests to ensure that `applyBlock` does successfully discover delegations made by the wallet under test, and only that wallet.
- [x]  Added tests to ensure that a wallet's delegation status is correctly updated in the context of discovered delegations.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
-->
