### PR TITLE
Improve logging documentation of configs

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -73,6 +73,7 @@ test-suite unit
     , cardano-wallet-core
     , filepath
     , hspec
+    , iohk-monitoring
     , memory
     , optparse-applicative
     , QuickCheck

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -58,6 +58,7 @@ module Cardano.CLI
     , withLogging
     , verbosityToArgs
     , verbosityToMinSeverity
+    , initTracer
 
     -- * ANSI Terminal Helpers
     , putErrLn

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -476,6 +476,12 @@ spec = do
             requireFilePath fp
             fileConfig <- getCG . fst . snd <$> initTracer (Just fp) Debug
             compareCfgs defaultConfig fileConfig
+        it "default setting" $ do
+            defaultConfig <- getCG . fst . snd <$> initTracer Nothing Debug
+            let fp = "../../specifications/logging/default.yaml"
+            requireFilePath fp
+            fileConfig <- getCG . fst . snd <$> initTracer (Just fp) Debug
+            compareCfgs defaultConfig fileConfig
   where
     backspace :: Text
     backspace = T.singleton (toEnum 127)

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -88,6 +88,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
             (hsPkgs."filepath" or (buildDepError "filepath"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."memory" or (buildDepError "memory"))
             (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))

--- a/specifications/logging/default.yaml
+++ b/specifications/logging/default.yaml
@@ -1,5 +1,4 @@
-# this is a default logging configuration of iohk-monitoring-framework
-# when initialized with defaultConfigStdout
+# this is a default logging configuration of cli
 
 # global filter; messages must have at least this severity to pass:
 minSeverity: Debug
@@ -23,7 +22,7 @@ defaultScribes:
 #hasPrometheus:
 
 # these backends are initialized:
-setupBackends: [KatipBK]
+setupBackends: [AggregationBK, KatipBK]
 
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:

--- a/specifications/logging/empty.yaml
+++ b/specifications/logging/empty.yaml
@@ -1,0 +1,41 @@
+# this is a default stdout configuration of iohk-monitoring-framework
+
+# global filter; messages must have at least this severity to pass:
+minSeverity: Debug
+
+# here we set up outputs of logging in 'katip':
+setupScribes:
+  - scKind: StdoutSK
+    scFormat: ScText
+    scName: text
+  - scKind: StdoutSK
+    scFormat: ScJson
+    scName: json
+
+# if not indicated otherwise, then log output is directed to this:
+defaultScribes:
+  - - StdoutSK
+    - text
+
+# these backends are initialized:
+setupBackends: [KatipBK]
+
+# if not indicated otherwise, then messages are passed to these backends:
+defaultBackends:
+  - KatipBK
+
+# more options which can be passed as key-value pairs:
+options:
+  mapSubtrace:
+    "#messagecounters.monitoring":
+      subtrace: NoTrace
+    "#messagecounters.ekgview":
+      subtrace: NoTrace
+    "#messagecounters.aggregation":
+      subtrace: NoTrace
+    "#messagecounters.graylog":
+      subtrace: NoTrace
+    "#messagecounters.katip":
+      subtrace: NoTrace
+    "#messagecounters.switchboard":
+      subtrace: NoTrace


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#961 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have replicated (tried to do it) monitoring config needed to retrieve what happens when just `defaultConfigStdout` from iohk-monitoring-framework is called
- [x] I have replicated (tried to do it) monitoring config needed to retrieve what happens when `initTracer` with Nothing from cli is called
- [ ] I have updated CLI Manual

# Comments

In order to test do : 
```
$ stack test --ta '-m "initTracer"' cardano-wallet-cli:unit
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
