### PR TITLE
Order pools arbitrarily in the first epoch

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -31,6 +31,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word64 )
+import System.Random
+    ( StdGen )
 
 -- | A Database interface for storing pool production in DB.
 --
@@ -76,6 +78,13 @@ data DBLayer m = forall stm. MonadFail stm => DBLayer
         -- be the last element in the list.
         --
         -- This is useful for the @NetworkLayer@ to know how far we have synced.
+
+    , readSystemSeed
+        :: stm StdGen
+        -- ^ Read the seed assigned to this particular database. The seed is
+        -- created with the database and is "unique" for each database. This
+        -- however allow to have a seed that can be used to produce consistent
+        -- results across requests.
 
     , rollbackTo
         :: SlotId -> stm ()

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -30,6 +30,8 @@ import Database.Persist.TH
     ( mkDeleteCascade, mkMigrate, mkPersist, persistLowerCase, share )
 import GHC.Generics
     ( Generic (..) )
+import System.Random
+    ( StdGen )
 
 import qualified Cardano.Wallet.DB.Sqlite.Types as W
 import qualified Cardano.Wallet.Primitive.Types as W
@@ -40,6 +42,12 @@ share
     , mkMigrate "migrateAll"
     ]
     [persistLowerCase|
+
+-- A unique, but arbitrary, value for this particular device
+ArbitrarySeed sql=arbitrary_seed
+    seedSeed                    StdGen       sql=seed
+
+    deriving Show Generic
 
 -- The set of stake pools that produced a given block
 PoolProduction sql=pool_production

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -231,13 +231,13 @@ newStakePoolLayer db@DBLayer{..} nl tr = StakePoolLayer
                 throwE $ ErrListStakePoolsMetricsInconsistency e
     }
   where
+    (_, bp) = staticBlockchainParameters nl
+    epochLength = bp ^. #getEpochLength
+
+    poolProductionTip :: IO (Maybe BlockHeader)
     poolProductionTip = atomically $ readPoolProductionCursor 1 >>= \case
         [x] -> return $ Just x
         _ -> return Nothing
-
-
-    (_, bp) = staticBlockchainParameters nl
-    epochLength = bp ^. #getEpochLength
 
     mkStakePool
         :: PoolId


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1103 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- commit a53c040e524537dbd14623fa0f0aff5e57433c31 slightly revise where clause in metrics module
    Adding type signature and reviewing declaration order to make it more readable

- commit a4edc9bb612600e9fd5840c6792b1e7fe2fca649 distinguish first epoch handling when listing stake pools
    This is because, during the first epoch, there's not enough
    data to provide accurate measures for all stake pools. Some
    pools may look "bad" at the beginning of an epoch while some
    others may look good just because they were by chance, elected
    for the first blocks.
    
    To circumvent this, we simply return pools in an arbitrary order
    during the first epoch, to make sure that results are not biased.

- commit 34a948c1c52288c30cb441abda5212849b0731cf add function to read an arbitrary seed from the pool database
    This is like a singleton pattern, the seed is generated once and then
    stored and retrieved.  The initial generation is arbitrary, and will
    allow different wallet installation to have different orders but also
    allow that order to remain consistent for calls on a same installation.

- commit 735c7a7774fc6c0edd5984a96039c691b86adbfd combined the above work to sort pools arbitrarily in the first epoch

# Comments

<!-- Additional comments or screenshots to attach if any -->

1. I forgot when writing the requirements that stake pools listing is actually independent from wallets. Therefore, we can't really _seed_ an arbitrary generator with a wallet id because.. there's no wallet at this point. Instead, I've chosen to generate an arbitrary seed and keep it in the database so that calls are consistent within a single installation but, different across users. That should be good enough for this purpose :) 

2. `mkSeed` from the other PR (#1102) is now basically useless so I might remove it in another PR.

3. It's a bit hard to test at the integration level. I'll do some manual smoke test but I am not yet convinced on a useful-but-not-time-consuming approach for automated integration tests for this. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
