### PR TITLE
Fix flaky next epoch test

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -102,8 +102,6 @@ module Cardano.Wallet.Primitive.Types
     , epochStartTime
     , epochPred
     , epochSucc
-    , epochCeiling
-    , epochFloor
     , SlotParameters (..)
     , syncProgress
     , syncProgressRelativeToTime
@@ -1201,36 +1199,6 @@ epochSucc :: EpochNo -> Maybe EpochNo
 epochSucc (EpochNo e)
     | e == maxBound = Nothing
     | otherwise = Just $ EpochNo $ succ e
-
--- | For the given time 't', calculate the number of the earliest epoch with
---   start time 's' such that 't ≤ s'.
---
--- Returns 'Nothing' if the calculation would result in an epoch number that is
--- not representable.
-epochCeiling :: SlotParameters -> UTCTime -> Maybe EpochNo
-epochCeiling sps t
-    | t < timeMin = Just minBound
-    | t > timeMax = Nothing
-    | otherwise = case slotCeiling sps t of
-        SlotId epoch 0 -> Just epoch
-        SlotId epoch _ -> epochSucc epoch
-  where
-    timeMin = epochStartTime sps minBound
-    timeMax = epochStartTime sps maxBound
-
--- | For the given time 't', calculate the number of the latest epoch with
---   start time 's' such that 's ≤ t'.
---
--- Returns 'Nothing' if the calculation would result in an epoch number that is
--- not representable.
-epochFloor :: SlotParameters -> UTCTime -> Maybe EpochNo
-epochFloor sps t
-    | t < timeMin = Nothing
-    | t > timeMax = Just maxBound
-    | otherwise = epochNumber <$> slotFloor sps t
-  where
-    timeMin = epochStartTime sps minBound
-    timeMax = epochStartTime sps maxBound
 
 instance NFData SlotId
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -54,8 +54,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , balance
     , computeUtxoStatistics
-    , epochCeiling
-    , epochFloor
     , epochPred
     , epochStartTime
     , epochSucc
@@ -488,110 +486,6 @@ spec = do
                     cover 10      withinBounds  "within bounds" $
                     cover 10 (not withinBounds) "out of bounds" $
                     expectedResult === predN n (succN n $ Just epoch)
-
-    describe "Epoch arithmetic: epochCeiling: core properties" $ do
-
-        it "epochStartTime (epochCeiling t) >= t" $
-            withMaxSuccess 1000 $ property $
-                \(SlotParametersAndTimePoint sps time) ->
-                    case epochCeiling sps time of
-                        Nothing -> time  > epochStartTime sps maxBound
-                        Just en -> time <= epochStartTime sps en
-
-        it "epochStartTime (epochPred (epochCeiling t)) < t" $
-            withMaxSuccess 1000 $ property $
-                \(SlotParametersAndTimePoint sps time) ->
-                    case epochCeiling sps time of
-                        Nothing -> time > epochStartTime sps maxBound
-                        Just e1 -> case epochPred e1 of
-                            Nothing -> e1 == minBound
-                            Just e2 -> time > epochStartTime sps e2
-
-    describe "Epoch arithmetic: epochFloor: core properties" $ do
-
-        it "epochStartTime (epochFloor t) <= t" $
-            withMaxSuccess 1000 $ property $
-                \(SlotParametersAndTimePoint sps time) ->
-                    case epochFloor sps time of
-                        Nothing -> time <  epochStartTime sps minBound
-                        Just en -> time >= epochStartTime sps en
-
-        it "epochStartTime (epochSucc (epochFloor t)) > t" $
-            withMaxSuccess 1000 $ property $
-                \(SlotParametersAndTimePoint sps time) ->
-                    case epochFloor sps time of
-                        Nothing -> time < epochStartTime sps minBound
-                        Just e1 -> case epochSucc e1 of
-                            Nothing -> e1 == maxBound
-                            Just e2 -> time < epochStartTime sps e2
-
-    describe "Epoch arithmetic: epochCeiling: boundary conditions" $ do
-
-        it "epochCeiling . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epochCeiling sps (epochStartTime sps epoch)
-                    === Just epoch
-
-        it "epochCeiling . utcTimePred . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epoch > minBound ==> do
-                    let fun = epochCeiling sps
-                            . utcTimePred
-                            . epochStartTime sps
-                    Just epoch === fun epoch
-
-        it "epochPred . epochCeiling . utcTimeSucc . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epoch < maxBound ==> do
-                    let fun = (epochPred =<<)
-                            . epochCeiling sps
-                            . utcTimeSucc
-                            . epochStartTime sps
-                    Just epoch === fun epoch
-
-        it "epochCeiling (utcTimePred (epochStartTime minBound)) == minBound" $
-            withMaxSuccess 1000 $ property $ \sps ->
-                epochCeiling sps (utcTimePred (epochStartTime sps minBound))
-                    === Just minBound
-
-        it "epochCeiling (utcTimeSucc (epochStartTime maxBound)) == Nothing" $
-            withMaxSuccess 1000 $ property $ \sps ->
-                epochCeiling sps (utcTimeSucc (epochStartTime sps maxBound))
-                    === Nothing
-
-    describe "Epoch arithmetic: epochFloor: boundary conditions" $ do
-
-        it "epochFloor . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epochFloor sps (epochStartTime sps epoch)
-                    === Just epoch
-
-        it "epochFloor . utcTimeSucc . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epoch < maxBound ==> do
-                    let fun = epochFloor sps
-                            . utcTimeSucc
-                            . epochStartTime sps
-                    Just epoch === fun epoch
-
-        it "epochSucc . epochFloor . utcTimePred . epochStartTime == id" $
-            withMaxSuccess 1000 $ property $ \(sps, epoch) ->
-                epoch > minBound ==> do
-                    let fun = (epochSucc =<<)
-                            . epochFloor sps
-                            . utcTimePred
-                            . epochStartTime sps
-                    Just epoch === fun epoch
-
-        it "epochFloor (utcTimePred (epochStartTime minBound)) == Nothing" $
-            withMaxSuccess 1000 $ property $ \sps ->
-                epochFloor sps (utcTimePred (epochStartTime sps minBound))
-                    === Nothing
-
-        it "epochFloor (utcTimeSucc (epochStartTime maxBound)) == maxBound" $
-            withMaxSuccess 1000 $ property $ \sps ->
-                epochFloor sps (utcTimeSucc (epochStartTime sps maxBound))
-                    === Just maxBound
 
     describe "Slot arithmetic" $ do
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1196 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- commit 88fd188343407f0f35d8c61b064536c6b15453d4

    simplify calculation of next epoch and remove deadcode
    
    The previous code was a bit more convoluted and re-doing
    time comparison and computations that were unnecessary.
    We know what the next epoch should be, it's the tip + 1.

- commit 42f71363016af4030f844fc31919c621d8877162

    remove usage of 'waitForNextEpoch' to check for the next epoch time

    This function uses the NODE tip to check whether we have moved to the next epoch or not.
    However, the next epoch start time is about where the network is at, so we are comparing
    apple and oranges here. Instead, the test now waits for the time indicated by the API and
    query the network tip right away to check whether we have indeed moved to the next epoch


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
