### PR TITLE
Log the epoch constants used when ranking stake pools

### DIFF
--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -288,13 +288,13 @@ newStakePoolLayer tr getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
         then do
             seed <- liftIO $ atomically readSystemSeed
             let epCst = getEpCst 0
-            combineWith epCst (sortArbitrarily seed) distr prod mempty
+            combineWith (sortArbitrarily seed) epCst distr prod mempty
 
         else do
             let currentEpoch = prodTip ^. #slotId . #epochNumber
             perfs <- liftIO $ readPoolsPerformances db currentEpoch
             let epCst = getEpCst currentEpoch
-            combineWith epCst (pure . sortByDesirability) distr prod perfs
+            combineWith (pure . sortByDesirability) epCst distr prod perfs
 
     readPoolProductionTip = readPoolProductionCursor 1 <&> \case
         []  -> header block0
@@ -321,13 +321,16 @@ newStakePoolLayer tr getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
     (block0, _) = staticBlockchainParameters nl
 
     combineWith
-        :: (Quantity "lovelace" Word64 -> EpochConstants)
-        -> ([(StakePool, [PoolOwner])] -> IO [(StakePool, [PoolOwner])])
+        :: ([(StakePool, [PoolOwner])] -> IO [(StakePool, [PoolOwner])])
+        -> (Quantity "lovelace" Word64 -> EpochConstants)
         -> Map PoolId (Quantity "lovelace" Word64)
         -> Map PoolId (Quantity "block" Word64)
         -> Map PoolId Double
         -> ExceptT ErrListStakePools IO [(StakePool, [PoolOwner])]
-    combineWith epCst sortResults distr prod perfs = do
+    combineWith sortResults mkEpCst distr prod perfs = do
+        liftIO $ do
+            traceWith tr $ MsgUsingTotalStakeForRanking totalStake
+            traceWith tr $ MsgUsingRankingEpochConstants epConstants
         case combineMetrics distr prod perfs of
             Left e ->
                 throwE $ ErrListStakePoolsMetricsInconsistency e
@@ -344,6 +347,8 @@ newStakePoolLayer tr getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
         totalStake =
             Quantity $ Map.foldl' (\a (Quantity b) -> a + b) 0 distr
 
+        epConstants = mkEpCst totalStake
+
         mergeRegistration poolId (stake, production, performance) =
             fmap mkStakePool <$> readPoolRegistration poolId
           where
@@ -356,9 +361,9 @@ newStakePoolLayer tr getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
                     , cost = poolCost
                     , margin = poolMargin
                     , saturation =
-                        Ranking.saturation (epCst totalStake) totalStake stake
+                        Ranking.saturation epConstants totalStake stake
                     , desirability =
-                        Ranking.desirability (epCst totalStake) $ Ranking.Pool
+                        Ranking.desirability epConstants $ Ranking.Pool
                             (unsafeMkRatio 0) -- pool leader pledge
                             poolCost
                             (unsafeMkRatio $ fromIntegral (getPercentage poolMargin) / 100)
@@ -538,6 +543,8 @@ data StakePoolLog
     | MsgStakePoolRegistration PoolRegistrationCertificate
     | MsgRollingBackTo SlotId
     | MsgApplyError ErrMonitorStakePools
+    | MsgUsingRankingEpochConstants EpochConstants
+    | MsgUsingTotalStakeForRanking (Quantity "lovelace" Word64)
     deriving (Show, Eq)
 
 instance DefinePrivacyAnnotation StakePoolLog
@@ -555,6 +562,16 @@ instance DefineSeverity StakePoolLog where
         MsgStakeDistribution _ -> Info
         MsgStakePoolRegistration _ -> Info
         MsgRollingBackTo _ -> Info
+        MsgUsingRankingEpochConstants ec
+            | (ec ^. #totalRewards) == Quantity 0
+                -> Notice
+            | otherwise
+                -> Debug
+        MsgUsingTotalStakeForRanking s
+            | s == Quantity 0
+                -> Notice
+            | otherwise
+                -> Debug
         MsgApplyError e -> case e of
             ErrMonitorStakePoolsNetworkUnavailable{} -> Notice
             ErrMonitorStakePoolsNetworkTip{} -> Notice
@@ -592,6 +609,10 @@ instance ToText StakePoolLog where
             "Writing stake-distribution for epoch " <> pretty ep
         MsgStakePoolRegistration pool ->
             "Discovered stake pool registration: " <> pretty pool
+        MsgUsingRankingEpochConstants csts ->
+            "Using ranking epoch constants: " <> pretty csts
+        MsgUsingTotalStakeForRanking s ->
+            "The total stake used to determine epoch constants was: " <> pretty s
         MsgRollingBackTo point ->
             "Rolling back to " <> pretty point
         MsgApplyError e -> case e of

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -563,12 +563,12 @@ instance DefineSeverity StakePoolLog where
         MsgStakePoolRegistration _ -> Info
         MsgRollingBackTo _ -> Info
         MsgUsingRankingEpochConstants ec
-            | (ec ^. #totalRewards) == Quantity 0
+            | (ec ^. #totalRewards) <= Quantity 100
                 -> Notice
             | otherwise
                 -> Debug
         MsgUsingTotalStakeForRanking s
-            | s == Quantity 0
+            | s <= Quantity 100
                 -> Notice
             | otherwise
                 -> Debug

--- a/lib/core/src/Cardano/Pool/Ranking.hs
+++ b/lib/core/src/Cardano/Pool/Ranking.hs
@@ -90,6 +90,8 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word64 )
+import Fmt
+    ( Buildable (..), blockListF', fmt )
 import GHC.Generics
     ( Generic )
 
@@ -180,6 +182,16 @@ data EpochConstants = EpochConstants
     , totalRewards :: Quantity "lovelace" Word64
       -- ^ Total rewards in an epoch. "R" in the spec.
     } deriving (Show, Eq, Generic)
+
+instance Buildable EpochConstants where
+    build ec = fmt "\n" <> blockListF' "" id
+        [ "leaderStakeInfluence (a0) =  "
+            <> build (getNonNegative $ leaderStakeInfluence ec)
+        , "desiredNumberOfPool (k) = "
+            <> build (getPositive $ desiredNumberOfPools ec)
+        , "totalRewards (R) = "
+            <> build (getQuantity $ totalRewards ec)
+        ]
 
 data Pool = Pool
     { leaderStake :: Ratio

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -53,6 +53,8 @@ import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Text.Read
     ( decimal )
+import Fmt
+    ( Buildable (..), fmt )
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
@@ -119,6 +121,12 @@ instance FromText b => FromText (Quantity sym b) where
 
 instance ToText b => ToText (Quantity sym b) where
     toText (Quantity b) = toText b
+
+-- Builds (Quantity "lovelace" Word64) as "42 lovelace"
+instance (KnownSymbol unit, Buildable a) => Buildable (Quantity unit a) where
+    build (Quantity a) = build a <> fmt " " <> build u
+      where
+        u = symbolVal (Proxy :: Proxy unit)
 
 {-------------------------------------------------------------------------------
                                 Percentage


### PR DESCRIPTION
# Issue Number

#1276 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I added a log for the `Ranking.EpochConstants` when used to sort pools. If the order of pools were to be messed up, this is useful information to have.

# Comments


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
