### PR TITLE
Introduce SomeMnemonic as source of root keys (instead of entropy)

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -236,6 +236,7 @@ test-suite unit
       Cardano.Pool.DB.SqliteSpec
       Cardano.Pool.MetadataSpec
       Cardano.Pool.MetricsSpec
+      Cardano.Wallet.Gen
       Cardano.Pool.PerformanceSpec
       Cardano.Pool.RankingSpec
       Cardano.Wallet.Api.ServerSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -138,6 +138,8 @@ import Data.Text.Class
     , fromTextToBoundedEnum
     , toTextFromBoundedEnum
     )
+import Data.Type.Equality
+    ( (:~:) (..), testEquality )
 import Data.Typeable
     ( Typeable )
 import Data.Word
@@ -148,8 +150,6 @@ import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( KnownNat, Nat, Symbol, natVal )
-
-import Data.Type.Equality
 import Type.Reflection
     ( typeOf )
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Mnemonic.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Mnemonic.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Primitive.Mnemonic
     , MnemonicWordsError(..)
     , ValidEntropySize
     , ValidChecksumSize
+    , ValidMnemonicSentence
     , ConsistentEntropy
     , CheckSumBits
     , EntropySize

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -100,7 +100,7 @@ import Cardano.Wallet.Primitive.Types
     , fromFlatSlot
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeMkSomeMnemonicFromEntropy, unsafeRunExceptT )
+    ( someDummyMnemonic, unsafeRunExceptT )
 import Control.DeepSeq
     ( NFData (..), force )
 import Control.Exception
@@ -147,7 +147,6 @@ import System.IO.Unsafe
 import System.Random
     ( mkStdGen, randoms )
 
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map.Strict as Map
 
@@ -635,12 +634,12 @@ testPk = PrimaryKey testWid
 ourAccount :: ShelleyKey 'AccountK XPub
 ourAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, Nothing) mempty
   where
-    seed = unsafeMkSomeMnemonicFromEntropy (Proxy @15) (BS.replicate 32 0)
+    seed = someDummyMnemonic (Proxy @15)
 
 rewardAccount :: ShelleyKey 'AddressK XPub
 rewardAccount = publicKey $ unsafeGenerateKeyFromSeed (seed, Nothing) mempty
   where
-    seed = unsafeMkSomeMnemonicFromEntropy (Proxy @15) (BS.replicate 32 0)
+    seed = someDummyMnemonic (Proxy @15)
 
 -- | Make a prefixed bytestring for use as a Hash or Address.
 label :: Show n => String -> n -> B8.ByteString

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -104,7 +104,7 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeMkSomeMnemonicFromEntropy )
+    ( someDummyMnemonic )
 import Control.Arrow
     ( second )
 import Control.DeepSeq
@@ -485,14 +485,14 @@ arbitrarySeqAccount
 arbitrarySeqAccount =
     publicKey $ unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where
-    mw = unsafeMkSomeMnemonicFromEntropy (Proxy @15) (BS.replicate 32 0)
+    mw = someDummyMnemonic (Proxy @15)
 
 arbitraryRewardAccount
     :: ShelleyKey 'AddressK XPub
 arbitraryRewardAccount =
     publicKey $ unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where
-    mw = unsafeMkSomeMnemonicFromEntropy (Proxy @15) (BS.replicate 32 0)
+    mw = someDummyMnemonic (Proxy @15)
 
 {-------------------------------------------------------------------------------
                                  Random State

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Shared QuickCheck generators for wallet types.
+--
+-- Our convention is to let each test module define its own @Arbitrary@ orphans.
+-- This module allows for code-reuse where desired, by providing generators.
+module Cardano.Wallet.Gen
+    ( genMnemonic
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Mnemonic
+    ( ConsistentEntropy, EntropySize, Mnemonic, entropyToMnemonic, mkEntropy )
+import Data.Proxy
+    ( Proxy (..) )
+import GHC.TypeLits
+    ( natVal )
+import Test.QuickCheck
+    ( Arbitrary (..), Gen, vectorOf )
+
+import qualified Data.ByteString as BS
+
+-- | Generates an arbitrary mnemonic of a size according to the type parameter.
+--
+-- E.g:
+-- >>> arbitrary = SomeMnemonic <$> genMnemonic @12
+genMnemonic
+    :: forall mw ent csz.
+     ( ConsistentEntropy ent mw csz
+     , EntropySize mw ~ ent
+     )
+    => Gen (Mnemonic mw)
+genMnemonic = do
+        let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
+        bytes <- BS.pack <$> vectorOf n arbitrary
+        let ent = either (error . show) id $ mkEntropy @(EntropySize mw) bytes
+        return $ entropyToMnemonic ent

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
@@ -22,8 +22,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Index
     , Index (..)
     , Passphrase (..)
+    , SomeMnemonic (..)
     , XPrv
-    , fromMnemonic
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..)
@@ -31,9 +31,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     , minSeedLengthBytes
     , unsafeGenerateKeyFromSeed
     )
