### PR TITLE
Remove pool id path parameter from the quit delegation endpoint

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -129,6 +129,7 @@ import Cardano.Wallet.Api.Types
     , ApiWalletDelegation (..)
     , ApiWalletDelegationNext (..)
     , ApiWalletDelegationStatus (..)
+    , BackwardCompatPlaceholder
     , ByronWalletStyle (..)
     , Iso8601Time (..)
     , WalletStyle (..)
@@ -794,9 +795,9 @@ joinStakePool ctx p (w, pass) = do
         (Link.joinStakePool (Identity p) w) Default payload
 
 quitStakePool
-    :: forall t w. (HasType (ApiT WalletId) w)
+    :: forall t s w. (HasType (ApiT WalletId) w, HasType (ApiT PoolId) s)
     => Context t
-    -> ApiT PoolId
+    -> BackwardCompatPlaceholder s
     -> (w, Text)
     -> IO (HTTP.Status, Either RequestException (ApiTransaction 'Testnet))
 quitStakePool ctx p (w, pass) = do
@@ -804,7 +805,7 @@ quitStakePool ctx p (w, pass) = do
             "passphrase": #{pass}
             } |]
     request @(ApiTransaction 'Testnet) ctx
-        (Link.quitStakePool (Identity p) w) Default payload
+        (Link.quitStakePool p w) Default payload
 
 selectCoins
     :: forall t w. (HasType (ApiT WalletId) w)

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -54,7 +54,7 @@ module Test.Integration.Framework.TestData
     , errMsg403NoPendingAnymore
     , errMsg404NoSuchPool
     , errMsg403PoolAlreadyJoined
-    , errMsg403WrongPool
+    , errMsg403NotDelegating
     , errMsg403NothingToMigrate
     , errMsg404NoEndpoint
     , errMsg404CannotFindTx
@@ -427,10 +427,10 @@ errMsg403PoolAlreadyJoined pid = "I couldn't join a stake pool with the given id
     ++ unpack pid ++ ". I have already joined this pool; joining again would "
     ++ "incur an unnecessary fee!"
 
-errMsg403WrongPool :: Text -> String
-errMsg403WrongPool pid = "I couldn't quit a stake pool with the given id: "
-    ++ unpack pid ++ ", because I'm not a member of this stake pool.\
-    \ Please check if you are using correct stake pool id in your request."
+errMsg403NotDelegating :: String
+errMsg403NotDelegating = "It seems that you're trying to retire from \
+    \delegation although you're not even delegating, nor won't be in an \
+    \immediate future."
 
 errMsg404CannotFindTx :: Text -> String
 errMsg404CannotFindTx tid = "I couldn't find a transaction with the given id: "

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -78,6 +78,7 @@ module Cardano.Wallet.Api
 
       -- * Miscellaneous Types
     , Any
+    , BackwardCompatPlaceholder(..)
     ) where
 
 import Prelude
@@ -103,6 +104,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiWallet
     , ApiWalletPassphrase
+    , BackwardCompatPlaceholder (..)
     , ByronWalletPostData
     , ByronWalletStyle (..)
     , Iso8601Time
@@ -350,7 +352,7 @@ type JoinStakePool n = "stake-pools"
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/quitStakePool
 type QuitStakePool n = "stake-pools"
-    :> Capture "stakePoolId" (ApiT PoolId)
+    :> Capture "*" (BackwardCompatPlaceholder (ApiT PoolId))
     :> "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiWalletPassphrase

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -47,6 +47,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiWallet (..)
     , ApiWalletPassphrase
+    , BackwardCompatPlaceholder (..)
     , DecodeAddress
     , EncodeAddress
     , Iso8601Time (..)
@@ -138,8 +139,7 @@ data WalletClient t = WalletClient
         -> ApiWalletPassphrase
         -> ClientM (ApiTransaction t)
     , quitStakePool
-        :: ApiT PoolId
-        -> ApiT WalletId
+        :: ApiT WalletId
         -> ApiWalletPassphrase
         -> ClientM (ApiTransaction t)
     , networkInformation
@@ -221,7 +221,7 @@ walletClient =
             , getWalletUtxoStatistics = _getWalletUtxoStatistics
             , listPools = _listPools
             , joinStakePool = _joinStakePool
