### PR TITLE
Revision on the apparent performance

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -103,6 +103,7 @@ library
       Cardano.Pool.DB.Sqlite.TH
       Cardano.Pool.Metrics
       Cardano.Pool.Metadata
+      Cardano.Pool.Performance
       Cardano.Pool.Ranking
       Cardano.Wallet
       Cardano.Wallet.Api
@@ -234,6 +235,7 @@ test-suite unit
       Cardano.Pool.DB.SqliteSpec
       Cardano.Pool.MetadataSpec
       Cardano.Pool.MetricsSpec
+      Cardano.Pool.PerformanceSpec
       Cardano.Pool.RankingSpec
       Cardano.Wallet.Api.ServerSpec
       Cardano.Wallet.Api.TypesSpec

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -32,7 +32,6 @@ module Cardano.Pool.Metrics
       -- * Combining Metrics
     , ErrMetricsInconsistency (..)
     , combineMetrics
-    , calculatePerformance
 
       -- * Associating metadata
     , associateMetadata
@@ -57,6 +56,8 @@ import Cardano.Pool.Metadata
     , getStakePoolMetadata
     , sameStakePoolMetadata
     )
+import Cardano.Pool.Performance
+    ( count, readPoolsPerformances )
 import Cardano.Wallet.Network
     ( ErrNetworkTip
     , ErrNetworkUnavailable
@@ -67,20 +68,16 @@ import Cardano.Wallet.Network
     , staticBlockchainParameters
     )
 import Cardano.Wallet.Primitive.Types
