### PR TITLE
Cache the stake pool metadata registry

### DIFF
--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -55,7 +55,7 @@ import Cardano.Pool.DB
 import Cardano.Pool.Metadata
     ( RegistryLog
     , StakePoolMetadata (..)
-    , getRegistryZipUrl
+    , getMetadataConfig
     , getStakePoolMetadata
     , sameStakePoolMetadata
     )
@@ -299,9 +299,9 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
         owners <- atomically $ mapM readStakePoolOwners poolIds
         -- note: this will become simpler once we cache metadata in the database
         let owners' = nub $ concat owners
-        url <- getRegistryZipUrl
+        cfg <- getMetadataConfig metadataDir
         let tr' = contramap (fmap MsgRegistry) tr
-        getStakePoolMetadata tr' metadataDir url owners' >>= \case
+        getStakePoolMetadata tr' cfg owners' >>= \case
             Left _ -> do
                 logTrace tr MsgMetadataUnavailable
                 pure $ replicate (length poolIds) Nothing

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -63,6 +63,7 @@ library
     , servant
     , servant-client
     , servant-client-core
+    , temporary
     , text
     , text-class
     , time

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -92,6 +92,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."servant" or (buildDepError "servant"))
           (hsPkgs."servant-client" or (buildDepError "servant-client"))
           (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
+          (hsPkgs."temporary" or (buildDepError "temporary"))
           (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."text-class" or (buildDepError "text-class"))
           (hsPkgs."time" or (buildDepError "time"))


### PR DESCRIPTION
Relates to #1164.

# Overview

Caches the downloaded stake pool metadata registry zip file in a temporary directory.
