### PR TITLE
Estimate fees for joining a stake pool

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1120,6 +1120,7 @@ walletClient =
 
         _listPools
             :<|> _joinStakePool
+            :<|> _joinStakePoolFee
             :<|> _quitStakePool
             = pools
 

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1120,10 +1120,9 @@ walletClient =
 
         _listPools
             :<|> _joinStakePool
-            :<|> _joinStakePoolFee
             :<|> _quitStakePool
+            :<|> _delegationFee
             = pools
-
 
         _networkInformation = network
     in

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -86,6 +86,7 @@ module Test.Integration.Framework.DSL
     , getFromResponseList
     , json
     , joinStakePool
+    , joinStakePoolFee
     , quitStakePool
     , listAddresses
     , listTransactions
@@ -123,6 +124,7 @@ module Test.Integration.Framework.DSL
     , getAddressesEp
     , listStakePoolsEp
     , joinStakePoolEp
+    , joinStakePoolFeeEp
     , quitStakePoolEp
     , stakePoolEp
     , postTxEp
@@ -162,6 +164,7 @@ import Cardano.Wallet.Api.Types
     , ApiByronWallet
     , ApiByronWalletBalance
     , ApiEpochInfo
+    , ApiFee
     , ApiStakePoolMetrics
     , ApiT (..)
     , ApiTransaction
