### PR TITLE
Make api handlers more polymorphic to reduce duplication

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -665,7 +665,7 @@ deleteWallet ctx wid = db & \DBLayer{..} -> do
 -- Rather than force all callers of 'readWallet' to wait for fetching the
 -- account balance (via the 'NetworkLayer'), we expose this function for it.
 fetchRewardBalance
-    :: forall ctx s k t.
+    :: forall ctx s t k.
         ( HasDBLayer s k ctx
         , HasNetworkLayer t ctx
         , HasRewardAccount s


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have made api handlers more polymorphic to reduce duplication

 It was okay-ish to duplicate handlers for Byron random wallets in order
to quickly iterate and develop handler for those. However, a lot of the
logic was duplicated in the process and, with the upcoming support of
Yoroi wallets, we would need even more. However, this commit take
re-locate the discrepency between wallets types to arguments passed to
other more generic functions. This way, we can group the logic for
top-level functions and adjust how wallets are represented when needed.

This enables rather seamless support for Yoroi wallets, pretty much out
of the box.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
