### PR TITLE
Account for "active slot coefficient" in apparent performance calculation

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -187,15 +187,13 @@ import Cardano.Wallet.Primitive.Fee
     , computeFee
     )
 import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..)
-    , Wallet
+    ( Wallet
     , applyBlocks
     , availableUTxO
     , blockchainParameters
     , currentTip
     , getState
     , initWallet
-    , slotParams
     , updateState
     )
 import Cardano.Wallet.Primitive.Types
@@ -203,6 +201,7 @@ import Cardano.Wallet.Primitive.Types
     , AddressState (..)
     , Block (..)
     , BlockHeader (..)
+    , BlockchainParameters (..)
     , ChimericAccount (..)
     , Coin (..)
     , DelegationCertificate (..)
@@ -233,6 +232,7 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , dlgCertPoolId
     , log10
+    , slotParams
     , slotRangeFromTimeRange
     , slotStartTime
     , syncProgressRelativeToTime

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -76,11 +76,10 @@ import Cardano.Wallet.Network
     ( NetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
     ( AddressState
     , Block
+    , BlockchainParameters
     , PoolId
     , SortOrder (..)
     , SyncTolerance

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -160,17 +160,12 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..) )
 import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters
-    , Wallet
-    , availableBalance
-    , currentTip
-    , getState
-    , totalBalance
-    )
+    ( Wallet, availableBalance, currentTip, getState, totalBalance )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , AddressState
     , Block
