### PR TITLE
LocalTxSubmission real implementation (remove 'localTxSubmissionNull' placeholder)

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -176,7 +176,7 @@ serveWallet Tracers{..} sTolerance databaseDir hostPref listen addrInfo beforeMa
     bp = blockchainParameters @n
 
     serveApp socket = do
-        let nl = newNetworkLayer nullTracer bp addrInfo (versionData @n)
+        nl <- newNetworkLayer nullTracer bp addrInfo (versionData @n)
         byronApi   <- apiLayer (newTransactionLayer @n) nl
         icarusApi  <- apiLayer (newTransactionLayer @n) nl
         startServer socket byronApi icarusApi $> ExitSuccess

--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -50,6 +50,7 @@ import Cardano.Wallet.Network
     , ErrNetworkUnavailable (..)
     , NetworkLayer (..)
     , NextBlocksResult (..)
+    , mapCursor
     )
 import Codec.SerialiseTerm
     ( CodecCBORTerm )

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -354,7 +354,7 @@ mkRawNetworkLayer (block0, bp) batchSize st j = NetworkLayer
 
     _nextBlocks
         :: Cursor t
-        -> ExceptT ErrGetBlock m (NextBlocksResult t block)
+        -> ExceptT ErrGetBlock m (NextBlocksResult (Cursor t) block)
     _nextBlocks cursor@(Cursor localChain) = do
         lift (runExceptT _currentNodeTip) >>= \case
             Right _ -> do
@@ -392,7 +392,7 @@ mkRawNetworkLayer (block0, bp) batchSize st j = NetworkLayer
         tryRollForward
             :: BlockHeader
             -> [block]
-            -> NextBlocksResult t block
+            -> NextBlocksResult (Cursor t) block
         tryRollForward tip = \case
             -- No more blocks to apply, no need to roll forward
             [] -> AwaitReply
@@ -420,13 +420,13 @@ mkRawNetworkLayer (block0, bp) batchSize st j = NetworkLayer
 
         rollBackward
             :: BlockHeader
-            -> NextBlocksResult t block
+            -> NextBlocksResult (Cursor t) block
         rollBackward point =
             RollBackward (cursorBackward point cursor)
 
         recover
             :: BlockHeaders
-            -> NextBlocksResult t block
+            -> NextBlocksResult (Cursor t) block
         recover chain = case (blockHeadersBase chain, blockHeadersTip chain) of
             (Just baseH, Just tipH) | baseH /= tipH ->
                 RollBackward (cursorBackward baseH cursor)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1346 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 9b89a053bb4f3e40a0f6909d89e3bc594c50579d
  Allow mapping on 'NextBlocksResult's cursor
  This makes the type slightly more flexible and avoid pushing down too
much unrelated context regarding cursors. See Byron.Network adjustments
in the next commit

- c9fba67e393d9f52bc113f4be554dca5534fe3f5
  define compatibility type translation between sealedtx and byron gentx
  
- ba8c30d48e9d982b1991d75e76f8529e287e3ad5
  rename 'NetworkClientCmd' to 'ChainSyncCmd'
  - And move 'Cursor' definition out of the chain sync client
- Also renamed 'queue' to 'chainSyncQ' to make the distinction with
  the upcoming local tx submission queue clearer

- 93865ae0b4f7465e943ade1429c7d00e29be11f0
  wire up 'LocalTxSubmission' protocol in Byron Network


# Comments

<!-- Additional comments or screenshots to attach if any -->

Testing will come soon, I first need to enable the transaction submission through the API (see #1347) and start a local blockchain. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
