### PR TITLE
Suppress automatic migrations for pre-existing wallet databases.

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -212,7 +212,7 @@ data AutoMigration
     = AutoMigrationOnCreate Migration
       -- ^ Perform the specified automatic migration when creating a new
       -- database.
-    | AutoMigrationOnCreateOrRestart Migration
+    | AutoMigrationAlways Migration
       -- ^ Perform the specified automatic migration when creating a new
       -- database or when restarting a pre-existing database.
 
@@ -243,10 +243,10 @@ startSqliteBackend manualMigration autoMigration trace fp = do
     let runQuery :: SqlPersistT IO a -> IO a
         runQuery cmd = withMVar lock $ const $ observe $ runSqlConn cmd backend
     let requiredAutoMigration = case (autoMigration, dbPopulationStatus) of
-            (AutoMigrationOnCreateOrRestart m, DbIsEmpty    ) -> Just m
-            (AutoMigrationOnCreateOrRestart m, DbIsPopulated) -> Just m
-            (AutoMigrationOnCreate          m, DbIsEmpty    ) -> Just m
-            (AutoMigrationOnCreate          _, DbIsPopulated) -> Nothing
+            (AutoMigrationAlways   m, DbIsEmpty    ) -> Just m
+            (AutoMigrationAlways   m, DbIsPopulated) -> Just m
+            (AutoMigrationOnCreate m, DbIsEmpty    ) -> Just m
+            (AutoMigrationOnCreate _, DbIsPopulated) -> Nothing
     autoMigrationResult <- case requiredAutoMigration of
         Nothing -> pure $ pure mempty
         Just am -> runQuery (runMigrationQuiet am)

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -209,9 +209,7 @@ destroyDBLayer (SqliteContext {getSqlBackend, trace, dbFile}) = do
 
 -- | Represents an automatic migration to be performed on a database.
 data AutoMigration
-    = AutoMigrationNone
-      -- ^ Do not perform an automatic migration.
-    | AutoMigrationOnCreate Migration
+    = AutoMigrationOnCreate Migration
       -- ^ Perform the specified automatic migration when creating a new
       -- database.
     | AutoMigrationOnCreateOrRestart Migration
@@ -245,7 +243,6 @@ startSqliteBackend manualMigration autoMigration trace fp = do
     let runQuery :: SqlPersistT IO a -> IO a
         runQuery cmd = withMVar lock $ const $ observe $ runSqlConn cmd backend
     let requiredAutoMigration = case (autoMigration, dbPopulationStatus) of
-            (AutoMigrationNone               , _            ) -> Nothing
             (AutoMigrationOnCreateOrRestart m, DbIsEmpty    ) -> Just m
             (AutoMigrationOnCreateOrRestart m, DbIsPopulated) -> Just m
             (AutoMigrationOnCreate          m, DbIsEmpty    ) -> Just m

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -47,20 +46,15 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , PoolRegistrationCertificate (..)
     , SlotId (..)
-    , slotMinBound
     )
 import Control.Exception
     ( bracket, throwIO )
