### PR TITLE
Add a manual DB migration step for `active_slot_coeff`.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -134,7 +134,7 @@ newDBLayer
        -- ^ Database file location, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp = do
-    let io = startSqliteBackend migrateAll trace fp
+    let io = startSqliteBackend (const $ pure ()) migrateAll trace fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
     return (ctx, DBLayer
         { putPoolProduction = \point pool -> ExceptT $

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -29,6 +29,7 @@ import Prelude
 
 import Cardano.DB.Sqlite
     ( DBLog (..)
+    , ManualMigration (..)
     , MigrationError (..)
     , SqliteContext (..)
     , destroyDBLayer
@@ -134,7 +135,11 @@ newDBLayer
        -- ^ Database file location, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp = do
-    let io = startSqliteBackend (const $ pure ()) migrateAll trace fp
+    let io = startSqliteBackend
+            (ManualMigration $ const $ pure ())
+            migrateAll
+            trace
+            fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
     return (ctx, DBLayer
         { putPoolProduction = \point pool -> ExceptT $

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -136,7 +136,7 @@ newDBLayer
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp = do
     let io = startSqliteBackend
-            (ManualMigration $ const $ pure ())
+            (ManualMigration mempty)
             migrateAll
             trace
             fp

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -42,6 +42,7 @@ import Cardano.BM.Data.Tracer
     ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
 import Cardano.DB.Sqlite
     ( DBLog (..)
+    , ManualMigration (..)
     , SqliteContext (..)
     , chunkSize
     , dbChunked
@@ -300,16 +301,16 @@ findDatabases tr dir = do
 migrateManually
     :: Tracer IO DBLog
     -> W.ActiveSlotCoefficient
-    -> Sqlite.Connection
-    -> IO ()
-migrateManually trace defaultActiveSlotCoeff conn =
-    addActiveSlotCoefficient
+    -> ManualMigration
+migrateManually trace defaultActiveSlotCoeff =
+    ManualMigration $
+        addActiveSlotCoefficient
   where
 
     -- | Adds an 'active_slot_coeff' column to the 'checkpoint' table if
     --   it is missing.
     --
-    addActiveSlotCoefficient = do
+    addActiveSlotCoefficient conn = do
         let report = traceWith trace . MsgManualMigration
         getCheckpointTableInfo <- Sqlite.prepare conn
             "select sql from sqlite_master\

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -340,15 +340,21 @@ newDBLayer trace defaultActiveSlotCoeff mDatabaseFile = do
                             "Checkpoint table is MISSING a required field: \
                             \active_slot_coeff."
 
-                        report
-                            "Adding required field active_slot_coeff to \
-                            \checkpoint table."
+                        let defaultActiveSlotCoeffText = toText $
+                                W.unActiveSlotCoefficient $
+                                defaultActiveSlotCoeff
+
+                        report $ mconcat
+                            [ "Adding required field active_slot_coeff to "
+                            , "checkpoint table with default value of "
+                            , defaultActiveSlotCoeffText
+                            , "."
+                            ]
                         addColumn <- Sqlite.prepare conn $ mconcat
                             [ "alter table checkpoint "
                             , "add column active_slot_coeff double not null "
                             , "default "
-                            , T.pack $ show $ W.unActiveSlotCoefficient
-                                defaultActiveSlotCoeff
+                            , defaultActiveSlotCoeffText
                             , ";"
                             ]
                         _ <- Sqlite.step addColumn

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -48,7 +48,7 @@ import Cardano.Launcher
 import Cardano.Wallet.DB
     ( DBLayer (..), PrimaryKey (..), cleanDB )
 import Cardano.Wallet.DB.Sqlite
-    ( newDBLayer )
+    ( DefaultFieldValues (..), newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0, genesisParameters, mkTxId )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -75,7 +75,8 @@ import Cardano.Wallet.Primitive.Mnemonic
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet, unsafeInitWallet )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
+    ( ActiveSlotCoefficient (..)
+    , Address (..)
     , BlockHeader (..)
     , Coin (..)
     , Direction (..)
@@ -333,8 +334,12 @@ withDB bm = envWithCleanup setupDB cleanupDB (\ ~(_, _, db) -> bm db)
 setupDB :: IO (FilePath, SqliteContext, DBLayerBench)
 setupDB = do
     f <- emptySystemTempFile "bench.db"
-    (ctx, db) <- newDBLayer nullTracer (Just f)
+    (ctx, db) <- newDBLayer nullTracer defaultFieldValues (Just f)
     pure (f, ctx, db)
+
+defaultFieldValues :: DefaultFieldValues
+defaultFieldValues = DefaultFieldValues
+    { defaultActiveSlotCoefficient = ActiveSlotCoefficient 1.0 }
 
 cleanupDB :: (FilePath, SqliteContext, DBLayerBench) -> IO ()
 cleanupDB (db, ctx, _) = do

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -264,7 +264,10 @@ serveWallet
         let (block0, bp) = staticBlockchainParameters nl
         let tracer = contramap MsgDatabaseStartup applicationTracer
         wallets <- maybe (pure []) (Sqlite.findDatabases @k tracer) databaseDir
-        db <- Sqlite.newDBFactory walletDbTracer databaseDir
+        db <- Sqlite.newDBFactory
+            walletDbTracer
+            (getActiveSlotCoefficient bp)
+            databaseDir
         Server.newApiLayer
             walletEngineTracer (toWLBlock block0, bp, sTolerance) nl' tl db wallets
       where

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -70,7 +70,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.DaedalusIPC
     ( DaedalusIPCLog, daedalusIPC )
 import Cardano.Wallet.DB.Sqlite
-    ( DatabasesStartupLog, PersistState )
+    ( DatabasesStartupLog, DefaultFieldValues (..), PersistState )
 import Cardano.Wallet.Jormungandr.Compatibility
     ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Network
@@ -266,7 +266,7 @@ serveWallet
         wallets <- maybe (pure []) (Sqlite.findDatabases @k tracer) databaseDir
         db <- Sqlite.newDBFactory
             walletDbTracer
-            (getActiveSlotCoefficient bp)
+            (DefaultFieldValues $ getActiveSlotCoefficient bp)
             databaseDir
         Server.newApiLayer
             walletEngineTracer (toWLBlock block0, bp, sTolerance) nl' tl db wallets


### PR DESCRIPTION
# Issue Number

#1251 

# Overview

This PR:

- [x] Adds the ability to perform manual DB migration actions after connecting to a SQLite database.
- [x] Uses this ability to detect whether or not the `active_slot_coeff` field is present in the `checkpoint` table.
- [x] Adds the `active_slot_coeff` field manually, if it was not present already, using a default value that is passed down from the network layer.
- [ ] Figure out the cause of repeated log entries of the form:
```hs
[cardano-wallet.wallet-engine:Info:29] [2020-01-16 09:05:14.78 UTC] e834cdb3: Try rolling back to 0.0
[cardano-wallet.wallet-engine:Info:29] [2020-01-16 09:05:14.78 UTC] e834cdb3: Rolled back to 0.0
```

# Comments