### PR TITLE
Enable storage of duplicate owners in registration certificates

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -178,7 +178,7 @@ newDBLayer logConfig trace fp = do
             let poolMargin_ = fromIntegral $ fromEnum poolMargin
             let poolCost_ = getQuantity poolCost
             insert_ $ PoolRegistration poolId ep_ poolMargin_ poolCost_
-            insertMany_ $ PoolOwner poolId <$> poolOwners
+            insertMany_ $ uncurry (PoolOwner poolId) <$> zip poolOwners [0..]
 
         , readPoolRegistration = \poolId -> do
             selectFirst [ PoolRegistrationPoolId ==. poolId ] [] >>= \case
@@ -189,7 +189,7 @@ newDBLayer logConfig trace fp = do
                     let poolCost = Quantity poolCost_
                     poolOwners <- fmap (poolOwnerOwner . entityVal) <$> selectList
                         [ PoolOwnerPoolId ==. poolId ]
-                        [ Asc PoolOwnerOwner ]
+                        [ Asc PoolOwnerIndex ]
                     pure $ Just $ PoolRegistrationCertificate
                         { poolId, poolOwners, poolMargin, poolCost }
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -73,8 +73,9 @@ StakeDistribution sql=stake_distribution
 PoolOwner sql=pool_owner
     poolOwnerPoolId     W.PoolId     sql=pool_id
     poolOwnerOwner      W.PoolOwner  sql=pool_owner
+    poolOwnerIndex      Word8        sql=pool_owner_index
 
-    Primary poolOwnerPoolId poolOwnerOwner
+    Primary poolOwnerPoolId poolOwnerOwner poolOwnerIndex
     Foreign PoolRegistration fk_registration_pool_id poolOwnerPoolId ! ON DELETE CASCADE
     deriving Show Generic
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -116,7 +116,7 @@ instance Arbitrary PoolRegistrationCertificate where
             <$> shrinkList (const []) xs
     arbitrary = PoolRegistrationCertificate
         <$> arbitrary
-        <*> fmap L.nub (scale (`mod` 8) (listOf arbitrary))
+        <*> scale (`mod` 8) (listOf arbitrary)
         <*> fmap toEnum (choose (0, 100))
         <*> fmap Quantity arbitrary
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -56,8 +56,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Text
     ( Text )
-import Data.Text.Class
-    ( toText )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -138,7 +136,7 @@ properties = do
             (property . prop_putStakeReadStake)
         it "putPoolRegistration then readPoolRegistration yields expected result"
             (property . prop_poolRegistration)
-        it "rollback of pool Registrations"
+        it "rollback of PoolRegistration"
             (property . prop_rollbackRegistration)
         it "readStake . putStake a1 . putStake s0 == pure a1"
             (property . prop_putStakePutStake)
@@ -371,7 +369,7 @@ prop_poolRegistration DBLayer {..} entries =
     monadicIO (setup >> prop)
   where
     setup = run $ atomically cleanDB
-    expected = L.sort (sortOwners <$> entries)
+    expected = L.sort entries
     prop = do
         run . atomically $ mapM_ (putPoolRegistration 0) entries
         pools <- run . atomically $ L.sort . catMaybes
@@ -398,7 +396,7 @@ prop_rollbackRegistration DBLayer{..} rollbackPoint entries =
                 error "unknown pool?"
             Just (ep, pool') ->
                 (ep <= epochNumber rollbackPoint) &&
-                (sortOwners pool == sortOwners pool')
+                (pool == pool')
 
     ownerHasManyPools =
         let owners = concatMap (poolOwners . snd) entries
@@ -470,8 +468,3 @@ allPoolProduction DBLayer{..} (StakePoolsFixture pairs _) = atomically $
   where
     rearrange ms = concat
         [ [ (slotId h, p) | h <- hs ] | (p, hs) <- concatMap Map.assocs ms ]
-
--- | Sort pool owners in a certificate by id
-sortOwners :: PoolRegistrationCertificate -> PoolRegistrationCertificate
-sortOwners registration = registration
-    { poolOwners = L.sortOn toText (poolOwners registration) }


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1181 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have stored pool owners with their registration index. And consequently, allowing pools to have multiple time the same owners with them. See also: input-output-hk/jormungandr#1366
- [x] I added a property label to make sure the case of multiple owners is tested 

# Comments

<!-- Additional comments or screenshots to attach if any -->

```
    Stake Pool properties
      putPoolRegistration then readPoolRegistration yields expected result
        +++ OK, passed 100 tests.
      rollback of PoolRegistration
        +++ OK, passed 100 tests:
        88% rolled back some
        74% owner has many pools
      putPoolRegistration . listRegisteredPools yield pools
        +++ OK, passed 100 tests 
        59% same owner multiple time in the same certificate
```

Note: this db change is incompatible with current `master`, meaning that existing databases built with master have to be wiped-out. 


<hr/>

Trying syncing with nightly with this fix, I can indeed sync with the network:

```
$ cardano-wallet network information
Ok.
{
    "network_tip": {
        "epoch_number": 1,
        "slot_number": 30494
    },
    "node_tip": {
        "height": {
            "quantity": 7261,
            "unit": "block"
        },
        "epoch_number": 1,
        "slot_number": 30494
    },
    "sync_progress": {
        "status": "ready"
    },
    "next_epoch": {
        "epoch_start_time": "2019-12-15T19:13:37Z",
        "epoch_number": 2
    }
}
```

And I can see the pool with duplicate owners:

```
$ cardano-wallet stake-pools list 
Ok.
[
...
    {
        "metrics": {
            "controlled_stake": {
                "quantity": 0,
                "unit": "lovelace"
            },
            "produced_blocks": {
                "quantity": 0,
                "unit": "block"
            }
        },
        "cost": {
            "quantity": 0,
            "unit": "lovelace"
        },
        "margin": {
            "quantity": 2,
            "unit": "percent"
        },
        "apparent_performance": 0,
        "metadata": {
            "homepage": "https://sanstone.io",
            "owner": "ed25519_pk120uk3rugx3fl2jrl2rfzmara6654klpywgwmwweu2n0z7mg7zc2s03jqsk",
            "name": "Sandstone Stake Pool",
            "ticker": "SAND",
            "pledge_address": "addr1s4flj6y03q698a2g0agdyt050ht2jkmuy3epmdem832dutmdrctp2f556fv"
        },
        "id": "03a01cb9acffb3374c9a86ff39b2b5d85128c9ce3ac3fdba51ceceaca0685f98"
    },
...
]
```

Also, looking into the sqlite database:

```
sqlite> SELECT pool_owner_index, pool_owner FROM pool_owner WHERE pool_id LIKE "%03a01%";
0|ed25519_pk120uk3rugx3fl2jrl2rfzmara6654klpywgwmwweu2n0z7mg7zc2s03jqsk
1|ed25519_pk120uk3rugx3fl2jrl2rfzmara6654klpywgwmwweu2n0z7mg7zc2s03jqsk
```

The owners are correctly stored (and identical) but with different indexes.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