-import Control.Monad
-    ( when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Tracer
     ( Tracer, traceWith )
-import Data.Function
-    ( (&) )
 import Data.List
     ( foldl' )
 import Data.Map.Strict
@@ -141,15 +135,13 @@ newDBLayer
        -- ^ Database file location, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp = do
-    let start = startSqliteBackend (ManualMigration mempty) migrateAll trace fp
-    (nMigrations, ctx) <- handlingPersistError trace fp start
-    let dbLayer = mkDBLayer ctx
-    when (nMigrations > Quantity 0) $ do
-        traceWith trace MsgForcedRollback
-        dbLayer & \DBLayer{..} -> atomically $ rollbackTo slotMinBound
-    pure (ctx, dbLayer)
-  where
-    mkDBLayer SqliteContext{runQuery} = DBLayer
+    let io = startSqliteBackend
+            (ManualMigration mempty)
+            migrateAll
+            trace
+            fp
+    ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
+    return (ctx, DBLayer
         { putPoolProduction = \point pool -> ExceptT $
             handleConstraint (ErrPointAlreadyExists point) $
                 insert_ (mkPoolProduction pool point)
@@ -242,7 +234,7 @@ newDBLayer trace fp = do
             deleteWhere ([] :: [Filter StakeDistribution])
 
         , atomically = runQuery
-        }
+        })
 
 -- | 'Temporary', catches migration error from previous versions and if any,
 -- _removes_ the database file completely before retrying to start the database.

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -28,7 +28,8 @@ module Cardano.Pool.DB.Sqlite
 import Prelude
 
 import Cardano.DB.Sqlite
-    ( DBLog (..)
+    ( AutoMigration (..)
+    , DBLog (..)
     , ManualMigration (..)
     , MigrationError (..)
     , SqliteContext (..)
@@ -137,7 +138,7 @@ newDBLayer
 newDBLayer trace fp = do
     let io = startSqliteBackend
             (ManualMigration mempty)
-            migrateAll
+            (AutoMigrationOnCreateOrRestart migrateAll)
             trace
             fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -138,7 +138,7 @@ newDBLayer
 newDBLayer trace fp = do
     let io = startSqliteBackend
             (ManualMigration mempty)
-            (AutoMigrationOnCreateOrRestart migrateAll)
+            (AutoMigrationAlways migrateAll)
             trace
             fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -44,7 +44,8 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
     ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
 import Cardano.DB.Sqlite
-    ( DBField (..)
+    ( AutoMigration (..)
+    , DBField (..)
     , DBLog (..)
     , ManualMigration (..)
     , SqliteContext (..)
@@ -401,7 +402,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile = do
         either throwIO pure =<<
         startSqliteBackend
             (migrateManually trace defaultFieldValues)
-            migrateAll
+            (AutoMigrationOnCreate migrateAll)
             trace
             mDatabaseFile
     return (ctx, DBLayer

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -424,15 +424,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile = do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
                 Just _  -> Right <$> do
-                    deleteWhere [WalId ==. wid]
-                    deleteWhere [TxMetaWalletId ==. wid]
-                    deleteWhere [PrivateKeyWalletId ==. wid]
-                    deleteWhere [SeqStateWalletId ==. wid]
-                    deleteWhere [SeqStatePendingWalletId ==. wid]
-                    deleteWhere [RndStateWalletId ==. wid]
-                    deleteWhere [RndStatePendingAddressWalletId ==. wid]
-                    deleteWhere [CertWalletId ==. wid]
-                    deleteCascadeWhere [CheckpointWalletId ==. wid]
+                    deleteCascadeWhere [WalId ==. wid]
                     deleteLooseTransactions
 
         , listWallets =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -396,16 +396,16 @@ newDBLayer
     -> Maybe FilePath
        -- ^ Path to database file, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO s k)
-newDBLayer trace defaultFieldValues fp = do
-    let manualMigrations = migrateManually trace defaultFieldValues
-    let start = startSqliteBackend manualMigrations migrateAll trace fp
-    (nMigrations, ctx@SqliteContext{runQuery}) <- either throwIO pure =<< start
-    let dbLayer = mkDBLayer ctx
-    when (nMigrations > Quantity 0) $ do
-        traceWith trace MsgForcedRollback *> runQuery forceRollback
-    pure (ctx, dbLayer)
-  where
-    mkDBLayer SqliteContext{runQuery} = DBLayer
+newDBLayer trace defaultFieldValues mDatabaseFile = do
+    ctx@SqliteContext{runQuery} <-
+        either throwIO pure =<<
+        startSqliteBackend
+            (migrateManually trace defaultFieldValues)
+            migrateAll
+            trace
+            mDatabaseFile
+    return (ctx, DBLayer
+
         {-----------------------------------------------------------------------
                                       Wallets
         -----------------------------------------------------------------------}
@@ -584,7 +584,7 @@ newDBLayer trace defaultFieldValues fp = do
 
         , atomically = runQuery
 
-        }
+        })
 
 delegationDiscoveredFromEntity
     :: DelegationCertificate
@@ -1013,27 +1013,6 @@ findNearestPoint wid sl =
 -- violated.
 data ErrRollbackTo = ErrNoOlderCheckpoint W.WalletId W.SlotId deriving (Show)
 instance Exception ErrRollbackTo
-
-
-{-------------------------------------------------------------------------------
-                                    Logging
--------------------------------------------------------------------------------}
-
--- | @persistent@ handles automatic migrations by creating copies of existing
--- tables, and re-creating them from scratch. When paired with automatic cascade
--- deletion, this has dramatic consequences on the wallet data integrity (when a
--- source table is deleted due to a migration, all foreign tables are also
--- deleted, but only the rows in the source table are replaced!).
---
--- To cope with this, when any automated migration is detected, we manually
--- roll back all rows referencing checkpoints and replace the genesis checkpoint.
-forceRollback
-    :: SqlPersistT IO ()
-forceRollback = do
-    deleteCascadeWhere [CheckpointSlot >. W.slotMinBound]
-    deleteWhere [CertSlot >. W.slotMinBound]
-    deleteWhere [TxMetaSlot >. W.slotMinBound]
-    deleteLooseTransactions
 
 {-------------------------------------------------------------------------------
                      DB queries for address discovery state

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -73,6 +73,7 @@ PrivateKey                             sql=private_key
     privateKeyHash      B8.ByteString  sql=hash
 
     Primary privateKeyWalletId
+    Foreign Wallet fk_wallet_private_key privateKeyWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Maps a transaction ID to its metadata (which is calculated when applying
@@ -91,6 +92,7 @@ TxMeta
     txMetaAmount       Natural      sql=amount
 
     Primary txMetaTxId txMetaWalletId
+    Foreign Wallet fk_wallet_tx_meta txMetaWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- A transaction input associated with TxMeta.
@@ -138,6 +140,7 @@ Checkpoint
     checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
+    Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet
@@ -147,6 +150,7 @@ DelegationCertificate
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
+    Foreign Wallet delegationCertificate certWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
@@ -180,6 +184,7 @@ SeqState
     seqStateRewardXPub      B8.ByteString     sql=reward_xpub
 
     Primary seqStateWalletId
+    Foreign Wallet seq_state seqStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Mapping of pool addresses to indices, and the slot
@@ -206,6 +211,7 @@ SeqStatePendingIx                            sql=seq_state_pending
     seqStatePendingIxIndex      Word32       sql=pending_ix
 
     Primary seqStatePendingWalletId seqStatePendingIxIndex
+    Foreign Wallet seq_state_address_pending seqStatePendingWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Random scheme address discovery state
@@ -217,6 +223,7 @@ RndState
     rndStateHdPassphrase    HDPassphrase      sql=hd_passphrase
 
     Primary rndStateWalletId
+    Foreign Wallet rnd_state rndStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The set of discovered addresses.
@@ -248,5 +255,6 @@ RndStatePendingAddress
         rndStatePendingAddressAccountIndex
         rndStatePendingAddressIndex
         rndStatePendingAddressAddress
+    Foreign Wallet rnd_state_pending_address rndStatePendingAddressWalletId ! ON DELETE CASCADE
     deriving Show Generic
 |]


### PR DESCRIPTION
# Issue Number

#1279 (wallet shows balance of **zero** after upgrade from older version)

In particular, see the following comments:
- https://github.com/input-output-hk/cardano-wallet/issues/1279#issuecomment-577213679
- https://github.com/input-output-hk/cardano-wallet/issues/1279#issuecomment-578242895

# Overview

This PR:
- [x] reverts the changes introduced in PR #1290.
- [x] suppresses automatic migrations for **_pre-existing file-based wallet databases_**, so that we rely entirely on the manual migration mechanism.

However, we still allow automatic migrations **_when creating new wallet databases_**. This is necessary, because `persistent` relies on the automatic migration mechanism in order to build new databases from scratch.

# Reproduction steps

1. Start with the `v2020-01-14` build (or earlier) of the wallet backend (`cardano-wallet`).
2. Create a Jörmungandr wallet with a non-zero balance `b`. (For example, create a wallet with the passphrase `vintage poem topic machine hazard cement dune glimpse fix brief account badge mass silly business`.)
3. Stop the wallet backend, but do not delete the database files created by step 2.
4. Start with the `v2020-01-21` build (or later) of `cardano-wallet`.
5. Observe the new balance of the wallet.

## Behaviour before application of this PR

The balance is 0.

## Behaviour after application of this PR

The balance is `b`.