### PR TITLE
Pool.DB.Sqlite: Close the database before attempting to wipe it

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -51,9 +51,7 @@ import Control.Exception
 import Control.Monad
     ( mapM_ )
 import Control.Monad.Catch
-    ( Handler (..) )
-import Control.Monad.Catch
-    ( MonadCatch (..), handleJust )
+    ( Handler (..), MonadCatch (..), handleJust )
 import Control.Monad.Logger
     ( LogLevel (..) )
 import Control.Retry

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -117,10 +117,6 @@ newtype MigrationError = MigrationError
     { getMigrationErrorMessage :: Text }
     deriving (Show, Eq, Generic, ToJSON)
 
-instance ToText MigrationError where
-    toText = getMigrationErrorMessage
-
--- fixme: poor practice to define exception instance when using checked exceptions.
 instance Exception MigrationError
 
 -- | Run a raw query from the outside using an instantiate DB layer. This is
@@ -247,13 +243,13 @@ instance ToText DBLog where
         MsgMigrations (Right n) ->
             fmt $ ""+||n||+" migrations were applied to the database."
         MsgMigrations (Left err) ->
-            "Failed to migrate the database: " <> toText err
+            "Failed to migrate the database: " <> getMigrationErrorMessage err
         MsgQuery stmt _ -> stmt
         MsgConnStr connStr -> "Using connection string: " <> connStr
         MsgClosing fp -> "Closing database ("+|fromMaybe "in-memory" fp|+")"
         MsgDatabaseReset ->
             "Non backward compatible database found. Removing old database \
-            \and re-creating it from scratch."
+            \and re-creating it from scratch. Ignore the previous error."
 
 {-------------------------------------------------------------------------------
                                Extra DB Helpers

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -312,6 +312,7 @@ newDBLayer
 newDBLayer logConfig trace mDatabaseFile = do
     let trace' = transformTextTrace trace
     ctx@SqliteContext{runQuery} <-
+        either throwIO pure =<<
         startSqliteBackend logConfig migrateAll trace' mDatabaseFile
     return (ctx, DBLayer
 

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -81,7 +81,7 @@ test_migrationFromv20191216 =
 
             length databaseConnMsg  `shouldBe` 3
             length databaseResetMsg `shouldBe` 1
-            length migrationErrMsg  `shouldBe` 0
+            length migrationErrMsg  `shouldBe` 1
 
 testingLogConfig :: IO CM.Configuration
 testingLogConfig = do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -102,8 +102,8 @@ import Test.QuickCheck
     , elements
     , expectFailure
     , frequency
+    , label
     , property
-    , withMaxSuccess
     , (.&&.)
     , (=/=)
     , (===)
@@ -325,12 +325,14 @@ prop_poolEventuallyDiscoverOurs
     -> (AddressPoolGap, Address)
     -> Property
 prop_poolEventuallyDiscoverOurs _proxy (g, addr) =
-    addr `elem` ours ==> withMaxSuccess 10 $ property prop
+    if addr `elem` ours then property $
+        (fromEnum <$> fst (lookupAddress addr pool)) === elemIndex addr ours
+    else
+        label "address not ours" (property True)
   where
     ours = take 25 (ourAddresses (Proxy @k) (accountingStyle @chain))
     pool = flip execState (mkAddressPool @chain @k ourAccount g mempty) $
         forM ours (state . lookupAddress)
-    prop = (fromEnum <$> fst (lookupAddress addr pool)) === elemIndex addr ours
 
 {-------------------------------------------------------------------------------
                     Properties for AddressScheme & PendingIxs


### PR DESCRIPTION
Relates to #1224.

# Overview

- If there was an error running db migrations, ensure that the database is closed before taking further action.

# Comments

- I have tested on Windows Server 2016 using `cardano-wallet-core-2019.12.23-test-unit.exe --match /Cardano.Pool.DB.Sqlite/`
   - The [build from this branch](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1226/cardano-wallet-jormungandr-tests-win64/latest) passes the tests.
   - The [build from master branch](https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-jormungandr-tests-win64/latest) also passes the tests