### PR TITLE
Fetch reward account balance when reading or listing wallets

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -50,6 +50,8 @@ import Test.Integration.Framework.DSL
     , amount
     , balanceAvailable
     , balanceTotal
+    , byronBalanceAvailable
+    , byronBalanceTotal
     , calculateByronMigrationCostEp
     , deleteByronWalletEp
     , deleteWalletEp
@@ -224,7 +226,7 @@ spec = do
         $ \ctx -> do
             -- Restore a Byron wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureByronWallet ctx
-            let originalBalance = view balanceAvailable sourceWallet
+            let originalBalance = view byronBalanceAvailable sourceWallet
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
@@ -284,9 +286,9 @@ spec = do
                 (getByronWalletEp wOld)
                 Default
                 Empty >>= flip verify
-                [ expectFieldSatisfy balanceAvailable (> 0)
+                [ expectFieldSatisfy byronBalanceAvailable (> 0)
                 ]
-        let originalBalance = view balanceAvailable wOld
+        let originalBalance = view byronBalanceAvailable wOld
 
         -- Calculate the expected migration fee:
         rFee <- request @ApiByronWalletMigrationInfo ctx
@@ -355,7 +357,7 @@ spec = do
                 (getByronWalletEp sourceWallet) Default Empty
             verify r1
                 [ expectResponseCode @IO HTTP.status200
-                , expectFieldSatisfy balanceAvailable (== 0)
+                , expectFieldSatisfy byronBalanceAvailable (== 0)
                 ]
 
     it "BYRON_MIGRATE_02 - \
@@ -395,7 +397,7 @@ spec = do
                     (getByronWalletEp sourceWallet)
                     Default
                     Empty >>= flip verify
-                    [ expectFieldSatisfy balanceAvailable (> 0)
+                    [ expectFieldSatisfy byronBalanceAvailable (> 0)
                     ]
 
             targetWallet <- emptyWallet ctx
@@ -752,8 +754,8 @@ spec = do
             }|]
         let expectations =
                     [ expectFieldEqual walletName name
-                    , expectFieldEqual balanceAvailable 0
-                    , expectFieldEqual balanceTotal 0
+                    , expectFieldEqual byronBalanceAvailable 0
+                    , expectFieldEqual byronBalanceTotal 0
                     , expectEventually ctx getByronWalletEp state Ready
                     , expectFieldNotEqual passphraseLastUpdate Nothing
                     ]
@@ -770,8 +772,8 @@ spec = do
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 1
             , expectListItemFieldEqual 0 walletName name
-            , expectListItemFieldEqual 0 balanceAvailable 0
-            , expectListItemFieldEqual 0 balanceTotal 0
+            , expectListItemFieldEqual 0 byronBalanceAvailable 0
+            , expectListItemFieldEqual 0 byronBalanceTotal 0
             ]
 
     it "BYRON_RESTORE_02 - One can restore previously deleted wallet" $

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -666,7 +666,8 @@ fetchRewardBalance
     :: forall ctx s k t.
         ( HasDBLayer s k ctx
         , HasNetworkLayer t ctx
-        , HasRewardAccount s k
+        , HasRewardAccount s
+        , k ~ RewardAccountKey s
         , WalletKey k
         )
     => ctx
@@ -707,7 +708,8 @@ listAddresses
         , KnownAddresses s
         , MkKeyFingerprint k Address
         , DelegationAddress n k
-        , HasRewardAccount s k
+        , HasRewardAccount s
+        , k ~ RewardAccountKey s
         )
     => ctx
     -> WalletId

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -621,7 +621,7 @@ listAddresses
     -> Handler [ApiAddress n]
 listAddresses ctx (ApiT wid) stateFilter = do
     addrs <- liftHandler $ withWorkerCtx ctx wid throwE $ \wrk ->
-        W.listAddresses wrk wid
+        W.listAddresses @_ @s @k @n wrk wid
     return $ coerceAddress <$> filter filterCondition addrs
   where
     filterCondition :: (Address, AddressState) -> Bool

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -94,6 +94,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddress (..)
     , ApiBlockReference (..)
     , ApiByronWallet (..)
+    , ApiByronWalletBalance (..)
     , ApiByronWalletMigrationInfo (..)
     , ApiErrorCode (..)
     , ApiFee (..)
@@ -1217,7 +1218,7 @@ mkApiByronWallet
     -> Set Tx
     -> ApiByronWallet
 mkApiByronWallet wid wallet meta progress pending = ApiByronWallet
