### PR TITLE
Gratuitous fixes in restoration worker (wrong log line + move pruning inside same tx)

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -607,12 +607,7 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
         liftIO $ logCheckpoint (NE.last cps)
         putCheckpoint (PrimaryKey wid) (NE.last cps)
 
-    -- NOTE
-    -- We prune the database in a separate db transaction since this is not
-    -- strictly required to maintain integrity of the data. It's quite a heavy
-    -- operation, so we may still want to unlock the database to allow some
-    -- other operations to flow in the meantime.
-    mapExceptT atomically $ prune (PrimaryKey wid)
+        prune (PrimaryKey wid)
 
     liftIO $ do
         progress <- walletSyncProgress @ctx ctx (NE.last cps)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -604,7 +604,7 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
                 liftIO $ logCheckpoint cp'
                 putCheckpoint (PrimaryKey wid) cp'
 
-        liftIO $ logCheckpoint cp
+        liftIO $ logCheckpoint (NE.last cps)
         putCheckpoint (PrimaryKey wid) (NE.last cps)
 
     -- NOTE


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed log line in the restoration function, logging the right checkpoint (i.e. the last one!)
- [x] Moved pruning of the database within the same db transaction as the one inserting checkpoints.. just in case..

# Comments

<!-- Additional comments or screenshots to attach if any -->

I noticed this looking at some user logs.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
