### PR TITLE
Add an extra scenario to illustrate the delegation "latency"

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -275,9 +275,18 @@ spec = do
             [ expectResponseCode HTTP.status202
             ]
 
+        reward <- eventually $ do
+            r <- request @ApiWallet ctx (getWalletEp w) Default Empty
+            verify r
+                [ expectFieldSatisfy balanceReward (> 0)
+                ]
+            pure $ getFromResponse balanceReward r
+
+        waitForNextEpoch ctx
+
         eventually $ do
             request @ApiWallet ctx (getWalletEp w) Default Empty >>= flip verify
-                [ expectFieldSatisfy balanceReward (> 0)
+                [ expectFieldSatisfy balanceReward (== reward)
                 ]
 
     it "STAKE_POOLS_JOIN_01 - I can join another stake-pool after previously \

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -251,6 +251,8 @@ spec = do
                 , expectListItemFieldEqual 1 status InLedger
                 ]
 
+        waitForNextEpoch ctx
+        waitForNextEpoch ctx
         reward <- getFromResponse balanceReward <$>
             request @ApiWallet ctx (getWalletEp w) Default Empty
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#904 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added an extra scenario regarding rewards behavior described below

# Comments

<!-- Additional comments or screenshots to attach if any -->

At epoch e: Join stake pool P1
At epoch e+1: Quit stake pool P1
At epoch e+2: Stake is being delegated to P1
At epoch e+3: Reward is earned from the delegation in e+2


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
