### PR TITLE
Allow switching on and off individual tracers via cli

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -36,6 +36,7 @@ library
     , bech32
     , bytestring
     , cardano-wallet-core
+    , contra-tracer
     , directory
     , extra
     , filepath

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -175,6 +175,7 @@ test-suite unit
     , cardano-wallet-test-utils
     , cborg
     , containers
+    , contra-tracer
     , cryptonite
     , directory
     , deepseq

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -212,7 +212,6 @@ test-suite unit
     , time
     , transformers
     , tree-diff
-    , unordered-containers
     , yaml
     , wai
     , warp

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -79,6 +79,8 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (unSlotNo)
     )
+import Cardano.Wallet.Registry
+    ( WorkerRegistryLog )
 import Control.Arrow
     ( first )
 import Control.Monad
@@ -603,6 +605,7 @@ associateMetadata poolOwners ownerMeta =
 -- | Messages associated with stake pool layer.
 data StakePoolLayerLog
     = MsgRegistry RegistryLog
+    | MsgStakePoolWorker WorkerRegistryLog
     | MsgListStakePoolsBegin
     | MsgMetadataUnavailable
     | MsgMetadataUsing PoolId PoolOwner StakePoolMetadata
@@ -615,6 +618,7 @@ instance DefinePrivacyAnnotation StakePoolLayerLog
 instance DefineSeverity StakePoolLayerLog where
     defineSeverity ev = case ev of
         MsgRegistry msg -> defineSeverity msg
+        MsgStakePoolWorker msg -> defineSeverity msg
         MsgListStakePoolsBegin -> Debug
         MsgMetadataUnavailable -> Notice
         MsgComputedProgress{} -> Debug
@@ -625,6 +629,7 @@ instance DefineSeverity StakePoolLayerLog where
 instance ToText StakePoolLayerLog where
     toText = \case
         MsgRegistry msg -> toText msg
+        MsgStakePoolWorker msg -> toText msg
         MsgListStakePoolsBegin -> "Listing stake pools"
         MsgMetadataUnavailable -> "Stake pool metadata is unavailable"
         MsgComputedProgress prodTip nodeTip -> mconcat

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -38,7 +38,8 @@ module Cardano.Pool.Metrics
     , associateMetadata
 
       -- * Logging
-    , StakePoolLayerMsg (..)
+    , StakePoolMonitorLog (..)
+    , StakePoolLayerLog (..)
     )
     where
 
@@ -48,8 +49,6 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
-import Cardano.BM.Trace
-    ( Trace, logDebug, logInfo, logNotice )
 import Cardano.Pool.DB
     ( DBLayer (..), ErrPointAlreadyExists )
 import Cardano.Pool.Metadata
@@ -60,7 +59,7 @@ import Cardano.Pool.Metadata
     , sameStakePoolMetadata
     )
 import Cardano.Wallet.Logging