@@ -1154,6 +1157,15 @@ quitStakePool ctx p (w, pass) = do
             } |]
     request @(ApiTransaction 'Testnet) ctx (quitStakePoolEp p w) Default payload
 
+joinStakePoolFee
+    :: forall t w. (HasType (ApiT WalletId) w)
+    => Context t
+    -> ApiT PoolId
+    -> w
+    -> IO (HTTP.Status, Either RequestException ApiFee)
+joinStakePoolFee ctx p w = do
+    request @ApiFee ctx (joinStakePoolFeeEp p w) Default Empty
+
 listAddresses
     :: Context t
     -> ApiWallet
@@ -1351,6 +1363,15 @@ joinStakePoolEp
     -> w
     -> (Method, Text)
 joinStakePoolEp = stakePoolEp "PUT"
+
+joinStakePoolFeeEp
+    :: forall w. (HasType (ApiT WalletId) w)
+    => ApiT PoolId
+    -> w
+    -> (Method, Text)
+joinStakePoolFeeEp pid w = (verb, path <> "/fee")
+    where
+       (verb, path) = stakePoolEp "GET" pid w
 
 quitStakePoolEp
     :: forall w. (HasType (ApiT WalletId) w)

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -86,7 +86,7 @@ module Test.Integration.Framework.DSL
     , getFromResponseList
     , json
     , joinStakePool
-    , joinStakePoolFee
+    , delegationFee
     , quitStakePool
     , listAddresses
     , listTransactions
@@ -124,7 +124,7 @@ module Test.Integration.Framework.DSL
     , getAddressesEp
     , listStakePoolsEp
     , joinStakePoolEp
-    , joinStakePoolFeeEp
+    , delegationFeeEp
     , quitStakePoolEp
     , stakePoolEp
     , postTxEp
@@ -1157,14 +1157,13 @@ quitStakePool ctx p (w, pass) = do
             } |]
     request @(ApiTransaction 'Testnet) ctx (quitStakePoolEp p w) Default payload
 
-joinStakePoolFee
+delegationFee
     :: forall t w. (HasType (ApiT WalletId) w)
     => Context t
-    -> ApiT PoolId
     -> w
     -> IO (HTTP.Status, Either RequestException ApiFee)
-joinStakePoolFee ctx p w = do
-    request @ApiFee ctx (joinStakePoolFeeEp p w) Default Empty
+delegationFee ctx w = do
+    request @ApiFee ctx (delegationFeeEp w) Default Empty
 
 listAddresses
     :: Context t
@@ -1364,14 +1363,15 @@ joinStakePoolEp
     -> (Method, Text)
 joinStakePoolEp = stakePoolEp "PUT"
 
-joinStakePoolFeeEp
+delegationFeeEp
     :: forall w. (HasType (ApiT WalletId) w)
-    => ApiT PoolId
-    -> w
+    => w
     -> (Method, Text)
-joinStakePoolFeeEp pid w = (verb, path <> "/fee")
-    where
-       (verb, path) = stakePoolEp "GET" pid w
+delegationFeeEp w =
+    ( "GET"
+    , "v2/wallets/" <> w ^. walletId <> "/delegations/fees"
+    )
+
 
 quitStakePoolEp
     :: forall w. (HasType (ApiT WalletId) w)

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -32,6 +32,10 @@ module Test.Integration.Framework.TestData
     , russianWalletName
     , wildcardsWalletName
 
+    -- * Stake pool ids
+    , nonExistingStakePool1
+    , invalidPoolIds
+
     -- * Helpers
     , addressPoolGapMax
     , addressPoolGapMin
@@ -265,6 +269,23 @@ arabicWalletName = "ثم نفس سقطت وبالتحديد،, جزيرتي با
 wildcardsWalletName :: Text
 wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 💕 💞 \
 \💓 💗 💖 💘 💝 💟 💜 💛 💚 💙0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
+
+
+--
+-- Stake Pools
+--
+
+nonExistingStakePool1 :: Text
+nonExistingStakePool1 = "008d686a02c6e625b5a59cc9e234f32e5d72987012f9c25c9a6b60ddade197d1"
+
+invalidPoolIds :: [(String, String)]
+invalidPoolIds =
+        [ ("64 chars non-hex", replicate 64 'ś')
+        , ("63 chars hex", replicate 63 '1')
+        , ("65 chars hex", replicate 65 '1')
+        , ("64 chars hex", replicate 64 '1')
+        , ("empty", "")
+        ]
 
 ---
 --- Helpers

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -32,10 +32,6 @@ module Test.Integration.Framework.TestData
     , russianWalletName
     , wildcardsWalletName
 
-    -- * Stake pool ids
-    , nonExistingStakePool1
-    , invalidPoolIds
-
     -- * Helpers
     , addressPoolGapMax
     , addressPoolGapMin
@@ -270,22 +266,6 @@ wildcardsWalletName :: Text
 wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 💕 💞 \
 \💓 💗 💖 💘 💝 💟 💜 💛 💚 💙0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟🇺🇸🇷🇺🇸 🇦🇫🇦🇲🇸"
 
-
---
--- Stake Pools
---
-
-nonExistingStakePool1 :: Text
-nonExistingStakePool1 = "008d686a02c6e625b5a59cc9e234f32e5d72987012f9c25c9a6b60ddade197d1"
-
-invalidPoolIds :: [(String, String)]
-invalidPoolIds =
-        [ ("64 chars non-hex", replicate 64 'ś')
-        , ("63 chars hex", replicate 63 '1')
-        , ("65 chars hex", replicate 65 '1')
-        , ("64 chars hex", replicate 64 '1')
-        , ("empty", "")
-        ]
 
 ---
 --- Helpers

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -138,8 +138,8 @@ type CoreApi t =
 type StakePoolApi t =
     ListStakePools
     :<|> JoinStakePool t
-    :<|> JoinStakePoolFee
     :<|> QuitStakePool t
+    :<|> DelegationFee
 
 type CompatibilityApi n =
     DeleteByronWallet
@@ -284,12 +284,11 @@ type JoinStakePool t = "stake-pools"
     :> PutAcccepted '[JSON] (ApiTransaction t)
 
 
--- | https://input-output-hk.github.io/cardano-wallet/api/#operation/joinStakePool
-type JoinStakePoolFee = "stake-pools"
-    :> Capture "stakePoolId" (ApiT PoolId)
-    :> "wallets"
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getDelegationFee
+type DelegationFee = "wallets"
     :> Capture "walletId" (ApiT WalletId)
-    :> "fee"
+    :> "delegations"
+    :> "fees"
     :> Get '[JSON] ApiFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/quitStakePool

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -138,6 +138,7 @@ type CoreApi t =
 type StakePoolApi t =
     ListStakePools
     :<|> JoinStakePool t
+    :<|> JoinStakePoolFee
     :<|> QuitStakePool t
 
 type CompatibilityApi n =
@@ -281,6 +282,15 @@ type JoinStakePool t = "stake-pools"
     :> Capture "walletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiWalletPassphrase
     :> PutAcccepted '[JSON] (ApiTransaction t)
+
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/joinStakePool
+type JoinStakePoolFee = "stake-pools"
+    :> Capture "stakePoolId" (ApiT PoolId)
+    :> "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "fee"
+    :> Get '[JSON] ApiFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/quitStakePool
 type QuitStakePool t = "stake-pools"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -787,8 +787,8 @@ stakePools
 stakePools ctx spl =
     listPools spl
     :<|> joinStakePool ctx spl
-    :<|> joinStakePoolFee ctx spl
     :<|> quitStakePool ctx
+    :<|> delegationFee ctx
 
 listPools
     :: StakePoolLayer IO
@@ -838,7 +838,7 @@ joinStakePool ctx spl (ApiT pid) (ApiT wid) (ApiWalletPassphrase (ApiT pwd)) = d
   where
     liftE = throwE . ErrJoinStakePoolNoSuchWallet
 
-joinStakePoolFee
+delegationFee
     :: forall ctx s t n k.
         ( DelegationAddress n k
         , Buildable (ErrValidateSelection t)
@@ -848,11 +848,9 @@ joinStakePoolFee
         , ctx ~ ApiLayer s t k
         )
     => ctx
-    -> StakePoolLayer IO
-    -> ApiT PoolId
     -> ApiT WalletId
     -> Handler ApiFee
-joinStakePoolFee ctx _spl (ApiT _pid) (ApiT wid) = do
+delegationFee ctx (ApiT wid) = do
     liftHandler $ withWorkerCtx ctx wid liftE $ \wrk ->
          apiFee <$> W.selectCoinsForDelegation @_ @s @t @k wrk wid
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -92,6 +92,9 @@ outputBalance = foldl' addTxOut 0 . outputs
 changeBalance :: CoinSelection -> Word64
 changeBalance = foldl' addCoin 0 . change
 
+feeBalance :: CoinSelection -> Word64
+feeBalance sel = inputBalance sel - outputBalance sel - changeBalance sel
+
 addTxOut :: Integral a => a -> TxOut -> a
 addTxOut total = addCoin total . coin
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -19,6 +19,7 @@ module Cardano.Wallet.Primitive.CoinSelection
     , inputBalance
     , outputBalance
     , changeBalance
+    , feeBalance
     , ErrCoinSelection (..)
     , CoinSelectionOptions (..)
     ) where

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -13,8 +13,6 @@ module Cardano.Wallet.Jormungandr.TransactionSpec
 
 import Prelude
 
