### PR TITLE
Revisions of the logic handling roll backs 

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -631,10 +631,8 @@ rollbackBlocks
     -> ExceptT ErrNoSuchWallet IO ()
 rollbackBlocks ctx wid point = db & \DBLayer{..} -> do
     liftIO $ logInfo tr $ "Try rolling back to " <> pretty point
-    mapExceptT atomically $ rollbackTo (PrimaryKey wid) point
-    -- TODO
-    -- point' <- mapExceptT atomically $ rollbackTo (PrimaryKey wid) point
-    -- liftIO $ logInfo tr $ "Rolled back to " <> pretty point'
+    point' <- mapExceptT atomically $ rollbackTo (PrimaryKey wid) point
+    liftIO $ logInfo tr $ "Rolled back to " <> pretty point'
   where
     db = ctx ^. dbLayer @s @k
     tr = ctx ^. logger

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -258,7 +258,7 @@ import Cardano.Wallet.Transaction
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( forM, forM_, void, when )
+    ( forM, forM_, when )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Monad.Trans.Class
@@ -605,8 +605,11 @@ restoreWallet
 restoreWallet ctx wid = db & \DBLayer{..} -> do
     cps <- liftIO $ atomically $ listCheckpoints (PrimaryKey wid)
     let forward bs h = run $ restoreBlocks @ctx @s @k ctx wid bs h
