### PR TITLE
Generalize `IsOurs` to work on different types of entity.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -429,7 +429,7 @@ createWallet
         , HasDBLayer s k ctx
         , Show s
         , NFData s
-        , IsOurs s
+        , IsOurs s Address
         )
     => ctx
     -> WalletId
@@ -632,7 +632,7 @@ deleteWallet ctx wid = db & \DBLayer{..} -> do
 listAddresses
     :: forall ctx s k n.
         ( HasDBLayer s k ctx
-        , IsOurs s
+        , IsOurs s Address
         , CompareDiscovery s
         , KnownAddresses s
         , MkKeyFingerprint k Address
@@ -845,7 +845,7 @@ assignMigrationTargetAddresses
     :: forall ctx s k.
         ( HasDBLayer s k ctx
         , GenChange s
-        , IsOurs s
+        , IsOurs s Address
         , NFData s
         , Show s
         )
@@ -956,7 +956,7 @@ signDelegation ctx wid argGenChange pwd coinSel poolId = db & \DBLayer{..} -> do
 -- | Construct transaction metadata from a current block header and a list
 -- of input and output.
 mkTxMeta
-    :: IsOurs s
+    :: IsOurs s Address
     => BlockchainParameters
     -> BlockHeader
     -> s

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -199,6 +199,7 @@ import Cardano.Wallet.Primitive.Types
     , AddressState (..)
     , Block (..)
     , BlockHeader (..)
+    , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
     , FeePolicy (LinearFee)
@@ -430,6 +431,7 @@ createWallet
         , Show s
         , NFData s
         , IsOurs s Address
+        , IsOurs s ChimericAccount
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -159,6 +159,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address
     , AddressState
     , Block
+    , ChimericAccount (..)
     , Coin (..)
     , Hash (..)
     , HistogramBar (..)
@@ -1093,6 +1094,7 @@ createWallet
         , Show s
         , NFData s
         , IsOurs s Address
+        , IsOurs s ChimericAccount
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1092,7 +1092,7 @@ createWallet
         , HasLogger (WorkerCtx ctx)
         , Show s
         , NFData s
-        , IsOurs s
+        , IsOurs s Address
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -177,6 +177,7 @@ import qualified Data.Text as T
 withDBLayer
     :: forall s k a.
         ( IsOurs s W.Address
+        , IsOurs s W.ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -201,6 +202,7 @@ withDBLayer logConfig trace mDatabaseDir action =
 mkDBFactory
     :: forall s k.
         ( IsOurs s W.Address
+        , IsOurs s W.ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -281,6 +283,7 @@ findDatabases tr dir = do
 newDBLayer
     :: forall s k.
         ( IsOurs s W.Address
+        , IsOurs s W.ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -562,7 +565,7 @@ mkCheckpointEntity wid wal =
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already by sorted by index.
 checkpointFromEntity
-    :: (IsOurs s W.Address, NFData s, Show s)
+    :: (IsOurs s W.Address, IsOurs s W.ChimericAccount, NFData s, Show s)
     => Checkpoint
     -> [UTxO]
     -> s

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -176,7 +176,7 @@ import qualified Data.Text as T
 -- library.
 withDBLayer
     :: forall s k a.
-        ( IsOurs s
+        ( IsOurs s W.Address
         , NFData s
         , Show s
         , PersistState s
@@ -200,7 +200,7 @@ withDBLayer logConfig trace mDatabaseDir action =
 -- | Instantiate a 'DBFactory' from a given directory
 mkDBFactory
     :: forall s k.
-        ( IsOurs s
+        ( IsOurs s W.Address
         , NFData s
         , Show s
         , PersistState s
@@ -280,7 +280,7 @@ findDatabases tr dir = do
 -- these things will be handled for you.
 newDBLayer
     :: forall s k.
-        ( IsOurs s
+        ( IsOurs s W.Address
         , NFData s
         , Show s
         , PersistState s
@@ -562,7 +562,7 @@ mkCheckpointEntity wid wal =
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already by sorted by index.
 checkpointFromEntity
-    :: (IsOurs s, NFData s, Show s)
+    :: (IsOurs s W.Address, NFData s, Show s)
     => Checkpoint
     -> [UTxO]
     -> s

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -36,7 +36,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( Address (..) )
 
--- | This abstraction exists to give us the ability to keep the wallet business
+-- | Checks whether or not a given entity belongs to us.
+--
+-- This abstraction exists to give us the ability to keep the wallet business
 -- logic agnostic to the address derivation and discovery mechanisms.
 --
 -- This is needed because two different address schemes lives on Cardano:
@@ -52,12 +54,12 @@ import Cardano.Wallet.Primitive.Types
 -- In practice, we will need a wallet that can support both, even if not at the
 -- same time, and this little abstraction can buy us this without introducing
 -- too much overhead.
-class IsOurs s where
+class IsOurs s entity where
     isOurs
-        :: Address
+        :: entity
         -> s
         -> (Bool, s)
-        -- ^ Checks whether an address is ours or not.
+        -- ^ Checks whether an entity is ours or not.
 
 -- | More powerful than 'isOurs', this abstractions offer the underlying state
 -- the ability to find / compute the address private key corresponding to a
@@ -67,7 +69,7 @@ class IsOurs s where
 -- the root private key of a particular wallet. This isn't true for externally
 -- owned wallet which would delegate its key management to a third party (like
 -- a hardware Ledger or Trezor).
-class IsOurs s => IsOwned s key where
+class IsOurs s Address => IsOwned s key where
     isOwned
         :: s
         -> (key 'RootK XPrv, Passphrase "encryption")

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -111,10 +111,10 @@ instance Buildable (RndState network) where
 -- | Shortcut type alias for HD random address derivation path.
 type DerivationPath = (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'AddressK)
 
--- An address is considered to belong to the 'RndState' wallet if it can be decoded
--- as a Byron HD random address, and where the wallet key can be used to decrypt
--- the address derivation path.
-instance IsOurs (RndState n) where
+-- An address is considered to belong to the 'RndState' wallet if it can be
+-- decoded as a Byron HD random address, and where the wallet key can be used
+-- to decrypt the address derivation path.
+instance IsOurs (RndState n) Address where
     isOurs addr st =
         (isJust path, maybe id (addDiscoveredAddress addr) path st)
       where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -51,7 +51,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..) )
+    ( Address (..), ChimericAccount )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
@@ -119,6 +119,10 @@ instance IsOurs (RndState n) Address where
         (isJust path, maybe id (addDiscoveredAddress addr) path st)
       where
         path = addressToPath addr (hdPassphrase st)
+
+instance IsOurs (RndState n) ChimericAccount where
+    -- Chimeric accounts are not supported, so always return 'False'.
+    isOurs _account state = (False, state)
 
 instance IsOwned (RndState n) ByronKey where
     isOwned st (key, pwd) addr =

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -83,7 +83,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address, invariant )
+    ( Address, ChimericAccount, invariant )
 import Control.Applicative
     ( (<|>) )
 import Control.DeepSeq
@@ -531,6 +531,10 @@ instance
             ours = isJust (internal <|> external)
         in
             (ixs' `deepseq` ours `deepseq` ours, SeqState s1' s2' ixs' rpk)
+
+instance IsOurs (SeqState n k) ChimericAccount where
+    -- TODO: Add support for identifying a 'ChimericAccount' here.
+    isOurs _account state = (False, state)
 
 instance
     ( SoftDerivation k

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -520,7 +520,7 @@ instance
     ( SoftDerivation k
     , MkKeyFingerprint k (k 'AddressK XPub)
     , MkKeyFingerprint k Address
-    ) => IsOurs (SeqState n k) where
+    ) => IsOurs (SeqState n k) Address where
     isOurs addr (SeqState !s1 !s2 !ixs !rpk) =
         let
             (internal, !s1') = lookupAddress addr s1

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -59,7 +60,8 @@ import Prelude
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
+    ( Address (..)
+    , Block (..)
     , BlockHeader (..)
     , Direction (..)
     , Dom (..)
@@ -153,7 +155,7 @@ import qualified Data.Text.Encoding as T
 -- Wallet SeqState Bitcoin
 -- @
 data Wallet s where
-    Wallet :: (IsOurs s, NFData s, Show s)
+    Wallet :: (IsOurs s Address, NFData s, Show s)
         => UTxO -- Unspent tx outputs belonging to this wallet
         -> BlockHeader -- Header of the latest applied block (current tip)
         -> s -- Address discovery state
@@ -229,7 +231,7 @@ slotParams bp =
 --
 -- The wallet tip will be set to the header of the applied genesis block.
 initWallet
-    :: (IsOurs s, NFData s, Show s)
+    :: (IsOurs s Address, NFData s, Show s)
     => Block
         -- ^ The genesis block
     -> BlockchainParameters
@@ -249,7 +251,7 @@ initWallet block bp s =
 -- wallet checkpoints from the database (where it is assumed a valid wallet was
 -- stored into the database).
 unsafeInitWallet
-    :: (IsOurs s, NFData s, Show s)
+    :: (IsOurs s Address, NFData s, Show s)
     => UTxO
        -- ^ Unspent tx outputs belonging to this wallet
     -> BlockHeader
@@ -263,7 +265,7 @@ unsafeInitWallet = Wallet
 
 -- | Update the state of an existing Wallet model
 updateState
-    :: (IsOurs s, NFData s, Show s)
+    :: (IsOurs s Address, NFData s, Show s)
     => s
     -> Wallet s
     -> Wallet s
@@ -389,7 +391,7 @@ blockchainParameters (Wallet _ _ _ bp) = bp
 -- in order, starting from the known inputs that can be spent (from the previous
 -- UTxO) and, collect resolved tx outputs that are ours as we apply transactions.
 prefilterBlock
-    :: (IsOurs s)
+    :: (IsOurs s Address)
     => Block
     -> UTxO
     -> s
@@ -407,7 +409,7 @@ prefilterBlock b u0 = runState $ do
         , amount = Quantity amt
         }
     applyTx
-        :: IsOurs s
+        :: IsOurs s Address
         => ([(Tx, TxMeta)], UTxO)
         ->Tx
         -> State s ([(Tx, TxMeta)], UTxO)
@@ -439,7 +441,7 @@ prefilterBlock b u0 = runState $ do
 -- can only discover new addresses when applying blocks. The state is
 -- therefore use in a read-only mode here.
 changeUTxO
-    :: IsOurs s
+    :: IsOurs s Address
     => Set Tx
     -> s
     -> UTxO
@@ -451,7 +453,7 @@ changeUTxO pending = evalState $
 -- ordered correctly, since they become available inputs for the subsequent
 -- blocks.
 utxoOurs
-    :: IsOurs s
+    :: IsOurs s Address
     => Tx
     -> s
     -> (UTxO, s)

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -63,6 +63,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
     , BlockHeader (..)
+    , ChimericAccount (..)
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
@@ -155,7 +156,12 @@ import qualified Data.Text.Encoding as T
 -- Wallet SeqState Bitcoin
 -- @
 data Wallet s where
-    Wallet :: (IsOurs s Address, NFData s, Show s)
+    Wallet ::
+        ( IsOurs s Address
+        , IsOurs s ChimericAccount
+        , NFData s
+        , Show s
+        )
         => UTxO -- Unspent tx outputs belonging to this wallet
         -> BlockHeader -- Header of the latest applied block (current tip)
         -> s -- Address discovery state
@@ -231,7 +237,7 @@ slotParams bp =
 --
 -- The wallet tip will be set to the header of the applied genesis block.
 initWallet
-    :: (IsOurs s Address, NFData s, Show s)
+    :: (IsOurs s Address, IsOurs s ChimericAccount, NFData s, Show s)
     => Block
         -- ^ The genesis block
     -> BlockchainParameters
@@ -251,7 +257,7 @@ initWallet block bp s =
 -- wallet checkpoints from the database (where it is assumed a valid wallet was
 -- stored into the database).
 unsafeInitWallet
-    :: (IsOurs s Address, NFData s, Show s)
+    :: (IsOurs s Address, IsOurs s ChimericAccount, NFData s, Show s)
     => UTxO
        -- ^ Unspent tx outputs belonging to this wallet
     -> BlockHeader

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -69,6 +69,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
     , BlockHeader (..)
+    , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
     , EpochLength (..)
@@ -167,7 +168,14 @@ import qualified Data.Map.Strict as Map
                                  Modifiers
 -------------------------------------------------------------------------------}
 
-type GenState s = (NFData s, Show s, IsOurs s Address, Arbitrary s, Buildable s)
+type GenState s =
+    ( Arbitrary s
+    , Buildable s
+    , IsOurs s Address
+    , IsOurs s ChimericAccount
+    , NFData s
+    , Show s
+    )
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -166,7 +167,7 @@ import qualified Data.Map.Strict as Map
                                  Modifiers
 -------------------------------------------------------------------------------}
 
-type GenState s = (NFData s, Show s, IsOurs s, Arbitrary s, Buildable s)
+type GenState s = (NFData s, Show s, IsOurs s Address, Arbitrary s, Buildable s)
 
 newtype KeyValPairs k v = KeyValPairs [(k, v)]
     deriving (Generic, Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -23,6 +24,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
+import Cardano.Wallet.Primitive.Types
+    ( Address )
 import Control.DeepSeq
     ( NFData )
 import Test.Hspec
@@ -45,5 +48,5 @@ instance Arbitrary DummyStateMVar where
 
 deriving instance NFData DummyStateMVar
 
-instance IsOurs DummyStateMVar where
+instance IsOurs DummyStateMVar Address where
     isOurs _ num = (True, num)

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -85,6 +85,7 @@ import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
     , Hash (..)
@@ -234,6 +235,7 @@ loggingSpec = withLoggingDB @(SeqState 'Testnet ShelleyKey) @ShelleyKey $ do
 -- variable.
 newMemoryDBLayer
     ::  ( IsOurs s Address
+        , IsOurs s ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -244,6 +246,7 @@ newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
 newMemoryDBLayer'
     ::  ( IsOurs s Address
+        , IsOurs s ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -290,6 +293,7 @@ testingLogConfig = do
 
 withLoggingDB
     ::  ( IsOurs s Address
+        , IsOurs s ChimericAccount
         , NFData s
         , Show s
         , PersistState s
@@ -423,7 +427,12 @@ fileModeSpec =  do
 -- SQLite session has the same effect as executing the same operations over
 -- multiple sessions.
 prop_randomOpChunks
-    :: (Eq s, IsOurs s Address, NFData s, Show s, PersistState s)
+    ::  ( Eq s
+        , IsOurs s Address
+        , IsOurs s ChimericAccount
+        , NFData s
+        , Show s
+        , PersistState s)
     => KeyValPairs (PrimaryKey WalletId) (Wallet s, WalletMetadata)
     -> Property
 prop_randomOpChunks (KeyValPairs pairs) =
@@ -506,7 +515,11 @@ withTestDBFile action expectations = do
         expectations fp
 
 inMemoryDBLayer
-    :: (IsOurs s Address, NFData s, Show s, PersistState s)
+    ::  ( IsOurs s Address
+        , IsOurs s ChimericAccount
+        , NFData s
+        , Show s
+        , PersistState s)
     => IO (SqliteContext, DBLayer IO s ShelleyKey)
 inMemoryDBLayer = newDBLayer' Nothing
 
@@ -514,7 +527,12 @@ temporaryDBFile :: IO FilePath
 temporaryDBFile = emptySystemTempFile "cardano-wallet-SqliteFileMode"
 
 newDBLayer'
-    :: (IsOurs s Address, NFData s, Show s, PersistState s)
+    ::  ( IsOurs s Address
+        , IsOurs s ChimericAccount
+        , NFData s
+        , Show s
+        , PersistState s
+        )
     => Maybe FilePath
     -> IO (SqliteContext, DBLayer IO s ShelleyKey)
 newDBLayer' fp = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -232,7 +233,7 @@ loggingSpec = withLoggingDB @(SeqState 'Testnet ShelleyKey) @ShelleyKey $ do
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.
 newMemoryDBLayer
-    ::  ( IsOurs s
+    ::  ( IsOurs s Address
         , NFData s
         , Show s
         , PersistState s
@@ -242,7 +243,7 @@ newMemoryDBLayer
 newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
 newMemoryDBLayer'
-    ::  ( IsOurs s
+    ::  ( IsOurs s Address
         , NFData s
         , Show s
         , PersistState s
@@ -288,7 +289,7 @@ testingLogConfig = do
     pure logConfig
 
 withLoggingDB
-    ::  ( IsOurs s
+    ::  ( IsOurs s Address
         , NFData s
         , Show s
         , PersistState s
@@ -422,7 +423,7 @@ fileModeSpec =  do
 -- SQLite session has the same effect as executing the same operations over
 -- multiple sessions.
 prop_randomOpChunks
-    :: (Eq s, IsOurs s, NFData s, Show s, PersistState s)
+    :: (Eq s, IsOurs s Address, NFData s, Show s, PersistState s)
     => KeyValPairs (PrimaryKey WalletId) (Wallet s, WalletMetadata)
     -> Property
 prop_randomOpChunks (KeyValPairs pairs) =
@@ -505,7 +506,7 @@ withTestDBFile action expectations = do
         expectations fp
 
 inMemoryDBLayer
-    :: (IsOurs s, NFData s, Show s, PersistState s)
+    :: (IsOurs s Address, NFData s, Show s, PersistState s)
     => IO (SqliteContext, DBLayer IO s ShelleyKey)
 inMemoryDBLayer = newDBLayer' Nothing
 
@@ -513,7 +514,7 @@ temporaryDBFile :: IO FilePath
 temporaryDBFile = emptySystemTempFile "cardano-wallet-SqliteFileMode"
 
 newDBLayer'
-    :: (IsOurs s, NFData s, Show s, PersistState s)
+    :: (IsOurs s Address, NFData s, Show s, PersistState s)
     => Maybe FilePath
     -> IO (SqliteContext, DBLayer IO s ShelleyKey)
 newDBLayer' fp = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -232,22 +232,22 @@ loggingSpec = withLoggingDB @(SeqState 'Testnet ShelleyKey) @ShelleyKey $ do
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.
 newMemoryDBLayer
-    :: ( IsOurs s
-       , NFData s
-       , Show s
-       , PersistState s
-       , PersistPrivateKey (k 'RootK)
-       )
+    ::  ( IsOurs s
+        , NFData s
+        , Show s
+        , PersistState s
+        , PersistPrivateKey (k 'RootK)
+        )
     => IO (DBLayer IO s k)
 newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
 newMemoryDBLayer'
-    :: ( IsOurs s
-       , NFData s
-       , Show s
-       , PersistState s
-       , PersistPrivateKey (k 'RootK)
-       )
+    ::  ( IsOurs s
+        , NFData s
+        , Show s
+        , PersistState s
+        , PersistPrivateKey (k 'RootK)
+        )
     => IO (TVar [LogObject Text], (SqliteContext, DBLayer IO s k))
 newMemoryDBLayer' = do
     logConfig <- testingLogConfig
@@ -288,12 +288,12 @@ testingLogConfig = do
     pure logConfig
 
 withLoggingDB
-    :: ( IsOurs s
-       , NFData s
-       , Show s
-       , PersistState s
-       , PersistPrivateKey (k 'RootK)
-       )
+    ::  ( IsOurs s
+        , NFData s
+        , Show s
+        , PersistState s
+        , PersistPrivateKey (k 'RootK)
+        )
     => SpecWith (IO [LogObject Text], DBLayer IO s k)
     -> Spec
 withLoggingDB = beforeAll newMemoryDBLayer' . beforeWith clean

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
     , BlockHeader (..)
+    , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
     , Dom (..)
@@ -297,6 +298,9 @@ instance IsOurs WalletState Address where
             (True, WalletState ours (Set.insert (ShowFmt addr) discovered))
         else
             (False, s)
+
+instance IsOurs WalletState ChimericAccount where
+    isOurs _account s = (False, s)
 
 instance Arbitrary WalletState where
     shrink = genericShrink

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -216,7 +219,7 @@ prop_initialBlockHeight s =
 
 -- Update UTxO as described in the formal specification, Fig 3. The basic model
 updateUTxO
-    :: IsOurs s
+    :: IsOurs s Address
     => Block
     -> UTxO
     -> State s UTxO
@@ -235,7 +238,7 @@ updateUTxO !b utxo = do
 --    return $ someComputation ours
 -- @
 txOutsOurs
-    :: forall s. (IsOurs s)
+    :: forall s. (IsOurs s Address)
     => Set Tx
     -> s
     -> (Set TxOut, s)
@@ -288,7 +291,7 @@ instance Semigroup WalletState where
             (WalletState ours (a <> b))
             (\_ -> ours == ours')
 
-instance IsOurs WalletState where
+instance IsOurs WalletState Address where
     isOurs addr s@(WalletState ours discovered) =
         if (ShowFmt addr) `elem` ours then
             (True, WalletState ours (Set.insert (ShowFmt addr) discovered))

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -469,7 +469,7 @@ instance Arbitrary DummyState where
     shrink _ = []
     arbitrary = return (DummyState mempty)
 
-instance IsOurs DummyState where
+instance IsOurs DummyState Address where
     isOurs _ s = (True, s)
 
 instance IsOwned DummyState ShelleyKey where

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -59,6 +59,7 @@ import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
     , EpochNo (..)
@@ -471,6 +472,9 @@ instance Arbitrary DummyState where
 
 instance IsOurs DummyState Address where
     isOurs _ s = (True, s)
+
+instance IsOurs DummyState ChimericAccount where
+    isOurs _ s = (False, s)
 
 instance IsOwned DummyState ShelleyKey where
     isOwned (DummyState m) (rootK, pwd) addr = do

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -88,7 +88,13 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address, Block, BlockHeader (..), Hash (..), SyncTolerance )
+    ( Address
+    , Block
+    , BlockHeader (..)
+    , ChimericAccount
+    , Hash (..)
+    , SyncTolerance
+    )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Concurrent
@@ -197,6 +203,7 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
     apiLayer
         :: forall s k.
             ( IsOurs s Address
+            , IsOurs s ChimericAccount
             , NFData s
             , Show s
             , PersistState s
@@ -230,6 +237,7 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
     dbFactory
         :: forall s k.
             ( IsOurs s Address
+            , IsOurs s ChimericAccount
             , NFData s
             , Show s
             , PersistState s

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -88,7 +88,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block, BlockHeader (..), Hash (..), SyncTolerance )
+    ( Address, Block, BlockHeader (..), Hash (..), SyncTolerance )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Concurrent
@@ -196,7 +196,7 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
 
     apiLayer
         :: forall s k.
-            ( IsOurs s
+            ( IsOurs s Address
             , NFData s
             , Show s
             , PersistState s
@@ -229,7 +229,7 @@ serveWallet (cfg, tr) sTolerance databaseDir hostPref listen lj beforeMainLoop =
 
     dbFactory
         :: forall s k.
-            ( IsOurs s
+            ( IsOurs s Address
             , NFData s
             , Show s
             , PersistState s


### PR DESCRIPTION
# Issue Number

#899 

# Overview

This PR:

- [x] Generalizes the definition of the `IsOurs` type class so that it can be applied to more types of entities than Address.
- [x] Adds an `IsOurs s ChimericAccount` constraint to the `Wallet` type.

# Comments

For the moment, we provide an instance of `IsOurs (SeqState n k) ChimericAccount` that always returns `False`. A further PR will add this implementation.