### PR TITLE
Include other types of byron wallets in tests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -31,7 +31,7 @@ import Test.Integration.Framework.DSL
     , Payload (..)
     , balanceAvailable
     , deleteWalletEp
-    , emptyRandomWallet
+    , emptyByronWallet
     , emptyWallet
     , emptyWalletWith
     , expectErrorMessage
@@ -63,13 +63,15 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
 spec = do
-    it "BYRON_ADDRESS_LIST - Byron wallet on Shelley ep" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let wid = w ^. walletId
-        let ep = ("GET", "v2/wallets/" <> wid <> "/addresses")
-        r <- request @[ApiAddress n] ctx ep Default Empty
-        expectResponseCode @IO HTTP.status404 r
-        expectErrorMessage (errMsg404NoWallet wid) r
+    describe "BYRON_ADDRESS_LIST - Byron wallet on Shelley ep" $ do
+        forM_ ["random", "icarus"] $ \style -> do
+            it ("Byron wallet on Shelley ep - " <> T.unpack style) $ \ctx -> do
+                w <- emptyByronWallet style ctx
+                let wid = w ^. walletId
+                let ep = ("GET", "v2/wallets/" <> wid <> "/addresses")
+                r <- request @[ApiAddress n] ctx ep Default Empty
+                expectResponseCode @IO HTTP.status404 r
+                expectErrorMessage (errMsg404NoWallet wid) r
 
     it "ADDRESS_LIST_01 - Can list known addresses on a default wallet" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronTransactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronTransactions.hs
@@ -28,8 +28,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , deleteByronWalletEp
-    , emptyIcarusWallet
-    , emptyRandomWallet
+    , emptyByronWallet
     , emptyWallet
     , expectErrorMessage
     , expectListSizeEqual
@@ -63,16 +62,6 @@ data TestCase a = TestCase
 spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
 spec = do
 
-    it "BYRON_TX_LIST_01 - 0 txs on empty Byron wallet"
-        $ \ctx -> forM_ [emptyRandomWallet, emptyIcarusWallet] $ \emptyByronWallet -> do
-            w <- emptyByronWallet ctx
-            r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty)
-                Default Empty
-            verify r
-                [ expectResponseCode @IO HTTP.status200
-                , expectListSizeEqual 0
-                ]
-
     it "BYRON_TX_LIST_01 - Can list transactions on Byron Wallet"
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
             w <- fixtureByronWallet ctx
@@ -82,95 +71,6 @@ spec = do
                 [ expectResponseCode @IO HTTP.status200
                 , expectListSizeEqual 10
                 ]
-
-    describe "BYRON_TX_LIST_01 - Faulty start, end, order values" $ do
-        let orderErr = "Please specify one of the following values:\
-            \ ascending, descending."
-        let startEndErr = "Expecting ISO 8601 date-and-time format\
-            \ (basic or extended), e.g. 2012-09-25T10:15:00Z."
-        let queries :: [TestCase [ApiTransaction n]] =
-                [
-                  TestCase
-                    { query = toQueryString [ ("start", "2009") ]
-                    , assertions =
-                             [ expectResponseCode @IO HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                    }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25T10:15:00Z")
-                             , ("end", "2016-11-21")
-                             ]
-                     , assertions =
-                             [ expectResponseCode @IO HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25")
-                             , ("end", "2016-11-21T10:15:00Z")
-                             ]
-                     , assertions =
-                             [ expectResponseCode @IO HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("end", "2012-09-25T10:15:00Z")
-                             , ("start", "2016-11-21")
-                             ]
-                     , assertions =
-                             [ expectResponseCode @IO HTTP.status400
-                             , expectErrorMessage startEndErr
-                             ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString [ ("order", "scending") ]
-                     , assertions =
-                            [ expectResponseCode @IO HTTP.status400
-                            , expectErrorMessage orderErr
-                            ]
-
-                     }
-                 , TestCase
-                     { query = toQueryString
-                             [ ("start", "2012-09-25T10:15:00Z")
-                             , ("order", "asc")
-                             ]
-                     , assertions =
-                             [ expectResponseCode @IO HTTP.status400
-                             , expectErrorMessage orderErr
-                             ]
-                     }
-                ]
-
-        forM_ queries $ \tc -> it (T.unpack $ query tc) $ \ctx -> do
-            w <- emptyRandomWallet ctx
-            r <- request @([ApiTransaction n]) ctx (listByronTxEp w (query tc))
-                Default Empty
-            verify r (assertions tc)
-
-    it "BYRON_TX_LIST_01 - Start time shouldn't be later than end time" $
-        \ctx -> do
-              w <- emptyRandomWallet ctx
-              let startTime = "2009-09-09T09:09:09Z"
-              let endTime = "2001-01-01T01:01:01Z"
-              let q = toQueryString
-                      [ ("start", T.pack startTime)
-                      , ("end", T.pack endTime)
-                      ]
-              r <- request @([ApiTransaction n]) ctx (listByronTxEp w q)
-                  Default Empty
-              expectResponseCode @IO HTTP.status400 r
-              expectErrorMessage
-                  (errMsg400StartTimeLaterThanEndTime startTime endTime) r
 
     it "BYRON_TX_LIST_02 -\
         \ Byron endpoint does not list Shelley wallet transactions" $ \ctx -> do
