### PR TITLE
Add stake pool metadata to swagger.yaml

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -799,6 +799,7 @@ listPools spl =
                 (Quantity $ fromIntegral $ getQuantity stake)
                 (Quantity $ fromIntegral $ getQuantity production))
             apparentPerformance
+            Nothing -- TODO: wire-up real metadata here when available.
 
 joinStakePool
     :: forall ctx s t n k.
@@ -847,7 +848,7 @@ joinStakePool ctx spl (ApiT poolId) (ApiT wid) passwd = do
     liftE2 = throwE . ErrSignCertNoSuchWallet
     liftE3 = throwE . ErrSubmitCertNoSuchWallet
     poolIsUnknown =
-        isNothing . L.find (\(ApiStakePool pId _ _) -> pId == ApiT poolId)
+        isNothing . L.find (\(ApiStakePool pId _ _ _) -> pId == ApiT poolId)
 
 quitStakePool
     :: forall n k.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -72,6 +72,8 @@ module Cardano.Wallet.Api.Types
 
 import Prelude
 
+import Cardano.Pool.Metrics
+    ( StakePoolMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( FromMnemonic (..)
     , NetworkDiscriminant (..)
@@ -96,8 +98,6 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , ShowFmt (..)
     , SlotNo (..)
-    , StakePoolMetadata (..)
-    , StakePoolTicker (..)
     , SyncProgress (..)
     , TxIn (..)
     , TxStatus (..)
@@ -218,6 +218,7 @@ data ApiStakePool = ApiStakePool
     { id :: !(ApiT PoolId)
     , metrics :: !ApiStakePoolMetrics
     , apparentPerformance :: !Double
+    , metadata :: !(Maybe StakePoolMetadata)
     } deriving (Eq, Generic, Show)
 
 data ApiStakePoolMetrics = ApiStakePoolMetrics
@@ -556,16 +557,6 @@ instance FromJSON ApiStakePoolMetrics where
     parseJSON = genericParseJSON defaultRecordTypeOptions
 instance ToJSON ApiStakePoolMetrics where
     toJSON = genericToJSON defaultRecordTypeOptions
-
-instance FromJSON (ApiT StakePoolMetadata) where
-    parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
-instance ToJSON (ApiT StakePoolMetadata) where
-    toJSON = genericToJSON defaultRecordTypeOptions . getApiT
-
-instance FromJSON StakePoolTicker where
-    parseJSON = parseJSON >=> eitherToParser . left ShowFmt . fromText
-instance ToJSON StakePoolTicker where
-    toJSON = toJSON . toText
 
 instance FromJSON (ApiT WalletName) where
     parseJSON = parseJSON >=> eitherToParser . bimap ShowFmt ApiT . fromText

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -97,6 +97,7 @@ import Cardano.Wallet.Primitive.Types
     , ShowFmt (..)
     , SlotNo (..)
     , StakePoolMetadata (..)
+    , StakePoolTicker (..)
     , SyncProgress (..)
     , TxIn (..)
     , TxStatus (..)
@@ -557,20 +558,14 @@ instance ToJSON ApiStakePoolMetrics where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT StakePoolMetadata) where
-    parseJSON = withObject "StakePoolMetadata" $ \v -> ApiT <$>
-        (StakePoolMetadata
-            <$> (v .: "ticker" >>= parseTicker)
-            <*> (v .: "homepage")
-            <*> (v .: "pledge_address"))
-      where
-        parseTicker = eitherToParser . left ShowFmt . fromText
-
+    parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
 instance ToJSON (ApiT StakePoolMetadata) where
-    toJSON (ApiT (StakePoolMetadata t h pa)) = object
-        [ "ticker" .= toText t
-        , "homepage" .= h
-        , "pledge_address" .= pa
-        ]
+    toJSON = genericToJSON defaultRecordTypeOptions . getApiT
+
+instance FromJSON StakePoolTicker where
+    parseJSON = parseJSON >=> eitherToParser . left ShowFmt . fromText
+instance ToJSON StakePoolTicker where
+    toJSON = toJSON . toText
 
 instance FromJSON (ApiT WalletName) where
     parseJSON = parseJSON >=> eitherToParser . bimap ShowFmt ApiT . fromText

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -96,6 +96,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , ShowFmt (..)
     , SlotNo (..)
+    , StakePoolMetadata (..)
     , SyncProgress (..)
     , TxIn (..)
     , TxStatus (..)
@@ -554,6 +555,22 @@ instance FromJSON ApiStakePoolMetrics where
     parseJSON = genericParseJSON defaultRecordTypeOptions
 instance ToJSON ApiStakePoolMetrics where
     toJSON = genericToJSON defaultRecordTypeOptions
+
+instance FromJSON (ApiT StakePoolMetadata) where
+    parseJSON = withObject "StakePoolMetadata" $ \v -> ApiT <$>
+        (StakePoolMetadata
+            <$> (v .: "ticker" >>= parseTicker)
+            <*> (v .: "homepage")
+            <*> (v .: "pledge_address"))
+      where
+        parseTicker = eitherToParser . left ShowFmt . fromText
+
+instance ToJSON (ApiT StakePoolMetadata) where
+    toJSON (ApiT (StakePoolMetadata t h pa)) = object
+        [ "ticker" .= toText t
+        , "homepage" .= h
+        , "pledge_address" .= pa
+        ]
 
 instance FromJSON (ApiT WalletName) where
     parseJSON = parseJSON >=> eitherToParser . bimap ShowFmt ApiT . fromText

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -117,8 +117,6 @@ module Cardano.Wallet.Primitive.Types
     -- * Stake Pools
     , PoolId(..)
     , StakeDistribution (..)
-    , StakePoolTicker
-    , StakePoolMetadata(..)
     , poolIdBytesLength
 
     -- * Querying
@@ -519,30 +517,6 @@ data StakeDistribution = StakeDistribution
     , pools :: [(PoolId, Quantity "lovelace" Word64)]
     , unassigned :: Quantity "lovelace" Word64
     } deriving (Eq, Show, Generic)
