### PR TITLE
Check Bech32 human-readable prefix literals at compile time.

### DIFF
--- a/lib/bech32/src/Codec/Binary/Bech32.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32.hs
@@ -32,7 +32,6 @@ module Codec.Binary.Bech32
     , HumanReadablePartError (..)
     , humanReadablePartFromText
     , humanReadablePartToText
-    , unsafeHumanReadablePartFromText
     ) where
 
 import Codec.Binary.Bech32.Internal

--- a/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
+++ b/lib/bech32/src/Codec/Binary/Bech32/Internal.hs
@@ -51,7 +51,6 @@ module Codec.Binary.Bech32.Internal
     , HumanReadablePart
     , HumanReadablePartError (..)
     , humanReadablePartFromText
-    , unsafeHumanReadablePartFromText
     , humanReadablePartToText
     , humanReadablePartToWords
     , humanReadablePartMinLength
@@ -108,8 +107,6 @@ import Data.Text.Class
     ( splitAtLastOccurrence )
 import Data.Word
     ( Word8 )
-import GHC.Stack
-    ( HasCallStack )
 
 import qualified Data.Array as Arr
 import qualified Data.ByteString as BS
@@ -257,23 +254,6 @@ humanReadablePartFromText hrp
   where
     invalidCharPositions = CharPosition . fst <$> filter
         ((not . humanReadableCharIsValid) . snd) ([0 .. ] `zip` T.unpack hrp)
-
--- | Like `humanReadablePartFromText`, but throws at runtime if given an invalid
--- `hrp` as text. It is recommended to only make use of this function when using
--- litterals. For example:
---
--- >>> unsafeHumanReadablePartFromText "addr"
--- HumanReadablePart "addr"
---
-unsafeHumanReadablePartFromText
-    :: HasCallStack
-    => Text
-    -> HumanReadablePart
-unsafeHumanReadablePartFromText =
-    either errUnsafe id . humanReadablePartFromText
-  where
-    errUnsafe e =
-        error $ "Whoops! Invalid bech32 human-readable part: " <> show e
 
 -- | Represents the set of error conditions that may occur while parsing the
 --   human-readable part of a Bech32 string.

--- a/lib/bech32/test/Codec/Binary/Bech32Spec.hs
+++ b/lib/bech32/test/Codec/Binary/Bech32Spec.hs
@@ -25,16 +25,11 @@ import Codec.Binary.Bech32.Internal
     , humanReadableCharMaxBound
     , humanReadableCharMinBound
     , humanReadablePartFromText
-    , humanReadablePartMaxLength
-    , humanReadablePartMinLength
     , humanReadablePartToText
     , separatorChar
-    , unsafeHumanReadablePartFromText
     )
 import Control.DeepSeq
     ( deepseq )
-import Control.Exception
-    ( evaluate )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bits
@@ -62,15 +57,7 @@ import Data.Vector
 import Data.Word
     ( Word8 )
 import Test.Hspec
