### PR TITLE
Test.Utils.Paths: Fix the test data directory for Windows and Nix

### DIFF
--- a/lib/test-utils/src/Test/Utils/Paths.hs
+++ b/lib/test-utils/src/Test/Utils/Paths.hs
@@ -10,15 +10,31 @@ module Test.Utils.Paths
 
 import Prelude
 
+import Control.Monad.IO.Class
+    ( liftIO )
 import Data.FileEmbed
     ( makeRelativeToProject )
 import Language.Haskell.TH.Syntax
     ( Exp, Q, liftData )
+import System.Environment
+    ( lookupEnv )
 import System.FilePath
     ( (</>) )
 
--- | A TH function to get the test data directory. It combines the current
--- source file location and cabal file to locate the package directory in such a
--- way that works in both the package build and ghci.
+-- | A TH function to get the test data directory.
+--
+-- It combines the current source file location and cabal file to locate the
+-- package directory in such a way that works in both the stack/cabal package
+-- build and ghci.
+--
+-- For the Nix build, rather than baking in a path that starts with @/build@, it
+-- makes the test data path relative to the current directory.
 getTestData :: Q Exp
-getTestData = makeRelativeToProject ("test" </> "data") >>= liftData
+getTestData = do
+    let relPath = "test" </> "data"
+    absPath <- makeRelativeToProject relPath
+
+    -- This environment variable indicates we are building under nix.
+    nixBuildDir <- liftIO $ lookupEnv "NIX_BUILD_TOP"
+
+    liftData $ maybe absPath (const relPath) nixBuildDir


### PR DESCRIPTION
# Issue Number

#703 

# Overview

When running tests under either Windows or Nix, we want the test data directory to be relative to the current directory, rather than an absolute path.

# Comments

Tests pass on Windows:

- [x] `cardano-wallet-core-2019.11.18-test-unit.exe`
- [x] `cardano-wallet-jormungandr-2019.11.18-test-unit.exe`
- [ ] `cardano-wallet-jormungandr-2019.11.18-test-integration.exe` (_running_)
- [x] `cardano-wallet-launcher-2019.11.18-test-unit.exe`
- [x] `cardano-wallet-cli-2019.11.18-test-unit.exe`
- [x] `bech32-2019.11.18-bech32-test.exe`
- [x] `text-class-2019.11.18-test-unit.exe`