-    ( ActiveSlotCoefficient (..)
-    , BlockHeader (..)
-    , EpochLength (..)
+    ( BlockHeader (..)
     , EpochNo (..)
-    , PoolId (..)
+    , PoolId
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
-    , SlotId (..)
-    , SlotNo (unSlotNo)
     )
 import Control.Arrow
     ( first )
 import Control.Monad
-    ( forM, forM_, when )
+    ( forM_, when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Class
@@ -94,11 +91,11 @@ import Data.Functor
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.List
-    ( foldl', nub, nubBy, sortOn, (\\) )
+    ( nub, nubBy, sortOn, (\\) )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Merge.Strict
-    ( dropMissing, traverseMissing, zipWithMatched )
+    ( traverseMissing, zipWithMatched )
 import Data.Map.Strict
     ( Map )
 import Data.Ord
@@ -382,92 +379,6 @@ readNewcomers DBLayer{..} elders avg = do
         (pids \\ elders)
         (repeat (Quantity 0, Quantity 0, avg))
 
-readPoolsPerformances
-    :: DBLayer m
-    -> ActiveSlotCoefficient
-    -> EpochLength
-    -> SlotId
-    -> m (Map PoolId Double)
-readPoolsPerformances DBLayer{..} activeSlotCoeff (EpochLength el) tip = do
-    atomically $ fmap avg $ forM historicalEpochs $ \ep -> calculatePerformance
-        activeSlotCoeff
-        (slotsInEpoch ep)
-        <$> (Map.fromList <$> readStakeDistribution ep)
-        <*> (count <$> readPoolProduction ep)
-  where
-    currentEpoch = tip ^. #epochNumber
-
-    historicalEpochs :: [EpochNo]
-    historicalEpochs
-        | currentEpoch > window = [currentEpoch - window .. currentEpoch]
-        | otherwise             = [0..currentEpoch]
-      where
-        window = 14
-
-    slotsInEpoch :: EpochNo -> Int
-    slotsInEpoch e =
-        if e == currentEpoch
-        then fromIntegral $ unSlotNo $ tip ^. #slotNumber
-        else fromIntegral el
-
-    -- | Performances are computed over many epochs to cope with the fact that
-    -- our data is sparse (regarding stake distribution at least).
-    --
-    -- So the approach is the following:
-    --
-    -- 1. Compute performances, if available, for the last `n` epochs
-    -- 2. Compute the average performance for all epochs for which we had data
-    avg :: [Map PoolId Double] -> Map PoolId Double
-    avg performances =
-        Map.map (/ len) . Map.unionsWith (+) $ performances
-      where
-        len = fromIntegral $ length $ filter (not . Map.null) performances
-
--- | Calculate pool apparent performance over the given data. The performance
--- is a 'Double' between 0 and 1 as:
---
--- @
---     p = n / (f * N) * S / s
---   where
---     n = number of blocks produced in an epoch e
---     N = number of slots in e
---     f = active slot coeff, i.e. % of slots for which a leader can be elected.
---     s = stake owned by the pool in e
---     S = total stake delegated to pools in e
--- @
---
--- Note that, this apparent performance is clamped to [0,1] as it may in
--- practice, be greater than 1 if a stake pool produces more than it is
--- expected.
-calculatePerformance
-    :: ActiveSlotCoefficient
-    -> Int
-    -> Map PoolId (Quantity "lovelace" Word64)
-    -> Map PoolId (Quantity "block" Word64)
-    -> Map PoolId Double
-calculatePerformance (ActiveSlotCoefficient f) nTotal mStake mProd =
-    let
-        stakeButNotProd = traverseMissing $ \_ _ -> 0
-        prodButNoStake  = dropMissing
-        stakeAndProd sTotal = zipWithMatched $ \_ s n ->
-            if (nTotal == 0 || s == Quantity 0) then
-                0
-            else
-                min 1 ((double n / (f * fromIntegral nTotal)) * (sTotal / double s))
-    in
-        Map.merge
-            stakeButNotProd
-            prodButNoStake
-            (stakeAndProd (sumQ mStake))
-            mStake
-            mProd
-  where
-    double :: Integral a => Quantity any a -> Double
-    double (Quantity a) = fromIntegral a
-
-    sumQ :: Integral a => Map k (Quantity any a) -> Double
-    sumQ = fromIntegral . foldl' (\y (Quantity x) -> (y + x)) 0 . Map.elems
-
 -- | Combines three different sources of data into one:
 --
 -- 1. A stake-distribution map
@@ -551,10 +462,6 @@ zipWithRightDefault combine onMissing rZero =
     leftButNotRight = traverseMissing $ \_k l -> pure (combine l rZero)
     rightButNotLeft = traverseMissing $ \k _r -> Left (onMissing k)
     bothPresent     = zipWithMatched  $ \_k l r -> (combine l r)
-
--- | Count elements inside a 'Map'
-count :: Map k [a] -> Map k (Quantity any Word64)
-count = Map.map (Quantity . fromIntegral . length)
 
 -- | Given a mapping from 'PoolId' -> 'PoolOwner' and a mapping between
 -- 'PoolOwner' <-> 'StakePoolMetadata', return a matching 'StakePoolMeta' entry

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -282,8 +282,8 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
             combineWith (sortArbitrarily seed) distr (count prod) mempty
 
         else do
-            let sl = prodTip ^. #slotId
-            perfs <- liftIO $ readPoolsPerformances db activeSlotCoeff epochLength sl
+            let currentEpoch = prodTip ^. #slotId . #epochNumber
+            perfs <- liftIO $ readPoolsPerformances db currentEpoch
             combineWith (pure . sortByPerformance) distr (count prod) perfs
 
     readPoolProductionTip = readPoolProductionCursor 1 <&> \case
@@ -308,9 +308,7 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
                 mapM_ (traceWith tr . fst) res
                 pure $ map snd res
 
-    (block0, bp) = staticBlockchainParameters nl
-    epochLength = bp ^. #getEpochLength
-    activeSlotCoeff = bp ^. #getActiveSlotCoefficient
+    (block0, _) = staticBlockchainParameters nl
 
     combineWith
         :: ([(StakePool, [PoolOwner])] -> IO [(StakePool, [PoolOwner])])

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -135,7 +135,7 @@ data StakePool = StakePool
     { poolId :: PoolId
     , stake :: Quantity "lovelace" Word64
     , production :: Quantity "block" Word64
-    , apparentPerformance :: Double
+    , performance :: Double
     , cost :: Quantity "lovelace" Word64
     , margin :: Percentage
     } deriving (Show, Generic)
@@ -332,7 +332,7 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
                     Map.traverseMaybeWithKey mergeRegistration (ps <> ns)
                 sortResults $ Map.elems pools
       where
-        mergeRegistration poolId (stake, production, apparentPerformance) =
+        mergeRegistration poolId (stake, production, performance) =
             fmap mkStakePool <$> readPoolRegistration poolId
           where
             mkStakePool PoolRegistrationCertificate{poolCost,poolMargin,poolOwners} =
@@ -340,7 +340,7 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
                     { poolId
                     , stake
                     , production
-                    , apparentPerformance
+                    , performance
                     , cost = poolCost
                     , margin = poolMargin
                     }
@@ -348,7 +348,7 @@ newStakePoolLayer tr db@DBLayer{..} nl metadataDir = StakePoolLayer
                 )
 
     sortByPerformance :: [(StakePool, a)] -> [(StakePool, a)]
-    sortByPerformance = sortOn (Down . apparentPerformance . fst)
+    sortByPerformance = sortOn (Down . performance . fst)
 
     sortArbitrarily :: StdGen -> [a] -> IO [a]
     sortArbitrarily = shuffleWith

--- a/lib/core/src/Cardano/Pool/Performance.hs
+++ b/lib/core/src/Cardano/Pool/Performance.hs
@@ -1,0 +1,198 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- This module defines necessary bits to compute an averaged apparent
+-- performance for stake pools. The definition is inspired from the "Design
+-- Specification for Delegation and Incentives in Cardano" by Kant et Al, yet
+-- deviates slightly from it because of different real constraints:
+--
+--     a) The wallet software doesn't have a reliable access to various epoch
+--     details such as the stake distribution for past epochs.
+--
+--     b) The wallet software makes therefore a significant use of the current
+--     epoch's data which represents unfinished snapshots of epochs which, because
+--     of their non-deterministic nature, may favor leaders elected early in the
+--     process more than those not yet elected.
+--
+-- To cope with these two issues, we try to harmonize past known epochs with the
+-- ongoing one by averaging over a whole range of epochs, simultaneously. This
+-- means computing a ratio of the total blocks produced by a leader on the total
+-- number of blocks we could reasonably expect a leader to have produced, across
+-- many epochs at once (i.e., doing a ratio of sums, instead of a sum of
+-- ratios).
+--
+-- This should be less punitive for leaders that have not yet been elected as
+-- part of the ongoing epoch while having still performed reasonably okay in the
+-- past.
+module Cardano.Pool.Performance
+    ( EpochStats (..)
+    , apparentPerformance
+    , readPoolsPerformances
+
+    -- * Helpers
+    , count
+    ) where
+
+
+import Prelude
+
+import Cardano.Pool.DB
+    ( DBLayer (..) )
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient (..)
+    , EpochLength (..)
+    , EpochNo (..)
+    , PoolId
+    , SlotId (..)
+    , SlotNo (..)
+    )
+import Control.Monad
+    ( forM )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Map.Merge.Strict
+    ( dropMissing, traverseMissing, zipWithMatched )
+import Data.Map.Strict
+    ( Map )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Word
+    ( Word64 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Data.Map.Merge.Strict as Map
+import qualified Data.Map.Strict as Map
+
+data EpochStats = EpochStats
+    { poolProduction :: !Natural
+    , poolStake :: !Natural
+    , totalStake :: !Natural
+    , epochHeight :: !Natural
+    } deriving (Generic, Show)
+
+-- We consider the following variables, indexed by a given epoch
+--
+-- - n(e) = number of blocks produced in an epoch e
+-- - N(e) = number of slots in e
+-- - s(e) = stake owned by the pool in e
+-- - S(e) = total stake delegated to pools in e
+-- - ε(e) = active slot coeff, i.e. % of slots for which a leader can be elected
+--
+-- From this, we define `μ` as the _reasonably expectable block production_:
+--
+--     μ(e) =
+--       ε(e) * N(e) * s(e) / S(e)
+--
+-- Intuitively, @μ@ corresponds to the number of blocks a particular pool should
+-- have produced provided the election was exactly proportional to its relative
+-- stake.
+--
+-- This gives us the apparent performance @p@ across many epochs as:
+--
+--          i
+--          Σ n(i)
+--     p =  -----
+--          i
+--          Σ μ(i)
+apparentPerformance
+    :: Double
+        -- ^ ε, considered constant across epochs
+    -> [EpochStats]
+        -- ^ Epoch statistics, for a given pool
+    -> Double
+        -- ^ Average performance
+apparentPerformance _     [] = 0
+apparentPerformance ε epochs =
+    sum (n <$> epochs) / sum (μ <$> epochs)
+  where
+    n = double . poolProduction
+    μ e = ε * _N * s / _S
+      where
+        _N = double (epochHeight e)
+        _S = double (totalStake e)
+        s  = double (poolStake e)
+
+-- | Read pool performances of many epochs from the database
+readPoolsPerformances
+    :: Monad m
+    => DBLayer m
+    -> ActiveSlotCoefficient
+    -> EpochLength
+    -> SlotId
+    -> m (Map PoolId Double)
+readPoolsPerformances DBLayer{..} (ActiveSlotCoefficient ε) epLen tip = do
+    stats <- atomically $ forM historicalEpochs $ \ep -> mkEpochStats
+        <$> (count <$> readPoolProduction ep)
+        <*> (Map.fromList <$> readStakeDistribution ep)
+        <*> pure (slotsInEpoch ep)
+    pure $ apparentPerformance ε <$> Map.unionsWith (<>) stats
+  where
+    mkEpochStats
+        :: Map PoolId (Quantity "block" Word64)
+        -> Map PoolId (Quantity "lovelace" Word64)
+        -> Natural
+        -> Map PoolId [EpochStats]
+    mkEpochStats mProduction mStake epHeight =
+        let
+            productionButNoStake =
+                dropMissing
+            stakeButNoProduction =
+                traverseMissing (\_ s -> pure [mkEpochStats_ (Quantity 0) s])
+            stakeAndProduction =
+                zipWithMatched (\_ p s -> [mkEpochStats_ p s])
+        in Map.merge
+            productionButNoStake
+            stakeButNoProduction
+            stakeAndProduction
+            mProduction
+            mStake
+      where
+        epTotalStake = sumQ mStake
+
+        mkEpochStats_
+            :: Quantity "block" Word64
+            -> Quantity "lovelace" Word64
+            -> EpochStats
+        mkEpochStats_ (Quantity epProduction) (Quantity epStake) = EpochStats
+            { poolProduction = fromIntegral epProduction
+            , poolStake = fromIntegral epStake
+            , totalStake = epTotalStake
+            , epochHeight = epHeight
+            }
+
+    sumQ :: Integral a => Map k (Quantity "lovelace" a) -> Natural
+    sumQ = fromIntegral . Map.foldl' (\a (Quantity b) -> a + b) 0
+
+    historicalEpochs :: [EpochNo]
+    historicalEpochs
+        | currentEpoch > window = [currentEpoch - window .. currentEpoch]
+        | otherwise             = [0..currentEpoch]
+      where
+        window = 14
+        currentEpoch = tip ^. #epochNumber
+
+    slotsInEpoch :: EpochNo -> Natural
+    slotsInEpoch e =
+        if e == tip ^. #epochNumber
+        then fromIntegral $ unSlotNo $ tip ^. #slotNumber
+        else fromIntegral $ unEpochLength epLen
+
+--------------------------------------------------------------------------------
+-- Internals / Helpers
+--------------------------------------------------------------------------------
+
+-- | Count elements inside a 'Map'
+count :: Map k [a] -> Map k (Quantity any Word64)
+count = Map.map (Quantity . fromIntegral . length)
+
+double :: Integral a => a -> Double
+double = fromIntegral

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1104,7 +1104,7 @@ listPools spl =
             (ApiStakePoolMetrics
                 (Quantity $ fromIntegral $ getQuantity $ stake sp)
                 (Quantity $ fromIntegral $ getQuantity $ production sp))
-            (sp ^. #apparentPerformance)
+            (sp ^. #performance)
             meta
             (fromIntegral <$> sp ^. #cost)
             (Quantity $ sp ^. #margin)

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -33,7 +33,6 @@ import Cardano.Pool.Metrics
     , StakePoolLayer (..)
     , StakePoolLog (..)
     , associateMetadata
-    , calculatePerformance
     , combineMetrics
     , monitorStakePools
     , newStakePoolLayer
@@ -78,8 +77,6 @@ import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Control.Monad.Trans.State.Strict
     ( StateT, evalStateT, get, modify' )
-import Data.Function
-    ( (&) )
 import Data.Functor
     ( ($>) )
 import Data.Map.Strict
@@ -137,13 +134,6 @@ spec = do
             $ checkCoverage
             $ property prop_combineIsLeftBiased
 
-    describe "calculatePerformances" $ do
-        it "performances are always between 0 and 1"
-            $ property prop_performancesBounded01
-
-        describe "golden test cases" $ do
-            performanceGoldens
-
     describe "monitorStakePools" $ do
         it "records all stake pool registrations in the database"
             $ property prop_trackRegistrations
@@ -191,69 +181,6 @@ prop_combineIsLeftBiased mStake_ mProd_ mPerf_ =
     mProd  = Map.mapKeys getLowEntropy mProd_
     mPerf  = Map.mapKeys getLowEntropy mPerf_
 {-# HLINT ignore prop_combineIsLeftBiased "Use ||" #-}
-
--- | Performances are always positive numbers
-prop_performancesBounded01
-    :: ActiveSlotCoefficient
-    -> Map (LowEntropy PoolId) (Quantity "lovelace" Word64)
-    -> Map (LowEntropy PoolId) (Quantity "block" Word64)
-    -> (NonNegative Int)
-    -> Property
-prop_performancesBounded01 coeff mStake_ mProd_ (NonNegative emptySlots) =
-    all (between 0 1) performances
-    & counterexample (show performances)
-    & classify (all (== 0) performances) "all null"
-  where
-    mStake = Map.mapKeys getLowEntropy mStake_
-    mProd  = Map.mapKeys getLowEntropy mProd_
-
-    performances :: [Double]
-    performances = Map.elems $ calculatePerformance coeff slots mStake mProd
-
-    slots :: Int
-    slots = emptySlots +
-        fromIntegral (Map.foldl (\y (Quantity x) -> (y + x)) 0 mProd)
-
-    between :: Ord a => a -> a -> a -> Bool
-    between inf sup x = x >= inf && x <= sup
-
-
-performanceGoldens :: Spec
-performanceGoldens = do
-    it "50% stake, coeff=1.0, producing 8/8 blocks => p=1.0" $ do
-        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production   = mkProduction [ (poolA, 8), (poolB, 0) ]
-        let performances = calculatePerformance 1.0 8 stake production
-        Map.lookup poolA performances `shouldBe` (Just 1)
-
-    it "50% stake, coeff=1.0, producing 4/8 blocks => p=1.0" $ do
-        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production   = mkProduction [ (poolA, 4), (poolB, 0) ]
-        let performances = calculatePerformance 1.0 8 stake production
-        Map.lookup poolA performances `shouldBe` (Just 1)
-
-    it "50% stake, coeff=1.0, producing 2/8 blocks => p=0.5" $ do
-        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production   = mkProduction [ (poolA, 2), (poolB, 0) ]
-        let performances = calculatePerformance 1.0 8 stake production
-        Map.lookup poolA performances `shouldBe` (Just 0.5)
-
-    it "50% stake, coeff=1.0, producing 0/8 blocks => p=0.0" $ do
-        let stake        = mkStake      [ (poolA, 1), (poolB, 1) ]
-        let production   = mkProduction [ (poolA, 0), (poolB, 0) ]
-        let performances = calculatePerformance 1.0 8 stake production
-        Map.lookup poolA performances `shouldBe` (Just 0)
-
-    it "100% stake, coeff=0.1, producing 1/10 blocks => p=1.0" $ do
-        let stake        = mkStake      [ (poolA, 1), (poolB, 0) ]
-        let production   = mkProduction [ (poolA, 1), (poolB, 0) ]
-        let performances = calculatePerformance 0.1 10 stake production
-        Map.lookup poolA performances `shouldBe` (Just 1.0)
-  where
-    poolA = PoolId "athena"
-    poolB = PoolId "nemesis"
-    mkStake = Map.map Quantity . Map.fromList
-    mkProduction = Map.map Quantity . Map.fromList
 
 -- | A list of chunks of blocks to be served up by the mock network layer.
 newtype RegistrationsTest = RegistrationsTest

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -97,12 +97,10 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , NonEmptyList (..)
-    , NonNegative (..)
     , Positive (..)
     , Property
     , checkCoverage
     , choose
-    , classify
     , counterexample
     , cover
     , elements

--- a/lib/core/test/unit/Cardano/Pool/PerformanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/PerformanceSpec.hs
@@ -10,15 +10,12 @@ import Prelude
 
 import Cardano.Pool.Performance
     ( EpochStats (..), apparentPerformance )
-import Cardano.Wallet.Primitive.Types
-    ( ActiveSlotCoefficient (..) )
 import Data.Function
     ( (&) )
 import Test.Hspec
     ( Spec, describe, it, shouldBe )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Gen
     , NonEmptyList (..)
     , Property
     , choose
@@ -50,17 +47,16 @@ spec = do
 
 -- | Performances are always positive numbers
 prop_performancesNonNegative
-    :: ActiveSlotCoefficient
-    -> [EpochStats]
+    :: [EpochStats]
     -> Property
-prop_performancesNonNegative (ActiveSlotCoefficient ε) stats =
+prop_performancesNonNegative stats =
     property (p >= 0.0)
     & counterexample ("p = " <> show p)
     & classify (p == 0)  ("p == 0")
     & classify (p >= 1)  ("p >= 1")
     & classify (p >= 10) ("p >= 10")
   where
-    p = apparentPerformance ε stats
+    p = apparentPerformance stats
 
 data EffectOnPerformance
     = PositiveEffect
@@ -71,11 +67,10 @@ data EffectOnPerformance
 prop_effectOnPerformance
     :: [EffectOnPerformance]
     -> (EpochStats -> EpochStats)
-    -> ActiveSlotCoefficient
     -> NonEmptyList EpochStats
     -> Property
 prop_effectOnPerformance
-  expectedEffects modifier (ActiveSlotCoefficient ε) (NonEmpty stats) =
+  expectedEffects modifier (NonEmpty stats) =
     property $ case pAfter `compare` pBefore of
         GT -> PositiveEffect `elem` expectedEffects
         LT -> NegativeEffect `elem` expectedEffects
@@ -83,74 +78,64 @@ prop_effectOnPerformance
     & counterexample ("pBefore = " <> show pBefore)
     & counterexample ("pAfter  = " <> show pAfter)
   where
-    pBefore = apparentPerformance ε stats
-    pAfter  = apparentPerformance ε (modifier <$> stats)
+    pBefore = apparentPerformance stats
+    pAfter  = apparentPerformance (modifier <$> stats)
 
 performanceGoldens :: Spec
 performanceGoldens = do
-    it "50% stake, ε=1.0, producing 8/8 blocks => p=2.0" $ do
-        flip shouldBe 2.0 $ apparentPerformance 1.0
+    it "50% stake, producing 8/8 blocks => p=2.0" $ do
+        flip shouldBe 2.0 $ apparentPerformance
             [ EpochStats
                 { poolProduction = 8
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 8
+                , totalProduction = 8
                 }
             ]
 
-    it "50% stake, ε=1.0, producing 4/8 blocks => p=1.0" $ do
-        flip shouldBe 1.0 $ apparentPerformance 1.0
+    it "50% stake, producing 4/8 blocks => p=1.0" $ do
+        flip shouldBe 1.0 $ apparentPerformance
             [ EpochStats
                 { poolProduction = 4
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 8
+                , totalProduction = 8
                 }
             ]
 
-    it "50% stake, ε=1.0, producing 2/8 blocks => p=0.5" $ do
-        flip shouldBe 0.5 $ apparentPerformance 1.0
+    it "50% stake, producing 2/8 blocks => p=0.5" $ do
+        flip shouldBe 0.5 $ apparentPerformance
             [ EpochStats
                 { poolProduction = 2
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 8
+                , totalProduction = 8
                 }
             ]
 
-    it "50% stake, ε=1.0, producing 0/8 blocks => p=0.0" $ do
-        flip shouldBe 0.0 $ apparentPerformance 1.0
+    it "50% stake, producing 0/8 blocks => p=0.0" $ do
+        flip shouldBe 0.0 $ apparentPerformance
             [ EpochStats
                 { poolProduction = 0
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 8
-                }
-            ]
-
-    it "100% stake, ε=0.1, producing 1/10 blocks => p=1.0" $ do
-        flip shouldBe 1.0 $ apparentPerformance 0.1
-            [ EpochStats
-                { poolProduction = 1
-                , poolStake = 100
-                , totalStake = 100
-                , epochHeight = 10
+                , totalProduction = 8
                 }
             ]
 
     it "50% + 1/8, 50% + 2/4 => p=0.5" $ do
-        flip shouldBe 0.5 $ apparentPerformance 1.0
+        flip shouldBe 0.5 $ apparentPerformance
             [ EpochStats
                 { poolProduction = 1
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 8
+                , totalProduction = 8
                 }
             , EpochStats
                 { poolProduction = 2
                 , poolStake = 50
                 , totalStake = 100
-                , epochHeight = 4
+                , totalProduction = 4
                 }
             ]
 
@@ -158,28 +143,16 @@ performanceGoldens = do
                                  Arbitrary
 -------------------------------------------------------------------------------}
 
-instance Arbitrary ActiveSlotCoefficient where
-    shrink (ActiveSlotCoefficient ε) =
-        ActiveSlotCoefficient <$> shrinkRatio ε
-    arbitrary =
-        ActiveSlotCoefficient <$> genRatio
-
 instance Arbitrary EpochStats where
     shrink _  = []
     arbitrary = do
-        height <- fromIntegral <$> choose @Int (0, 1000)
-        production <- fromIntegral <$> choose @Int (0, fromIntegral height)
-        total <- fromIntegral <$> choose @Int (1, 1000)
-        ratio <- genRatio
+        totalP <- fromIntegral <$> choose @Int (0, 1000)
+        production <- fromIntegral <$> choose @Int (0, fromIntegral totalP)
+        totalS <- fromIntegral <$> choose @Int (1, 1000)
+        ratio <- choose @Double (0.001, 1.0)
         pure EpochStats
             { poolProduction = production
-            , poolStake = ceiling (fromIntegral total * ratio)
-            , totalStake = total
-            , epochHeight = height
+            , totalProduction = totalP
+            , poolStake = ceiling (fromIntegral totalS * ratio)
+            , totalStake = totalS
             }
-
-genRatio :: Gen Double
-genRatio = choose (0.001, 1.0)
-
-shrinkRatio :: Double -> [Double]
-shrinkRatio ε = filter (\ε' -> ε' > 0.001 && ε' <= 1.0) (shrink ε)

--- a/lib/core/test/unit/Cardano/Pool/PerformanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/PerformanceSpec.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Pool.PerformanceSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Pool.Performance
+    ( EpochStats (..), apparentPerformance )
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient (..) )
+import Data.Function
+    ( (&) )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Property
+    , choose
+    , classify
+    , counterexample
+    , property
+    )
+
+spec :: Spec
+spec = do
+    describe "apparentPerformance" $ do
+        it "performances are non negative"
+            $ property prop_performancesNonNegative
+
+        describe "golden test cases" $ do
+            performanceGoldens
+
+-- | Performances are always positive numbers
+prop_performancesNonNegative
+    :: ActiveSlotCoefficient
+    -> [EpochStats]
+    -> Property
+prop_performancesNonNegative (ActiveSlotCoefficient ε) stats =
+    property (p >= 0.0)
+    & counterexample ("p = " <> show p)
+    & classify (p == 0)  ("p == 0")
+    & classify (p >= 1)  ("p >= 1")
+    & classify (p >= 10) ("p >= 10")
+  where
+    p = apparentPerformance ε stats
+
+performanceGoldens :: Spec
+performanceGoldens = do
+    it "50% stake, ε=1.0, producing 8/8 blocks => p=2.0" $ do
+        flip shouldBe 2.0 $ apparentPerformance 1.0
+            [ EpochStats
+                { poolProduction = 8
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 8
+                }
+            ]
+
+    it "50% stake, ε=1.0, producing 4/8 blocks => p=1.0" $ do
+        flip shouldBe 1.0 $ apparentPerformance 1.0
+            [ EpochStats
+                { poolProduction = 4
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 8
+                }
+            ]
+
+    it "50% stake, ε=1.0, producing 2/8 blocks => p=0.5" $ do
+        flip shouldBe 0.5 $ apparentPerformance 1.0
+            [ EpochStats
+                { poolProduction = 2
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 8
+                }
+            ]
+
+    it "50% stake, ε=1.0, producing 0/8 blocks => p=0.0" $ do
+        flip shouldBe 0.0 $ apparentPerformance 1.0
+            [ EpochStats
+                { poolProduction = 0
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 8
+                }
+            ]
+
+    it "100% stake, ε=0.1, producing 1/10 blocks => p=1.0" $ do
+        flip shouldBe 1.0 $ apparentPerformance 0.1
+            [ EpochStats
+                { poolProduction = 1
+                , poolStake = 100
+                , totalStake = 100
+                , epochHeight = 10
+                }
+            ]
+
+    it "50% + 1/8, 50% + 2/4 => p=0.5" $ do
+        flip shouldBe 0.5 $ apparentPerformance 1.0
+            [ EpochStats
+                { poolProduction = 1
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 8
+                }
+            , EpochStats
+                { poolProduction = 2
+                , poolStake = 50
+                , totalStake = 100
+                , epochHeight = 4
+                }
+            ]
+
+{-------------------------------------------------------------------------------
+                                 Arbitrary
+-------------------------------------------------------------------------------}
+
+instance Arbitrary ActiveSlotCoefficient where
+    shrink (ActiveSlotCoefficient ε) =
+        ActiveSlotCoefficient <$> shrinkRatio ε
+    arbitrary =
+        ActiveSlotCoefficient <$> genRatio
+
+instance Arbitrary EpochStats where
+    shrink _  = []
+    arbitrary = do
+        height <- fromIntegral <$> choose @Int (0, 1000)
+        production <- fromIntegral <$> choose @Int (0, fromIntegral height)
+        total <- fromIntegral <$> choose @Int (1, 1000)
+        ratio <- genRatio
+        pure EpochStats
+            { poolProduction = production
+            , poolStake = ceiling (fromIntegral total * ratio)
+            , totalStake = total
+            , epochHeight = height
+            }
+
+genRatio :: Gen Double
+genRatio = choose (0.001, 1.0)
+
+shrinkRatio :: Double -> [Double]
+shrinkRatio ε = filter (\ε' -> ε' > 0.001 && ε' <= 1.0) (shrink ε)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -413,7 +413,7 @@ x-stakePoolApparentPerformance: &stakePoolApparentPerformance
       - above `1` means the pool is performing beyond expectations.
 
     Pools that are lucky enough to win most of their slots early in the epoch will tend to look
-    like they're over-performing for a while. Having a wallet reguarly connected to the network
+    like they're over-performing for a while. Having a wallet regularly connected to the network
     would harmonize the performance and give better results.
 
   type: number

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -406,13 +406,18 @@ x-stakePoolApparentPerformance: &stakePoolApparentPerformance
     are therefore an average measure that is more accurate for servers that are online
     often.
 
-    The performance is a float with double-precision between `0` and `1`:
+    The performance is a float with double-precision which is _typically_ within `0` and `1`:
 
       - `0` means that a pool is not performing well.
-      - `1` means that a pool is performing _as expected_ (or better).
+      - `1` means that a pool is performing _as expected_.
+      - above `1` means the pool is performing beyond expectations.
+
+    Pools that are lucky enough to win most of their slots early in the epoch will tend to look
+    like they're over-performing for a while. Having a wallet reguarly connected to the network
+    would harmonize the performance and give better results.
+
   type: number
   minimum: 0
-  maximum: 1
   example: 0.5053763440860215
 
 x-stakePoolMetadata: &stakePoolMetadata


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1276 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 12c00c537ef57998c94c9098a4bf22b8f8b9542a
  move and revise pool performance calculation
  
- d99ff41bd23e669b2b880b900c65c4befe2bf139
  replace old performance calculation with new one
  
- 91e9c221589202b1d3f6101b427b532d86a0fd11
  rename pool's internal performance field to avoid name clash
  
- 2e0af3c0b3ba1ddfe81844e3f9377f6265d8d5a6
  additional property to visualize the influence of the production on the performance
  
- 0808991542effad8bfe50bfcee44977348450270
  revise apparent performance specification and documentation
  We'll now allow pool performance to go beyond 1, effectively showing if pools are
over performing.

- 54fbb534d90c8b704c2ce3aef145eca68bad6438
  use total block production instead of epoch length for performance


# Comments

<!-- Additional comments or screenshots to attach if any -->

Currently on the ITN (I have epoch 34 data + ongoing epoch 35):

```yaml
---
- apparent_performance: 4
  ticker: KICK
- apparent_performance: 3
  ticker: VIPER
- apparent_performance: 3
  ticker: CHARM
- apparent_performance: 3
  ticker: DDPL
- apparent_performance: 2.5030104132526505
  ticker: HRBR
- apparent_performance: 2.2979821642228466
  ticker: STORM
- apparent_performance: 2.2534217371750844
  ticker: PFL
- apparent_performance: 2.127709920944696
  ticker: DYLLO
- apparent_performance: 2.0466421332764924
  ticker: WALL
- apparent_performance: 2
  ticker: FNSP
- apparent_performance: 2
  ticker: MLMA
- apparent_performance: 1.971795982169012
  ticker: VIBE
- apparent_performance: 1.8937665007965672
  ticker: NEO1
- apparent_performance: 1.8915875799377535
  ticker: HRMA
- apparent_performance: 1.8859037140067032
  ticker: 1PCT5
- apparent_performance: 1.8682242130200568
  ticker: 2EMUR
- apparent_performance: 1.8252760747962953
  ticker: AAA2
- apparent_performance: 1.8043579097713018
  ticker: OCEAN
- apparent_performance: 1.8004932290426474
  ticker: FRGL
- apparent_performance: 1.754967081431054
  ticker: RDLRT
- apparent_performance: 1.754866237005601
  ticker: CLIO1
- apparent_performance: 1.734793034613511
  ticker: AAA
- apparent_performance: 1.6976977358811547
  ticker: GOLD
- apparent_performance: 1.6918378848633793
  ticker: 2LVLY
- apparent_performance: 1.6842500829483222
  ticker: ALPHA
- apparent_performance: 1.6818449185908526
  ticker: 1PCT0
- apparent_performance: 1.6398095469613152
  ticker: SPS
- apparent_performance: 1.6127584784285234
  ticker: PHX
- apparent_performance: 1.6083032768905146
  ticker: STACK
- apparent_performance: 1.6075641151422642
  ticker: HRMS
- apparent_performance: 1.5913229714487231
  ticker: 1PCT2
- apparent_performance: 1.581996983751478
  ticker: '000'
- apparent_performance: 1.5732045546698417
  ticker: 1PCT6
- apparent_performance: 1.57165084749748
  ticker: TAPSY
- apparent_performance: 1.5696428236013071
  ticker: LEAF
- apparent_performance: 1.5676529863179764
  ticker: 1PCT8
- apparent_performance: 1.5635416319988074
  ticker: QUEEN
- apparent_performance: 1.5578654746055116
  ticker: ABBA
- apparent_performance: 1.5552377938049937
  ticker: ADM
- apparent_performance: 1.547551956087259
  ticker: LATAM
- apparent_performance: 1.5403852842170194
  ticker: BNTY1
- apparent_performance: 1.5346131590244738
  ticker: HEX
- apparent_performance: 1.5324316228293744
  ticker: NGINE
- apparent_performance: 1.530127010374451
  ticker: 1PCT7
- apparent_performance: 1.4876299636435164
  ticker: 1PCT3
- apparent_performance: 1.467095698365949
  ticker: 1PCT
- apparent_performance: 1.465599559252684
  ticker: PEYAD
- apparent_performance: 1.438075410802057
  ticker: LION
- apparent_performance: 1.435525231825086
  ticker: 1PCT9
- apparent_performance: 1.4354732191138506
  ticker: ADAG1
- apparent_performance: 1.421728183886218
  ticker: 1PCT4
- apparent_performance: 1.40875798020387
  ticker: 4ADA
- apparent_performance: 1.3938758501899744
  ticker: COOL
- apparent_performance: 1.3900983602459884
  ticker: JILL
- apparent_performance: 1.3852834736685502
  ticker: KNTI
- apparent_performance: 1.383040748266533
  ticker: APP
- apparent_performance: 1.3730563090139347
  ticker: AAA
- apparent_performance: 1.3677184933951267
  ticker: ZZZ3
- apparent_performance: 1.3659391713285103
  ticker: KTN2
- apparent_performance: 1.3640892026574383
  ticker: ANP
- apparent_performance: 1.3607348491918418
  ticker: JAZZ3
- apparent_performance: 1.348195362290689
  ticker: KRIS
- apparent_performance: 1.3226286361235664
  ticker: SINGU
- apparent_performance: 1.3211486583907328
  ticker: GOD
- apparent_performance: 1.3187679410887063
  ticker: MONKY
- apparent_performance: 1.300008249287563
  ticker: KELLY
- apparent_performance: 1.2851863409285311
  ticker: SCAN
- apparent_performance: 1.2817105192496452
  ticker: BCSH
- apparent_performance: 1.27825263284757
  ticker: 1PCT1
- apparent_performance: 1.265247954906971
  ticker: ACL
- apparent_performance: 1.2582579070882454
  ticker: ADAP
- apparent_performance: 1.2402977807759912
  ticker: LION4
- apparent_performance: 1.205023459917515
  ticker: KTN3
- apparent_performance: 1.198314973229918
  ticker: SCAN1
- apparent_performance: 1.1823510464179467
  ticker: ONEW
- apparent_performance: 1.1625280680089056
  ticker: NUTJP
- apparent_performance: 1.1580265113674864
  ticker: MASP
- apparent_performance: 1.156464434443822
  ticker: HEL
- apparent_performance: 1.1542925831578221
  ticker: SEXY
- apparent_performance: 1.1522969995775634
  ticker: STKH
- apparent_performance: 1.1502355839170204
  ticker: UNDR
- apparent_performance: 1.1470497962135118
  ticker: ZONE
- apparent_performance: 1.1465945389437657
  ticker: EPIC
- apparent_performance: 1.1464251138630501
  ticker: SAND
- apparent_performance: 1.1449458852488597
  ticker: BUZZ
- apparent_performance: 1.1245900489878322
  ticker: BAKE1
- apparent_performance: 1.1172404380971526
  ticker: JAPAN
- apparent_performance: 1.1030991547510485
  ticker: DIGI
- apparent_performance: 1.0921798291417428
  ticker: MASTR
- apparent_performance: 1.0910779437754503
  ticker: 1EMUR
- apparent_performance: 1.091051897702671
  ticker: 3EMUR
- apparent_performance: 1.0787582910113651
  ticker: NUTZA
- apparent_performance: 1.064408828729496
  ticker: CSP
- apparent_performance: 1.0555575771261307
  ticker: JP3
- apparent_performance: 1.0490565363277682
  ticker: '247'
- apparent_performance: 1.0225669543126856
  ticker: KTN
- apparent_performance: 1.0108735193794474
  ticker: JOY
- apparent_performance: 1.0047638820767955
  ticker: RELY
- apparent_performance: 1.003948851316149
  ticker: JAZZ2
- apparent_performance: 1.0018971623055877
  ticker: CALM
- apparent_performance: 1.0008507904513884
  ticker: S4M
- apparent_performance: 1.0005995869834026
  ticker: PEGA
- apparent_performance: 1
  ticker: OUROS
- apparent_performance: 1
  ticker: COBOY
- apparent_performance: 1
  ticker: ARM1
- apparent_performance: 1
  ticker: BULL
- apparent_performance: 1
  ticker: SQUID
- apparent_performance: 1
  ticker: COOL2
- apparent_performance: 1
  ticker: 
- apparent_performance: 1
  ticker: GENE
- apparent_performance: 1
  ticker: KKTRN
- apparent_performance: 1
  ticker: SCAR2
- apparent_performance: 1
  ticker: APEX
- apparent_performance: 1
  ticker: ACL
- apparent_performance: 1
  ticker: MOON9
- apparent_performance: 1
  ticker: ELMO
- apparent_performance: 1
  ticker: TTNK
- apparent_performance: 0.9987657993719135
  ticker: LVLY
- apparent_performance: 0.9986526197826991
  ticker: SOBIT
- apparent_performance: 0.9877963208511145
  ticker: FROG
- apparent_performance: 0.9840560388750441
  ticker: SYNRG
- apparent_performance: 0.9691053182659877
  ticker: HASH
- apparent_performance: 0.9608453489706668
  ticker: CRDNS
- apparent_performance: 0.9582905871746447
  ticker: POP
- apparent_performance: 0.946513059122691
  ticker: ADALO
- apparent_performance: 0.9454042114179498
  ticker: EPIC2
- apparent_performance: 0.9409996868181397
  ticker: ZZZ4
- apparent_performance: 0.9385194297501002
  ticker: ADAGO
- apparent_performance: 0.9350246046566412
  ticker: NUTS
- apparent_performance: 0.9177442701621215
  ticker: SKY
- apparent_performance: 0.9131656069833767
  ticker: CHEAP
- apparent_performance: 0.8752641190842012
  ticker: ONYX
- apparent_performance: 0.8726643073191231
  ticker: JP2
- apparent_performance: 0.8712125825768346
  ticker: DIGI2
- apparent_performance: 0.8533191947848023
  ticker: D360
- apparent_performance: 0.8518303042375713
  ticker: SFADA
- apparent_performance: 0.8513250087194146
  ticker: ZZZ2
- apparent_performance: 0.8510315359516789
  ticker: GPOOL
- apparent_performance: 0.8496384704529651
  ticker: LOVE
- apparent_performance: 0.8399619754030149
  ticker: 4ADA2
- apparent_performance: 0.8282416928768747
  ticker: ZZZ
- apparent_performance: 0.8231935081717068
  ticker: THETA
- apparent_performance: 0.814450076430557
  ticker: HODL
- apparent_performance: 0.8141117488379146
  ticker: VAULT
- apparent_performance: 0.8080522894434417
  ticker: ADAAP
- apparent_performance: 0.7913578852764133
  ticker: POP2
- apparent_performance: 0.7529086363676252
  ticker: 
- apparent_performance: 0.7487216179907739
  ticker: ZZZ5
- apparent_performance: 0.7450046287167224
  ticker: SCAN2
- apparent_performance: 0.7321461417812232
  ticker: CHKN
- apparent_performance: 0.7237489135770735
  ticker: FRGL1
- apparent_performance: 0.7097462357064597
  ticker: JAZZ
- apparent_performance: 0.7056011676122546
  ticker: MERRY
- apparent_performance: 0.7055324414148989
  ticker: KIWI
- apparent_performance: 0.6510561957404389
  ticker: HAPPY
- apparent_performance: 0.6421759336716045
  ticker: ADAFR
- apparent_performance: 0.640658978824282
  ticker: CARPE
- apparent_performance: 0.6281418769156106
  ticker: BMAGE
- apparent_performance: 0.6247472164792256
  ticker: DEPOT
- apparent_performance: 0.5795511728894602
  ticker: PREV1
- apparent_performance: 0.5621989234259013
  ticker: VALUE
- apparent_performance: 0.5361547054945356
  ticker: SCAR
- apparent_performance: 0.509915761122895
  ticker: AAV
- apparent_performance: 0.5060154166019997
  ticker: 0NN
- apparent_performance: 0.5003240649995537
  ticker: PARTY
- apparent_performance: 0.484637984029082
  ticker: IOHK3
- apparent_performance: 0.4774488207435589
  ticker: BOI
- apparent_performance: 0.46096134291102425
  ticker: SAS1
- apparent_performance: 0.4362846898887217
  ticker: KOR02
- apparent_performance: 0.43105792311952906
  ticker: ARM2
- apparent_performance: 0.35996258718022034
  ticker: LCP01
- apparent_performance: 0.35521563218180535
  ticker: 
- apparent_performance: 0.3322066511051962
  ticker: ADAPL
- apparent_performance: 0.315495738956593
  ticker: FMCA3
- apparent_performance: 0.29966226599597356
  ticker: 
- apparent_performance: 0.27386723575735666
  ticker: IOHK1
- apparent_performance: 0.25136757286625966
  ticker: 
- apparent_performance: 0.25136757286625966
  ticker: 
- apparent_performance: 0.25136757286625966
  ticker: 
- apparent_performance: 0.2310881526273319
  ticker: IOHK4
- apparent_performance: 0.20233851966900596
  ticker: TIM
- apparent_performance: 0.18828109922345318
  ticker: BRIO
- apparent_performance: 0.1662323045126511
  ticker: IOHK2
- apparent_performance: 0.13122215168812087
  ticker: PUDIM
- apparent_performance: 0.10603104732495151
  ticker: CAZ
- apparent_performance: 0.07623697236145761
  ticker: XPOOL
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
