### PR TITLE
Calculate pool desirability according to delegation design spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ cabal-dev
 *.chi
 *.chs.h
 *.dyn_o
+*.dump-hi
 *.dyn_hi
 .hpc
 .hsenv

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -103,6 +103,7 @@ library
       Cardano.Pool.DB.Sqlite.TH
       Cardano.Pool.Metrics
       Cardano.Pool.Metadata
+      Cardano.Pool.Ranking
       Cardano.Wallet
       Cardano.Wallet.Api
       Cardano.Wallet.Api.Client
@@ -231,8 +232,9 @@ test-suite unit
       Cardano.Pool.DB.Arbitrary
       Cardano.Pool.DB.Properties
       Cardano.Pool.DB.SqliteSpec
-      Cardano.Pool.MetricsSpec
       Cardano.Pool.MetadataSpec
+      Cardano.Pool.MetricsSpec
+      Cardano.Pool.RankingSpec
       Cardano.Wallet.Api.ServerSpec
       Cardano.Wallet.Api.TypesSpec
       Cardano.Wallet.ApiSpec

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | A self contained module for ranking pools according to the delegation design
+-- spec /Design Specification for Delegation and Incentives in Cardano/
+-- [(Kant et al, 2019)](https://hydra.iohk.io/build/1389333/download/1/delegation_design_spec.pdf).
+--
+-- The module currently implements the non-myopic desirability, and might later
+-- support calculating the full non-myopic pool member rewards. The latter being
+-- the recomended way to rank stake-pools (see section 4.3).
+--
+-- The term non-myopic is explained on page 37:
+--
+-- @
+-- It would be short-sighted (“myopic”) for stakeholders to directly use the
+-- reward splitting formulas from Section 6.5. They should instead take the
+-- long-term (“non-myopic”) view. To this end, the system will calculate and
+-- display the “non-myopic” rewards that pool leaders and pool members can
+-- expect, thus supporting stakeholders in their decision whether to create a
+-- pool and to which pool to delegate their stake.
+--
+-- The idea is to first rank all pools by “desirability”, to then assume that
+-- the k most desirable pools will eventually be saturated, whereas all other
+-- pools will lose all their members, then to finally base all reward
+-- calculations on these assumptions.
+-- @
+--
+-- == Relevant identifiers
+--
+-- Epoch Parameters
+--
+-- +------------+-------------+------------------------------------------------+
+-- |identifier  | domain      | description                                    |
+-- +============+=============+================================================+
+-- + R          | @ [0, ∞) @  | total available rewards for the epoch (in ada).|
+-- +------------+-------------+------------------------------------------------+
+-- + a0         | @ [0, ∞) @  | owner-stake influence on pool rewards.         |
+-- +------------+-------------+------------------------------------------------+
+-- + k          | @ [0, ∞) @  | desired number of pools                        |
+-- +------------+-------------+------------------------------------------------+
+-- + z0         | 1/k         | relative stake of a saturated pool             |
+-- +------------+-------------+------------------------------------------------+
+--
+-- Pool's Parameters
+--
+-- +------------+-------------+------------------------------------------------+
+-- |identifier  | domain      | description                                    |
+-- +============+=============+================================================+
+-- | c          | @ [0, ∞)@   | costs                                          |
+-- +------------+-------------+------------------------------------------------+
+-- | f          | @ [0, ∞) @  | rewards                                        |
+-- +------------+-------------+------------------------------------------------+
+-- | m          | @ [0, 1] @  | margin                                         |
+-- +------------+-------------+------------------------------------------------+
+-- | p_apparent | @ [0, 1] @  | apparent performance                           |
+-- +------------+-------------+------------------------------------------------+
+-- | s          | @ [0, ∞) @  | relative stake of the pool leader (i.e pledge) |
+-- +------------+-------------+------------------------------------------------+
+-- | σ          | @ [0, 1] @  | total relative stake of the pool               |
+-- +------------+-------------+------------------------------------------------+
+module Cardano.Pool.Ranking
+    (
+      -- * Formulas
+      desirability
+
+    , saturatedPoolRewards
+    , saturatedPoolSize
+
+      -- * Types
+    , EpochConstants (..)
+    , Pool (..)
+    , RelativeStakeOf (..)
+    , mkRelativeStake
+    , Lovelace (..)
+    , Margin
+    , unsafeMkMargin
+    , getMargin
+    , NonNegative (..)
+    , Positive (..)
+    , unsafeToPositive
+    , unsafeToNonNegative
+    )
+    where
+
+import Prelude
+
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( Symbol )
+
+--------------------------------------------------------------------------------
+-- Formulas from spec
+--------------------------------------------------------------------------------
+
+-- | Non-myopic pool desirability according to section 5.6.1.
+--
+-- Is /not/ affected by oversaturation nor pool stake in general.
+desirability
+    :: EpochConstants
+    -> Pool
+    -> Double
+desirability constants pool
+    | f_saturated <= c = 0
+    | otherwise    = (f_saturated - c) * (1 - m)
+  where
+    f_saturated = saturatedPoolRewards constants pool
+    m = getMargin $ margin pool
+    c = getNonNegative $ getLovelace $ cost pool
+
+-- | Total rewards for a pool if it were saturated.
+--
+-- When a0 = 0 this reduces to just p*R*z0 (tested
+-- by @prop_saturatedPoolRewardsReduces@)
+saturatedPoolRewards :: EpochConstants -> Pool -> Double
+saturatedPoolRewards constants pool =
+    let
+        a0 = getNonNegative $ leaderStakeInfluence constants
+        z0 = unRelativeStake $ saturatedPoolSize constants
+        s = unRelativeStake $ leaderStake pool
+        _R = getNonNegative $ getLovelace $ totalRewards constants
+        p = getNonNegative $ recentAvgPerformance pool
+        -- ^ technically \hat{p} in the spec
+    in
+        (p * _R) / (1 + a0)
+        * (z0 + ((min s z0) * a0))
+
+-- | Determines z0, i.e 1 / k
+saturatedPoolSize :: EpochConstants -> RelativeStakeOf "pool"
+saturatedPoolSize constants =
+    RelativeStake $ 1 / fromIntegral (getPositive $ optimalNumberOfPools constants)
+
+--------------------------------------------------------------------------------
+-- Types
+--------------------------------------------------------------------------------
+
+data EpochConstants = EpochConstants
+    { leaderStakeInfluence :: NonNegative Double
+      -- ^ a_0
+    , optimalNumberOfPools :: Positive Int
+      -- ^ k
+    , totalRewards :: Lovelace
+      -- ^ Total rewards in an epoch. "R" in the spec.
+    } deriving (Show, Eq, Generic)
+
+data Pool = Pool
+    { leaderStake :: RelativeStakeOf "pool leader"
+    , cost :: Lovelace
+    , margin :: Margin
+    , recentAvgPerformance :: NonNegative Double
+      -- ^ An already averaged performance-value
+    } deriving (Show, Eq, Generic)
+
+newtype Lovelace = Lovelace { getLovelace :: NonNegative Double }
+    deriving (Show, Eq)
+    deriving newtype (Ord, Num)
+
+newtype Margin = Margin { getMargin :: Double }
+    deriving (Show, Eq)
+    deriving newtype Ord
+
+unsafeMkMargin :: Double -> Margin
+unsafeMkMargin x
+    | x >= 0 && x <= 1  = Margin x
+    | otherwise         = error $ "unsafeMkMargin: " ++ show x
+                          ++ "not in range [0, 1]"
+
+-- | Stake relative to the total active stake in an epoch
+--
+-- The value
+-- 0.01 :: RelativeStakeOf "pool"
+-- would mean that a pool has a stake that is 1% of the total active stake in
+-- the epoch.
+newtype RelativeStakeOf (tag :: Symbol)
+    = RelativeStake { unRelativeStake :: Double }
+    deriving (Eq, Ord, Show, Generic)
+    deriving newtype (Num, Fractional)
+
+mkRelativeStake :: Lovelace -> EpochConstants -> RelativeStakeOf (tag :: Symbol)
+mkRelativeStake (Lovelace (NonNegative stake)) constants =
+    RelativeStake $ stake / total
+  where
+    total = getNonNegative $ getLovelace $ totalRewards constants
+
+newtype Positive a = Positive { getPositive :: a }
+    deriving (Generic, Eq, Show)
+    deriving newtype (Ord, Num)
+
+unsafeToPositive :: (Ord a, Show a, Num a) => a -> (Positive a)
+unsafeToPositive x
+    | x > 0    = Positive x
+    | otherwise = error $ "unsafeToPositive: " ++ show x ++ " > 0 does not hold"
+
+newtype NonNegative a = NonNegative { getNonNegative :: a }
+    deriving (Generic, Eq, Show)
+    deriving newtype (Ord, Num)
+
+unsafeToNonNegative :: (Ord a, Show a, Num a) => a -> (NonNegative a)
+unsafeToNonNegative x
+    | x >= 0    = NonNegative x
+    | otherwise = error $ "unsafeToNegative: " ++ show x ++ " >= 0 does not hold"

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -77,9 +77,9 @@ module Cardano.Pool.Ranking
     , RelativeStakeOf (..)
     , mkRelativeStake
     , Lovelace (..)
-    , Margin
-    , unsafeMkMargin
-    , getMargin
+    , Ratio
+    , unsafeToRatio
+    , getRatio
     , NonNegative (..)
     , Positive (..)
     , unsafeToPositive
@@ -110,7 +110,7 @@ desirability constants pool
     | otherwise    = (f_saturated - c) * (1 - m)
   where
     f_saturated = saturatedPoolRewards constants pool
-    m = getMargin $ margin pool
+    m = getRatio $ margin pool
     c = getNonNegative $ getLovelace $ cost pool
 
 -- | Total rewards for a pool if it were saturated.
@@ -153,7 +153,7 @@ data Pool = Pool
       -- ^ s
     , cost :: Lovelace
       -- ^ c
-    , margin :: Margin
+    , margin :: Ratio
       -- ^ m
     , recentAvgPerformance :: NonNegative Double
       -- ^ \hat{p}, an already averaged performance-value.
@@ -165,14 +165,14 @@ newtype Lovelace = Lovelace { getLovelace :: NonNegative Double }
     deriving (Show, Eq)
     deriving newtype (Ord, Num)
 
-newtype Margin = Margin { getMargin :: Double }
+newtype Ratio = Ratio { getRatio :: Double }
     deriving (Show, Eq)
     deriving newtype Ord
 
-unsafeMkMargin :: Double -> Margin
-unsafeMkMargin x
-    | x >= 0 && x <= 1  = Margin x
-    | otherwise         = error $ "unsafeMkMargin: " ++ show x
+unsafeToRatio :: Double -> Ratio
+unsafeToRatio x
+    | x >= 0 && x <= 1  = Ratio x
+    | otherwise         = error $ "unsafeToRatio: " ++ show x
                           ++ "not in range [0, 1]"
 
 -- | Stake relative to the total active stake in an epoch

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -153,9 +153,10 @@ data Pool = Pool
     , margin :: Ratio
       -- ^ m
     , recentAvgPerformance :: NonNegative Double
-      -- ^ \hat{p}, an already averaged performance-value.
+      -- ^ \hat{p}, an already averaged (apparent) performance-value.
       --
-      -- Should mostly be in the range [0, 1], but lucky pools may exceed 1.
+      -- Should mostly be in the range [0, 1]. May be higher than 1 due to
+      -- randomness.
     } deriving (Show, Eq, Generic)
 
 newtype Lovelace = Lovelace { getLovelace :: Word64 }

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -133,7 +133,7 @@ saturatedPoolRewards constants pool =
 -- | Determines z0, i.e 1 / k
 saturatedPoolSize :: EpochConstants -> RelativeStakeOf "pool"
 saturatedPoolSize constants =
