### PR TITLE
endpoint: force wallet resync

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -338,12 +338,19 @@ expectSuccess (_, res) = case res of
 
 -- | Expect a given response code on the response.
 expectResponseCode
-    :: (MonadIO m)
+    :: (MonadIO m, Show a)
     => HTTP.Status
     -> (HTTP.Status, a)
     -> m ()
-expectResponseCode want (got, _) =
-    got `shouldBe` want
+expectResponseCode want (got, a) =
+    if got == want
+        then pure ()
+        else liftIO $ expectationFailure $ unlines
+            [ "expected: " <> show want
+            , " but got: " <> show got
+            , ""
+            , "from the following response: " <> show a
+            ]
 
 expectFieldEqual
     :: (MonadIO m, MonadFail m, Show a, Eq a)

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -77,6 +77,7 @@ module Test.Integration.Framework.TestData
     , errMsg500
     , errMsg400NumberOfWords
     , errMsgNotInDictionary
+    , errMsg403RejectedTip
     ) where
 
 import Prelude
@@ -480,3 +481,9 @@ errMsgNotInDictionary = "Found an unknown word not present in the pre-defined\
 
 errMsg400NumberOfWords :: String
 errMsg400NumberOfWords = "Invalid number of words:"
+
+errMsg403RejectedTip :: String
+errMsg403RejectedTip =
+    "I am sorry but I refuse to rollback to the given point. \
+    \Notwithstanding I'll willingly rollback to the genesis point (0, 0) \
+    \should you demand it."

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -62,6 +62,7 @@ library
     , http-media
     , http-types
     , iohk-monitoring
+    , lifted-base
     , memory
     , monad-logger
     , network

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -74,6 +74,7 @@ module Cardano.Wallet
     , updateWalletPassphrase
     , walletSyncProgress
     , fetchRewardBalance
+    , rollbackBlocks
     , ErrWalletAlreadyExists (..)
     , ErrNoSuchWallet (..)
     , ErrListUTxOStatistics (..)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Api
         , PutWallet
         , PutWalletPassphrase
         , GetUTxOsStatistics
+        , ForceResyncWallet
 
     , Addresses
         , ListAddresses
@@ -49,6 +50,7 @@ module Cardano.Wallet.Api
         , GetByronWallet
         , ListByronWallets
         , PostByronWallet
+        , ForceResyncByronWallet
 
     , ByronTransactions
         , ListByronTransactions
@@ -89,6 +91,7 @@ import Cardano.Wallet.Api.Types
     , ApiCoinSelection
     , ApiFee
     , ApiNetworkInformation
+    , ApiNetworkTip
     , ApiSelectCoinsData
     , ApiStakePool
     , ApiT
@@ -192,6 +195,7 @@ type Wallets =
     :<|> PutWallet
     :<|> PutWalletPassphrase
     :<|> GetUTxOsStatistics
+    :<|> ForceResyncWallet
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteWallet
 type DeleteWallet = "wallets"
