### PR TITLE
Update nixpkgs channel to 19.09

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -163,6 +163,7 @@ buildStep dryRun bk =
             [ color "always"
             , [ "test" ]
             , fast opt
+            , interleavedOutput False -- Work around stuck jormungandr processes.
             , case qaLevel bk of
                 QuickTest -> skip "integration"
                 FullTest -> []
@@ -179,6 +180,7 @@ buildStep dryRun bk =
     skip  arg = ["--skip", arg]
     match arg = ["--match", arg]
     ta    arg = ["--ta", T.unwords arg]
+    interleavedOutput arg = ["--" <> (if arg then "" else "no-") <> "interleaved-output"]
 
     serialTests = "SERIAL"
 

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
     name = "cardano-wallet-src";
   };
 
-  jmPkgs = import ./nix/jormungandr.nix { inherit iohkLib; };
+  jmPkgs = import ./nix/jormungandr.nix { inherit system; };
   inherit (jmPkgs) jormungandr jormungandr-cli;
 
   haskellPackages = import ./nix/pkgs.nix {

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -17,8 +17,7 @@ let
     walletJobs (import ../default.nix { inherit system; })
   ) {
     x86_64-linux = {};
-    # Uncomment to test build on macOS too
-    # x86_64-darwin = {};
+    x86_64-darwin = {};
   };
 
   crossSystems = with lib.systems.examples;

--- a/nix/haskell-nix-src.json
+++ b/nix/haskell-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/haskell.nix",
-  "rev": "d7d24fde4b5c0ebcd704e96aba79e2a148583af7",
-  "date": "2020-01-09T16:07:34+10:00",
-  "sha256": "1p3frk62gb85jb0cdw2rkrsyxaafij98ir45icil30bcwhp4j4q3",
+  "rev": "e68599bec9a14c7745918e8dd9f155e37c0c6bad",
+  "date": "2020-01-16T16:25:31+08:00",
+  "sha256": "093xcnjp96bq0ijja8zyqi9lmf7blmsfsq8h1b9lgx4zii1im9vc",
   "fetchSubmodules": false
 }

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -29,7 +29,8 @@
 #
 ############################################################################
 
-{ iohkLib ? import ./iohk-common.nix {}
+{ iohkLib ? import ./iohk-common.nix { inherit system; }
+, system ? builtins.currentSystem
 , pkgs ? iohkLib.pkgs
 }:
 

--- a/nix/nixpkgs-src.json
+++ b/nix/nixpkgs-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/NixOS/nixpkgs",
-  "rev": "a8f81dc037a5977414a356dd068f2621b3c89b60",
-  "date": "2019-10-13T18:41:59-04:00",
-  "sha256": "01z13axll5g5yl00lz9adr2jw2bs12g9skhbb1vxy8p7fjjbhhhm",
+  "rev": "644045de8b97234057b7c19afb44c6900687cafb",
+  "date": "2020-01-14T18:09:57+01:00",
+  "sha256": "0ajscjlxycs98xm7sj3p2mbfllvka63v53khqy2ma0af18h5w95i",
   "fetchSubmodules": false
 }

--- a/release.nix
+++ b/release.nix
@@ -36,7 +36,7 @@ with (import iohkLib.release-lib) {
   gitrev = cardano-wallet.rev;
 };
 
-with pkgs.lib;
+with project.pkgs.lib;
 
 let
   testsSupportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