-
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
+import Cardano.Wallet.Unsafe
+    ( unsafeMkMnemonic )
 import Control.Monad
     ( (<=<) )
 import Data.ByteArray.Encoding
@@ -62,7 +63,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_keyDerivation
-    :: Passphrase "seed"
+    :: SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
@@ -97,11 +98,11 @@ data GenerateKeyFromSeed = GenerateKeyFromSeed
 
 generateTest :: GenerateKeyFromSeed -> Expectation
 generateTest GenerateKeyFromSeed{..} =
-    getKey (generateKeyFromSeed (Passphrase seed) pwd)
+    getKey (generateKeyFromSeed mw pwd)
     `shouldBe`
     getKey rootKey
   where
-    Right (Passphrase seed) = fromMnemonic @'[12] mnem
+    mw = SomeMnemonic $ unsafeMkMnemonic @12 mnem
 
 generateTest1 :: GenerateKeyFromSeed
 generateTest1 = GenerateKeyFromSeed

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -30,6 +30,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Passphrase (..)
     , PaymentAddress (..)
     , SoftDerivation (..)
+    , SomeMnemonic (..)
     , WalletKey (..)
     , XPrv
     )
@@ -46,8 +47,12 @@ import Cardano.Wallet.Primitive.Mnemonic
     ( ConsistentEntropy, EntropySize, mkMnemonic )
 import Cardano.Wallet.Primitive.Types
     ( Address )
+import Cardano.Wallet.Unsafe
+    ( unsafeMkSomeMnemonicFromEntropy )
 import Control.Monad
     ( forM_ )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.Text
     ( Text )
 import Test.Hspec
@@ -69,7 +74,8 @@ import qualified Data.Text as T
 spec :: Spec
 spec = do
     describe "Golden Tests - Icarus' style addresses" $ do
-        let seed0 = Passphrase "4\175\242L\184\243\191 \169]\171 \207\r\v\233\NUL~&\ETB"
+        let seed0 = unsafeMkSomeMnemonicFromEntropy (Proxy @15)
+                "4\175\242L\184\243\191 \169]\171 \207\r\v\233\NUL~&\ETB"
 
         goldenAddressGeneration $ GoldenAddressGeneration
             seed0 (toEnum 0x80000000) UTxOExternal (toEnum 0x00000000)
@@ -82,11 +88,10 @@ spec = do
         goldenAddressGeneration $ GoldenAddressGeneration
             seed0 (toEnum 0x8000000E) UTxOInternal (toEnum 0x0000002A)
             "Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi"
-
         let (Right seed1) = fromMnemonic @'[12]
-                [ "ghost", "buddy", "neutral", "broccoli", "face", "rack"
-                , "relief", "odor", "swallow", "real", "once", "ecology"
-                ]
+              [ "ghost", "buddy", "neutral", "broccoli", "face", "rack"
+              , "relief", "odor", "swallow", "real", "once", "ecology"
+              ]
 
         goldenAddressGeneration $ GoldenAddressGeneration
             seed1 (toEnum 0x80000000) UTxOExternal (toEnum 0x00000000)