-
--- | Information about a stake pool. This information is not used directly by
--- cardano-wallet. It is sourced from the stake pool registry and passed
--- straight through to API consumers.
-data StakePoolMetadata = StakePoolMetadata
-    { ticker :: StakePoolTicker
-    -- ^ Short human-readable ID for the stake pool.
-    , homepage :: Text
-    -- ^ Absolute URL for the stake pool's homepage link.
-    , pledgeAddress :: Text
-    -- ^ Bech32-encoded address.
-    } deriving (Eq, Show, Generic)
-
--- | Very short name for a stake pool.
-newtype StakePoolTicker = StakePoolTicker { unStakePoolTicker :: Text }
-    deriving (Show, Eq, NFData, ToText)
-
-instance FromText StakePoolTicker where
-    fromText t
-        | T.length t == 3 || T.length t == 4
-            = Right $ StakePoolTicker t
-        | otherwise
-            = Left . TextDecodingError $
-                "stake pool ticker length must be 3-4 characters"
 
 {-------------------------------------------------------------------------------
                                     Block

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -117,6 +117,8 @@ module Cardano.Wallet.Primitive.Types
     -- * Stake Pools
     , PoolId(..)
     , StakeDistribution (..)
+    , StakePoolTicker
+    , StakePoolMetadata(..)
     , poolIdBytesLength
 
     -- * Querying
@@ -517,6 +519,30 @@ data StakeDistribution = StakeDistribution
     , pools :: [(PoolId, Quantity "lovelace" Word64)]
     , unassigned :: Quantity "lovelace" Word64
     } deriving (Eq, Show, Generic)
