### PR TITLE
Set log level of individual loggers

### DIFF
--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -26,7 +26,7 @@ module Cardano.Wallet.Registry
     , HasWorkerCtx (..)
 
       -- * Logging
-    , WorkerLog (..)
+    , WithWorkerKey (..)
     ) where
 
 import Prelude hiding
@@ -200,12 +200,12 @@ newWorker ctx k (MkWorker before main after acquire) = do
             }
   where
     tr = ctx ^. logger
-    tr' = contramap (fmap (toText . WorkerLog k)) $ appendName "worker" tr
+    tr' = contramap (fmap (toText . WithWorkerKey k)) $ appendName "worker" tr
     cleanup mvar e = tryPutMVar mvar Nothing *> after tr' e
 
 -- | A worker log event includes the key (i.e. wallet ID) as context.
-data WorkerLog key = WorkerLog key Text
+data WithWorkerKey key = WithWorkerKey key Text
     deriving (Eq, Show)
 
-instance ToText key => ToText (WorkerLog key) where
-    toText (WorkerLog k msg) = T.take 8 (toText k) <> ": " <> msg
+instance ToText key => ToText (WithWorkerKey key) where
+    toText (WithWorkerKey k msg) = T.take 8 (toText k) <> ": " <> msg

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -24,6 +24,9 @@ module Cardano.Wallet.Registry
 
       -- * Context
     , HasWorkerCtx (..)
+
+      -- * Logging
+    , WorkerLog (..)
     ) where
 
 import Prelude hiding
@@ -49,6 +52,8 @@ import Control.Exception
     ( SomeException, finally )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Tracer
+    ( contramap )
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens
@@ -195,5 +200,12 @@ newWorker ctx k (MkWorker before main after acquire) = do
             }
   where
     tr = ctx ^. logger
-    tr' = appendName ("worker." <> T.take 8 (toText k)) tr
+    tr' = contramap (fmap (toText . WorkerLog k)) $ appendName "worker" tr
     cleanup mvar e = tryPutMVar mvar Nothing *> after tr' e
+
+-- | A worker log event includes the key (i.e. wallet ID) as context.
+data WorkerLog key = WorkerLog key Text
+    deriving (Eq, Show)
+
+instance ToText key => ToText (WorkerLog key) where
+    toText (WorkerLog k msg) = T.take 8 (toText k) <> ": " <> msg

--- a/lib/core/src/Network/Wai/Middleware/Logging.hs
+++ b/lib/core/src/Network/Wai/Middleware/Logging.hs
@@ -114,9 +114,9 @@ withApiLogger t0 settings app req0 sendResponse = do
             _ -> logInfo t payload
         unless (BS.null body) $ logDebug t (T.decodeUtf8 body)
 
-    withRequestId :: RequestId -> LoggerName -> LoggerName
-    withRequestId (RequestId rid) name = mconcat
-        [ name, "request-", T.pack $ show rid ]
+    withRequestId :: RequestId -> [LoggerName] -> [LoggerName]
+    withRequestId (RequestId rid) name = name <>
+        [ "request-" <> T.pack (show rid) ]
 
     -- | Removes sensitive details from valid request payloads and completely
     -- obfuscate invalid payloads.

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -52,7 +52,6 @@ import Cardano.CLI
     , stateDirOption
     , syncToleranceOption
     , verbosityOption
-    , verbosityToMinSeverity
     , withLogging
     )
 import Cardano.Launcher
@@ -165,7 +164,7 @@ data LaunchArgs = LaunchArgs
     , _stateDir :: Maybe FilePath
     , _loggingConfigFile :: Maybe FilePath
     , _syncTolerance :: SyncTolerance
-    , _verbosity :: Verbosity
+    , _verbosity :: [(Text, Verbosity)]
     , _jormungandrArgs :: JormungandrArgs
     }
 
@@ -212,7 +211,7 @@ cmdLaunch dataDir = command "launch" $ info (helper <*> cmd) $ mempty
             <$> genesisBlockOption
             <*> extraArguments)
     exec (LaunchArgs hostPreference listen nodePort mStateDir logCfg sTolerance verbosity jArgs) = do