-    RelativeStake $ 1 / fromIntegral (getPositive $ optimalNumberOfPools constants)
+    RelativeStake $ 1 / fromIntegral (getPositive $ desiredNumberOfPools constants)
 
 --------------------------------------------------------------------------------
 -- Types
@@ -142,7 +142,7 @@ saturatedPoolSize constants =
 data EpochConstants = EpochConstants
     { leaderStakeInfluence :: NonNegative Double
       -- ^ a_0
-    , optimalNumberOfPools :: Positive Int
+    , desiredNumberOfPools :: Positive Int
       -- ^ k
     , totalRewards :: Lovelace
       -- ^ Total rewards in an epoch. "R" in the spec.
@@ -150,10 +150,15 @@ data EpochConstants = EpochConstants
 
 data Pool = Pool
     { leaderStake :: RelativeStakeOf "pool leader"
+      -- ^ s
     , cost :: Lovelace
+      -- ^ c
     , margin :: Margin
+      -- ^ m
     , recentAvgPerformance :: NonNegative Double
-      -- ^ An already averaged performance-value
+      -- ^ \hat{p}, an already averaged performance-value.
+      --
+      -- Should mostly be in the range [0, 1], but lucky pools may exceed 1.
     } deriving (Show, Eq, Generic)
 
 newtype Lovelace = Lovelace { getLovelace :: NonNegative Double }

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -75,13 +75,13 @@ module Cardano.Pool.Ranking
     , Pool (..)
     , Lovelace (..)
     , Ratio
-    , unsafeToRatio
+    , unsafeMkRatio
     , getRatio
     , unsafeMkRelativeStake
     , NonNegative (..)
     , Positive (..)
-    , unsafeToPositive
-    , unsafeToNonNegative
+    , unsafeMkPositive
+    , unsafeMkNonNegative
     )
     where
 