@@ -183,35 +83,6 @@ spec = do
             , expectErrorMessage (errMsg404NoWallet wid)
             ]
 
-    it "BYRON_TX_LIST_03 -\
-        \ Shelley endpoint does not list Byron wallet transactions" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let wid = w ^. walletId
-        let ep = ("GET", "v2/wallets/" <> wid <> "/transactions")
-        r <- request @([ApiTransaction n]) ctx ep Default Empty
-        verify r
-            [ expectResponseCode @IO HTTP.status404
-            , expectErrorMessage (errMsg404NoWallet wid)
-            ]
-
-    it "BYRON_TX_LIST_04 - 'almost' valid walletId" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let endpoint = "v2/byron-wallets/"
-                <> T.unpack (T.append (w ^. walletId) "0")
-                <> "/transactions"
-        r <- request @([ApiTransaction n]) ctx ("GET", T.pack endpoint)
-                Default Empty
-        expectResponseCode @IO HTTP.status404 r
-        expectErrorMessage errMsg404NoEndpoint r
-
-    it "BYRON_TX_LIST_04 - Deleted wallet" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        _ <- request @ApiByronWallet ctx (deleteByronWalletEp w) Default Empty
-        r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty)
-            Default Empty
-        expectResponseCode @IO HTTP.status404 r
-        expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
-
     describe "BYRON_TX_LIST_04 - False wallet ids" $ do
         forM_ falseWalletIds $ \(title, walId) -> it title $ \ctx -> do
             let endpoint = "v2/byron-wallets/" <> walId <> "/transactions"
@@ -223,9 +94,144 @@ spec = do
             else
                 expectErrorMessage errMsg404NoEndpoint r :: IO ()
 