@@ -185,7 +190,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 data GoldenAddressGeneration = GoldenAddressGeneration
-    { goldSeed :: Passphrase "seed"
+    { goldSeed :: SomeMnemonic
     , goldAcctIx :: Index 'Hardened 'AccountK
     , goldAcctStyle :: AccountingStyle
     , goldAddrIx :: Index 'Soft 'AddressK
@@ -244,7 +249,7 @@ goldenHardwareLedger
     -> Spec
 goldenHardwareLedger encPwd sentence addrs =
     it title $ do
-        let Right mnemonic = mkMnemonic @mw sentence
+        let Right mnemonic = SomeMnemonic <$> mkMnemonic @mw sentence
         let rootXPrv = generateKeyFromHardwareLedger mnemonic encPwd
         let acctXPrv = deriveAccountPrivateKey encPwd rootXPrv minBound
         let deriveAddr = deriveAddressPrivateKey encPwd acctXPrv UTxOExternal
@@ -278,7 +283,7 @@ goldenHardwareLedger encPwd sentence addrs =
 --
 -- For details see <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key bip-0039>
 prop_publicChildKeyDerivation
-    :: Passphrase "seed"
+    :: SomeMnemonic
     -> Passphrase "encryption"
     -> AccountingStyle
     -> Index 'Soft 'AddressK
@@ -293,7 +298,7 @@ prop_publicChildKeyDerivation seed encPwd cc ix =
     addrXPub2 = deriveAddressPublicKey (publicKey accXPrv) cc ix
 
 prop_accountKeyDerivation
-    :: Passphrase "seed"
+    :: SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'Hardened 'AccountK
     -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
@@ -26,6 +26,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Passphrase (..)
     , PaymentAddress (..)
     , SoftDerivation (..)
+    , SomeMnemonic
     , WalletKey (..)
     , XPrv
     , XPub (..)
@@ -139,7 +140,7 @@ prop_roundtripEnumAccountingStyle ix =
 --
 -- For details see <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#private-parent-key--public-child-key bip-0039>
 prop_publicChildKeyDerivation
-    :: (Passphrase "seed", Passphrase "generation")
+    :: (SomeMnemonic, Maybe SomeMnemonic)
     -> Passphrase "encryption"
     -> AccountingStyle
     -> Index 'Soft 'AddressK
@@ -154,7 +155,7 @@ prop_publicChildKeyDerivation (seed, recPwd) encPwd cc ix =
     addrXPub2 = deriveAddressPublicKey (publicKey accXPrv) cc ix
 
 prop_accountKeyDerivation
-    :: (Passphrase "seed", Passphrase "generation")
+    :: (SomeMnemonic, Maybe SomeMnemonic)
     -> Passphrase "encryption"
     -> Index 'Hardened 'AccountK
     -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -64,7 +64,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Types
     ( Address (..), ShowFmt (..) )
 import Cardano.Wallet.Unsafe
-    ( unsafeMkSomeMnemonicFromEntropy )
+    ( someDummyMnemonic )
 import Control.Monad
     ( forM, forM_, unless )
 import Control.Monad.IO.Class
@@ -114,7 +114,6 @@ import Test.Text.Roundtrip
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
-import qualified Data.ByteString as BS
 
 spec :: Spec
 spec = do
@@ -343,7 +342,7 @@ prop_genChangeGap
 prop_genChangeGap g =
     property prop
   where
-    mw = unsafeMkSomeMnemonicFromEntropy (Proxy @12) "0000000000000000"
+    mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     s0 = mkSeqState (key, mempty) g
     prop =
@@ -377,7 +376,7 @@ prop_lookupDiscovered
 prop_lookupDiscovered (s0, addr) =
     let (ours, s) = isOurs addr s0 in ours ==> prop s
   where
-    mw = unsafeMkSomeMnemonicFromEntropy (Proxy @12) "0000000000000000"
+    mw = someDummyMnemonic (Proxy @12)
     key = Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
     prop s = monadicIO $ liftIO $ do
         unless (isJust $ isOwned s (key, mempty) addr) $ do
@@ -524,8 +523,7 @@ instance AddressPoolTest IcarusKey where
     ourAccount = publicKey $
         Icarus.unsafeGenerateKeyFromSeed mw mempty
       where
-        mw = unsafeMkSomeMnemonicFromEntropy (Proxy @12)
-                (BS.pack $ replicate 16 0)
+        mw = someDummyMnemonic (Proxy @12)
 
     ourAddresses _proxy cc =
         mkAddress . deriveAddressPublicKey ourAccount cc <$> [minBound..maxBound]
@@ -539,8 +537,7 @@ instance AddressPoolTest ShelleyKey where
     ourAccount = publicKey $
         Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
       where
-        mw = unsafeMkSomeMnemonicFromEntropy (Proxy @15)
-                (BS.pack $ replicate 32 0)
+        mw = someDummyMnemonic (Proxy @15)
 
     ourAddresses _proxy cc =
         mkAddress . deriveAddressPublicKey ourAccount cc <$> [minBound..maxBound]
@@ -555,7 +552,7 @@ rewardAccount
 rewardAccount = publicKey $
     Shelley.unsafeGenerateKeyFromSeed (mw, Nothing) mempty
   where
-    mw = unsafeMkSomeMnemonicFromEntropy (Proxy @15) (BS.pack $ replicate 32 0)
+    mw = someDummyMnemonic (Proxy @15)
 
 changeAddresses
     :: [Address]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -13,6 +13,8 @@ module Cardano.Wallet.Primitive.AddressDiscoverySpec
 
 import Prelude
 
+import Cardano.Wallet.Gen
+    ( genMnemonic )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (AccountK, AddressK, RootK)
     , DerivationType (..)
@@ -20,6 +22,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , NetworkDiscriminant (..)
     , Passphrase (..)
     , PaymentAddress (..)
+    , SomeMnemonic (..)
     , XPrv
     , passphraseMaxLength
     , passphraseMinLength
@@ -27,11 +30,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , unXPrv
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey
-    , generateKeyFromSeed
-    , minSeedLengthBytes
-    , unsafeGenerateKeyFromSeed
-    )
+    ( ByronKey, generateKeyFromSeed, unsafeGenerateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..), knownAddresses )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
@@ -51,7 +50,6 @@ import Test.QuickCheck
     , arbitraryPrintableChar
     , choose
     , property