-        withLogging logCfg (verbosityToMinSeverity verbosity) $ \(cfg, tr) -> do
+        withLogging logCfg verbosity $ \(cfg, tr) -> do
             case genesisBlock jArgs of
                 Right block0File -> requireFilePath block0File
                 Left _ -> pure ()
@@ -250,7 +249,7 @@ data ServeArgs = ServeArgs
     , _database :: Maybe FilePath
     , _loggingConfigFile :: Maybe FilePath
     , _syncTolerance :: SyncTolerance
-    , _verbosity :: Verbosity
+    , _verbosity :: [(Text, Verbosity)]
     , _block0H :: Hash "Genesis"
     }
 
@@ -272,8 +271,7 @@ cmdServe = command "serve" $ info (helper <*> cmd) $ mempty
         :: ServeArgs
         -> IO ()
     exec (ServeArgs hostPreference listen nodePort databaseDir logCfg sTolerance verbosity block0H) = do
-        let minSeverity = verbosityToMinSeverity verbosity
-        withLogging logCfg minSeverity $ \(cfg, tr) -> do
+        withLogging logCfg verbosity $ \(cfg, tr) -> do
             let baseUrl = localhostBaseUrl $ getPort nodePort
             let cp = JormungandrConnParams block0H baseUrl
             whenJust databaseDir $ setupDirectory (logInfo tr)

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -12,8 +12,6 @@ module Main where
 
 import Prelude
 
-import Cardano.BM.Data.Severity
-    ( Severity (..) )
 import Cardano.BM.Trace
     ( Trace )
 import Cardano.CLI
@@ -98,7 +96,7 @@ instance KnownCommand Jormungandr where
     commandName = "cardano-wallet-jormungandr"
 
 main :: forall t. (t ~ Jormungandr) => IO ()
-main = withUtf8Encoding $ withLogging Nothing Info $ \logging ->
+main = withUtf8Encoding $ withLogging Nothing [] $ \logging ->
     hspec $ do
         describe "No backend required" $ do
             describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -38,6 +38,7 @@ library
     , iohk-monitoring
     , process
     , text
+    , text-class
   hs-source-dirs:
       src
   exposed-modules:

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -69,6 +69,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
           (hsPkgs."process" or (buildDepError "process"))
           (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."text-class" or (buildDepError "text-class"))
           ] ++ (if system.isWindows
           then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
           else [ (hsPkgs."unix" or (buildDepError "unix")) ]);

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,8 +5,10 @@
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
+        "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
+        "katip" = (((hackage.katip)."0.8.3.0").revisions).default;
         bech32 = ./bech32.nix;
         cardano-wallet-core = ./cardano-wallet-core.nix;
         cardano-wallet-core-integration = ./cardano-wallet-core-integration.nix;
@@ -21,28 +23,14 @@
         cardano-crypto = ./cardano-crypto.nix;
         contra-tracer = ./contra-tracer.nix;
         iohk-monitoring = ./iohk-monitoring.nix;
+        lobemo-backend-aggregation = ./lobemo-backend-aggregation.nix;
+        lobemo-backend-monitoring = ./lobemo-backend-monitoring.nix;
+        ekg-prometheus-adapter = ./ekg-prometheus-adapter.nix;
         };
       compiler.version = "8.6.5";
       compiler.nix-name = "ghc865";
       };
   resolver = "lts-13.24";
-  modules = [
-    ({ lib, ... }:
-      {
-        packages = {
-          "iohk-monitoring" = {
-            flags = {
-              "disable-examples" = lib.mkOverride 900 true;
-              "disable-ekg" = lib.mkOverride 900 true;
-              "disable-systemd" = lib.mkOverride 900 true;
-              "disable-prometheus" = lib.mkOverride 900 true;
-              "disable-gui" = lib.mkOverride 900 true;
-              "disable-graylog" = lib.mkOverride 900 true;
-              };
-            };
-          };
-        })
-    { packages = {}; }
-    ];
+  modules = [ ({ lib, ... }: { packages = {}; }) { packages = {}; } ];
   compiler = "ghc-8.6.5";
   }

