### PR TITLE
Add `epochCeiling` function to `Primitive.Types`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -90,6 +90,8 @@ module Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , unsafeEpochNo
     , epochStartTime
+    , epochPred
+    , epochSucc
     , SlotParameters (..)
     , SlotLength (..)
     , EpochLength (..)
@@ -1099,6 +1101,20 @@ unsafeEpochNo epochNo
 -- | Calculate the time at which an epoch begins.
 epochStartTime :: SlotParameters -> EpochNo -> UTCTime
 epochStartTime sps e = slotStartTime sps $ SlotId e 0
+
+-- | Return the epoch immediately before the given epoch, or 'Nothing' if there
+--   is no representable epoch before the given epoch.
+epochPred :: EpochNo -> Maybe EpochNo
+epochPred (EpochNo e)
+    | e == minBound = Nothing
+    | otherwise = Just $ EpochNo $ pred e
+
+-- | Return the epoch immediately after the given epoch, or 'Nothing' if there
+--   is no representable epoch after the given epoch.
+epochSucc :: EpochNo -> Maybe EpochNo
+epochSucc (EpochNo e)
+    | e == maxBound = Nothing
+    | otherwise = Just $ EpochNo $ succ e
 
 instance NFData SlotId
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -89,6 +89,7 @@ module Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , EpochNo (..)
     , unsafeEpochNo
+    , epochStartTime
     , SlotParameters (..)
     , SlotLength (..)
     , EpochLength (..)
@@ -1094,6 +1095,10 @@ unsafeEpochNo epochNo
   where
     maxEpochNo :: Word32
     maxEpochNo = fromIntegral @Word31 $ unEpochNo maxBound
+
+-- | Calculate the time at which an epoch begins.
+epochStartTime :: SlotParameters -> EpochNo -> UTCTime
+epochStartTime sps e = slotStartTime sps $ SlotId e 0
 
 instance NFData SlotId
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -92,6 +92,8 @@ module Cardano.Wallet.Primitive.Types
     , epochStartTime
     , epochPred
     , epochSucc
+    , epochCeiling
+    , epochFloor
     , SlotParameters (..)
     , SlotLength (..)
     , EpochLength (..)
@@ -1115,6 +1117,36 @@ epochSucc :: EpochNo -> Maybe EpochNo
 epochSucc (EpochNo e)
     | e == maxBound = Nothing
     | otherwise = Just $ EpochNo $ succ e
+
+-- | For the given time 't', calculate the number of the earliest epoch with
+--   start time 's' such that 't ≤ s'.
+--
+-- Returns 'Nothing' if the calculation would result in an epoch number that is
+-- not representable.
+epochCeiling :: SlotParameters -> UTCTime -> Maybe EpochNo
+epochCeiling sps t
+    | t < timeMin = Just minBound
+    | t > timeMax = Nothing
+    | otherwise = case slotCeiling sps t of
+        SlotId epoch 0 -> Just epoch
+        SlotId epoch _ -> epochSucc epoch
+  where
+    timeMin = epochStartTime sps minBound
+    timeMax = epochStartTime sps maxBound
+
+-- | For the given time 't', calculate the number of the latest epoch with
+--   start time 's' such that 's ≤ t'.
+--
+-- Returns 'Nothing' if the calculation would result in an epoch number that is
+-- not representable.
+epochFloor :: SlotParameters -> UTCTime -> Maybe EpochNo
+epochFloor sps t
+    | t < timeMin = Nothing
+    | t > timeMax = Just maxBound
+    | otherwise = epochNumber <$> slotFloor sps t
+  where
+    timeMin = epochStartTime sps minBound
+    timeMax = epochStartTime sps maxBound
 
 instance NFData SlotId
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -1144,6 +1144,10 @@ instance Arbitrary BlockHeader where
             , pure $ Hash "BLOCK03"
             ]
 
+instance Arbitrary EpochNo where
+    arbitrary = EpochNo <$> arbitrary
+    shrink = genericShrink
+
 instance Arbitrary SlotId where
     shrink _ = []
     arbitrary = do

