### PR TITLE
Update stack.yaml (add clock-0.8)

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -6,6 +6,7 @@
         "OddWord" = (((hackage.OddWord)."1.0.2.0").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
+        "clock" = (((hackage.clock)."0.8").revisions).default;
         "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,7 @@ extra-deps:
 - OddWord-1.0.2.0
 - quickcheck-state-machine-0.6.0
 - command-0.1.1
+- clock-0.8
 
 # 'zip' with an extra flag to disable bzlib2 library
 - git: https://github.com/mrkkrp/zip


### PR DESCRIPTION
clock-0.8 finally lifts a bug in the clock package that prevents it from being cross compiled.