### PR TITLE
Docker image fixes

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -33,6 +33,9 @@ let
     mkdir -p ${dataDir}
     ln -s ${dataDir} /cardano-wallet
 
+    # set up /tmp (override with TMPDIR variable)
+    mkdir -p /tmp
+
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
     exec ${cardano-wallet-jormungandr}/bin/cardano-wallet-jormungandr "$@"
   '';


### PR DESCRIPTION
Addresses part of issue #1256.

# Overview

- b45a5e66f3b424b45b4d0e47516752089d402ee9
  Docker: add inputoutput/cardano-wallet:latest tag
  Adds Docker tags to get the latest release and latest master branch
build.

- bb95d3b26e6701cbdf22cd17bfd818704c3cd814
  Docker: add /tmp directory to container
  Ensures that there is a location to store the stake pool metadata
registry download.



# Comments

There is a new [Docker wiki page](https://github.com/input-output-hk/cardano-wallet/wiki/Docker) with some help and info.

Buildkite job tested with:

```
nix-build .buildkite/docker-build-push.nix --argstr dockerHubRepoName rodney/cardano-wallet -o docker-build-push

BUILDKITE_BRANCH=master BUILDKITE_COMMIT=abcdef ./docker-build-push

BUILDKITE_TAG=v1234 ./docker-build-push
```
