### PR TITLE
Seeded Random Shuffle

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -139,6 +139,7 @@ library
       Data.Time.Text
       Data.Time.Utils
       Data.Quantity
+      Data.Vector.Shuffle
       Network.Wai.Middleware.ServantError
       Network.Wai.Middleware.Logging
   other-modules:
@@ -262,6 +263,7 @@ test-suite unit
       Data.QuantitySpec
       Data.Time.TextSpec
       Data.Time.UtilsSpec
+      Data.Vector.ShuffleSpec
       Network.Wai.Middleware.LoggingSpec
       Spec
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -171,11 +171,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..)
-    , CoinSelectionOptions (..)
-    , ErrCoinSelection (..)
-    , shuffle
-    )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Migration
     ( depleteUTxO, idealBatchSize )
 import Cardano.Wallet.Primitive.Fee
@@ -287,6 +283,8 @@ import Data.Text
     ( Text )
 import Data.Time.Clock
     ( UTCTime, getCurrentTime )
+import Data.Vector.Shuffle
+    ( shuffle )
 import Data.Word
     ( Word16 )
 import Fmt

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -21,32 +21,20 @@ module Cardano.Wallet.Primitive.CoinSelection
     , changeBalance
     , ErrCoinSelection (..)
     , CoinSelectionOptions (..)
-
-    -- * Helpers
-    , shuffle
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
     ( Coin (..), TxIn, TxOut (..) )