@@ -167,15 +167,15 @@ newtype Ratio = Ratio { getRatio :: Double }
     deriving (Show, Eq)
     deriving newtype Ord
 
-unsafeToRatio :: Double -> Ratio
-unsafeToRatio x
+unsafeMkRatio :: Double -> Ratio
+unsafeMkRatio x
     | x >= 0 && x <= 1  = Ratio x
-    | otherwise         = error $ "unsafeToRatio: " ++ show x
+    | otherwise         = error $ "unsafeMkRatio: " ++ show x
                           ++ "not in range [0, 1]"
 
 unsafeMkRelativeStake :: Lovelace -> EpochConstants -> Ratio
 unsafeMkRelativeStake (Lovelace stake) constants =
-    unsafeToRatio $ (fromIntegral stake) / total
+    unsafeMkRatio $ (fromIntegral stake) / total
   where
     total = fromIntegral . getLovelace . totalRewards $ constants
 
@@ -183,16 +183,16 @@ newtype Positive a = Positive { getPositive :: a }
     deriving (Generic, Eq, Show)
     deriving newtype (Ord, Num)
 
-unsafeToPositive :: (Ord a, Show a, Num a) => a -> (Positive a)
-unsafeToPositive x
+unsafeMkPositive :: (Ord a, Show a, Num a) => a -> (Positive a)
+unsafeMkPositive x
     | x > 0    = Positive x
-    | otherwise = error $ "unsafeToPositive: " ++ show x ++ " > 0 does not hold"
+    | otherwise = error $ "unsafeMkPositive: " ++ show x ++ " > 0 does not hold"
 
 newtype NonNegative a = NonNegative { getNonNegative :: a }
     deriving (Generic, Eq, Show)
     deriving newtype (Ord, Num)
 
-unsafeToNonNegative :: (Ord a, Show a, Num a) => a -> (NonNegative a)
-unsafeToNonNegative x
+unsafeMkNonNegative :: (Ord a, Show a, Num a) => a -> (NonNegative a)
+unsafeMkNonNegative x
     | x >= 0    = NonNegative x
-    | otherwise = error $ "unsafeToNegative: " ++ show x ++ " >= 0 does not hold"
+    | otherwise = error $ "unsafeMkNegative: " ++ show x ++ " >= 0 does not hold"

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -87,6 +87,8 @@ module Cardano.Pool.Ranking
 
 import Prelude
 
+import Data.Word
+    ( Word64 )
 import GHC.Generics
     ( Generic )
 
@@ -107,7 +109,7 @@ desirability constants pool
   where
     f_saturated = saturatedPoolRewards constants pool
     m = getRatio $ margin pool
-    c = getNonNegative $ getLovelace $ cost pool
+    c = fromIntegral $ getLovelace $ cost pool
 
 -- | Total rewards for a pool if it were saturated.
 --
@@ -119,7 +121,7 @@ saturatedPoolRewards constants pool =
         a0 = getNonNegative $ leaderStakeInfluence constants
         z0 = getRatio $ saturatedPoolSize constants
         s = getRatio $ leaderStake pool
-        _R = getNonNegative $ getLovelace $ totalRewards constants
+        _R = fromIntegral $ getLovelace $ totalRewards constants
         p = getNonNegative $ recentAvgPerformance pool
         -- ^ technically \hat{p} in the spec
     in
@@ -157,7 +159,7 @@ data Pool = Pool
       -- Should mostly be in the range [0, 1], but lucky pools may exceed 1.
     } deriving (Show, Eq, Generic)
 
-newtype Lovelace = Lovelace { getLovelace :: NonNegative Double }
+newtype Lovelace = Lovelace { getLovelace :: Word64 }
     deriving (Show, Eq)
     deriving newtype (Ord, Num)
 
@@ -172,10 +174,10 @@ unsafeToRatio x
                           ++ "not in range [0, 1]"
 
 unsafeMkRelativeStake :: Lovelace -> EpochConstants -> Ratio
-unsafeMkRelativeStake (Lovelace (NonNegative stake)) constants =
-    unsafeToRatio $ stake / total
+unsafeMkRelativeStake (Lovelace stake) constants =
+    unsafeToRatio $ (fromIntegral stake) / total
   where
-    total = getNonNegative $ getLovelace $ totalRewards constants
+    total = fromIntegral . getLovelace . totalRewards $ constants
 
 newtype Positive a = Positive { getPositive :: a }
     deriving (Generic, Eq, Show)

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -77,7 +77,6 @@ module Cardano.Pool.Ranking
     , Ratio
     , unsafeMkRatio
     , getRatio
-    , unsafeMkRelativeStake
     , NonNegative (..)
     , Positive (..)
     , unsafeMkPositive