@@ -231,6 +235,13 @@ type GetUTxOsStatistics = "wallets"
     :> "statistics"
     :> "utxos"
     :> Get '[JSON] ApiUtxoStatistics
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/forceResync
+type ForceResyncWallet = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "tip"
+    :> ReqBody '[JSON] ApiNetworkTip
+    :> PutNoContent '[Any] NoContent
 
 {-------------------------------------------------------------------------------
                                   Addresses
@@ -362,6 +373,7 @@ type ByronWallets =
     :<|> DeleteByronWallet
     :<|> GetByronWallet
     :<|> ListByronWallets
+    :<|> ForceResyncByronWallet
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronWallet
 type PostByronWallet (style :: ByronWalletStyle) = "byron-wallets"
@@ -382,6 +394,13 @@ type GetByronWallet = "byron-wallets"
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronWallets
 type ListByronWallets = "byron-wallets"
     :> Get '[JSON] [ApiByronWallet]
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/forceResyncByron
+type ForceResyncByronWallet = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "tip"
+    :> ReqBody '[JSON] ApiNetworkTip
+    :> PutNoContent '[Any] NoContent
 
 {-------------------------------------------------------------------------------
                                  Byron Transactions

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -38,6 +38,7 @@ import Cardano.Wallet.Api.Types
     ( ApiAddress
     , ApiFee
     , ApiNetworkInformation (..)
+    , ApiNetworkTip
     , ApiStakePool
     , ApiT (..)
     , ApiTransaction
@@ -103,6 +104,10 @@ data WalletClient t = WalletClient
         :: ApiT WalletId
         -> WalletPutPassphraseData
         -> ClientM NoContent
+    , forceResyncWallet
+        :: ApiT WalletId
+        -> ApiNetworkTip
+        -> ClientM NoContent
     , listTransactions
         :: ApiT WalletId
         -> Maybe Iso8601Time
@@ -167,6 +172,7 @@ walletClient =
             :<|> _putWallet
             :<|> _putWalletPassphrase
             :<|> _getWalletUtxoStatistics
+            :<|> _forceResyncWallet
             = wallets
 
         _listAddresses =
@@ -200,6 +206,7 @@ walletClient =
             , postWallet = _postWallet
             , putWallet = _putWallet
             , putWalletPassphrase = _putWalletPassphrase
+            , forceResyncWallet = _forceResyncWallet
             , listTransactions = _listTransactions
             , postTransaction = _postTransaction
             , postExternalTransaction = _postExternalTransaction

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -77,6 +77,7 @@ module Cardano.Wallet.Api.Link
     , postExternalTransaction
 
     , PostWallet
+    , Discriminate
     ) where
 
 import Prelude

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -48,6 +48,7 @@ module Cardano.Wallet.Api.Link
     , getUTxOsStatistics
     , getMigrationInfo
     , migrateWallet
+    , forceResyncWallet
 
       -- * Addresses
     , listAddresses
@@ -238,6 +239,19 @@ getMigrationInfo
     -> (Method, Text)
 getMigrationInfo w =
     endpoint @Api.GetByronWalletMigrationInfo (wid &)
+  where
+    wid = w ^. typed @(ApiT WalletId)
+
+forceResyncWallet
+    :: forall style w.
+        ( HasType (ApiT WalletId) w
+        , Discriminate style
+        )
+    => w
+    -> (Method, Text)
+forceResyncWallet w = discriminate @style
+    (endpoint @Api.ForceResyncWallet (wid &))
+    (endpoint @Api.ForceResyncByronWallet (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -790,8 +790,8 @@ deleteWallet
     -> Handler NoContent
 deleteWallet ctx (ApiT wid) = do
     liftHandler $ withWorkerCtx @_ @s @k ctx wid throwE $ \_ -> pure ()
-    liftIO $ removeDatabase df wid
     liftIO $ Registry.remove re wid
+    liftIO $ removeDatabase df wid
     return NoContent
   where
     re = ctx ^. workerRegistry @s @k

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -415,6 +415,7 @@ data ApiErrorCode
     | PoolAlreadyJoined
     | NotDelegatingTo
     | InvalidRestorationParameters
+    | RejectedTip
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -57,20 +56,18 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word32 )
-import GHC.Generics
-    ( Generic )
 
 import qualified Data.List as L
 
 -- | Instantiate database layers at will
 data DBFactory m s k = DBFactory
-    { withDatabase :: WalletId -> (DBLayer m s k -> IO ()) -> IO ()
+    { withDatabase :: forall a. WalletId -> (DBLayer m s k -> IO a) -> IO a
         -- ^ Creates a new or use an existing database, maintaining an open
         -- connection so long as necessary
 
     , removeDatabase :: WalletId -> IO ()
         -- ^ Erase any trace of the database
-    } deriving (Generic)
+    }
 
 -- | A Database interface for storing various things in a DB. In practice,
 -- we'll need some extra contraints on the wallet state that allows us to

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1412,6 +1412,9 @@ instance ToSchema ApiUtxoStatistics where
 instance ToSchema ApiNetworkInformation where
     declareNamedSchema _ = declareSchemaForDefinition "ApiNetworkInformation"
 
+instance ToSchema ApiNetworkTip where
+    declareNamedSchema _ = declareSchemaForDefinition "ApiNetworkTip"
+
 -- | Utility function to provide an ad-hoc 'ToSchema' instance for a definition:
 -- we simply look it up within the Swagger specification.
 declareSchemaForDefinition :: T.Text -> Declare (Definitions Schema) NamedSchema

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -66,6 +66,8 @@ import System.Environment
     ( setEnv )
 import System.FilePath
     ( (</>) )
+import System.IO.Temp
+    ( withSystemTempDirectory )
 import Test.Hspec
     ( Spec, SpecWith, after, describe, hspec, parallel )
 import Test.Hspec.Extra
@@ -171,8 +173,15 @@ specWithServer tr = aroundAll withContext . after tearDown
     withServer setup =
         withConfig $ \jmCfg ->
         withMetadataRegistry $
-            serveWallet @'Testnet tracers (SyncTolerance 10) Nothing "127.0.0.1"
-                ListenOnRandomPort (Launch jmCfg) setup
+        withSystemTempDirectory "cardano-wallet-databases" $ \db ->
+            serveWallet @'Testnet
+                tracers
+                (SyncTolerance 10)
+                (Just db)
+                "127.0.0.1"
+                ListenOnRandomPort
+                (Launch jmCfg)
+                setup
 
     tracers = setupTracers (tracerSeverities (Just Info)) tr
 

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -88,6 +88,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."http-media" or (buildDepError "http-media"))
           (hsPkgs."http-types" or (buildDepError "http-types"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."lifted-base" or (buildDepError "lifted-base"))
           (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."monad-logger" or (buildDepError "monad-logger"))
           (hsPkgs."network" or (buildDepError "network"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -65,6 +65,22 @@ x-blockReference: &blockReference
     epoch_number: *epochNumber
     height: *numberOfBlocks
 
+x-genesisBlock: &genesisBlock
+  description: A reference to a particular block.
+  type: object
+  required:
+    - slot_number
+    - epoch_number
+  properties:
+    slot_number:
+      <<: *slotNumber
+      maximum: 0
+      example: 0
+    epoch_number:
+      <<: *epochNumber
+      maximum: 0
+      example: 0
+
 x-percentage: &percentage
   type: object
   required:
@@ -492,16 +508,6 @@ x-networkInformationNodeTip: &networkInformationNodeTip
   <<: *blockReference
   description: Underlying node's tip
 
-x-networkInformationNetworkTip: &networkInformationNetworkTip
-  description: Projected network's tip
-  type: object
-  required:
-    - slot_number
-    - epoch_number
-  properties:
-    slot_number: *slotNumber
-    epoch_number: *epochNumber
-
 x-networkInformationProtocolUpdate: &networkInformationProtocolUpdate
   type: string
   description: |
@@ -536,6 +542,16 @@ definitions:
       epoch_number: *epochNumber
       epoch_start_time: *date
 
+  ApiNetworkTip: &ApiNetworkTip
+    description: A network tip
+    type: object
+    required:
+      - slot_number
+      - epoch_number
+    properties:
+      slot_number: *slotNumber
+      epoch_number: *epochNumber
+
   ApiNetworkInformation: &ApiNetworkInformation
     type: object
     required:
@@ -546,7 +562,7 @@ definitions:
     properties:
       sync_progress: *networkInformationSyncProgress
       node_tip: *networkInformationNodeTip
-      network_tip: *networkInformationNetworkTip
+      network_tip: *ApiNetworkTip
       next_epoch: *ApiEpochInfo
 
   ApiSelectCoinsData: &ApiSelectCoinsData
@@ -1057,6 +1073,16 @@ x-responsesDeleteWallet: &responsesDeleteWallet
   204:
     description: No Content
 
+x-responsesForceResyncWallet: &responsesForceResyncWallet
+  <<: *responsesErr400
+  <<: *responsesErr403
+  <<: *responsesErr404
+  <<: *responsesErr405
+  <<: *responsesErr406
+  <<: *responsesErr415
+  204:
+    description: No Content
+
 x-responsesPutWallet: &responsesPutWallet
   <<: *responsesErr400
   <<: *responsesErr404
@@ -1276,6 +1302,27 @@ paths:
         - <<: *parametersBody
           schema: *ApiWalletPutData
       responses: *responsesPutWallet
+
+  /wallets/{walletId}/tip:
+    put:
+      operationId: forceResync
+      tags: ["Wallets"]
+      summary: Force Resync
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Force the wallet to rewind back to the given block and sync again with the chain.
+        Any incoming transaction will be erased whereas outgoing transactions will be put back
+        as pending. This action should only be taken as an extreme measure to resolve potential
+        syncing issues. If its use is required, please submit a ticket to https://github.com/input-output-hk/cardano-wallet/issues.
+
+        > ⚠️ At this stage, the server only allows resyncing to genesis (i.e. `(0,0)`).
+        > Any other point will yield a `403 Forbidden` error.
+      parameters:
+        - *parametersWalletId
+        - <<: *parametersBody
+          schema: *genesisBlock
+      responses: *responsesForceResyncWallet
 
   /wallets/{walletId}/statistics/utxos:
     get:
@@ -1570,6 +1617,27 @@ paths:
       parameters:
         - *parametersWalletId
       responses: *responsesDeleteWallet
+
+  /byron-wallets/{walletId}/tip:
+    put:
+      operationId: forceResyncByron
+      tags: ["Byron Wallets"]
+      summary: Force Resync
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Force the wallet to rewind back to the given block and sync again with the chain.
+        Any incoming transaction will be erased whereas outgoing transactions will be put back
+        as pending. This action should only be taken as an extreme measure to resolve potential
+        syncing issues. If its use is required, please submit a ticket to https://github.com/input-output-hk/cardano-wallet/issues.
+
+        > ⚠️ At this stage, the server only allows resyncing to genesis (i.e. `(0,0)`).
+        > Any other point will yield a `403 Forbidden` error.
+      parameters:
+        - *parametersWalletId
+        - <<: *parametersBody
+          schema: *genesisBlock
+      responses: *responsesForceResyncWallet
 
   /byron-wallets/{walletId}/transactions:
     get:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1146 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 92c2aa01289c6274a94fa07d55eac6181e35ecb5
  extend swagger specification with 'forceResync'
  As an extreme measure to force re-sync the wallet

- 206affcab73d87d1e7c0c46c433eb2ea9494993c
  extend API with 'forceResync' operation
  - Added a 'forceResync' link
- Extended the servant Client
- Provide an initial straightforward implementation re-using 'rollbackBlocks'

- 3d9bc77220fa58341cfe803d4720db04d0422e92
  implement 'forceResync' handler properly
  Taking care of concurrent workers possibly acting on the database
at the same time as well as restarting the restoration worker at
the right point

- 4b06845b9fdacccf268302aa443fbf4cfb812366
  add integration test for the 'forceResync' endpoint
  Doesn't pass currently because of the in-memory sqlite implementation.
It works like a charm with the file database though:

```
(Right before making the request, observe the thread id #142)
[cardano-wallet.wallet-engine:Info:142] [2020-01-15 10:38:04.54 UTC] bdb212cc: In sync with the node.

(Upon receiving the request)
[cardano-wallet.api-server:Info:526] [2020-01-15 10:38:04.97 UTC] [RequestId 10] [DELETE] /v2/wallets/bdb212ccd1d556b62a59f4a4a1de0cff29f61ac1/utxos

(Turning off the worker, rolling back, and switching the worker back on)
[cardano-wallet.wallet-engine:Info:142] [2020-01-15 10:38:04.97 UTC] bdb212cc: Worker has exited: main action is over.
[cardano-wallet.wallet-engine:Info:526] [2020-01-15 10:38:04.98 UTC] bdb212cc: Try rolling back to 0.0
[cardano-wallet.wallet-engine:Info:526] [2020-01-15 10:38:05.00 UTC] bdb212cc: Rolled back to 0.0

(Responding to the request)
[cardano-wallet.api-server:Info:526] [2020-01-15 10:38:05.01 UTC] [RequestId 10] 204 No Content in 0.044038928s

(And later, the worker restarted, applying blocks from the start, new thread id #528).
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.03 UTC] bdb212cc: Applying blocks [1136063.1 ... 1144130.1]
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.03 UTC] bdb212cc: Creating checkpoint at feb1b2c2-[1136063.1#1]
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.04 UTC] bdb212cc: Creating checkpoint at 8920cbb4-[1136063.2#2]
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.04 UTC] bdb212cc: Creating checkpoint at 73a21e9f-[1136063.3#3]

[...]

(Eventually, reaches the tip)
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.18 UTC] bdb212cc: MyWallet, created at 2020-01-15 10:35:28.24351865 UTC, not delegating
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.18 UTC] bdb212cc: syncProgress: restored
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.18 UTC] bdb212cc: discovered 0 new transaction(s)
[cardano-wallet.wallet-engine:Info:528] [2020-01-15 10:38:05.18 UTC] bdb212cc: local tip: 8b9aba60-[1144130.1#100]
```

- d196fd1be0d19021ca500e53ba32881765c4ac55
  preserve in-memory database states between calls
  For the in-memory Sqlite database, we do actually preserve the database
after the 'action' is done. This allows for calling 'withDatabase'
several times within the same execution and get back the same database.
The memory is only cleaned up when calling 'removeDatabase', to mimic
the way the file database works!

Without this, code like:

```hs
  Registry.remove re wid
  registerWorker ctx wid
```

would lead to weird behavior where the wallet `wid` which existed when
the worker was stopped didn't exist anymore when register the worker
again. This was because, killing the worker closes the connection
to the database and re-opening the "same" connection on the in-memory
database actually yield a completely different memory representation!

- 423296b5e3a62db258a269027f5672b703f0a09c
  revise 'expectResponseCode' to give more details on failure
  It was kinda hard to understand what was going on from the error message.
This is now slightly better and at least, allow some reasonning

- 5eae1fa032ec1c62935236bd04b903eaccc17829
  re-generate nix machinery
  
- fab6e17d2c88a073a1a883a80491318537a0ca83
  fix database closing error handling
  - Added some additional log messages
- Added an extra exception handler
- Swapped worker removal with database closing
- Reviewed how the in-memory database got cleaned up to avoid race condition

- 9babcc2c202a51d300520f0618d50c3871f476c3
  use on-disk database in integration tests

# Comments

<!-- Additional comments or screenshots to attach if any -->

![Screenshot from 2020-01-15 16-50-37](https://user-images.githubusercontent.com/5680256/72448387-3373ee80-37b7-11ea-962d-60c507ea4617.png)

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