-import Control.Monad
-    ( forM_ )
-import Crypto.Number.Generate
-    ( generateBetween )
 import Data.List
     ( foldl' )
-import Data.Vector.Mutable
-    ( IOVector )
 import Data.Word
     ( Word64, Word8 )
 import Fmt
     ( Buildable (..), blockListF, blockListF', listF, nameF )
 import GHC.Generics
     ( Generic )
-
-import qualified Data.Vector as V
-import qualified Data.Vector.Mutable as MV
 
 {-------------------------------------------------------------------------------
                                 Coin Selection
@@ -131,32 +119,3 @@ data ErrCoinSelection e
     -- backend has extra-limitations not covered by our coin selection
     -- algorithm.
     deriving (Show, Eq)
-
-{-------------------------------------------------------------------------------
-                                   Helpers
--------------------------------------------------------------------------------}
-
--- | Shuffles a list of elements.
---
--- >>> shuffle (outputs coinSel)
--- [...]
---
-shuffle :: [a] -> IO [a]
-shuffle = modifyInPlace $ \v -> do
-    let (lo, hi) = (0, MV.length v - 1)
-    forM_ [lo .. hi] $ \i -> do
-      j <- fromInteger <$> generateBetween (fromIntegral lo) (fromIntegral hi)
-      swapElems v i j
-  where
-    swapElems :: IOVector a -> Int -> Int -> IO ()
-    swapElems v i j = do
-        x <- MV.read v i
-        y <- MV.read v j
-        MV.write v i y
-        MV.write v j x
-
-    modifyInPlace :: forall a. (IOVector a -> IO ()) -> [a] -> IO [a]
-    modifyInPlace f xs = do
-        v' <- V.thaw $ V.fromList xs
-        f v'
-        V.toList <$> V.freeze v'

--- a/lib/core/src/Data/Vector/Shuffle.hs
+++ b/lib/core/src/Data/Vector/Shuffle.hs
@@ -8,10 +8,10 @@ import Prelude
 
 import Control.Monad
     ( forM_ )
-import Crypto.Number.Generate
-    ( generateBetween )
 import Data.Vector.Mutable
     ( IOVector )
+import System.Random
+    ( randomRIO )
 
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
@@ -24,7 +24,7 @@ shuffle :: [a] -> IO [a]
 shuffle = modifyInPlace $ \v -> do
     let (lo, hi) = (0, MV.length v - 1)
     forM_ [lo .. hi] $ \i -> do
-      j <- fromInteger <$> generateBetween (fromIntegral lo) (fromIntegral hi)
+      j <- fromInteger <$> randomRIO (fromIntegral lo, fromIntegral hi)
       swapElems v i j
   where
     swapElems :: IOVector a -> Int -> Int -> IO ()

--- a/lib/core/src/Data/Vector/Shuffle.hs
+++ b/lib/core/src/Data/Vector/Shuffle.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Data.Vector.Shuffle
+    ( shuffle
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( forM_ )
+import Crypto.Number.Generate
+    ( generateBetween )
+import Data.Vector.Mutable
+    ( IOVector )
+
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as MV
+
+-- | Shuffles a list of elements.
+--
+-- >>> shuffle (outputs coinSel)
+-- [...]
+shuffle :: [a] -> IO [a]
+shuffle = modifyInPlace $ \v -> do
+    let (lo, hi) = (0, MV.length v - 1)
+    forM_ [lo .. hi] $ \i -> do
+      j <- fromInteger <$> generateBetween (fromIntegral lo) (fromIntegral hi)
+      swapElems v i j
+  where
+    swapElems :: IOVector a -> Int -> Int -> IO ()
+    swapElems v i j = do
+        x <- MV.read v i
+        y <- MV.read v j
+        MV.write v i y
+        MV.write v j x
+
+    modifyInPlace :: forall a. (IOVector a -> IO ()) -> [a] -> IO [a]
+    modifyInPlace f xs = do
+        v' <- V.thaw $ V.fromList xs
+        f v'
+        V.toList <$> V.freeze v'

--- a/lib/core/src/Data/Vector/Shuffle.hs
+++ b/lib/core/src/Data/Vector/Shuffle.hs
@@ -1,7 +1,13 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Data.Vector.Shuffle
-    ( shuffle
+    ( -- * Simple
+      shuffle
+
+      -- * Advanced
+    , mkSeed
+    , shuffleWith
     ) where
 
 import Prelude
@@ -12,13 +18,35 @@ import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.State.Strict
     ( evalStateT, state )
+import Crypto.Hash
+    ( hash )
+import Crypto.Hash.Algorithms
+    ( MD5 )
+import Data.Text
+    ( Text )
 import Data.Vector.Mutable
     ( IOVector )
+import Data.Word
+    ( Word8 )
 import System.Random
-    ( RandomGen, newStdGen, randomR )
+    ( RandomGen, StdGen, mkStdGen, newStdGen, randomR )
 
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
+
+
+-- | Generate a random generator seed from a text string
+mkSeed :: Text -> StdGen
+mkSeed = mkStdGen . toInt . quickHash . T.encodeUtf16LE
+  where
+    quickHash = BA.convert . hash @_ @MD5
+    toInt = snd . BS.foldl' exponentiation (0,0)
+      where
+        exponentiation :: (Int, Int) -> Word8 -> (Int, Int)
+        exponentiation (e, n) i = (e+1, n + fromIntegral i*2^e)
 
 -- | Shuffles a list of elements.
 --
@@ -29,6 +57,11 @@ shuffle xs = newStdGen >>= flip shuffleWith xs
 
 -- | Like 'shuffle', but from a given seed. 'shuffle' will use a randomly
 -- generate seed using 'newStdGen' from @System.Random@.
+--
+-- __Properties:__
+--
+-- - @shuffleWith g es == shuffleWith g es@
+-- - @∃Δ> 1. g ≠g', length es > Δ⇒ shuffleWith g es ≠shuffleWith g' es@
 shuffleWith :: RandomGen g => g -> [a] -> IO [a]
 shuffleWith seed = modifyInPlace $ \v -> flip evalStateT seed $ do
     let (lo, hi) = (0, MV.length v - 1)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -25,11 +25,7 @@ module Cardano.Wallet.Primitive.CoinSelectionSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..)
-    , CoinSelectionOptions (..)
-    , ErrCoinSelection (..)
-    , shuffle
-    )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -45,6 +41,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes )
+import Data.Vector.Shuffle
+    ( shuffle )
 import Data.Word
     ( Word64, Word8 )
 import Fmt
@@ -55,7 +53,6 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Confidence (..)
     , Gen
-    , NonEmptyList (..)
     , Property
     , checkCoverageWith
     , choose
@@ -70,20 +67,13 @@ import Test.QuickCheck.Monadic
     ( monadicIO )
 
 import qualified Data.ByteString as BS
-import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Test.QuickCheck.Monadic as QC
 
 spec :: Spec
 spec = do
-    describe "Coin selection properties : shuffle" $ do
-        it "every non-empty list can be shuffled, ultimately"
-            (checkCoverageWith lowerConfidence prop_shuffleCanShuffle)
-        it "shuffle is non-deterministic"
-            (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
-        it "sort (shuffled xs) == sort xs"
-            (checkCoverageWith lowerConfidence prop_shufflePreserveElements)
+    describe "Coin selection properties" $ do
         it "UTxO toList order deterministic" $
             checkCoverageWith
                 lowerConfidence
@@ -95,28 +85,6 @@ spec = do
 {-------------------------------------------------------------------------------
                                  Properties
 -------------------------------------------------------------------------------}
-
-prop_shuffleCanShuffle
-    :: NonEmptyList Int
-    -> Property
-prop_shuffleCanShuffle (NonEmpty xs) = monadicIO $ QC.run $ do
-    xs' <- shuffle xs
-    return $ cover 90 (xs /= xs') "shuffled" ()
-
-prop_shuffleNotDeterministic
-    :: NonEmptyList Int
-    -> Property
-prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ QC.run $ do
-    xs1 <- shuffle xs
-    xs2 <- shuffle xs
-    return $ cover 90 (xs1 /= xs2) "not deterministic" ()
-
-prop_shufflePreserveElements
-    :: [Int]
-    -> Property
-prop_shufflePreserveElements xs = monadicIO $ QC.run $ do
-    xs' <- shuffle xs
-    return $ cover 90 (not $ null xs) "non-empty" (L.sort xs == L.sort xs')
 
 prop_utxoToListOrderDeterministic
     :: UTxO

--- a/lib/core/test/unit/Data/Vector/ShuffleSpec.hs
+++ b/lib/core/test/unit/Data/Vector/ShuffleSpec.hs
@@ -1,0 +1,56 @@
+module Data.Vector.ShuffleSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Vector.Shuffle
+    ( shuffle )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Confidence (..), NonEmptyList (..), Property, checkCoverageWith, cover )
+import Test.QuickCheck.Monadic
+    ( monadicIO, run )
+
+import qualified Data.List as L
+
+
+spec :: Spec
+spec = do
+    describe "shuffle" $ do
+        it "every non-empty list can be shuffled, ultimately"
+            (checkCoverageWith lowerConfidence prop_shuffleCanShuffle)
+        it "shuffle is non-deterministic"
+            (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
+        it "sort (shuffled xs) == sort xs"
+            (checkCoverageWith lowerConfidence prop_shufflePreserveElements)
+  where
+    lowerConfidence :: Confidence
+    lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
+
+{-------------------------------------------------------------------------------
+                                 Properties
+-------------------------------------------------------------------------------}
+
+prop_shuffleCanShuffle
+    :: NonEmptyList Int
+    -> Property
+prop_shuffleCanShuffle (NonEmpty xs) = monadicIO $ run $ do
+    xs' <- shuffle xs
+    return $ cover 90 (xs /= xs') "shuffled" ()
+
+prop_shuffleNotDeterministic
+    :: NonEmptyList Int
+    -> Property
+prop_shuffleNotDeterministic (NonEmpty xs) = monadicIO $ run $ do
+    xs1 <- shuffle xs
+    xs2 <- shuffle xs
+    return $ cover 90 (xs1 /= xs2) "not deterministic" ()
+
+prop_shufflePreserveElements
+    :: [Int]
+    -> Property
+prop_shufflePreserveElements xs = monadicIO $ run $ do
+    xs' <- shuffle xs
+    return $ cover 90 (not $ null xs) "non-empty" (L.sort xs == L.sort xs')

--- a/lib/core/test/unit/Data/Vector/ShuffleSpec.hs
+++ b/lib/core/test/unit/Data/Vector/ShuffleSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Data.Vector.ShuffleSpec
     ( spec
     ) where
@@ -5,16 +7,27 @@ module Data.Vector.ShuffleSpec
 import Prelude
 
 import Data.Vector.Shuffle
-    ( shuffle )
+    ( mkSeed, shuffle, shuffleWith )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
-    ( Confidence (..), NonEmptyList (..), Property, checkCoverageWith, cover )
+    ( Confidence (..)
+    , NonEmptyList (..)
+    , Positive (..)
+    , PrintableString (..)
+    , Property
+    , arbitrary
+    , checkCoverageWith
+    , cover
+    , label
+    , vectorOf
+    , (==>)
+    )
 import Test.QuickCheck.Monadic
-    ( monadicIO, run )
+    ( assert, monadicIO, monitor, pick, run )
 
 import qualified Data.List as L
-
+import qualified Data.Text as T
 
 spec :: Spec
 spec = do
@@ -25,6 +38,13 @@ spec = do
             (checkCoverageWith lowerConfidence prop_shuffleNotDeterministic)
         it "sort (shuffled xs) == sort xs"
             (checkCoverageWith lowerConfidence prop_shufflePreserveElements)
+
+    describe "shuffleWith / mkSeed" $ do
+        it "shuffling with the same seed is deterministic"
+            (checkCoverageWith lowerConfidence prop_shuffleWithDeterministic)
+        it "different seed means different shuffles"
+            (checkCoverageWith lowerConfidence prop_shuffleDifferentSeed)
+
   where
     lowerConfidence :: Confidence
     lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
@@ -54,3 +74,43 @@ prop_shufflePreserveElements
 prop_shufflePreserveElements xs = monadicIO $ run $ do
     xs' <- shuffle xs
     return $ cover 90 (not $ null xs) "non-empty" (L.sort xs == L.sort xs')
+
+-- ∀(g :: RandomGen).
+-- ∀(es :: [a]).
+--
+-- shuffleWith g es == shuffleWith g es
+prop_shuffleWithDeterministic
+    :: PrintableString
+    -> NonEmptyList Int
+    -> Property
+prop_shuffleWithDeterministic (PrintableString seed) (NonEmpty xs) =
+    monadicIO $ do
+        ys0 <- run $ shuffleWith (mkSeed $ T.pack seed) xs
+        ys1 <- run $ shuffleWith (mkSeed $ T.pack seed) xs
+        monitor $ cover 90 (length xs > 1) "non singleton"
+        assert (ys0 == ys1)
+
+-- ∀(x0 : Text, x1 : Text). g0 = mkSeed x0, g1 = mkSeed x1
+-- ∃(Δ: Int).
+-- ∀(es :: [a]).
+--
+-- g0 ≠g1, length es > Δ⇒ shuffleWith g0 es ≠shuffleWith g1 es
+prop_shuffleDifferentSeed
+    :: (PrintableString, PrintableString)
+    -> Positive Int
+    -> Property
+prop_shuffleDifferentSeed (x0, x1) (Positive len) = do
+    x0 /= x1 ==> monadicIO $ do
+        let g0 = mkSeed $ T.pack $ getPrintableString x0
+        let g1 = mkSeed $ T.pack $ getPrintableString x1
+        es <- pick $ vectorOf len (arbitrary @Int)
+        ys0 <- run $ shuffleWith g0 es
+        ys1 <- run $ shuffleWith g1 es
+        monitor $ label (prettyLen es)
+        monitor $ cover 90 (ys0 /= ys1) "different"
+  where
+    prettyLen :: [a] -> String
+    prettyLen xs = case length xs of
+        n | n <= 1 -> "singleton"
+        n | n <= 10 -> "small list"
+        _ -> "big list"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1102 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 995e00668 move 'shuffle' (and specs) into a separate module
    In order to extend this and use it in other places than just the coin selection
    it makes sense to give it a proper home.

- 9064a7827 replace 'Crypto.Number.Generate' by 'System.Random'
    We don't need a crypto-resistent generator here and a system generator
    will do for shuffling outputs or stake pools

- 5a7bb3798 allow shuffle to be seeded with a 'RandomGen'

- 7c95cec01 implement 'mkSeed' to generate a seed from a text
    This would be pretty useful to bridge use any entity (e.g. WalletId) with a
    ToText instance as a seed for such generator

# Comments

<!-- Additional comments or screenshots to attach if any -->

```
Data.Vector.Shuffle
  shuffle
    every non-empty list can be shuffled, ultimately
      +++ OK, passed 100 tests (92% shuffled).
    shuffle is non-deterministic
      +++ OK, passed 100 tests (92% not deterministic).
    sort (shuffled xs) == sort xs
      +++ OK, passed 100 tests (93% non-empty).
  shuffleWith / mkSeed
    shuffling with the same seed is deterministic
      +++ OK, passed 100 tests (94% non singleton).
    different seed means different shuffles
      +++ OK, passed 200 tests; 21 discarded:
      91.0% different
      
      66.0% big list
      28.0% small list
       6.0% singleton
```


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
