### PR TITLE
Buildkite nightly: Fix benchmark executable paths

### DIFF
--- a/.buildkite/bench-db.sh
+++ b/.buildkite/bench-db.sh
@@ -17,7 +17,7 @@ if [ -n "${SCRATCH_DIR:-}" ]; then
   export TMPDIR="$SCRATCH_DIR"
 fi
 
-./$bench_name/cardano-wallet-core*/db --json $bench_name.json -o $bench_name.html | tee $bench_name.txt
+./$bench_name/bin/db --json $bench_name.json -o $bench_name.html | tee $bench_name.txt
 
 printf 'Link to \033]1339;url=artifact://'$bench_name.html';content='"Benchmark Report"'\a\n'
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -60,9 +60,7 @@ let
           pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
             build-tools = [ pkgs.makeWrapper];
             postInstall = ''
-              makeWrapper \
-                $out/cardano-wallet-*/latency \
-                $out/bin/latency \
+              wrapProgram $out/bin/latency \
                 --run "cd $src" \
                 --prefix PATH : ${jmPkgs.jormungandr}/bin
             '';


### PR DESCRIPTION
Relates to #1252.

# Overview

Since 944ecdbd5f5c1cf5b5a0b927cd25fc1c6ae95120, the benchmark executables are installed under `bin`, instead of a path containing the Cabal package name and version.

This updates the paths in the Buildkite scripts accordingly.

# Comments

[Link to build](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=rvl%2F1252%2Ffix-nightly)
