### PR TITLE
Core Benchmark Adjustments

### DIFF
--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -391,15 +391,16 @@ benchReadTxHistory sortOrder (inf, sup) mstatus DBLayer{..} =
 
 mkTxHistory :: Int -> Int -> Int -> [Word64] -> [(Tx, TxMeta)]
 mkTxHistory numTx numInputs numOutputs range =
-    [ ( force (Tx (mkTxId inps outs) inps outs)
-      , force TxMeta
-          { status = [InLedger, Pending] !! (i `mod` 2)
-          , direction = Incoming
-          , slotId = sl i
-          , blockHeight = Quantity $ fromIntegral $ unSlotNo $ slotNumber $ sl i
-          , amount = Quantity (fromIntegral numOutputs)
-          }
-      )
+    [ force
+        ( (Tx (mkTxId inps outs) inps outs)
+        , TxMeta
+            { status = [InLedger, Pending] !! (i `mod` 2)
+            , direction = Incoming
+            , slotId = sl i
+            , blockHeight = Quantity $ fromIntegral $ unSlotNo $ slotNumber $ sl i
+            , amount = Quantity (fromIntegral numOutputs)
+            }
+        )
     | !i <- [1..numTx]
     , let inps = (mkInputs i numInputs)
     , let outs = (mkOutputs i numOutputs)
@@ -409,7 +410,7 @@ mkTxHistory numTx numInputs numOutputs range =
 
 mkInputs :: Int -> Int -> [(TxIn, Coin)]
 mkInputs prefix n =
-    [force
+    [ force
         ( TxIn (Hash (label lbl i)) (fromIntegral i)
         , Coin $ fromIntegral n
         )
@@ -419,7 +420,10 @@ mkInputs prefix n =
 
 mkOutputs :: Int -> Int -> [TxOut]
 mkOutputs prefix n =
-    [force (TxOut (mkAddress prefix i) (Coin 1)) | !i <- [1..n]]
+    [ force
+        (TxOut (mkAddress prefix i) (Coin 1))
+    | !i <- [1..n]
+    ]
 
 withTxHistory
     :: NFData b
@@ -464,7 +468,9 @@ mkCheckpoints numCheckpoints utxoSize =
         initDummyState
         genesisParameters
 
-    utxo i = force (Map.fromList (zip (map fst $ mkInputs i utxoSize) (mkOutputs i utxoSize)))
+    utxo i = Map.fromList $ zip
+        (map fst $ mkInputs i utxoSize)
+        (mkOutputs i utxoSize)
 
 benchReadUTxO :: DBLayerBench -> IO (Maybe WalletBench)
 benchReadUTxO DBLayer{..} = atomically $ readCheckpoint testPk

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -177,17 +177,15 @@ bgroupWriteUTxO db = bgroup "UTxO (Write)"
     --
     --      #Checkpoints   UTxO Size
     [ bUTxO            1           0
-    , bUTxO          100           0
-    , bUTxO         1000           0
     , bUTxO           10          10
-    , bUTxO          100          10
-    , bUTxO         1000          10
     , bUTxO           10         100
-    , bUTxO          100         100
-    , bUTxO         1000         100
     , bUTxO           10        1000
+    , bUTxO           10       10000
+    , bUTxO          100           0
+    , bUTxO          100          10
+    , bUTxO          100         100
     , bUTxO          100        1000
-    , bUTxO            1       10000
+    , bUTxO          100       10000
     ]
   where
     bUTxO n s = bench lbl $ withCleanDB db $ benchPutUTxO n s
@@ -196,15 +194,12 @@ bgroupWriteUTxO db = bgroup "UTxO (Write)"
 bgroupReadUTxO :: DBLayerBench -> Benchmark
 bgroupReadUTxO db = bgroup "UTxO (Read)"
     --      #Checkpoints   UTxO Size
-    [ bUTxO           10         100
-    , bUTxO          100         100
-    , bUTxO         1000         100
-    , bUTxO           10        1000
-    , bUTxO          100        1000
-    , bUTxO         1000        1000
-    , bUTxO           10       10000
-    , bUTxO          100       10000
-    , bUTxO         1000       10000
+    [ bUTxO            1           0
+    , bUTxO            1          10
+    , bUTxO            1         100
+    , bUTxO            1        1000
+    , bUTxO            1       10000
+    , bUTxO            1      100000
     ]
   where
     bUTxO n s = bench lbl $ withUTxO db n s benchReadUTxO
@@ -213,16 +208,17 @@ bgroupReadUTxO db = bgroup "UTxO (Read)"
 ----------------------------------------------------------------------------
 -- Wallet State (Sequential Scheme) Benchmarks
 --
--- Currently the DBLayer will only store a single checkpoint (no rollback), so
--- the #Checkpoints axis is a bit meaningless.
 bgroupSeqState :: DBLayerBench -> Benchmark
 bgroupSeqState db = bgroup "SeqState"
     --      #Checkpoints  #Addresses
-    [ bSeqState      100          10
+    [ bSeqState       10          10
+    , bSeqState       10         100
+    , bSeqState       10        1000
+    , bSeqState       10       10000
+    , bSeqState      100          10
     , bSeqState      100         100
     , bSeqState      100        1000
-    , bSeqState     1000          10
-    , bSeqState     1000         100
+    , bSeqState      100       10000
     ]
   where
     bSeqState n a = bench lbl $ withCleanDB db $ benchPutSeqState n a

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -103,8 +103,6 @@ import Control.DeepSeq
     ( NFData (..), force )
 import Control.Exception
     ( bracket, handle )
-import Control.Monad
-    ( forM_ )
 import Control.Monad.Trans.Except
     ( mapExceptT )
 import Criterion.Main
@@ -122,8 +120,6 @@ import Data.ByteString
     ( ByteString )
 import Data.Functor
     ( ($>) )
-import Data.List.Split
-    ( chunksOf )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Time.Clock.System
@@ -455,7 +451,7 @@ txHistoryFixture db@DBLayer{..} bSize range = do
 benchPutUTxO :: Int -> Int -> DBLayerBench -> IO ()
 benchPutUTxO numCheckpoints utxoSize DBLayer{..} = do
     let cps = mkCheckpoints numCheckpoints utxoSize
-    unsafeRunExceptT $ mapM_ (mapExceptT atomically . putCheckpoint testPk) cps
+    unsafeRunExceptT $ mapExceptT atomically $ mapM_ (putCheckpoint testPk) cps
 
 mkCheckpoints :: Int -> Int -> [WalletBench]
 mkCheckpoints numCheckpoints utxoSize =
@@ -498,7 +494,7 @@ utxoFixture db@DBLayer{..} numCheckpoints utxoSize = do
 
 benchPutSeqState :: Int -> Int -> DBLayerBench -> IO ()
 benchPutSeqState numCheckpoints numAddrs DBLayer{..} =
-    unsafeRunExceptT $ mapM_ (mapExceptT atomically . putCheckpoint testPk)
+    unsafeRunExceptT $ mapExceptT atomically $ mapM_ (putCheckpoint testPk)
         [ snd $ initWallet block0 genesisParameters $
             SeqState
                 (mkPool numAddrs i)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1067 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

1/ Use db transactions "correctly" :s .. I noticed that the benchmark where doing a lot of mapM_ (atomically action) instead of atomitically (mapM_ action). The difference is subtle but the later is much faster (one db transaction) and actually, better reflects what the actual code does in the wallet engine.
2/ I've removed some pointless extreme case like trying to insert 1000 checkpoints. We insert at most k/100 + 10 checkpoints, so that's ~30 checkpoints. So, now, the worst case bench is just about inserting 100 checkpoints. Though, as a counterpart, I've increased the max size of the UTxO to make sure they better reflect what we might face.
3/ I've removed the "NBatch" parameter for transactions. We always insert transaction history as one batch (though the internal db engine might do multiple batch, that's irrelevant for the bench setup).
4/ I've added some heavier transaction write with 255 and 255 max inputs / outputs since this is the actual limit of Jörmungandr (which didn't end up using a soft tx limit in the end).


# Comments

<!-- Additional comments or screenshots to attach if any -->

Nightly here: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/303

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
