### PR TITLE
Use $STRIP instead of hardcoding `strip`

### DIFF
--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -35,7 +35,7 @@ let
       cp -R ${cardano-wallet-jormungandr} $out
       chmod -R +w $out
       ${setGitRev}
-      strip $out/bin/cardano-wallet-jormungandr
+      $STRIP $out/bin/cardano-wallet-jormungandr
       wrapProgram $out/bin/cardano-wallet-jormungandr \
         --prefix PATH : ${jormungandr}/bin
     '';
@@ -44,7 +44,7 @@ let
       cp -R ${cardano-wallet-jormungandr} $out
       chmod -R +w $out
       ${setGitRev}
-      strip $out/bin/cardano-wallet-jormungandr
+      $STRIP $out/bin/cardano-wallet-jormungandr
     '';
 
     darwin = buildCommand [] ''


### PR DESCRIPTION
Nix will supply the correct strip command via the STRIP env variable. This will include the proper target prefix if needed.