--- a/nix/.stack.nix/ekg-prometheus-adapter.nix
+++ b/nix/.stack.nix/ekg-prometheus-adapter.nix
@@ -42,15 +42,15 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
-      license = "Apache-2.0";
-      copyright = "2019 IOHK";
-      maintainer = "operations@iohk.io";
-      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      identifier = { name = "ekg-prometheus-adapter"; version = "0.2.0.1"; };
+      license = "MIT";
+      copyright = "2016 Alfredo Di Napoli";
+      maintainer = "alfredo.dinapoli@gmail.com";
+      author = "Alfredo Di Napoli";
+      homepage = "https://github.com/CodiePP/ekg-prometheus-adapter";
       url = "";
-      synopsis = "A simple interface for logging, tracing or monitoring.";
-      description = "";
+      synopsis = "Easily expose your EKG metrics to Prometheus";
+      description = "Forked from original implementation by Alfredo Di Napoli on https://github.com/adinapoli/ekg-prometheus-adapter";
       buildType = "Simple";
       isLocal = true;
       };
@@ -58,15 +58,30 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+          (hsPkgs."prometheus" or (buildDepError "prometheus"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."containers" or (buildDepError "containers"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."microlens-th" or (buildDepError "microlens-th"))
+          ];
         buildable = true;
+        };
+      tests = {
+        "tests" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."ekg-prometheus-adapter" or (buildDepError "ekg-prometheus-adapter"))
+            ];
+          buildable = true;
+          };
         };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
-      sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
+      url = "https://github.com/CodiePP/ekg-prometheus-adapter";
+      rev = "1a258b6df7d9807d4c4ff3e99722223d31a2c320";
+      sha256 = "0jzr1afb4vanhcc2gzlybzr0jnh66cap8kh00fkd4c22882jqkh8";
       });
-    postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -41,15 +41,18 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "1.10";
-      identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
+      specVersion = "2.0";
+      identifier = {
+        name = "lobemo-backend-aggregation";
+        version = "0.1.0.0";
+        };
       license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
-      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
       url = "";
-      synopsis = "A simple interface for logging, tracing or monitoring.";
+      synopsis = "provides a backend implementation to aggregate traced values";
       description = "";
       buildType = "Simple";
       isLocal = true;
@@ -58,7 +61,17 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          ] ++ (if system.isWindows
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+          else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
         buildable = true;
         };
       };
@@ -68,5 +81,5 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
       sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
       });
-    postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-editor.nix
+++ b/nix/.stack.nix/lobemo-backend-editor.nix
@@ -41,15 +41,15 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "1.10";
-      identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
+      specVersion = "2.0";
+      identifier = { name = "lobemo-backend-editor"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
-      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
       url = "";
-      synopsis = "A simple interface for logging, tracing or monitoring.";
+      synopsis = "provides a backend implementation to interactively manage configuration";
       description = "";
       buildType = "Simple";
       isLocal = true;
@@ -58,7 +58,21 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."directory" or (buildDepError "directory"))
+          (hsPkgs."filepath" or (buildDepError "filepath"))
+          (hsPkgs."safe" or (buildDepError "safe"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."threepenny-gui" or (buildDepError "threepenny-gui"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          ] ++ (if system.isWindows
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+          else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
         buildable = true;
         };
       };
@@ -68,5 +82,5 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
       sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
       });
-    postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/plugins/backend-editor; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -41,15 +41,15 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "1.10";
-      identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
+      specVersion = "2.0";
+      identifier = { name = "lobemo-backend-ekg"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
-      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
       url = "";
-      synopsis = "A simple interface for logging, tracing or monitoring.";
+      synopsis = "provides a backend implementation to EKG";
       description = "";
       buildType = "Simple";
       isLocal = true;
@@ -58,7 +58,20 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."ekg" or (buildDepError "ekg"))
+          (hsPkgs."ekg-core" or (buildDepError "ekg-core"))
+          (hsPkgs."ekg-prometheus-adapter" or (buildDepError "ekg-prometheus-adapter"))
+          (hsPkgs."prometheus" or (buildDepError "prometheus"))
+          (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
+          (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."time" or (buildDepError "time"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          (hsPkgs."warp" or (buildDepError "warp"))
+          ];
         buildable = true;
         };
       };