+    , BlockchainParameters
     , ChimericAccount (..)
     , Coin (..)
     , Hash (..)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -555,6 +555,8 @@ mkCheckpointEntity wid wal =
         , checkpointEpochLength = coerce (bp ^. #getEpochLength)
         , checkpointTxMaxSize = coerce (bp ^. #getTxMaxSize)
         , checkpointEpochStability = coerce (bp ^. #getEpochStability)
+        , checkpointActiveSlotCoeff =
+            W.unActiveSlotCoefficient (bp ^. #getActiveSlotCoefficient)
         }
     utxo =
         [ UTxO wid sl (TxId input) ix addr coin
@@ -589,6 +591,7 @@ checkpointFromEntity cp utxo s =
         epochLength
         txMaxSize
         epochStability
+        activeSlotCoeff
         ) = cp
     header = (W.BlockHeader slot (Quantity bh) headerHash parentHeaderHash)
     utxo' = W.UTxO . Map.fromList $
@@ -603,6 +606,7 @@ checkpointFromEntity cp utxo s =
         , getEpochLength = W.EpochLength epochLength
         , getTxMaxSize = Quantity txMaxSize
         , getEpochStability = Quantity epochStability
+        , getActiveSlotCoefficient = W.ActiveSlotCoefficient activeSlotCoeff
         }
 
 mkTxHistory

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -125,18 +125,19 @@ TxOut
 -- A checkpoint for a given wallet is referred to by (wallet_id, slot).
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint
-    checkpointWalletId       W.WalletId   sql=wallet_id
-    checkpointSlot           W.SlotId     sql=slot
-    checkpointHeaderHash     BlockId      sql=header_hash
-    checkpointParentHash     BlockId      sql=parent_header_hash
-    checkpointBlockHeight    Word32       sql=block_height
-    checkpointGenesisHash    BlockId      sql=genesis_hash
-    checkpointGenesisStart   UTCTime      sql=genesis_start
-    checkpointFeePolicy      W.FeePolicy  sql=fee_policy
-    checkpointSlotLength     Word64       sql=slot_length
-    checkpointEpochLength    Word32       sql=epoch_length
-    checkpointTxMaxSize      Word16       sql=tx_max_size
-    checkpointEpochStability Word32       sql=epoch_stability
+    checkpointWalletId          W.WalletId   sql=wallet_id
+    checkpointSlot              W.SlotId     sql=slot
+    checkpointHeaderHash        BlockId      sql=header_hash
+    checkpointParentHash        BlockId      sql=parent_header_hash
+    checkpointBlockHeight       Word32       sql=block_height
+    checkpointGenesisHash       BlockId      sql=genesis_hash
+    checkpointGenesisStart      UTCTime      sql=genesis_start
+    checkpointFeePolicy         W.FeePolicy  sql=fee_policy
+    checkpointSlotLength        Word64       sql=slot_length
+    checkpointEpochLength       Word32       sql=epoch_length
+    checkpointTxMaxSize         Word16       sql=tx_max_size
+    checkpointEpochStability    Word32       sql=epoch_stability
+    checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -31,10 +31,9 @@ import Prelude
 
 import Cardano.BM.Trace
     ( Trace, logDebug, logError, logInfo, logWarning )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
+    , BlockchainParameters (..)
     , ChimericAccount (..)
     , EpochNo
     , Hash (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1129,7 +1129,7 @@ instance Buildable BlockchainParameters where
 newtype ActiveSlotCoefficient
     = ActiveSlotCoefficient { unActiveSlotCoefficient :: Double }
     deriving stock (Generic, Eq, Show)
-    deriving newtype (Buildable)
+    deriving newtype (Buildable, Num, Fractional)
 
 instance NFData ActiveSlotCoefficient
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -46,7 +46,6 @@ module Cardano.Wallet.Primitive.Types
     , TxWitness(..)
     , SealedTx (..)
     , TransactionInfo (..)
-    , FeePolicy (..)
     , UnsignedTx (..)
     , txIns
     , isPending
@@ -85,15 +84,20 @@ module Cardano.Wallet.Primitive.Types
 
     -- * BlockchainParameters
     , BlockchainParameters (..)
+    , ActiveSlotCoefficient (..)
+    , EpochLength (..)
+    , EpochNo (..)
+    , FeePolicy (..)
+    , SlotId (..)
+    , SlotLength (..)
+    , SlotNo (..)
+    , StartTime (..)
     , slotParams
 
     -- * Slotting
     , SyncProgress(..)
     , SyncTolerance(..)
     , mkSyncTolerance
-    , SlotId (..)
-    , SlotNo (..)
-    , EpochNo (..)
     , unsafeEpochNo
     , epochStartTime
     , epochPred
@@ -101,9 +105,6 @@ module Cardano.Wallet.Primitive.Types
     , epochCeiling
     , epochFloor
     , SlotParameters (..)
-    , SlotLength (..)
-    , EpochLength (..)
-    , StartTime (..)
     , syncProgress
     , syncProgressRelativeToTime
     , flatSlot
@@ -1095,6 +1096,9 @@ data BlockchainParameters = BlockchainParameters
         -- ^ Maximum size of a transaction (soft or hard limit).
     , getEpochStability :: Quantity "block" Word32
         -- ^ Length of the suffix of the chain considered unstable
+    , getActiveSlotCoefficient :: ActiveSlotCoefficient
+        -- ^ In Genesis/Praos, corresponds to the % of active slots
+        -- (i.e. slots for which someone can be elected as leader).
     } deriving (Generic, Show, Eq)
 
 instance NFData BlockchainParameters
@@ -1111,6 +1115,7 @@ instance Buildable BlockchainParameters where
             (bp :: BlockchainParameters))
         , "Tx max size:        " <> txMaxSizeF (getTxMaxSize bp)
         , "Epoch stability:    " <> epochStabilityF (getEpochStability bp)
+        , "Active slot coeff:  " <> build (getActiveSlotCoefficient bp)
         ]
       where
         genesisF = build . T.decodeUtf8 . convertToBase Base16 . getHash
@@ -1120,6 +1125,13 @@ instance Buildable BlockchainParameters where
         epochLengthF (EpochLength s) = build s
         txMaxSizeF (Quantity s) = build s
         epochStabilityF (Quantity s) = build s
+
+newtype ActiveSlotCoefficient
+    = ActiveSlotCoefficient { unActiveSlotCoefficient :: Double }
+    deriving stock (Generic, Eq, Show)
+    deriving newtype (Buildable)
+
+instance NFData ActiveSlotCoefficient
 
 slotParams :: BlockchainParameters -> SlotParameters
 slotParams bp =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -83,6 +83,10 @@ module Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
 
+    -- * BlockchainParameters
+    , BlockchainParameters (..)
+    , slotParams
+
     -- * Slotting
     , SyncProgress(..)
     , SyncTolerance(..)
@@ -218,7 +222,7 @@ import Data.Text.Class
 import Data.Time.Clock
     ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word16, Word32, Word64 )
 import Data.Word.Odd
     ( Word31 )
 import Fmt
