### PR TITLE
Recovery week - cleaning number 1

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -967,7 +967,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected [a], encountered String"
+            , expectErrorMessage (servantErrorMsg "[a]" "String")
             ]
 
     it "BYRON_RESTORE_05 - Num as mnemonic_sentence -> fail" $ \ctx -> do
@@ -979,7 +979,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected [a], encountered Number"
+            , expectErrorMessage (servantErrorMsg "[a]" "Number")
             ]
 
     it "BYRON_RESTORE_05 - mnemonic_sentence param missing -> fail" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -38,6 +38,8 @@ import Data.Text
     ( Text )
 import Data.Word
     ( Word64 )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Test.Hspec
     ( SpecWith, describe, it )
 import Test.Hspec.Expectations.Lifted
@@ -873,7 +875,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "BYRON_RESTORE_04 - Num as name -> fail" $ \ctx -> do
@@ -885,7 +887,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage (servantErrorMsg "Text" "Number")
             ]
 
     it "BYRON_RESTORE_04 - Name param missing -> fail" $ \ctx -> do
@@ -1057,7 +1059,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "BYRON_RESTORE_06 - Num as passphrase -> fail" $ \ctx -> do
@@ -1069,7 +1071,7 @@ spec = do
         r <- request @ApiByronWallet ctx postByronWalletEp Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage (servantErrorMsg"Text" "Number")
             ]
 
     it "BYRON_RESTORE_06 - passphrase param missing -> fail" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -1892,36 +1892,34 @@ spec = do
         [ ( "Quantity = 1.5"
         , [json|{"quantity": 1.5, "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered\
-              \ floating number 1.5" ]
+          , expectErrorMessage (servantErrorMsg "Natural" "floating number 1.5")]
         )
         , ( "Quantity = -1000"
         , [json|{"quantity": -1000, "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered\
-              \ negative number -1000" ]
+          , expectErrorMessage (servantErrorMsg "Natural" "negative number -1000")]
         )
         , ( "Quantity = \"-1000\""
         , [json|{"quantity": "-1000", "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered String" ]
+          , expectErrorMessage (servantErrorMsg "Natural"  "String")]
         )
         , ( "Quantity = []"
         , [json|{"quantity": [], "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered Array" ]
+          , expectErrorMessage (servantErrorMsg "Natural" "Array")]
         )
         , ( "Quantity = \"string with diacritics\""
         , [json|{"quantity": #{polishWalletName}
                 , "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered String" ]
+          , expectErrorMessage (servantErrorMsg "Natural" "String")]
         )
         , ( "Quantity = \"string with wildcards\""
         , [json|{"quantity": #{wildcardsWalletName}
                 , "unit": "lovelace"}|]
         , [ expectResponseCode HTTP.status400
-          , expectErrorMessage "expected Natural, encountered String" ]
+          , expectErrorMessage (servantErrorMsg "Natural" "String")]
         )
         , ( "Quantity missing"
         , [json|{"unit": "lovelace"}|]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -48,6 +48,8 @@ import Data.Time.Utils
     ( utcTimePred, utcTimeSucc )
 import Network.HTTP.Types.Method
     ( Method )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -539,7 +541,7 @@ spec = do
         r <- request @(ApiTransaction n) ctx (postTxEp wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "TRANS_CREATE_05 - Num as address" $ \ctx -> do
@@ -557,7 +559,7 @@ spec = do
         r <- request @(ApiTransaction n) ctx (postTxEp wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status400
-            , expectErrorMessage "expected Text, encountered Num"
+            , expectErrorMessage (servantErrorMsg "Text" "Num")
             ]
 
     it "TRANS_CREATE_05 - address param missing" $ \ctx -> do
@@ -1016,7 +1018,7 @@ spec = do
         r <- request @ApiFee ctx (postTxFeeEp wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "TRANS_ESTIMATE_05 - Num as address" $ \ctx -> do
@@ -1033,7 +1035,7 @@ spec = do
         r <- request @ApiFee ctx (postTxFeeEp wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status400
-            , expectErrorMessage "expected Text, encountered Num"
+            , expectErrorMessage (servantErrorMsg "Text" "Num")
             ]
 
     it "TRANS_ESTIMATE_05 - address param missing" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -423,7 +423,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected [a], encountered String"
+            , expectErrorMessage (servantErrorMsg "[a]" "String")
             ]
 
     it "WALLETS_CREATE_05 - Num as mnemonic_sentence -> fail" $ \ctx -> do
@@ -435,7 +435,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected [a], encountered Number"
+            , expectErrorMessage (servantErrorMsg "[a]" "Number")
             ]
 
     it "WALLETS_CREATE_05 - mnemonic_sentence param missing -> fail" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -43,6 +43,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( toText )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -295,7 +297,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "WALLETS_CREATE_04 - Num as name -> fail" $ \ctx -> do
@@ -307,7 +309,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage (servantErrorMsg "Text" "Number")
             ]
 
     it "WALLETS_CREATE_04 - Name param missing -> fail" $ \ctx -> do
