### PR TITLE
Force rollback of tables with foreign keys / cascading deletes on automatic db migrations

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -424,7 +424,15 @@ newDBLayer trace defaultFieldValues fp = do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
                 Just _  -> Right <$> do
-                    deleteCascadeWhere [WalId ==. wid]
+                    deleteWhere [WalId ==. wid]
+                    deleteWhere [TxMetaWalletId ==. wid]
+                    deleteWhere [PrivateKeyWalletId ==. wid]
+                    deleteWhere [SeqStateWalletId ==. wid]
+                    deleteWhere [SeqStatePendingWalletId ==. wid]
+                    deleteWhere [RndStateWalletId ==. wid]
+                    deleteWhere [RndStatePendingAddressWalletId ==. wid]
+                    deleteWhere [CertWalletId ==. wid]
+                    deleteCascadeWhere [CheckpointWalletId ==. wid]
                     deleteLooseTransactions
 
         , listWallets =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -396,16 +396,16 @@ newDBLayer
     -> Maybe FilePath
        -- ^ Path to database file, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO s k)
-newDBLayer trace defaultFieldValues mDatabaseFile = do
-    ctx@SqliteContext{runQuery} <-
-        either throwIO pure =<<
-        startSqliteBackend
-            (migrateManually trace defaultFieldValues)
-            migrateAll
-            trace
-            mDatabaseFile
-    return (ctx, DBLayer
-
+newDBLayer trace defaultFieldValues fp = do
+    let manualMigrations = migrateManually trace defaultFieldValues
+    let start = startSqliteBackend manualMigrations migrateAll trace fp
+    (nMigrations, ctx@SqliteContext{runQuery}) <- either throwIO pure =<< start
+    let dbLayer = mkDBLayer ctx
+    when (nMigrations > Quantity 0) $ do
+        traceWith trace MsgForcedRollback *> runQuery forceRollback
+    pure (ctx, dbLayer)
+  where
+    mkDBLayer SqliteContext{runQuery} = DBLayer
         {-----------------------------------------------------------------------
                                       Wallets
         -----------------------------------------------------------------------}
@@ -568,7 +568,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile = do
 
         , atomically = runQuery
 
-        })
+        }
 
 delegationFromEntity
     :: Maybe DelegationCertificate
@@ -991,6 +991,27 @@ findNearestPoint wid sl =
 -- violated.
 data ErrRollbackTo = ErrNoOlderCheckpoint W.WalletId W.SlotId deriving (Show)
 instance Exception ErrRollbackTo