@@ -1071,6 +1075,58 @@ computeUtxoStatistics btype utxos =
 
     (^!) :: Word64 -> Word64 -> Word64
     (^!) = (^)
+
+{-------------------------------------------------------------------------------
+                             Blockchain Parameters
+-------------------------------------------------------------------------------}
+
+data BlockchainParameters = BlockchainParameters
+    { getGenesisBlockHash :: Hash "Genesis"
+        -- ^ Hash of the very first block
+    , getGenesisBlockDate :: StartTime
+        -- ^ Start time of the chain.
+    , getFeePolicy :: FeePolicy
+        -- ^ Policy regarding transaction fee.
+    , getSlotLength :: SlotLength
+        -- ^ Length, in seconds, of a slot.
+    , getEpochLength :: EpochLength
+        -- ^ Number of slots in a single epoch.
+    , getTxMaxSize :: Quantity "byte" Word16
+        -- ^ Maximum size of a transaction (soft or hard limit).
+    , getEpochStability :: Quantity "block" Word32
+        -- ^ Length of the suffix of the chain considered unstable
+    } deriving (Generic, Show, Eq)
+
+instance NFData BlockchainParameters
+
+instance Buildable BlockchainParameters where
+    build bp = blockListF' "" id
+        [ "Genesis block hash: " <> genesisF (getGenesisBlockHash bp)
+        , "Genesis block date: " <> startTimeF (getGenesisBlockDate
+            (bp :: BlockchainParameters))
+        , "Fee policy:         " <> feePolicyF (getFeePolicy bp)
+        , "Slot length:        " <> slotLengthF (getSlotLength
+            (bp :: BlockchainParameters))
+        , "Epoch length:       " <> epochLengthF (getEpochLength
+            (bp :: BlockchainParameters))
+        , "Tx max size:        " <> txMaxSizeF (getTxMaxSize bp)
+        , "Epoch stability:    " <> epochStabilityF (getEpochStability bp)
+        ]
+      where
+        genesisF = build . T.decodeUtf8 . convertToBase Base16 . getHash
+        startTimeF (StartTime s) = build s
+        feePolicyF = build . toText
+        slotLengthF (SlotLength s) = build s
+        epochLengthF (EpochLength s) = build s
+        txMaxSizeF (Quantity s) = build s
+        epochStabilityF (Quantity s) = build s
+
+slotParams :: BlockchainParameters -> SlotParameters
+slotParams bp =
+    SlotParameters
+        (bp ^. #getEpochLength)
+        (bp ^. #getSlotLength)
+        (bp ^. #getGenesisBlockDate)
 
 {-------------------------------------------------------------------------------
                                    Slotting

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -16,7 +16,8 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Block (..)
+    ( ActiveSlotCoefficient (..)
+    , Block (..)
     , BlockHeader (..)
     , BlockchainParameters (..)
     , Coin (..)
@@ -75,6 +76,7 @@ genesisParameters = BlockchainParameters
     , getEpochLength = EpochLength 21600
     , getTxMaxSize = Quantity 8192
     , getEpochStability = Quantity 2160
+    , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     }
 
 

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -15,11 +15,10 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
+    , BlockchainParameters (..)
     , Coin (..)
     , EpochLength (..)
     , FeePolicy (..)

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -47,10 +47,9 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     , NextBlocksResult (..)
     )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..), slotParams )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
+    , BlockchainParameters (..)
     , Coin (..)
     , EpochLength (..)
     , Hash (..)
@@ -61,6 +60,7 @@ import Cardano.Wallet.Primitive.Types
     , flatSlot
     , flatSlot
     , fromFlatSlot
+    , slotParams
     , slotSucc
     )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -220,29 +220,35 @@ prop_performancesBounded01 mStake_ mProd_ (NonNegative emptySlots) =
 
 performanceGoldens :: Spec
 performanceGoldens = do
-    it "50% stake, producing 8/8 blocks => performance=1.0" $ do
-        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production = mkProduction [ (poolA, 8), (poolB, 0) ]
-        let performances = calculatePerformance 8 stake production
+    it "50% stake, coeff=1.0, producing 8/8 blocks => p=1.0" $ do
+        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production   = mkProduction [ (poolA, 8), (poolB, 0) ]
+        let performances = calculatePerformance 1.0 8 stake production
         Map.lookup poolA performances `shouldBe` (Just 1)
 
