### PR TITLE
Fix cabal v2-build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,12 @@ steps:
     agents:
       system: x86_64-linux
 
-  - label: Check auto-generated Nix
+  - label: 'Check Cabal Configure'
+    command: 'nix-shell --run "cabal v2-update && cabal v2-configure --enable-tests --enable-benchmarks"'
+    agents:
+      system: x86_64-linux
+
+  - label: 'Check auto-generated Nix'
     command: 'nix-build -A iohkLib.check-nix-tools -o check-nix-tools.sh && ./check-nix-tools.sh'
     agents:
       system: x86_64-linux

--- a/cabal.project
+++ b/cabal.project
@@ -5,12 +5,32 @@ flags: +development
 
 package cardano-crypto
   tests: False
+  benchmarks: False
 
 package contra-tracer
   tests: False
+  benchmarks: False
 
 package iohk-monitoring
   tests: False
+  benchmarks: False
+
+package lobemo-backend-aggregation
+  tests: False
+  benchmarks: False
+
+package lobemo-backend-monitoring
+  tests: False
+  benchmarks: False
+
+package ekg-prometheus-adapter
+  tests: False
+  benchmarks: False
+
+package zip
+  tests: False
+  benchmarks: False
+  flags: +disable-bzip2
 
 source-repository-package
   type: git
@@ -20,14 +40,33 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+  tag: b4643defabb23b3d78f4b690a01bb6a41a3cd203
   subdir: contra-tracer
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: bd31cd2f3922010ddb76bb869f29c4e63bb8001b
+  tag: b4643defabb23b3d78f4b690a01bb6a41a3cd203
   subdir: iohk-monitoring
 
-constraints:
-  servant-server == 0.15
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: b4643defabb23b3d78f4b690a01bb6a41a3cd203
+  subdir: plugins/backend-aggregation
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/iohk-monitoring-framework
+  tag: b4643defabb23b3d78f4b690a01bb6a41a3cd203
+  subdir: plugins/backend-monitoring
+
+source-repository-package
+  type: git
+  location: https://github.com/CodiePP/ekg-prometheus-adapter
+  tag: 1a258b6df7d9807d4c4ff3e99722223d31a2c320
+
+source-repository-package
+  type: git
+  location: https://github.com/mrkkrp/zip
+  tag: 5a39029cebc9ad5b16ed6a5f2f495714b34b02f8

--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,6 @@
 packages:
   lib/*/*.cabal
 
-flags: +development
-
 package cardano-crypto
   tests: False
   benchmarks: False

--- a/default.nix
+++ b/default.nix
@@ -62,7 +62,8 @@ let
         ++ [(pkgs.callPackage ./nix/stylish-haskell.nix {})]
         ++ (with iohkLib; [ openapi-spec-validator ])
         ++ [ jormungandr jormungandr-cli
-             pkgs.pkgconfig pkgs.sqlite-interactive ];
+             pkgs.pkgconfig pkgs.sqlite-interactive
+             pkgs.cabal-install ];
       meta.platforms = pkgs.lib.platforms.unix;
     };
     stackShell = import ./nix/stack-shell.nix {

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -62,9 +62,9 @@ test-suite unit
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -156,9 +156,9 @@ test-suite unit
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base
@@ -278,9 +278,9 @@ benchmark db
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -29,6 +29,7 @@ library
       -fwarn-redundant-constraints
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base
@@ -91,9 +92,9 @@ executable cardano-wallet-jormungandr
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base
@@ -122,9 +123,9 @@ test-suite unit
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base
@@ -180,9 +181,9 @@ test-suite integration
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base
@@ -266,9 +267,9 @@ benchmark latency
   ghc-options:
       -threaded -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -61,9 +61,9 @@ test-suite unit
       -threaded
       -rtsopts
       -Wall
-      -O2
   if (!flag(development))
     ghc-options:
+      -O2
       -Werror
   build-depends:
       base


### PR DESCRIPTION
- The dependencies in cabal.project were out of sync with stack.yaml.
- I haven't measured whether we even need to build with `-O2`, but it's certainly not needed when `-fdevelopment` is enabled.