@@ -610,7 +612,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "WALLETS_CREATE_07 - Num as passphrase -> fail" $ \ctx -> do
@@ -622,7 +624,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage (servantErrorMsg "Text" "Number")
             ]
 
     it "WALLETS_CREATE_07 - passphrase param missing -> fail" $ \ctx -> do
@@ -1095,7 +1097,7 @@ spec = do
         ru <- request @ApiWallet ctx ("PUT", "v2/wallets" </> walId) Default payload
         verify ru
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Text" "Array")
             ]
 
     it "WALLETS_UPDATE_02 - Num as name -> fail" $ \ctx -> do
@@ -1107,7 +1109,7 @@ spec = do
         ru <- request @ApiWallet ctx ("PUT", "v2/wallets" </> walId) Default payload
         verify ru
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage (servantErrorMsg "Text" "Number")
             ]
 
     it "WALLETS_UPDATE_02 - Name param missing -> OK" $ \ctx -> do
@@ -1329,7 +1331,7 @@ spec = do
                         "new_passphrase": []
                           } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "expected Text, encountered Array" ]
+                     , expectErrorMessage (servantErrorMsg "Text" "Array") ]
                    )
                  , ( "[] as old passphrase"
                    , Json [json| {
@@ -1337,7 +1339,7 @@ spec = do
                        "new_passphrase": "Secure passphrase"
                          } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "expected Text, encountered Array" ]
+                     , expectErrorMessage (servantErrorMsg "Text" "Array") ]
                    )
                  , ( "Num as old passphrase"
                    , Json [json| {
@@ -1345,7 +1347,7 @@ spec = do
                       "new_passphrase": "Secure passphrase"
                          } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "expected Text, encountered Number" ]
+                     , expectErrorMessage (servantErrorMsg "Text" "Number") ]
                    )
                  , ( "Num as new passphrase"
                    , Json [json| {
@@ -1353,7 +1355,7 @@ spec = do
                       "new_passphrase": 12345678910
                          } |]
                    , [ expectResponseCode @IO HTTP.status400
-                     , expectErrorMessage "expected Text, encountered Number" ]
+                     , expectErrorMessage (servantErrorMsg "Text" "Number") ]
                    )
                  , ( "Missing old passphrase"
                    , Json [json| {

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -719,7 +719,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Integer, encountered floating number"
+            , expectErrorMessage (servantErrorMsg "Integer" "floating number")
             ]
 
 
@@ -733,7 +733,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Integer, encountered floating number"
+            , expectErrorMessage (servantErrorMsg "Integer" "floating number")
             ]
 
     it "WALLETS_CREATE_08 - [] as address_pool_gap -> fail" $ \ctx -> do
@@ -746,7 +746,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Integer, encountered Array"
+            , expectErrorMessage (servantErrorMsg "Integer" "Array")
             ]
 
     it "WALLETS_CREATE_08 - String as address_pool_gap -> fail" $ \ctx -> do
@@ -759,7 +759,7 @@ spec = do
         r <- request @ApiWallet ctx ("POST", "v2/wallets") Default payload
         verify r
             [ expectResponseCode @IO HTTP.status400
-            , expectErrorMessage "expected Integer, encountered String"
+            , expectErrorMessage (servantErrorMsg "Integer" "String")
             ]
 
     it "WALLETS_CREATE_08 - default address_pool_gap" $ \ctx -> do

--- a/lib/core/src/Network/Wai/Middleware/ServantError.hs
+++ b/lib/core/src/Network/Wai/Middleware/ServantError.hs
@@ -9,6 +9,7 @@
 
 module Network.Wai.Middleware.ServantError
     ( handleRawError
+    , servantErrorMsg
     ) where
 
 import Prelude