--- a/lib/test-utils/src/Test/Utils/Time.hs
+++ b/lib/test-utils/src/Test/Utils/Time.hs
@@ -9,13 +9,19 @@
 module Test.Utils.Time
     ( UniformTime
     , genUniformTime
+    , genUniformTimeWithinRange
     , getUniformTime
     ) where
 
 import Prelude
 
 import Data.Time
-    ( Day (ModifiedJulianDay), NominalDiffTime, UTCTime (..), addUTCTime )
+    ( Day (ModifiedJulianDay)
+    , NominalDiffTime
+    , UTCTime (..)
+    , addUTCTime
+    , toModifiedJulianDay
+    )
 import Test.QuickCheck
     ( Arbitrary, Gen, arbitrary, choose, oneof )
 
@@ -31,30 +37,51 @@ instance Arbitrary UniformTime where
 -- | Generate 'UTCTime' values over a uniform range of dates and a mixture of
 --   time precisions.
 --
+-- Dates will be generated in a range that's bounded by 'defaultLowerBound' and
+-- 'defaultUpperBound'.
+
 genUniformTime :: Gen UTCTime
-genUniformTime = oneof
-    [ genWith
-        hoursToNominalDiffTime
-        hoursInOneDay
-    , genWith
-        secondsToNominalDiffTime
-        secondsInOneDay
-    , genWith
-        picosecondsToNominalDiffTime
-        picosecondsInOneDay
-    ]
+genUniformTime = genUniformTimeWithinRange defaultLowerBound defaultUpperBound
+
+-- | Generate 'UTCTime' values over a uniform range of dates and a mixture of
+--   time precisions.
+--
+-- Dates will be generated in a range that's bounded by the given minimum and
+-- maximum Julian day arguments.
+--
+genUniformTimeWithinRange :: Day -> Day -> Gen UTCTime
+genUniformTimeWithinRange lowerBound upperBound
+    | lowerBound > upperBound = error $
+        "genUniformTimeWithinRange: invalid bounds: "
+            <> show (lowerBound, upperBound)
+    | otherwise = oneof
+        [ genWith
+            hoursToNominalDiffTime
+            hoursInOneDay
+        , genWith
+            secondsToNominalDiffTime
+            secondsInOneDay
+        , genWith
+            picosecondsToNominalDiffTime
+            picosecondsInOneDay
+        ]
   where
     genWith :: (Integer -> NominalDiffTime) -> Integer -> Gen UTCTime
     genWith unitsToNominalDiffTime unitsInOneDay = do
         numberOfDays <- ModifiedJulianDay
-            <$> choose (0, daysInFiftyYears)
+            <$> choose
+                ( toModifiedJulianDay lowerBound
+                , toModifiedJulianDay upperBound
+                )
         timeSinceMidnight <- unitsToNominalDiffTime
             <$> choose (0, unitsInOneDay)
         pure $ addUTCTime timeSinceMidnight (UTCTime numberOfDays 0)
 
--- | The approximate number of days in fifty years.
-daysInFiftyYears :: Integral a => a
-daysInFiftyYears = 365 * 50
+defaultLowerBound :: Day
+defaultLowerBound = ModifiedJulianDay 0
+
+defaultUpperBound :: Day
+defaultUpperBound = ModifiedJulianDay $ 365 * 50
 
 -- | The number of hours in a day.
 hoursInOneDay :: Integral a => a


### PR DESCRIPTION
# Issue Number

#1086 

# Overview

This PR:

- [x] Adds the functions `epoch{Ceiling,Floor}`
  - `epochCeiling` calculates the _earliest_ `EpochNo` whose start time is _greater than or equal to_ the specified time. (Required by issue #1086.)
  - `epochFloor`  calculates the _latest_ `EpochNo` whose start time is _less than or equal to_ the specified time. (Added for completeness.)
- [x] Adds the `epochStartTime` and `epoch{Pred,Succ}` helper functions.
- [x] Adds a set of property tests for the above.

# Comments

The functions added by this PR follow the same general pattern as the following existing functions:
* `slot{Ceiling,Floor}`
* `slot{Pred,Succ}`
* `slotStartTime`