### PR TITLE
Add `nextEpoch` field to `ApiNetworkInformation` type.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -65,6 +65,7 @@ module Test.Integration.Framework.DSL
     , feeEstimator
     , inputs
     , metrics
+    , nextEpoch
     , outputs
     , passphraseLastUpdate
     , stake
@@ -160,6 +161,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddress
     , ApiByronWallet
     , ApiByronWalletBalance
+    , ApiEpochInfo
     , ApiStakePoolMetrics
     , ApiT (..)
     , ApiTransaction
@@ -853,6 +855,15 @@ metrics =
     _get :: HasType ApiStakePoolMetrics s => s -> ApiStakePoolMetrics
     _get = view typed
     _set :: HasType ApiStakePoolMetrics s => (s, ApiStakePoolMetrics) -> s
+    _set (s, v) = set typed v s
+
+nextEpoch :: HasType ApiEpochInfo s => Lens' s ApiEpochInfo
+nextEpoch =
+    lens _get _set
+  where
+    _get :: HasType ApiEpochInfo s => s -> ApiEpochInfo
+    _get = view typed
+    _set :: HasType ApiEpochInfo s => (s, ApiEpochInfo) -> s
     _set (s, v) = set typed v s
 
 stake

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -49,37 +49,57 @@ spec = do
             r <- request @ApiNetworkInformation ctx networkInfoEp Default Empty
             verify r [ expectFieldEqual syncProgress Ready ]
 
