### PR TITLE
Provide implementation of `selectCoins` API function.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -60,6 +60,8 @@ module Test.Integration.Framework.DSL
     , balanceTotal
     , balanceReward
     , blocks
+    , coinSelectionInputs
+    , coinSelectionOutputs
     , delegation
     , direction
     , feeEstimator
@@ -167,6 +169,7 @@ import Cardano.Wallet.Api.Types
     , ApiByronWallet
     , ApiByronWalletBalance
     , ApiCoinSelection
+    , ApiCoinSelectionInput
     , ApiEpochInfo
     , ApiFee
     , ApiNetworkInformation
@@ -836,6 +839,32 @@ outputs =
     _get :: s -> [a]
     _get = NE.toList . view typed
     _set :: (s, [a]) -> s
+    _set (s, v) = set typed (NE.fromList v) s
+
+coinSelectionInputs
+    :: forall s n a.
+        ( s ~ ApiCoinSelection n
+        , a ~ ApiCoinSelectionInput n
+        , HasType (NonEmpty a) s
+        )
+    => Lens' s [a]
+coinSelectionInputs =
+    lens _get _set
+  where
+    _get = NE.toList . view typed
+    _set (s, v) = set typed (NE.fromList v) s
+
+coinSelectionOutputs
+    :: forall s n a.
+        ( s ~ ApiCoinSelection n
+        , a ~ AddressAmount n
+        , HasType (NonEmpty a) s
+        )
+    => Lens' s [a]
+coinSelectionOutputs =
+    lens _get _set
+  where
+    _get = NE.toList . view typed
     _set (s, v) = set typed (NE.fromList v) s
 
 status :: HasType (ApiT TxStatus) s => Lens' s TxStatus

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -1483,7 +1483,7 @@ spec = do
         let amount = Quantity 1
         let payment = AddressAmount {address, amount}
         selectCoins ctx wSource (payment :| []) >>= flip verify
-            [ expectResponseCode HTTP.status501 ]
+            [ expectResponseCode HTTP.status200 ]
 
     it "WALLETS_UTXO_01 - Wallet's inactivity is reflected in utxo" $ \ctx -> do
         w <- emptyWallet ctx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -224,6 +224,7 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxStatus (..)
     , UTxOStatistics
+    , UnsignedTx (..)
     , WalletDelegation (..)
     , WalletId (..)
     , WalletMetadata (..)
@@ -1003,10 +1004,7 @@ selectCoinsExternal
     -> WalletId
     -> ArgGenChange s
     -> NonEmpty TxOut
-    -> ExceptT (ErrSelectCoinsExternal e) IO
-        ( NonEmpty (TxIn, TxOut)
-        , NonEmpty TxOut
-        )
+    -> ExceptT (ErrSelectCoinsExternal e) IO UnsignedTx
 selectCoinsExternal ctx wid argGenChange payments = do
     CoinSelection mInputs mPayments mChange <-
         withExceptT ErrSelectCoinsExternalUnableToMakeSelection $
@@ -1019,7 +1017,8 @@ selectCoinsExternal ctx wid argGenChange payments = do
                     argGenChange mPayments mChange $ getState cp
                 putCheckpoint (PrimaryKey wid) (updateState s' cp)
                 pure mOutputs
-    (,) <$> ensureNonEmpty mInputs  ErrSelectCoinsExternalUnableToAssignInputs
+    UnsignedTx
+        <$> ensureNonEmpty mInputs  ErrSelectCoinsExternalUnableToAssignInputs
         <*> ensureNonEmpty mOutputs ErrSelectCoinsExternalUnableToAssignOutputs
   where
     db = ctx ^. dbLayer @s @k

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.Primitive.Types
     , SealedTx (..)
     , TransactionInfo (..)
     , FeePolicy (..)
+    , UnsignedTx (..)
     , txIns
     , isPending
     , inputs
@@ -735,6 +736,18 @@ instance FromText TxStatus where
 
 instance ToText TxStatus where
     toText = toTextFromBoundedEnum SnakeLowerCase
+
+-- | An unsigned transaction.
+--
+-- See 'Tx' for a signed transaction.
+--
+data UnsignedTx = UnsignedTx
+    { unsignedInputs
+        :: NonEmpty (TxIn, TxOut)
+    , unsignedOutputs
+        :: NonEmpty TxOut
+    }
+    deriving (Eq, Show)
 
 -- | The effect of a @Transaction@ on the wallet balance.
 data Direction


### PR DESCRIPTION
# Issue Number

#1136 

# Overview

This PR:

- [x] Provides an implementation of the `selectCoins` API function.
- [x] Provides an integration test to verify that a singleton payment is included in the output.
- [x] Provides an integration test to verify that multiple payments are included in the output.
- [x] Adds an `UnsignedTx` type to capture the concept of a set of inputs and outputs that are ready to be signed into a real `Tx`.