-    ( Spec
-    , anyErrorCall
-    , describe
-    , expectationFailure
-    , it
-    , shouldBe
-    , shouldSatisfy
-    , shouldThrow
-    )
+    ( Spec, describe, expectationFailure, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Positive (..)
@@ -415,36 +402,6 @@ spec = do
 
     describe "Pointless test to trigger coverage on derived instances" $ do
         it (show $ humanReadablePartFromText $ T.pack "ca") True
-
-    describe "unsafeHumanReadablePartFromText" $ do
-        forM_ validHRPPrefixes $ \hrp -> do
-            let title t = "Works as expected for valid HRP: " <> t
-            it (title $ T.unpack hrp) $ do
-                Right (unsafeHumanReadablePartFromText hrp)
-                    `shouldBe` humanReadablePartFromText hrp
-
-        forM_ invalidHRPPrefixes $ \hrp -> do
-            let base = "Throws when provided with an invalid HRP: "
-            it (base <> T.unpack hrp) $ do
-                evaluate (unsafeHumanReadablePartFromText hrp)
-                    `shouldThrow` anyErrorCall
-
-validHRPPrefixes :: [Text]
-validHRPPrefixes =
-    [ "testnet"
-    , "ca"
-    , "addr"
-    , "xprv_"
-    , "awesome!"
-    ]
-
-invalidHRPPrefixes :: [Text]
-invalidHRPPrefixes =
-    [ T.replicate (humanReadablePartMaxLength + 1) "_"
-    , T.replicate (humanReadablePartMinLength - 1) "_"
-    , T.pack [pred humanReadableCharMinBound]
-    , T.pack [succ humanReadableCharMaxBound]
-    ]
 
 -- Taken from the BIP 0173 specification: https://git.io/fjBIN
 validBech32Strings :: [Text]

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -259,6 +260,7 @@ import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -352,7 +354,7 @@ cmdMnemonicRewardCredentials =
         let rootXPrv = Shelley.generateKeyFromSeed (wSeed, wSndFactor) mempty
         let rewardAccountXPrv = deriveRewardAccount mempty rootXPrv
 
-        let hrp = Bech32.unsafeHumanReadablePartFromText "ed25519e_sk"
+        let hrp = [Bech32.humanReadablePart|ed25519e_sk|]
         let dp = Bech32.dataPartFromBytes
                 $ BS.take 64
                 $ unXPrv

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -142,6 +142,7 @@ library
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version
       Cardano.Wallet.Version.TH
+      Codec.Binary.Bech32.TH
       Data.Binary.Get.Safe
       Data.Function.Utils
       Data.Time.Text

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -143,7 +144,7 @@ import Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     )
 import Codec.Binary.Bech32
-    ( dataPartFromBytes, dataPartToBytes, unsafeHumanReadablePartFromText )
+    ( dataPartFromBytes, dataPartToBytes )
 import Control.Applicative
     ( optional )
 import Control.Arrow
@@ -220,6 +221,7 @@ import Web.HttpApiData
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString.Lazy as BL
@@ -1079,7 +1081,7 @@ gEncodeAddress (Address bytes) =
   where
     base58 = T.decodeUtf8 $ encodeBase58 bitcoinAlphabet bytes
     bech32 = Bech32.encodeLenient hrp (dataPartFromBytes bytes)
-      where hrp = unsafeHumanReadablePartFromText "addr"
+    hrp = [Bech32.humanReadablePart|addr|]
 
 -- | Decode text string into an 'Address'. Jörmungandr recognizes two kind of
 -- addresses:

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -249,6 +250,7 @@ import Safe
     ( readMay )
 
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Control.Foldl as F
 import qualified Data.ByteString as BS
 import qualified Data.Char as C
@@ -542,7 +544,7 @@ newtype PoolOwner = PoolOwner { getPoolOwner :: ByteString }
     deriving (Generic, Eq, Show, Ord)
 
 poolOwnerPrefix :: Bech32.HumanReadablePart
-poolOwnerPrefix = Bech32.unsafeHumanReadablePartFromText "ed25519_pk"
+poolOwnerPrefix = [Bech32.humanReadablePart|ed25519_pk|]
 
 instance NFData PoolOwner
 

--- a/lib/core/src/Codec/Binary/Bech32/TH.hs
+++ b/lib/core/src/Codec/Binary/Bech32/TH.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- This module contains Template-Haskell-specific extensions to the Bech32
+-- library.
+
+module Codec.Binary.Bech32.TH
+    ( humanReadablePart
+    ) where
+
+import Prelude
+
+import Codec.Binary.Bech32
+    ( HumanReadablePart, humanReadablePartFromText, humanReadablePartToText )
+import Language.Haskell.TH.Quote
+    ( QuasiQuoter (..) )
+import Language.Haskell.TH.Syntax
+    ( Lift, lift )
+
+import qualified Data.Text as T
+
+-- | A quasiquoter for Bech32 human-readable prefixes.
+--
+-- This allows the construction of prefixes to be checked at compile time.
+--
+humanReadablePart :: QuasiQuoter
+humanReadablePart = QuasiQuoter
+    { quoteExp  = lift . unsafeHumanReadablePartFromText . T.pack
+    , quotePat  = notHandled "patterns"
+    , quoteType = notHandled "types"
+    , quoteDec  = notHandled "declarations"
+    }
+  where
+    notHandled things =
+      error $ things <>
+          " are not handled by the Bech32 humanReadablePart quasiquoter."
+
+unsafeHumanReadablePartFromText :: T.Text -> HumanReadablePart
+unsafeHumanReadablePartFromText t =
+    either throwError id $ humanReadablePartFromText t
+  where
+    throwError e = error $ mconcat
+        [ show e
+        , " when processing text "
+        , show t
+        , "."
+        ]
+
+instance Lift HumanReadablePart where
+    lift t =
+        [|unsafeHumanReadablePartFromText $ T.pack
+            $(lift $ T.unpack $ humanReadablePartToText t)|]
+

