### PR TITLE
Buildkite: Make docker push step soft-failable

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -44,7 +44,7 @@ in
   '' + concatMapStringsSep "\n" (image: ''
     branch="''${BUILDKITE_BRANCH:-}"
     tag="''${BUILDKITE_TAG:-}"
-    if [[ -n "$tag" ]] || [[ "$branch" = "rvl/923/docker" ]]; then
+    if [[ -n "$tag" ]]; then
       tag="${image.imageTag}"
     elif [[ "$branch" = master ]]; then
       tag="$(echo ${image.imageTag} | sed -e s/${image.version}/''${BUILDKITE_COMMIT:-dev}/)"
@@ -58,5 +58,6 @@ in
     if [ "$tagged" != "${image.imageName}:${image.imageTag}" ]; then
       docker tag "${image.imageName}:${image.imageTag}" "$tagged"
     fi
+    echo "Pushing $tagged"
     docker push "$tagged"
   '') images)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,3 +41,5 @@ steps:
       - "./docker-build-push"
     agents:
       system: x86_64-linux
+    soft_fail:
+      - exit_status: '*'

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -22,10 +22,17 @@
 
 let
   defaultPort = "8090";
+  dataDir = "/data";
 
   startScript = writeScriptBin "start-cardano-wallet-jormungandr" ''
     #!${runtimeShell}
     set -euo pipefail
+
+    # set up data volume
+    export XDG_DATA_HOME=/
+    mkdir -p ${dataDir}
+    ln -s ${dataDir} /cardano-wallet
+
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     exec ${cardano-wallet-jormungandr}/bin/cardano-wallet-jormungandr "$@"
   '';
@@ -47,9 +54,9 @@ in
     ];
     config = {
       EntryPoint = [ "start-cardano-wallet-jormungandr" ];
-      # Cmd = [ "--port" defaultPort ];
       ExposedPorts = {
         "${defaultPort}/tcp" = {}; # wallet api
       };
+      Volume = [ dataDir ];
     };
   } // { inherit (cardano-wallet-jormungandr) version; }


### PR DESCRIPTION
# Overview

Buildkite builds are often [failing on master](https://buildkite.com/input-output-hk/cardano-wallet/builds?branch=master).

1. Docker image push does not work all the time due to credentials issues. It seems like something that may be flaky anyway. So mark it as "soft fail" in Buildkite.

2. While we're thinking about Docker... Added a data volume `/data`, which is the wallet state directory by default.