@@ -68,5 +81,5 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
       sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
       });
-    postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -39,17 +39,17 @@ let
       '';
 in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
-    flags = { disable-observables = false; performance-test-queue = false; };
+    flags = {};
     package = {
-      specVersion = "1.10";
-      identifier = { name = "iohk-monitoring"; version = "0.1.10.1"; };
+      specVersion = "2.0";
+      identifier = { name = "lobemo-backend-monitoring"; version = "0.1.0.0"; };
       license = "Apache-2.0";
-      copyright = "2018 IOHK";
-      maintainer = "";
-      author = "Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      copyright = "2019 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
       url = "";
-      synopsis = "logging, benchmarking and monitoring framework";
+      synopsis = "provides a backend implementation for monitoring";
       description = "";
       buildType = "Simple";
       isLocal = true;
@@ -58,36 +58,14 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       "library" = {
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
-          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
           (hsPkgs."aeson" or (buildDepError "aeson"))
-          (hsPkgs."array" or (buildDepError "array"))
           (hsPkgs."async" or (buildDepError "async"))
-          (hsPkgs."async-timer" or (buildDepError "async-timer"))
-          (hsPkgs."attoparsec" or (buildDepError "attoparsec"))
-          (hsPkgs."auto-update" or (buildDepError "auto-update"))
-          (hsPkgs."base64-bytestring" or (buildDepError "base64-bytestring"))
-          (hsPkgs."bytestring" or (buildDepError "bytestring"))
-          (hsPkgs."clock" or (buildDepError "clock"))
-          (hsPkgs."containers" or (buildDepError "containers"))
-          (hsPkgs."contravariant" or (buildDepError "contravariant"))
-          (hsPkgs."directory" or (buildDepError "directory"))
-          (hsPkgs."filepath" or (buildDepError "filepath"))
-          (hsPkgs."katip" or (buildDepError "katip"))
-          (hsPkgs."lens" or (buildDepError "lens"))
-          (hsPkgs."mtl" or (buildDepError "mtl"))
-          (hsPkgs."safe" or (buildDepError "safe"))
           (hsPkgs."safe-exceptions" or (buildDepError "safe-exceptions"))
-          (hsPkgs."scientific" or (buildDepError "scientific"))
           (hsPkgs."stm" or (buildDepError "stm"))
-          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
           (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."time-units" or (buildDepError "time-units"))
-          (hsPkgs."transformers" or (buildDepError "transformers"))
           (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-          (hsPkgs."vector" or (buildDepError "vector"))
-          (hsPkgs."yaml" or (buildDepError "yaml"))
-          (hsPkgs."libyaml" or (buildDepError "libyaml"))
           ] ++ (if system.isWindows
           then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
           else [ (hsPkgs."unix" or (buildDepError "unix")) ]);
@@ -99,6 +77,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."lobemo-backend-monitoring" or (buildDepError "lobemo-backend-monitoring"))
             (hsPkgs."aeson" or (buildDepError "aeson"))
             (hsPkgs."array" or (buildDepError "array"))
             (hsPkgs."async" or (buildDepError "async"))
@@ -138,5 +117,5 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
       sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
       });