--- a/lib/jormungandr/test/integration/Cardano/Faucet.hs
+++ b/lib/jormungandr/test/integration/Cardano/Faucet.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -64,6 +65,7 @@ import Test.Integration.Jcli
     ( argHex, argInt, getBlock0H, jcli, jcli_, sinkAddress )
 
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -102,7 +104,7 @@ mkTxBuilder (LinearFee cst coeff _) (TxIn inpTx inpIx, key) (addr, Coin amt) =
 
     prepareTx :: FilePath -> IO ()
     prepareTx txFile = do
-        let hrp = Bech32.unsafeHumanReadablePartFromText "addr"
+        let hrp = [Bech32.humanReadablePart|addr|]
         let dp  = Bech32.dataPartFromBytes (unAddress addr)
         jcli_
             [ "transaction"

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -115,6 +115,7 @@ import Test.QuickCheck
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
@@ -140,7 +141,7 @@ spec = do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         addrs <- listAddresses ctx wDest
 
-        let hrp = Bech32.unsafeHumanReadablePartFromText "addr"
+        let hrp = [Bech32.humanReadablePart|addr|]
         bytes <- generate (vectorOf 32 arbitrary)
         let (utxoAmt, utxoAddr) =
                 ( 14 :: Natural

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -54,6 +55,7 @@ import Test.Integration.Framework.TestData
     )
 
 import qualified Codec.Binary.Bech32 as Bech32
+import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteString as BS
 import qualified Data.List as L
 import qualified Data.Text as T
@@ -196,7 +198,7 @@ mnemonicsToAccountAddress m1 m2 = do
         . publicKey
         . deriveRewardAccount mempty
       where
-        hrp = Bech32.unsafeHumanReadablePartFromText "addr"
+        hrp = [Bech32.humanReadablePart|addr|]
 
 getRewardCredentialsViaCli
     :: forall t. KnownCommand t


### PR DESCRIPTION
# Issue Number

#1325 

# Overview

This PR:

- [x] Introduces a new quasiquoter `Bech32.humanReadablePart` that makes it possible to write Bech32 human-readable prefix literals that are checked for validity at **compile time**.
- [x] Removes the `unsafeHumanReadablePartFromText` function from our local copy of the `bech32` library.

A sample error produced when attempting to compile with an invalid Bech32 prefix literal:
```hs
/home/jsk/projects/input-output-hk/cardano-wallet/lib/core/src/Cardano/Wallet/Primitive/Types.hs:546:19: error:
    • Exception when trying to run compile-time code:
        HumanReadablePartContainsInvalidChars [CharPosition 0,CharPosition 1,CharPosition 2,CharPosition 3] when processing text "\33253\34382\34255\40845ed25519_pk".
CallStack (from HasCallStack):
  error, called at src/Codec/Binary/Bech32/TH.hs:47:20 in cardano-wallet-core-2020.1.27-CMaJoUKlZ2DGqxtjoUjXZ8:Codec.Binary.Bech32.TH
      Code: Language.Haskell.TH.Quote.quoteExp
              Bech32.humanReadablePart "\33253\34382\34255\40845ed25519_pk"
    • In the quasi-quotation:
        [Bech32.humanReadablePart|臥虎藏龍ed25519_pk|]
    |
546 | poolOwnerPrefix = [Bech32.humanReadablePart|臥虎藏龍ed25519_pk|]
```
