### PR TITLE
use another stake pool with metadata in STAKE_POOL_LIST_04

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Fixture.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Fixture.hs
@@ -156,13 +156,17 @@ nextFaucet owner = liftIO (takeMVar faucet) >>= \case
 faucetAmt :: Int
 faucetAmt = 10000
 
+-- | corresponds with metadata stored in:
+-- lib/jormungandr/test/data/jormungandr/stake_pools/registry/test-integration-registry.zip
 {-# NOINLINE faucetWithMetadata #-}
 faucetWithMetadata :: MVar [(String, String, String)]
 faucetWithMetadata = unsafePerformIO $ newMVar
-    [ ( "ed25519_sk1qm2de9sa6w5ccvrrh7dh7fgpzeupulsjkz3fdqanm2w7e6h0rgasxex46t"
+    [  -- ticker: SWIM
+      ( "ed25519_sk1qm2de9sa6w5ccvrrh7dh7fgpzeupulsjkz3fdqanm2w7e6h0rgasxex46t"
       , "ed25519_pk1kpudvc46w3nnwjfw5zzsrj7jxqwm4znhltkas8yzx9lcezs5e8cswtvx8t"
       , "account1skc834nzhf6xwd6f96sg2qwt6gcpmw52wlawmkqusgchlry2znylzam4v5a"
       )
+      -- ticker: LIVER
     , ( "ed25519_sk103yerx2fq2juzpjda2c0ghz5646cwezd0gvmtxa2jg9qj7hgj0es604myw"
       , "ed25519_pk1577ny3x5etp748l09l594t4lh3tlhxpekalhw0j4fe5ava2jam3shm08mf"
       , "account1sknm6vjy6n9v865lauh7sk4wh77907uc8xmh7ae7248xn4n42thwxlc0c70"

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -192,6 +192,7 @@ spec = do
 
         (poolIdA, poolAOwner)  <- registerStakePool ctx WithMetadata
         (poolIdB, _poolBOwner) <- registerStakePool ctx WithoutMetadata
+        (poolIdC, poolCOwner)  <- registerStakePool ctx WithMetadata
 
         waitForNextEpoch ctx
         waitForNextEpoch ctx
@@ -199,13 +200,16 @@ spec = do
             unsafeRequest @[ApiStakePool] ctx listStakePoolsEp Empty
 
         nWithoutMetadata pools' `shouldBe` nWithoutMetadata pools + 1
-        nWithMetadata pools' `shouldBe` nWithMetadata pools + 1
+        nWithMetadata pools' `shouldBe` nWithMetadata pools + 2
 
         let (Just poolA) = find ((== ApiT poolIdA) . view #id) pools'
         fmap (view #owner) (poolA ^. #metadata) `shouldBe` Just poolAOwner
 
         let (Just poolB) = find ((== ApiT poolIdB) . view #id) pools'
         (poolB ^. #metadata) `shouldBe` Nothing
+
+        let (Just poolC) = find ((== ApiT poolIdC) . view #id) pools'
+        fmap (view #owner) (poolC ^. #metadata) `shouldBe` Just poolCOwner
 
     it "STAKE_POOLS_JOIN_01 - Can join a stakepool" $ \ctx -> do
         w <- fixtureWallet ctx


### PR DESCRIPTION
# Issue Number

#1065

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I thought it will be useful to use the second stake-pool with metadata as well. If anything bad happens, it is more likely to be discovered when there are more pools... I think. (Also added some more comments around the stake pool faucet)


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
