### PR TITLE
Update Hercules-CI build file

### DIFF
--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -52,16 +52,17 @@ let
           ];
           unit.build-tools = [ jmPkgs.jormungandr ];
         };
-        packages.cardano-wallet-jormungandr.components.benchmarks.latency = {
-          build-tools = [ pkgs.makeWrapper];
-          postInstall = ''
-            makeWrapper \
-              $out/cardano-wallet-*/latency \
-              $out/bin/latency \
-              --run "cd $src" \
-              --prefix PATH : ${jmPkgs.jormungandr}/bin
-          '';
-        };
+        packages.cardano-wallet-jormungandr.components.benchmarks.latency =
+          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+            build-tools = [ pkgs.makeWrapper];
+            postInstall = ''
+              makeWrapper \
+                $out/cardano-wallet-*/latency \
+                $out/bin/latency \
+                --run "cd $src" \
+                --prefix PATH : ${jmPkgs.jormungandr}/bin
+            '';
+          };
 
         packages.cardano-wallet-core.components.tests.unit.preBuild = ''
           export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}


### PR DESCRIPTION
Disable x86_64-pc-mingw32.benchmarks.cardano-wallet-jormungandr.latency, due to bash not building when cross compiled to windows.

This change red crosses into green ticks on GitHub PRs.