-    describe "BYRON_TX_LIST_05 - Request headers" $ do
-        forM_ (getHeaderCases HTTP.status200)
-            $ \(title, h, expec) -> it title $ \ctx -> do
-            w <- emptyRandomWallet ctx
-            r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty) h Empty
-            verify r expec
+    describe "TX_BYRON_WALLETS - random, sequential" $ do
+        forM_ ["random", "icarus"] $ \style -> do
+
+            it ("BYRON_TX_LIST_01 - 0 txs on empty Byron wallet - "
+                <> T.unpack style) $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty)
+                        Default Empty
+                    verify r
+                        [ expectResponseCode @IO HTTP.status200
+                        , expectListSizeEqual 0
+                        ]
+
+            describe ("BYRON_TX_LIST_01 - Faulty start, end, order values"
+                <> T.unpack style) $ do
+                let orderErr = "Please specify one of the following values:\
+                    \ ascending, descending."
+                let startEndErr = "Expecting ISO 8601 date-and-time format\
+                    \ (basic or extended), e.g. 2012-09-25T10:15:00Z."
+                let queries :: [TestCase [ApiTransaction n]] =
+                        [
+                          TestCase
+                            { query = toQueryString [ ("start", "2009") ]
+                            , assertions =
+                                     [ expectResponseCode @IO HTTP.status400
+                                     , expectErrorMessage startEndErr
+                                     ]
+
+                            }
+                         , TestCase
+                             { query = toQueryString
+                                     [ ("start", "2012-09-25T10:15:00Z")
+                                     , ("end", "2016-11-21")
+                                     ]
+                             , assertions =
+                                     [ expectResponseCode @IO HTTP.status400
+                                     , expectErrorMessage startEndErr
+                                     ]
+
+                             }
+                         , TestCase
+                             { query = toQueryString
+                                     [ ("start", "2012-09-25")
+                                     , ("end", "2016-11-21T10:15:00Z")
+                                     ]
+                             , assertions =
+                                     [ expectResponseCode @IO HTTP.status400
+                                     , expectErrorMessage startEndErr
+                                     ]
+
+                             }
+                         , TestCase
+                             { query = toQueryString
+                                     [ ("end", "2012-09-25T10:15:00Z")
+                                     , ("start", "2016-11-21")
+                                     ]
+                             , assertions =
+                                     [ expectResponseCode @IO HTTP.status400
+                                     , expectErrorMessage startEndErr
+                                     ]
+
+                             }
+                         , TestCase
+                             { query = toQueryString [ ("order", "scending") ]
+                             , assertions =
+                                    [ expectResponseCode @IO HTTP.status400
+                                    , expectErrorMessage orderErr
+                                    ]
+
+                             }
+                         , TestCase
+                             { query = toQueryString
+                                     [ ("start", "2012-09-25T10:15:00Z")
+                                     , ("order", "asc")
+                                     ]
+                             , assertions =
+                                     [ expectResponseCode @IO HTTP.status400
+                                     , expectErrorMessage orderErr
+                                     ]
+                             }
+                        ]
+
+                forM_ queries $ \tc -> it (T.unpack $ query tc) $ \ctx -> do
+                        w <- emptyByronWallet style ctx
+                        r <- request @([ApiTransaction n]) ctx (listByronTxEp w (query tc))
+                            Default Empty
+                        verify r (assertions tc)
+
+            it ("BYRON_TX_LIST_01 - Start time shouldn't be later than end time"
+                <> T.unpack style) $ \ctx -> do
+                      w <- emptyByronWallet style ctx
+                      let startTime = "2009-09-09T09:09:09Z"
+                      let endTime = "2001-01-01T01:01:01Z"
+                      let q = toQueryString
+                              [ ("start", T.pack startTime)
+                              , ("end", T.pack endTime)
+                              ]
+                      r <- request @([ApiTransaction n]) ctx (listByronTxEp w q)
+                          Default Empty
+                      expectResponseCode @IO HTTP.status400 r
+                      expectErrorMessage
+                          (errMsg400StartTimeLaterThanEndTime startTime endTime) r
+
+            it ("BYRON_TX_LIST_03 -\
+                \ Shelley endpoint does not list Byron wallet transactions"
+                <> T.unpack style) $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    let wid = w ^. walletId
+                    let ep = ("GET", "v2/wallets/" <> wid <> "/transactions")
+                    r <- request @([ApiTransaction n]) ctx ep Default Empty
+                    verify r
+                        [ expectResponseCode @IO HTTP.status404
+                        , expectErrorMessage (errMsg404NoWallet wid)
+                        ]
+
+            it ("BYRON_TX_LIST_04 - 'almost' valid walletId"
+                <> T.unpack style) $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    let endpoint = "v2/byron-wallets/"
+                            <> T.unpack (T.append (w ^. walletId) "0")
+                            <> "/transactions"
+                    r <- request @([ApiTransaction n]) ctx ("GET", T.pack endpoint)
+                            Default Empty
+                    expectResponseCode @IO HTTP.status404 r
+                    expectErrorMessage errMsg404NoEndpoint r
+
+            it ("BYRON_TX_LIST_04 - Deleted wallet"
+                <> T.unpack style) $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    _ <- request @ApiByronWallet ctx (deleteByronWalletEp w) Default Empty
+                    r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty)
+                        Default Empty
+                    expectResponseCode @IO HTTP.status404 r
+                    expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
+
+            describe ("BYRON_TX_LIST_05 - Request headers" <> T.unpack style) $ do
+                forM_ (getHeaderCases HTTP.status200)
+                    $ \(title, h, expec) -> it title $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    r <- request @([ApiTransaction n]) ctx (listByronTxEp w mempty) h Empty
+                    verify r expec

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -59,7 +59,7 @@ import Test.Integration.Framework.DSL
     , coinSelectionOutputs
     , delegation
     , deleteWalletEp
