### PR TITLE
Fix missing test data in windows testing bundle

### DIFF
--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -224,6 +224,7 @@ test-suite integration
     , network
     , persistent
     , process
+    , random-shuffle
     , retry
     , safe
     , servant
@@ -233,6 +234,7 @@ test-suite integration
     , text-class
     , time
     , transformers
+    , unliftio
     , warp
     , yaml
   build-tools:
@@ -258,6 +260,7 @@ test-suite integration
       Test.Integration.Jormungandr.Scenario.CLI.StakePools
       Test.Integration.Jormungandr.Scenario.CLI.Transactions
       Test.Integration.Jormungandr.Scenario.CLI.Mnemonics
+      Test.Utils.Ports
 
 benchmark latency
   default-language:

--- a/lib/jormungandr/test/integration/Test/Utils/Ports.hs
+++ b/lib/jormungandr/test/integration/Test/Utils/Ports.hs
@@ -11,36 +11,18 @@
 module Test.Utils.Ports
     ( randomUnusedTCPPorts
     , findPort
-    , isPortOpen
-    , simpleSockAddr
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Network.Ports
+    ( isPortOpen, simpleSockAddr )
 import Control.Monad
     ( filterM )
 import Data.List
     ( sort )
-import Data.Word
-    ( Word8 )
-import Foreign.C.Error
-    ( Errno (..), eCONNREFUSED )
-import GHC.IO.Exception
-    ( IOException (..) )
-import Network.Socket
-    ( Family (AF_INET)
-    , PortNumber
-    , SockAddr (SockAddrInet)
-    , SocketType (Stream)
-    , close'
-    , connect
-    , socket
-    , tupleToHostAddress
-    )
 import System.Random.Shuffle
     ( shuffleM )
-import UnliftIO.Exception
-    ( bracket, throwIO, try )
 
 -- | Get a list of random TCPv4 ports that currently do not have any servers
 -- listening on them. It may return less than the requested number of ports.
@@ -59,27 +41,3 @@ randomUnusedTCPPorts count = do
 -- called.
 findPort :: IO Int
 findPort = head <$> randomUnusedTCPPorts 1
-
--- | Checks whether @connect()@ to a given TCPv4 `SockAddr` succeeds or
--- returns `eCONNREFUSED`.
---
--- Rethrows connection exceptions in all other cases (e.g. when the host
--- is unroutable).
-isPortOpen :: SockAddr -> IO Bool
-isPortOpen sockAddr = do
-  bracket (socket AF_INET Stream 6 {- TCP -}) close' $ \sock -> do
-    res <- try $ connect sock sockAddr
-    case res of
-      Right () -> return True
-      Left e ->
-        if (Errno <$> ioe_errno e) == Just eCONNREFUSED
-          then return False
-          else throwIO e
-
-
--- | Creates a `SockAttr` from host IP and port number.
---
--- Example:
--- > simpleSockAddr (127,0,0,1) 8000
-simpleSockAddr :: (Word8, Word8, Word8, Word8) -> PortNumber -> SockAddr
-simpleSockAddr addr port = SockAddrInet port (tupleToHostAddress addr)

--- a/lib/jormungandr/test/integration/js/mock-daedalus.js
+++ b/lib/jormungandr/test/integration/js/mock-daedalus.js
@@ -36,8 +36,8 @@ function main() {
             console.log("JS: response from wallet: " + res.statusCode);
             res.resume();
             res.on("end", () => {
-              console.log("JS: request response from wallet finished, exiting.");
-              process.exit(0);
+              console.log("JS: request response from wallet finished, disconnecting.");
+              proc.disconnect();
             });
           });
         }
@@ -58,8 +58,8 @@ function main() {
             console.log("JS: response from wallet: " + res.statusCode);
             res.resume();
             res.on("end", () => {
-              console.log("JS: request response from wallet finished, exiting.");
-              process.exit(0);
+              console.log("JS: request response from wallet finished, disconnecting.");
+              proc.disconnect();
             });
           });
         }
