### PR TITLE
Buildkite: Prevent broken .stack caches

### DIFF
--- a/.buildkite/.envrc
+++ b/.buildkite/.envrc
@@ -1,0 +1,1 @@
+eval $(lorri direnv --shell-file default.nix)

--- a/.buildkite/default.nix
+++ b/.buildkite/default.nix
@@ -7,7 +7,7 @@ with pkgs;
 
 let
   buildTools = [
-    gnused coreutils git nix gnumake gnutar gzip lz4
+    gnused gnugrep coreutils git nix gnumake gnutar gzip lz4
     stack walletPackages.iohkLib.stack-hpc-coveralls
     haskellPackages.weeder
   ];


### PR DESCRIPTION
# Overview

Sometimes the `.stack` directory extracted from the cache would have references to Nix store paths which have been deleted.
    
That will cause builds to fail.
    
This commit fixes the error by "realising" all Nix store paths in `.stack` and `.stack-work` after restoring the cache.
