### PR TITLE
Lenses integration tests 2

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -56,7 +56,6 @@ module Test.Integration.Framework.DSL
     , blocks
     , coinSelectionInputs
     , coinSelectionOutputs
-    , delegation
     , direction
     , feeEstimator
     , inputs
@@ -169,7 +168,6 @@ import Cardano.Wallet.Primitive.Types
     , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics (..)
-    , WalletDelegation (..)
     , WalletId (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
@@ -639,17 +637,6 @@ expectPathEventuallyExist filepath = do
 
 -- Lenses
 --
-
-delegation
-    :: forall s d. (d ~ WalletDelegation (ApiT PoolId), HasType (ApiT d) s)
-    => Lens' s (WalletDelegation (ApiT PoolId))
-delegation =
-    lens _get _set
-  where
-    _get :: s -> d
-    _get = getApiT . view typed
-    _set :: (s, d) -> s
-    _set (s, v) = set typed (ApiT v ) s
 
 feeEstimator
     :: Lens' (Context t) (TxDescription -> (Natural, Natural))

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -61,7 +61,6 @@ module Test.Integration.Framework.DSL
     , nextEpoch
     , outputs
     , stake
-    , syncProgress
     , walletId
 
     -- * Helpers
@@ -156,7 +155,6 @@ import Cardano.Wallet.Primitive.Types
     , HistogramBar (..)
     , PoolId (..)
     , SortOrder (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxOut (..)
     , UTxO (..)
@@ -689,15 +687,6 @@ coinSelectionOutputs =
   where
     _get = NE.toList . view typed
     _set (s, v) = set typed (NE.fromList v) s
-
-syncProgress :: HasType (ApiT SyncProgress) s => Lens' s SyncProgress
-syncProgress =
-    lens _get _set
-  where
-    _get :: HasType (ApiT SyncProgress) s => s -> SyncProgress
-    _get = getApiT . view typed
-    _set :: HasType (ApiT SyncProgress) s => (s, SyncProgress) -> s
-    _set (s, v) = set typed (ApiT v) s
 
 metrics :: HasType ApiStakePoolMetrics s => Lens' s ApiStakePoolMetrics
 metrics =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -51,15 +51,11 @@ module Test.Integration.Framework.DSL
     , RequestException(..)
 
     -- * Lens
-    , blocks
     , coinSelectionInputs
     , coinSelectionOutputs
     , feeEstimator
     , inputs
-    , metrics
-    , nextEpoch
     , outputs
-    , stake
     , walletId
 
     -- * Helpers
@@ -130,10 +126,8 @@ import Cardano.Wallet.Api.Types
     , ApiByronWallet
     , ApiCoinSelection
     , ApiCoinSelectionInput
-    , ApiEpochInfo
     , ApiFee
     , ApiNetworkInformation
-    , ApiStakePoolMetrics
     , ApiT (..)
     , ApiTransaction
     , ApiTxInput (..)
@@ -194,8 +188,6 @@ import Data.Generics.Internal.VL.Lens
     ( Lens', lens, set, view, (^.) )
 import Data.Generics.Labels
     ()
-import Data.Generics.Product.Fields
-    ( HasField', getField, setField )
 import Data.Generics.Product.Typed
     ( HasType, typed )
 import Data.List
@@ -686,38 +678,6 @@ coinSelectionOutputs =
   where
     _get = NE.toList . view typed
     _set (s, v) = set typed (NE.fromList v) s
-
-metrics :: HasType ApiStakePoolMetrics s => Lens' s ApiStakePoolMetrics
-metrics =
-    lens _get _set
-  where
-    _get :: HasType ApiStakePoolMetrics s => s -> ApiStakePoolMetrics
-    _get = view typed
-    _set :: HasType ApiStakePoolMetrics s => (s, ApiStakePoolMetrics) -> s
-    _set (s, v) = set typed v s
-
-nextEpoch :: HasType ApiEpochInfo s => Lens' s ApiEpochInfo
-nextEpoch =
-    lens _get _set
-  where
-    _get :: HasType ApiEpochInfo s => s -> ApiEpochInfo
-    _get = view typed
-    _set :: HasType ApiEpochInfo s => (s, ApiEpochInfo) -> s
-    _set (s, v) = set typed v s
-
-stake
-    :: HasField' "controlledStake" s (Quantity "lovelace" Natural)
-    => Lens' s Natural
-stake = lens
-    (getQuantity . getField @"controlledStake")
-    (\(s, v) -> setField @"controlledStake" (Quantity v) s)
-
-blocks
-    :: HasField' "producedBlocks" s (Quantity "block" Natural)
-    => Lens' s Natural
-blocks = lens
-    (getQuantity . getField @"producedBlocks")
-    (\(s, v) -> setField @"producedBlocks" (Quantity v) s)
 
 --
 -- Helpers

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -53,8 +53,6 @@ module Test.Integration.Framework.DSL
     -- * Lens
     , coinSelectionInputs
     , coinSelectionOutputs
-    , inputs
-    , outputs
     , walletId
 
     -- * Helpers
@@ -129,7 +127,6 @@ import Cardano.Wallet.Api.Types
     , ApiNetworkInformation
     , ApiT (..)
     , ApiTransaction
-    , ApiTxInput (..)
     , ApiUtxoStatistics (..)
     , ApiWallet
     , ByronWalletStyle (..)
@@ -623,26 +620,6 @@ walletId =
     _get = T.pack . show . getWalletId . getApiT . view typed
     _set :: HasType (ApiT WalletId) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletId (unsafeCreateDigest v)) s
-
-inputs :: HasType [ApiTxInput t] s => Lens' s [ApiTxInput t]
-inputs =
-    lens _get _set
-  where
-    _get :: HasType [ApiTxInput t] s => s -> [ApiTxInput t]
-    _get = view typed
-    _set :: HasType [ApiTxInput t] s => (s, [ApiTxInput t]) -> s
-    _set (s, v) = set typed v s
-
-outputs
-    :: forall s t a. (a ~ AddressAmount t, HasType (NonEmpty a) s)
-    => Lens' s [a]
-outputs =
-    lens _get _set
-  where
-    _get :: s -> [a]
-    _get = NE.toList . view typed
-    _set :: (s, [a]) -> s
-    _set (s, v) = set typed (NE.fromList v) s
 
 coinSelectionInputs
     :: forall s n a.

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -66,7 +66,6 @@ module Test.Integration.Framework.DSL
     , status
     , syncProgress
     , walletId
-    , walletName
 
     -- * Helpers
     , (</>)
@@ -168,7 +167,6 @@ import Cardano.Wallet.Primitive.Types
     , UTxO (..)
     , UTxOStatistics (..)
     , WalletId (..)
-    , WalletName (..)
     , computeUtxoStatistics
     , log10
     )
@@ -390,8 +388,8 @@ expectFieldNotEqual getter a (_, res) = case res of
 -- | Expects that returned data list's particular item field
 --   matches the expected value.
 --   e.g.
---   expectListItemFieldEqual 0 walletName "first" response
---   expectListItemFieldEqual 1 walletName "second" response
+--   expectListItemFieldEqual 0 (#name . #getApiT . #getWalletName) "first" r
+--   expectListItemFieldEqual 1 (#name . #getApiT . #getWalletName) "second" r
 expectListItemFieldEqual
     :: (MonadIO m, MonadFail m, Show a, Eq a)
     => Int
@@ -643,15 +641,6 @@ feeEstimator =
   where
     _get = _feeEstimator
     _set (ctx, v) = ctx { _feeEstimator = v }
-
-walletName :: HasType (ApiT WalletName) s => Lens' s Text
-walletName =
-    lens _get _set
-  where
-    _get :: HasType (ApiT WalletName) s => s -> Text
-    _get = getWalletName . getApiT . view typed
-    _set :: HasType (ApiT WalletName) s => (s, Text) -> s
-    _set (s, v) = set typed (ApiT $ WalletName v) s
 
 walletId :: HasType (ApiT WalletId) s => Lens' s Text
 walletId =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -53,7 +53,6 @@ module Test.Integration.Framework.DSL
     -- * Lens
     , coinSelectionInputs
     , coinSelectionOutputs
-    , feeEstimator
     , inputs
     , outputs
     , walletId
@@ -615,14 +614,6 @@ expectPathEventuallyExist filepath = do
 
 -- Lenses
 --
-
-feeEstimator
-    :: Lens' (Context t) (TxDescription -> (Natural, Natural))
-feeEstimator =
-    lens _get _set
-  where
-    _get = _feeEstimator
-    _set (ctx, v) = ctx { _feeEstimator = v }
 
 walletId :: HasType (ApiT WalletId) s => Lens' s Text
 walletId =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -51,7 +51,6 @@ module Test.Integration.Framework.DSL
     , RequestException(..)
 
     -- * Lens
-    , amount
     , apparentPerformance
     , blocks
     , coinSelectionInputs
@@ -224,8 +223,6 @@ import Data.Time.Text
     ( iso8601ExtendedUtc, utcTimeToText )
 import Data.Word
     ( Word64 )
-import GHC.TypeLits
-    ( Symbol )
 import Language.Haskell.TH.Quote
     ( QuasiQuoter )
 import Network.HTTP.Client
@@ -651,15 +648,6 @@ walletId =
     _set :: HasType (ApiT WalletId) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletId (unsafeCreateDigest v)) s
 
-amount :: HasType (Quantity "lovelace" Natural) s => Lens' s Natural
-amount =
-    lens _get _set
-  where
-    _get :: HasType (Quantity "lovelace" Natural) s => s -> Natural
-    _get = fromQuantity @"lovelace" @Natural . view typed
-    _set :: HasType (Quantity "lovelace" Natural) s => (s, Natural) -> s
-    _set (s, v) = set typed (Quantity @"lovelace" @Natural v) s
-
 direction :: HasType (ApiT Direction) s => Lens' s Direction
 direction =
     lens _get _set
@@ -1048,9 +1036,6 @@ faucetUtxoAmt :: Natural
 faucetUtxoAmt = ada 100_000
   where
     ada = (*) (1_000_000)
-
-fromQuantity :: Quantity (u :: Symbol) a -> a
-fromQuantity (Quantity a) = a
 
 getFromResponse
     :: Lens' s a

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -51,7 +51,6 @@ module Test.Integration.Framework.DSL
     , RequestException(..)
 
     -- * Lens
-    , apparentPerformance
     , blocks
     , coinSelectionInputs
     , coinSelectionOutputs
@@ -719,15 +718,6 @@ blocks
 blocks = lens
     (getQuantity . getField @"producedBlocks")
     (\(s, v) -> setField @"producedBlocks" (Quantity v) s)
-
-apparentPerformance :: HasType Double s => Lens' s Double
-apparentPerformance =
-    lens _get _set
-  where
-    _get :: HasType Double s => s -> Double
-    _get = view typed
-    _set :: HasType Double s => (s, Double) -> s
-    _set (s, v) = set typed v s
 
 --
 -- Helpers

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -61,7 +61,6 @@ module Test.Integration.Framework.DSL
     , nextEpoch
     , outputs
     , stake
-    , status
     , syncProgress
     , walletId
 
@@ -160,7 +159,6 @@ import Cardano.Wallet.Primitive.Types
     , SyncProgress (..)
     , TxIn (..)
     , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics (..)
     , WalletId (..)
@@ -691,15 +689,6 @@ coinSelectionOutputs =
   where
     _get = NE.toList . view typed
     _set (s, v) = set typed (NE.fromList v) s
-
-status :: HasType (ApiT TxStatus) s => Lens' s TxStatus
-status =
-    lens _get _set
-  where
-    _get :: HasType (ApiT TxStatus) s => s -> TxStatus
-    _get = getApiT . view typed
-    _set :: HasType (ApiT TxStatus) s => (s, TxStatus) -> s
-    _set (s, v) = set typed (ApiT v) s
 
 syncProgress :: HasType (ApiT SyncProgress) s => Lens' s SyncProgress
 syncProgress =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -51,8 +51,6 @@ module Test.Integration.Framework.DSL
     , RequestException(..)
 
     -- * Lens
-    , coinSelectionInputs
-    , coinSelectionOutputs
     , walletId
 
     -- * Helpers
@@ -122,7 +120,6 @@ import Cardano.Wallet.Api.Types
     , ApiAddress
     , ApiByronWallet
     , ApiCoinSelection
-    , ApiCoinSelectionInput
     , ApiFee
     , ApiNetworkInformation
     , ApiT (..)
@@ -252,7 +249,6 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BL8
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -620,32 +616,6 @@ walletId =
     _get = T.pack . show . getWalletId . getApiT . view typed
     _set :: HasType (ApiT WalletId) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletId (unsafeCreateDigest v)) s
-
-coinSelectionInputs
-    :: forall s n a.
-        ( s ~ ApiCoinSelection n
-        , a ~ ApiCoinSelectionInput n
-        , HasType (NonEmpty a) s
-        )
-    => Lens' s [a]
-coinSelectionInputs =
-    lens _get _set
-  where
-    _get = NE.toList . view typed
-    _set (s, v) = set typed (NE.fromList v) s
-
-coinSelectionOutputs
-    :: forall s n a.
-        ( s ~ ApiCoinSelection n
-        , a ~ AddressAmount n
-        , HasType (NonEmpty a) s
-        )
-    => Lens' s [a]
-coinSelectionOutputs =
-    lens _get _set
-  where
-    _get = NE.toList . view typed
-    _set (s, v) = set typed (NE.fromList v) s
 
 --
 -- Helpers

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -55,7 +55,6 @@ module Test.Integration.Framework.DSL
     , blocks
     , coinSelectionInputs
     , coinSelectionOutputs
-    , direction
     , feeEstimator
     , inputs
     , metrics
@@ -154,7 +153,6 @@ import Cardano.Wallet.Primitive.Mnemonic
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , Direction (..)
     , Hash (..)
     , HistogramBar (..)
     , PoolId (..)
@@ -647,15 +645,6 @@ walletId =
     _get = T.pack . show . getWalletId . getApiT . view typed
     _set :: HasType (ApiT WalletId) s => (s, Text) -> s
     _set (s, v) = set typed (ApiT $ WalletId (unsafeCreateDigest v)) s
-
-direction :: HasType (ApiT Direction) s => Lens' s Direction
-direction =
-    lens _get _set
-  where
-    _get :: HasType (ApiT Direction) s => s -> Direction
-    _get = getApiT . view typed
-    _set :: HasType (ApiT Direction) s => (s, Direction) -> s
-    _set (s, v) = set typed (ApiT v) s
 
 inputs :: HasType [ApiTxInput t] s => Lens' s [ApiTxInput t]
 inputs =

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -62,7 +62,6 @@ module Test.Integration.Framework.DSL
     , metrics
     , nextEpoch
     , outputs
-    , passphraseLastUpdate
     , stake
     , status
     , syncProgress
@@ -170,7 +169,6 @@ import Cardano.Wallet.Primitive.Types
     , UTxOStatistics (..)
     , WalletId (..)
     , WalletName (..)
-    , WalletPassphraseInfo (..)
     , computeUtxoStatistics
     , log10
     )
@@ -645,18 +643,6 @@ feeEstimator =
   where
     _get = _feeEstimator
     _set (ctx, v) = ctx { _feeEstimator = v }
-
-passphraseLastUpdate
-    :: forall s i. (i ~ WalletPassphraseInfo, HasType (Maybe (ApiT i)) s)
-    => Lens' s (Maybe Text)
-passphraseLastUpdate =
-    lens _get _set
-  where
-    _get :: s -> Maybe Text
-    _get = fmap (T.pack . show . lastUpdatedAt . getApiT) . view typed
-    _set :: (s, Maybe Text) -> s
-    _set (s, v) =
-        set typed (ApiT . WalletPassphraseInfo . read . T.unpack <$> v) s
 
 walletName :: HasType (ApiT WalletName) s => Lens' s Text
 walletName =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -88,7 +88,6 @@ import Test.Integration.Framework.DSL
     , fixtureWallet
     , getFromResponse
     , json
-    , passphraseLastUpdate
     , request
     , unsafeRequest
     , verify
@@ -825,7 +824,7 @@ spec = do
                             , expectFieldEqual (#balance . #total) (Quantity 0)
                             , expectEventually ctx (Link.getWallet @'Byron)
                                     (#state . #getApiT) Ready
-                            , expectFieldNotEqual passphraseLastUpdate Nothing
+                            , expectFieldNotEqual #passphrase Nothing
                             ]
                 -- create
                 r <- request @ApiByronWallet ctx endpoint Default payload

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -92,7 +92,6 @@ import Test.Integration.Framework.DSL
     , unsafeRequest
     , verify
     , walletId
-    , walletName
     , withMethod
     , withPathParam
     )
@@ -685,9 +684,12 @@ spec = do
             verify rl
                 [ expectResponseCode @IO HTTP.status200
                 , expectListSizeEqual 3
-                , expectListItemFieldEqual 0 walletName "b1"
-                , expectListItemFieldEqual 1 walletName "b2"
-                , expectListItemFieldEqual 2 walletName "b3"
+                , expectListItemFieldEqual 0
+                        (#name . #getApiT . #getWalletName) "b1"
+                , expectListItemFieldEqual 1
+                        (#name . #getApiT . #getWalletName) "b2"
+                , expectListItemFieldEqual 2
+                        (#name . #getApiT . #getWalletName) "b3"
                 ]
 
     it "BYRON_LIST_01 - Interleave of Icarus and Random wallets" $ \ctx -> do
@@ -699,9 +701,9 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 3
-            , expectListItemFieldEqual 0 walletName "ica1"
-            , expectListItemFieldEqual 1 walletName "rnd2"
-            , expectListItemFieldEqual 2 walletName "ica3"
+            , expectListItemFieldEqual 0 (#name . #getApiT . #getWalletName) "ica1"
+            , expectListItemFieldEqual 1 (#name . #getApiT . #getWalletName) "rnd2"
+            , expectListItemFieldEqual 2 (#name . #getApiT . #getWalletName) "ica3"
             ]
 
     it "BYRON_LIST_02,03 -\
@@ -723,18 +725,24 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 3
-            , expectListItemFieldEqual 0 walletName "byron1"
-            , expectListItemFieldEqual 1 walletName "byron2"
-            , expectListItemFieldEqual 2 walletName "byron3"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "byron1"
+            , expectListItemFieldEqual 1
+                    (#name . #getApiT . #getWalletName) "byron2"
+            , expectListItemFieldEqual 2
+                    (#name . #getApiT . #getWalletName) "byron3"
             ]
         --list only shelley
         rl2 <- request @[ApiWallet] ctx (Link.listWallets @'Shelley) Default Empty
         verify rl2
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 3
-            , expectListItemFieldEqual 0 walletName "shelley1"
-            , expectListItemFieldEqual 1 walletName "shelley2"
-            , expectListItemFieldEqual 2 walletName "shelley3"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "shelley1"
+            , expectListItemFieldEqual 1
+                    (#name . #getApiT . #getWalletName) "shelley2"
+            , expectListItemFieldEqual 2
+                    (#name . #getApiT . #getWalletName) "shelley3"
             ]
 
     it "BYRON_LIST_04, DELETE_01 -\
@@ -759,16 +767,20 @@ spec = do
         verify rdl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 2
-            , expectListItemFieldEqual 0 walletName "byron1"
-            , expectListItemFieldEqual 1 walletName "byron3"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "byron1"
+            , expectListItemFieldEqual 1
+                    (#name . #getApiT . #getWalletName) "byron3"
             ]
         --list only shelley
         rdl2 <- request @[ApiWallet] ctx (Link.listWallets @'Shelley) Default Empty
         verify rdl2
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 2
-            , expectListItemFieldEqual 0 walletName "shelley1"
-            , expectListItemFieldEqual 1 walletName "shelley2"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "shelley1"
+            , expectListItemFieldEqual 1
+                    (#name . #getApiT . #getWalletName) "shelley2"
             ]
 
     describe "BYRON_LIST_05 - HTTP headers" $ do
@@ -819,7 +831,8 @@ spec = do
                         "passphrase": "Secure Passphrase"
                     }|]
                 let expectations =
-                            [ expectFieldEqual walletName name
+                            [ expectFieldEqual
+                                    (#name . #getApiT . #getWalletName) name
                             , expectFieldEqual (#balance . #available) (Quantity 0)
                             , expectFieldEqual (#balance . #total) (Quantity 0)
                             , expectEventually ctx (Link.getWallet @'Byron)
@@ -838,9 +851,12 @@ spec = do
                 verify rl
                     [ expectResponseCode @IO HTTP.status200
                     , expectListSizeEqual 1
-                    , expectListItemFieldEqual 0 walletName name
-                    , expectListItemFieldEqual 0 (#balance . #available) (Quantity 0)
-                    , expectListItemFieldEqual 0 (#balance . #total) (Quantity 0)
+                    , expectListItemFieldEqual 0
+                            (#name . #getApiT . #getWalletName) name
+                    , expectListItemFieldEqual 0
+                            (#balance . #available) (Quantity 0)
+                    , expectListItemFieldEqual 0
+                            (#balance . #total) (Quantity 0)
                     ]
 
         let scenarioFailure endpoint mnemonic ctx = do
@@ -926,12 +942,13 @@ spec = do
         let matrix =
                 [ ( show walletNameMinLength ++ " char long", "1"
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName "1"
+                    , expectFieldEqual (#name . #getApiT . #getWalletName) "1"
                     ]
                   )
                 , ( show walletNameMaxLength ++ " char long", walNameMax
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName walNameMax
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) walNameMax
                     ]
                   )
                 , ( show (walletNameMaxLength + 1) ++ " char long"
@@ -949,27 +966,32 @@ spec = do
                   )
                 , ( "Russian name", russianWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName russianWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) russianWalletName
                     ]
                   )
                 , ( "Polish name", polishWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName polishWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) polishWalletName
                     ]
                   )
                 , ( "Kanji name", kanjiWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName kanjiWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) kanjiWalletName
                     ]
                   )
                 , ( "Arabic name", arabicWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName arabicWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) arabicWalletName
                     ]
                   )
                 , ( "Wildcards name", wildcardsWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName wildcardsWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) wildcardsWalletName
                     ]
                   )
                 ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -40,7 +40,6 @@ import Test.Integration.Framework.DSL
     , expectFieldSatisfy
     , expectResponseCode
     , getFromResponse
-    , nextEpoch
     , request
     , verify
     )
@@ -59,7 +58,7 @@ spec = do
                 Link.getNetworkInfo Default Empty
             expectResponseCode @IO HTTP.status200 r
             verify r
-                [ expectFieldSatisfy nextEpoch ((> now) . epochStartTime)
+                [ expectFieldSatisfy #nextEpoch ((> now) . epochStartTime)
                 , expectFieldEqual (#syncProgress . #getApiT) Ready
                 ]
             return r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -42,7 +42,6 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , nextEpoch
     , request
-    , syncProgress
     , verify
     )
 import Test.Integration.Framework.TestData
@@ -61,7 +60,7 @@ spec = do
             expectResponseCode @IO HTTP.status200 r
             verify r
                 [ expectFieldSatisfy nextEpoch ((> now) . epochStartTime)
-                , expectFieldEqual syncProgress Ready
+                , expectFieldEqual (#syncProgress . #getApiT) Ready
                 ]
             return r
 
@@ -93,7 +92,7 @@ spec = do
             w <- emptyWallet ctx
             eventually_ $ do
                 sync <- getNetworkInfo
-                verify sync [ expectFieldEqual syncProgress Ready ]
+                verify sync [ expectFieldEqual (#syncProgress . #getApiT) Ready ]
             r <- getNetworkInfo
 
             let epochNum =
@@ -120,7 +119,7 @@ spec = do
             w <- emptyRandomWallet ctx
             eventually_ $ do
                 sync <- getNetworkInfo
-                verify sync [ expectFieldEqual syncProgress Ready ]
+                verify sync [ expectFieldEqual (#syncProgress . #getApiT) Ready ]
             r <- getNetworkInfo
 
             let epochNum =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -77,7 +77,6 @@ import Test.Integration.Framework.DSL
     , expectSuccess
     , faucetAmt
     , faucetUtxoAmt
-    , feeEstimator
     , fixturePassphrase
     , fixtureRandomWallet
     , fixtureWallet
@@ -135,7 +134,7 @@ spec = do
         \ Transaction to self shows only fees as a tx amount\
         \ while both, pending and in_ledger" $ \ctx -> do
         wSrc <- fixtureWallet ctx
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 1
                 , nOutputs = 1
                 , nChanges = 1
@@ -198,7 +197,7 @@ spec = do
 
     it "TRANS_CREATE_01 - Single Output Transaction" $ \ctx -> do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 1
                 , nOutputs = 1
                 , nChanges = 1
@@ -265,7 +264,7 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -328,7 +327,7 @@ spec = do
                 ],
                 "passphrase": "cardano-wallet"
             }|]
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -398,7 +397,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_03 - 0 balance after transaction" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 0
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 0
         let amt = 1
         wSrc <- fixtureWalletWith ctx [feeMin+amt]
         wDest <- emptyWallet ctx
@@ -454,7 +453,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin `div` 2]
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest
@@ -477,7 +476,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_04 - Not enough money" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin]
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest
@@ -826,7 +825,7 @@ spec = do
                     }
                 }]
             }|]
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 1
                 , nOutputs = 1
                 , nChanges = 1
@@ -864,7 +863,7 @@ spec = do
                     }
                 }]
             }|]
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -905,7 +904,7 @@ spec = do
                     }
                 ]
             }|]
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -951,7 +950,7 @@ spec = do
             ]
 
     it "TRANS_ESTIMATE_03 - we see result when we can't cover fee" $ \ctx -> do
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription 1 1 0
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 0
         wSrc <- fixtureWalletWith ctx [feeMin `div` 2]
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest
@@ -974,7 +973,7 @@ spec = do
             ]
 
     it "TRANS_ESTIMATE_04 - Not enough money" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin]
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses ctx wDest

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -62,7 +62,6 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , TxDescription (..)
-    , direction
     , emptyRandomWallet
     , emptyWallet
     , eventually_