-    ( logTrace )
+    ( fromLogObject )
 import Cardano.Wallet.Network
     ( ErrNetworkTip
     , ErrNetworkUnavailable
@@ -91,7 +90,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
     ( ExceptT (..), mapExceptT, runExceptT, throwE, withExceptT )
 import Control.Tracer
-    ( contramap )
+    ( Tracer, contramap, traceWith )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
@@ -159,19 +158,14 @@ data StakePool = StakePool
 -- The pool productions and stake distrubtions in the db can /never/ be from
 -- different forks such that it's safe for readers to access it.
 monitorStakePools
-    :: Trace IO Text
+    :: Tracer IO StakePoolMonitorLog
     -> NetworkLayer IO t Block
     -> DBLayer IO
     -> IO ()
 monitorStakePools tr nl db@DBLayer{..} = do
     cursor <- initCursor
-    logInfo tr $ mconcat
-        [ "Monitoring stake pools. Currently at "
-        , case cursor of
-            [] -> "genesis"
-            _  -> pretty (last cursor)
-        ]
-    follow nl tr cursor forward header >>= \case
+    traceWith tr $ MsgStartMonitoring cursor
+    follow nl trFollow cursor forward header >>= \case
         Nothing    -> pure ()
         Just point -> do
             liftIO . atomically $ rollbackTo point
@@ -201,32 +195,28 @@ monitorStakePools tr nl db@DBLayer{..} = do
             networkTip nl
         when (nodeTip /= currentTip) $ throwE ErrMonitorStakePoolsWrongTip
 
-        liftIO $ logInfo tr $ "Writing stake-distribution for epoch " <> pretty ep
+        liftIO $ traceWith tr $ MsgStakeDistribution ep
         mapExceptT atomically $ do
             lift $ putStakeDistribution ep (Map.toList dist)
             forM_ blocks $ \b -> do
                 forM_ (poolRegistrations b) $ \pool -> do
                     lift $ putPoolRegistration (b ^. #header . #slotId) pool
-                    liftIO
-                        $ logInfo tr
-                        $ "Discovered stake pool registration: " <> pretty pool
+                    liftIO $ traceWith tr $ MsgStakePoolRegistration pool
                 withExceptT ErrMonitorStakePoolsPoolAlreadyExists $
                     putPoolProduction (header b) (producer b)
       where
         handler action = runExceptT action >>= \case
-            Left ErrMonitorStakePoolsNetworkUnavailable{} -> do
-                logNotice tr "Network is not available."
-                pure RetryLater
-            Left ErrMonitorStakePoolsNetworkTip{} -> do
-                logNotice tr "Network is not available."
-                pure RetryLater
-            Left ErrMonitorStakePoolsWrongTip{} -> do
-                logDebug tr "Race condition when fetching stake distribution."
-                pure RetryImmediately
-            Left e@ErrMonitorStakePoolsPoolAlreadyExists{} ->
-                pure (ExitWith e)
+            Left e -> do
+                traceWith tr (MsgApplyError e)
+                pure $ case e of
+                    ErrMonitorStakePoolsNetworkUnavailable{} -> RetryLater
+                    ErrMonitorStakePoolsNetworkTip{} -> RetryLater
+                    ErrMonitorStakePoolsWrongTip{} -> RetryImmediately
+                    ErrMonitorStakePoolsPoolAlreadyExists{} -> ExitWith e
             Right () ->
                 pure Continue
+
+    trFollow = fromLogObject (contramap MsgFollow tr)
 
 -- | Internal error data-type used to drive the 'forward' logic
 data ErrMonitorStakePools
@@ -260,7 +250,7 @@ data ErrListStakePools
      deriving (Show)
 
 newStakePoolLayer
-    :: Trace IO StakePoolLayerMsg
+    :: Tracer IO StakePoolLayerLog
     -> DBLayer IO
     -> NetworkLayer IO t Block
     -> FilePath
@@ -269,7 +259,7 @@ newStakePoolLayer
     -> StakePoolLayer IO
 newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
     { listStakePools = do
-        lift $ logTrace tr MsgListStakePoolsBegin
+        lift $ traceWith tr MsgListStakePoolsBegin
         stakePools <- sortKnownPools
         meta <- lift $ findMetadata (map (first (^. #poolId)) stakePools)
         pure $ zip (map fst stakePools) meta
@@ -290,7 +280,7 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
             <*> readPoolProductionTip
 
         when (Map.null distr || Map.null prod) $ do
-            liftIO $ logTrace tr $ MsgComputedProgress prodTip nodeTip
+            liftIO $ traceWith tr $ MsgComputedProgress prodTip nodeTip
             throwE $ ErrMetricsIsUnsynced $ computeProgress prodTip nodeTip
 
         if nodeEpoch == genesisEpoch
@@ -315,14 +305,14 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
         let (poolIds, owners) = unzip pools
         let owners' = nub $ concat owners
         cfg <- getMetadataConfig metadataDir
-        let tr' = contramap (fmap MsgRegistry) tr
+        let tr' = contramap MsgRegistry tr
         getStakePoolMetadata tr' cfg owners' >>= \case
             Left _ -> do
-                logTrace tr MsgMetadataUnavailable
+                traceWith tr MsgMetadataUnavailable
                 pure $ replicate (length poolIds) Nothing
             Right metas -> do
                 let res = associateMetadata pools (zip owners' metas)
-                mapM_ (logTrace tr . fst) res
+                mapM_ (traceWith tr . fst) res
                 pure $ map snd res
 
     (block0, bp) = staticBlockchainParameters nl
@@ -584,7 +574,7 @@ associateMetadata
     -- ^ Ordered mapping from pool to owner(s).
     -> [(PoolOwner, Maybe StakePoolMetadata)]
     -- ^ Association between owner and metadata
-    -> [(StakePoolLayerMsg, Maybe StakePoolMetadata)]
+    -> [(StakePoolLayerLog, Maybe StakePoolMetadata)]
 associateMetadata poolOwners ownerMeta =
     map (uncurry getResult . fmap associate) poolOwners
   where
@@ -598,7 +588,7 @@ associateMetadata poolOwners ownerMeta =
     getResult
         :: PoolId
         -> [(PoolOwner, StakePoolMetadata)]
-        -> (StakePoolLayerMsg, Maybe StakePoolMetadata)
+        -> (StakePoolLayerLog, Maybe StakePoolMetadata)
     getResult pid metas = case nubBy sameMeta metas of
         [(owner, meta)] -> (MsgMetadataUsing pid owner meta, Just meta)
         [] -> (MsgMetadataMissing pid, Nothing)
@@ -610,7 +600,8 @@ associateMetadata poolOwners ownerMeta =
                                     Logging
 -------------------------------------------------------------------------------}
 
-data StakePoolLayerMsg
+-- | Messages associated with stake pool layer.
+data StakePoolLayerLog
     = MsgRegistry RegistryLog
     | MsgListStakePoolsBegin
     | MsgMetadataUnavailable
@@ -620,8 +611,8 @@ data StakePoolLayerMsg
     | MsgComputedProgress BlockHeader BlockHeader
     deriving (Show, Eq)
 
-instance DefinePrivacyAnnotation StakePoolLayerMsg
-instance DefineSeverity StakePoolLayerMsg where
+instance DefinePrivacyAnnotation StakePoolLayerLog
+instance DefineSeverity StakePoolLayerLog where
     defineSeverity ev = case ev of
         MsgRegistry msg -> defineSeverity msg
         MsgListStakePoolsBegin -> Debug
@@ -631,7 +622,7 @@ instance DefineSeverity StakePoolLayerMsg where
         MsgMetadataMissing{} -> Debug
         MsgMetadataMultiple{} -> Debug
 
-instance ToText StakePoolLayerMsg where
+instance ToText StakePoolLayerLog where
     toText = \case
         MsgRegistry msg -> toText msg
         MsgListStakePoolsBegin -> "Listing stake pools"
@@ -650,3 +641,48 @@ instance ToText StakePoolLayerMsg where
             "No stake pool metadata for " <> toText pid
         MsgMetadataMultiple pid _ ->
             "Multiple different metadata registered for " <> toText pid
+
+-- | Messages associated with stake pool monitoring
+data StakePoolMonitorLog
+    = MsgStartMonitoring [BlockHeader]
+    | MsgFollow Text
+    | MsgStakeDistribution EpochNo
+    | MsgStakePoolRegistration PoolRegistrationCertificate
+    | MsgApplyError ErrMonitorStakePools
+    deriving (Show, Eq)
+
+instance ToText StakePoolMonitorLog where
+    toText = \case
+        MsgStartMonitoring cursor -> mconcat
+            [ "Monitoring stake pools. Currently at "
+            , case cursor of
+                [] -> "genesis"
+                _  -> pretty (last cursor)
+            ]
+        MsgFollow txt -> txt
+        MsgStakeDistribution ep ->
+            "Writing stake-distribution for epoch " <> pretty ep
+        MsgStakePoolRegistration pool ->
+            "Discovered stake pool registration: " <> pretty pool
+        MsgApplyError e -> case e of
+            ErrMonitorStakePoolsNetworkUnavailable{} ->
+                "Network is not available."
+            ErrMonitorStakePoolsNetworkTip{} ->
+                "Network is not available."
+            ErrMonitorStakePoolsWrongTip{} ->
+                "Race condition when fetching stake distribution."
+            ErrMonitorStakePoolsPoolAlreadyExists{} ->
+                ""
+
+instance DefinePrivacyAnnotation StakePoolMonitorLog
+instance DefineSeverity StakePoolMonitorLog where
+    defineSeverity = \case
+        MsgStartMonitoring _ -> Info
+        MsgFollow _ -> Info
+        MsgStakeDistribution _ -> Info
+        MsgStakePoolRegistration _ -> Info
+        MsgApplyError e -> case e of
+            ErrMonitorStakePoolsNetworkUnavailable{} -> Notice
+            ErrMonitorStakePoolsNetworkTip{} -> Notice
+            ErrMonitorStakePoolsWrongTip{} -> Debug
+            ErrMonitorStakePoolsPoolAlreadyExists{} -> Debug

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -31,7 +31,7 @@ module Cardano.Wallet.DB.Sqlite
     , PersistState (..)
 
     -- * Logging
-    , WalletDatabasesLog (..)
+    , DatabasesStartupLog (..)
     ) where
 
 import Prelude
@@ -257,7 +257,7 @@ newDBFactory tr mDatabaseDir = do
 --   specified directory.
 findDatabases
     :: forall k. WalletKey k
-    => Tracer IO WalletDatabasesLog
+    => Tracer IO DatabasesStartupLog
     -> FilePath
     -> IO [W.WalletId]
 findDatabases tr dir = do
@@ -1094,12 +1094,12 @@ selectRndStatePending wid = do
 -------------------------------------------------------------------------------}
 
 -- | Log messages arising from accessing the wallet repository.
-data WalletDatabasesLog
+data DatabasesStartupLog
     = MsgFoundDatabase FilePath W.WalletId
     | MsgUnknownFile FilePath
     deriving (Show, Eq)
 
-instance ToText WalletDatabasesLog where
+instance ToText DatabasesStartupLog where
     toText = \case
         MsgFoundDatabase _file wid ->
             "Found existing wallet: " <> toText wid
@@ -1108,8 +1108,8 @@ instance ToText WalletDatabasesLog where
             , "the database folder: ", T.pack file
             ]
 
-instance DefinePrivacyAnnotation WalletDatabasesLog
-instance DefineSeverity WalletDatabasesLog where
+instance DefinePrivacyAnnotation DatabasesStartupLog
+instance DefineSeverity DatabasesStartupLog where
     defineSeverity = \case
         MsgFoundDatabase _ _ -> Info
         MsgUnknownFile _ -> Notice

--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -7,18 +13,28 @@
 module Cardano.Wallet.Logging
     ( transformTextTrace
     , logTrace
+    , fromLogObject
+    , trMessage
+    , trMessageText
+    , filterTraceSeverity
     ) where
 
 import Prelude
 
+import Cardano.BM.Data.LogItem
+    ( LOContent (..), LOMeta (..), LogObject (..), mkLOMeta )
+import Cardano.BM.Data.Severity
+    ( Severity )
 import Cardano.BM.Data.Tracer
-    ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
+    ( DefinePrivacyAnnotation (..), DefineSeverity (..), Transformable (..) )
 import Cardano.BM.Trace
     ( Trace, traceNamedItem )
+import Control.Monad
+    ( when )
 import Control.Monad.IO.Class
     ( MonadIO (..) )
 import Control.Tracer
-    ( contramap )
+    ( Tracer (..), contramap, nullTracer, traceWith )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -27,7 +43,7 @@ import Data.Text.Class
 -- | Converts a 'Text' trace into any other type of trace that has a 'ToText'
 -- instance.
 transformTextTrace :: ToText a => Trace IO Text -> Trace IO a
-transformTextTrace = contramap (fmap toText)
+transformTextTrace = contramap (fmap toText) . filterNonEmpty
 
 -- | Traces some data.
 logTrace
@@ -39,3 +55,64 @@ logTrace tr msg = traceNamedItem tr priv sev msg
   where
     priv = definePrivacyAnnotation msg
     sev = defineSeverity msg
+
+-- | Strips out the data that 'trMessage' (or
+-- "Cardano.BM.Data.Tracer.toLogObject") adds.
+fromLogObject :: Show a => Tracer IO a -> Tracer IO (LogObject a)
+fromLogObject = contramap (getLogMessage . loContent)
+  where
+    getLogMessage (LogMessage a) = a
+    getLogMessage msg = error $
+        "internal error: unable to extract log message from content\n"
+        <> show msg
+
+-- | Tracer transformer which transforms traced items to their 'ToText'
+-- representation and further traces them as a 'LogObject'. If the 'ToText'
+-- representation is empty, then no tracing happens.
+trMessageText
+    :: (MonadIO m, ToText a, DefinePrivacyAnnotation a, DefineSeverity a)
+    => Tracer m (LogObject Text)
+    -> Tracer m a
+trMessageText tr = Tracer $ \arg -> do
+   let msg = toText arg
+       tracer = if msg == mempty then nullTracer else tr
+   lo <- LogObject
+       <$> pure mempty
+       <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
+       <*> pure (LogMessage msg)
+   traceWith tracer lo
+
+trMessage
+    :: (MonadIO m, DefinePrivacyAnnotation a, DefineSeverity a)
+    => Tracer m (LogObject a)
+    -> Tracer m a
+trMessage tr = Tracer $ \arg ->
+   traceWith tr =<< LogObject
+       <$> pure mempty
+       <*> (mkLOMeta (defineSeverity arg) (definePrivacyAnnotation arg))
+       <*> pure (LogMessage arg)
+
+instance forall m a. (MonadIO m, ToText a, DefinePrivacyAnnotation a, DefineSeverity a) => Transformable Text m a where
+    trTransformer _fmt _verb = Tracer . traceWith . trMessageText
+
+-- | Tracer transformer which removes tracing below the qgiven severity limit.
+filterTraceSeverity
+    :: forall m a. (Monad m)
+    => Severity
+    -> Trace m a
+    -> Trace m a
+filterTraceSeverity sevlimit tr = Tracer $ \arg -> do
+    when (severity (loMeta arg) >= sevlimit) $
+        traceWith tr arg
+
+-- | Trace transformer which removes empty traces.
+filterNonEmpty
+    :: forall m a. (Monad m, Monoid a, Eq a)
+    => Trace m a
+    -> Trace m a
+filterNonEmpty tr = Tracer $ \arg -> do
+    when (nonEmptyMessage (loContent arg)) $
+        traceWith tr arg
+  where
+    nonEmptyMessage (LogMessage msg) = msg /= mempty
+    nonEmptyMessage _ = True

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -143,7 +143,6 @@ import System.IO.Unsafe
 import System.Random
     ( mkStdGen, randoms )
 
-import qualified Cardano.BM.Configuration.Model as CM
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -333,9 +332,8 @@ withDB bm = envWithCleanup setupDB cleanupDB (\ ~(_, _, db) -> bm db)
 
 setupDB :: IO (FilePath, SqliteContext, DBLayerBench)
 setupDB = do
-    logConfig <- CM.empty
     f <- emptySystemTempFile "bench.db"
-    (ctx, db) <- newDBLayer logConfig nullTracer (Just f)
+    (ctx, db) <- newDBLayer nullTracer (Just f)
     pure (f, ctx, db)
 
 cleanupDB :: (FilePath, SqliteContext, DBLayerBench) -> IO ()

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -11,14 +11,10 @@ module Cardano.Pool.DB.Properties
 
 import Prelude
 
-import Cardano.BM.Configuration.Model
-    ( Configuration )
-import Cardano.BM.Data.LogItem
-    ( LogObject (..) )
 import Cardano.BM.Trace
     ( traceInTVarIO )
 import Cardano.DB.Sqlite
-    ( SqliteContext )
+    ( DBLog (..), SqliteContext )
 import Cardano.Pool.DB
     ( DBLayer (..), ErrPointAlreadyExists (..) )
 import Cardano.Pool.DB.Arbitrary
@@ -54,8 +50,6 @@ import Data.Ord
     ( Down (..) )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Text
-    ( Text )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -92,15 +86,13 @@ withDB create = beforeAll create . beforeWith
 
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.
-newMemoryDBLayer :: IO Configuration -> IO (DBLayer IO)
-newMemoryDBLayer conf = snd . snd <$> (newMemoryDBLayer' conf)
+newMemoryDBLayer :: IO (DBLayer IO)
+newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
-newMemoryDBLayer'
-    :: IO Configuration -> IO (TVar [LogObject Text], (SqliteContext, DBLayer IO))
-newMemoryDBLayer' testingLogConfig = do
-    logConfig <- testingLogConfig
+newMemoryDBLayer' :: IO (TVar [DBLog], (SqliteContext, DBLayer IO))
+newMemoryDBLayer' = do
     logVar <- newTVarIO []
-    (logVar, ) <$> newDBLayer logConfig (traceInTVarIO logVar) Nothing
+    (logVar, ) <$> newDBLayer (traceInTVarIO logVar) Nothing
 
 properties :: SpecWith (DBLayer IO)
 properties = do

--- a/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
@@ -7,8 +7,6 @@ module Cardano.Pool.MetadataSpec (spec) where
 
 import Prelude
 
-import Cardano.BM.Trace
-    ( Trace )
 import Cardano.Pool.Metadata
     ( FetchError (..)
     , MetadataConfig (..)
@@ -28,6 +26,8 @@ import Codec.Archive.Zip
     ( CompressionMethod (..), addEntry, createArchive, mkEntrySelector )
 import Control.Monad
     ( forM_, replicateM, void )
+import Control.Tracer
+    ( Tracer )
 import Data.Aeson
     ( encode )
 import Data.ByteString
@@ -137,7 +137,7 @@ spec = do
                                  Test fixtures
 -------------------------------------------------------------------------------}
 
-withFixtures :: ((MetadataConfig, Trace IO RegistryLog, IO [RegistryLog]) -> IO a) -> IO a
+withFixtures :: ((MetadataConfig, Tracer IO RegistryLog, IO [RegistryLog]) -> IO a) -> IO a
 withFixtures action =
     withStaticServer dataDir $ \baseUrl ->
     withSystemTempDirectory "stake-pool-metadata" $ \metadataDir ->

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -31,7 +31,8 @@ import Cardano.Pool.Metrics
     ( Block (..)
     , ErrListStakePools (..)
     , StakePoolLayer (..)
-    , StakePoolLayerMsg (..)
+    , StakePoolLayerLog (..)
+    , StakePoolMonitorLog (..)
     , associateMetadata
     , calculatePerformance
     , combineMetrics
@@ -88,8 +89,6 @@ import Data.Maybe
     ( catMaybes )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Text
-    ( Text )
 import Data.Text.Class
     ( toText )
 import Data.Word
@@ -307,8 +306,9 @@ prop_trackRegistrations test = monadicIO $ do
         . mconcat
         . getRegistrationsTest
 
-    isDiscoveryMsg :: Text -> Bool
-    isDiscoveryMsg = T.isInfixOf "Discovered stake pool registration"
+    isDiscoveryMsg :: StakePoolMonitorLog -> Bool
+    isDiscoveryMsg (MsgStakePoolRegistration _) = True
+    isDiscoveryMsg _ = False
 
     getNumRegistrations :: RegistrationsTest -> Int
     getNumRegistrations =

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -367,8 +367,6 @@ loggingTracersOptions :: Parser TracerSeverities
 loggingTracersOptions = Tracers
     <$> traceOpt applicationTracer (Just Info)
     <*> traceOpt apiServerTracer (Just Info)
-    <*> traceOpt apiWorkerTracer (Just Info)
-    <*> traceOpt walletDatabasesTracer (Just Info)
     <*> traceOpt walletDbTracer (Just Info)
     <*> traceOpt networkTracer (Just Info)
     <*> traceOpt stakePoolMonitorTracer (Just Info)

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -367,13 +367,13 @@ loggingTracersOptions :: Parser TracerSeverities
 loggingTracersOptions = Tracers
     <$> traceOpt applicationTracer (Just Info)
     <*> traceOpt apiServerTracer (Just Info)
+    <*> traceOpt walletEngine (Just Info)
     <*> traceOpt walletDbTracer (Just Info)
     <*> traceOpt networkTracer (Just Info)
     <*> traceOpt stakePoolMonitorTracer (Just Info)
     <*> traceOpt stakePoolLayerTracer (Just Info)
     <*> traceOpt stakePoolDBTracer (Just Info)
     <*> traceOpt daedalusIPCTracer (Just Info)
-    <*> traceOpt workerRegistryTracer (Just Info)
   where
     traceOpt field def = fmap Const . option loggingSeverityOrOffReader $ mempty
         <> long ("trace-" <> T.unpack (getConst (field tracerLabels)))

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -357,10 +357,10 @@ loggingOptions = LoggingOptions
   where
     minSev = option loggingSeverityReader $ mempty
         <> long "log-level"
-        <> value Debug
+        <> value Info
         <> metavar "SEVERITY"
         <> help ("Global minimum severity for a message to be logged. " <>
-            "Defaults to \"DEBUG\" unless otherwise configured.")
+            "Defaults to \"INFO\" unless otherwise configured.")
         <> hidden
 
 loggingTracersOptions :: Parser TracerSeverities
@@ -396,7 +396,7 @@ helperTracingText = unlines $
     [ "Additional tracing options:"
     , ""
     , "  --log-level SEVERITY     Global minimum severity for a message to be logged."
-    , "                           Defaults to \"DEBUG\" unless otherwise configured."
+    , "                           Defaults to \"INFO\" unless otherwise configured."
     , "  --trace-NAME=off         Disable logging on the given tracer."
     , "  --trace-NAME=SEVERITY    Set the minimum logging severity for the given"
     , "                           tracer. Defaults to \"INFO\"."

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -405,4 +405,10 @@ helperTracingText = unlines $
     , "  " ++ unwords (map fst loggingSeverities)
     , ""
     , "The possible tracers are:"
-    ] ++ ["  " ++ name ++ "  " ++ desc | (name, desc) <- tracerDescriptions]
+    ] ++ [ pretty name desc | (name, desc) <- tracerDescriptions]
+  where
+    maxLength = maximum $ map (length . fst) tracerDescriptions
+    pretty name desc =
+        "  " ++ padRight maxLength ' ' name ++ "  " ++ desc
+      where
+        padRight n char str = take n $ str ++ replicate n char

--- a/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+
 module Cardano.Pool.MetricsSpec where
 
 import Prelude
 
-import Cardano.BM.Configuration.Static
-    ( defaultConfigStdout )
 import Cardano.BM.Trace
     ( nullTracer )
 import Cardano.Pool.DB
@@ -123,5 +122,4 @@ spec = around setup $ do
     withDB name action =
         withSystemTempDirectory "stake-pool" $ \dir -> do
             let dbFile = dir </> name
-            cfg <- defaultConfigStdout
-            Pool.withDBLayer cfg nullTracer (Just dbFile) action
+            Pool.withDBLayer nullTracer (Just dbFile) action

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -151,7 +151,7 @@ spec = do
                     , "--secret", secret
                     ]
             (Exit c, Stdout o, Stderr _) <- cardanoWalletCLI @t args
-            c `shouldBe` ExitFailure 1
+            c `shouldBe` ExitFailure 33
             o `shouldContain`
                 ("As far as I can tell, this isn't a valid block file: " <> secret)
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -113,23 +113,6 @@ spec = do
             waitForProcess ph `shouldReturn` ExitSuccess
 
     describe "LOGGING - cardano-wallet serve logging [SERIAL]" $ do
-        it "LOGGING - Serve --quiet logs Error only" $ \ctx -> do
-            withTempFile $ \logs hLogs -> do
-                let cmd = Command
-                        (commandName @t)
-                        ["serve"
-                        , "--node-port", show (ctx ^. typed @(Port "node"))
-                        , "--random-port"
-                        , "--quiet"
-                        , "--genesis-block-hash", block0H
-                        ]
-                        (pure ())
-                        (UseHandle hLogs)
-                void $ withBackendProcess nullTracer cmd $ do
-                    threadDelay (10 * oneSecond)
-                hClose hLogs
-                TIO.readFile logs `shouldReturn` mempty
-
         it "LOGGING - Serve default logs Info" $ \ctx -> do
             withTempFile $ \logs hLogs -> do
                 let cmd = Command
@@ -156,7 +139,7 @@ spec = do
                         , "--database", "/does-not-exist"
                         , "--node-port", show (ctx ^. typed @(Port "node"))
                         , "--random-port"
-                        , "--verbose"
+                        , "--log-level", "DEBUG"
                         , "--genesis-block-hash", block0H
                         ]
                         (pure ())

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -70,12 +70,14 @@ test-suite unit
     , async
     , cardano-wallet-launcher
     , cardano-wallet-test-utils
+    , contra-tracer
     , fmt
     , hspec
     , iohk-monitoring
     , process
     , retry
     , text
+    , text-class
     , time
   build-tools:
       hspec-discover

--- a/lib/launcher/src/Cardano/Launcher/POSIX.hs
+++ b/lib/launcher/src/Cardano/Launcher/POSIX.hs
@@ -10,12 +10,8 @@ module Cardano.Launcher.POSIX
 
 import Prelude
 
-import Cardano.BM.Trace
-    ( Trace, logNotice )
 import Control.Monad
     ( void )
-import Data.Text
-    ( Text )
 import System.Posix.Signals
     ( Handler (..)
     , installHandler
@@ -26,10 +22,10 @@ import System.Posix.Signals
 
 -- | Convert any SIGTERM received to SIGINT, for which the runtime system has
 -- handlers that will correctly clean up sub-processes.
-installSignalHandlers :: Trace IO Text -> IO ()
-installSignalHandlers tr = void $
+installSignalHandlers :: IO () -> IO ()
+installSignalHandlers notify = void $
     installHandler softwareTermination termHandler Nothing
     where
         termHandler = CatchOnce $ do
-            logNotice tr "Terminated by signal."
+            notify
             raiseSignal keyboardSignal

--- a/lib/launcher/src/Cardano/Launcher/Windows.hs
+++ b/lib/launcher/src/Cardano/Launcher/Windows.hs
@@ -10,11 +10,6 @@ module Cardano.Launcher.Windows
 
 import Prelude
 
-import Cardano.BM.Trace
-    ( Trace )
-import Data.Text
-    ( Text )
-
 -- | Stub function for windows.
-installSignalHandlers :: Trace IO Text -> IO ()
+installSignalHandlers :: IO () -> IO ()
 installSignalHandlers _ = pure ()

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -31,6 +31,7 @@ library
   build-depends:
       base
     , async
+    , contra-tracer
     , filepath
     , file-embed
     , hspec

--- a/lib/test-utils/src/Test/Utils/Trace.hs
+++ b/lib/test-utils/src/Test/Utils/Trace.hs
@@ -12,32 +12,25 @@ module Test.Utils.Trace
 
 import Prelude
 
-import Cardano.BM.Data.LogItem
-    ( LOContent (..), LogObject (..) )
 import Cardano.BM.Trace
-    ( Trace, traceInTVarIO )
+    ( traceInTVarIO )
 import Control.Concurrent.STM.TVar
     ( newTVarIO, readTVarIO )
-import Data.Maybe
-    ( mapMaybe )
+import Control.Tracer
+    ( Tracer )
 
 -- | Run an action with a logging 'Trace' object, and a function to get all
 -- messages that have been traced.
-withLogging :: ((Trace IO msg, IO [msg]) -> IO a) -> IO a
+withLogging :: ((Tracer IO msg, IO [msg]) -> IO a) -> IO a
 withLogging action = do
     tvar <- newTVarIO []
-    let getMsgs = reverse . mapMaybe getLogMessage <$> readTVarIO tvar
+    let getMsgs = reverse <$> readTVarIO tvar
     action (traceInTVarIO tvar, getMsgs)
 
 -- | Run an action with a 'Trace', returning captured log messages along with
 -- the result of the action.
-captureLogging :: (Trace IO msg -> IO a) -> IO ([msg], a)
+captureLogging :: (Tracer IO msg -> IO a) -> IO ([msg], a)
 captureLogging action = withLogging $ \(tr, getMsgs) -> do
     res <- action tr
     msgs <- getMsgs
     pure (msgs, res)
-
-getLogMessage :: LogObject msg -> Maybe msg
-getLogMessage lo = case loContent lo of
-    LogMessage msg -> Just msg
-    _ -> Nothing

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -64,6 +64,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."bech32" or (buildDepError "bech32"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."directory" or (buildDepError "directory"))
           (hsPkgs."extra" or (buildDepError "extra"))
           (hsPkgs."filepath" or (buildDepError "filepath"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -133,6 +133,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."containers" or (buildDepError "containers"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
             (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
             (hsPkgs."directory" or (buildDepError "directory"))
             (hsPkgs."deepseq" or (buildDepError "deepseq"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -170,7 +170,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."time" or (buildDepError "time"))
             (hsPkgs."transformers" or (buildDepError "transformers"))
             (hsPkgs."tree-diff" or (buildDepError "tree-diff"))
-            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
             (hsPkgs."yaml" or (buildDepError "yaml"))
             (hsPkgs."wai" or (buildDepError "wai"))
             (hsPkgs."warp" or (buildDepError "warp"))

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -79,12 +79,14 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."async" or (buildDepError "async"))
             (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."process" or (buildDepError "process"))
             (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."text-class" or (buildDepError "text-class"))
             (hsPkgs."time" or (buildDepError "time"))
             ];
           build-tools = [

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -62,6 +62,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
           (hsPkgs."async" or (buildDepError "async"))
+          (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."filepath" or (buildDepError "filepath"))
           (hsPkgs."file-embed" or (buildDepError "file-embed"))
           (hsPkgs."hspec" or (buildDepError "hspec"))


### PR DESCRIPTION
Relates to #1235 

# Overview

- Adds structured logging in more places
- Allow switching on or off individual tracers via cli options.
- Change the type of logging from Trace -> Tracer.

# Comments

```
$ cardano-wallet-jormungandr launch --help-tracing 
Additional tracing options:

  --log-level SEVERITY     Global minimum severity for a message to be logged.
                           Defaults to "DEBUG" unless otherwise configured.
  --trace-NAME=off         Disable logging on the given tracer.
  --trace-NAME=SEVERITY    Set the minimum logging severity for the given
                           tracer. Defaults to "INFO".

The possible log levels (lowest to highest) are:
  debug info notice warning error critical alert emergency

The possible tracers are:
  application  
  api-server  
  api-worker  
  wallet-databases  
  wallet-db  
  network  
  stake-pool-monitor  
  stake-pool-layer  
  stake-pool-db  
  daedalus-ipc  
  worker-registry  
```
