### PR TITLE
Simplify worker registration lifecycle.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1613,7 +1613,8 @@ registerWorker ctx wid = do
     df = ctx ^. dbFactory
     config = MkWorker
         { workerBefore = \ctx' _ ->
-            runExceptT (W.checkWalletIntegrity ctx' wid bp) >>= either throwIO pure
+            runExceptT (W.checkWalletIntegrity ctx' wid bp)
+                >>= either throwIO pure
 
         , workerMain = \ctx' _ -> do
             -- FIXME:

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1474,7 +1474,7 @@ initWorker ctx wid createWallet restoreWallet =
         Just _ ->
             throwE $ ErrCreateWalletAlreadyExists $ ErrWalletAlreadyExists wid
         Nothing ->
-            liftIO (Registry.register @_ @ctx ctx wid re config) >>= \case
+            liftIO (Registry.register @_ @ctx re ctx wid config) >>= \case
                 Nothing ->
                     throwE ErrCreateWalletFailedToCreateWorker
                 Just _ ->
@@ -1601,7 +1601,7 @@ registerWorker
     -> WalletId
     -> IO ()
 registerWorker ctx wid =
-    void $ Registry.register @_ @ctx ctx wid re config
+    void $ Registry.register @_ @ctx re ctx wid config
   where
     (_, bp, _) = ctx ^. genesisData
     re = ctx ^. workerRegistry

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -58,6 +58,8 @@ import Control.Exception
     , asyncExceptionFromException
     , finally
     )
+import Control.Monad
+    ( void )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Tracer
@@ -240,11 +242,10 @@ register registry ctx k (MkWorker before main after acquire) = do
                 }
         registry `insert` worker
         return worker
-    cleanup mvar e = finally
-        (registry `unregister` k)
-        (finally
-            (tryPutMVar mvar Nothing)
-            (after tr e))
+    cleanup mvar e = do
+        registry `unregister` k
+        void $ tryPutMVar mvar Nothing
+        after tr e
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -173,7 +173,8 @@ data MkWorker key resource msg ctx = MkWorker
         -- returns.
     , workerMain :: WorkerCtx ctx -> key -> IO ()
         -- ^ A task for the worker, possibly infinite
-    , workerAfter :: Tracer IO (WorkerLog key msg) -> Either SomeException () -> IO ()
+    , workerAfter
+        :: Tracer IO (WorkerLog key msg) -> Either SomeException () -> IO ()
         -- ^ Action to run when the worker exits
     , workerAcquire :: (resource -> IO ()) -> IO ()
         -- ^ A bracket-style factory to acquire a resource

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -217,12 +217,12 @@ register
         , HasLogger (WorkerLog key msg) ctx
         , HasWorkerCtx resource ctx
         )
-    => ctx
+    => WorkerRegistry key resource
+    -> ctx
     -> key
-    -> WorkerRegistry key resource
     -> MkWorker key resource msg ctx
     -> IO (Maybe (Worker key resource))
-register ctx k registry (MkWorker before main after acquire) = do
+register registry ctx k (MkWorker before main after acquire) = do
     mvar <- newEmptyMVar
     let io = acquire $ \resource -> do
             let ctx' = hoistResource resource (MsgFromWorker k) ctx

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -137,6 +137,16 @@ insert
 insert (WorkerRegistry mvar) wrk =
     modifyMVar_ mvar (pure . Map.insert (workerId wrk) wrk)
 
+-- | Unregister a worker from the registry, but don't cancel the running task.
+--
+unregister
+    :: Ord key
+    => WorkerRegistry key resource
+    -> key
+    -> IO ()
+unregister (WorkerRegistry mvar) k =
+    modifyMVar_ mvar (pure . Map.delete k)
+
 -- | Remove a worker from the registry (and cancel any running task)
 remove
     :: Ord key

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -21,7 +21,8 @@ import Cardano.Wallet.Registry
     , MkWorker (..)
     , Worker
     , WorkerLog
-    , newWorker
+    , empty
+    , register
     , workerThread
     )
 import Control.Concurrent
@@ -281,7 +282,8 @@ workerTest (WorkerTest before main acquire concurrently assertion timeout) = do
             , workerAfter = \_ -> putMVar onExit
             , workerAcquire = acquire
             }
-    newWorker ctx wid config >>= \case
+    registry <- empty
+    register ctx wid registry config >>= \case
         Nothing -> assertion WorkerNotStarted
         Just worker -> do
             concurrently worker

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -283,7 +283,7 @@ workerTest (WorkerTest before main acquire concurrently assertion timeout) = do
             , workerAcquire = acquire
             }
     registry <- empty
-    register ctx wid registry config >>= \case
+    register registry ctx wid config >>= \case
         Nothing -> assertion WorkerNotStarted
         Just worker -> do
             concurrently worker


### PR DESCRIPTION
# Issue Number

#1292 

# Overview

This PR adjusts the worker registration life cycle so that creating and registering a worker is now a single operation, rather than a two-step operation.

Whereas previously callers would need to first call `newWorker` followed by `insert`, they now only need to call `register`.

In addition, we now provide automatic garbage collection of stale worker references from the registry, so that attempting to look up a previously-registered but prematurely-terminated thread will result in `Nothing`. 