-            , quitStakePool = _quitStakePool
+            , quitStakePool = _quitStakePool Placeholder
             , networkInformation = _networkInformation
             , networkParameters = _networkParameters
             }

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -84,7 +84,7 @@ module Cardano.Wallet.Api.Link
 import Prelude
 
 import Cardano.Wallet.Api
-    ( Api )
+    ( Api, BackwardCompatPlaceholder )
 import Cardano.Wallet.Api.Types
     ( ApiEpochNumber
     , ApiT (..)
@@ -100,7 +100,7 @@ import Cardano.Wallet.Primitive.Types
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens
-    ( (^.) )
+    ( view, (^.) )
 import Data.Generics.Product.Typed
     ( HasType, typed )
 import Data.Proxy
@@ -396,13 +396,13 @@ quitStakePool
         ( HasType (ApiT PoolId) s
         , HasType (ApiT WalletId) w
         )
-    => s
+    => BackwardCompatPlaceholder s
     -> w
     -> (Method, Text)
 quitStakePool s w =
     endpoint @(Api.QuitStakePool Net) (\mk -> mk sid wid)
   where
-    sid = s ^. typed @(ApiT PoolId)
+    sid = fmap (view (typed @(ApiT PoolId))) s
     wid = w ^. typed @(ApiT WalletId)
 
 getDelegationFee

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -392,20 +392,20 @@ instance Buildable WalletDelegation where
         ", something wrong with awaiting"
 
 class IsDelegatingTo a where
-    isDelegatingTo :: PoolId -> a -> Bool
+    isDelegatingTo :: (PoolId -> Bool) -> a -> Bool
 
 instance IsDelegatingTo WalletDelegationStatus where
-    isDelegatingTo pid = \case
-        Delegating pid' -> pid' == pid
-        NotDelegating   -> False
+    isDelegatingTo predicate = \case
+        Delegating pid -> predicate pid
+        NotDelegating  -> False
 
 instance IsDelegatingTo WalletDelegationNext where
-    isDelegatingTo pid WalletDelegationNext{status} =
-        isDelegatingTo pid status
+    isDelegatingTo predicate WalletDelegationNext{status} =
+        isDelegatingTo predicate status
 
 instance IsDelegatingTo WalletDelegation where
-    isDelegatingTo pid WalletDelegation{active,next} =
-        isDelegatingTo pid active || any (isDelegatingTo pid) next
+    isDelegatingTo predicate WalletDelegation{active,next} =
+        isDelegatingTo predicate active || any (isDelegatingTo predicate) next
 
 newtype WalletPassphraseInfo = WalletPassphraseInfo
     { lastUpdatedAt :: UTCTime }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1574,7 +1574,9 @@ instance (KnownSymbol param, HasPath sub) => HasPath (Capture param t :> sub)
   where
     getPath _ =
         let (verb, sub) = getPath (Proxy @sub)
-        in (verb, "/{" <> symbolVal (Proxy :: Proxy param) <> "}" <> sub)
+        in case symbolVal (Proxy :: Proxy param) of
+            sym | sym == "*" -> (verb, "/" <> sym <> sub)
+            sym -> (verb, "/{" <> sym <> "}" <> sub)
 
 instance HasPath sub => HasPath (ReqBody a b :> sub) where
     getPath _ = getPath (Proxy @sub)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -20,6 +20,7 @@ import Cardano.Wallet.Api.Types
     , ApiT (..)
     , ApiTransaction
     , ApiWallet
+    , BackwardCompatPlaceholder (..)
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -96,9 +97,9 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( errMsg403DelegationFee
+    , errMsg403NotDelegating
     , errMsg403PoolAlreadyJoined
     , errMsg403WrongPass
-    , errMsg403WrongPool
     , errMsg404NoEndpoint
     , errMsg404NoSuchPool
     , errMsg404NoWallet
@@ -324,7 +325,7 @@ spec = do
                 ]
 
         -- Quit a pool
-        quitStakePool ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
+        quitStakePool ctx placeholder (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             , expectField (#status . #getApiT) (`shouldBe` Pending)
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
@@ -366,7 +367,7 @@ spec = do
 
         waitForNextEpoch ctx
 
-        quitStakePool ctx (p1 ^. #id) (w, fixturePassphrase) >>= flip verify
+        quitStakePool ctx placeholder (w, fixturePassphrase) >>= flip verify
             [ expectResponseCode HTTP.status202
             ]
 
@@ -426,8 +427,8 @@ spec = do
             let (feeJoin, _) = ctx ^. #_feeEstimator $ DelegDescription 1 1 1
             let (feeQuit, _) = ctx ^. #_feeEstimator $ DelegDescription 1 0 1
             let initBalance = [feeJoin + feeQuit]
-            (w, p) <- joinStakePoolWithWalletBalance ctx initBalance
-            rq <- quitStakePool ctx (p ^. #id) (w, "Secure Passphrase")
+            (w, _) <- joinStakePoolWithWalletBalance ctx initBalance
+            rq <- quitStakePool ctx placeholder (w, "Secure Passphrase")
             expectResponseCode HTTP.status202 rq
             eventually $ do
                 request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
@@ -444,8 +445,8 @@ spec = do
             let (feeJoin, _) = ctx ^. #_feeEstimator $ DelegDescription 1 1 1
             let (feeQuit, _) = ctx ^. #_feeEstimator $ DelegDescription 0 0 1
             let initBalance = [feeJoin+1]
-            (w, p) <- joinStakePoolWithWalletBalance ctx initBalance
-            rq <- quitStakePool ctx (p ^. #id) (w, "Secure Passphrase")
+            (w, _) <- joinStakePoolWithWalletBalance ctx initBalance
+            rq <- quitStakePool ctx placeholder (w, "Secure Passphrase")
             verify rq
                 [ expectResponseCode HTTP.status403
                 , expectErrorMessage (errMsg403DelegationFee (feeQuit - 1))
@@ -540,7 +541,7 @@ spec = do
                 verifyIt ctx joinStakePool passphrase expec
 
             it ("Quit: " ++ expec) $ \ctx -> do
-                verifyIt ctx quitStakePool passphrase expec
+                verifyIt ctx (\_ _ -> quitStakePool ctx placeholder) passphrase expec
 
     describe "STAKE_POOLS_JOIN/QUIT_02 - Passphrase must be text" $ do
         let verifyIt ctx sPoolEndp = do
@@ -557,7 +558,7 @@ spec = do
         it "Join" $ \ctx -> do
             verifyIt ctx Link.joinStakePool
         it "Quit" $ \ctx -> do
-            verifyIt ctx Link.quitStakePool
+            verifyIt ctx (\_ -> Link.quitStakePool placeholder)
 
     it "STAKE_POOLS_JOIN_03 - Byron wallet cannot join stake pool" $ \ctx -> do
         (_, p:_) <- eventually $
@@ -654,7 +655,7 @@ spec = do
         it "Join" $ \ctx -> do
             verifyIt ctx Link.joinStakePool
         it "Quit" $ \ctx -> do
-            verifyIt ctx Link.quitStakePool
+            verifyIt ctx (\_ -> Link.quitStakePool placeholder)
 
     describe "STAKE_POOLS_JOIN/QUIT_05 -  Methods Not Allowed" $ do
         let methods = ["POST", "CONNECT", "TRACE", "OPTIONS"]
@@ -707,42 +708,21 @@ spec = do
                 verifyIt ctx Link.joinStakePool headers expectations
         forM_ payloadHeaderCases $ \(title, headers, expectations) -> do
             it ("Quit: " ++ title) $ \ctx ->
-                verifyIt ctx Link.quitStakePool headers expectations
+                verifyIt ctx (\_ -> Link.quitStakePool placeholder) headers expectations
 
     it "STAKE_POOLS_QUIT_01 - Quiting before even joining" $ \ctx -> do
-        (_, p:_) <- eventually $
-            unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
         w <- emptyWallet ctx
 
-        r <- quitStakePool ctx (p ^. #id) (w, "Secure Passprase")
+        r <- quitStakePool ctx placeholder (w, "Secure Passprase")
         expectResponseCode HTTP.status403 r
-        expectErrorMessage (errMsg403WrongPool $ toText $ getApiT $ p ^. #id) r
+        expectErrorMessage errMsg403NotDelegating r
 
     it "STAKE_POOLS_QUIT_02 - Passphrase must be correct to quit" $ \ctx -> do
-        (w, p) <- joinStakePoolWithFixtureWallet ctx
+        (w, _) <- joinStakePoolWithFixtureWallet ctx
 
-        r <- quitStakePool ctx (p ^. #id) (w, "Incorrect Passphrase")
+        r <- quitStakePool ctx placeholder (w, "Incorrect Passphrase")
         expectResponseCode HTTP.status403 r
         expectErrorMessage errMsg403WrongPass r
-
-    it "STAKE_POOLS_QUIT_02 - Cannot quit existant stake pool \
-       \I have not joined" $ \ctx -> do
-        (_, p1:p2:_) <- eventually $
-            unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
-        w <- fixtureWallet ctx
-        r <- joinStakePool ctx (p1 ^. #id) (w, fixturePassphrase)
-        expectResponseCode HTTP.status202 r
-        eventually $ do
-            let ep = Link.listTransactions @'Shelley w
-            request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
-                [ expectListField 0 (#direction . #getApiT) (`shouldBe` Outgoing)
-                , expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
-                ]
-        let pId = p2 ^. #id
-        let wrongPoolId = toText $ getApiT pId
-        rq <- quitStakePool ctx pId (w, fixturePassphrase)
-        expectResponseCode HTTP.status403 rq
-        expectErrorMessage (errMsg403WrongPool wrongPoolId) rq
 
     it "STAKE_POOLS_JOIN/QUIT - Checking delegation expectations" $ \ctx -> do
         (_, p1:p2:_) <- eventually $
@@ -806,7 +786,7 @@ spec = do
                 ]
 
         --quiting
-        r3 <- quitStakePool ctx (p2 ^. #id) (w, fixturePassphrase)
+        r3 <- quitStakePool ctx placeholder (w, fixturePassphrase)
         expectResponseCode HTTP.status202 r3
         eventually $ do
             let ep = Link.listTransactions @'Shelley w
@@ -1021,3 +1001,6 @@ getSlotParams ctx = do
     let sp = SlotParameters (EpochLength epochL) (SlotLength slotL) genesisBlockDate (ActiveSlotCoefficient coeff)
 
     return (currentEpoch, sp)
+
+placeholder :: BackwardCompatPlaceholder (Identity (ApiT PoolId))
+placeholder = Placeholder

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1602,6 +1602,7 @@ paths:
           schema: *parametersJoinStakePool
       responses: *responsesJoinStakePool
 
+  /stake-pools/*/wallets/{walletId}:
     delete:
       operationId: quitStakePool
       tags: ["Stake Pools"]
@@ -1610,8 +1611,15 @@ paths:
         <p align="right">status: <strong>stable</strong></p>
 
         Stop delegating completely. The wallet's stake will become inactive.
+
+        > ⚠️  Disclaimer ⚠️
+        >
+        > This endpoint historically use to take a stake pool id as a path parameter.
+        > However, retiring from delegation is ubiquitous and not tight to a particular
+        > stake pool. For backward-compatibility reasons, sending stake pool ids as path
+        > parameter will still be accepted by the server but new integrations are
+        > encouraged to provide a placeholder asterisk `*` instead.
       parameters:
-        - *parametersStakePoolId
         - *parametersWalletId
         - <<: *parametersBody
           schema: *parametersQuitStakePool


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1342 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 8185ced2a86a1ee61fe8ebb895a33def2d6b1c8c
  remove pool-id path parameter from 'quitStakePool'
  Saying that one is "quitting pool A" doesn't actually
reflect what happens in reality. When one quits, one
quits delegation altogether. The retirement is ubiquitous
and therefore, the paremeter is superfluous.

- b7f36260b6ecf3aeea6cc763b7d4deb12c5d4a2e
  add an extra integration test to show backward compatibility of the quitstakepool

# Comments

<!-- Additional comments or screenshots to attach if any -->

- The change is backward-compatible to avoid pushing breaking changes onto clients.

![Screenshot from 2020-02-14 15-45-51](https://user-images.githubusercontent.com/5680256/74541028-23c80100-4f41-11ea-9867-85180db9ac61.png)


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