-    let backward sid = run $ mapExceptT atomically $ rollbackTo (PrimaryKey wid) sid
-    void $ liftIO $ follow nw tr cps forward backward (view #header)
+    liftIO (follow nw tr cps forward (view #header)) >>= \case
+        Nothing -> pure ()
+        Just point -> do
+            rollbackBlocks @ctx @s @k ctx wid point
+            restoreWallet @ctx @s @t @k ctx wid
   where
     db = ctx ^. dbLayer @s @k
     nw = ctx ^. networkLayer @t
@@ -614,6 +617,27 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
 
     run :: ExceptT ErrNoSuchWallet IO () -> IO (FollowAction ErrNoSuchWallet)
     run = fmap (either ExitWith (const Continue)) . runExceptT
+
+-- | Rewind the UTxO snapshots, transaction history and other information to a
+-- the earliest point in the past that is before or is the point of rollback.
+rollbackBlocks
+    :: forall ctx s k.
+        ( HasLogger ctx
+        , HasDBLayer s k ctx
+        )
+    => ctx
+    -> WalletId
+    -> SlotId
+    -> ExceptT ErrNoSuchWallet IO ()
+rollbackBlocks ctx wid point = db & \DBLayer{..} -> do
+    liftIO $ logInfo tr $ "Try rolling back to " <> pretty point
+    mapExceptT atomically $ rollbackTo (PrimaryKey wid) point
+    -- TODO
+    -- point' <- mapExceptT atomically $ rollbackTo (PrimaryKey wid) point
+    -- liftIO $ logInfo tr $ "Rolled back to " <> pretty point'
+  where
+    db = ctx ^. dbLayer @s @k
+    tr = ctx ^. logger
 
 -- | Apply the given blocks to the wallet and update the wallet state,
 -- transaction history and corresponding metadata.

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -225,8 +225,13 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , rollbackTo
         :: PrimaryKey WalletId
         -> SlotId
-        -> ExceptT ErrNoSuchWallet stm ()
+        -> ExceptT ErrNoSuchWallet stm SlotId
         -- ^ Drops all checkpoints and transaction data after the given slot.
+        --
+        -- Returns the actual slot to which the database has rolled back. This
+        -- slot is guaranteed to be smaller or equal to the given point of
+        -- rollback but can't be guaranteed to be exactly the same because the
+        -- database only keeps sparse checkpoints.
 
     , prune
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -229,9 +229,9 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ Drops all checkpoints and transaction data after the given slot.
         --
         -- Returns the actual slot to which the database has rolled back. This
-        -- slot is guaranteed to be smaller or equal to the given point of
-        -- rollback but can't be guaranteed to be exactly the same because the
-        -- database only keeps sparse checkpoints.
+        -- slot is guaranteed to be earlier than (or identical to) the given
+        -- point of rollback but can't be guaranteed to be exactly the same
+        -- because the database may only keep sparse checkpoints.
 
     , prune
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -235,7 +235,7 @@ mRemovePendingTx wid tid db@(Database wallets txs) = case Map.lookup wid wallets
         updateWallets = Map.adjust changeTxMeta wid wallets
         changeTxMeta meta = meta { txHistory = Map.delete tid (txHistory meta) }
 
-mRollbackTo :: Ord wid => wid -> SlotId -> ModelOp wid s xprv ()
+mRollbackTo :: Ord wid => wid -> SlotId -> ModelOp wid s xprv SlotId
 mRollbackTo wid point db@(Database wallets txs) = case Map.lookup wid wallets of
     Nothing ->
         ( Left (NoSuchWallet wid), db )
@@ -253,7 +253,7 @@ mRollbackTo wid point db@(Database wallets txs) = case Map.lookup wid wallets of
                             Map.mapMaybe (rescheduleOrForget nearest) (txHistory wal)
                         }
                 in
-                    ( Right ()
+                    ( Right nearest
                     , Database (Map.insert wid wal' wallets) txs
                     )
   where

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -367,7 +367,7 @@ newDBLayer logConfig trace mDatabaseFile = do
                 Nothing -> selectLatestCheckpoint wid >>= \case
                     Nothing -> pure $ Left $ ErrNoSuchWallet wid
                     Just _  -> lift $ throwIO (ErrNoOlderCheckpoint wid point)
-                Just nearestPoint -> Right <$> do
+                Just nearestPoint -> do
                     deleteCheckpoints wid
                         [ CheckpointSlot >. point
                         ]
@@ -385,6 +385,7 @@ newDBLayer logConfig trace mDatabaseFile = do
                         [ TxMetaDirection ==. W.Incoming
                         , TxMetaSlot >. point
                         ]
+                    pure (Right nearestPoint)
 
         , prune = \(PrimaryKey wid) -> ExceptT $ do
             selectLatestCheckpoint wid >>= \case

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -68,9 +68,9 @@ followSpec =
             let tr = traceInTVarIO tvar
             let getHeader = header
             let advance _blocks _h = return $ Continue @()
-            let rollback _slot = return $ Continue @()
-            void $ race (threadDelay $ 10 * second)
-                (follow mockNetworkLayer tr [] advance rollback getHeader)
+            void $ race
+                (threadDelay $ 10 * second)
+                (follow mockNetworkLayer tr [] advance getHeader)
             errors <- mapMaybe (unMsg . loContent) <$> readTVarIO tvar
             case length errors of
                 x | x == 5 -> return ()


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1146 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- f8f7f225caa33366a444d5d6687b233a68495324
  exits 'follow' when node switches chain
  This has several advantages:

1. It reduces some logic duplication and actually, manages rollbacks
   very much like a restart. So, there's now only one way of syncing
   with the chain, regardless of whether this is immediately after
   rolling back or, if this is after a long period of inactivity with
   the wallet shut down.

2. it gives clients more flexibility about what they want to do
   in case of rollbacks.

3. It makes the overall logic for 'follow' a bit easier.

- f52946f348d74e36ef096b78d0703c78e59ca28e
  log actual point of rollback returned by db
  
- c64eb3d4d7657aca832a09f820beeb8d3e2d5fdc
  review wording in comment: before ~> earlier


# Comments

<!-- Additional comments or screenshots to attach if any -->

The issue on #1146 is relatively hard to reproduce, so here it's mostly a guess based on [this analysis](https://github.com/input-output-hk/cardano-wallet/issues/1146#issuecomment-569610564). 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