@@ -151,7 +150,7 @@ spec = do
             -- tx amount includes only fees because it is tx to self address
             -- when tx is pending
             , expectFieldBetween (#amount . #getQuantity) (feeMin, feeMax)
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
 
@@ -165,7 +164,7 @@ spec = do
                 -- also when tx is already in ledger
                 , expectListItemFieldBetween 0
                         (#amount . #getQuantity) (feeMin, feeMax)
-                , expectListItemFieldEqual 0 direction Outgoing
+                , expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -193,7 +192,7 @@ spec = do
                 [] ->
                     fail "Tx no longer pending, need to retry scenario."
                 tx':_ -> do
-                    tx' ^. direction `shouldBe` Outgoing
+                    tx' ^. (#direction . #getApiT) `shouldBe` Outgoing
                     tx' ^. status `shouldBe` Pending
                     insertedAt tx' `shouldBe` Nothing
                     pendingSince tx' `shouldBe` pendingSince tx
@@ -212,7 +211,7 @@ spec = do
             , expectResponseCode HTTP.status202
             , expectFieldBetween
                     (#amount . #getQuantity) (feeMin + amt, feeMax + amt)
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
 
@@ -279,7 +278,7 @@ spec = do
             [ expectResponseCode HTTP.status202
             , expectFieldBetween
                     (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
         verify ra
@@ -342,7 +341,7 @@ spec = do
             [ expectResponseCode HTTP.status202
             , expectFieldBetween
                     (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
         verify ra
@@ -421,7 +420,7 @@ spec = do
         verify r
             [ expectResponseCode HTTP.status202
             , expectFieldEqual (#amount . #getQuantity) (feeMin + amt)
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
 
@@ -1191,8 +1190,8 @@ spec = do
         expectResponseCode @IO HTTP.status200 r
 
         verify r
-            [ expectListItemFieldEqual 0 direction Outgoing
-            , expectListItemFieldEqual 1 direction Incoming
+            [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
+            , expectListItemFieldEqual 1 (#direction . #getApiT) Incoming
             ]
 
     -- This scenario covers the following matrix of cases. Cases were generated
@@ -1611,7 +1610,7 @@ spec = do
         verify rMkTx
             [ expectSuccess
             , expectResponseCode HTTP.status202
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual status Pending
             ]
 
@@ -1642,7 +1641,7 @@ spec = do
         eventually_ $ do
             let ep = Link.listTransactions @'Shelley wSrc
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -1650,7 +1649,7 @@ spec = do
         eventually_ $ do
             let ep = Link.listTransactions @'Shelley wDest
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Incoming
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Incoming
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -1683,7 +1682,7 @@ spec = do
         eventually_ $ do
             let ep = Link.listTransactions @'Shelley wSrc
             request @([ApiTransaction n]) ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -74,7 +74,6 @@ import Test.Integration.Framework.DSL
     , Payload (..)
     , coinSelectionInputs
     , coinSelectionOutputs
-    , delegation
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyWallet
@@ -171,7 +170,7 @@ spec = do
             , expectFieldEqual (#balance . #getApiT . #reward) (Quantity 0)
             , expectEventually ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
-            , expectFieldEqual delegation (NotDelegating)
+            , expectFieldEqual (#delegation . #getApiT) NotDelegating
             , expectFieldEqual walletId
                 "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
             , expectFieldNotEqual passphraseLastUpdate Nothing
@@ -951,7 +950,7 @@ spec = do
             , expectFieldEqual (#balance . #getApiT . #reward) (Quantity 0)
             , expectEventually ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
-            , expectFieldEqual delegation (NotDelegating)
+            , expectFieldEqual (#delegation . #getApiT) NotDelegating
             , expectFieldEqual walletId (w ^. walletId)
             , expectFieldNotEqual passphraseLastUpdate Nothing
             ]
@@ -1023,7 +1022,7 @@ spec = do
                     (#balance . #getApiT . #total) (Quantity 0)
             , expectListItemFieldEqual 0
                     (#balance . #getApiT . #reward) (Quantity 0)
-            , expectListItemFieldEqual 0 delegation (NotDelegating)
+            , expectListItemFieldEqual 0 (#delegation . #getApiT) NotDelegating
             , expectListItemFieldEqual 0 walletId
                 "dfe87fcf0560fb57937a6468ea51e860672fad79"
             ]
@@ -1099,7 +1098,7 @@ spec = do
                             (#balance . #getApiT . #total) (Quantity 0)
                     , expectEventually ctx (Link.getWallet @'Shelley)
                             (#state . #getApiT) Ready
-                    , expectFieldEqual delegation (NotDelegating)
+                    , expectFieldEqual (#delegation . #getApiT) NotDelegating
                     , expectFieldEqual walletId walId
                     , expectFieldEqual passphraseLastUpdate passLastUpdateValue
                     ]
@@ -1116,7 +1115,7 @@ spec = do
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectListItemFieldEqual 0 (#balance . #getApiT . #available) (Quantity 0)
             , expectListItemFieldEqual 0 (#balance . #getApiT . #total) (Quantity 0)
-            , expectListItemFieldEqual 0 delegation (NotDelegating)
+            , expectListItemFieldEqual 0 (#delegation . #getApiT) NotDelegating
             , expectListItemFieldEqual 0 walletId walId
             , expectListItemFieldEqual 0 passphraseLastUpdate passLastUpdateValue
             ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -96,7 +96,6 @@ import Test.Integration.Framework.DSL
     , unsafeRequest
     , verify
     , walletId
-    , walletName
     , withMethod
     , withPathParam
     , (</>)
@@ -161,7 +160,7 @@ spec = do
         r <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default payload
         verify r
             [ expectResponseCode @IO HTTP.status201
-            , expectFieldEqual walletName "1st Wallet"
+            , expectFieldEqual (#name . #getApiT . #getWalletName) "1st Wallet"
             , expectFieldEqual
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 30
             , expectFieldEqual (#balance . #getApiT . #available) (Quantity 0)
@@ -298,12 +297,13 @@ spec = do
         let matrix =
                 [ ( show walletNameMinLength ++ " char long", "1"
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName "1"
+                    , expectFieldEqual (#name . #getApiT . #getWalletName) "1"
                     ]
                   )
                 , ( show walletNameMaxLength ++ " char long", walNameMax
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName walNameMax
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) walNameMax
                     ]
                   )
                 , ( show (walletNameMaxLength + 1) ++ " char long"
@@ -321,27 +321,32 @@ spec = do
                   )
                 , ( "Russian name", russianWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName russianWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) russianWalletName
                     ]
                   )
                 , ( "Polish name", polishWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName polishWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) polishWalletName
                     ]
                   )
                 , ( "Kanji name", kanjiWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName kanjiWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) kanjiWalletName
                     ]
                   )
                 , ( "Arabic name", arabicWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName arabicWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) arabicWalletName
                     ]
                   )
                 , ( "Wildcards name", wildcardsWalletName
                   , [ expectResponseCode @IO HTTP.status201
-                    , expectFieldEqual walletName wildcardsWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) wildcardsWalletName
                     ]
                   )
                 ]
@@ -941,7 +946,7 @@ spec = do
         rg <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
         verify rg
             [ expectResponseCode @IO HTTP.status200
-            , expectFieldEqual walletName "Secure Wallet"
+            , expectFieldEqual (#name . #getApiT . #getWalletName) "Secure Wallet"
             , expectFieldEqual
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectFieldEqual (#balance . #getApiT . #available) (Quantity 0)
@@ -1012,7 +1017,8 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 1
-            , expectListItemFieldEqual 0 walletName "Wallet to be listed"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "Wallet to be listed"
             , expectListItemFieldEqual 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectListItemFieldEqual 0
@@ -1037,9 +1043,9 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 3
-            , expectListItemFieldEqual 0 walletName "1"
-            , expectListItemFieldEqual 1 walletName "2"
-            , expectListItemFieldEqual 2 walletName "3"
+            , expectListItemFieldEqual 0 (#name . #getApiT . #getWalletName) "1"
+            , expectListItemFieldEqual 1 (#name . #getApiT . #getWalletName) "2"
+            , expectListItemFieldEqual 2 (#name . #getApiT . #getWalletName) "3"
             ]
 
     it "WALLETS_LIST_02 - Deleted wallet not listed" $ \ctx -> do
@@ -1088,7 +1094,8 @@ spec = do
         let newName = updateNamePayload "New great name"
         let walId = getFromResponse walletId r
         let expectations = [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName "New great name"
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) "New great name"
                     , expectFieldEqual
                             (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
                     , expectFieldEqual
@@ -1109,7 +1116,8 @@ spec = do
         verify rl
             [ expectResponseCode @IO HTTP.status200
             , expectListSizeEqual 1
-            , expectListItemFieldEqual 0 walletName "New great name"
+            , expectListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) "New great name"
             , expectListItemFieldEqual 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectListItemFieldEqual 0 (#balance . #getApiT . #available) (Quantity 0)
@@ -1124,12 +1132,13 @@ spec = do
         let matrix =
                 [ ( show walletNameMinLength ++ " char long", "1"
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName "1"
+                    , expectFieldEqual (#name . #getApiT . #getWalletName) "1"
                     ]
                   )
                 , ( show walletNameMaxLength ++ " char long", walNameMax
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName walNameMax
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) walNameMax
                     ]
                   )
                 , ( show (walletNameMaxLength + 1) ++ " char long"
@@ -1147,27 +1156,32 @@ spec = do
                   )
                 , ( "Russian name", russianWalletName
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName russianWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) russianWalletName
                     ]
                   )
                 , ( "Polish name", polishWalletName
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName polishWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) polishWalletName
                     ]
                   )
                 , ( "Kanji name", kanjiWalletName
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName kanjiWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) kanjiWalletName
                     ]
                   )
                 , ( "Arabic name", arabicWalletName
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName arabicWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) arabicWalletName
                     ]
                   )
                 , ( "Wildcards name", wildcardsWalletName
                   , [ expectResponseCode @IO HTTP.status200
-                    , expectFieldEqual walletName wildcardsWalletName
+                    , expectFieldEqual
+                            (#name . #getApiT . #getWalletName) wildcardsWalletName
                     ]
                   )
                 ]
@@ -1209,7 +1223,7 @@ spec = do
         ru <- request @ApiWallet ctx ("PUT", "v2/wallets" </> walId) Default payload
         verify ru
             [ expectResponseCode @IO HTTP.status200
-            , expectFieldEqual walletName "Secure Wallet"
+            , expectFieldEqual (#name . #getApiT . #getWalletName) "Secure Wallet"
             ]
 
     it "WALLETS_UPDATE_02 - No payload -> fail" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -91,7 +91,6 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , json
     , listAddresses
-    , passphraseLastUpdate
     , request
     , selectCoins
     , unsafeRequest
@@ -173,7 +172,7 @@ spec = do
             , expectFieldEqual (#delegation . #getApiT) NotDelegating
             , expectFieldEqual walletId
                 "2cf060fe53e4e0593f145f22b858dfc60676d4ab"
-            , expectFieldNotEqual passphraseLastUpdate Nothing
+            , expectFieldNotEqual #passphrase Nothing
             ]
 
     describe "OWASP_INJECTION_CREATE_WALLET_01 - \
@@ -952,7 +951,7 @@ spec = do
                     (#state . #getApiT) Ready
             , expectFieldEqual (#delegation . #getApiT) NotDelegating
             , expectFieldEqual walletId (w ^. walletId)
-            , expectFieldNotEqual passphraseLastUpdate Nothing
+            , expectFieldNotEqual #passphrase Nothing
             ]
 
     it "WALLETS_GET_02, WALLETS_DELETE_01 - Deleted wallet is not available" $ \ctx -> do
@@ -1085,7 +1084,7 @@ spec = do
     it "WALLETS_UPDATE_01 - Updated wallet name is available" $ \ctx -> do
 
         r <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default simplePayload
-        let passLastUpdateValue = getFromResponse passphraseLastUpdate r
+        let passLastUpdateValue = getFromResponse #passphrase r
         let newName = updateNamePayload "New great name"
         let walId = getFromResponse walletId r
         let expectations = [ expectResponseCode @IO HTTP.status200
@@ -1100,7 +1099,7 @@ spec = do
                             (#state . #getApiT) Ready
                     , expectFieldEqual (#delegation . #getApiT) NotDelegating
                     , expectFieldEqual walletId walId
-                    , expectFieldEqual passphraseLastUpdate passLastUpdateValue
+                    , expectFieldEqual #passphrase passLastUpdateValue
                     ]
         ru <- request @ApiWallet ctx ("PUT", "v2/wallets" </> walId) Default newName
         verify ru expectations
@@ -1117,7 +1116,7 @@ spec = do
             , expectListItemFieldEqual 0 (#balance . #getApiT . #total) (Quantity 0)
             , expectListItemFieldEqual 0 (#delegation . #getApiT) NotDelegating
             , expectListItemFieldEqual 0 walletId walId
-            , expectListItemFieldEqual 0 passphraseLastUpdate passLastUpdateValue
+            , expectListItemFieldEqual 0 #passphrase passLastUpdateValue
             ]
 
     describe "WALLETS_UPDATE_02 - Various names" $ do
@@ -1296,9 +1295,9 @@ spec = do
         expectResponseCode @IO HTTP.status204 rup
 
         let getEndpoint = "v2/wallets" </> (getFromResponse walletId r)
-        let originalPassUpdateDateTime = getFromResponse passphraseLastUpdate r
+        let originalPassUpdateDateTime = getFromResponse #passphrase r
         rg <- request @ApiWallet ctx ("GET", getEndpoint) Default Empty
-        expectFieldNotEqual passphraseLastUpdate originalPassUpdateDateTime rg
+        expectFieldNotEqual #passphrase originalPassUpdateDateTime rg
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
         let minLength = passphraseMinLength (Proxy @"encryption")

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -72,8 +72,6 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
-    , coinSelectionInputs
-    , coinSelectionOutputs
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyWallet
@@ -198,7 +196,7 @@ spec = do
             r <- request @ApiWallet ctx postWallet Default payload
             verify r
                 [ expectResponseCode @IO HTTP.status201
-                , expectFieldEqual walletName nameOut
+                , expectFieldEqual (#name . #getApiT . #getWalletName) nameOut
                 , expectFieldEqual
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
                 , expectFieldEqual
@@ -207,10 +205,10 @@ spec = do
                 , expectFieldEqual (#balance . #getApiT . #reward) (Quantity 0)
                 , expectEventually ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
-                , expectFieldEqual delegation (NotDelegating)
+                , expectFieldEqual (#delegation . #getApiT) (NotDelegating)
                 , expectFieldEqual walletId
                     "135bfb99b9f7a0c702bf8c658cc0d9b1a0d797a2"
-                , expectFieldNotEqual passphraseLastUpdate Nothing
+                , expectFieldNotEqual #passphrase Nothing
                 ]
             let listWallets = Link.listWallets @'Shelley
             rl <- request @[ApiWallet] ctx listWallets Default Empty
@@ -1609,9 +1607,9 @@ spec = do
             let payment = AddressAmount targetAddress amount
             selectCoins ctx source (payment :| []) >>= flip verify
                 [ expectResponseCode HTTP.status200
-                , expectFieldSatisfy coinSelectionInputs (not . null)
-                , expectFieldSatisfy coinSelectionOutputs ((> 1) . length)
-                , expectFieldSatisfy coinSelectionOutputs (payment `elem`)
+                , expectFieldSatisfy #inputs (not . null)
+                , expectFieldSatisfy #outputs ((> 1) . length)
+                , expectFieldSatisfy #outputs (payment `elem`)
                 ]
 
     it "WALLETS_COIN_SELECTION_02 - \
@@ -1629,11 +1627,11 @@ spec = do
                 [ expectResponseCode
                     HTTP.status200
                 , expectFieldSatisfy
-                    coinSelectionInputs (not . null)
+                    #inputs (not . null)
                 , expectFieldSatisfy
-                    coinSelectionOutputs ((> paymentCount) . length)
+                    #outputs ((> paymentCount) . length)
                 , expectFieldSatisfy
-                    coinSelectionOutputs (flip all payments . flip elem)
+                    #outputs (flip all payments . flip elem)
                 ]
 
     describe "WALLETS_COIN_SELECTION_03 - non-existing wallets" $  do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -63,7 +63,6 @@ import Test.Integration.Framework.DSL
     , cardanoWalletCLI
     , deleteTransactionViaCLI
     , deleteWalletViaCLI
-    , direction
     , emptyRandomWallet
     , emptyWallet
     , eventually_
@@ -125,7 +124,7 @@ spec = do
         txJson <- postTxViaCLI ctx wSrc wDest amt
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + amt, feeMax + amt)
-            , expectCliFieldEqual direction Outgoing
+            , expectCliFieldEqual (#direction . #getApiT) Outgoing
             , expectCliFieldEqual status Pending
             ]
 
@@ -178,7 +177,7 @@ spec = do
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
-            , expectCliFieldEqual direction Outgoing
+            , expectCliFieldEqual (#direction . #getApiT) Outgoing
             , expectCliFieldEqual status Pending
             ]
         c `shouldBe` ExitSuccess
@@ -234,7 +233,7 @@ spec = do
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
-            , expectCliFieldEqual direction Outgoing
+            , expectCliFieldEqual (#direction . #getApiT) Outgoing
             , expectCliFieldEqual status Pending
             ]
         c `shouldBe` ExitSuccess
@@ -298,7 +297,7 @@ spec = do
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
             [ expectCliFieldEqual (#amount . #getQuantity) (feeMin+amt)
-            , expectCliFieldEqual direction Outgoing
+            , expectCliFieldEqual (#direction . #getApiT) Outgoing
             , expectCliFieldEqual status Pending
             ]
         c `shouldBe` ExitSuccess
@@ -706,8 +705,8 @@ spec = do
         code `shouldBe` ExitSuccess
         outJson <- expectValidJSON (Proxy @([ApiTransaction n])) out
         verify outJson
-            [ expectCliListItemFieldEqual 0 direction Outgoing
-            , expectCliListItemFieldEqual 1 direction Incoming
+            [ expectCliListItemFieldEqual 0 (#direction . #getApiT) Outgoing
+            , expectCliListItemFieldEqual 1 (#direction . #getApiT) Incoming
             ]
 
     describe "TRANS_LIST_02 - Start time shouldn't be later than end time" $
@@ -911,7 +910,7 @@ spec = do
         -- post transaction
         txJson <- postTxViaCLI ctx wSrc wDest 1
         verify txJson
-            [ expectCliFieldEqual direction Outgoing
+            [ expectCliFieldEqual (#direction . #getApiT) Outgoing
             , expectCliFieldEqual status Pending
             ]
         let txId =  getTxId txJson
@@ -920,7 +919,7 @@ spec = do
             (fromStdout <$> listTransactionsViaCLI @t ctx [wSrcId])
                 >>= expectValidJSON (Proxy @([ApiTransaction n]))
                 >>= flip verify
-                    [ expectCliListItemFieldEqual 0 direction Outgoing
+                    [ expectCliListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                     , expectCliListItemFieldEqual 0 status InLedger
                     ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -72,7 +72,6 @@ import Test.Integration.Framework.DSL
     , expectEventually'
     , expectValidJSON
     , faucetAmt
-    , feeEstimator
     , fixtureWallet
     , fixtureWalletWith
     , getWalletViaCLI
@@ -114,7 +113,7 @@ spec = do
     it "TRANS_CREATE_01 - Can create transaction via CLI" $ \ctx -> do
         wSrc <- fixtureWallet ctx
         wDest <- emptyWallet ctx
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 1
                 , nOutputs = 1
                 , nChanges = 1
@@ -159,7 +158,7 @@ spec = do
         let addr1 = encodeAddress @n (getApiT $ fst $ addr !! 1 ^. #id)
         let addr2 = encodeAddress @n (getApiT $ fst $ addr !! 2 ^. #id)
         let amt = 14
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -215,7 +214,7 @@ spec = do
         let addr1' = encodeAddress @n (getApiT $ fst $ addr1 ^. #id)
         let addr2' = encodeAddress @n (getApiT $ fst $ addr2 ^. #id)
         let amt = 14
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -280,7 +279,7 @@ spec = do
         c `shouldBe` ExitFailure 1
 
     it "TRANS_CREATE_03 - 0 balance after transaction" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 0
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 0
         let amt = 1
         wSrc <- fixtureWalletWith ctx [feeMin+amt]
         wDest <- emptyWallet ctx
@@ -344,7 +343,7 @@ spec = do
         c `shouldBe` ExitFailure 1
 
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin `div` 2]
         wDest <- emptyWallet ctx
         addrs:_ <- listAddresses ctx wDest
@@ -360,7 +359,7 @@ spec = do
         c `shouldBe` ExitFailure 1
 
     it "TRANS_CREATE_04 - Not enough money" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin]
         wDest <- emptyWallet ctx
         addrs:_ <- listAddresses ctx wDest
@@ -484,7 +483,7 @@ spec = do
         addr:_ <- listAddresses ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
         let amt = 14
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 1
                 , nOutputs = 1
                 , nChanges = 1
@@ -508,7 +507,7 @@ spec = do
         let addr1 = encodeAddress @n (getApiT $ fst $ addr !! 1 ^. #id)
         let addr2 = encodeAddress @n (getApiT $ fst $ addr !! 2 ^. #id)
         let amt = 14 :: Natural
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -536,7 +535,7 @@ spec = do
         let addr1' = encodeAddress @n (getApiT $ fst $ addr1 ^. #id)
         let addr2' = encodeAddress @n (getApiT $ fst $ addr2 ^. #id)
         let amt = 14 :: Natural
-        let (feeMin, feeMax) = ctx ^. feeEstimator $ PaymentDescription
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
                 { nInputs = 2
                 , nOutputs = 2
                 , nChanges = 2
@@ -593,7 +592,7 @@ spec = do
         c `shouldBe` ExitFailure 1
 
     it "TRANS_ESTIMATE_06 - we give fee estimation when we can't cover fee" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin `div` 2]
         wDest <- emptyWallet ctx
         addrs:_ <- listAddresses ctx wDest
@@ -608,7 +607,7 @@ spec = do
         c `shouldBe` ExitSuccess
 
     it "TRANS_ESTIMATE_07 - Not enough money" $ \ctx -> do
-        let (feeMin, _) = ctx ^. feeEstimator $ PaymentDescription 1 1 1
+        let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith ctx [feeMin]
         wDest <- emptyWallet ctx
         addrs:_ <- listAddresses ctx wDest

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -81,7 +81,6 @@ import Test.Integration.Framework.DSL
     , listTransactionsViaCLI
     , postTransactionFeeViaCLI
     , postTransactionViaCLI
-    , status
     , utcIso8601ToText
     , verify
     , walletId
@@ -125,7 +124,7 @@ spec = do
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + amt, feeMax + amt)
             , expectCliFieldEqual (#direction . #getApiT) Outgoing
-            , expectCliFieldEqual status Pending
+            , expectCliFieldEqual (#status . #getApiT) Pending
             ]
 
         -- verify balance on src wallet
@@ -178,7 +177,7 @@ spec = do
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
             , expectCliFieldEqual (#direction . #getApiT) Outgoing
-            , expectCliFieldEqual status Pending
+            , expectCliFieldEqual (#status . #getApiT) Pending
             ]
         c `shouldBe` ExitSuccess
 
@@ -234,7 +233,7 @@ spec = do
         verify txJson
             [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
             , expectCliFieldEqual (#direction . #getApiT) Outgoing
-            , expectCliFieldEqual status Pending
+            , expectCliFieldEqual (#status . #getApiT) Pending
             ]
         c `shouldBe` ExitSuccess
 
@@ -298,7 +297,7 @@ spec = do
         verify txJson
             [ expectCliFieldEqual (#amount . #getQuantity) (feeMin+amt)
             , expectCliFieldEqual (#direction . #getApiT) Outgoing
-            , expectCliFieldEqual status Pending
+            , expectCliFieldEqual (#status . #getApiT) Pending
             ]
         c `shouldBe` ExitSuccess
 
@@ -911,7 +910,7 @@ spec = do
         txJson <- postTxViaCLI ctx wSrc wDest 1
         verify txJson
             [ expectCliFieldEqual (#direction . #getApiT) Outgoing
-            , expectCliFieldEqual status Pending
+            , expectCliFieldEqual (#status . #getApiT) Pending
             ]
         let txId =  getTxId txJson
 
@@ -920,7 +919,7 @@ spec = do
                 >>= expectValidJSON (Proxy @([ApiTransaction n]))
                 >>= flip verify
                     [ expectCliListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                    , expectCliListItemFieldEqual 0 status InLedger
+                    , expectCliListItemFieldEqual 0 (#status . #getApiT) InLedger
                     ]
 
      -- Try Forget transaction once it's no longer pending

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -60,7 +60,6 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand
     , TxDescription (..)
-    , amount
     , cardanoWalletCLI
     , deleteTransactionViaCLI
     , deleteWalletViaCLI
@@ -125,7 +124,7 @@ spec = do
         let amt = 14
         txJson <- postTxViaCLI ctx wSrc wDest amt
         verify txJson
-            [ expectCliFieldBetween amount (feeMin + amt, feeMax + amt)
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + amt, feeMax + amt)
             , expectCliFieldEqual direction Outgoing
             , expectCliFieldEqual status Pending
             ]
@@ -178,7 +177,7 @@ spec = do
         err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin + (2*amt), feeMax + (2*amt))
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
             , expectCliFieldEqual direction Outgoing
             , expectCliFieldEqual status Pending
             ]
@@ -234,7 +233,7 @@ spec = do
         err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin + (2*amt), feeMax + (2*amt))
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin + (2*amt), feeMax + (2*amt))
             , expectCliFieldEqual direction Outgoing
             , expectCliFieldEqual status Pending
             ]
@@ -298,7 +297,7 @@ spec = do
         err `shouldBe` "Please enter your passphrase: *****************\nOk.\n"
         txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
         verify txJson
-            [ expectCliFieldEqual amount (feeMin+amt)
+            [ expectCliFieldEqual (#amount . #getQuantity) (feeMin+amt)
             , expectCliFieldEqual direction Outgoing
             , expectCliFieldEqual status Pending
             ]
@@ -500,7 +499,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin - amt, feeMax + amt)
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin - amt, feeMax + amt)
             ]
         c `shouldBe` ExitSuccess
 
@@ -525,7 +524,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin, feeMax)
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin, feeMax)
             ]
         c `shouldBe` ExitSuccess
 
@@ -553,7 +552,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliFieldBetween amount (feeMin, feeMax)
+            [ expectCliFieldBetween (#amount . #getQuantity) (feeMin, feeMax)
             ]
         c `shouldBe` ExitSuccess
 
@@ -743,26 +742,26 @@ spec = do
                 code `shouldBe` ExitFailure 1
 
     it "TRANS_LIST_03 - Can order results" $ \ctx -> do
-        let a1 = sum $ replicate 10 1
-        let a2 = sum $ replicate 10 2
+        let a1 = Quantity $ sum $ replicate 10 1
+        let a2 = Quantity $ sum $ replicate 10 2
         w <- fixtureWalletWith ctx $ mconcat
                 [ replicate 10 1
                 , replicate 10 2
                 ]
         let orderings =
                 [ ( mempty
-                  , [ expectCliListItemFieldEqual 0 amount a2
-                    , expectCliListItemFieldEqual 1 amount a1
+                  , [ expectCliListItemFieldEqual 0 #amount a2
+                    , expectCliListItemFieldEqual 1 #amount a1
                     ]
                   )
                 , ( [ "--order", "ascending" ]
-                  , [ expectCliListItemFieldEqual 0 amount a1
-                    , expectCliListItemFieldEqual 1 amount a2
+                  , [ expectCliListItemFieldEqual 0 #amount a1
+                    , expectCliListItemFieldEqual 1 #amount a2
                     ]
                   )
                 , ( [ "--order", "descending" ]
-                  , [ expectCliListItemFieldEqual 0 amount a2
-                    , expectCliListItemFieldEqual 1 amount a1
+                  , [ expectCliListItemFieldEqual 0 #amount a2
+                    , expectCliListItemFieldEqual 1 #amount a1
                     ]
                   )
                 ]

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -60,7 +60,6 @@ import Test.Integration.Framework.DSL
     , KnownCommand
     , cardanoWalletCLI
     , createWalletViaCLI
-    , delegation
     , deleteWalletViaCLI
     , emptyRandomWallet
     , emptyWallet
@@ -174,7 +173,7 @@ spec = do
             , expectCliFieldEqual (#balance . #getApiT . #reward) (Quantity 0)
             , expectEventually' ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
-            , expectCliFieldEqual delegation (NotDelegating)
+            , expectCliFieldEqual (#delegation . #getApiT) NotDelegating
             , expectCliFieldNotEqual passphraseLastUpdate Nothing
             ]
 
@@ -426,7 +425,7 @@ spec = do
             , expectCliFieldEqual (#balance . #getApiT . #reward) (Quantity 0)
             , expectEventually' ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
-            , expectCliFieldEqual delegation (NotDelegating)
+            , expectCliFieldEqual (#delegation . #getApiT) (NotDelegating)
             , expectCliFieldNotEqual passphraseLastUpdate Nothing
             ]
 
@@ -459,7 +458,7 @@ spec = do
                     (#balance . #getApiT . #total) (Quantity 0)
             , expectCliListItemFieldEqual 0
                     (#balance . #getApiT . #reward) (Quantity 0)
-            , expectCliListItemFieldEqual 0 delegation (NotDelegating)
+            , expectCliListItemFieldEqual 0 (#delegation . #getApiT) NotDelegating
             , expectCliListItemFieldEqual 0 walletId (T.pack w1)
             ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -76,7 +76,6 @@ import Test.Integration.Framework.DSL
     , getWalletViaCLI
     , listAddresses
     , listWalletsViaCLI
-    , passphraseLastUpdate
     , postTransactionViaCLI
     , updateWalletNameViaCLI
     , updateWalletPassphraseViaCLI
@@ -174,7 +173,7 @@ spec = do
             , expectEventually' ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
             , expectCliFieldEqual (#delegation . #getApiT) NotDelegating
-            , expectCliFieldNotEqual passphraseLastUpdate Nothing
+            , expectCliFieldNotEqual #passphrase Nothing
             ]
 
     it "WALLETS_CREATE_02 - Restored wallet preserves funds" $ \ctx -> do
@@ -348,7 +347,7 @@ spec = do
             c `shouldBe` ExitSuccess
             T.unpack e `shouldContain` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) o
-            expectCliFieldNotEqual passphraseLastUpdate Nothing j
+            expectCliFieldNotEqual #passphrase Nothing j
 
     describe "WALLETS_CREATE_07 - When passphrase is invalid" $ do
         let proxy_ = Proxy @"encryption"
@@ -426,7 +425,7 @@ spec = do
             , expectEventually' ctx (Link.getWallet @'Shelley)
                     (#state . #getApiT) Ready
             , expectCliFieldEqual (#delegation . #getApiT) (NotDelegating)
-            , expectCliFieldNotEqual passphraseLastUpdate Nothing
+            , expectCliFieldNotEqual #passphrase Nothing
             ]
 
     describe "WALLETS_GET_03,04 - Cannot get wallets with false ids" $ do
@@ -495,7 +494,7 @@ spec = do
             let ppNew = "new secure passphrase"
             let addrPoolMin = fromIntegral @_ @Int $ getAddressPoolGap minBound
             w <- emptyWalletWith ctx (name, T.pack ppOld, addrPoolMin)
-            let initPassUpdateTime = w ^. passphraseLastUpdate
+            let initPassUpdateTime = w ^. #passphrase
             let wid = T.unpack $ w ^. walletId
 
             --update pass
@@ -508,7 +507,7 @@ spec = do
             --verify passphraseLastUpdate was updated
             Stdout o <- getWalletViaCLI @t ctx wid
             j <- expectValidJSON (Proxy @ApiWallet) o
-            expectCliFieldNotEqual passphraseLastUpdate initPassUpdateTime j
+            expectCliFieldNotEqual #passphrase initPassUpdateTime j
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
         let minLength = passphraseMinLength (Proxy @"encryption")

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -81,7 +81,6 @@ import Test.Integration.Framework.DSL
     , updateWalletPassphraseViaCLI
     , verify
     , walletId
-    , walletName
     )
 import Test.Integration.Framework.TestData
     ( arabicWalletName
@@ -164,7 +163,7 @@ spec = do
         T.unpack err `shouldContain` cmdOk
         j <- expectValidJSON (Proxy @ApiWallet) out
         verify j
-            [ expectCliFieldEqual walletName "n"
+            [ expectCliFieldEqual (#name . #getApiT . #getWalletName) "n"
             , expectCliFieldEqual
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectCliFieldEqual (#balance . #getApiT . #available) (Quantity 0)
@@ -243,7 +242,7 @@ spec = do
         c1 `shouldBe` ExitSuccess
         T.unpack e1 `shouldContain` cmdOk
         j <- expectValidJSON (Proxy @ApiWallet) o1
-        expectCliFieldEqual walletName "n1" j
+        expectCliFieldEqual (#name . #getApiT . #getWalletName) "n1" j
 
         (c2, o2, e2) <- createWalletViaCLI @t ctx ["n2"] m1 m2 "Xsecure-passphraseX"
         c2 `shouldBe` ExitFailure 1
@@ -259,7 +258,7 @@ spec = do
             c `shouldBe` ExitSuccess
             T.unpack e `shouldContain` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) o
-            expectCliFieldEqual walletName (T.pack n) j
+            expectCliFieldEqual (#name . #getApiT . #getWalletName) (T.pack n) j
 
     it "WALLETS_CREATE_04 - Cannot create wallet when name exceeds length" $ \ctx -> do
         let n = replicate (walletNameMaxLength + 1) 'ą'
@@ -281,7 +280,8 @@ spec = do
             c `shouldBe` ExitSuccess
             T.unpack err `shouldContain` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) out
-            expectCliFieldEqual walletName (T.pack name) j
+            expectCliFieldEqual
+                    (#name . #getApiT . #getWalletName) (T.pack name) j
 
     describe "WALLETS_CREATE_05 - Can't create wallet with wrong size of mnemonic" $ do
         forM_ ["9", "12"] $ \(size) -> it size $ \ctx -> do
@@ -309,7 +309,8 @@ spec = do
             c `shouldBe` ExitSuccess
             T.unpack err `shouldContain` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) out
-            expectCliFieldEqual walletName (T.pack name) j
+            expectCliFieldEqual
+                    (#name . #getApiT . #getWalletName) (T.pack name) j
 
     describe "WALLETS_CREATE_06 - Can't create wallet with wrong size of mnemonic snd factor" $ do
         forM_ ["15", "18", "21", "24"] $ \(size) -> it size $ \ctx -> do
@@ -416,7 +417,8 @@ spec = do
         err `shouldBe` cmdOk
         j <- expectValidJSON (Proxy @ApiWallet) out
         verify j
-            [ expectCliFieldEqual walletName "Empty Wallet"
+            [ expectCliFieldEqual
+                    (#name . #getApiT . #getWalletName) "Empty Wallet"
             , expectCliFieldEqual
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 20
             , expectCliFieldEqual (#balance . #getApiT . #available) (Quantity 0)
@@ -448,7 +450,8 @@ spec = do
         j <- expectValidJSON (Proxy @[ApiWallet]) out
         length j `shouldBe` 2
         verify j
-            [ expectCliListItemFieldEqual 0 walletName name
+            [ expectCliListItemFieldEqual 0
+                    (#name . #getApiT . #getWalletName) name
             , expectCliListItemFieldEqual 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) 21
             , expectCliListItemFieldEqual 0
@@ -485,7 +488,7 @@ spec = do
             c `shouldBe` ExitSuccess
             err `shouldBe` cmdOk
             j <- expectValidJSON (Proxy @ApiWallet) out
-            expectCliFieldEqual walletName (T.pack n) j
+            expectCliFieldEqual (#name . #getApiT . #getWalletName) (T.pack n) j
 
     it "WALLETS_UPDATE_PASS_01 - Can update passphrase normally"
         $ \ctx -> do

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -54,7 +54,6 @@ import Test.Integration.Framework.DSL
     , TxDescription (..)
     , amount
     , blocks
-    , delegation
     , delegationFee
     , direction
     , emptyRandomWallet
@@ -391,7 +390,7 @@ spec = do
                 , expectListItemFieldEqual 0 status InLedger
                 ]
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldEqual delegation (Delegating (p1 ^. #id))
+            [ expectFieldEqual (#delegation . #getApiT) (Delegating (p1 ^. #id))
             ]
 
         -- Join pool p2
@@ -411,7 +410,7 @@ spec = do
                 [ expectListSizeEqual 0
                 ]
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldEqual delegation (Delegating (p2 ^. #id))
+            [ expectFieldEqual (#delegation . #getApiT) (Delegating (p2 ^. #id))
             ]
 
     describe "STAKE_POOLS_JOIN_01x - Fee boundary values" $ do
@@ -457,7 +456,7 @@ spec = do
             expectResponseCode HTTP.status202 rq
             eventually $ do
                 request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                    [ expectFieldEqual delegation (NotDelegating)
+                    [ expectFieldEqual (#delegation . #getApiT) NotDelegating
                     -- balance is 0 because the rest was used for fees
                     , expectFieldEqual (#balance . #getApiT . #total) (Quantity 0)
                     , expectFieldEqual (#balance . #getApiT . #available) (Quantity 0)
@@ -495,21 +494,21 @@ spec = do
         expectResponseCode HTTP.status202 r
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldEqual delegation (Delegating (p1 ^. #id))
+                [ expectFieldEqual (#delegation . #getApiT) (Delegating (p1 ^. #id))
                 ]
 
         r1q <- quitStakePool ctx (p1 ^. #id) (w, fixturePassphrase)
         expectResponseCode HTTP.status202 r1q
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldEqual delegation (NotDelegating)
+                [ expectFieldEqual (#delegation . #getApiT) NotDelegating
                 ]
 
         r2 <- joinStakePool ctx (p2 ^. #id) (w, fixturePassphrase)
         expectResponseCode HTTP.status202 r2
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldEqual delegation (Delegating (p2 ^. #id))
+                [ expectFieldEqual (#delegation . #getApiT) (Delegating (p2 ^. #id))
                 ]
 
     it "STAKE_POOLS_JOIN_01 - Cannot join non-existant stakepool" $ \ctx -> do
@@ -542,12 +541,12 @@ spec = do
 
         -- Verify the wallet is now delegating
         request @ApiWallet ctx (Link.getWallet @'Shelley wA) Default Empty >>= flip verify
-            [ expectFieldEqual delegation (Delegating (p ^. #id))
+            [ expectFieldEqual (#delegation . #getApiT) (Delegating (p ^. #id))
             ]
 
         -- Verify the other is NOT delegating
         request @ApiWallet ctx (Link.getWallet @'Shelley wB) Default Empty >>= flip verify
-            [ expectFieldEqual delegation NotDelegating
+            [ expectFieldEqual (#delegation . #getApiT) NotDelegating
             ]
 
     it "STAKE_POOLS_JOIN_02 - Passphrase must be correct to join" $ \ctx -> do
@@ -769,7 +768,7 @@ spec = do
                 ]
 
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldEqual delegation NotDelegating
+            [ expectFieldEqual (#delegation . #getApiT) NotDelegating
             ]
 
     it "STAKE_POOLS_QUIT_01 - Quiting before even joining" $ \ctx -> do
@@ -797,7 +796,7 @@ spec = do
         expectResponseCode HTTP.status202 r
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-                [ expectFieldEqual delegation (Delegating (p1 ^. #id))
+                [ expectFieldEqual (#delegation . #getApiT) (Delegating (p1 ^. #id))
                 ]
 
         let pId = p2 ^. #id
@@ -825,7 +824,7 @@ joinStakePoolWithWalletBalance ctx balance = do
     -- Verify the wallet is now delegating
     eventually $ do
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldEqual delegation (Delegating (p ^. #id))
+            [ expectFieldEqual (#delegation . #getApiT) (Delegating (p ^. #id))
             ]
     return (w, p)
 
@@ -841,6 +840,6 @@ joinStakePoolWithFixtureWallet ctx = do
     -- Verify the wallet is now delegating
     eventually $ do
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
-            [ expectFieldEqual delegation (Delegating (p ^. #id))
+            [ expectFieldEqual (#delegation . #getApiT) (Delegating (p ^. #id))
             ]
     return (w, p)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -54,7 +54,6 @@ import Test.Integration.Framework.DSL
     , TxDescription (..)
     , blocks
     , delegationFee
-    , direction
     , emptyRandomWallet
     , emptyWallet
     , eventually
@@ -242,14 +241,14 @@ spec = do
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
         -- Wait for the certificate to be inserted
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -262,14 +261,14 @@ spec = do
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
         -- Wait for the certificate to be inserted
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -294,12 +293,12 @@ spec = do
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -313,14 +312,14 @@ spec = do
         quitStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
-                , expectListItemFieldEqual 1 direction Outgoing
+                , expectListItemFieldEqual 1 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 1 status InLedger
                 ]
 
@@ -380,12 +379,12 @@ spec = do
         joinStakePool ctx (p1 ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
@@ -396,7 +395,7 @@ spec = do
         joinStakePool ctx (p2 ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
@@ -422,7 +421,7 @@ spec = do
             joinStakePool ctx (p ^. #id) (w, "Secure Passphrase")>>= flip verify
                 [ expectResponseCode HTTP.status202
                 , expectFieldEqual status Pending
-                , expectFieldEqual direction Outgoing
+                , expectFieldEqual (#direction . #getApiT) Outgoing
                 ]
 
         it "STAKE_POOLS_JOIN_01x - \
@@ -527,14 +526,14 @@ spec = do
         joinStakePool ctx (p ^. #id) (wA, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectFieldEqual status Pending
-            , expectFieldEqual direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
         -- Wait for the certificate to be inserted
         eventually $ do
             let ep = Link.listTransactions @'Shelley wA
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
                 ]
 
@@ -761,9 +760,9 @@ spec = do
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListItemFieldEqual 0 direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 status InLedger
-                , expectListItemFieldEqual 1 direction Outgoing
+                , expectListItemFieldEqual 1 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 1 status InLedger
                 ]
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -272,7 +272,7 @@ spec = do
         let contributedStake = faucetUtxoAmt - fee
         eventually $ do
             v <- request @[ApiStakePool] ctx Link.listStakePools Default Empty
-            verify (sortByPerformance v)
+            verify v
                 [ expectListItemFieldSatisfy 0 (#metrics . #controlledStake)
                     (> Quantity (existingPoolStake + contributedStake))
                     -- No exact equality since the delegation from previous

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -52,7 +52,6 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , TxDescription (..)
-    , amount
     , blocks
     , delegationFee
     , direction
@@ -620,12 +619,13 @@ spec = do
             unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
         w <- fixtureWallet ctx
         r <- delegationFee ctx w
+        print r
         verify r
             [ expectResponseCode HTTP.status200
             ]
-        let fee = getFromResponse amount r
+        let fee = getFromResponse #amount r
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
-            [ expectFieldEqual amount fee
+            [ expectFieldEqual #amount fee
             ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_01x - edge-case fee in-between coeff" $ \ctx -> do
@@ -635,7 +635,7 @@ spec = do
         let (fee, _) = ctx ^. feeEstimator $ DelegDescription 2 1 1
         verify r
             [ expectResponseCode HTTP.status200
-            , expectFieldEqual amount fee
+            , expectFieldEqual #amount (Quantity fee)
             ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_02 - \

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -79,7 +79,6 @@ import Test.Integration.Framework.DSL
     , quitStakePool
     , request
     , stake
-    , status
     , unsafeRequest
     , verify
     , waitForNextEpoch
@@ -240,7 +239,7 @@ spec = do
         -- Join a pool
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
@@ -249,7 +248,7 @@ spec = do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
 
     it "STAKE_POOLS_JOIN_01 - Controlled stake increases when joining" $ \ctx -> do
@@ -260,7 +259,7 @@ spec = do
         -- Join a pool
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
@@ -269,7 +268,7 @@ spec = do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
 
         let (fee, _) = ctx ^. feeEstimator $ DelegDescription 1 1 1
@@ -292,14 +291,14 @@ spec = do
         -- Join a pool
         joinStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
 
         -- Wait for money to flow
@@ -311,16 +310,16 @@ spec = do
         -- Quit a pool
         quitStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 , expectListItemFieldEqual 1 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 1 status InLedger
+                , expectListItemFieldEqual 1 (#status . #getApiT) InLedger
                 ]
 
         waitForNextEpoch ctx
@@ -378,14 +377,14 @@ spec = do
         -- Join pool p1
         joinStakePool ctx (p1 ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
             [ expectFieldEqual (#delegation . #getApiT) (Delegating (p1 ^. #id))
@@ -394,7 +393,7 @@ spec = do
         -- Join pool p2
         joinStakePool ctx (p2 ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
         eventually $ do
@@ -420,7 +419,7 @@ spec = do
             w <- fixtureWalletWith ctx [fee]
             joinStakePool ctx (p ^. #id) (w, "Secure Passphrase")>>= flip verify
                 [ expectResponseCode HTTP.status202
-                , expectFieldEqual status Pending
+                , expectFieldEqual (#status . #getApiT) Pending
                 , expectFieldEqual (#direction . #getApiT) Outgoing
                 ]
 
@@ -525,7 +524,7 @@ spec = do
         -- Join a pool
         joinStakePool ctx (p ^. #id) (wA, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             , expectFieldEqual (#direction . #getApiT) Outgoing
             ]
 
@@ -534,7 +533,7 @@ spec = do
             let ep = Link.listTransactions @'Shelley wA
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
 
         -- Verify the wallet is now delegating
@@ -761,9 +760,9 @@ spec = do
             let ep = Link.listTransactions @'Shelley w
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 , expectListItemFieldEqual 1 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 1 status InLedger
+                , expectListItemFieldEqual 1 (#status . #getApiT) InLedger
                 ]
 
         request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -101,7 +101,6 @@ import Test.Integration.Framework.DSL as DSL
     , status
     , verify
     , walletId
-    , walletName
     )
 import Test.Integration.Framework.Request
     ( RequestException )
@@ -475,7 +474,7 @@ fixtureExternalTx ctx toSend = do
         @ApiWallet ctx ("POST", "v2/wallets") Default restoreFaucetWallet
     verify r0
         [ expectResponseCode @IO HTTP.status201
-        , expectFieldEqual walletName "Faucet Wallet"
+        , expectFieldEqual (#name . #getApiT . #getWalletName) "Faucet Wallet"
         ]
     let wSrc = getFromResponse Prelude.id r0
     -- we take input by lookking at transactions of the faucet wallet
@@ -498,7 +497,7 @@ fixtureExternalTx ctx toSend = do
             } |]
     r1 <- request @ApiWallet ctx ("POST", "v2/wallets") Default createWallet
     verify r1
-        [ expectFieldEqual walletName "Destination Wallet"
+        [ expectFieldEqual (#name . #getApiT . #getWalletName) "Destination Wallet"
         , expectEventually ctx (Link.getWallet @'Shelley) (#state . #getApiT) Ready
         ]
     let wDest = getFromResponse Prelude.id r1

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -96,7 +96,6 @@ import Test.Integration.Framework.DSL as DSL
     , listAddresses
     , listAllTransactions
     , request
-    , status
     , verify
     , walletId
     )
@@ -171,7 +170,7 @@ spec = do
         verify r
             [ expectResponseCode HTTP.status202
             , expectFieldEqual (#direction . #getApiT) Outgoing
-            , expectFieldEqual DSL.status Pending
+            , expectFieldEqual (#status . #getApiT) Pending
             ]
 
         eventually_ $ do
@@ -181,7 +180,7 @@ spec = do
                 Empty
                 >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
-                , expectListItemFieldEqual 0 DSL.status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 ]
             request @([ApiTransaction n]) ctx
                 (Link.listTransactions @'Shelley wDest)
@@ -189,7 +188,7 @@ spec = do
                 Empty
                 >>= flip verify
                 [ expectListItemFieldEqual 0 (#direction . #getApiT) Incoming
-                , expectListItemFieldEqual 0 DSL.status InLedger
+                , expectListItemFieldEqual 0 (#status . #getApiT) InLedger
                 , expectListItemFieldEqual 0 #amount (Quantity utxoAmt)
                 ]
             request @ApiWallet ctx

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -76,7 +76,6 @@ import Test.Integration.Framework.DSL as DSL
     , Headers (..)
     , Payload (..)
     , TxDescription (..)
-    , direction
     , emptyRandomWallet
     , emptyWallet
     , eventually_
@@ -171,7 +170,7 @@ spec = do
         r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
-            , expectFieldEqual DSL.direction Outgoing
+            , expectFieldEqual (#direction . #getApiT) Outgoing
             , expectFieldEqual DSL.status Pending
             ]
 
@@ -181,7 +180,7 @@ spec = do
                 Default
                 Empty
                 >>= flip verify
-                [ expectListItemFieldEqual 0 DSL.direction Outgoing
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Outgoing
                 , expectListItemFieldEqual 0 DSL.status InLedger
                 ]
             request @([ApiTransaction n]) ctx
@@ -189,7 +188,7 @@ spec = do
                 Default
                 Empty
                 >>= flip verify
-                [ expectListItemFieldEqual 0 DSL.direction Incoming
+                [ expectListItemFieldEqual 0 (#direction . #getApiT) Incoming
                 , expectListItemFieldEqual 0 DSL.status InLedger
                 , expectListItemFieldEqual 0 #amount (Quantity utxoAmt)
                 ]

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -76,7 +76,6 @@ import Test.Integration.Framework.DSL as DSL
     , Headers (..)
     , Payload (..)
     , TxDescription (..)
-    , amount
     , direction
     , emptyRandomWallet
     , emptyWallet
@@ -192,7 +191,7 @@ spec = do
                 >>= flip verify
                 [ expectListItemFieldEqual 0 DSL.direction Incoming
                 , expectListItemFieldEqual 0 DSL.status InLedger
-                , expectListItemFieldEqual 0 DSL.amount utxoAmt
+                , expectListItemFieldEqual 0 #amount (Quantity utxoAmt)
                 ]
             request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -87,7 +87,6 @@ import Test.Integration.Framework.DSL as DSL
     , expectResponseCode
     , expectSuccess
     , faucetAmt
-    , feeEstimator
     , fixturePassphrase
     , fixtureRawTx
     , fixtureWallet
@@ -514,7 +513,7 @@ fixtureExternalTx ctx toSend = do
             , (addrChng, keysAddrChng)
             , (addrDest', keysAddrDest)
             ]
-    let (fee, _) = ctx ^. feeEstimator $ PaymentDescription
+    let (fee, _) = ctx ^. #_feeEstimator $ PaymentDescription
             { nInputs = 1
             , nOutputs = 1
             , nChanges = 1


### PR DESCRIPTION
# Issue Number

#1237 

# Overview

- 5ac1ccb820e2fa5f595b9ea2ce8bd077f3ed233d
  Remove delegation lens
  
- d318824641db81397bc1afa52506f6b9c2f98b51
  Remove passphraseLastUpdate lens
  
- 61c13bbcb38a65e715dec92a5de033b277057f27
  Remove walletName lens
  
- d73ba40e2612a9173db6e02ee7f488116752fc6e
  Remove amount lens
  
- f3f82eb43d4a6fbb81d6abfa2db1d2c9b27454cc
  Remove direction lens
  
- ad59dd0fe9dd7ea462de7e57c33a999e1488662c
  Remove status lens
  
- ae44680fbf2960b24474c16c5cd96095327562d6
  Remove syncProgress lens
  
- 5caaf88507c5529bea13a8e1b73b062560753c12
  Remove apparentPerformance lens
  
- c7c27c4151d84b5a203fce113b2fa74e89e256f9
  Remove metrics, stake, blocks, nextEpoch lenses
  
- dcd45a7ad8bfbb0718a6aec109cefacf2f0a0f86
  Remove feeEstimator lens
  
- 0c3578a6215fba48d67308fdd3562f98e0656490
  Remove input, output lenses
  
- f51cc75508e24df1a2afd13eba775b2f5d5feea6
  Remove coinSelectionInputs, coinSelectionOutputs lenses and rebase

# Comments

All defined lenses removed from `DSL.hs` except for `walletId`, which perhaps we might save, since it seems to be handy?

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
