### PR TITLE
Credentials and address for reward account

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -33,6 +33,7 @@ library
     , aeson-pretty
     , ansi-terminal
     , base
+    , bech32
     , bytestring
     , cardano-wallet-core
     , directory

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -126,6 +126,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Passphrase (..)
     , PassphraseMaxLength
     , PassphraseMinLength
+    , WalletKey (..)
+    , deriveRewardAccount
+    , unXPrv
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, defaultAddressPoolGap )
@@ -196,6 +199,7 @@ import Options.Applicative
     , customExecParser
     , eitherReader
     , flag'
+    , footer
     , header
     , help
     , helper
@@ -257,10 +261,13 @@ import System.IO
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
+import qualified Codec.Binary.Bech32 as Bech32
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Bifunctor as Bi
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.List.NonEmpty as NE
@@ -302,6 +309,7 @@ cmdMnemonic = command "mnemonic" $ info (helper <*> cmds) $ mempty
   where
     cmds = subparser $ mempty
         <> cmdMnemonicGenerate
+        <> cmdMnemonicRewardCredentials
 
 -- | Arguments for 'mnemonic generate' command
 newtype MnemonicGenerateArgs = MnemonicGenerateArgs
@@ -322,6 +330,43 @@ cmdMnemonicGenerate = command "generate" $ info (helper <*> cmd) $ mempty
             MS_21 -> mnemonicToText @21 . entropyToMnemonic <$> genEntropy
             MS_24 -> mnemonicToText @24 . entropyToMnemonic <$> genEntropy
         TIO.putStrLn $ T.unwords m
+
+cmdMnemonicRewardCredentials :: Mod CommandFields (IO ())
+cmdMnemonicRewardCredentials =
+    command "reward-credentials" $ info (helper <*> cmd) $ mempty
+        <> progDesc "Derive reward account private key from a given mnemonic."
+        <> footer "/!\\ Only for the Incentivized Testnet /!\\"
+  where
+    cmd = pure exec
+    exec = do
+        wSeed <- fst <$> do
+            let prompt = "Please enter your 15-word mnemonic sentence: "
+            let parser = fromMnemonic @'[15] @"seed" . T.words
+            getLine prompt parser
+        wSndFactor <- maybe mempty fst <$> do
+            let prompt =
+                    "(Enter a blank line if you didn't use a second factor.)\n"
+                    <> "Please enter your 9–12 word mnemonic second factor: "
+            let parser =
+                    optionalE (fromMnemonic @'[9,12] @"generation") . T.words
+            getLine prompt parser <&> \case
+                (Nothing, _) -> Nothing
+                (Just a, t) -> Just (a, t)
+
+        let rootXPrv = Shelley.generateKeyFromSeed (wSeed, wSndFactor) mempty
+        let rewardAccountXPrv = deriveRewardAccount mempty rootXPrv
+
+        let hrp = Bech32.unsafeHumanReadablePartFromText "ed25519e_sk"
+        let dp = Bech32.dataPartFromBytes
+                $ BS.take 64
+                $ unXPrv
+                $ getRawKey
+                rewardAccountXPrv
+        TIO.putStrLn $ mconcat
+            [ "\nHere's your reward account private key:\n\n"
+            , "    ", Bech32.encodeLenient hrp dp
+            , "\n\nKeep it safe!"
+            ]
 
 {-------------------------------------------------------------------------------
                             Commands - 'wallet'

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -335,7 +335,7 @@ cmdMnemonicRewardCredentials :: Mod CommandFields (IO ())
 cmdMnemonicRewardCredentials =
     command "reward-credentials" $ info (helper <*> cmd) $ mempty
         <> progDesc "Derive reward account private key from a given mnemonic."
-        <> footer "/!\\ Only for the Incentivized Testnet /!\\"
+        <> footer "!!! Only for the Incentivized Testnet !!!"
   where
     cmd = pure exec
     exec = do

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -123,6 +123,8 @@ spec = do
             , "Available commands:"
             , "  generate                 Generate English BIP-0039 compatible"
             , "                           mnemonic words."
+            , "  reward-credentials       Derive reward account private key from"
+            , "                           a given mnemonic."
             ]
 
         ["mnemonic", "generate", "--help"] `shouldShowUsage`
@@ -133,6 +135,16 @@ spec = do
             , "  -h,--help                Show this help text"
             , "  --size INT               number of mnemonic words to"
             , "                           generate. (default: 15)"
+            ]
+
+        ["mnemonic", "reward-credentials", "--help"] `shouldShowUsage`
+            [ "Usage:  mnemonic reward-credentials "
+            , "  Derive reward account private key from a given mnemonic."
+            , ""
+            , "Available options:"
+            , "  -h,--help                Show this help text"
+            , ""
+            , "!!! Only for the Incentivized Testnet !!!"
             ]
 
         ["wallet", "--help"] `shouldShowUsage`

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -251,3 +251,4 @@ test-suite integration
       Test.Integration.Jormungandr.Scenario.CLI.Server
       Test.Integration.Jormungandr.Scenario.CLI.StakePools
       Test.Integration.Jormungandr.Scenario.CLI.Transactions
+      Test.Integration.Jormungandr.Scenario.CLI.Mnemonics

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -76,6 +76,7 @@ import qualified Data.Text as T
 import qualified Test.Integration.Jormungandr.Scenario.API.StakePools as StakePoolsApiJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.API.Transactions as TransactionsApiJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Launcher as LauncherCLI
+import qualified Test.Integration.Jormungandr.Scenario.CLI.Mnemonics as MnemonicsJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.StakePools as StakePoolsCliJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Transactions as TransactionsCliJormungandr
@@ -103,6 +104,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \logging ->
         describe "No backend required" $ do
             describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec
             describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