-    { balance = getWalletBalance wallet pending
+    { balance = getByronWalletBalance wallet pending
     , id = ApiT wid
     , name = ApiT $ meta ^. #name
     , passphrase = ApiT <$> meta ^. #passphraseInfo
@@ -1230,6 +1231,12 @@ getWalletBalance wallet pending = ApiT $ WalletBalance
     { available = Quantity $ availableBalance pending wallet
     , total = Quantity $ totalBalance pending wallet
     , reward = Quantity 0
+    }
+
+getByronWalletBalance :: Wallet s -> Set Tx -> ApiByronWalletBalance
+getByronWalletBalance wallet pending = ApiByronWalletBalance
+    { available = Quantity $ availableBalance pending wallet
+    , total = Quantity $ totalBalance pending wallet
     }
 
 getWalletTip :: Wallet s -> ApiBlockReference

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -58,6 +58,7 @@ module Cardano.Wallet.Api.Types
 
     -- * API Types (Byron)
     , ApiByronWallet (..)
+    , ApiByronWalletBalance (..)
     , ApiByronWalletMigrationInfo (..)
     , ByronWalletPostData (..)
 
@@ -396,7 +397,7 @@ instance ToHttpApiData Iso8601Time where
 
 data ApiByronWallet = ApiByronWallet
     { id :: !(ApiT WalletId)
-    , balance :: !(ApiT WalletBalance)
+    , balance :: !(ApiByronWalletBalance)
     , name :: !(ApiT WalletName)
     , passphrase :: !(Maybe (ApiT WalletPassphraseInfo))
     , state :: !(ApiT SyncProgress)
@@ -548,6 +549,16 @@ instance FromJSON (ApiT WalletBalance) where
     parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
 instance ToJSON (ApiT WalletBalance) where
     toJSON = genericToJSON defaultRecordTypeOptions . getApiT
+
+data ApiByronWalletBalance = ApiByronWalletBalance
+    { available :: !(Quantity "lovelace" Natural)
+    , total :: !(Quantity "lovelace" Natural)
+    } deriving (Eq, Generic, Show)
+
+instance FromJSON ApiByronWalletBalance where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiByronWalletBalance where
+    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT PoolId) where
     parseJSON = parseJSON >=> eitherToParser . bimap ShowFmt ApiT . fromText

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Network
     , ErrNetworkTip (..)
     , ErrGetBlock (..)
     , ErrPostTx (..)
+    , ErrGetAccountBalance (..)
 
     -- * Initialization
     , defaultRetryPolicy
@@ -35,6 +36,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types
     ( Block
     , BlockHeader (..)
+    , ChimericAccount (..)
     , EpochNo
     , Hash (..)
     , PoolId (..)
@@ -132,6 +134,9 @@ data NetworkLayer m target block = NetworkLayer
             ( EpochNo
             , Map PoolId (Quantity "lovelace" Word64)
             )
+    , getAccountBalance
+        :: ChimericAccount
+        -> ExceptT ErrGetAccountBalance m (Quantity "lovelace" Word64)
     }
 
 instance Functor m => Functor (NetworkLayer m target) where
@@ -173,6 +178,11 @@ data ErrPostTx
     deriving (Generic, Show, Eq)
 
 instance Exception ErrPostTx
+
+data ErrGetAccountBalance
+    = ErrGetAccountBalanceNetworkUnreachable ErrNetworkUnavailable
+    | ErrGetAccountBalanceAccountNotFound ChimericAccount
+    deriving (Generic, Eq, Show)
 
 {-------------------------------------------------------------------------------
                               Initialization

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -128,5 +128,6 @@ class KnownAddresses s where
         :: s
         -> [Address]
 
-class HasRewardAccount s k | s -> k where
-    rewardAccount :: s -> k 'AddressK XPub
+class HasRewardAccount s where
+    type RewardAccountKey s :: Depth -> * -> *
+    rewardAccount :: s -> (RewardAccountKey s) 'AddressK XPub

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -25,12 +25,13 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     , GenChange(..)
     , CompareDiscovery(..)
     , KnownAddresses(..)
+    , HasRewardAccount(..)
     ) where
 
 import Prelude
 
 import Cardano.Crypto.Wallet
-    ( XPrv )
+    ( XPrv, XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
@@ -126,3 +127,6 @@ class KnownAddresses s where
     knownAddresses
         :: s
         -> [Address]
+
+class HasRewardAccount s k | s -> k where
+    rewardAccount :: s -> k 'AddressK XPub

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -80,6 +80,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( CompareDiscovery (..)
     , GenChange (..)
+    , HasRewardAccount (..)
     , IsOurs (..)
     , IsOwned (..)
     , KnownAddresses (..)
@@ -626,3 +627,6 @@ instance
           mkAddress fingerprint = liftDelegationAddress @n @k
               fingerprint
               (rewardAccountKey s)
+
+instance HasRewardAccount (SeqState n k) k where
+    rewardAccount = rewardAccountKey

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -628,5 +628,6 @@ instance
               fingerprint
               (rewardAccountKey s)
 
-instance HasRewardAccount (SeqState n k) k where
+instance forall n k. HasRewardAccount (SeqState n k) where
+    type RewardAccountKey (SeqState n k) = k
     rewardAccount = rewardAccountKey

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -31,6 +31,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddress (..)
     , ApiBlockReference (..)
     , ApiByronWallet (..)
+    , ApiByronWalletBalance (..)
     , ApiByronWalletMigrationInfo (..)
     , ApiEpochInfo (..)
     , ApiFee (..)
@@ -271,6 +272,7 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @(ApiTransaction 'Testnet)
             jsonRoundtripAndGolden $ Proxy @ApiWallet
             jsonRoundtripAndGolden $ Proxy @ApiByronWallet
+            jsonRoundtripAndGolden $ Proxy @ApiByronWalletBalance
             jsonRoundtripAndGolden $ Proxy @ApiByronWalletMigrationInfo
             jsonRoundtripAndGolden $ Proxy @ApiWalletPassphrase
             jsonRoundtripAndGolden $ Proxy @ApiUtxoStatistics
@@ -934,6 +936,10 @@ instance Arbitrary ApiWallet where
     shrink = genericShrink
 
 instance Arbitrary ApiByronWallet where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary ApiByronWalletBalance where
     arbitrary = genericArbitrary
     shrink = genericShrink
 

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -95,6 +95,7 @@ mockNetworkLayer = NetworkLayer
     , postTx = \_ -> error "the tx is not a thing that can be posted"
     , staticBlockchainParameters = error "static blockchain params don't exist"
     , stakeDistribution = error "stake? no."
+    , getAccountBalance = error "it is empty"
     }
 
 testShow :: Show a => a -> Spec

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Trace
-    ( Trace )
+    ( Trace, logInfo )
 import Cardano.CLI
     ( Port (..), withLogging )
 import Cardano.Faucet
@@ -131,13 +131,14 @@ specWithServer
     :: (CM.Configuration, Trace IO Text)
     -> SpecWith (Context Jormungandr)
     -> Spec
-specWithServer logCfg = aroundAll withContext . after tearDown
+specWithServer logCfg@(_, trace) = aroundAll withContext . after tearDown
   where
     withContext :: (Context Jormungandr -> IO ()) -> IO ()
     withContext action = do
         ctx <- newEmptyMVar
         let setupContext wAddr nPort bp = do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
+                logInfo trace baseUrl
                 let sixtySeconds = 60*1000*1000 -- 60s in microseconds
                 manager <- (baseUrl,) <$> newManager (defaultManagerSettings
                     { managerResponseTimeout =

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -203,8 +203,6 @@ spec = do
         let existingPoolStake = getQuantity $ p ^. #metrics . #controlledStake
         let contributedStake = faucetUtxoAmt - stakeDelegationFee
         eventually $ do
-            print contributedStake
-            print existingPoolStake
             request @[ApiStakePool] ctx listStakePoolsEp Default Empty >>= flip verify
                 [ expectListItemFieldSatisfy 0 (metrics . stake)
                     (> (existingPoolStake + contributedStake))
@@ -325,7 +323,6 @@ spec = do
                 unsafeRequest @[ApiStakePool] ctx listStakePoolsEp Empty
             w <- fixtureWalletWith ctx [stakeDelegationFee - 1]
             r <- joinStakePool ctx (p ^. #id) (w, "Secure Passphrase")
-            print r
             expectResponseCode HTTP.status403 r
             expectErrorMessage (errMsg403DelegationFee 1) r
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -210,6 +210,20 @@ x-walletBalance: &walletBalance
       <<: *amount
       description: Total balance (available balance plus pending change)
 
+x-byronWalletBalance: &byronWalletBalance
+  description: Byron wallet's current balance(s)
+  type: object
+  required:
+    - available
+    - total
+  properties:
+    available:
+      <<: *amount
+      description: Available balance (funds that can be spent)
+    total:
+      <<: *amount
+      description: Total balance (available balance plus pending change)
+
 x-walletDelegation: &walletDelegation
   description: Delegation settings
   type: object
@@ -571,7 +585,7 @@ definitions:
       - tip
     properties:
       id: *walletId
-      balance: *walletBalance
+      balance: *byronWalletBalance
       name: *walletName
       passphrase: *walletPassphraseInfo
       state: *walletState


### PR DESCRIPTION
# Issue Number

#904 


# Overview

- [x] Byron wallets no longer have a `reward`-field in their `balance`.
- [x] Fetch reward balance when reading or listing Shelley wallets:
    - [x] I have added a `HasRewardAccount` an instance for `SeqState`.
    - [x] I added `getAccountBalance` to `NetworkLayer` which calls `getAccountState` of `JormungandrClient`
    - [x] I added `Cardano.Wallet.fetchRewardBalance` calling `getAccountBalance` with some error-handling.
    - [x] I made sure created Api Wallets ask `fetchRewardBalance` for the reward balance.
- [x] I required the controlled-stake of the pool to increase in `STAKE_POOL_JOIN_01`
- [x] Commented integration test checking that the `rewardBalance` increases

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
