### PR TITLE
fix 'Hash' generation in benchmark: must be 32 bytes

### DIFF
--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -638,7 +638,7 @@ rewardAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, mempty) mempty
 
 -- | Make a prefixed bytestring for use as a Hash or Address.
 label :: Show n => String -> n -> B8.ByteString
-label prefix n = B8.pack (prefix <> show n)
+label prefix n = B8.take 32 $ B8.pack (prefix <> show n) <> B8.replicate 32 '0'
 
 mkAddress :: Int -> Int -> Address
 mkAddress i j =


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1067 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed 'Hash' generation in benchmark: must be 32 bytes
- [x] I have fixed 'Address' generation in benchmark: must have valid discriminant byte.

# Comments

<!-- Additional comments or screenshots to attach if any -->

~~Test build going on here: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/298~~ (failed because of address generation in the address pools).

~~New try: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/300~~ (I built the wrong branch :disappointed: ... this was `master` ...)

Another try: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/301

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
