### PR TITLE
Add registered stake pool owners to database schema

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -20,7 +20,7 @@ module Cardano.Pool.DB
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader, EpochNo (..), PoolId, SlotId (..) )
+    ( BlockHeader, EpochNo (..), PoolId, PoolOwner (..), SlotId (..) )
 import Control.Monad.Fail
     ( MonadFail )
 import Control.Monad.Trans.Except
@@ -78,6 +78,18 @@ data DBLayer m = forall stm. MonadFail stm => DBLayer
         -- be the last element in the list.
         --
         -- This is useful for the @NetworkLayer@ to know how far we have synced.
+
+    , putStakePoolOwner
+        :: PoolId
+        -> PoolOwner
+        -> stm ()
+        -- ^ Add a mapping between stake pools and owners. If the mapping
+        -- already exists, this will be a no-op.
+
+    , readStakePoolOwners
+        :: PoolId
+        -> stm [PoolOwner]
+        -- ^ List the owners of a given stake pool.
 
     , readSystemSeed
         :: stm StdGen

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -26,9 +26,11 @@ import Cardano.Pool.DB.Model
     , mCleanPoolProduction
     , mPutPoolProduction
     , mPutStakeDistribution
+    , mPutStakePoolOwner
     , mReadCursor
     , mReadPoolProduction
     , mReadStakeDistribution
+    , mReadStakePoolOwners
     , mReadSystemSeed
     , mRollbackTo
     )
@@ -67,6 +69,12 @@ newDBLayer = do
 
         , readPoolProductionCursor =
             readPoolDB db . mReadCursor
+
+        , putStakePoolOwner = \a0 a1 ->
+            void $ alterPoolDB (const Nothing) db (mPutStakePoolOwner a0 a1)
+
+        , readStakePoolOwners =
+            readPoolDB db . mReadStakePoolOwners
 
         , readSystemSeed =
             modifyMVar db (fmap swap . mReadSystemSeed)

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -68,4 +68,12 @@ StakeDistribution sql=stake_distribution
 
     Primary stakeDistributionPoolId stakeDistributionEpoch
     deriving Show Generic
+
+-- Mapping from pool id to owner
+PoolOwner sql=pool_owner
+    poolOwnerPoolId     W.PoolId     sql=pool_id
+    poolOwnerOwner      W.PoolOwner  sql=pool_owner
+
+    Primary poolOwnerPoolId poolOwnerOwner
+    deriving Show Generic
 |]

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy
     , Hash (..)
     , PoolId
+    , PoolOwner (..)
     , SlotId (..)
     , SlotNo (..)
     , SyncProgress (..)
@@ -417,6 +418,19 @@ instance ToJSON PoolId where
 
 instance FromJSON PoolId where
     parseJSON = aesonFromText "PoolId"
+
+----------------------------------------------------------------------------
+-- PoolOwner
+
+instance PersistField PoolOwner where
+    toPersistValue = toPersistValue . toText
+    fromPersistValue = fromPersistValueFromText
+
+instance PersistFieldSql PoolOwner where
+    sqlType _ = sqlType (Proxy @Text)
+
+instance Read PoolOwner where
+    readsPrec _ = error "readsPrec stub needed for persistent"
 
 ----------------------------------------------------------------------------
 -- HDPassphrase


### PR DESCRIPTION
# Issue Number

Relates to #1091.

# Overview

- Adds database table for stake pool owners
- Adds sqlite queries for adding owners and querying by pool id.
- Adds model/mvar implementation (fwiw)
- Property test combinines the put and read functions.

# Comments

This will cause a database migration, which is adding a new table.