-    , emptyRandomWallet
+    , emptyByronWallet
     , emptyWallet
     , expectErrorMessage
     , expectEventually
@@ -1751,37 +1751,47 @@ spec = do
             expectResponseCode @IO HTTP.status405 r
             expectErrorMessage errMsg405 r
 
-    it "BYRON_WALLETS_UTXO -\
-        \ Cannot show Byron wal utxo with shelley ep (404)" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let wid = w ^. walletId
-        let endpoint =
-                    "v2/wallets"
-                    </> wid
-                    </> ("statistics/utxos" :: Text)
-        r <- request @ApiUtxoStatistics ctx ("GET", endpoint) Default Empty
-        expectResponseCode @IO HTTP.status404 r
-        expectErrorMessage (errMsg404NoWallet wid) r
+    describe "BYRON_WALLETS_NEGATIVE" $ do
+        forM_ ["random", "icarus"] $ \style -> do
+            it ("BYRON_WALLETS_UTXO -\
+                \ Cannot show Byron wal utxo with shelley ep (404) - "
+                <> T.unpack style)
+                $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    let wid = w ^. walletId
+                    let endpoint =
+                                "v2/wallets"
+                                </> wid
+                                </> ("statistics/utxos" :: Text)
+                    r <- request @ApiUtxoStatistics ctx
+                        ("GET", endpoint)
+                        Default Empty
+                    expectResponseCode @IO HTTP.status404 r
+                    expectErrorMessage (errMsg404NoWallet wid) r
 
-    it "BYRON_WALLETS_UPDATE_PASS -\
-        \ Cannot update Byron wal with shelley ep (404)" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let payload = updatePassPayload "Secure passphrase" "Secure passphrase2"
-        let wid = w ^. walletId
-        let endpoint =
-                "v2/wallets"
-                </> wid
-                </> ("passphrase" :: Text)
-        rup <- request @ApiWallet ctx ("PUT", endpoint) Default payload
-        expectResponseCode @IO HTTP.status404 rup
-        expectErrorMessage (errMsg404NoWallet wid) rup
+            it ("BYRON_WALLETS_UPDATE_PASS -\
+                \ Cannot update Byron wal with shelley ep (404) - "
+                <> T.unpack style)
+                $ \ctx -> do
+                w <- emptyByronWallet style ctx
+                let payload = updatePassPayload "Secure passphrase" "Secure passphrase2"
+                let wid = w ^. walletId
+                let endpoint =
+                        "v2/wallets"
+                        </> wid
+                        </> ("passphrase" :: Text)
+                rup <- request @ApiWallet ctx ("PUT", endpoint) Default payload
+                expectResponseCode @IO HTTP.status404 rup
+                expectErrorMessage (errMsg404NoWallet wid) rup
 
-    it "BYRON_WALLETS_UPDATE -\
-        \ Cannot update Byron wal with shelley ep (404)" $ \ctx -> do
-        w <- emptyRandomWallet ctx
-        let wid = w ^. walletId
-        let endpoint = "v2/wallets" </> wid
-        let newName = updateNamePayload "new name"
-        ru <- request @ApiWallet ctx ("GET", endpoint) Default newName
-        expectResponseCode @IO HTTP.status404 ru
-        expectErrorMessage (errMsg404NoWallet wid) ru
+            it ("BYRON_WALLETS_UPDATE -\
+                \ Cannot update Byron wal with shelley ep (404) - "
+                <> T.unpack style)
+                $ \ctx -> do
+                    w <- emptyByronWallet style ctx
+                    let wid = w ^. walletId
+                    let endpoint = "v2/wallets" </> wid
+                    let newName = updateNamePayload "new name"
+                    ru <- request @ApiWallet ctx ("GET", endpoint) Default newName
+                    expectResponseCode @IO HTTP.status404 ru
+                    expectErrorMessage (errMsg404NoWallet wid) ru


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have included random, icarus, trezor and ledger byron wallets in existing tests for byron wallets. No new tests have been added.


# Comments
Those changes increased execution time to 1400 s (24 minutes) for whole suite (I think it was ~ 15min before). So maybe some parts can be revised...