@@ -86,3 +87,7 @@ responseBody = \case
         Nothing
     ResponseStream{} ->
         Nothing
+
+servantErrorMsg :: String -> String -> String
+servantErrorMsg expected received =
+    "expected " <> expected <> ", encountered " <> received

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -184,6 +184,8 @@ import Data.Word.Odd
     ( Word31 )
 import GHC.TypeLits
     ( KnownSymbol, natVal, symbolVal )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Numeric.Natural
     ( Natural )
 import Servant
@@ -403,8 +405,7 @@ spec = do
             |] `shouldBe` (Left @String @(ApiT AddressPoolGap) msg)
 
         it "ApiT AddressPoolGap (not a integer)" $ do
-            let msg = "Error in $: expected Integer, encountered floating number\
-                    \ 2.5"
+            let msg = "Error in $: " <> servantErrorMsg "Integer" "floating number 2.5"
             Aeson.parseEither parseJSON [aesonQQ|
                 2.5
             |] `shouldBe` (Left @String @(ApiT AddressPoolGap) msg)
@@ -424,8 +425,8 @@ spec = do
             |] `shouldBe` (Left @String @(ApiT WalletId) msg)
 
         it "AddressAmount (too small)" $ do
-            let msg = "Error in $.amount.quantity: expected Natural, \
-                    \encountered negative number -14"
+            let msg = "Error in $.amount.quantity: "
+                    <> servantErrorMsg "Natural" "negative number -14"
             Aeson.parseEither parseJSON [aesonQQ|
                 { "address": "ta1sdaa2wrvxxkrrwnsw6zk2qx0ymu96354hq83s0r6203l9pqe6677ztw225s"
                 , "amount": {"unit":"lovelace","quantity":-14}

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -30,6 +30,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
     ( fromText, toText )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -574,7 +576,7 @@ spec = do
                 r <- request @(ApiTransaction n) ctx (sPoolEndp (p ^. #id) w)
                         Default payload
                 expectResponseCode HTTP.status400 r
-                expectErrorMessage "expected Text, encountered Number" r
+                expectErrorMessage (servantErrorMsg "Text" "Number") r
         it "Join" $ \ctx -> do
             verifyIt ctx joinStakePoolEp
         it "Quit" $ \ctx -> do

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
@@ -36,6 +36,8 @@ import Data.Text.Class
     ( ToText (..) )
 import Data.Word
     ( Word64 )
+import Network.Wai.Middleware.ServantError
+    ( servantErrorMsg )
 import Test.Aeson.Internal.RoundtripSpecs
     ( roundtripSpecs )
 import Test.Hspec
@@ -153,7 +155,7 @@ spec = do
             let exampleStake = "{\"epoch\": 252054,\"stake\": {\"dangling\":0,\"\
                     \pools\":[[12345,1]],\"unassigned\":100100000000000}}"
             decodeJSON exampleStake `shouldBe`
-                Left "Error in $.stake.pools[0][0]: expected Text, encountered Number"
+                Left ("Error in $.stake.pools[0][0]: " <> servantErrorMsg "Text" "Number")
             return ()
 
         it "invalid stake pair in endpoint response gives expected error" $ do

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
@@ -173,8 +173,7 @@ spec = do
                     \pools\":[[\"7d749ef424507fb80fed0d2289d535a94f6870add0cf8b3\
                     \74cfe6cae078320ec\",1]],\"unassigned\":[]}}"
             decodeJSON exampleStake `shouldBe`
-                Left "Error in $.stake.unassigned: expected Word64, \
-                     \encountered Array"
+                Left ("Error in $.stake.unassigned: " <> servantErrorMsg "Word64" "Array")
             return ()
 
         it "invalid non-numerical field value in endpoint response gives expected error" $ do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
Recovery week

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have introduced `servantErrorMsg` and use it in tens of examples

When doing servant bump during sync-tolerance PR month ago there was a need to change tens of error messages : 
```
-            , expectErrorMessage "expected [a], encountered String"
+            , expectErrorMessage "parsing [] failed, expected Array, but \
+                                 \encountered String"

-            , expectErrorMessage "expected Text, encountered Number"
+            , expectErrorMessage "parsing Text failed, expected String, but \
+                                 \encountered Number"
```
So this messages were delocalized and independently used in many places. I think it is good to introduce `servantErrorMsg` in one place and reuse it in those tens of places.  

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
