### PR TITLE
Update to latest haskell.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,6 +24,9 @@ let
     inherit pkgs src jmPkgs;
   };
 
+  filterCardanoPackages = pkgs.lib.filterAttrs (_: package: isCardanoWallet package);
+  getPackageChecks = pkgs.lib.mapAttrs (_: package: package.checks);
+
   self = {
     inherit pkgs iohkLib src haskellPackages;
     inherit jormungandr jormungandr-cli;
@@ -36,8 +39,12 @@ let
       haskellBuildUtils = iohkLib.haskellBuildUtils.package;
     };
 
+    # `tests` are the test suites which have been built
     tests = collectComponents "tests" isCardanoWallet haskellPackages;
     benchmarks = collectComponents "benchmarks" isCardanoWallet haskellPackages;
+    # `checks` are the result of executing the tests
+    checks = pkgs.recurseIntoAttrs (getPackageChecks
+       (filterCardanoPackages haskellPackages));
 
     dockerImage = pkgs.callPackage ./nix/docker.nix {
       inherit (self) cardano-wallet-jormungandr;

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -191,9 +191,9 @@ setupMockCommands
         }
     setupWin True = MockCommands
         { mockCommand = \success before -> if success
-                then Command "PING" ["127.0.0.1", "-n", "1", "-w", "1000"] before Inherit
+                then Command "PING" ["/n", "1", "/w", "1000", "127.0.0.1"] before Inherit
                 else Command "START" ["/wait", "xyzzy"] before Inherit
-        , foreverCommand = Command "ping" ["127.0.0.1", "-n", "20", "-w", "1000"] (pure ()) Inherit
+        , foreverCommand = Command "PING" ["/n", "20", "/w", "1000", "127.0.0.1"] (pure ()) Inherit
         }
 
 -- | Use the presence of @winepath.exe@ to detect when running tests under Wine.

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -9,7 +9,7 @@ let
     walletPkgs.pkgs.recurseIntoAttrs {
       inherit (walletPkgs)
         cardano-wallet-jormungandr
-        tests
+        checks
         benchmarks;
     };
 

--- a/nix/haskell-nix-src.json
+++ b/nix/haskell-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "2e4b4ebbb3a0b627fc5e80b11db508306e8bb767",
-  "date": "2019-11-18T16:46:39+10:00",
-  "sha256": "1h1xyg0rdspwm6szfpqvqh9yhv6b40azzaqzygh8shpikqk32fmj",
+  "rev": "d7d24fde4b5c0ebcd704e96aba79e2a148583af7",
+  "date": "2020-01-09T16:07:34+10:00",
+  "sha256": "1p3frk62gb85jb0cdw2rkrsyxaafij98ir45icil30bcwhp4j4q3",
   "fetchSubmodules": false
 }

--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -59,6 +59,7 @@ let
       cp -R ${cardano-wallet-jormungandr} $out
       chmod -R +w $out
       ${setGitRev}