-    it "NETWORK_SHELLEY - Wallet has the same tip as network/information" $ \ctx -> do
-        let getNetworkInfo = request @ApiNetworkInformation ctx networkInfoEp Default Empty
-        w <- emptyWallet ctx
-        eventually_ $ do
-            sync <- getNetworkInfo
-            verify sync [ expectFieldEqual syncProgress Ready ]
-        r <- getNetworkInfo
-        let epochNum = getFromResponse (#nodeTip . #epochNumber . #getApiT) r
-        let slotNum = getFromResponse (#nodeTip . #slotNumber . #getApiT) r
-        let blockHeight = getFromResponse (#nodeTip . #height) r
+    it "NETWORK_SHELLEY - Wallet has the same tip as network/information" $
+        \ctx -> do
+            let getNetworkInfo = request @ApiNetworkInformation
+                    ctx networkInfoEp Default Empty
+            w <- emptyWallet ctx
+            eventually_ $ do
+                sync <- getNetworkInfo
+                verify sync [ expectFieldEqual syncProgress Ready ]
+            r <- getNetworkInfo
 
-        expectEventually' ctx getWalletEp state Ready w
-        expectEventually' ctx getWalletEp (#tip . #epochNumber . #getApiT) epochNum w
-        expectEventually' ctx getWalletEp (#tip . #slotNumber . #getApiT) slotNum  w
-        expectEventually' ctx getWalletEp (#tip . #height) blockHeight w
+            let epochNum =
+                    getFromResponse (#nodeTip . #epochNumber . #getApiT) r
+            let slotNum =
+                    getFromResponse (#nodeTip . #slotNumber . #getApiT) r
+            let blockHeight =
+                    getFromResponse (#nodeTip . #height) r
 
-    it "NETWORK_BYRON - Byron wallet has the same tip as network/information" $ \ctx -> do
-        let getNetworkInfo = request @ApiNetworkInformation ctx networkInfoEp Default Empty
-        w <- emptyByronWallet ctx
-        eventually_ $ do
-            sync <- getNetworkInfo
-            verify sync [ expectFieldEqual syncProgress Ready ]
-        r <- getNetworkInfo
-        let epochNum = getFromResponse (#nodeTip . #epochNumber . #getApiT) r
-        let slotNum = getFromResponse (#nodeTip . #slotNumber . #getApiT) r
-        let blockHeight = getFromResponse (#nodeTip . #height) r
+            expectEventually' ctx getWalletEp
+                state Ready w
+            expectEventually' ctx getWalletEp
+                (#tip . #epochNumber . #getApiT) epochNum w
+            expectEventually' ctx getWalletEp
+                (#tip . #slotNumber . #getApiT) slotNum  w
+            expectEventually' ctx getWalletEp
+                (#tip . #height) blockHeight w
 
-        expectEventually' ctx getByronWalletEp state Ready w
-        expectEventually' ctx getByronWalletEp (#tip . #epochNumber . #getApiT) epochNum w
-        expectEventually' ctx getByronWalletEp (#tip . #slotNumber . #getApiT) slotNum  w
-        expectEventually' ctx getByronWalletEp (#tip . #height) blockHeight w
+    it "NETWORK_BYRON - Byron wallet has the same tip as network/information" $
+        \ctx -> do
+            let getNetworkInfo = request @ApiNetworkInformation
+                    ctx networkInfoEp Default Empty
+            w <- emptyByronWallet ctx
+            eventually_ $ do
+                sync <- getNetworkInfo
+                verify sync [ expectFieldEqual syncProgress Ready ]
+            r <- getNetworkInfo
+
+            let epochNum =
+                    getFromResponse (#nodeTip . #epochNumber . #getApiT) r
+            let slotNum =
+                    getFromResponse (#nodeTip . #slotNumber . #getApiT) r
+            let blockHeight =
+                    getFromResponse (#nodeTip . #height) r
+
+            expectEventually' ctx getByronWalletEp
+                state Ready w
+            expectEventually' ctx getByronWalletEp
+                (#tip . #epochNumber . #getApiT) epochNum w
+            expectEventually' ctx getByronWalletEp
+                (#tip . #slotNumber . #getApiT) slotNum w
+            expectEventually' ctx getByronWalletEp
+                (#tip . #height) blockHeight w
 
     describe "NETWORK - v2/network/information - Methods Not Allowed" $ do
         let matrix = ["POST", "CONNECT", "TRACE", "OPTIONS"]
@@ -92,5 +112,6 @@ spec = do
     describe "NETWORK - HTTP headers" $ do
         forM_ (getHeaderCases HTTP.status200)
             $ \(title, headers, expectations) -> it title $ \ctx -> do
-                r <- request @ApiNetworkInformation ctx networkInfoEp headers Empty
+                r <- request @ApiNetworkInformation
+                    ctx networkInfoEp headers Empty
                 verify r expectations

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -97,6 +97,7 @@ import Cardano.Wallet.Api.Types
     , ApiByronWallet (..)
     , ApiByronWalletBalance (..)
     , ApiByronWalletMigrationInfo (..)
+    , ApiEpochInfo (..)
     , ApiErrorCode (..)
     , ApiFee (..)
     , ApiNetworkInformation (..)
@@ -898,6 +899,17 @@ network ctx = do
         (bp ^. #getEpochLength)
         (bp ^. #getSlotLength)
         (bp ^. #getGenesisBlockDate)
+
+newtype ErrNextEpoch = ErrNextEpochCannotBeCalculated Iso8601Time
+
+calculateNextEpoch
+    :: W.SlotParameters -> UTCTime -> Either ErrNextEpoch ApiEpochInfo
+calculateNextEpoch sps time = case W.epochCeiling sps time of
+    Nothing -> Left $ ErrNextEpochCannotBeCalculated $ Iso8601Time time
+    Just en -> Right $ ApiEpochInfo
+        { epochNumber = ApiT en
+        , epochStartTime = W.epochStartTime sps en
+        }
 
 {-------------------------------------------------------------------------------
                                Compatibility API

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -326,6 +326,7 @@ data ApiNetworkTip = ApiNetworkTip
 
 data ApiNetworkInformation = ApiNetworkInformation
     { syncProgress :: !(ApiT SyncProgress)
+    , nextEpoch :: !ApiEpochInfo
     , nodeTip :: !ApiBlockReference
     , networkTip :: !ApiNetworkTip
     } deriving (Eq, Generic, Show)

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkInformation.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkInformation.json
@@ -3,7 +3,7 @@
     "samples": [
         {
             "network_tip": {
-                "epoch_number": 9422698,
+                "epoch_number": 5944,
                 "slot_number": 6008
             },
             "node_tip": {
@@ -11,20 +11,24 @@
                     "quantity": 12714,
                     "unit": "block"
                 },
-                "epoch_number": 16523145,
+                "epoch_number": 1988,
                 "slot_number": 7378
             },
             "sync_progress": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 85,
+                    "quantity": 94,
                     "unit": "percent"
                 }
+            },
+            "next_epoch": {
+                "epoch_start_time": "1901-08-03T13:39:44Z",
+                "epoch_number": 14380
             }
         },
         {
             "network_tip": {
-                "epoch_number": 16289700,
+                "epoch_number": 26506,
                 "slot_number": 31372
             },
             "node_tip": {
@@ -32,16 +36,20 @@
                     "quantity": 10776,
                     "unit": "block"
                 },
-                "epoch_number": 7398920,
+                "epoch_number": 25762,
                 "slot_number": 13741
             },
             "sync_progress": {
                 "status": "ready"
+            },
+            "next_epoch": {
+                "epoch_start_time": "1903-05-04T23:00:00Z",
+                "epoch_number": 20327
             }
         },
         {
             "network_tip": {
-                "epoch_number": 10164666,
+                "epoch_number": 21899,
                 "slot_number": 17028
             },
             "node_tip": {
@@ -49,16 +57,20 @@
                     "quantity": 28458,
                     "unit": "block"
                 },
-                "epoch_number": 6732849,
+                "epoch_number": 23986,
                 "slot_number": 16895
             },
             "sync_progress": {
                 "status": "ready"
+            },
+            "next_epoch": {
+                "epoch_start_time": "1896-08-03T06:18:35Z",
+                "epoch_number": 17460
             }
         },
         {
             "network_tip": {
-                "epoch_number": 13841867,
+                "epoch_number": 29015,
                 "slot_number": 3056
             },
             "node_tip": {
@@ -66,16 +78,20 @@
                     "quantity": 8851,
                     "unit": "block"
                 },
-                "epoch_number": 4737735,
+                "epoch_number": 18786,
                 "slot_number": 10716
             },
             "sync_progress": {
                 "status": "ready"
+            },
+            "next_epoch": {
+                "epoch_start_time": "1886-10-16T08:43:52Z",
+                "epoch_number": 771
             }
         },
         {
             "network_tip": {
-                "epoch_number": 10849552,
+                "epoch_number": 26226,
                 "slot_number": 7658
             },
             "node_tip": {
@@ -83,20 +99,24 @@
                     "quantity": 16194,
                     "unit": "block"
                 },
-                "epoch_number": 8668723,
+                "epoch_number": 7604,
                 "slot_number": 2570
             },
             "sync_progress": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 71,
+                    "quantity": 76,
                     "unit": "percent"
                 }
+            },
+            "next_epoch": {
+                "epoch_start_time": "1906-06-21T03:00:00Z",
+                "epoch_number": 4054
             }
         },
         {
             "network_tip": {
-                "epoch_number": 392246,
+                "epoch_number": 9915,
                 "slot_number": 12652
             },
             "node_tip": {
@@ -104,20 +124,24 @@
                     "quantity": 30387,
                     "unit": "block"
                 },
-                "epoch_number": 1437253,
+                "epoch_number": 31724,
                 "slot_number": 13789
             },
             "sync_progress": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 43,
+                    "quantity": 20,
                     "unit": "percent"
                 }
+            },
+            "next_epoch": {
+                "epoch_start_time": "1883-02-14T07:00:00Z",
+                "epoch_number": 28977
             }
         },
         {
             "network_tip": {
-                "epoch_number": 8731352,
+                "epoch_number": 967,
                 "slot_number": 25884
             },
             "node_tip": {
@@ -125,20 +149,24 @@
                     "quantity": 28802,
                     "unit": "block"
                 },
-                "epoch_number": 14940919,
+                "epoch_number": 2250,
                 "slot_number": 28790
             },
             "sync_progress": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 89,
+                    "quantity": 25,
                     "unit": "percent"
                 }
+            },
+            "next_epoch": {
+                "epoch_start_time": "1901-12-24T06:44:26.334991934085Z",
+                "epoch_number": 16751
             }
         },
         {
             "network_tip": {
-                "epoch_number": 5256271,
+                "epoch_number": 23998,
                 "slot_number": 10727
             },
             "node_tip": {
@@ -146,16 +174,20 @@
                     "quantity": 13753,
                     "unit": "block"
                 },
-                "epoch_number": 2771000,
+                "epoch_number": 7542,
                 "slot_number": 12641
             },
             "sync_progress": {
                 "status": "ready"
+            },
+            "next_epoch": {
+                "epoch_start_time": "1897-10-18T07:10:13Z",
+                "epoch_number": 3142
             }
         },
         {
             "network_tip": {
-                "epoch_number": 12765005,
+                "epoch_number": 30452,
                 "slot_number": 31882
             },
             "node_tip": {
@@ -163,16 +195,20 @@
                     "quantity": 14970,
                     "unit": "block"
                 },
-                "epoch_number": 2752074,
+                "epoch_number": 8394,
                 "slot_number": 20203
             },
             "sync_progress": {
                 "status": "ready"
+            },
+            "next_epoch": {
+                "epoch_start_time": "1859-05-03T00:15:15.611113201235Z",
+                "epoch_number": 1940
             }
         },
         {
             "network_tip": {
-                "epoch_number": 8359058,
+                "epoch_number": 25538,
                 "slot_number": 14050
             },
             "node_tip": {
@@ -180,15 +216,19 @@
                     "quantity": 19661,
                     "unit": "block"
                 },
-                "epoch_number": 2095135,
+                "epoch_number": 10060,
                 "slot_number": 1740
             },
             "sync_progress": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 6,
+                    "quantity": 7,
                     "unit": "percent"
                 }
+            },
+            "next_epoch": {
+                "epoch_start_time": "1889-12-04T10:10:47Z",
+                "epoch_number": 17819
             }
         }
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -750,6 +750,7 @@ spec = do
             let
                 x' = ApiNetworkInformation
                     { syncProgress = syncProgress (x :: ApiNetworkInformation)
+                    , nextEpoch = nextEpoch (x :: ApiNetworkInformation)
                     , nodeTip = nodeTip (x :: ApiNetworkInformation)
                     , networkTip = networkTip (x :: ApiNetworkInformation)
                     }

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -497,16 +497,27 @@ definitions:
       id: *addressId
       state: *addressState
 
+  ApiEpochInfo: &ApiEpochInfo
+    type: object
+    required:
+      - epoch_number
+      - epoch_start_time
+    properties:
+      epoch_number: *epochNumber
+      epoch_start_time: *date
+
   ApiNetworkInformation: &ApiNetworkInformation
     type: object
     required:
       - sync_progress
       - node_tip
       - network_tip
+      - next_epoch
     properties:
       sync_progress: *networkInformationSyncProgress
       node_tip: *networkInformationNodeTip
       network_tip: *networkInformationNetworkTip
+      next_epoch: *ApiEpochInfo
 
   ApiStakePool: &ApiStakePool
     type: object


### PR DESCRIPTION
# Issue Number

#1088 

# Overview

This PR:

- [x] Adds a function `calculateNextEpoch`, which calculates the next epoch after the specified time.
- [x] Adds a `nextEpoch` field to the `ApiNetworkInformation` type.
- [x] Updates integration tests to check that the `nextEpoch` field is present and valid.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
