### PR TITLE
Disable foreign key constraints during automatic database migration.

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -233,6 +233,19 @@ startSqliteBackend manualMigration migrateAll trace fp = do
             pure $ Left e
         Right _ -> pure $ Right ctx
 
+-- | Run the given task in a context where foreign key constraints are
+--   /temporarily disabled/, before re-enabling them.
+--
+withForeignKeysDisabled
+    :: Tracer IO DBLog
+    -> Sqlite.Connection
+    -> IO a
+    -> IO a
+withForeignKeysDisabled t c =
+    bracket_
+        (updateForeignKeysSetting t c ForeignKeysDisabled)
+        (updateForeignKeysSetting t c ForeignKeysEnabled)
+
 -- | Specifies whether or not foreign key constraints are enabled, equivalent
 --   to the Sqlite 'foreign_keys' setting.
 --

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -47,20 +46,15 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , PoolRegistrationCertificate (..)
     , SlotId (..)
-    , slotMinBound
     )
 import Control.Exception
     ( bracket, throwIO )
-import Control.Monad
-    ( when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Tracer
     ( Tracer, traceWith )
-import Data.Function
-    ( (&) )
 import Data.List
     ( foldl' )
 import Data.Map.Strict
@@ -141,15 +135,13 @@ newDBLayer
        -- ^ Database file location, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp = do
-    let start = startSqliteBackend (ManualMigration mempty) migrateAll trace fp
-    (nMigrations, ctx) <- handlingPersistError trace fp start
-    let dbLayer = mkDBLayer ctx
-    when (nMigrations > Quantity 0) $ do
-        traceWith trace MsgForcedRollback
-        dbLayer & \DBLayer{..} -> atomically $ rollbackTo slotMinBound
-    pure (ctx, dbLayer)
-  where
-    mkDBLayer SqliteContext{runQuery} = DBLayer
+    let io = startSqliteBackend
+            (ManualMigration mempty)
+            migrateAll
+            trace
+            fp
+    ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
+    return (ctx, DBLayer
         { putPoolProduction = \point pool -> ExceptT $
             handleConstraint (ErrPointAlreadyExists point) $
                 insert_ (mkPoolProduction pool point)
@@ -242,7 +234,7 @@ newDBLayer trace fp = do
             deleteWhere ([] :: [Filter StakeDistribution])
 
         , atomically = runQuery
-        }
+        })
 
 -- | 'Temporary', catches migration error from previous versions and if any,
 -- _removes_ the database file completely before retrying to start the database.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -424,15 +424,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile = do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
                 Just _  -> Right <$> do
-                    deleteWhere [WalId ==. wid]
-                    deleteWhere [TxMetaWalletId ==. wid]
-                    deleteWhere [PrivateKeyWalletId ==. wid]
-                    deleteWhere [SeqStateWalletId ==. wid]
-                    deleteWhere [SeqStatePendingWalletId ==. wid]
-                    deleteWhere [RndStateWalletId ==. wid]
-                    deleteWhere [RndStatePendingAddressWalletId ==. wid]
-                    deleteWhere [CertWalletId ==. wid]
-                    deleteCascadeWhere [CheckpointWalletId ==. wid]
+                    deleteCascadeWhere [WalId ==. wid]
                     deleteLooseTransactions
 
         , listWallets =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -396,16 +396,16 @@ newDBLayer
     -> Maybe FilePath
        -- ^ Path to database file, or Nothing for in-memory database
     -> IO (SqliteContext, DBLayer IO s k)
-newDBLayer trace defaultFieldValues fp = do
-    let manualMigrations = migrateManually trace defaultFieldValues
-    let start = startSqliteBackend manualMigrations migrateAll trace fp
-    (nMigrations, ctx@SqliteContext{runQuery}) <- either throwIO pure =<< start
-    let dbLayer = mkDBLayer ctx
-    when (nMigrations > Quantity 0) $ do
-        traceWith trace MsgForcedRollback *> runQuery forceRollback
-    pure (ctx, dbLayer)
-  where
-    mkDBLayer SqliteContext{runQuery} = DBLayer
+newDBLayer trace defaultFieldValues mDatabaseFile = do
+    ctx@SqliteContext{runQuery} <-
+        either throwIO pure =<<
+        startSqliteBackend
+            (migrateManually trace defaultFieldValues)
+            migrateAll
+            trace
+            mDatabaseFile
+    return (ctx, DBLayer
+
         {-----------------------------------------------------------------------
                                       Wallets
         -----------------------------------------------------------------------}
@@ -584,7 +584,7 @@ newDBLayer trace defaultFieldValues fp = do
 
         , atomically = runQuery
 
-        }
+        })
 
 delegationDiscoveredFromEntity
     :: DelegationCertificate