@@ -84,8 +84,9 @@ function main() {
   });
 
   proc.on("disconnect", function() {
-    console.log("JS: child_process disconnected");
-    process.exit(2);
+    console.log("JS: child_process disconnected.");
+    console.log("JS: waiting 2 seconds before exiting...");
+    setTimeout(function() { process.exit(2); }, 2000);
   });
 
   proc.on("error", function(err) {
@@ -95,7 +96,7 @@ function main() {
 
   proc.on("exit", function(code, signal) {
     console.log("JS: child_process exited with status " + code + " or signal " + signal);
-    process.exit(4);
+    process.exit(code === 0 ? 0 : 4);
   });
 
   test();

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -39,11 +39,9 @@ library
     , iohk-monitoring
     , network
     , QuickCheck
-    , random-shuffle
     , stm
     , template-haskell
     , time
-    , unliftio
     , wai-app-static
     , warp
   hs-source-dirs:
@@ -51,7 +49,6 @@ library
   exposed-modules:
       Test.Hspec.Extra
       Test.Utils.Paths
-      Test.Utils.Ports
       Test.Utils.StaticServer
       Test.Utils.Time
       Test.Utils.Trace

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -199,6 +199,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."network" or (buildDepError "network"))
             (hsPkgs."persistent" or (buildDepError "persistent"))
             (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))
             (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."safe" or (buildDepError "safe"))
             (hsPkgs."servant" or (buildDepError "servant"))
@@ -208,6 +209,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."text-class" or (buildDepError "text-class"))
             (hsPkgs."time" or (buildDepError "time"))
             (hsPkgs."transformers" or (buildDepError "transformers"))
+            (hsPkgs."unliftio" or (buildDepError "unliftio"))
             (hsPkgs."warp" or (buildDepError "warp"))
             (hsPkgs."yaml" or (buildDepError "yaml"))
             ];

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -70,11 +70,9 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
           (hsPkgs."network" or (buildDepError "network"))
           (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
-          (hsPkgs."random-shuffle" or (buildDepError "random-shuffle"))
           (hsPkgs."stm" or (buildDepError "stm"))
           (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
           (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."unliftio" or (buildDepError "unliftio"))
           (hsPkgs."wai-app-static" or (buildDepError "wai-app-static"))
           (hsPkgs."warp" or (buildDepError "warp"))
           ];

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -18,6 +18,7 @@ let
   testData = {
     core = ../lib/core/test/data;
     jormungandr = ../lib/jormungandr/test/data;
+    daedalusIPC = ../lib/jormungandr/test/integration/js;
   };
 
   name = "cardano-wallet-jormungandr-${project.version}-tests-win64";
@@ -40,12 +41,13 @@ in pkgs.runCommand name {
   nativeBuildInputs = [ pkgs.zip pkgs.gnused project.jormungandr-cli ];
   passthru = { inherit tests benchmarks; };
 } ''
-  mkdir -pv jm jm/test/data $out/nix-support
+  mkdir -pv jm jm/test/data jm/test/integration $out/nix-support
   cd jm
 
   cp -v ${cardano-wallet-jormungandr}/bin/* .
   cp -v ${nodejs}/node.exe .
   cp -Rv --no-preserve=mode ${testData.core}/* ${testData.jormungandr}/* test/data
+  cp -Rv --no-preserve=mode ${testData.daedalusIPC} test/integration/js
   cp -v ${jm-bat} jm.bat
   hash="$(jcli genesis hash --input test/data/jormungandr/block0.bin)"
   sed -e "s/HASH/$hash/" ${cw-bat} > cw.bat


### PR DESCRIPTION
Relates to #1228.

# Overview

- Adds `mock-daedalus.js` to the windows testing bundle so that the DaedalusIPC tests can run.
- Fixes a failing DaedalusIPC test case.
- Makes `mock-daedalus.js` use `child_process.disconnect()` rather than exiting and leaving behind stray processes on windows.

# Comments

[Latest build](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1231/cardano-wallet-jormungandr-tests-win64)
