### PR TITLE
Removing lenses from integration tests (state, addressPoolGap, balance*)

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -51,7 +51,6 @@ module Test.Integration.Framework.DSL
     , RequestException(..)
 
     -- * Lens
-    , addressPoolGap
     , amount
     , apparentPerformance
     , byronBalanceAvailable
@@ -161,8 +160,6 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
-    ( AddressPoolGap, getAddressPoolGap, mkAddressPoolGap )
 import Cardano.Wallet.Primitive.Mnemonic
     ( entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
@@ -651,15 +648,6 @@ expectPathEventuallyExist filepath = do
 
 -- Lenses
 --
-addressPoolGap :: HasType (ApiT AddressPoolGap) s => Lens' s Int
-addressPoolGap =
-    lens _get _set
-  where
-    _get :: HasType (ApiT AddressPoolGap) s => s -> Int
-    _get = fromIntegral . getAddressPoolGap . getApiT . view typed
-    _set :: HasType (ApiT AddressPoolGap) s => (s, Int) -> s
-    _set (s, v) = set typed (ApiT $ unsafeMkAddressPoolGap v) s
-
 balanceAvailable :: HasType (ApiT WalletBalance) s => Lens' s Natural
 balanceAvailable =
     lens _get _set
@@ -1324,11 +1312,6 @@ unsafeCreateDigest :: Text -> Digest Blake2b_160
 unsafeCreateDigest s = fromMaybe
     (error $ "unsafeCreateDigest failed to create digest from: " <> show s)
     (digestFromByteString $ B8.pack $ T.unpack s)
-
-unsafeMkAddressPoolGap :: Int -> AddressPoolGap
-unsafeMkAddressPoolGap g = case (mkAddressPoolGap $ fromIntegral g) of
-    Right a -> a
-    Left _ -> error $ "unsafeMkAddressPoolGap: bad argument: " <> show g
 
 wantedSuccessButError
     :: (MonadFail m, Show e)

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -70,7 +70,6 @@ module Test.Integration.Framework.DSL
     , outputs
     , passphraseLastUpdate
     , stake
-    , state
     , status
     , syncProgress
     , walletId
@@ -749,15 +748,6 @@ passphraseLastUpdate =
     _set :: (s, Maybe Text) -> s
     _set (s, v) =
         set typed (ApiT . WalletPassphraseInfo . read . T.unpack <$> v) s
-
-state :: HasField' "state" s (ApiT t) => Lens' s t
-state =
-    lens _get _set
-  where
-    _get :: HasField' "state" s (ApiT t) => s -> t
-    _get = getApiT . getField @"state"
-    _set :: HasField' "state" s (ApiT t) => (s, t) -> s
-    _set (s, v) = setField @"state" (ApiT v) s
 
 walletName :: HasType (ApiT WalletName) s => Lens' s Text
 walletName =

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -86,6 +86,9 @@ import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Data.Text
     ( Text, pack, unpack )
+import Data.Word
+    ( Word32 )
+import qualified Network.HTTP.Types.Status as HTTP
 import Numeric.Natural
     ( Natural )
 import Test.Integration.Framework.DSL
@@ -96,8 +99,6 @@ import Test.Integration.Framework.DSL
     , expectResponseCode
     , json
     )
-
-import qualified Network.HTTP.Types.Status as HTTP
 
 -- useful for testing POST/PUT endpoints (ones with payload)
 postHeaderCases
@@ -288,10 +289,10 @@ passphraseMinLength = 10
 passphraseMaxLength :: Int
 passphraseMaxLength = 255
 
-addressPoolGapMin :: Int
+addressPoolGapMin :: Word32
 addressPoolGapMin = 10
 
-addressPoolGapMax :: Int
+addressPoolGapMax :: Word32
 addressPoolGapMax = 100
 
 payloadWith :: Text -> [Text] -> Payload

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -34,12 +34,8 @@ module Test.Integration.Framework.TestData
     , wildcardsWalletName
 
     -- * Helpers
-    , addressPoolGapMax
-    , addressPoolGapMin
     , cmdOk
     , versionLine
-    , passphraseMaxLength
-    , passphraseMinLength
     , payloadWith
     , simplePayload
     , updateNamePayload