-    postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-scribe-systemd.nix
+++ b/nix/.stack.nix/lobemo-scribe-systemd.nix
@@ -41,24 +41,38 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
   {
     flags = {};
     package = {
-      specVersion = "1.10";
-      identifier = { name = "contra-tracer"; version = "0.1.0.0"; };
+      specVersion = "2.0";
+      identifier = { name = "lobemo-scribe-systemd"; version = "0.1.0.0"; };
       license = "Apache-2.0";
       copyright = "2019 IOHK";
       maintainer = "operations@iohk.io";
-      author = "Neil Davies, Alexander Diemand, Andreas Triantafyllos";
-      homepage = "";
+      author = "Alexander Diemand";
+      homepage = "https://github.com/input-output-hk/iohk-monitoring-framework";
       url = "";
-      synopsis = "A simple interface for logging, tracing or monitoring.";
+      synopsis = "provides a backend for logging to systemd/journal";
       description = "";
       buildType = "Simple";
       isLocal = true;
       };
     components = {
       "library" = {
-        depends = [
+        depends = ([
           (hsPkgs."base" or (buildDepError "base"))
-          ] ++ (pkgs.lib).optional (compiler.isGhc && (compiler.version).lt "8.5") (hsPkgs."contravariant" or (buildDepError "contravariant"));
+          (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."aeson" or (buildDepError "aeson"))
+          (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."katip" or (buildDepError "katip"))
+          (hsPkgs."text" or (buildDepError "text"))
+          (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
+          (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+          ] ++ (if system.isWindows
+          then [ (hsPkgs."Win32" or (buildDepError "Win32")) ]
+          else [
+            (hsPkgs."unix" or (buildDepError "unix"))
+            ])) ++ (pkgs.lib).optionals (system.isLinux) [
+          (hsPkgs."hsyslog" or (buildDepError "hsyslog"))
+          (hsPkgs."libsystemd-journal" or (buildDepError "libsystemd-journal"))
+          ];
         buildable = true;
         };
       };
@@ -68,5 +82,5 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       rev = "4956b32f039579a0e7e4fd10793f65b4c77d9044";
       sha256 = "03lyb2m4i6p7rpjqarnhsx21nx48fwk6rzsrx15k6274a4bv0pix";
       });
-    postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
     }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -72,22 +72,6 @@ let
         packages.cardano-wallet-jormungandr.components.all.preBuild = pkgs.lib.mkForce "";
       }
 
-      # Misc. build fixes for dependencies
-      {
-        # Cut down iohk-monitoring deps
-        packages.iohk-monitoring.flags = {
-          disable-ekg = true;
-          disable-examples = true;
-          disable-graylog = true;
-          disable-gui = true;
-          disable-prometheus = true;
-          disable-systemd = true;
-        };
-
-        # Katip has Win32 (>=2.3 && <2.6) constraint
-        packages.katip.doExactConfig = true;
-      }
-
       # Musl libc fully static build
       (with pkgs.stdenv; let
         gplWallet = true; # fixme

--- a/stack.yaml
+++ b/stack.yaml
@@ -33,22 +33,22 @@ extra-deps:
 
 # iohk-monitoring-framework
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+  commit: 4956b32f039579a0e7e4fd10793f65b4c77d9044
   subdirs:
     - contra-tracer
     - iohk-monitoring
+    - plugins/backend-aggregation
+    - plugins/backend-monitoring
+    # - plugins/backend-editor
+    # - plugins/backend-ekg
+    # - plugins/scribe-systemd
+# dependencies of iohk-monitoring-framework
+- git: https://github.com/CodiePP/ekg-prometheus-adapter
+  commit: 1a258b6df7d9807d4c4ff3e99722223d31a2c320
+- prometheus-2.1.2
 - time-units-1.0.0
 - libsystemd-journal-1.4.4
-
-flags:
-  # Bring in less dependencies from iohk-monitoring
-  iohk-monitoring:
-    disable-ekg: true
-    disable-examples: true
-    disable-graylog: true
-    disable-gui: true
-    disable-prometheus: true
-    disable-systemd: true
+- katip-0.8.3.0
 
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
# Overview

Currently if debug logging is enabled (`--verbose` option), there is way too much information logged. This modifies the CLI options to allow setting the log levels of individual loggers.

- Modifies verbose/quiet CLI options to accept a logger name.
- Updates iohk-monitoring framework version
- Begin adopting some logging patterns such as DefineSeverity.

# Comments

- There are better ways to enable/disable loggers (e.g. how it's done in cardano-node), but that will be more work to implement. So this is just the fastest way of doing it.