+
+-- | Information about a stake pool. This information is not used directly by
+-- cardano-wallet. It is sourced from the stake pool registry and passed
+-- straight through to API consumers.
+data StakePoolMetadata = StakePoolMetadata
+    { ticker :: StakePoolTicker
+    -- ^ Short human-readable ID for the stake pool.
+    , homepage :: Text
+    -- ^ Absolute URL for the stake pool's homepage link.
+    , pledgeAddress :: Text
+    -- ^ Bech32-encoded address.
+    } deriving (Eq, Show, Generic)
+
+-- | Very short name for a stake pool.
+newtype StakePoolTicker = StakePoolTicker { unStakePoolTicker :: Text }
+    deriving (Show, Eq, NFData, ToText)
+
+instance FromText StakePoolTicker where
+    fromText t
+        | T.length t == 3 || T.length t == 4
+            = Right $ StakePoolTicker t
+        | otherwise
+            = Left . TextDecodingError $
+                "stake pool ticker length must be 3-4 characters"
 
 {-------------------------------------------------------------------------------
                                     Block

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTStakePoolMetadata.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTStakePoolMetadata.json
@@ -1,0 +1,55 @@
+{
+    "seed": 7984932456561319472,
+    "samples": [
+        {
+            "homepage": "m㰹񑻩jns𘽱\u0017򥚳q񜝜s򋡣􏭵󎯚*Or",
+            "ticker": "TWp\u001b",
+            "pledge_address": "/񋖷𢟅tf\u001dxZ󩥐"
+        },
+        {
+            "homepage": "󉐇",
+            "ticker": "񱾬p?`",
+            "pledge_address": "\u0018󮬎'󈸸^\u0007𛌵"
+        },
+        {
+            "homepage": "\u0016\u000fk񚼶.󋶽_\u00054󕯛񚩋",
+            "ticker": "\u0000py",
+            "pledge_address": "򦽃c2J訲\u000f᫘`\u0007\u000b𡳨\u0003\u0008.\u0019^bHlU򘱘\u0004\u0014𩀰%#Pp"
+        },
+        {
+            "homepage": "񄘝\u001d\\E\u0005a򵰝񲆫\u0012&o=򻙉Fv=񴂮󯿡򉊸\u0003pX󷣴|4𿾈",
+            "ticker": "@󖋍8\u001b",
+            "pledge_address": "Otn򏳏`(𐰉E_\u0018O󢮷;򷡢>n񆣕!񭆻%Tuw1򀁠"
+        },
+        {
+            "homepage": "Ꝧw𴃦󦖿\u0000􍄼񃌞JDt/󉮍񑕉D񎨡w\u001c󣄝ef\u001e󻎁P",
+            "ticker": "󋩐u򩶧",
+            "pledge_address": "oW 򼽒zQ񗌜Q|@\u0018d\u001cF󮐋\u0018 s򐏒"
+        },
+        {
+            "homepage": "\u0019sXW-$$",
+            "ticker": "1FV",
+            "pledge_address": "/􀔧>\u0015N𯍓𲡺"
+        },
+        {
+            "homepage": "^=󬈵X󞻙%",
+            "ticker": "V󎑉{c",
+            "pledge_address": "󌾕i\u0014󳆟'\u0001-󐣨\u0015"
+        },
+        {
+            "homepage": "",
+            "ticker": "𥠼$𵦈񽥫",
+            "pledge_address": ""
+        },
+        {
+            "homepage": "[򜧜y\u0002𵫍𷍡F>vm\u0008n𞚴\u000fwZ/\u0003\u0000k 1]g󱋪IXG\r",
+            "ticker": "I򽁅򄳂",
+            "pledge_address": "򭁇c򳖌𬎏e񱟂\u001b\u001b䛶'|"
+        },
+        {
+            "homepage": "y,\nk\u001ebu",
+            "ticker": ")aO:",
+            "pledge_address": "Z7򳣣x\u0005\u001c\u0013vp7\u000b"
+        }
+    ]
+}

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -21,6 +21,8 @@ module Cardano.Wallet.Api.TypesSpec (spec) where
 import Prelude hiding
     ( id )
 
+import Cardano.Pool.Metrics
+    ( StakePoolMetadata (..), StakePoolTicker )
 import Cardano.Wallet.Api
     ( Api )
 import Cardano.Wallet.Api.Types
@@ -98,8 +100,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
-    , StakePoolMetadata (..)
-    , StakePoolTicker
     , SyncProgress (..)
     , TxIn (..)
     , TxIn (..)
@@ -282,13 +282,13 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @(ApiT Address, Proxy 'Testnet)
             jsonRoundtripAndGolden $ Proxy @(ApiT AddressPoolGap)
             jsonRoundtripAndGolden $ Proxy @(ApiT Direction)
-            jsonRoundtripAndGolden $ Proxy @(ApiT StakePoolMetadata)
             jsonRoundtripAndGolden $ Proxy @(ApiT TxStatus)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletBalance)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletId)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletName)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletPassphraseInfo)
             jsonRoundtripAndGolden $ Proxy @(ApiT SyncProgress)