@@ -1013,27 +1013,6 @@ findNearestPoint wid sl =
 -- violated.
 data ErrRollbackTo = ErrNoOlderCheckpoint W.WalletId W.SlotId deriving (Show)
 instance Exception ErrRollbackTo
-
-
-{-------------------------------------------------------------------------------
-                                    Logging
--------------------------------------------------------------------------------}
-
--- | @persistent@ handles automatic migrations by creating copies of existing
--- tables, and re-creating them from scratch. When paired with automatic cascade
--- deletion, this has dramatic consequences on the wallet data integrity (when a
--- source table is deleted due to a migration, all foreign tables are also
--- deleted, but only the rows in the source table are replaced!).
---
--- To cope with this, when any automated migration is detected, we manually
--- roll back all rows referencing checkpoints and replace the genesis checkpoint.
-forceRollback
-    :: SqlPersistT IO ()
-forceRollback = do
-    deleteCascadeWhere [CheckpointSlot >. W.slotMinBound]
-    deleteWhere [CertSlot >. W.slotMinBound]
-    deleteWhere [TxMetaSlot >. W.slotMinBound]
-    deleteLooseTransactions
 
 {-------------------------------------------------------------------------------
                      DB queries for address discovery state

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -73,6 +73,7 @@ PrivateKey                             sql=private_key
     privateKeyHash      B8.ByteString  sql=hash
 
     Primary privateKeyWalletId
+    Foreign Wallet fk_wallet_private_key privateKeyWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Maps a transaction ID to its metadata (which is calculated when applying
@@ -91,6 +92,7 @@ TxMeta
     txMetaAmount       Natural      sql=amount
 
     Primary txMetaTxId txMetaWalletId
+    Foreign Wallet fk_wallet_tx_meta txMetaWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- A transaction input associated with TxMeta.
@@ -138,6 +140,7 @@ Checkpoint
     checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
+    Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet
@@ -147,6 +150,7 @@ DelegationCertificate
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
+    Foreign Wallet delegationCertificate certWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The UTxO for a given wallet checkpoint is a one-to-one mapping from TxIn ->
@@ -180,6 +184,7 @@ SeqState
     seqStateRewardXPub      B8.ByteString     sql=reward_xpub
 
     Primary seqStateWalletId
+    Foreign Wallet seq_state seqStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Mapping of pool addresses to indices, and the slot
@@ -206,6 +211,7 @@ SeqStatePendingIx                            sql=seq_state_pending
     seqStatePendingIxIndex      Word32       sql=pending_ix
 
     Primary seqStatePendingWalletId seqStatePendingIxIndex
+    Foreign Wallet seq_state_address_pending seqStatePendingWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Random scheme address discovery state
@@ -217,6 +223,7 @@ RndState
     rndStateHdPassphrase    HDPassphrase      sql=hd_passphrase
 
     Primary rndStateWalletId
+    Foreign Wallet rnd_state rndStateWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The set of discovered addresses.
@@ -248,5 +255,6 @@ RndStatePendingAddress
         rndStatePendingAddressAccountIndex
         rndStatePendingAddressIndex
         rndStatePendingAddressAddress
+    Foreign Wallet rnd_state_pending_address rndStatePendingAddressWalletId ! ON DELETE CASCADE
     deriving Show Generic
 |]


### PR DESCRIPTION
# Issue Number

#1279 

# Overview

This PR:

- [x] Adds support for **_enabling_** and **_disabling_** foreign key constraints in SQLite databases.
- [x] Adds a bracket-style function to execute a task in a context where foreign key constraints are _**temporarily disabled**_.
- [x] Temporarily disables foreign key constraints while applying automatic updates generated by `persistent`.

This approach works because it prevents cascading deletes while automatic updates are being applied, _even though_ tables are dropped and recreated in the course of a migration.

# Testing

I have tested this informally (with a database created using the `v2019-12-14` version of `cardano-wallet` and I have also run the state migration tests as follows:

```hs
rm -rf state-migration-test-*
nix-build nix/migration-tests.nixnix -o migration-tests
./migration-tests/runall.sh
```