### PR TITLE
Add integration test for CLI tracer options

### DIFF
--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -17,6 +17,7 @@ module Cardano.Wallet.Logging
     , trMessage
     , trMessageText
     , filterTraceSeverity
+    , stdoutTextTracer
     ) where
 
 import Prelude
@@ -39,6 +40,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
+
+import qualified Data.Text.IO as T
 
 -- | Converts a 'Text' trace into any other type of trace that has a 'ToText'
 -- instance.
@@ -82,6 +85,8 @@ trMessageText tr = Tracer $ \arg -> do
        <*> pure (LogMessage msg)
    traceWith tracer lo
 
+-- | Tracer transformer which converts 'Trace m a' to 'Tracer m a' by wrapping
+-- typed log messages into a 'LogObject'.
 trMessage
     :: (MonadIO m, DefinePrivacyAnnotation a, DefineSeverity a)
     => Tracer m (LogObject a)
@@ -116,3 +121,8 @@ filterNonEmpty tr = Tracer $ \arg -> do
   where
     nonEmptyMessage (LogMessage msg) = msg /= mempty
     nonEmptyMessage _ = True
+
+-- | Creates a tracer that prints any 'ToText' log message. This is useful for
+-- debugging functions in the REPL, when you need a 'Tracer' object.
+stdoutTextTracer :: (MonadIO m, ToText a) => Tracer m a
+stdoutTextTracer = Tracer $ liftIO . T.putStrLn . toText

--- a/lib/core/src/Cardano/Wallet/Version.hs
+++ b/lib/core/src/Cardano/Wallet/Version.hs
@@ -22,6 +22,8 @@ module Cardano.Wallet.Version
     ( -- * Values computed at compile-time
       version
     , gitRevision
+    , GitRevision
+    , Version
 
       -- * Displaying Versions
     , showVersion
@@ -47,7 +49,7 @@ import Paths_cardano_wallet_core
 
 import qualified Data.Text as T
 
-newtype GitRevision = GitRevision Text
+newtype GitRevision = GitRevision Text deriving (Show, Eq)
 
 -- | Like 'showVersion', but also show the git revision.
 showFullVersion :: Version -> GitRevision -> String

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -103,6 +103,7 @@ executable cardano-wallet-jormungandr
     , optparse-applicative
     , process
     , text
+    , text-class
   hs-source-dirs:
       exe
   main-is:

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -580,3 +580,8 @@ instance DefineSeverity NetworkLayerLog where
     defineSeverity ev = case ev of
         MsgLauncher msg -> defineSeverity msg
         MsgWaitForService msg -> defineSeverity msg
+
+instance ToText JormungandrBackend where
+    toText = \case
+        UseRunning _ -> "Using running Jörmungandr"
+        Launch _ -> "Launching Jörmungandr"

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -83,10 +83,9 @@ spec = do
                     , "--"
                     , "--secret", secret
                     ]
-            (Exit c, Stdout o, Stderr e) <- cardanoWalletCLI @t args
+            (Exit c, Stdout _, Stderr e) <- cardanoWalletCLI @t args
             c `shouldBe` ExitFailure 1
-            o `shouldBe` mempty
-            e `shouldBe` f ++ " must be a directory, but it is a file. Exiting.\n"
+            e `shouldContain` f ++ " must be a directory, but it is a file. Exiting.\n"
 
         describe "LAUNCH - Can start launcher with --state-dir" $ do
             let tests =
@@ -137,9 +136,8 @@ spec = do
                     , "--"
                     , "--secret", secret
                     ]
-            (Exit c, Stdout o, Stderr e) <- cardanoWalletCLI @t args
+            (Exit c, Stdout _, Stderr e) <- cardanoWalletCLI @t args
             c `shouldBe` ExitFailure 1
-            o `shouldBe` mempty
             e `shouldContain`
                 ("I couldn't find any file at the given location: " <> block0')
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -142,7 +142,7 @@ spec = do
                         , "--random-port"
                         , "--genesis-block-hash", block0H
                         , "--log-level", "debug"
-                        , "--trace-stake-pool-db", "debug"
+                        , "--trace-pools-db", "debug"
                         ]
                         (pure ())
                         (UseHandle hLogs)
@@ -150,11 +150,10 @@ spec = do
                     threadDelay (5 * oneSecond)
                 hClose hLogs
                 logged <- T.lines <$> TIO.readFile logs
-                let allDebugLogs = grep "Debug" logged
-                let componentDebugLogs = grep "stake-pool-db" allDebugLogs
-                let networkDebugLogs = grep "network" allDebugLogs
-                length componentDebugLogs `shouldNotBe` 0
-                length networkDebugLogs `shouldBe` 0
+                let poolsDebugLogs = grep "cardano-wallet.pools-db:Debug" logged
+                let netDebugLogs = grep "cardano-wallet.network:Debug" logged
+                length poolsDebugLogs `shouldNotBe` 0
+                length netDebugLogs `shouldBe` 0
 
         it "LOGGING - Serve disable logs for one component" $ \ctx -> do
             withTempFile $ \logs hLogs -> do

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -111,6 +111,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."optparse-applicative" or (buildDepError "optparse-applicative"))
             (hsPkgs."process" or (buildDepError "process"))
             (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."text-class" or (buildDepError "text-class"))
             ];
           buildable = true;
           };


### PR DESCRIPTION
Relates to #1235.

# Overview

- 758ab28117e55d4a54c59f53231becd04a40596a
  Add Cardano.Wallet.Logging.stdoutTextTracer
  This comes in handy when trying functions in GHCi.

- fd4069cdc82e06e4a45d064d74b9d531e629beb1
  More logging information at program startup
  
- dd22021afab13ae37808335510b2e5c319d9611e
  tests: Add integration test for per-component tracing