-    it "50% stake, producing 4/8 blocks => performance=1.0" $ do
-        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production = mkProduction [ (poolA, 4), (poolB, 0) ]
-        let performances = calculatePerformance 8 stake production
+    it "50% stake, coeff=1.0, producing 4/8 blocks => p=1.0" $ do
+        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production   = mkProduction [ (poolA, 4), (poolB, 0) ]
+        let performances = calculatePerformance 1.0 8 stake production
         Map.lookup poolA performances `shouldBe` (Just 1)
 
-    it "50% stake, producing 2/8 blocks => performance=0.5" $ do
-        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production = mkProduction [ (poolA, 2), (poolB, 0) ]
-        let performances = calculatePerformance 8 stake production
+    it "50% stake, coeff=1.0, producing 2/8 blocks => p=0.5" $ do
+        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production   = mkProduction [ (poolA, 2), (poolB, 0) ]
+        let performances = calculatePerformance 1.0 8 stake production
         Map.lookup poolA performances `shouldBe` (Just 0.5)
 
-    it "50% stake, producing 0/8 blocks => performance=0.0" $ do
-        let stake      = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production = mkProduction [ (poolA, 0), (poolB, 0) ]
-        let performances = calculatePerformance 8 stake production
+    it "50% stake, coeff=1.0, producing 0/8 blocks => p=0.0" $ do
+        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
+        let production   = mkProduction [ (poolA, 0), (poolB, 0) ]
+        let performances = calculatePerformance 1.0 8 stake production
         Map.lookup poolA performances `shouldBe` (Just 0)
+
+    it "100% stake, coeff=0.1, producing 1/10 blocks => p=1.0" $ do
+        let stake        = mkStake      [ (poolA, 1), (poolB, 0) ]
+        let production   = mkProduction [ (poolA, 1), (poolB, 0) ]
+        let performances = calculatePerformance 0.1 10 stake production
+        Map.lookup poolA performances `shouldBe` (Just 1.0)
   where
     poolA = PoolId "athena"
     poolB = PoolId "nemesis"

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -426,6 +426,7 @@ mockBlockchainParameters = BlockchainParameters
     , getEpochLength = error "mockBlockchainParameters: getEpochLength"
     , getTxMaxSize = error "mockBlockchainParameters: getTxMaxSize"
     , getEpochStability = error "mockBlockchainParameters: getEpochStability"
+    , getActiveSlotCoefficient = error "mockBlockchainParameters: getActiveSlotCoefficient"
     }
 
 header0 :: BlockHeader

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -55,10 +55,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     )
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , BlockchainParameters (..)
     , ChimericAccount (..)
     , Coin (..)
     , Direction (..)

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -72,10 +72,8 @@ import Cardano.Wallet.Logging
     ( transformTextTrace )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), SyncTolerance )
+    ( BlockchainParameters, Hash (..), SyncTolerance )
 import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Control.Applicative

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -89,12 +89,11 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , Block
     , BlockHeader (..)
+    , BlockchainParameters (..)
     , ChimericAccount
     , Hash (..)
     , SyncTolerance

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -68,10 +68,14 @@ import Cardano.Wallet.Network
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
     )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SealedTx, SlotLength (..) )
+    ( Block (..)
+    , BlockHeader (..)
+    , BlockchainParameters (..)
+    , Hash (..)
+    , SealedTx
+    , SlotLength (..)
+    )
 import Control.Arrow
     ( left )
 import Control.Exception

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -117,10 +117,9 @@ import Cardano.Wallet.Network.BlockHeaders
     )
 import Cardano.Wallet.Network.Ports
     ( PortNumber, getRandomPort, waitForPort )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
