### PR TITLE
Use database temp dir for wallet db in integration tests instead of in-memory DB

### DIFF
--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -71,7 +71,7 @@ import System.FilePath
 import System.IO.Temp
     ( withSystemTempDirectory )
 import Test.Hspec
-    ( Spec, SpecWith, after, describe, hspec, parallel )
+    ( Spec, SpecWith, after, describe, hspec )
 import Test.Hspec.Extra
     ( aroundAll )
 import Test.Integration.Framework.DSL
@@ -115,11 +115,11 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(conf,tr) -> do
     let logging = (conf, transformTextTrace tr)
     hspec $ do
         describe "No backend required" $ do
-            describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec
-            describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
-            describe "Mnemonics CLI tests (Jormungandr)" $ parallel (MnemonicsJormungandr.spec @t)
-            describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
-            describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
+            describe "Cardano.Wallet.NetworkSpec" $ NetworkLayer.spec
+            describe "Mnemonics CLI tests" $ (MnemonicsCLI.spec @t)
+            describe "Mnemonics CLI tests (Jormungandr)" $ (MnemonicsJormungandr.spec @t)
+            describe "Miscellaneous CLI tests" $ (MiscellaneousCLI.spec @t)
+            describe "Launcher CLI tests" $ (LauncherCLI.spec @t)
             describe "Stake Pool Metrics" MetricsSpec.spec
 
         describe "API Specifications" $ specWithServer logging $ do


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have modified integration tests so they are using temp dir during test execution


# Comments

Unfortunately tests failed for me locally with:

```
[cardano-wallet.worker:Error:4762] [2019-12-31 12:34:49.81 UTC] 7f084053: Recoverable error following the chain: SQLite3 returned ErrorMisuse while attempting to perform bind text.
Statement[cardano-wallet.worker:Info:4762] [2019-12-31 12:34:50.36 UTC] 7f084053: Applying blocks [1079666.5 ... 1079677.5]
AlreadyFinalized "BEGIN"
[cardano-wallet.worker:Error:4762] [2019-12-31 12:34:50.36 UTC] 7f084053: Recoverable error following the chain: StatementAlreadyFinalized "BEGIN"
[cardano-wallet.stake-pools:Info:2025] [2019-12-31 12:34:51.17 UTC] Applying blocks [1079681.7 ... 1079681.7]
malloc(): memory corruption

```

During the test I was also  observing a lot of errors after deleting the wallet:

```
[cardano-wallet.worker:Error:4683] [2019-12-31 12:34:49.33 UTC] c0486500: Worker has exited unexpectedly: SQLite3 returned ErrorMisuse while attempting to perform close: bad parameter or other API misuse

```