+            describe "Mnemonics CLI tests (Jormungandr)" $ parallel (MnemonicsJormungandr.spec @t)
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
             describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
             describe "Stake Pool Metrics" MetricsSpec.spec

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Jormungandr.Scenario.CLI.Mnemonics
+    ( spec
+    ) where
+
+import Prelude hiding
+    ( lines )
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , FromMnemonic (..)
+    , NetworkDiscriminant (..)
+    , WalletKey (..)
+    , XPrv
+    , XPub (..)
+    , deriveRewardAccount
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( KnownNetwork (..), ShelleyKey (..), generateKeyFromSeed )
+import Data.Text
+    ( Text )
+import System.Command
+    ( Stdout (..) )
+import System.IO
+    ( Handle, hClose, hFlush, hPutStr )
+import System.Process
+    ( withCreateProcess )
+import Test.Hspec
+    ( SpecWith, it )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe )
+import Test.Integration.Framework.DSL
+    ( KnownCommand (..), generateMnemonicsViaCLI, proc' )
+
+import qualified Codec.Binary.Bech32 as Bech32
+import qualified Data.ByteString as BS
+import qualified Data.List as L
+import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
+
+spec :: forall t. KnownCommand t => SpecWith ()
+spec = do
+    it "CLI_MNEMONICS_REWARD_CREDENTIALS - \
+        \address obtained with credentials matches JCLI" $ do
+        Stdout stdout <- generateMnemonicsViaCLI @t []
+        let mnemonics = T.words (T.pack stdout)
+        addr  <- mnemonicsToAccountAddress mnemonics
+        xprv  <- walletRewardCredentials @t mnemonics
+        xpub  <- jcliKeyToPublic xprv
+        addr' <- jcliAddressAccount xpub
+        addr `shouldBe` addr'
+
+{-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------}
+
+-- Like hGetContents but trim any extra newline or space
+hGetTrimmedContents :: Handle -> IO Text
+hGetTrimmedContents =
+    fmap (T.filter (`notElem` ['\n', ' '])) . TIO.hGetContents
+
+mnemonicsToAccountAddress
+    :: [Text]
+        -- ^ A list of mnemonics
+    -> IO Text
+        -- ^ An encoded address
+mnemonicsToAccountAddress mnemonics = do
+    seed <- either (fail . show) pure $ fromMnemonic @'[15] mnemonics
+    pure $ mkAccountAddress $ generateKeyFromSeed (seed, mempty) mempty
+  where
+    -- Derive an account address corresponding to a reward account, from a root key
+    mkAccountAddress
+        :: ShelleyKey 'RootK XPrv
+        -> Text
+    mkAccountAddress =
+        Bech32.encodeLenient hrp
+        . Bech32.dataPartFromBytes
+        . (BS.pack [addrAccount @'Testnet] <>)
+        . xpubPublicKey
+        . getRawKey
+        . publicKey
+        . deriveRewardAccount mempty
+      where
+        hrp = Bech32.unsafeHumanReadablePartFromText "addr"
+
+walletRewardCredentials
+    :: forall t. KnownCommand t
+    => [Text]
+        -- ^ A list of mnemonics
+    -> IO Text
+        -- ^ An encoded extended private key
+walletRewardCredentials mnemonics = do
+    lines <- withCreateProcess
+        (proc' (commandName @t)  ["mnemonic", "reward-credentials"])
+        $ \(Just stdin) (Just stdout) _ _ -> do
+            hPutStr stdin $ T.unpack (T.unwords mnemonics) ++ "\n"
+            hPutStr stdin "\n"
+            hFlush stdin
+            hClose stdin
+            T.lines <$> TIO.hGetContents stdout
+
+    let errNoKey = unwords
+            [ "expected an encoded extended secret key in the output"
+            , "but it's not there. Output is:"
+            , T.unpack (T.unlines lines)
+            ]
+
+    maybe (fail errNoKey) pure $
+        T.filter (/= ' ') <$> L.find (T.isInfixOf "ed25519e_sk") lines
+
+jcliKeyToPublic
+    :: Text
+        -- ^ An encoded private key
+    -> IO Text
+        -- ^ An encoded public key
+jcliKeyToPublic xprv = withCreateProcess
+    ( proc' "jcli" ["key", "to-public"]
+    ) $ \(Just stdin) (Just stdout) _ _ -> do
+        hPutStr stdin (T.unpack xprv)
+        hFlush stdin
+        hClose stdin
+        hGetTrimmedContents stdout
+
+jcliAddressAccount
+    :: Text
+        -- ^ An encoded public key
+    -> IO Text
+        -- ^ An encoded address account
+jcliAddressAccount xpub = withCreateProcess
+    ( proc' "jcli"
+        [ "address", "account", T.unpack xpub
+        , "--testing"
+        , "--prefix", "addr"]
+    ) $ \_ (Just stdout) _ _ -> do
+        hGetTrimmedContents stdout

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -61,6 +61,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."aeson-pretty" or (buildDepError "aeson-pretty"))
           (hsPkgs."ansi-terminal" or (buildDepError "ansi-terminal"))
           (hsPkgs."base" or (buildDepError "base"))
+          (hsPkgs."bech32" or (buildDepError "bech32"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
           (hsPkgs."directory" or (buildDepError "directory"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1119 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added a command to our CLI to spit out the reward account extended private key from a given mnemonic. 

# Comments

<!-- Additional comments or screenshots to attach if any -->

```
$ cardano-wallet-jormungandr mnemonic reward-credentials 
Please enter your 15-word mnemonic sentence: perfect canvas ...
(Enter a blank line if you didn't use a second factor.)
Please enter your 9–12 word mnemonic second factor: 

Here's your reward account private key:

    ed25519e_sk17zph7f___wrwlv2

Keep it safe!
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
