### PR TITLE
Show newcomers when listing stake pools (with an average perf)

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -204,7 +204,6 @@ spec = do
         (poolIdC, poolCOwner)  <- registerStakePool ctx WithMetadata
 
         waitForNextEpoch ctx
-        waitForNextEpoch ctx
         (_, pools') <- eventually $
             unsafeRequest @[ApiStakePool] ctx listStakePoolsEp Empty
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1090 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added newcomer pools to listing, according to section 5.6.6 of the delegation design which suggest initializing the newcomers to the average performance of the top existing pools. 
- [x] I have slightly adjusted one integration tests to wait one epoch less since new pools now show up earlier (hence, also proving that newcomers are added as expected).

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
