### PR TITLE
cardano-wallet-jormungandr: Set default minimum log-level to Debug

### DIFF
--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -358,12 +358,17 @@ loggingOptions = LoggingOptions
     <$> minSev
     <*> loggingTracersOptions
   where
+    -- Note: If the global log level is Info then there will be no Debug-level
+    --   messages whatsoever.
+    --   If the global log level is Debug then there will be Debug, Info, and
+    --   higher-severity messages.
+    --   So the default global log level is Debug.
     minSev = option loggingSeverityReader $ mempty
         <> long "log-level"
-        <> value Info
+        <> value Debug
         <> metavar "SEVERITY"
         <> help ("Global minimum severity for a message to be logged. " <>
-            "Defaults to \"INFO\" unless otherwise configured.")
+            "Defaults to \"DEBUG\" unless otherwise configured.")
         <> hidden
 
 loggingTracersOptions :: Parser TracerSeverities
@@ -398,16 +403,13 @@ helperTracingText = unlines $
     [ "Additional tracing options:"
     , ""
     , "  --log-level SEVERITY     Global minimum severity for a message to be logged."
-    , "                           Defaults to \"INFO\" unless otherwise configured."
+    , "                           Defaults to \"DEBUG\" unless otherwise configured."
     , "  --trace-NAME=off         Disable logging on the given tracer."
     , "  --trace-NAME=SEVERITY    Set the minimum logging severity for the given"
     , "                           tracer. Defaults to \"INFO\"."
     , ""
     , "The possible log levels (lowest to highest) are:"
     , "  " ++ unwords (map fst loggingSeverities)
-    , ""
-    , "Note: to get any debug logging, ensure that the global minimum severity is"
-    , "  also at debug level."
     , ""
     , "The possible tracers are:"
     ] ++ [ pretty name desc | (name, desc) <- tracerDescriptions]

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -141,7 +141,6 @@ spec = do
                         , "--node-port", show (ctx ^. typed @(Port "node"))
                         , "--random-port"
                         , "--genesis-block-hash", block0H
-                        , "--log-level", "debug"
                         , "--trace-pools-db", "debug"
                         ]
                         (pure ())
@@ -190,7 +189,6 @@ spec = do
                         , "--database", dirShouldFailToCreate
                         , "--node-port", show (ctx ^. typed @(Port "node"))
                         , "--random-port"
-                        , "--log-level", "DEBUG"
                         , "--genesis-block-hash", block0H
                         ]
                         (pure ())

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -114,6 +114,7 @@ spec = do
 
     describe "LOGGING - cardano-wallet serve logging [SERIAL]" $ do
         let grep str = filter (T.isInfixOf str)
+            grepNot str = filter (not . T.isInfixOf str)
 
         it "LOGGING - Serve default logs Info" $ \ctx -> do
             withTempFile $ \logs hLogs -> do
@@ -130,8 +131,9 @@ spec = do
                     threadDelay (10 * oneSecond)
                 hClose hLogs
                 logged <- T.lines <$> TIO.readFile logs
-                grep "Debug" logged `shouldBe` []
-                grep "Info" logged `shouldNotBe` []
+                let loggedNotMain = grepNot "cardano-wallet.main:Debug" logged
+                grep "Debug" loggedNotMain `shouldBe` []
+                grep "Info" loggedNotMain `shouldNotBe` []
 
         it "LOGGING - Serve debug logs for one component" $ \ctx -> do
             withTempFile $ \logs hLogs -> do


### PR DESCRIPTION
Relates to #1235.

# Overview

- Sets default global minimum log level to DEBUG in the CLI.

# Comments

From https://github.com/input-output-hk/cardano-wallet/pull/1257#discussion_r367837659