+
+
+{-------------------------------------------------------------------------------
+                                    Logging
+-------------------------------------------------------------------------------}
+
+-- | @persistent@ handles automatic migrations by creating copies of existing
+-- tables, and re-creating them from scratch. When paired with automatic cascade
+-- deletion, this has dramatic consequences on the wallet data integrity (when a
+-- source table is deleted due to a migration, all foreign tables are also
+-- deleted, but only the rows in the source table are replaced!).
+--
+-- To cope with this, when any automated migration is detected, we manually
+-- roll back all rows referencing checkpoints and replace the genesis checkpoint.
+forceRollback
+    :: SqlPersistT IO ()
+forceRollback = do
+    deleteCascadeWhere [CheckpointSlot >. W.slotMinBound]
+    deleteWhere [CertSlot >. W.slotMinBound]
+    deleteWhere [TxMetaSlot >. W.slotMinBound]
+    deleteLooseTransactions
 
 {-------------------------------------------------------------------------------
                      DB queries for address discovery state

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -73,7 +73,6 @@ PrivateKey                             sql=private_key
     privateKeyHash      B8.ByteString  sql=hash
 
     Primary privateKeyWalletId
-    Foreign Wallet fk_wallet_private_key privateKeyWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Maps a transaction ID to its metadata (which is calculated when applying
@@ -92,7 +91,6 @@ TxMeta
     txMetaAmount       Natural      sql=amount
 
     Primary txMetaTxId txMetaWalletId
-    Foreign Wallet fk_wallet_tx_meta txMetaWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- A transaction input associated with TxMeta.
@@ -140,7 +138,6 @@ Checkpoint
     checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
-    Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet
@@ -150,7 +147,6 @@ DelegationCertificate
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
-    Foreign Wallet delegationCertificate certWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
@@ -184,7 +180,6 @@ SeqState
     seqStateRewardXPub      B8.ByteString     sql=reward_xpub
 
     Primary seqStateWalletId
-    Foreign Wallet seq_state seqStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Mapping of pool addresses to indices, and the slot
@@ -211,7 +206,6 @@ SeqStatePendingIx                            sql=seq_state_pending
     seqStatePendingIxIndex      Word32       sql=pending_ix
 
     Primary seqStatePendingWalletId seqStatePendingIxIndex
-    Foreign Wallet seq_state_address_pending seqStatePendingWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Random scheme address discovery state
@@ -223,7 +217,6 @@ RndState
     rndStateHdPassphrase    HDPassphrase      sql=hd_passphrase
 
     Primary rndStateWalletId
-    Foreign Wallet rnd_state rndStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The set of discovered addresses.
@@ -255,6 +248,5 @@ RndStatePendingAddress
         rndStatePendingAddressAccountIndex
         rndStatePendingAddressIndex
         rndStatePendingAddressAddress
-    Foreign Wallet rnd_state_pending_address rndStatePendingAddressWalletId ! ON DELETE CASCADE
     deriving Show Generic
 |]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1279 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 74c232e1ee94ec9c79152312f7294ebe2da7cc64
  force rollback to genesis after automated migrations
    `persistent` clear foreign tables on automatic migration due to
  cascading delete. One possible approach to solve this: forcing a
  manual rollback to genesis whenever there are migrations applied
  to the database, regardless of the migration. Only the foreign
  tables are affected, so static metadata and wallet credentials
  are preserved. This mean that we would force resync of wallets
  on every updates that have database changes, but that's a fair
  price to pay for now.

- de3825dd82ae2f0f7caf7b80102dccddebd00aa8
  remove foreign keys to 'Wallet' table and cascade deletes manually
  This to prevent 'persistent' from doing it during automated migration! We don't do
this for checkpoints because the cascading updates are truly helpful there to manage
the database state and, can be more easily rolled back at any time (since the data
regarding checkpoints entirely comes from the chain).


# Comments

<!-- Additional comments or screenshots to attach if any -->

~~:warning: Currently manually testing db migration from various previous versions.~~

Automated migration passes! And on old version, we have a nice log showing what's going on, including manual migration, and handling of automated ones!

```
 *** Migrating from v2019-12-13 ***

[cardano-wallet.application:Info:22] [2020-01-20 17:58:12.47 UTC] Found existing wallet: 99ef09bdab5f62579f2d6db02ba7df5e88b7e865
[cardano-wallet.wallet-db:Notice:28] [2020-01-20 17:58:12.47 UTC] checkpoint table does not contain required field 'active_slot_coeff'. Adding this field with a default value of 1.0.
[cardano-wallet.wallet-db:Notice:28] [2020-01-20 17:58:12.52 UTC] 48 migrations were applied to the database.
[cardano-wallet.wallet-db:Notice:28] [2020-01-20 17:58:12.52 UTC] Some automated database migrations happened. Forced to rollback to genesis.
[cardano-wallet.main:Info:22] [2020-01-20 17:58:12.53 UTC] Wallet backend server listening on 127.0.0.1:8090
[cardano-wallet.wallet-engine:Info:28] [2020-01-20 17:58:12.53 UTC] 99ef09bd: Applying blocks [1167051.7 ... 1167051.7]
[cardano-wallet.wallet-engine:Info:28] [2020-01-20 17:58:12.53 UTC] 99ef09bd: Creating checkpoint at 3b2894d8-[1167051.7#1]
```

So, to summarize what's happening:

1. An existing wallet database is found. 
2. Before running any automatic migration, the database is inspected and an extra column is found. So we manually alter the table to add a column with a default value.
3. Then, persistent runs its own set of automated migrations on top of the database, running 48 of them.
4. This is then detected and induces immediately a rollback to genesis of all the on-chain data.
5. The wallet starts applying blocks and creating checkpoints, starting with a checkpoint at height `#1` (right after genesis)

:tada: 


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
