### PR TITLE
Rename `greaterThan` to `(.>)`

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -35,7 +35,8 @@ module Test.Integration.Framework.DSL
     , expectCliListField
     , expectWalletUTxO
     , between
-    , greaterThan
+    , (.>=)
+    , (.>)
     , verify
     , Headers(..)
     , Payload(..)
@@ -48,7 +49,6 @@ module Test.Integration.Framework.DSL
     -- * Helpers
     , (</>)
     , (!!)
-    , (.>=)
     , emptyRandomWallet
     , emptyIcarusWallet
     , emptyByronWalletWith
@@ -458,8 +458,8 @@ between (min', max') x
             , show max'
             ]
 
-greaterThan :: (Ord a, Show a) => a -> a -> Expectation
-greaterThan bound x
+(.>) :: (Ord a, Show a) => a -> a -> Expectation
+x .> bound
     | x > bound
         = return ()
     | otherwise
@@ -469,7 +469,6 @@ greaterThan bound x
             , show bound
             , ")"
             ]
-
 
 (.>=) :: (Ord a, Show a) => a -> a -> Expectation
 a .>= b

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -83,7 +83,6 @@ import Test.Integration.Framework.DSL
     , fixtureRandomWallet
     , fixtureWallet
     , getFromResponse
-    , greaterThan
     , json
     , request
     , unsafeRequest
@@ -91,6 +90,7 @@ import Test.Integration.Framework.DSL
     , walletId
     , withMethod
     , withPathParam
+    , (.>)
     )
 import Test.Integration.Framework.TestData
     ( arabicWalletName
@@ -149,7 +149,7 @@ spec = do
             verify r
                 [ expectResponseCode @IO HTTP.status200
                 , expectField (#migrationCost . #getQuantity)
-                    (greaterThan 0)
+                    (.> 0)
                 ]
 
     it "BYRON_CALCULATE_02 - \
@@ -235,7 +235,7 @@ spec = do
                 (Link.getMigrationInfo sourceWallet) Default Empty
             verify r0
                 [ expectResponseCode @IO HTTP.status200
-                , expectField #migrationCost (greaterThan $ Quantity 0)
+                , expectField #migrationCost (.> Quantity 0)
                 ]
             let expectedFee = getFromResponse (#migrationCost . #getQuantity) r0
 
@@ -289,7 +289,7 @@ spec = do
                 (Link.getWallet @'Byron wOld)
                 Default
                 Empty >>= flip verify
-                [ expectField (#balance . #available) (greaterThan $ Quantity 0)
+                [ expectField (#balance . #available) (.> Quantity 0)
                 ]
         let originalBalance = view (#balance . #available . #getQuantity) wOld
 
@@ -300,7 +300,7 @@ spec = do
             Empty
         verify rFee
             [ expectResponseCode @IO HTTP.status200
-            , expectField #migrationCost (greaterThan $ Quantity 0)
+            , expectField #migrationCost (.> Quantity 0)
             ]
         let expectedFee = getFromResponse (#migrationCost . #getQuantity) rFee
 
@@ -401,7 +401,7 @@ spec = do
                     (Link.getWallet @'Byron sourceWallet)
                     Default
                     Empty >>= flip verify
-                    [ expectField (#balance . #available) (greaterThan $ Quantity 0)
+                    [ expectField (#balance . #available) (.> Quantity 0)
                     ]
 
             targetWallet <- emptyWallet ctx
@@ -425,7 +425,7 @@ spec = do
             r0 <- request @ApiByronWalletMigrationInfo ctx ep0 Default Empty
             verify r0
                 [ expectResponseCode @IO HTTP.status200
-                , expectField #migrationCost (greaterThan $ Quantity 0)
+                , expectField #migrationCost (.> Quantity 0)
                 ]
 
             -- Perform the migration.

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -44,9 +44,9 @@ import Test.Integration.Framework.DSL
     , expectResponseCode
     , expectedBlockchainParams
     , getFromResponse
-    , greaterThan
     , request
     , verify
+    , (.>)
     )
 import Test.Integration.Framework.TestData
     ( errMsg400MalformedEpoch, errMsg404NoEpochNo, errMsg405, getHeaderCases )
@@ -64,7 +64,7 @@ spec = do
                 Link.getNetworkInfo Default Empty
             expectResponseCode @IO HTTP.status200 r
             verify r
-                [ expectField #nextEpoch ((greaterThan now) . epochStartTime)
+                [ expectField #nextEpoch ((.> now) . epochStartTime)
                 , expectField (#syncProgress . #getApiT) (`shouldBe` Ready)
                 ]
             return r

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -84,7 +84,6 @@ import Test.Integration.Framework.DSL
     , fixtureWallet
     , fixtureWalletWith
     , getFromResponse
-    , greaterThan
     , joinStakePool
     , json
     , quitStakePool
@@ -94,6 +93,7 @@ import Test.Integration.Framework.DSL
     , waitForNextEpoch
     , walletId
     , withMethod
+    , (.>)
     , (.>=)
     )
 import Test.Integration.Framework.TestData
@@ -162,14 +162,14 @@ spec = do
                     (#metrics . #controlledStake) (`shouldBe` Quantity 1000)
 
                 , expectListField 0
-                    (#metrics . #producedBlocks) (greaterThan $ Quantity 1)
+                    (#metrics . #producedBlocks) (.> Quantity 1)
                 , expectListField 1
                     (#metrics . #producedBlocks) (`shouldBe` Quantity 0)
                 , expectListField 2
                     (#metrics . #producedBlocks) (`shouldBe` Quantity 0)
 
                 , expectListField 0
-                    #apparentPerformance (greaterThan 0)
+                    #apparentPerformance (.> 0)
                 , expectListField 1
                     #apparentPerformance (`shouldBe` 0)
                 , expectListField 2
@@ -293,7 +293,7 @@ spec = do
             v <- request @[ApiStakePool] ctx Link.listStakePools Default Empty
             verify v
                 [ expectListField 0 (#metrics . #controlledStake)
-                    (greaterThan $ Quantity (existingPoolStake + contributedStake))
+                    (.> Quantity (existingPoolStake + contributedStake))
                     -- No exact equality since the delegation from previous
                     -- tests may take effect.
                 ]
@@ -322,7 +322,7 @@ spec = do
         eventually $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
                 [ expectField (#balance . #getApiT . #reward)
-                    (greaterThan (Quantity 0))
+                    (.> (Quantity 0))
                 ]
 
         -- Quit a pool
@@ -377,7 +377,7 @@ spec = do
             verify r
                 [ expectField
                         (#balance . #getApiT . #reward)
-                        (greaterThan (Quantity 0))
+                        (.> Quantity 0)
                 ]
             pure $ getFromResponse (#balance . #getApiT . #reward) r
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

Follow up to #1317 

# Overview

- [x] I renamed `greaterThan` to `(.>)`

# Comments

- For consistency with the also-existing `(.>=)`.
- The other way around, having `greaterThanOrEqual` sounded more impractical because the lines would have been longer and could have required more wrapping.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
