### PR TITLE
Make stake pools engine rollback faster.

### DIFF
--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -177,7 +177,7 @@ monitorStakePools tr nl db@DBLayer{..} = do
                 readPoolRegistration poolId >>= \case
                     Nothing -> putPoolRegistration sl0 r
                     Just{}  -> pure ()
-            readPoolProductionCursor k
+            readPoolProductionCursor (max 100 k)
 
     forward
         :: NonEmpty Block

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -73,6 +73,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
+    , SlotId
     )
 import Control.Arrow
     ( first )
@@ -161,6 +162,7 @@ monitorStakePools tr nl db@DBLayer{..} = do
     follow nl trFollow cursor forward header >>= \case
         Nothing    -> pure ()
         Just point -> do
+            traceWith tr $ MsgRollingBackTo point
             liftIO . atomically $ rollbackTo point
             monitorStakePools tr nl db
   where
@@ -514,6 +516,7 @@ data StakePoolLog
     | MsgFollow FollowLog
     | MsgStakeDistribution EpochNo
     | MsgStakePoolRegistration PoolRegistrationCertificate
+    | MsgRollingBackTo SlotId
     | MsgApplyError ErrMonitorStakePools
     deriving (Show, Eq)
 
@@ -531,6 +534,7 @@ instance DefineSeverity StakePoolLog where
         MsgFollow msg -> defineSeverity msg
         MsgStakeDistribution _ -> Info
         MsgStakePoolRegistration _ -> Info
+        MsgRollingBackTo _ -> Info
         MsgApplyError e -> case e of
             ErrMonitorStakePoolsNetworkUnavailable{} -> Notice
             ErrMonitorStakePoolsNetworkTip{} -> Notice
@@ -568,6 +572,8 @@ instance ToText StakePoolLog where
             "Writing stake-distribution for epoch " <> pretty ep
         MsgStakePoolRegistration pool ->
             "Discovered stake pool registration: " <> pretty pool
+        MsgRollingBackTo point ->
+            "Rolling back to " <> pretty point
         MsgApplyError e -> case e of
             ErrMonitorStakePoolsNetworkUnavailable{} ->
                 "Network is not available."

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -301,9 +301,16 @@ mkRawNetworkLayer (block0, bp) batchSize st j = NetworkLayer
         _getAccountBalance
     }
   where
-    -- security parameter, the maximum number of unstable blocks
+    -- security parameter, the maximum number of unstable blocks.
+    -- When @k@ is too small, we use an arbitrary bigger (although still
+    -- reasonably sized) value to make sure that our observation window is
+    -- big-enough. This allows for re-syncing faster when connecting to a
+    -- network after a long period of time where the node might have drifted
+    -- completely. In theory, nodes can't switch to chains that are longer than
+    -- @k@ but in practice with Jörmungandr, nodes can make jumps longer than
+    -- that.
     k :: Quantity "block" Word32
-    k = getEpochStability bp
+    k = (max 100) <$> getEpochStability bp
 
     genesis :: Hash "Genesis"
     genesis = getGenesisBlockHash bp


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1281 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- fe138cca759b973c2b67c0b23cf5982e7d3ff4f3
  Log roll back attempts in pools monitoring
    When rolling back, we currently only log monitoring restarts, which
  can be somewhat confusing when done several times in a row:

  [pools-engine] Monitoring stake pools. Currently at f4260343-[1158372.5#220]
  [pools-engine] Monitoring stake pools. Currently at 20bd31a4-[1158372.1#216]
  [pools-engine] Monitoring stake pools. Currently at 437a7400-[1158371.6#212]
  [pools-engine] Monitoring stake pools. Currently at 5c874264-[1158371.2#208]

  Although this is typical of rollbacks, it's better to mention it
  explicitely to better track what the system is doing.

- 76bf85aa68403760a9e77e2df6de96322a5a1fbc
  increase network layer observation window's length

# Comments

<!-- Additional comments or screenshots to attach if any -->

See details in #1281 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