-    , vectorOf
     , (.&&.)
     )
 
@@ -74,7 +72,7 @@ spec = do
 
 prop_derivedKeysAreOurs
     :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey)
-    => Passphrase "seed"
+    => SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK
     -> Index 'WholeDomain 'AddressK
@@ -108,10 +106,9 @@ instance Arbitrary (ByronKey 'RootK XPrv) where
 
 genRootKeys :: Gen (ByronKey 'RootK XPrv)
 genRootKeys = do
-    (s, e) <- (,)
-        <$> genPassphrase @"seed" (16, 32)
-        <*> genPassphrase @"encryption" (0, 16)
-    return $ generateKeyFromSeed s e
+    mnemonic <- arbitrary
+    e <- genPassphrase @"encryption" (0, 16)
+    return $ generateKeyFromSeed mnemonic e
   where
     genPassphrase :: (Int, Int) -> Gen (Passphrase purpose)
     genPassphrase range = do
@@ -129,9 +126,5 @@ instance {-# OVERLAPS #-} Arbitrary (Passphrase "encryption") where
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes
 
-instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
-    arbitrary = do
-        n <- choose (minSeedLengthBytes, 64)
-        bytes <- BS.pack <$> vectorOf n arbitrary
-        return $ Passphrase $ BA.convert bytes
-
+instance Arbitrary SomeMnemonic where
+    arbitrary = SomeMnemonic <$> genMnemonic @12

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -16,7 +16,7 @@ module Cardano.Wallet.Primitive.TypesSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Passphrase (..), WalletKey (..), XPrv, digest, publicKey )
+    ( Depth (..), WalletKey (..), XPrv, digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
@@ -96,7 +96,7 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
+    ( unsafeFromHex, unsafeMkSomeMnemonicFromEntropy )
 import Control.DeepSeq
     ( deepseq )
 import Control.Exception
@@ -105,8 +105,6 @@ import Control.Monad
     ( forM_, replicateM )
 import Crypto.Hash
     ( hash )
-import Data.ByteString
-    ( ByteString )
 import Data.Either
     ( isRight )
 import Data.Function
@@ -180,7 +178,6 @@ import Test.Text.Roundtrip
 import Test.Utils.Time
     ( genUniformTime, genUniformTimeWithinRange, getUniformTime )
 
-import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -215,8 +212,10 @@ spec = do
 
     describe "Buildable" $ do
         it "WalletId" $ do
-            let seed = Passphrase (BA.convert @ByteString "0000000000000000")
-            let xprv = generateKeyFromSeed (seed, mempty) mempty :: ShelleyKey 'RootK XPrv
+            let mw = unsafeMkSomeMnemonicFromEntropy (Proxy @12)
+                    "0000000000000000"
+            let xprv = generateKeyFromSeed
+                    (mw, Nothing) mempty :: ShelleyKey 'RootK XPrv
             let wid = WalletId $ digest $ publicKey xprv
             "336c96f1...b8cac9ce" === pretty @_ @Text wid
         it "TxMeta (1)" $ do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -96,7 +96,7 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex, unsafeMkSomeMnemonicFromEntropy )
+    ( someDummyMnemonic, unsafeFromHex )
 import Control.DeepSeq
     ( deepseq )
 import Control.Exception
@@ -212,12 +212,11 @@ spec = do
 
     describe "Buildable" $ do
         it "WalletId" $ do
-            let mw = unsafeMkSomeMnemonicFromEntropy (Proxy @12)
-                    "0000000000000000"
+            let mw = someDummyMnemonic (Proxy @12)
             let xprv = generateKeyFromSeed
                     (mw, Nothing) mempty :: ShelleyKey 'RootK XPrv
             let wid = WalletId $ digest $ publicKey xprv
-            "336c96f1...b8cac9ce" === pretty @_ @Text wid
+            "c225b83f...1d9d620e" === pretty @_ @Text wid
         it "TxMeta (1)" $ do
             let txMeta = TxMeta
                     { status = Pending

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -33,6 +33,8 @@ import Cardano.Wallet.DB
     ( DBLayer (..), ErrNoSuchWallet (..), PrimaryKey (..), putTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget, block0, genesisParameters, mkTxId )
+import Cardano.Wallet.Gen
+    ( genMnemonic )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..)
     , Depth (..)
@@ -41,6 +43,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , HardDerivation (..)
     , Index
     , Passphrase (..)
+    , SomeMnemonic (..)
     , XPrv
     , publicKey
     )
@@ -510,13 +513,17 @@ instance Arbitrary (Passphrase purpose) where
     arbitrary =
         Passphrase . BA.convert . BS.pack <$> replicateM 16 arbitrary
 
+
+instance Arbitrary SomeMnemonic where
+    arbitrary = SomeMnemonic <$> genMnemonic @12
+
 instance {-# OVERLAPS #-} Arbitrary (ShelleyKey 'RootK XPrv, Passphrase "encryption")
   where
     shrink _ = []
     arbitrary = do
-        seed <- Passphrase . BA.convert . BS.pack <$> replicateM 32 arbitrary
         pwd <- arbitrary
-        let key = generateKeyFromSeed (seed, mempty) pwd
+        mw <- arbitrary
+        let key = generateKeyFromSeed (mw, Nothing) pwd
         return (key, pwd)
 
 instance Arbitrary SlotId where

--- a/lib/jormungandr/test/integration/Cardano/Faucet.hs
+++ b/lib/jormungandr/test/integration/Cardano/Faucet.hs
@@ -25,8 +25,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..)
     , HardDerivation (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
+    , SomeMnemonic (..)
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -34,13 +34,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Mnemonic
-    ( Mnemonic
-    , entropyToBytes
-    , entropyToMnemonic
-    , genEntropy
-    , mnemonicToEntropy
-    , mnemonicToText
-    )
+    ( Mnemonic, entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
     ( Address (..), Coin (..), Hash (..), TxIn (..), TxOut (..) )
 import Cardano.Wallet.Unsafe
@@ -53,6 +47,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Text
     ( Text )
+import GHC.TypeLits
+    ( KnownNat )
 import Network.Socket
     ( SockAddr (..) )
 import System.FilePath
@@ -1475,11 +1471,11 @@ genFaucets file n = do
     appendFile :: Text -> IO ()
     appendFile txt = TIO.appendFile file (txt <> "\n")
 
-    addresses :: Mnemonic n -> [Address]
+    addresses :: KnownNat n => Mnemonic n -> [Address]
     addresses mw =
         let
             (seed, pwd) =
-                (Passphrase $ entropyToBytes $ mnemonicToEntropy mw, mempty)
+                (SomeMnemonic mw, mempty)
             rootXPrv =
                 generateKeyFromSeed seed pwd
             accXPrv =

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -547,9 +547,9 @@ fixtureExternalTx ctx toSend = do
         }
   where
       getSeqState mnemonic password =
-          let (Right seed) = fromMnemonic @'[15] @"seed" mnemonic
+          let (Right seed) = fromMnemonic @'[15] mnemonic
               pwd = Passphrase $ BA.convert $ T.encodeUtf8 password
-              rootXPrv = generateKeyFromSeed (seed, mempty) pwd
+              rootXPrv = generateKeyFromSeed (seed, Nothing) pwd
           in (rootXPrv
              , pwd
              , mkSeqState @n (rootXPrv, pwd) defaultAddressPoolGap

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Mnemonics.hs
@@ -17,7 +17,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , FromMnemonic (..)
     , NetworkDiscriminant (..)
-    , Passphrase
+    , SomeMnemonic
     , WalletKey (..)
     , XPrv
     , XPub (..)
@@ -176,13 +176,15 @@ mnemonicsToAccountAddress
         -- ^ An encoded address
 mnemonicsToAccountAddress m1 m2 = do
     seed <- unsafeFromMnemonic  @'[15,18,21,24] m1
-    sndFactor <- if m2 == "\n" then mempty else (unsafeFromMnemonic @'[9,12]) m2
+    sndFactor <- if m2 == "\n"
+        then return Nothing
+        else Just <$> (unsafeFromMnemonic @'[9,12] m2)
     pure $ mkAccountAddress $ generateKeyFromSeed (seed, sndFactor) mempty
   where
     unsafeFromMnemonic
-        :: forall (mz :: [Nat]) any. (FromMnemonic mz any)
+        :: forall (mz :: [Nat]). (FromMnemonic mz)
         => Text
-        -> IO (Passphrase any)
+        -> IO SomeMnemonic
     unsafeFromMnemonic = either (fail . show) pure . fromMnemonic @mz . T.words
 
     -- Derive an account address corresponding to a reward account, from a root key

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -44,7 +44,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
+    ( unsafeFromHex, unsafeMkSomeMnemonicFromEntropy )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertToBase )
 import Data.ByteString
@@ -62,7 +62,6 @@ import Test.QuickCheck
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
-import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -529,23 +528,25 @@ goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inps outs bytes'
 xprvSeqFromSeed
     :: ByteString
     -> (ShelleyKey depth XPrv, Passphrase "encryption")
-xprvSeqFromSeed seed =
-    ( Seq.unsafeGenerateKeyFromSeed (Passphrase (BA.convert seed), mempty) pwd
+xprvSeqFromSeed bytes =
+    ( Seq.unsafeGenerateKeyFromSeed (seed, Nothing) pwd
     , pwd
     )
   where
     pwd = mempty
+    seed = unsafeMkSomeMnemonicFromEntropy (Proxy @12) bytes
 
 xprvRndFromSeed
     :: ByteString
     -> (ByronKey 'AddressK XPrv, Passphrase "encryption")
-xprvRndFromSeed seed =
-    ( Rnd.unsafeGenerateKeyFromSeed derPath (Passphrase $ BA.convert seed) pwd
+xprvRndFromSeed bytes =
+    ( Rnd.unsafeGenerateKeyFromSeed derPath seed pwd
     , pwd
     )
   where
     pwd = mempty
     derPath = (minBound, minBound)
+    seed = unsafeMkSomeMnemonicFromEntropy (Proxy @12) bytes
 
 mkKeystore :: Ord k => [(k,v)] -> (k -> Maybe v)
 mkKeystore pairs k =


### PR DESCRIPTION
# Issue Number

#1316, preliminary work to unblock #1321 
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- Add SomeMnemonic as return type of fromMnemonic
- Make e.g. unsafeGenerateKeyFromSeed take a SomeMnemonic instead
entropy. This is more similar to `Icarus.generateKeyFromHardwareLedger`
- Add genMnemonic helper in a shared location

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