@@ -172,12 +171,6 @@ unsafeMkRatio x
     | x >= 0 && x <= 1  = Ratio x
     | otherwise         = error $ "unsafeMkRatio: " ++ show x
                           ++ "not in range [0, 1]"
-
-unsafeMkRelativeStake :: Lovelace -> EpochConstants -> Ratio
-unsafeMkRelativeStake (Lovelace stake) constants =
-    unsafeMkRatio $ (fromIntegral stake) / total
-  where
-    total = fromIntegral . getLovelace . totalRewards $ constants
 
 newtype Positive a = Positive { getPositive :: a }
     deriving (Generic, Eq, Show)

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -1,30 +1,56 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Cardano.Pool.RankingSpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Pool.Ranking
+    ( EpochConstants (..)
+    , Lovelace (..)
+    , Margin (..)
+    , Pool (..)
+    , RelativeStakeOf (..)
+    , desirability
+    , mkRelativeStake
+    , saturatedPoolRewards
+    , saturatedPoolSize
+    , unsafeMkMargin
+    , unsafeToNonNegative
+    )
+import Data.Bifunctor
+    ( bimap )
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens
-    ( Lens', view, (.~) )
+    ( (.~), (^.) )
 import Data.Generics.Labels
     ()
+import Data.Generics.Product.Fields
+    ( HasField', field' )
 import Data.Ord
     ( Ordering (..) )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.Word
     ( Word64 )
+import GHC.TypeLits
+    ( KnownSymbol, Symbol, symbolVal )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
@@ -49,53 +75,42 @@ spec :: Spec
 spec = do
     describe "Stake Pool Ranking" $ do
         describe "all else equal..." $ do
-            it "higher margin => lower desirability (or equal)" $
-                property $
-                    allElseEqualProperty
-                        "margin"
-                        #margin
-                        (show . R.getMargin)
-                        NegativeEffect
+            it "higher margin => lower desirability (or equal)"
+                $ property
+                $ allElseEqualProperty @"margin" NegativeEffect
 
-            it "higher cost => lower desirability (or equal)" $
-                property $ do
-                    allElseEqualProperty
-                        "cost"
-                        #cost
-                        (show . R.getLovelace)
-                        NegativeEffect
+            it "higher cost => lower desirability (or equal)"
+                $ property
+                $ allElseEqualProperty @"cost" NegativeEffect
 
-            it "higher performance => higher desirability (or equal)" $
-                property $
-                    allElseEqualProperty
-                        "performance"
-                        #recentAvgPerformance
-                        (show . R.getNonNegative)
-                        PositiveEffect
+            it "higher performance => higher desirability (or equal)"
+                $ property
+                $ allElseEqualProperty @"recentAvgPerformance" PositiveEffect
 
-            it "higher oversaturation => desirability NOT affected" $
-                property prop_oversaturationDoesNotInfluenceDesirability
+            it "higher oversaturation => desirability NOT affected"
+                $ property prop_oversaturationDoesNotInfluenceDesirability
 
-        describe "desiraility" $ do
+        describe "desirability" $ do
             it "desirability >= 0"
-                (property prop_desirabilityNonNegative)
+                $ property prop_desirabilityNonNegative
 
         describe "saturatedPoolRewards" $ do
             it "a0 == 0 => saturatedPoolRewards == p*R*z0"
-                (property prop_saturatedPoolRewardsReduces)
+                $ property prop_saturatedPoolRewardsReduces
+
             it "saturatedPoolRewards >= 0"
-                (property prop_saturatedPoolRewardsNonNegative)
+                $ property prop_saturatedPoolRewardsNonNegative
 
         describe "mkRelativeStake" $ do
             it "stake > R, R >= 1 => mkRelativeStake ∈ [0,1] (even with conversions)"
                 $ property prop_mkRelativeStakeBounds
 
-prop_mkRelativeStakeBounds :: R.EpochConstants -> Word64 -> Word64 -> Property
+prop_mkRelativeStakeBounds :: EpochConstants -> Word64 -> Word64 -> Property
 prop_mkRelativeStakeBounds constants' tot stake =
     let
-        rel = R.unRelativeStake
-            $ R.mkRelativeStake
-                (R.Lovelace $ fromIntegral stake)
+        rel = unRelativeStake
+            $ mkRelativeStake
+                (Lovelace $ fromIntegral stake)
                 constants
     in
         counterexample ("relative stake = " ++ show rel) $
@@ -104,42 +119,44 @@ prop_mkRelativeStakeBounds constants' tot stake =
                     property $ rel >= 0 && rel <= 1
 
   where
-    constants = constants'{R.totalRewards = R.Lovelace . R.unsafeToNonNegative $ fromIntegral tot}
+    constants = constants'
+        { totalRewards = Lovelace . unsafeToNonNegative $ fromIntegral tot }
 
-prop_desirabilityNonNegative :: R.EpochConstants -> R.Pool -> Property
+prop_desirabilityNonNegative :: EpochConstants -> Pool -> Property
 prop_desirabilityNonNegative constants pool = property $
-    R.desirability constants pool >= 0
+    desirability constants pool >= 0
 
-prop_saturatedPoolRewardsNonNegative :: R.EpochConstants -> R.Pool -> Property
+prop_saturatedPoolRewardsNonNegative :: EpochConstants -> Pool -> Property
 prop_saturatedPoolRewardsNonNegative constants pool = property $
-    R.saturatedPoolRewards constants pool >= 0
+    saturatedPoolRewards constants pool >= 0
 
-prop_saturatedPoolRewardsReduces :: R.EpochConstants -> R.Pool -> Property
+prop_saturatedPoolRewardsReduces :: EpochConstants -> Pool -> Property
 prop_saturatedPoolRewardsReduces constants' pool =
     let
-        constants = constants'{R.leaderStakeInfluence = R.unsafeToNonNegative 0 }
-        z0 = R.unRelativeStake $ R.saturatedPoolSize constants
-        _R =  R.getNonNegative $ R.getLovelace $ R.totalRewards constants
-        p = R.getNonNegative $ R.recentAvgPerformance pool
+        constants = constants'
+            { leaderStakeInfluence = unsafeToNonNegative 0 }
+        z0 = unRelativeStake  $ saturatedPoolSize constants
+        _R = R.getNonNegative $ getLovelace $ totalRewards constants
+        p  = R.getNonNegative $ recentAvgPerformance pool
     in
-        R.saturatedPoolRewards constants pool === p*_R*z0
+        saturatedPoolRewards constants pool === p*_R*z0
 
 prop_oversaturationDoesNotInfluenceDesirability
-    :: R.Pool
-    -> R.EpochConstants
+    :: Pool
+    -> EpochConstants
     -> Property
 prop_oversaturationDoesNotInfluenceDesirability pool constants =
     forAll arbitrary $ \v1 v2 -> do
         let (higherStake, lowerStake) = sortTuple (v1, v2)
-        let z0 = R.unRelativeStake $ R.saturatedPoolSize constants
+        let z0 = unRelativeStake $ saturatedPoolSize constants
         higherStake > z0 ==>
             des higherStake === des lowerStake
   where
     sortTuple (a, b)
-        | a > b     = (a,b)
+        | a > b     = (a, b)
         | otherwise = (b, a)
 
-    des _stake = R.desirability constants pool
+    des _stake = desirability constants pool
     -- TODO: set pool{R.stake = stake}, but that field doesn't even exist!
 
 data EffectOnDesirability
@@ -150,77 +167,88 @@ data EffectOnDesirability
 -- | All else equal, what effect on the desirability does changing a single
 -- field have?
 allElseEqualProperty
-    :: (Arbitrary a, Show a, Ord a)
-    => String
-    -> Lens' R.Pool a
-    -> (a -> String)
-       -- ^ Debug print a field-value
-    -> EffectOnDesirability
-    -> R.Pool
+    :: forall (field :: Symbol) a.
+        ( Arbitrary a
+        , Show a
+        , Ord a
+        , HasField' field Pool a
+        , KnownSymbol field
+        )
+    => EffectOnDesirability
+        -- ^ Expected effect on the desirability
+    -> Pool
        -- ^ The base pool which is later modified
-    -> R.EpochConstants
+    -> EpochConstants
        -- ^ Constants used
     -> Property
-allElseEqualProperty desc field showValue eff p constants =
-    forAll arbitrary $ \value1 value2 -> do
-        let (higherVal, lowerVal) = sortTuple (value1, value2)
+allElseEqualProperty expectedEffect pool constants =
+    forAll arbitrary $ \(value1 :: a) (value2 :: a) -> do
+        let (poolLower, poolHigher) = sortTuple (value1, value2)
+                & bimap poolWith poolWith
 
-        let poolRankDesc = "Pools:\n" ++ showPool 1 (poolWith higherVal) ++ "\n" ++ showPool 2 (poolWith lowerVal)
+        let (dLower, dHigher) =
+                ( desirability constants poolLower
+                , desirability constants poolHigher
+                )
 
-        case des (poolWith higherVal) `compare` des (poolWith lowerVal) of
-            GT -> eff === PositiveEffect
+        let poolRankDesc = unlines
+                [ "Pools:"
+                , showPool poolLower  dLower
+                , showPool poolHigher dHigher
+                ]
+
+        case dLower `compare` dHigher of
             EQ -> property True
             -- A reason we end up in this case could be that both pools are
             -- un-profitable. It would be interesting to re-run tests with
             -- a higher total reward pot. But as long we hit the other cases we
             -- should be fine, really.
-
-            LT -> eff === NegativeEffect
-
-            & counterexample poolRankDesc
-            & classify
-                    (des (poolWith higherVal) == des (poolWith lowerVal))
-                    "equal desirability"
-
+            GT -> expectedEffect === PositiveEffect
+            LT -> expectedEffect === NegativeEffect
+          & counterexample poolRankDesc
+          & classify (dLower == dHigher) "same desirability"
   where
-    poolWith val = p & field .~ val
+    poolWith :: a -> Pool
+    poolWith val = pool & (field' @field) .~ val
+
+    sortTuple :: (a, a) -> (a, a)
     sortTuple (a, b)
-        | a > b = (a,b)
-        | otherwise     = (b, a)
+        | a > b     = (a, b)
+        | otherwise = (b, a)
 
-    showPool :: Int -> R.Pool -> String
-    showPool rank x =
-        show rank
-            ++ ". "
-            ++ desc
-            ++ " = "
-            ++ showValue (view field x)
-            ++ ", desirability = "
-            ++ show (des x)
+    showPool :: Pool -> Double -> String
+    showPool x d = unwords
+        [ show (symbolVal $ Proxy @field)
+        , "="
+        , show (x ^. field' @field)
+        , ", desirability ="
+        , show d
+        ]
 
-    des = R.desirability constants
-
-instance Arbitrary R.Pool where
+instance Arbitrary Pool where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
-instance Arbitrary (R.RelativeStakeOf a) where
-    arbitrary = R.RelativeStake <$> choose (0, 1)
-    shrink (R.RelativeStake x) = map R.RelativeStake $ filter (\a -> a >= 0 && a <= 1) $ shrink x
+instance Arbitrary (RelativeStakeOf a) where
+    arbitrary =
+        RelativeStake <$> choose (0, 1)
+
+    shrink (RelativeStake x) =
+        map RelativeStake $ filter (\a -> a >= 0 && a <= 1) $ shrink x
 
 -- TODO: We should ideally not export the NonNegative and Positive constructors,
 -- in which case we wouldn't be able to use derivingVia.
-deriving via (NonNegative Double) instance (Arbitrary R.Lovelace)
+deriving via (NonNegative Double) instance (Arbitrary Lovelace)
 deriving via (NonNegative Double) instance (Arbitrary (R.NonNegative Double))
 deriving via (Positive Int) instance (Arbitrary (R.Positive Int))
 
-instance Arbitrary R.Margin where
-    arbitrary = R.unsafeMkMargin <$> choose (0, 1)
-    shrink = map R.unsafeMkMargin
+instance Arbitrary Margin where
+    arbitrary = unsafeMkMargin <$> choose (0, 1)
+    shrink = map unsafeMkMargin
         . filter (\a -> a >= 0 && a <= 1)
-        . map R.getMargin
+        . map getMargin
         . shrink
 
-instance Arbitrary R.EpochConstants where
+instance Arbitrary EpochConstants where
     arbitrary = genericArbitrary
     shrink = genericShrink

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -64,7 +64,6 @@ import Test.QuickCheck
     , property
     , (.&&.)
     , (===)
-    , (==>)
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
@@ -86,9 +85,6 @@ spec = do
             it "higher performance => higher desirability (or equal)"
                 $ property
                 $ allElseEqualProperty @"recentAvgPerformance" PositiveEffect
-
-            it "higher oversaturation => desirability NOT affected"
-                $ property prop_oversaturationDoesNotInfluenceDesirability
 
         describe "desirability" $ do
             it "desirability >= 0"
@@ -160,24 +156,6 @@ prop_saturatedPoolRewardsReduces constants' pool =
         p  = R.getNonNegative $ recentAvgPerformance pool
     in
         saturatedPoolRewards constants pool === p*_R*z0
-
-prop_oversaturationDoesNotInfluenceDesirability
-    :: Pool
-    -> EpochConstants
-    -> Property
-prop_oversaturationDoesNotInfluenceDesirability pool constants =
-    forAll arbitrary $ \v1 v2 -> do
-        let (higherStake, lowerStake) = sortTuple (v1, v2)
-        let z0 = getRatio $ saturatedPoolSize constants
-        higherStake > z0 ==>
-            des higherStake === des lowerStake
-  where
-    sortTuple (a, b)
-        | a > b     = (a, b)
-        | otherwise = (b, a)
-
-    des _stake = desirability constants pool
-    -- TODO: set pool{R.stake = stake}, but that field doesn't even exist!
 
 data EffectOnDesirability
     = PositiveEffect

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -30,7 +30,6 @@ import Cardano.Pool.Ranking
     , saturatedPoolSize
     , unsafeMkNonNegative
     , unsafeMkRatio
-    , unsafeMkRelativeStake
     )
 import Control.Exception
     ( SomeException, evaluate, try )
@@ -102,10 +101,6 @@ spec = do
             it "saturatedPoolRewards >= 0"
                 $ property prop_saturatedPoolRewardsNonNegative
 
-        describe "unsafeMkRelativeStake" $ do
-            it "R > 0, stake > R => unsafeMkRelativeStake ∈ [0,1]"
-                $ property prop_unsafeMkRelativeStakeBounds
-
         describe "unsafeMk- newtypes" $ do
             it "unsafeMkRatio requires ∈ [0,1]"
                 $ property $ \v -> ioProperty $
@@ -146,17 +141,6 @@ prop_unsafeMk isValid f g x = do
 
         & classify valid "valid"
         & classify (not valid) "error"
-
-prop_unsafeMkRelativeStakeBounds :: EpochConstants -> Lovelace -> Property
-prop_unsafeMkRelativeStakeBounds constants stake =
-    let
-        s = getRatio $ unsafeMkRelativeStake stake constants
-        total = totalRewards constants
-    in
-        total > 0 ==>
-            total >= stake ==>
-                property $ s >= 0 && s <= 1
-        & counterexample ("relative stake = " ++ show s)
 
 prop_desirabilityNonNegative :: EpochConstants -> Pool -> Property
 prop_desirabilityNonNegative constants pool = property $

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -23,15 +23,15 @@ import Prelude
 import Cardano.Pool.Ranking
     ( EpochConstants (..)
     , Lovelace (..)
-    , Margin (..)
     , Pool (..)
+    , Ratio (..)
     , RelativeStakeOf (..)
     , desirability
     , mkRelativeStake
     , saturatedPoolRewards
     , saturatedPoolSize
-    , unsafeMkMargin
     , unsafeToNonNegative
+    , unsafeToRatio
     )
 import Control.Exception
     ( SomeException, evaluate, try )
@@ -109,13 +109,13 @@ spec = do
             it "stake > R, R >= 1 => mkRelativeStake ∈ [0,1] (even with conversions)"
                 $ property prop_mkRelativeStakeBounds
 
-        describe "newtypes" $ do
-            it "unsafeMkMargin requires ∈ [0,1]"
+        describe "unsafeTo- newtypes" $ do
+            it "unsafeToRatio requires ∈ [0,1]"
                 $ property $ \v -> ioProperty $
                     prop_unsafeTo
                         (\x -> x >= 0 && x <= 1)
-                        R.unsafeMkMargin
-                        R.getMargin
+                        R.unsafeToRatio
+                        R.getRatio
                         v
             it "unsafeToPositive requires > 0" $
                 property $ \(v :: Int) -> ioProperty $
@@ -287,11 +287,11 @@ deriving via (NonNegative Double) instance (Arbitrary Lovelace)
 deriving via (NonNegative Double) instance (Arbitrary (R.NonNegative Double))
 deriving via (Positive Int) instance (Arbitrary (R.Positive Int))
 
-instance Arbitrary Margin where
-    arbitrary = unsafeMkMargin <$> choose (0, 1)
-    shrink = map unsafeMkMargin
+instance Arbitrary Ratio where
+    arbitrary = unsafeToRatio <$> choose (0, 1)
+    shrink = map unsafeToRatio
         . filter (\a -> a >= 0 && a <= 1)
-        . map getMargin
+        . map getRatio
         . shrink
 
 instance Arbitrary EpochConstants where

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -267,7 +267,7 @@ allElseEqualProperty expectedEffect pool constants =
 
 instance Arbitrary Pool where
     arbitrary = genericArbitrary
-    shrink _ = [] -- TODO: Implement a shrinker that works.
+    shrink = genericShrink
 
 -- TODO: We should ideally not export the NonNegative and Positive constructors,
 -- in which case we wouldn't be able to use DerivingVia.
@@ -277,9 +277,7 @@ deriving via (Positive Int) instance (Arbitrary (R.Positive Int))
 
 instance Arbitrary Ratio where
     arbitrary = unsafeMkRatio <$> choose (0, 1)
-    shrink = map unsafeMkRatio
-        . map getRatio
-        . shrink
+    shrink _ = [] -- TODO: Implement a shrinker that works.
 
 instance Arbitrary EpochConstants where
     arbitrary = genericArbitrary

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -70,7 +70,7 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary, genericShrink )
+    ( genericArbitrary )
 
 import qualified Cardano.Pool.Ranking as R
 
@@ -265,7 +265,7 @@ allElseEqualProperty expectedEffect pool constants =
 
 instance Arbitrary Pool where
     arbitrary = genericArbitrary
-    shrink = genericShrink
+    shrink _ = []
 
 -- TODO: We should ideally not export the NonNegative and Positive constructors,
 -- in which case we wouldn't be able to use DerivingVia.
@@ -282,4 +282,4 @@ instance Arbitrary Ratio where
 
 instance Arbitrary EpochConstants where
     arbitrary = genericArbitrary
-    shrink = genericShrink
+    shrink _ = []

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Cardano.Pool.RankingSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( Lens', view, (.~) )
+import Data.Generics.Labels
+    ()
+import Data.Ord
+    ( Ordering (..) )
+import Data.Word
+    ( Word64 )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , NonNegative (..)
+    , Positive (..)
+    , Property
+    , choose
+    , classify
+    , counterexample
+    , forAll
+    , property
+    , (===)
+    , (==>)
+    )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+
+import qualified Cardano.Pool.Ranking as R
+
+spec :: Spec
+spec = do
+    describe "Stake Pool Ranking" $ do
+        describe "all else equal..." $ do
+            it "higher margin => lower desirability (or equal)" $
+                property $
+                    allElseEqualProperty
+                        "margin"
+                        #margin
+                        (show . R.getMargin)
+                        NegativeEffect
+
+            it "higher cost => lower desirability (or equal)" $
+                property $ do
+                    allElseEqualProperty
+                        "cost"
+                        #cost
+                        (show . R.getLovelace)
+                        NegativeEffect
+
+            it "higher performance => higher desirability (or equal)" $
+                property $
+                    allElseEqualProperty
+                        "performance"
+                        #recentAvgPerformance
+                        (show . R.getNonNegative)
+                        PositiveEffect
+
+            it "higher oversaturation => desirability NOT affected" $
+                property prop_oversaturationDoesNotInfluenceDesirability
+
+        describe "desiraility" $ do
+            it "desirability >= 0"
+                (property prop_desirabilityNonNegative)
+
+        describe "saturatedPoolRewards" $ do
+            it "a0 == 0 => saturatedPoolRewards == p*R*z0"
+                (property prop_saturatedPoolRewardsReduces)
+            it "saturatedPoolRewards >= 0"
+                (property prop_saturatedPoolRewardsNonNegative)
+
+        describe "mkRelativeStake" $ do
+            it "stake > R, R >= 1 => mkRelativeStake ∈ [0,1] (even with conversions)"
+                $ property prop_mkRelativeStakeBounds
+
+prop_mkRelativeStakeBounds :: R.EpochConstants -> Word64 -> Word64 -> Property
+prop_mkRelativeStakeBounds constants' tot stake =
+    let
+        rel = R.unRelativeStake
+            $ R.mkRelativeStake
+                (R.Lovelace $ fromIntegral stake)
+                constants
+    in
+        counterexample ("relative stake = " ++ show rel) $
+            tot >= 1 ==>
+                tot >= stake ==>
+                    property $ rel >= 0 && rel <= 1
+
+  where
+    constants = constants'{R.totalRewards = R.Lovelace . R.unsafeToNonNegative $ fromIntegral tot}
+
+prop_desirabilityNonNegative :: R.EpochConstants -> R.Pool -> Property
+prop_desirabilityNonNegative constants pool = property $
+    R.desirability constants pool >= 0
+
+prop_saturatedPoolRewardsNonNegative :: R.EpochConstants -> R.Pool -> Property
+prop_saturatedPoolRewardsNonNegative constants pool = property $
+    R.saturatedPoolRewards constants pool >= 0
+
+prop_saturatedPoolRewardsReduces :: R.EpochConstants -> R.Pool -> Property
+prop_saturatedPoolRewardsReduces constants' pool =
+    let
+        constants = constants'{R.leaderStakeInfluence = R.unsafeToNonNegative 0 }
+        z0 = R.unRelativeStake $ R.saturatedPoolSize constants
+        _R =  R.getNonNegative $ R.getLovelace $ R.totalRewards constants
+        p = R.getNonNegative $ R.recentAvgPerformance pool
+    in
+        R.saturatedPoolRewards constants pool === p*_R*z0
+
+prop_oversaturationDoesNotInfluenceDesirability
+    :: R.Pool
+    -> R.EpochConstants
+    -> Property
+prop_oversaturationDoesNotInfluenceDesirability pool constants =
+    forAll arbitrary $ \v1 v2 -> do
+        let (higherStake, lowerStake) = sortTuple (v1, v2)
+        let z0 = R.unRelativeStake $ R.saturatedPoolSize constants
+        higherStake > z0 ==>
+            des higherStake === des lowerStake
+  where
+    sortTuple (a, b)
+        | a > b     = (a,b)
+        | otherwise = (b, a)
+
+    des _stake = R.desirability constants pool
+    -- TODO: set pool{R.stake = stake}, but that field doesn't even exist!
+
+data EffectOnDesirability
+    = PositiveEffect
+    | NegativeEffect
+    deriving (Show, Eq)
+
+-- | All else equal, what effect on the desirability does changing a single
+-- field have?
+allElseEqualProperty
+    :: (Arbitrary a, Show a, Ord a)
+    => String
+    -> Lens' R.Pool a
+    -> (a -> String)
+       -- ^ Debug print a field-value
+    -> EffectOnDesirability
+    -> R.Pool
+       -- ^ The base pool which is later modified
+    -> R.EpochConstants
+       -- ^ Constants used
+    -> Property
+allElseEqualProperty desc field showValue eff p constants =
+    forAll arbitrary $ \value1 value2 -> do
+        let (higherVal, lowerVal) = sortTuple (value1, value2)
+
+        let poolRankDesc = "Pools:\n" ++ showPool 1 (poolWith higherVal) ++ "\n" ++ showPool 2 (poolWith lowerVal)
+
+        case des (poolWith higherVal) `compare` des (poolWith lowerVal) of
+            GT -> eff === PositiveEffect
+            EQ -> property True
+            -- A reason we end up in this case could be that both pools are
+            -- un-profitable. It would be interesting to re-run tests with
+            -- a higher total reward pot. But as long we hit the other cases we
+            -- should be fine, really.
+
+            LT -> eff === NegativeEffect
+
+            & counterexample poolRankDesc
+            & classify
+                    (des (poolWith higherVal) == des (poolWith lowerVal))
+                    "equal desirability"
+
+  where
+    poolWith val = p & field .~ val
+    sortTuple (a, b)
+        | a > b = (a,b)
+        | otherwise     = (b, a)
+
+    showPool :: Int -> R.Pool -> String
+    showPool rank x =
+        show rank
+            ++ ". "
+            ++ desc
+            ++ " = "
+            ++ showValue (view field x)
+            ++ ", desirability = "
+            ++ show (des x)
+
+    des = R.desirability constants
+
+instance Arbitrary R.Pool where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary (R.RelativeStakeOf a) where
+    arbitrary = R.RelativeStake <$> choose (0, 1)
+    shrink (R.RelativeStake x) = map R.RelativeStake $ filter (\a -> a >= 0 && a <= 1) $ shrink x
+
+-- TODO: We should ideally not export the NonNegative and Positive constructors,
+-- in which case we wouldn't be able to use derivingVia.
+deriving via (NonNegative Double) instance (Arbitrary R.Lovelace)
+deriving via (NonNegative Double) instance (Arbitrary (R.NonNegative Double))
+deriving via (Positive Int) instance (Arbitrary (R.Positive Int))
+
+instance Arbitrary R.Margin where
+    arbitrary = R.unsafeMkMargin <$> choose (0, 1)
+    shrink = map R.unsafeMkMargin
+        . filter (\a -> a >= 0 && a <= 1)
+        . map R.getMargin
+        . shrink
+
+instance Arbitrary R.EpochConstants where
+    arbitrary = genericArbitrary
+    shrink = genericShrink

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -104,9 +104,9 @@ spec = do
             it "saturatedPoolRewards >= 0"
                 $ property prop_saturatedPoolRewardsNonNegative
 
-        describe "mkRelativeStake" $ do
-            it "stake > R, R >= 1 => mkRelativeStake ∈ [0,1] (even with conversions)"
-                $ property prop_mkRelativeStakeBounds
+        describe "unsafeMkRelativeStake" $ do
+            it "R > 0, stake > R => unsafeMkRelativeStake ∈ [0,1]"
+                $ property prop_unsafeMkRelativeStakeBounds
 
         describe "unsafeTo- newtypes" $ do
             it "unsafeToRatio requires ∈ [0,1]"
@@ -149,16 +149,16 @@ prop_unsafeTo isValid f g x = do
         & classify valid "valid"
         & classify (not valid) "error"
 
-prop_mkRelativeStakeBounds :: EpochConstants -> Lovelace -> Property
-prop_mkRelativeStakeBounds constants stake =
+prop_unsafeMkRelativeStakeBounds :: EpochConstants -> Lovelace -> Property
+prop_unsafeMkRelativeStakeBounds constants stake =
     let
         s = getRatio $ unsafeMkRelativeStake stake constants
         total = totalRewards constants
     in
-            total >= 1 ==>
-                total >= stake ==>
-                    property $ s >= 0 && s <= 1
-            & counterexample ("relative stake = " ++ show s)
+        total > 0 ==>
+            total >= stake ==>
+                property $ s >= 0 && s <= 1
+        & counterexample ("relative stake = " ++ show s)
 
 prop_desirabilityNonNegative :: EpochConstants -> Pool -> Property
 prop_desirabilityNonNegative constants pool = property $

--- a/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/RankingSpec.hs
@@ -70,7 +70,7 @@ import Test.QuickCheck
     , (==>)
     )
 import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary )
+    ( genericArbitrary, genericShrink )
 
 import qualified Cardano.Pool.Ranking as R
 
@@ -265,7 +265,7 @@ allElseEqualProperty expectedEffect pool constants =
 
 instance Arbitrary Pool where
     arbitrary = genericArbitrary
-    shrink _ = []
+    shrink _ = [] -- TODO: Implement a shrinker that works.
 
 -- TODO: We should ideally not export the NonNegative and Positive constructors,
 -- in which case we wouldn't be able to use DerivingVia.
@@ -276,10 +276,9 @@ deriving via (Positive Int) instance (Arbitrary (R.Positive Int))
 instance Arbitrary Ratio where
     arbitrary = unsafeToRatio <$> choose (0, 1)
     shrink = map unsafeToRatio
-        . filter (\a -> a >= 0 && a <= 1)
         . map getRatio
         . shrink
 
 instance Arbitrary EpochConstants where
     arbitrary = genericArbitrary
-    shrink _ = []
+    shrink = genericShrink


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1250 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] New completely isolated module implementing ~`nonMyopicMemberRewards`~ `desirability` and related helper functions from the [spec](https://hydra.iohk.io/build/1389333/download/1/delegation_design_spec.pdf).
- [x] Some simple unit/property tests as sanity checks

# Comments

- To be squashed before merging. Leaving a couple un-squashed for now, for history.

⬇️ Now reverted. Coming in a later PR! (Task #1276 )

Work in progress example ranking (without averaging, and with some hard-coded slightly off values)
<img width="1072" alt="Skärmavbild 2020-01-10 kl  18 46 39" src="https://user-images.githubusercontent.com/304423/72174259-8f1a3280-33d9-11ea-9c66-a6b6ec276cfa.png">

With basic averaging (not exponential):

<img width="1042" alt="Skärmavbild 2020-01-10 kl  21 06 41" src="https://user-images.githubusercontent.com/304423/72183065-30f74a80-33ed-11ea-8de8-188d04b12e5a.png">

A newer screenshot (lots of 1PCT pools at the top now):

<img width="1054" alt="Skärmavbild 2020-01-13 kl  15 47 52" src="https://user-images.githubusercontent.com/304423/72279476-82464a80-3636-11ea-8ea9-2a9150ac4166.png">

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