-import Cardano.Wallet.Jormungandr.Compatibility
-    ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Transaction
     ( ErrExceededInpsOrOuts (..), newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -509,7 +507,7 @@ goldenTestStdTx tl keystore inps outs bytes' = it title $ do
     title = "golden test mkStdTx: " <> show inps <> show outs
 
 goldenTestDelegationCertTx
-    :: forall t k. (t ~ Jormungandr, HasCallStack)
+    :: forall t k. (HasCallStack)
     => TransactionLayer t k
     -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
     -> PoolId

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1035,6 +1035,7 @@ x-responsesPostExternalTransaction: &responsesPostExternalTransaction
 
 x-responsesPostTransactionFee: &responsesPostTransactionFee
   <<: *responsesErr400
+  <<: *responsesErr403
   <<: *responsesErr404
   <<: *responsesErr405
   <<: *responsesErr406
@@ -1044,7 +1045,8 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
     schema:
       <<: *ApiFee
 
-x-responsesGetJoinStakePoolFee: &responsesGetJoinStakePoolFee
+x-responsesGetDelegationFee: &responsesGetDelegationFee
+  <<: *responsesErr403
   <<: *responsesErr404
   <<: *responsesErr405
   <<: *responsesErr406
@@ -1252,7 +1254,7 @@ paths:
     post:
       operationId: postTransactionFee
       tags: ["Transactions"]
-      summary: Estimate
+      summary: Estimate Fee
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
@@ -1345,19 +1347,21 @@ paths:
           schema: *parametersQuitStakePool
       responses: *responsesQuitStakePool
 
-  /stake-pools/{stakePoolId}/wallets/{walletId}/fee:
+  /wallets/{walletId}/delegations/fees:
     get:
-      operationId: joinStakePoolFee
+      operationId: getDelegationFee
       tags: ["Stake Pools"]
-      summary: Estimate
+      summary: Estimate Fee
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
-        Estimate fee for joining a stake pool.
+        Estimate fee for joining or leaving a stake pool. Note that it is an
+        estimation because a delegation induces a transaction for which coins
+        have to be selected randomly within the wallet. Because of this randomness,
+        fees can only be estimated.
       parameters:
-        - *parametersStakePoolId
         - *parametersWalletId
-      responses: *responsesGetJoinStakePoolFee
+      responses: *responsesGetDelegationFee
 
   /byron-wallets:
     get:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1044,6 +1044,15 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
     schema:
       <<: *ApiFee
 
+x-responsesGetJoinStakePoolFee: &responsesGetJoinStakePoolFee
+  <<: *responsesErr404
+  <<: *responsesErr405
+  <<: *responsesErr406
+  200:
+    description: Ok
+    schema:
+        <<: *ApiFee
+
 x-responsesListAddresses: &responsesListAddresses
   <<: *responsesErr400
   <<: *responsesErr404
@@ -1335,6 +1344,20 @@ paths:
         - <<: *parametersBody
           schema: *parametersQuitStakePool
       responses: *responsesQuitStakePool
+
+  /stake-pools/{stakePoolId}/wallets/{walletId}/fee:
+    get:
+      operationId: joinStakePoolFee
+      tags: ["Stake Pools"]
+      summary: Estimate
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Estimate fee for joining a stake pool.
+      parameters:
+        - *parametersStakePoolId
+        - *parametersWalletId
+      responses: *responsesGetJoinStakePoolFee
 
   /byron-wallets:
     get:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1042,11 +1042,7 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
   200:
     description: Ok
     schema:
-      type: object
-      required:
-        - amount
-      properties:
-        amount: *ApiFee
+      <<: *ApiFee
 
 x-responsesListAddresses: &responsesListAddresses
   <<: *responsesErr400


### PR DESCRIPTION
# Issue Number

WB-32: #1094 #1096 (Found it easier to tackle both at once)

# Overview

Also see commit history, but main points:

- [x] Added API endpoint *GET /stake-pools/{stake-pool}/wallets/{wallet}/fee*
- [x] Added `feeBalance :: CoinSelection -> Word64`. I re-use `selectCoinsForDelegation` together with `feeBalance` to implement the `joinStakePoolFee` handler.
- [x] Integration tests:
    - STAKE_POOLS_ESTIMATE_FEE_01 - fee matches eventual cost
    - STAKE_POOLS_ESTIMATE_FEE_02 - empty wallet cannot estimate fee
    - STAKE_POOLS_ESTIMATE_FEE_03 - can't use byron wallets
    - STAKE_POOLS_ESTIMATE_FEE_04 - invalid pool and wallet ids

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