+    , BlockchainParameters (..)
     , ChimericAccount (..)
     , EpochNo
     , Hash (..)

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -49,10 +49,8 @@ import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncTolerance (..) )
+    ( BlockchainParameters (..), SyncTolerance (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -42,10 +42,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncTolerance (..) )
+    ( BlockchainParameters (..), SyncTolerance (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -24,10 +24,13 @@ import Cardano.Wallet.Network
     ( Cursor, ErrGetBlock (..), NetworkLayer (..), NextBlocksResult (..) )
 import Cardano.Wallet.Network.BlockHeaders
     ( emptyBlockHeaders )
-import Cardano.Wallet.Primitive.Model
-    ( BlockchainParameters (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), Hash (..), SlotId (..), SlotNo (unSlotNo) )
+    ( BlockHeader (..)
+    , BlockchainParameters (..)
+    , Hash (..)
+    , SlotId (..)
+    , SlotNo (unSlotNo)
+    )
 import Control.Concurrent.MVar.Lifted
     ( newMVar )
 import Control.Monad.Fail

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -393,6 +393,7 @@ mockJormungandrClient logLine = JormungandrClient
             , getEpochLength = error "mock bp"
             , getTxMaxSize = error "mock bp"
             , getEpochStability = Quantity (fromIntegral k)
+            , getActiveSlotCoefficient = error "mock bp"
             })
 
     , postMessage = \_ -> error "mock postMessage"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1188 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- commit 84c49e45deca3ff7732b9bc39aad741ddf62fbf7
    Move 'BlockchainParameters' from Primitive.Model -> Primitive.Types
    
    1. No reasons it's define in the Model rather than the types (although we should really break this gigantic .Types into smaller pieces)
    2. Without this, finding a good home for 'ActiveSlotCoefficient' would have been awkward

- commit 3eb58962b1d45f2408b103ce382a954e0a93fa91
    add 'ActiveSlotCoefficient' to blockchain parameters

- commit 7c7dd0a91194a9283ffe1026a97d366373547186
    Add extra unit test to pools perf illustrating the influence of f
    Currently fails, as expected:
    ```
    1) Cardano.Pool.Metrics.calculatePerformances, golden test cases, 100% stake, coeff=0.1, producing 1/10 blocks => p=1.0
         expected: Just 1.0
          but got: Just 0.1
    ```

- commit cb780de860cec5f43509429625001b9179351ec1
    take 'active slot coefficient' into account in the apparent performance calculation


# Comments

<!-- Additional comments or screenshots to attach if any -->

<details><summary>TOP 10 Pools on Nightly</summary>

```json
[
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "IOHK2" },
        "id": "05663389504cd649fdd6cfc406c31872c32399ae6721642245f76946e55bb1fe"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "FRGL" },
        "id": "1171304154a20bd28cae430c7e9c915e5bdc1eec69893dc69d7267be7197ae21"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "IOHK3" },
        "id": "26c1deb80f2e041fe5a6d67d3f4c4b27dde24ea532a11633ec0d6cfc14a880f7"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "RELY" },
        "id": "27793e62100b6fefbbc4ea54af4bfb24454eb7c5e04b5e3ebe191ba0db8efd55"
    },
    {
        "apparent_performance": 1,
        "id": "3f096d23d43efaa13ec6d903304e23a2ef552cc460d39cdb1cafa233bc5394ef"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "HEL" },
        "id": "46221fb809db63e408ce1751196705a88af6e27ccac1acb92b8b705dfbfceb6a"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "COOL" },
        "id": "7062afd7fd83c372fc65438c302f3db23bd3404edc043e4806ec3ba6a486be3b"
    },
    {
        "apparent_performance": 1,
        "id": "8819ca23c3ac6865d6578350de0bcb072e797519410b923d18f56b61370d93ff"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "JBREW" },
        "id": "8ca014edc250a888645dacf3e7803d9bf217148d2534e80ee99257479a074aa2"
    },
    {
        "apparent_performance": 1,
        "metadata": { "ticker": "247" },
        "id": "9d16d5dfb84296c54868050e0e9f3130632d9a3fe2aa4febd65cb5235a84557e"
    }
]
```
</details>

<details><summary>All pools performances seen on nightly</summary>

```
0
0.11336765496849342
0.17989919600079335
0.20586241451124396
0.3139972298831227
0.3583264647256367
0.5
0.5451975737056386
0.7106819593189653
0.7227635377048117
0.8973330307767313
0.9052103033417835
0.9480349364235434
0.9507090156555771
0.9583850034019517
0.9816576385996468
1
```
</details>

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