@@ -86,9 +82,6 @@ import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Data.Text
     ( Text, pack, unpack )
-import Data.Word
-    ( Word32 )
-import qualified Network.HTTP.Types.Status as HTTP
 import Numeric.Natural
     ( Natural )
 import Test.Integration.Framework.DSL
@@ -99,6 +92,8 @@ import Test.Integration.Framework.DSL
     , expectResponseCode
     , json
     )
+
+import qualified Network.HTTP.Types.Status as HTTP
 
 -- useful for testing POST/PUT endpoints (ones with payload)
 postHeaderCases
@@ -282,18 +277,6 @@ wildcardsWalletName = "`~`!@#$%^&*()_+-=<>,./?;':\"\"'{}[]\\|❤️ 💔 💌 �
 
 cmdOk :: String
 cmdOk = "Ok.\n"
-
-passphraseMinLength :: Int
-passphraseMinLength = 10
-
-passphraseMaxLength :: Int
-passphraseMaxLength = 255
-
-addressPoolGapMin :: Word32
-addressPoolGapMin = 10
-
-addressPoolGapMax :: Word32
-addressPoolGapMax = 100
 
 payloadWith :: Text -> [Text] -> Payload
 payloadWith name mnemonics = Json [json| {

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -184,7 +184,6 @@ spec = do
             (Link.getWallet @'Shelley wDest) Default Empty
         expectEventually ctx (Link.getWallet @'Shelley)
                 (#balance . #getApiT . #available) (Quantity 10) rb
-        print rb
 
         -- verify new address_pool_gap has been created
         rAddr <- request @[ApiAddress n] ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -42,7 +42,6 @@ import Test.Integration.Framework.DSL
     , json
     , listAddresses
     , request
-    , state
     , verify
     , walletId
     , withMethod
@@ -78,7 +77,7 @@ spec = do
         expectResponseCode @IO HTTP.status200 r
         expectListSizeEqual g r
         forM_ [0..(g-1)] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused r
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused r
 
     it "ADDRESS_LIST_01 - Can list addresses with non-default pool gap" $ \ctx -> do
         let g = 15
@@ -88,7 +87,7 @@ spec = do
         expectResponseCode @IO HTTP.status200 r
         expectListSizeEqual g r
         forM_ [0..(g-1)] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused r
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused r
 
     it "ADDRESS_LIST_02 - Can filter used and unused addresses" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
@@ -98,13 +97,13 @@ spec = do
         expectResponseCode @IO HTTP.status200 rUsed
         expectListSizeEqual 10 rUsed
         forM_ [0..9] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Used rUsed
+            expectListItemFieldEqual addrNum (#state . #getApiT) Used rUsed
         rUnused <- request @[ApiAddress n] ctx
             (Link.listAddresses' w (Just Unused)) Default Empty
         expectResponseCode @IO HTTP.status200 rUnused
         expectListSizeEqual g rUnused
         forM_ [10..(g-1)] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused rUnused
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused rUnused
 
     it "ADDRESS_LIST_02 - Shows nothing when there are no used addresses"
         $ \ctx -> do
@@ -118,7 +117,7 @@ spec = do
         expectResponseCode @IO HTTP.status200 rUnused
         expectListSizeEqual 20 rUnused
         forM_ [0..19] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused rUnused
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused rUnused
 
     describe "ADDRESS_LIST_02 - Invalid filters are bad requests" $ do
         let filters =
@@ -158,7 +157,7 @@ spec = do
             , expectListSizeEqual 10
             ]
         forM_ [0..9] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused r
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused r
         addrs <- listAddresses ctx wDest
 
         -- run 10 transactions to make all addresses `Used`
@@ -192,9 +191,9 @@ spec = do
             , expectListSizeEqual 20
             ]
         forM_ [0..9] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Used rAddr
+            expectListItemFieldEqual addrNum (#state . #getApiT) Used rAddr
         forM_ [10..19] $ \addrNum -> do
-            expectListItemFieldEqual addrNum state Unused rAddr
+            expectListItemFieldEqual addrNum (#state . #getApiT) Unused rAddr
 
     describe "ADDRESS_LIST_04 - False wallet ids" $ do
         forM_ falseWalletIds $ \(title, walId) -> it title $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -23,13 +23,14 @@ import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
+import Data.Quantity
+    ( Quantity (..) )
 import Test.Hspec
     ( SpecWith, describe, it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)
     , Payload (..)
-    , balanceAvailable
     , emptyRandomWallet
     , emptyWallet
     , emptyWalletWith
@@ -181,7 +182,9 @@ spec = do
         -- make sure all transactions are in ledger
         rb <- request @ApiWallet ctx
             (Link.getWallet @'Shelley wDest) Default Empty
-        expectEventually ctx (Link.getWallet @'Shelley) balanceAvailable 10 rb
+        expectEventually ctx (Link.getWallet @'Shelley)
+                (#balance . #getApiT . #available) (Quantity 10) rb
+        print rb
 
         -- verify new address_pool_gap has been created
         rAddr <- request @[ApiAddress n] ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -87,7 +87,6 @@ import Test.Integration.Framework.DSL
     , json
     , passphraseLastUpdate
     , request
-    , state
     , unsafeRequest
     , verify
     , walletId
@@ -814,7 +813,8 @@ spec = do
                             [ expectFieldEqual walletName name
                             , expectFieldEqual byronBalanceAvailable 0
                             , expectFieldEqual byronBalanceTotal 0
-                            , expectEventually ctx (Link.getWallet @'Byron) state Ready
+                            , expectEventually ctx (Link.getWallet @'Byron)
+                                    (#state . #getApiT) Ready
                             , expectFieldNotEqual passphraseLastUpdate Nothing
                             ]
                 -- create

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -42,7 +42,6 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , nextEpoch
     , request
-    , state
     , syncProgress
     , verify
     )
@@ -108,7 +107,7 @@ spec = do
                 res <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley w) Default Empty
                 verify res
-                    [ expectFieldEqual state Ready
+                    [ expectFieldEqual (#state . #getApiT) Ready
                     , expectFieldEqual (#tip . #epochNumber . #getApiT) epochNum
                     , expectFieldEqual (#tip . #slotNumber  . #getApiT) slotNum
                     , expectFieldEqual (#tip . #height) blockHeight
@@ -135,7 +134,7 @@ spec = do
                 res <- request @ApiByronWallet ctx
                     (Link.getWallet @'Byron w) Default Empty
                 verify res
-                    [ expectFieldEqual state Ready
+                    [ expectFieldEqual (#state . #getApiT) Ready
                     , expectFieldEqual (#tip . #epochNumber . #getApiT) epochNum
                     , expectFieldEqual (#tip . #slotNumber  . #getApiT) slotNum
                     , expectFieldEqual (#tip . #height) blockHeight

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -91,7 +91,6 @@ import Test.Integration.Framework.DSL
     , passphraseLastUpdate
     , request
     , selectCoins
-    , state
     , unsafeRequest
     , verify
     , walletId
@@ -170,7 +169,8 @@ spec = do
             , expectFieldEqual balanceAvailable 0
             , expectFieldEqual balanceTotal 0
             , expectFieldEqual balanceReward 0
-            , expectEventually ctx (Link.getWallet @'Shelley) state Ready
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#state . #getApiT) Ready
             , expectFieldEqual delegation (NotDelegating)
             , expectFieldEqual walletId
                 "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
@@ -897,7 +897,8 @@ spec = do
             , expectFieldEqual balanceAvailable 0
             , expectFieldEqual balanceTotal 0
             , expectFieldEqual balanceReward 0
-            , expectEventually ctx (Link.getWallet @'Shelley) state Ready
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#state . #getApiT) Ready
             , expectFieldEqual delegation (NotDelegating)
             , expectFieldEqual walletId (w ^. walletId)
             , expectFieldNotEqual passphraseLastUpdate Nothing
@@ -1039,7 +1040,8 @@ spec = do
                             (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
                     , expectFieldEqual balanceAvailable 0
                     , expectFieldEqual balanceTotal 0
-                    , expectEventually ctx (Link.getWallet @'Shelley) state Ready
+                    , expectEventually ctx (Link.getWallet @'Shelley)
+                            (#state . #getApiT) Ready
                     , expectFieldEqual delegation (NotDelegating)
                     , expectFieldEqual walletId walId
                     , expectFieldEqual passphraseLastUpdate passLastUpdateValue

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -65,7 +65,6 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
-    , addressPoolGap
     , balanceAvailable
     , balanceReward
     , balanceTotal
@@ -166,7 +165,8 @@ spec = do
         verify r
             [ expectResponseCode @IO HTTP.status201
             , expectFieldEqual walletName "1st Wallet"
-            , expectFieldEqual addressPoolGap 30
+            , expectFieldEqual
+                    (#addressPoolGap . #getApiT . #getAddressPoolGap) 30
             , expectFieldEqual balanceAvailable 0
             , expectFieldEqual balanceTotal 0
             , expectFieldEqual balanceReward 0
@@ -662,24 +662,31 @@ spec = do
             ]
 
     describe "WALLETS_CREATE_08 - address_pool_gap" $ do
+        let addrPoolMin, addrPoolMax :: Int
+            addrPoolMin = fromIntegral addressPoolGapMin
+            addrPoolMax = fromIntegral addressPoolGapMax
         let matrix =
-                [ ( show addressPoolGapMin, addressPoolGapMin
+                [ ( show addressPoolGapMin
+                  , addrPoolMin
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual addressPoolGap addressPoolGapMin
+                    , expectFieldEqual
+                            (#addressPoolGap . #getApiT . #getAddressPoolGap)
+                            addressPoolGapMin
                     ]
                   )
                 , ( show (addressPoolGapMin - 1) ++ " -> fail"
-                  , (addressPoolGapMin - 1)
+                  , addrPoolMin - 1
                   , [ expectResponseCode @IO HTTP.status400
                     , expectErrorMessage "An address pool gap must be a natural\
                       \ number between 10 and 100."
                     ]
                   )
-                , ( show addressPoolGapMax, addressPoolGapMax
+                , ( show addressPoolGapMax
+                  , addrPoolMax
                   , [ expectResponseCode @IO HTTP.status201 ]
                   )
                 , ( show (addressPoolGapMax + 1) ++ " -> fail"
-                  , addressPoolGapMax + 1
+                  , (addrPoolMax + 1)
                   , [ expectResponseCode @IO HTTP.status400
                     , expectErrorMessage "An address pool gap must be a natural\
                       \ number between 10 and 100."
@@ -794,7 +801,8 @@ spec = do
         r <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default payload
         verify r
             [ expectResponseCode @IO HTTP.status201
-            , expectFieldEqual addressPoolGap 20
+            , expectFieldEqual
+                    (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             ]
 
     describe "WALLETS_CREATE_09 - HTTP headers" $ do
@@ -884,7 +892,8 @@ spec = do
         verify rg
             [ expectResponseCode @IO HTTP.status200
             , expectFieldEqual walletName "Secure Wallet"
-            , expectFieldEqual addressPoolGap 20
+            , expectFieldEqual
+                    (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectFieldEqual balanceAvailable 0
             , expectFieldEqual balanceTotal 0
             , expectFieldEqual balanceReward 0
@@ -953,7 +962,8 @@ spec = do
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 1
             , expectListItemFieldEqual 0 walletName "Wallet to be listed"
-            , expectListItemFieldEqual 0 addressPoolGap 20
+            , expectListItemFieldEqual 0
+                    (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectListItemFieldEqual 0 balanceAvailable 0
             , expectListItemFieldEqual 0 balanceTotal 0
             , expectListItemFieldEqual 0 balanceReward 0
@@ -1025,7 +1035,8 @@ spec = do
         let walId = getFromResponse walletId r
         let expectations = [ expectResponseCode @IO HTTP.status200
                     , expectFieldEqual walletName "New great name"
-                    , expectFieldEqual addressPoolGap 20
+                    , expectFieldEqual
+                            (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
                     , expectFieldEqual balanceAvailable 0
                     , expectFieldEqual balanceTotal 0
                     , expectEventually ctx (Link.getWallet @'Shelley) state Ready
@@ -1042,7 +1053,8 @@ spec = do
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 1
             , expectListItemFieldEqual 0 walletName "New great name"
-            , expectListItemFieldEqual 0 addressPoolGap 20
+            , expectListItemFieldEqual 0
+                    (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectListItemFieldEqual 0 balanceAvailable 0
             , expectListItemFieldEqual 0 balanceTotal 0
             , expectListItemFieldEqual 0 delegation (NotDelegating)

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
@@ -48,7 +48,6 @@ import Test.Integration.Framework.DSL
     , fixtureWallet
     , listAddressesViaCLI
     , postTransactionViaCLI
-    , state
     , walletId
     )
 import Test.Integration.Framework.TestData
@@ -71,7 +70,7 @@ spec = do
         json <- expectValidJSON (Proxy @[ApiAddress n]) out
         length json `shouldBe` g
         forM_ [0..(g-1)] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused json
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused json
 
     it "ADDRESS_LIST_01 - Can list addresses - non-default poolGap" $ \ctx -> do
         let addrPoolGap = 60
@@ -83,7 +82,7 @@ spec = do
         json <- expectValidJSON (Proxy @[ApiAddress n]) out
         length json `shouldBe` addrPoolGap
         forM_ [0..59] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused json
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused json
 
     it "ADDRESS_LIST_02 - Can filter used and unused addresses" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
@@ -95,7 +94,7 @@ spec = do
         j1 <- expectValidJSON (Proxy @[ApiAddress n]) o1
         length j1 `shouldBe` 10
         forM_ [0..9] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Used j1
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Used j1
         (Exit c2, Stdout o2, Stderr e2)
             <- listAddressesViaCLI @t ctx ["--state", "unused", walId]
         e2 `shouldBe` "Ok.\n"
@@ -103,7 +102,7 @@ spec = do
         j2 <- expectValidJSON (Proxy @[ApiAddress n]) o2
         length j2 `shouldBe` g
         forM_ [0..(g-10)] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused j2
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused j2
 
     it "ADDRESS_LIST_02 - Shows nothing when there are no used addresses"
         $ \ctx -> do
@@ -122,7 +121,7 @@ spec = do
         j2 <- expectValidJSON (Proxy @[ApiAddress n]) o2
         length j2 `shouldBe` 20
         forM_ [0..19] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused j2
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused j2
 
     describe "ADDRESS_LIST_02 - Invalid filters show error message" $ do
         let filters =
@@ -159,7 +158,7 @@ spec = do
         j <- expectValidJSON (Proxy @[ApiAddress n]) o
         length j `shouldBe` initPoolGap
         forM_ [0..initPoolGap - 1] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused j
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused j
 
         -- run 10 transactions to make all addresses `Used`
         forM_ [0..initPoolGap - 1] $ \addrNum -> do
@@ -178,9 +177,9 @@ spec = do
         j1 <- expectValidJSON (Proxy @[ApiAddress n]) o1
         length j1 `shouldBe` 2*initPoolGap
         forM_ [0..initPoolGap - 1] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Used j1
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Used j1
         forM_ [initPoolGap..2*initPoolGap - 1] $ \addrNum -> do
-            expectCliListItemFieldEqual addrNum state Unused j1
+            expectCliListItemFieldEqual addrNum (#state . #getApiT) Unused j1
 
     describe "ADDRESS_LIST_04 - False wallet ids" $ do
         forM_ falseWalletIds $ \(title, walId) -> it title $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
@@ -24,6 +24,8 @@ import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text
     ( Text )
 import System.Command
@@ -37,7 +39,6 @@ import Test.Hspec.Expectations.Lifted
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand
-    , balanceAvailable
     , deleteWalletViaCLI
     , emptyRandomWallet
     , emptyWallet
@@ -168,7 +169,8 @@ spec = do
             cTx `shouldBe` ExitSuccess
 
         -- make sure all transactions are in ledger
-        expectEventually' ctx (Link.getWallet @'Shelley) balanceAvailable 10 wDest
+        expectEventually' ctx (Link.getWallet @'Shelley)
+                (#balance . #getApiT . #available) (Quantity 10) wDest
 
         -- verify new address_pool_gap has been created
         (Exit c1, Stdout o1, Stderr e1) <- listAddressesViaCLI @t ctx [widDest]

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -75,7 +75,6 @@ import Test.Integration.Framework.DSL
     , listWalletsViaCLI
     , passphraseLastUpdate
     , postTransactionViaCLI
-    , state
     , updateWalletNameViaCLI
     , updateWalletPassphraseViaCLI
     , verify
@@ -173,7 +172,8 @@ spec = do
             , expectCliFieldEqual balanceAvailable 0
             , expectCliFieldEqual balanceTotal 0
             , expectCliFieldEqual balanceReward 0
-            , expectEventually' ctx (Link.getWallet @'Shelley) state Ready
+            , expectEventually' ctx (Link.getWallet @'Shelley)
+                    (#state . #getApiT) Ready
             , expectCliFieldEqual delegation (NotDelegating)
             , expectCliFieldNotEqual passphraseLastUpdate Nothing
             ]
@@ -219,7 +219,8 @@ spec = do
         T.unpack e2 `shouldContain` cmdOk
         wRestored <- expectValidJSON (Proxy @ApiWallet) o2
         verify wRestored
-            [ expectEventually' ctx (Link.getWallet @'Shelley) state Ready
+            [ expectEventually' ctx (Link.getWallet @'Shelley)
+                    (#state . #getApiT) Ready
             , expectCliFieldEqual walletId (wDest ^. walletId)
             ]
 
@@ -414,7 +415,8 @@ spec = do
             , expectCliFieldEqual balanceAvailable 0
             , expectCliFieldEqual balanceTotal 0
             , expectCliFieldEqual balanceReward 0
-            , expectEventually' ctx (Link.getWallet @'Shelley) state Ready
+            , expectEventually' ctx (Link.getWallet @'Shelley)
+                    (#state . #getApiT) Ready
             , expectCliFieldEqual delegation (NotDelegating)
             , expectCliFieldNotEqual passphraseLastUpdate Nothing
             ]

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -105,7 +105,6 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
-    , balanceAvailable
     , expectEventually
     , expectResponseCode
     , expectSuccess
@@ -222,7 +221,8 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         rWal1 <- request @ApiWallet ctx (Link.getWallet @'Shelley wDest) Default Empty
         verify rWal1
             [ expectSuccess
-            , expectEventually ctx (Link.getWallet @'Shelley) balanceAvailable amtExp
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#balance . #getApiT . #available . #getQuantity) amtExp
             ]
 
         rDel <- request @ApiWallet ctx (Link.deleteWallet @'Shelley wSrc) Default Empty
@@ -256,7 +256,9 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         rWal1 <- request @ApiWallet ctx (Link.getWallet @'Shelley wDest) Default Empty
         verify rWal1
             [ expectSuccess
-            , expectEventually ctx (Link.getWallet @'Shelley) balanceAvailable (fromIntegral amtExp)
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#balance . #getApiT . #available . #getQuantity)
+                    (fromIntegral amtExp)
             ]
 
         rStat <- request @ApiUtxoStatistics ctx (Link.getUTxOsStatistics wDest) Default Empty

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -21,7 +21,10 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant (..) )
+    ( NetworkDiscriminant (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    )
 import Cardano.Wallet.Primitive.Types
     ( Direction (..), PoolId (..), TxStatus (..), WalletDelegation (..) )
 import Control.Monad
@@ -34,6 +37,8 @@ import Data.List
     ( find )
 import Data.Maybe
     ( isJust, isNothing )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
@@ -98,8 +103,6 @@ import Test.Integration.Framework.TestData
     , errMsg415
     , falseWalletIds
     , getHeaderCases
-    , passphraseMaxLength
-    , passphraseMinLength
     )
 import Test.Integration.Jormungandr.Fixture
     ( OwnerIdentity (..), registerStakePool )
@@ -544,8 +547,8 @@ spec = do
     describe "STAKE_POOLS_JOIN/QUIT_02 -\
         \ Passphrase must have appropriate length" $ do
 
-        let pMax = passphraseMaxLength
-        let pMin = passphraseMinLength
+        let pMax = passphraseMaxLength (Proxy @"encryption")
+        let pMin = passphraseMinLength (Proxy @"encryption")
         let tooShort =
                 "passphrase is too short: expected at least 10 characters"
         let tooLong =

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -49,9 +49,6 @@ import Test.Integration.Framework.DSL
     , TxDescription (..)
     , amount
     , apparentPerformance
-    , balanceAvailable
-    , balanceReward
-    , balanceTotal
     , blocks
     , delegation
     , delegationFee
@@ -294,7 +291,7 @@ spec = do
         -- Wait for money to flow
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldSatisfy balanceReward (> 0)
+                [ expectFieldSatisfy (#balance . #getApiT . #reward) (> (Quantity 0))
                 ]
 
         -- Quit a pool
@@ -314,12 +311,14 @@ spec = do
 
         waitForNextEpoch ctx
         waitForNextEpoch ctx
-        reward <- getFromResponse balanceReward <$>
+        reward <- getFromResponse (#balance . #getApiT . #reward) <$>
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
 
         waitForNextEpoch ctx
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldSatisfy balanceReward (== reward)
+            [ expectFieldSatisfy
+                    (#balance . #getApiT . #reward)
+                    (== reward)
             ]
 
     it "STAKE_POOLS_JOIN_04 -\
@@ -341,15 +340,19 @@ spec = do
         reward <- eventually $ do
             r <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
             verify r
-                [ expectFieldSatisfy balanceReward (> 0)
+                [ expectFieldSatisfy
+                        (#balance . #getApiT . #reward)
+                        (> (Quantity 0))
                 ]
-            pure $ getFromResponse balanceReward r
+            pure $ getFromResponse (#balance . #getApiT . #reward) r
 
         waitForNextEpoch ctx
 
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldSatisfy balanceReward (== reward)
+                [ expectFieldSatisfy
+                        (#balance . #getApiT . #reward)
+                        (== reward)
                 ]
 
     it "STAKE_POOLS_JOIN_01 - I can join another stake-pool after previously \
@@ -439,8 +442,8 @@ spec = do
                 request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
                     [ expectFieldEqual delegation (NotDelegating)
                     -- balance is 0 because the rest was used for fees
-                    , expectFieldEqual balanceTotal 0
-                    , expectFieldEqual balanceAvailable 0
+                    , expectFieldEqual (#balance . #getApiT . #total) (Quantity 0)
+                    , expectFieldEqual (#balance . #getApiT . #available) (Quantity 0)
                     ]
 
         it "STAKE_POOLS_QUIT_01x - \

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -77,8 +77,6 @@ import Test.Integration.Framework.DSL as DSL
     , Payload (..)
     , TxDescription (..)
     , amount
-    , balanceAvailable
-    , balanceTotal
     , direction
     , emptyRandomWallet
     , emptyWallet
@@ -202,8 +200,10 @@ spec = do
                 Default
                 Empty
                 >>= flip verify
-                [ expectFieldEqual balanceAvailable utxoAmt
-                , expectFieldEqual balanceTotal utxoAmt
+                [ expectFieldEqual
+                        (#balance . #getApiT . #available) (Quantity utxoAmt)
+                , expectFieldEqual
+                        (#balance . #getApiT . #total) (Quantity utxoAmt)
                 ]
 
     it "TRANS_ESTIMATE_09 - \
@@ -236,8 +236,10 @@ spec = do
         request @ApiTxId ctx Link.postExternalTransaction headers (NonJson payload)
             >>= expectResponseCode HTTP.status202
 
-        expectEventually' ctx (Link.getWallet @'Shelley) balanceAvailable amt w
-        expectEventually' ctx (Link.getWallet @'Shelley) balanceTotal amt w
+        expectEventually' ctx (Link.getWallet @'Shelley)
+                (#balance . #getApiT . #available) (Quantity amt) w
+        expectEventually' ctx (Link.getWallet @'Shelley)
+                (#balance . #getApiT . #total) (Quantity amt) w
 
     describe "TRANS_DELETE_05 - Cannot forget external tx -> 404" $ do
         let txDeleteTest05
@@ -267,8 +269,10 @@ spec = do
                 expectErrorMessage (errMsg404CannotFindTx txid) ra
 
                 -- tx eventually gets into ledger (funds are on the target wallet)
-                expectEventually' ctx (Link.getWallet @'Shelley) balanceAvailable amt wal
-                expectEventually' ctx (Link.getWallet @'Shelley) balanceTotal amt wal
+                expectEventually' ctx (Link.getWallet @'Shelley)
+                        (#balance . #getApiT . #available) (Quantity amt) wal
+                expectEventually' ctx (Link.getWallet @'Shelley)
+                        (#balance . #getApiT . #total) (Quantity amt) wal
 
 
         txDeleteTest05 "wallets" emptyWallet
@@ -295,12 +299,18 @@ spec = do
         rb <- request @ApiWallet ctx (Link.getWallet @'Shelley wDest) Default Empty
         verify rb
             [ expectSuccess
-            , expectEventually ctx (Link.getWallet @'Shelley) balanceTotal (initTotal + toSend)
-            , expectEventually ctx (Link.getWallet @'Shelley) balanceAvailable (initAvailable + toSend)
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#balance . #getApiT . #total . #getQuantity)
+                    (initTotal + toSend)
+            , expectEventually ctx (Link.getWallet @'Shelley)
+                    (#balance . #getApiT . #available . #getQuantity)
+                    (initAvailable + toSend)
             ]
         ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
         verify ra
-            [ expectEventually ctx (Link.getWallet @'Shelley) balanceAvailable (faucetAmt - fee - toSend)
+            [ expectEventually ctx (Link.getWallet @'Shelley)
+                    (#balance . #getApiT . #available . #getQuantity)
+                    (faucetAmt - fee - toSend)
             ]
 
     it "TRANS_EXTERNAL_CREATE_02 - proper single output transaction and \
@@ -542,6 +552,8 @@ fixtureExternalTx ctx toSend = do
 getWalletBalance :: Context t -> ApiWallet -> IO (Natural, Natural)
 getWalletBalance ctx w = do
     r <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
-    let total = getFromResponse balanceTotal r
-    let available = getFromResponse balanceAvailable r
+    let total =
+            getFromResponse (#balance . #getApiT . #total . #getQuantity) r
+    let available =
+            getFromResponse (#balance . #getApiT . #available . #getQuantity) r
     return (total, available)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -100,7 +100,6 @@ import Test.Integration.Framework.DSL as DSL
     , listAddresses
     , listAllTransactions
     , request
-    , state
     , status
     , verify
     , walletId
@@ -490,7 +489,7 @@ fixtureExternalTx ctx toSend = do
     r1 <- request @ApiWallet ctx ("POST", "v2/wallets") Default createWallet
     verify r1
         [ expectFieldEqual walletName "Destination Wallet"
-        , expectEventually ctx (Link.getWallet @'Shelley) state Ready
+        , expectEventually ctx (Link.getWallet @'Shelley) (#state . #getApiT) Ready
         ]
     let wDest = getFromResponse Prelude.id r1
     addrsDest <- listAddresses ctx wDest

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
@@ -58,7 +59,6 @@ import Test.Integration.Framework.DSL
     , expectValidJSON
     , generateMnemonicsViaCLI
     , proc'
-    , state
     , waitForServer
     )
 import Test.Utils.Paths
@@ -210,7 +210,8 @@ spec = do
                 TIO.hGetContents e >>= TIO.putStrLn
             withCreateProcess process $ \_ (Just o) (Just e) ph -> do
                 waitForServer @t ctx
-                expectEventually' ctx (Link.getWallet @'Shelley) state Ready wallet
+                expectEventually' ctx (Link.getWallet @'Shelley)
+                        (#state . #getApiT) Ready wallet
               `finally` do
                 terminateProcess ph
                 TIO.hGetContents o >>= TIO.putStrLn


### PR DESCRIPTION
# Issue Number

#1237

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- b43b949ffa63acf4e7f8a7d88da0d7df92dc1844
  Remove addressPoolGap lens
  
- 24d318ca75b8eccf732f1b0bfbbf01fde4944e92
  Remove state lens
  
- 446f7812916ca96380fb7f4946a4a057e6f7b634
  Remove balance lenses:  - byronBalanceAvailable  - balanceAvailable  - byronBalanceTotal  - balanceTotal  - balanceReward
  
- 9d2e67981eeb63698dc69994c758013601e8802f
  get rid of duplicate magic constants
  - addressPoolGapMin
  - addressPoolGapMax
  - passphraseMinLength
  - passphraseMaxLength

Also got rid of an extra print statement that slipped through

# Comments


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