@@ -64,7 +64,7 @@ let
       collectTests jobs.native.benchmarks ++
       [ jobs.native.cardano-wallet-jormungandr.x86_64-linux
         jobs.native.cardano-wallet-jormungandr.x86_64-darwin
-        jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux
+        jobs.x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux
         jobs.native.shell.x86_64-linux
         jobs.native.shell.x86_64-darwin
         jobs.cardano-wallet-jormungandr-win64
@@ -77,21 +77,21 @@ let
     daedalus-jormungandr = with jobs; {
       linux = native.cardano-wallet-jormungandr.x86_64-linux;
       macos = native.cardano-wallet-jormungandr.x86_64-darwin;
-      windows = x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+      windows = x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux;
     };
 
     # Windows release ZIP archive
     cardano-wallet-jormungandr-win64 = import ./nix/windows-release.nix {
       inherit pkgs project;
-      cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+      cardano-wallet-jormungandr = jobs.x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux;
     };
 
     # This is used for testing the build on windows.
     cardano-wallet-jormungandr-tests-win64 = import ./nix/windows-testing-bundle.nix {
       inherit pkgs project;
-      cardano-wallet-jormungandr = jobs.x86_64-pc-mingw32.cardano-wallet-jormungandr.x86_64-linux;
-      tests = collectTests jobs.x86_64-pc-mingw32.tests;
-      benchmarks = collectTests jobs.x86_64-pc-mingw32.benchmarks;
+      cardano-wallet-jormungandr = jobs.x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux;
+      tests = collectTests jobs.x86_64-w64-mingw32.tests;
+      benchmarks = collectTests jobs.x86_64-w64-mingw32.benchmarks;
     };
 
     # For testing migration tests on windows


### PR DESCRIPTION
# Overview

This updates the nixpkgs version to 19.09 (latest stable release) from 19.03 (unsupported old release).

# Details

haskell.nix (as referenced in this repository) for the purpose of running CI, was using a custom nixpkgs-19.03 branch. It has been the goal for a while to upgrade from nixpkgs-19.03 to nixpkgs-19.09. Ideally to the stock upstream one without custom patches. This PR updates the nixpkgs-19.03 pin to nixpkgs-19.09 and fixes the issues (as encountered below) in haskell.nix. Subsequently this PR also contains a updated haskell.nix pin. The `w64` issue stems from nixpkgs changing the identifier for windows cross from `x86_64-pc-mingw32` to `x86_64-w64-mingw32` from nixpkgs 19.03 to 19.09. This interacts badly with the jormungandr reference for windows, and @rvl will take a look at that within cardano-wallet, as it can not be fixed in haskell.nix.

# Comments

Issues encountered:
- [x] ```error: attribute 'series3' missing, at /nix/store/87zygi9fxvgqkdflsd5hmx947aj3mf1m-nixpkgs/pkgs/misc/emulators/wine/packages.nix:6:11```
     This is due to missing https://github.com/NixOS/nixpkgs/pull/71216

- [x] ```Unknown vendor: w64```
   This seems to be due to jourmungandr using some 18.09git checkout, which doesn't sport the `w64` vendor, but uses `pc` instead.

- [x] ```/nix/store/d7q2kp5saj7xd9wii7cyfis8y3s4d2sj-network-2.6.3.6-setup-x86_64-w64-mingw32/bin/Setup: error while loading shared libraries: libgmp.so.10: cannot open shared object file: No such file or directory```
   Which is due to
   ```
   ldd /nix/store/d7q2kp5saj7xd9wii7cyfis8y3s4d2sj-network-2.6.3.6-setup-x86_64-w64-mingw32/bin/Setup
           linux-vdso.so.1 (0x00007ffeb9369000)
           libm.so.6 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/libm.so.6 (0x00007f7a4695c000)
           librt.so.1 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/librt.so.1 (0x00007f7a46952000)
           libutil.so.1 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/libutil.so.1 (0x00007f7a4694d000)
           libdl.so.2 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/libdl.so.2 (0x00007f7a46948000)
           libpthread.so.0 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/libpthread.so.0 (0x00007f7a46927000)
           libgmp.so.10 => not found
           libffi.so.6 => not found
           libc.so.6 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib/libc.so.6 (0x00007f7a4676f000)
           /nix/store/wx1vk75bpdr65g6xwxbj4rw0pk04v5j3-glibc-2.27/lib/ld-linux-x86-64.so.2 => /nix/store/pnd2kl27sag76h23wa5kl95a76n3k9i3-glibc-2.27/lib64/ld-linux-x86-64.so.2 (0x00007f7a46af4000)
   ```
   Which originated from nixos/nixpkgs#56555 where `NIX_DONT_SET_RPATH` is now set on more leniently.  This requires us to properly fix the build level we build the Setup.hs with in haskell.nix; it needs to come from the `buildPackages.stdenv`, not from the `stdenv`, which in the case of cross compilation would be the one for the final host.


[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1265)
