### PR TITLE
widen 'isMigrationError' to catch constraint errors

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -45,7 +45,7 @@ import Control.Concurrent.MVar
 import Control.Exception
     ( Exception, bracket_, tryJust )
 import Control.Monad
-    ( mapM_ )
+    ( join, mapM_ )
 import Control.Monad.Catch
     ( Handler (..), MonadCatch (..), handleIf, handleJust )
 import Control.Monad.Logger
@@ -191,6 +191,8 @@ startSqliteBackend migrateAll trace fp = do
     migrations <- runQuery (runMigrationQuiet migrateAll)
         & tryJust (matchMigrationError @PersistException)
         & tryJust (matchMigrationError @SqliteException)
+        & fmap join
+        :: IO (Either MigrationError [Text])
     traceWith trace $ MsgMigrations (fmap length migrations)
     let ctx = SqliteContext backend runQuery fp trace
     case migrations of

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -53,9 +53,7 @@ test_migrationFromv20191216 =
                 withDBLayer tr (Just path) $ \_ -> pure ()
 
             let databaseConnMsg  = filter isMsgConnStr logs
-
             let databaseResetMsg = filter (== MsgDatabaseReset) logs
-
             let migrationErrMsg  = filter isMsgMigrationError logs
 
             length databaseConnMsg  `shouldBe` 3


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1251 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- c68cc47dd148911f7b84ca475a56fb898cb841d7
  widen 'isMigrationError' to catch constraint errors
  On start-up, we run persistent migrations and in case of migration issues, we
execute some particular handling (e.g. the pool db resets itself). Yet, we
failed at catching migration issues coming from constraints introduced later
and that can't be satisfied on already existing data. This commit fixes it.

#### Before

```
[cardano-wallet.network:Info:22] Jörmungandr is ready.
cardano-wallet-jormungandr: SQLite3 returned ErrorConstraint while attempting to perform step: NOT NULL constraint failed: pool_owner_backup.pool_owner_index
(exiting with an error code)
```

#### After

```
[cardano-wallet.network:Info:22] Jörmungandr is ready.
[cardano-wallet.stake-pool-db:Error:22]  Failed to migrate the database: : NOT NULL constraint failed: pool_owner_backup.pool_owner_index
[cardano-wallet.stake-pool-db:Notice:22] Non backward compatible database found. Removing old database and re-creating it from scratch. Ignore the previous error.
[cardano-wallet.stake-pool-db:Notice:22] 1 migrations were applied to the database.
(... and continuing as normal)
```

- 25fa3182322ae508a6397c27000012a02b6c803c
  rename 'IsMigration...' to 'MatchMigration...'
  
- 9d6143765eba02c53137b6ca42606b4970813579
  flatten result after tryJust to a single 'Either'

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
