### PR TITLE
Define and use safe 'eitherRunGet' to avoid throwing on binary decoding

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -139,6 +139,7 @@ library
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version
       Cardano.Wallet.Version.TH
+      Data.Binary.Get.Safe
       Data.Function.Utils
       Data.Time.Text
       Data.Time.Utils

--- a/lib/core/src/Data/Binary/Get/Safe.hs
+++ b/lib/core/src/Data/Binary/Get/Safe.hs
@@ -1,0 +1,26 @@
+-- |
+-- Copyright: © 2018-2019 IOHK
+-- License: Apache-2.0
+--
+-- Extra helpers for safe decoding of binary data.
+
+module Data.Binary.Get.Safe
+    ( eitherRunGet
+    ) where
+
+import Prelude
+
+import Data.Binary.Get
+    ( Get, runGetOrFail )
+
+import qualified Data.ByteString.Lazy as BL
+
+
+-- | A safe version of 'runGet' which doesn't throw on error.
+eitherRunGet
+    :: Get a
+    -> BL.ByteString
+    -> Either String a
+eitherRunGet decoder bytes = case runGetOrFail decoder bytes of
+    Right (_, _, a) -> Right a
+    Left  (_, _, e) -> Left  e

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -153,6 +153,7 @@ test-suite unit
     , monad-loops
     , QuickCheck
     , safe
+    , servant
     , text
     , text-class
     , time

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
@@ -33,7 +33,7 @@ module Cardano.Wallet.Jormungandr.Api.Types
 import Prelude
 
 import Cardano.Wallet.Jormungandr.Binary
-    ( Block, getBlock, runGet )
+    ( Block, eitherRunGet, getBlock )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
     , Hash (..)
@@ -109,7 +109,7 @@ instance ToHttpApiData AccountId where
 
 instance MimeUnrender JormungandrBinary [BlockId] where
     mimeUnrender _ =
-        pure . fmap (BlockId . Hash) . runGet (many $ getByteString 32)
+        fmap (map (BlockId . Hash)) . eitherRunGet (many $ getByteString 32)
 
 instance MimeUnrender Hex BlockId where
     mimeUnrender _ bs =
@@ -134,7 +134,7 @@ instance Accept JormungandrBinary where
     contentType _ = contentType $ Proxy @Servant.OctetStream
 
 instance MimeUnrender JormungandrBinary Block where
-    mimeUnrender _ = pure . runGet getBlock
+    mimeUnrender _ = eitherRunGet getBlock
 
 instance MimeRender JormungandrBinary SealedTx where
     mimeRender _ (SealedTx bytes) = BL.fromStrict bytes

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -135,6 +135,8 @@ import Data.Binary.Get
     , runGetOrFail
     , skip
     )
+import Data.Binary.Get.Safe
+    ( eitherRunGet )
 import Data.Binary.Put
     ( Put, PutM, putByteString, putWord16be, putWord64be, putWord8, runPut )
 import Data.Bits
@@ -971,15 +973,6 @@ withRaw get = do
     -- After decoding once, go back and get the raw bytes.
     raw <- getByteString (end - start)
     pure (raw, a)
-
--- | A safe version of 'runGet' which doesn't throw on error.
-eitherRunGet
-    :: Get a
-    -> BL.ByteString
-    -> Either String a
-eitherRunGet decoder bytes = case runGetOrFail decoder bytes of
-    Right (_, _, a) -> Right a
-    Left  (_, _, e) -> Left  e
 
 {-------------------------------------------------------------------------------
                                 Conversions

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -72,6 +72,7 @@ module Cardano.Wallet.Jormungandr.Binary
       -- * Re-export
     , Get
     , runGet
+    , eitherRunGet
     , runGetOrFail
     , Put
     , runPut
@@ -970,6 +971,15 @@ withRaw get = do
     -- After decoding once, go back and get the raw bytes.
     raw <- getByteString (end - start)
     pure (raw, a)
+
+-- | A safe version of 'runGet' which doesn't throw on error.
+eitherRunGet
+    :: Get a
+    -> BL.ByteString
+    -> Either String a
+eitherRunGet decoder bytes = case runGetOrFail decoder bytes of
+    Right (_, _, a) -> Right a
+    Left  (_, _, e) -> Left  e
 
 {-------------------------------------------------------------------------------
                                 Conversions

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
@@ -16,8 +16,11 @@ import Cardano.Wallet.Jormungandr.Api.Types
     ( AccountState (..)
     , ApiStakeDistribution (..)
     , ApiT (..)
+    , JormungandrBinary
     , StakeApiResponse (..)
     )
+import Cardano.Wallet.Jormungandr.Binary
+    ( Block )
 import Cardano.Wallet.Primitive.Types
     ( PoolId (..) )
 import Cardano.Wallet.Unsafe
@@ -28,6 +31,8 @@ import Data.Aeson
     ( eitherDecode )
 import Data.Aeson.QQ
     ( aesonQQ )
+import Data.Either
+    ( isLeft )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -36,10 +41,12 @@ import Data.Text.Class
     ( ToText (..) )
 import Data.Word
     ( Word64 )
+import Servant.API
+    ( MimeUnrender (..) )
 import Test.Aeson.Internal.RoundtripSpecs
     ( roundtripSpecs )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe )
+    ( Spec, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
     ( Arbitrary (..) )
 
@@ -192,6 +199,12 @@ spec = do
                 Left "Error in $.stake.unassigned: Word64 is either floating or \
                      \will cause over or underflow: 1.001000023e7"
             return ()
+
+        describe "MimeUnrender decoding" $ do
+            it "returns 'Left' when encountering an invalid binary block" $ do
+                mimeUnrender (Proxy @JormungandrBinary) ""
+                    `shouldSatisfy` (isLeft @_ @Block)
+
   where
     decodeJSON = eitherDecode :: BL.ByteString -> Either String StakeApiResponse
 

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -149,6 +149,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."monad-loops" or (buildDepError "monad-loops"))
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
             (hsPkgs."safe" or (buildDepError "safe"))
+            (hsPkgs."servant" or (buildDepError "servant"))
             (hsPkgs."text" or (buildDepError "text"))
             (hsPkgs."text-class" or (buildDepError "text-class"))
             (hsPkgs."time" or (buildDepError "time"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1228 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- ca2675b014b63e0b7b504c1c0d67e885fb56c4a8
  illustrate non-safety in Jörmungandr API client binary decoders
  
- 8e87584965bdf14a165b0cf0625627f6b18ecd28
  define and export a safe version of 'runGet'
  
- 428d0c8a6ff184ce718caac20f75bfe9f6125d53
  use safe 'eitherRunGet' to decode API types
  
- 36d794baa544302dc998f3a2f3c9fc2b18d0a901
  move 'eitherRunGet' into its own module for re-usability
  
- f6bec23ee15233471bba69487eb56f2aa50c5630
  safely decode IPC messages on Windows using eitherRunGet
  
- 26dd771e89ff402d9cb24490d529e83d50de3b59
  re-generate nix machinery