+      rm $out/bin/libffi-6.dll
       cp -v ${pkgs.libffi}/bin/libffi-6.dll $out/bin
       cp ${jormungandr-win64}/bin/* $out/bin
     '';

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -31,12 +31,16 @@ let
       # Add source filtering to local packages
       {
         packages.cardano-wallet-core.src = filterSubDir /lib/core;
+        packages.cardano-wallet-core.components.tests.unit.keepSource = true;
         packages.cardano-wallet-core-integration.src = filterSubDir /lib/core-integration;
         packages.cardano-wallet-cli.src = filterSubDir /lib/cli;
         packages.cardano-wallet-launcher.src = filterSubDir /lib/launcher;
         packages.cardano-wallet-jormungandr.src = filterSubDir /lib/jormungandr;
+        packages.cardano-wallet-jormungandr.components.tests.unit.keepSource = true;
+        packages.cardano-wallet-jormungandr.components.tests.integration.keepSource = true;
         packages.cardano-wallet-test-utils.src = filterSubDir /lib/test-utils;
         packages.text-class.src = filterSubDir /lib/text-class;
+        packages.text-class.components.tests.unit.keepSource = true;
         packages.bech32.src = filterSubDir /lib/bech32;
       }
 
@@ -44,7 +48,7 @@ let
       {
         packages.cardano-wallet-jormungandr.components.tests = {
           # Some tests want to write ~/.local/share/cardano-wallet
-          integration.preBuild = "export HOME=`pwd`";
+          integration.preCheck = "export HOME=`pwd`";
           # provide jormungandr command to test suites
           integration.build-tools = [
             jmPkgs.jormungandr
@@ -71,7 +75,6 @@ let
         # Workaround for Haskell.nix issue
         packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";
         packages.cardano-wallet-core.components.all.preBuild = pkgs.lib.mkForce "";
-        packages.cardano-wallet-jormungandr.components.all.preBuild = pkgs.lib.mkForce "";
       }
 
       # Musl libc fully static build

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -4,8 +4,9 @@ with pkgs.lib;
 
 {
   isCardanoWallet = package:
-    (hasPrefix "cardano-wallet" package.identifier.name) ||
-    (elem package.identifier.name [ "text-class" "bech32" ]);
+    (package.isHaskell or false) &&
+      ((hasPrefix "cardano-wallet" package.identifier.name) ||
+       (elem package.identifier.name [ "text-class" "bech32" ]));
 
   inherit (pkgs.haskell-nix.haskellLib) collectComponents;
 }

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -56,19 +56,17 @@ in pkgs.runCommand name {
       ${testData.jormungandr}/jormungandr/config.yaml > config.yaml
 
   ${pkgs.lib.concatMapStringsSep "\n" (test: ''
-    pkg=`ls -1 ${test} | head -1`
-    exe=`cd ${test}/$pkg; ls -1 *.exe`
-    name=$pkg-test-$exe
-    cp ${test}/$pkg/$exe $name
+    exe=`cd ${test}/bin; ls -1 *.exe`
+    name=${test.packageName}-test-$exe
+    cp ${test}/bin/$exe $name
     echo $name >> tests.bat
     echo "if %errorlevel% neq 0 exit /b %errorlevel%" >> tests.bat
   '') tests}
 
   ${pkgs.lib.concatMapStringsSep "\n" (bench: ''
-    pkg=`ls -1 ${bench} | head -1`
-    exe=`cd ${bench}/$pkg; ls -1 *.exe`
-    name=$pkg-bench-$exe
-    cp ${bench}/$pkg/$exe $name
+    exe=`cd ${bench}/bin; ls -1 *.exe`
+    name=${bench.packageName}-bench-$exe
+    cp ${bench}/bin/$exe $name
   '') benchmarks}
 
   chmod -R +w .


### PR DESCRIPTION
This PR is to prepare for updating to latest haskell.nix.  It is likely we will need #1100 and #1101 to get the tests to pass.

[Hydra jobs](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1106#tabs-jobs) - See under `x86_64-pc-mingw32.checks` for tests running under wine.

- x86_64-pc-mingw32.checks.bech32.bech32-test.x86_64-linux - pass
- x86_64-pc-mingw32.checks.cardano-wallet-cli.unit.x86_64-linux - pass
- x86_64-pc-mingw32.checks.cardano-wallet-core.unit.x86_64-linux - pass
- x86_64-pc-mingw32.checks.cardano-wallet-jormungandr.integration.x86_64-linux - [failed](https://hydra.iohk.io/build/1550317/nixlog/1)
- x86_64-pc-mingw32.checks.cardano-wallet-jormungandr.unit.x86_64-linux - pass	
- x86_64-pc-mingw32.checks.cardano-wallet-launcher.unit.x86_64-linux - [failed](https://hydra.iohk.io/build/1550326/nixlog/2)
- x86_64-pc-mingw32.checks.text-class.unit.x86_64-linux - pass