+            jsonRoundtripAndGolden $ Proxy @StakePoolMetadata
 
     describe "Textual encoding" $ do
         describe "Can perform roundtrip textual encoding & decoding" $ do
@@ -446,7 +446,7 @@ spec = do
                 "4c43d68b21921034519c36d2475f5adba989bb4465ec"
             |] `shouldBe` (Left @String @(ApiT PoolId) msg)
 
-        it "ApiT StakePoolMetadata" $ do
+        it "StakePoolMetadata" $ do
             let msg = "Error in $.ticker: stake pool ticker length must be 3-4 characters"
             Aeson.parseEither parseJSON [aesonQQ|
                 {
@@ -454,7 +454,7 @@ spec = do
                     "ticker": "too long",
                     "pledge_address": "ed25519_pk15vz9yc5c3upgze8tg5kd7kkzxqgqfxk5a3kudp22hdg0l2za00sq2ufkk7"
                 }
-            |] `shouldBe` (Left @String @(ApiT StakePoolMetadata) msg)
+            |] `shouldBe` (Left @String @StakePoolMetadata msg)
 
     describe "verify HttpApiData parsing failures too" $ do
         it "ApiT WalletId" $ do
@@ -973,6 +973,7 @@ instance Arbitrary ApiStakePool where
         <$> arbitrary
         <*> arbitrary
         <*> choose (0.0, 1.0)
+        <*> arbitrary
 
 instance Arbitrary StakePoolMetadata where
     arbitrary = StakePoolMetadata

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -447,7 +447,7 @@ spec = do
             |] `shouldBe` (Left @String @(ApiT PoolId) msg)
 
         it "ApiT StakePoolMetadata" $ do
-            let msg = "Error in $: stake pool ticker length must be 3-4 characters"
+            let msg = "Error in $.ticker: stake pool ticker length must be 3-4 characters"
             Aeson.parseEither parseJSON [aesonQQ|
                 {
                     "homepage": "https://12345",

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -364,6 +364,28 @@ x-stakePoolApparentPerformance: &stakePoolApparentPerformance
   minimum: 0
   maximum: 1
 
+x-stakePoolMetadata: &stakePoolMetadata
+  description: |
+    Information about the stake pool.
+  type: object
+  required:
+    - ticker
+    - homepage
+    - pledge_address
+  additionalProperties: false
+  properties:
+    ticker:
+      type: string
+      minLength: 3
+      maxLength: 4
+    homepage:
+      type: string
+      format: uri
+    pledge_address:
+      type: string
+      format: bech32
+      example: addr1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2xfvz82xgwh7wal6g2xt8n996s3xvu5g
+
 x-networkInformationSyncProgress: &networkInformationSyncProgress
   <<: *syncProgress
   description: |
@@ -465,6 +487,7 @@ definitions:
       id: *stakePoolId
       metrics: *stakePoolMetrics
       apparent_performance: *stakePoolApparentPerformance
+      metadata: *stakePoolMetadata
 
   ApiFee: &ApiFee
     type: object


### PR DESCRIPTION
Relates to #1063.

# Overview

Adds types, API JSON instances, and swagger spec for stake pool metadata.
