### PR TITLE
Extend byron API to support making transactions from byron wallets 

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -129,8 +129,10 @@ test-suite cardano-node-integration
     , cardano-wallet-test-utils
     , directory
     , filepath
+    , generic-lens
     , hspec
     , http-client
+    , http-types
     , iohk-monitoring
     , network
     , ouroboros-network
@@ -151,3 +153,4 @@ test-suite cardano-node-integration
   other-modules:
       Cardano.Wallet.Byron.Faucet
       Cardano.Wallet.Byron.Config
+      Test.Integration.Byron.Scenario.API.Transactions

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -78,6 +78,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
     , NetworkDiscriminantVal
+    , PaymentAddress
     , PersistPrivateKey
     , WalletKey
     , networkDiscriminantVal
@@ -150,6 +151,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 serveWallet
     :: forall (n :: NetworkDiscriminant) t.
         ( NetworkDiscriminantVal n
+        , PaymentAddress n IcarusKey
         , DecodeAddress n
         , EncodeAddress n
         , WorstSizeOf Address n IcarusKey

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Byron.Network
 import Cardano.Wallet.Byron.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.Byron.Transaction.Size
-    ( WorstSizeOf )
+    ( MaxSizeOf )
 import Cardano.Wallet.DB.Sqlite
     ( DatabasesStartupLog, DefaultFieldValues (..), PersistState )
 import Cardano.Wallet.Logging
@@ -154,8 +154,8 @@ serveWallet
         , PaymentAddress n IcarusKey
         , DecodeAddress n
         , EncodeAddress n
-        , WorstSizeOf Address n IcarusKey
-        , WorstSizeOf Address n ByronKey
+        , MaxSizeOf Address n IcarusKey
+        , MaxSizeOf Address n ByronKey
         , t ~ IO Byron
         )
     => Tracers IO

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.Byron.Compatibility
     , fromByronHash
     , fromChainHash
     , fromGenesisData
+    , fromNetworkMagic
     , fromSlotNo
     , fromTip
     , fromTxAux
@@ -371,3 +372,7 @@ fromGenesisData (genesisData, genesisHash) =
         }
     , fromNonAvvmBalances . gdNonAvvmBalances $ genesisData
     )
+
+fromNetworkMagic :: NetworkMagic -> W.ProtocolMagic
+fromNetworkMagic (NetworkMagic magic) =
+    W.ProtocolMagic (fromIntegral magic)

--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -24,7 +24,7 @@ module Cardano.Wallet.Byron.Network
     , withNetworkLayer
 
       -- * Transport Helpers
-    , AddrInfo
+    , AddrInfo(..)
     , localSocketAddrInfo
     ) where
 

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
@@ -24,7 +24,7 @@ import Prelude
 import Cardano.Wallet.Byron.Compatibility
     ( Byron )
 import Cardano.Wallet.Byron.Transaction.Size
-    ( WorstSizeOf, sizeOfSignedTx, worstSizeOf )
+    ( MaxSizeOf, maxSizeOf, sizeOfSignedTx )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
@@ -87,7 +87,7 @@ newTransactionLayer
     :: forall (n :: NetworkDiscriminant) k t.
         ( t ~ IO Byron
         , WalletKey k
-        , WorstSizeOf Address n k
+        , MaxSizeOf Address n k
         )
     => ProtocolMagic
     -> TransactionLayer t k
@@ -211,9 +211,9 @@ fromGenesisTxOut out@(TxOut (Address bytes) _) =
     Tx (Hash $ blake2b256 bytes) [] [out]
 
 dummyAddress
-    :: forall (n :: NetworkDiscriminant) k. (WorstSizeOf Address n k) => Address
+    :: forall (n :: NetworkDiscriminant) k. (MaxSizeOf Address n k) => Address
 dummyAddress =
-    Address $ BS.replicate (worstSizeOf @Address @n @k) 0
+    Address $ BS.replicate (maxSizeOf @Address @n @k) 0
 
 mkWitness
     :: WalletKey k

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
@@ -17,8 +17,10 @@ module Cardano.Wallet.Byron.Transaction.Size
     , sizeOfTxWitness
     , sizeOfTxOut
     , sizeOfCoin
-    , worstSizeOf
-    , WorstSizeOf
+    , maxSizeOf
+    , MaxSizeOf
+    , minSizeOf
+    , MinSizeOf
     ) where
 
 import Prelude
@@ -123,8 +125,11 @@ sizeOfCoin = sizeOf . CBOR.encodeWord64 . getCoin
 sizeOf :: CBOR.Encoding -> Int
 sizeOf = fromIntegral . BL.length . CBOR.toLazyByteString
 
-class WorstSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
-    worstSizeOf :: Int
+class MaxSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
+    maxSizeOf :: Int
+
+class MinSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
+    minSizeOf :: Int
 
 -- ADDRESS (MainNet, Icarus)
 --     = CBOR-LIST-LEN (2)    --     1 byte
@@ -149,7 +154,8 @@ class WorstSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) whe
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (Ø)       --     1 byte
 --             | U8                   --     1 bytes
-instance WorstSizeOf Address 'Mainnet IcarusKey where worstSizeOf = 44
+instance MaxSizeOf Address 'Mainnet IcarusKey where maxSizeOf = 44
+instance MinSizeOf Address 'Mainnet IcarusKey where minSizeOf = 40
 
 -- ADDRESS (TestNet, Icarus)
 --     = CBOR-LIST-LEN (2)    --     1 byte
@@ -174,7 +180,8 @@ instance WorstSizeOf Address 'Mainnet IcarusKey where worstSizeOf = 44
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (8)       --     8 bytes
 --             | U8                   --     1 bytes
-instance WorstSizeOf Address 'Testnet IcarusKey where worstSizeOf = 51
+instance MaxSizeOf Address 'Testnet IcarusKey where maxSizeOf = 51
+instance MinSizeOf Address 'Testnet IcarusKey where minSizeOf = 47
 
 -- ADDRESS (MainNet, Random)
 --     = CBOR-LIST-LEN (2)    --     1 byte
@@ -199,7 +206,8 @@ instance WorstSizeOf Address 'Testnet IcarusKey where worstSizeOf = 51
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (34)      --    34 bytes
 --             | U8                   --     1 bytes
-instance WorstSizeOf Address 'Mainnet ByronKey where worstSizeOf = 77
+instance MaxSizeOf Address 'Mainnet ByronKey where maxSizeOf = 77
+instance MinSizeOf Address 'Mainnet ByronKey where minSizeOf = 73
 
 -- ADDRESS (TestNet, Random)
 --     = CBOR-LIST-LEN (2)    --     1 byte
@@ -224,4 +232,5 @@ instance WorstSizeOf Address 'Mainnet ByronKey where worstSizeOf = 77
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (41)      --    41 bytes
 --             | U8                   --     1 bytes
-instance WorstSizeOf Address 'Testnet ByronKey where worstSizeOf = 84
+instance MaxSizeOf Address 'Testnet ByronKey where maxSizeOf = 84
+instance MinSizeOf Address 'Testnet ByronKey where minSizeOf = 80

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
@@ -54,12 +54,14 @@ sizeOfTx inps outs = 6
 
 -- SIGNED-TX
 --     = CBOR-LIST-LEN (2)    -- 1 byte
+--     | U8                   -- 1 byte
+--     | CBOR-LIST-LEN (2)    -- 1 byte
 --     | TX                   -- sizeOf(TX) bytes
 --     | CBOR-LIST-LEN (n)    -- 1-2 bytes (assuming n < 255)
 --     | *WITNESS             -- n * 139 bytes
---                            == 1 + sizeOf(TX) + 1-2 + n * 139
+--                            == 3 + sizeOf(TX) + 1-2 + n * 139
 sizeOfSignedTx :: [TxIn] -> [TxOut] -> Int
-sizeOfSignedTx inps outs = 1
+sizeOfSignedTx inps outs = 3
     + sizeOfTx inps outs
     + sizeOf (CBOR.encodeListLen $ fromIntegral n)
     + n * sizeOfTxWitness

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -80,8 +80,9 @@ import Test.Integration.Framework.DSL
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
-import qualified Test.Integration.Scenario.API.ByronTransactions as ByronTransactions
-import qualified Test.Integration.Scenario.API.ByronWallets as ByronWallets
+import qualified Test.Integration.Byron.Scenario.API.Transactions as TransactionsByron
+import qualified Test.Integration.Scenario.API.ByronTransactions as TransactionsCommon
+import qualified Test.Integration.Scenario.API.ByronWallets as WalletsCommon
 import qualified Test.Integration.Scenario.API.Network as Network
 
 -- | Define the actual executable name for the bridge CLI
@@ -92,8 +93,9 @@ main :: forall t. (t ~ Byron) => IO ()
 main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
     hspec $ do
         describe "API Specifications" $ specWithServer tr $ do
-            ByronWallets.spec
-            ByronTransactions.spec
+            WalletsCommon.spec
+            TransactionsByron.spec
+            TransactionsCommon.spec
             Network.spec
 
 specWithServer

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -105,12 +105,12 @@ import qualified Test.Integration.Scenario.API.Network as Network
 instance KnownCommand Byron where
     commandName = "cardano-wallet-byron"
 
-main :: forall t. (t ~ Byron) => IO ()
+main :: forall t n. (t ~ Byron, n ~ 'Mainnet) => IO ()
 main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
     hspec $ do
         describe "API Specifications" $ specWithServer tr $ do
             WalletsCommon.spec
-            TransactionsByron.spec
+            (TransactionsByron.spec @n)
             TransactionsCommon.spec
             Network.spec
 

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Integration.Byron.Scenario.API.Transactions
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Link
+    ( Discriminate )
+import Cardano.Wallet.Api.Types
+    ( ApiByronWallet
+    , ApiT (..)
+    , ApiTransaction
+    , EncodeAddress (..)
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( Mnemonic )
+import Cardano.Wallet.Primitive.Types
+    ( Address, Direction (..), TxStatus (..), WalletId )
+import Data.Aeson
+    ( FromJSON )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Generics.Product.Typed
+    ( HasType )
+import Data.Quantity
+    ( Quantity (..) )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( SpecWith, describe, it, shouldBe )
+import Test.Integration.Framework.DSL
+    ( Context
+    , Headers (..)
+    , Payload (..)
+    , TxDescription (..)
+    , between
+    , eventually
+    , expectField
+    , expectResponseCode
+    , faucetAmt
+    , fixtureIcarusWallet
+    , fixturePassphrase
+    , fixtureRandomWallet
+    , icarusAddresses
+    , json
+    , randomAddresses
+    , request
+    , verify
+    )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall t n. (n ~ 'Mainnet) => SpecWith (Context t)
+spec = describe "BYRON_TXS" $ do
+    scenario_TRANS_CREATE_01 @'Byron fixtureRandomWallet (randomAddresses @n)
+    scenario_TRANS_CREATE_01 @'Byron fixtureIcarusWallet (icarusAddresses @n)
+
+--
+-- Scenarios
+--
+
+scenario_TRANS_CREATE_01
+    :: forall style t n mw wallet.
+        ( n ~ 'Mainnet
+        , Discriminate style
+        , HasType (ApiT WalletId) wallet
+        , FromJSON wallet
+        , Generic wallet
+        , Show wallet
+        )
+    => (Context t -> IO (wallet, Mnemonic mw))
+    -> (Mnemonic mw -> [Address])
+    -> SpecWith (Context t)
+scenario_TRANS_CREATE_01 fixtureWallet fixtureAddresses =
+  it "TRANS_CREATE_01 - Single Output Transaction" $ \ctx -> do
+    -- SETUP
+    (wSrc, _)   <- fixtureWallet ctx
+    (wDest, mw) <- fixtureWallet ctx
+
+    -- ACTION
+    let addr = encodeAddress @n $ head $ fixtureAddresses mw
+    let amnt = 1 :: Natural
+    let body = [json|{
+            "payments": [{
+                "address": #{addr},
+                "amount": {
+                    "quantity": #{amnt},
+                    "unit": "lovelace"
+                }
+            }],
+            "passphrase": #{fixturePassphrase}
+        }|]
+    r <- request @(ApiTransaction n) ctx
+        (Link.createTransaction @style wSrc) Default (Json body)
+
+    -- ASSERTIONS
+    let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
+            { nInputs  = 1
+            , nOutputs = 1
+            , nChanges = 1
+            }
+    verify r
+        [ expectResponseCode HTTP.status202
+        , expectField #amount $ between
+              ( Quantity (feeMin + amnt)
+              , Quantity (feeMax + amnt)
+              )
+        , expectField #direction (`shouldBe` ApiT Outgoing)
+        , expectField #status (`shouldBe` ApiT Pending)
+        ]
+
+    eventually "source balance decreases" $ do
+        rSrc <- request @ApiByronWallet ctx
+            (Link.getWallet @'Byron wSrc) Default Empty
+        verify rSrc
+            [ expectField (#balance . #available) $ between
+                ( Quantity (faucetAmt - amnt - feeMax)
+                , Quantity (faucetAmt - amnt - feeMin)
+                )
+            ]
+
+    eventually "destination balance increases" $ do
+        rDest <- request @ApiByronWallet ctx
+            (Link.getWallet @'Byron wDest) Default Empty
+        verify rDest
+            [ expectField (#balance . #available)
+                (`shouldBe` Quantity (faucetAmt + amnt))
+            ]

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -17,6 +17,7 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiByronWallet
+    , ApiFee
     , ApiT (..)
     , ApiTransaction
     , DecodeAddress (..)
@@ -29,6 +30,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( entropyToMnemonic, genEntropy )
 import Cardano.Wallet.Primitive.Types
     ( Address, Direction (..), TxStatus (..) )
 import Control.Monad
@@ -37,6 +40,8 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -47,21 +52,40 @@ import Test.Integration.Framework.DSL
     , Payload (..)
     , TxDescription (..)
     , between
+    , emptyIcarusWallet
+    , emptyRandomWallet
     , eventually
+    , expectErrorMessage
     , expectField
     , expectResponseCode
     , faucetAmt
     , fixtureIcarusWallet
     , fixtureIcarusWalletAddrs
+    , fixtureIcarusWalletWith
     , fixturePassphrase
     , fixtureRandomWallet
     , fixtureRandomWalletAddrs
+    , fixtureRandomWalletWith
+    , icarusAddresses
     , json
+    , randomAddresses
     , request
     , verify
+    , walletId
+    )
+import Test.Integration.Framework.Request
+    ( RequestException )
+import Test.Integration.Framework.TestData
+    ( errMsg403Fee
+    , errMsg403InputsDepleted
+    , errMsg403NotEnoughMoney_
+    , errMsg403UTxO
+    , errMsg403WrongPass
+    , errMsg404NoWallet
     )
 
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Aeson as Aeson
 import qualified Network.HTTP.Types.Status as HTTP
 
 spec
@@ -74,34 +98,51 @@ spec
     => SpecWith (Context t)
 spec = describe "BYRON_TXS" $ do
     -- Random → Random
-    scenario_TRANS_CREATE_01_02 @n
-        fixtureRandomWallet
+    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
         [ fixtureRandomWalletAddrs @n
         ]
 
     -- Random → [Random, Icarus]
-    scenario_TRANS_CREATE_01_02 @n
-        fixtureRandomWallet
+    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
         [ fixtureRandomWalletAddrs @n
         , fixtureIcarusWalletAddrs @n
         ]
 
     -- Icarus → Icarus
-    scenario_TRANS_CREATE_01_02 @n
-        fixtureIcarusWallet
+    scenario_TRANS_CREATE_01_02 @n fixtureIcarusWallet
         [ fixtureIcarusWalletAddrs @n
         ]
 
     -- Icarus → [Icarus, Random]
-    scenario_TRANS_CREATE_01_02 @n
-        fixtureRandomWallet
+    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
         [ fixtureIcarusWalletAddrs @n
         , fixtureRandomWalletAddrs @n
         ]
 
---    scenario_TRANS_CREATE_02x @n
---        (fixtureRandomWalletWith [1_000_000_000])
---        fixtureByronAddress
+    scenario_TRANS_CREATE_02x @n
+
+    -- TRANS_CREATE_03 requires actually being able to compute exact fees, which
+    -- is not really possible w/ cardano-node. So, skipping.
+
+    scenario_TRANS_CREATE_04a @n
+    scenario_TRANS_CREATE_04b @n
+    scenario_TRANS_CREATE_04c @n
+    scenario_TRANS_CREATE_04d @n
+
+    scenario_TRANS_CREATE_07 @n
+
+    scenario_TRANS_ESTIMATE_01_02 @n fixtureRandomWallet
+        [ randomAddresses @n . entropyToMnemonic <$> genEntropy
+        ]
+
+    scenario_TRANS_ESTIMATE_01_02 @n fixtureIcarusWallet
+        [ icarusAddresses @n . entropyToMnemonic <$> genEntropy
+        , icarusAddresses @n . entropyToMnemonic <$> genEntropy
+        ]
+
+    scenario_TRANS_ESTIMATE_04a @n
+    scenario_TRANS_ESTIMATE_04b @n
+    scenario_TRANS_ESTIMATE_04c @n
 
 --
 -- Scenarios
@@ -117,39 +158,26 @@ scenario_TRANS_CREATE_01_02
     -> SpecWith (Context t)
 scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- SETUP
-    let amnt = 1 :: Natural
+    let amnt = 100_000 :: Natural
     wSrc <- fixtureSource ctx
     (recipients, payments) <- fmap unzip $ forM fixtures $ \fixtureTarget -> do
         (wDest, addrs) <- fixtureTarget ctx
-        let addr = encodeAddress @n $ head addrs
-        pure (wDest, [json|
-            { "address": #{addr}
-            , "amount":
-                { "quantity": #{amnt}
-                , "unit": "lovelace"
-                }
-            }|])
-
+        pure (wDest, mkPayment @n (head addrs) amnt)
 
     -- ACTION
-    let body = [json|
-            { "payments": #{payments}
-            , "passphrase": #{fixturePassphrase}
-            }|]
-    r <- request @(ApiTransaction n) ctx
-        (Link.createTransaction @'Byron wSrc) Default (Json body)
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
 
     -- ASSERTIONS
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
-            { nInputs  = length fixtures
-            , nOutputs = length fixtures
-            , nChanges = length fixtures
+            { nInputs  = fromIntegral n
+            , nOutputs = fromIntegral n
+            , nChanges = fromIntegral n
             }
     verify r
         [ expectResponseCode HTTP.status202
         , expectField #amount $ between
-              ( Quantity (feeMin + amnt)
-              , Quantity (feeMax + amnt)
+              ( Quantity (feeMin + n * amnt)
+              , Quantity (feeMax + n * amnt)
               )
         , expectField #direction (`shouldBe` ApiT Outgoing)
         , expectField #status (`shouldBe` ApiT Pending)
@@ -160,8 +188,8 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
             (Link.getWallet @'Byron wSrc) Default Empty
         verify rSrc
             [ expectField (#balance . #available) $ between
-                ( Quantity (faucetAmt - amnt - feeMax)
-                , Quantity (faucetAmt - amnt - feeMin)
+                ( Quantity (faucetAmt - (n * amnt) - feeMax)
+                , Quantity (faucetAmt - (n * amnt) - feeMin)
                 )
             ]
 
@@ -174,5 +202,403 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
                     (`shouldBe` Quantity (faucetAmt + amnt))
                 ]
   where
-    title =
-        "TRANS_CREATE_01/02 - " ++ show (length fixtures) ++ " recipients"
+    title = "TRANS_CREATE_01/02 - " ++ show n ++ " recipient(s)"
+    n = fromIntegral $ length fixtures
+
+scenario_TRANS_ESTIMATE_01_02
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        )
+    => (Context t -> IO ApiByronWallet)
+    -> [IO [Address]]
+    -> SpecWith (Context t)
+scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
+    -- SETUP
+    let amnt = 100_000 :: Natural
+    wSrc <- fixtureSource ctx
+    payments <- forM fixtures $ \fixtureTarget -> do
+        addrs <- fixtureTarget
+        pure $ mkPayment @n (head addrs) amnt
+
+    -- ACTION
+    r <- estimateByronTransaction ctx wSrc payments
+
+    -- ASSERTIONS
+    let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
+            { nInputs  = length fixtures
+            , nOutputs = length fixtures
+            , nChanges = length fixtures
+            }
+    verify r
+        [ expectResponseCode HTTP.status202
+        , expectField #amount $ between (Quantity feeMin, Quantity feeMax)
+        ]
+  where
+    title = "TRANS_ESTIMATE_01/02 - " ++ show (length fixtures) ++ " recipient(s)"
+
+scenario_TRANS_CREATE_02x
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_02x = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureSingleUTxO @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403UTxO
+        ]
+  where
+    title = "TRANS_CREATE_02x - Multi-output failure w/ single UTxO"
+
+scenario_TRANS_CREATE_04a
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403InputsDepleted
+        ]
+  where
+    title = "TRANS_CREATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_CREATE_04b
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_04b = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403Fee
+        ]
+  where
+    title = "TRANS_CREATE_04 - Can't cover fee"
+
+scenario_TRANS_CREATE_04c
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_04c = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403NotEnoughMoney_
+        ]
+  where
+    title = "TRANS_CREATE_04 - Not enough money"
+
+scenario_TRANS_CREATE_04d
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_04d = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureWrongPassphrase @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments "This passphrase is wrong"
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403WrongPass
+        ]
+  where
+    title = "TRANS_CREATE_04 - Wrong password"
+
+scenario_TRANS_ESTIMATE_04a
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_ESTIMATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted @n ctx
+
+    -- ACTION
+    r <- estimateByronTransaction ctx wSrc payments
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403InputsDepleted
+        ]
+  where
+    title = "TRANS_ESTIMATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_ESTIMATE_04b
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+
+    -- ACTION
+    r <- estimateByronTransaction ctx wSrc payments
+
+    -- ASSERTIONS
+    let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
+            { nInputs  = 1
+            , nOutputs = 1
+            , nChanges = 0
+            }
+    verify r
+        [ expectResponseCode HTTP.status202
+        , expectField #amount $ between (Quantity feeMin, Quantity feeMax)
+        ]
+  where
+    title = "TRANS_ESTIMATE_04 - Can't cover fee"
+
+scenario_TRANS_ESTIMATE_04c
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_ESTIMATE_04c = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+
+    -- ACTION
+    r <- estimateByronTransaction ctx wSrc payments
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403NotEnoughMoney_
+        ]
+  where
+    title = "TRANS_ESTIMATE_04 - Not enough money"
+
+scenario_TRANS_CREATE_07
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_07 = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureDeletedWallet @n ctx
+
+    -- ACTION
+    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode @IO HTTP.status404
+        , expectErrorMessage $ errMsg404NoWallet (wSrc ^. walletId)
+        ]
+  where
+    title = "TRANS_CREATE_07 - Deleted wallet"
+
+
+--
+-- More Elaborated Fixtures
+--
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureSingleUTxO
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureSingleUTxO ctx = do
+    wSrc  <- fixtureRandomWalletWith @n ctx [1_000_000]
+    addrs <- randomAddresses @n . entropyToMnemonic <$> genEntropy
+    let payments =
+            [ mkPayment @n (head addrs) 100_000
+            , mkPayment @n (head addrs) 100_000
+            ]
+    pure (wSrc, payments)
+
+-- | Returns a source wallet and a list of payments. If submitted, the payments
+-- should result in an error 403.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureErrInputsDepleted
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureErrInputsDepleted ctx = do
+    wSrc  <- fixtureRandomWalletWith @n ctx [12_000_000, 20_000_000, 17_000_000]
+    addrs <- randomAddresses @n . entropyToMnemonic <$> genEntropy
+    let amnts = [40_000_000, 22, 22] :: [Natural]
+    let payments = flip map (zip addrs amnts) $ uncurry (mkPayment @n)
+    pure (wSrc, payments)
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureCantCoverFee
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureCantCoverFee ctx = do
+    let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
+    wSrc <- fixtureIcarusWalletWith @n ctx [feeMin `div` 2]
+    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment @n (head addrs) 1])
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureNotEnoughMoney
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureNotEnoughMoney ctx = do
+    wSrc <- emptyIcarusWallet ctx
+    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment @n (head addrs) 1])
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureWrongPassphrase
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n IcarusKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureWrongPassphrase ctx = do
+    (wSrc, addrs) <- fixtureIcarusWalletAddrs @n ctx
+    pure (wSrc, [mkPayment @n (head addrs) 100_000])
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureDeletedWallet
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        , PaymentAddress n ByronKey
+        )
+    => Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureDeletedWallet ctx = do
+    wSrc <- emptyRandomWallet ctx
+    _ <- request @() ctx (Link.deleteWallet @'Byron wSrc) Default Empty
+    addrs <- randomAddresses @n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment @n (head addrs) 100_000])
+
+--
+-- Helpers
+--
+
+-- | Construct a JSON payload for a single payment (address + amount)
+mkPayment
+    :: forall (n :: NetworkDiscriminant).
+        ( EncodeAddress n
+        )
+    => Address
+    -> Natural
+    -> Aeson.Value
+mkPayment addr_ amnt = [json|
+    { "address": #{addr}
+    , "amount":
+        { "quantity": #{amnt}
+        , "unit": "lovelace"
+        }
+    } |]
+  where
+    addr = encodeAddress @n addr_
+
+postByronTransaction
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        )
+    => Context t
+        -- A surrounding API context
+    -> ApiByronWallet
+        -- ^ Source wallet
+    -> [Aeson.Value]
+        -- ^ A list of payment
+    -> Text
+        -- ^ Passphrase
+    -> IO (HTTP.Status, Either RequestException (ApiTransaction n))
+postByronTransaction ctx wSrc payments passphrase = do
+    let body = [json|
+            { "payments": #{payments}
+            , "passphrase": #{passphrase}
+            }|]
+    request ctx (Link.createTransaction @'Byron wSrc) Default (Json body)
+
+estimateByronTransaction
+    :: Context t
+        -- A surrounding API context
+    -> ApiByronWallet
+        -- ^ Source wallet
+    -> [Aeson.Value]
+        -- ^ A list of payment
+    -> IO (HTTP.Status, Either RequestException ApiFee)
+estimateByronTransaction ctx wSrc payments = do
+    let body = [json| { "payments": #{payments} }|]
+    request ctx (Link.getTransactionFee @'Byron wSrc) Default (Json body)

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -787,7 +787,7 @@ fixtureWalletWith ctx coins0 = do
                 "passphrase": #{fixturePassphrase}
             }|]
         request @(ApiTransaction 'Testnet) ctx
-            (Link.createTransaction src) Default payload
+            (Link.createTransaction @'Shelley src) Default payload
             >>= expectResponseCode HTTP.status202
         eventually "balance available = balance total" $ do
             rb <- request @ApiWallet ctx

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -47,6 +47,7 @@ module Test.Integration.Framework.TestData
     , errMsg403Fee
     , errMsg403DelegationFee
     , errMsg403NotEnoughMoney
+    , errMsg403NotEnoughMoney_
     , errMsg403UTxO
     , errMsg403WrongPass
     , errMsg403NoPendingAnymore
@@ -265,6 +266,11 @@ errMsg403DelegationFee :: Natural -> String
 errMsg403DelegationFee n =
     "I'm unable to select enough coins to pay for a delegation certificate. \
     \I need: " ++ show n ++ " Lovelace."
+
+errMsg403NotEnoughMoney_ :: String
+errMsg403NotEnoughMoney_ =
+    "I can't process this payment because there's \
+    \not enough UTxO available in the wallet."
 
 errMsg403NotEnoughMoney :: Int -> Int -> String
 errMsg403NotEnoughMoney has needs = "I can't process this payment because there's\

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -175,7 +175,7 @@ spec = do
                 }|]
 
             rTrans <- request @(ApiTransaction n) ctx
-                (Link.createTransaction wSrc) Default payload
+                (Link.createTransaction @'Shelley wSrc) Default payload
             expectResponseCode @IO HTTP.status202 rTrans
 
         -- make sure all transactions are in ledger

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronTransactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronTransactions.hs
@@ -68,7 +68,8 @@ spec = do
                 ]
 
     it "BYRON_TX_LIST_01 - Can list transactions on Byron Wallet"
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
             w <- fixtureByronWallet ctx
             let link = Link.listTransactions @'Byron w
             r <- request @([ApiTransaction n]) ctx link Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -93,7 +93,8 @@ spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
 spec = do
     it "BYRON_CALCULATE_01 - \
         \for non-empty wallet calculated fee is > zero."
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
             w <- fixtureByronWallet ctx
             let ep = Link.getMigrationInfo w
             r <- request @ApiByronWalletMigrationInfo ctx ep Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
@@ -120,8 +120,8 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
-            Default payload
+        rTrans <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         expectResponseCode @IO HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do
@@ -216,8 +216,8 @@ spec = do
                     }],
                     "passphrase": "cardano-wallet"
                 }|]
-            rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
-                Default payload
+            rTrans <- request @(ApiTransaction n) ctx
+                (Link.createTransaction @'Shelley wSrc) Default payload
             expectResponseCode @IO HTTP.status403 rTrans
             expectErrorMessage (errMsg403NoRootKey $ wSrc ^. walletId) rTrans
 
@@ -287,7 +287,8 @@ spec = do
                     }]
                 }|]
 
-            rFee <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+            rFee <- request @ApiFee ctx
+                (Link.getTransactionFee @'Shelley wSrc) Default payload
             expectResponseCode @IO HTTP.status202 rFee
 
         it "Can delete" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -128,7 +128,10 @@ spec = do
                 }
 
         let amt = 1000
-        r <- postTx ctx (wSrc, Link.createTransaction, fixturePassphrase) wSrc amt
+        r <- postTx ctx
+            (wSrc, Link.createTransaction @'Shelley, fixturePassphrase)
+            wSrc
+            amt
         verify r
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -160,7 +163,10 @@ spec = do
         eventually "Pending tx has pendingSince field" $ do
             -- Post Tx
             let amt = (1 :: Natural)
-            r <- postTx ctx (wSrc, Link.createTransaction ,"Secure Passphrase") wDest amt
+            r <- postTx ctx
+                (wSrc, Link.createTransaction @'Shelley,"Secure Passphrase")
+                wDest
+                amt
             let tx = getFromResponse Prelude.id r
             tx ^. (#status . #getApiT) `shouldBe` Pending
             insertedAt tx `shouldBe` Nothing
@@ -189,7 +195,10 @@ spec = do
                 , nChanges = 1
                 }
         let amt = (1 :: Natural)
-        r <- postTx ctx (wa, Link.createTransaction, "cardano-wallet") wb amt
+        r <- postTx ctx
+            (wa, Link.createTransaction @'Shelley, "cardano-wallet")
+            wb
+            amt
         verify r
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -256,7 +265,8 @@ spec = do
                 , nChanges = 2
                 }
 
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
         verify r
             [ expectResponseCode HTTP.status202
@@ -322,7 +332,8 @@ spec = do
                 , nChanges = 2
                 }
 
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
         verify r
             [ expectResponseCode HTTP.status202
@@ -381,7 +392,8 @@ spec = do
                 "passphrase": "Secure Passphrase"
             }|]
 
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403UTxO
@@ -405,7 +417,8 @@ spec = do
                 }],
                 "passphrase": "Secure Passphrase"
             }|]
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#amount . #getQuantity) (`shouldBe` feeMin + amt)
@@ -439,7 +452,8 @@ spec = do
 
     it "TRANS_CREATE_04 - Error shown when ErrInputsDepleted encountered" $ \ctx -> do
         (wSrc, payload) <- fixtureErrInputsDepleted ctx
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403InputsDepleted
@@ -462,7 +476,8 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Fee
@@ -485,7 +500,8 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage $
@@ -508,7 +524,8 @@ spec = do
                 }],
                 "passphrase": "This password is wrong"
             }|]
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403WrongPass
@@ -622,7 +639,8 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction w) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley w) Default payload
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
@@ -644,8 +662,8 @@ spec = do
         forM_ matrix $ \(name, nonJson) -> it name $ \ctx -> do
             w <- emptyWallet ctx
             let payload = nonJson
-            r <- request @(ApiTransaction n) ctx (Link.createTransaction w)
-                    Default payload
+            r <- request @(ApiTransaction n) ctx
+                (Link.createTransaction @'Shelley w) Default payload
             expectResponseCode @IO HTTP.status400 r
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do
@@ -666,8 +684,8 @@ spec = do
         forM_ matrix $ \(name, nonJson) -> it name $ \ctx -> do
             w <- emptyWallet ctx
             let payload = nonJson
-            r <- request @ApiFee ctx (Link.getTransactionFee w)
-                    Default payload
+            r <- request @ApiFee ctx
+                (Link.getTransactionFee @'Shelley w) Default payload
             expectResponseCode @IO HTTP.status400 r
 
     it "TRANS_ESTIMATE_01 - Single Output Fee Estimation" $ \ctx -> do
@@ -691,7 +709,8 @@ spec = do
                 , nChanges = 1
                 }
 
-        r <- request @ApiFee ctx (Link.getTransactionFee wa) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wa) Default payload
         verify r
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -729,7 +748,8 @@ spec = do
                 , nChanges = 2
                 }
 
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#amount . #getQuantity) $
@@ -770,7 +790,8 @@ spec = do
                 , nChanges = 2
                 }
 
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#amount . #getQuantity) $
@@ -803,7 +824,8 @@ spec = do
                 ]
             }|]
 
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403UTxO
@@ -826,7 +848,8 @@ spec = do
                     }
                 }]
             }|]
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#amount . #getQuantity) $
@@ -849,7 +872,8 @@ spec = do
                     }
                 }]
             }|]
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage $
@@ -858,7 +882,8 @@ spec = do
 
     it "TRANS_ESTIMATE_04 - Error shown when ErrInputsDepleted encountered" $ \ctx -> do
         (wSrc, payload) <- fixtureErrInputsDepleted ctx
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403InputsDepleted
@@ -966,7 +991,8 @@ spec = do
                     }
                 }]
             }|]
-        r <- request @ApiFee ctx (Link.getTransactionFee w) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley w) Default payload
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
@@ -988,7 +1014,8 @@ spec = do
                 "passphrase": "cardano-wallet"
             }|]
 
-        tx <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        tx <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 tx
         eventually "Wallet balance is as expected" $ do
             rGet <- request @ApiWallet ctx
@@ -1370,7 +1397,10 @@ spec = do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
         let amt = (1 :: Natural)
-        rMkTx <- postTx ctx (wSrc, Link.createTransaction, "cardano-wallet") wDest amt
+        rMkTx <- postTx ctx
+            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            wDest
+            amt
         let txid = getFromResponse #id rMkTx
         verify rMkTx
             [ expectSuccess
@@ -1442,7 +1472,10 @@ spec = do
 
         -- post transaction
         rTx <-
-            postTx ctx (wSrc, Link.createTransaction, "cardano-wallet") wDest (1 :: Natural)
+            postTx ctx
+            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            wDest
+            (1 :: Natural)
         let txid = getFromResponse #id rTx
 
         eventually "Transaction is accepted" $ do
@@ -1581,7 +1614,7 @@ spec = do
             -- post tx
             (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
             rMkTx <- postTx ctx
-                (wSrc, Link.createTransaction, "cardano-wallet")
+                (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
                 wDest
                 (1 :: Natural)
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -251,8 +251,8 @@ spec = do
                 }],
                 "passphrase": "cardano-wallet"
             }|]
-        rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
-            Default payload
+        rTrans <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         expectResponseCode @IO HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do
@@ -1222,7 +1222,8 @@ spec = do
                     }],
                     "passphrase": #{pass}
                     }|]
-            r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payloadTrans
+            r <- request @(ApiTransaction n) ctx
+                (Link.createTransaction @'Shelley wSrc) Default payloadTrans
             verify r expectations
 
     describe "WALLETS_UPDATE_PASS_07 - HTTP headers" $ do
@@ -1391,8 +1392,8 @@ spec = do
                     }],
                     "passphrase": "cardano-wallet"
                 }|]
-            rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
-                Default payload
+            rTrans <- request @(ApiTransaction n) ctx
+                (Link.createTransaction @'Shelley wSrc) Default payload
             expectResponseCode @IO HTTP.status202 rTrans
 
             let coinsSent = map fromIntegral $ take alreadyAbsorbed coins

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -1718,7 +1718,8 @@ spec = do
     it "BYRON_MIGRATE_01 - \
         \after a migration operation successfully completes, the correct \
         \amount eventually becomes available in the target wallet."
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
             -- Restore a Byron wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureByronWallet ctx
             let originalBalance =
@@ -1839,7 +1840,8 @@ spec = do
 
     it "BYRON_MIGRATE_01 - \
         \a migration operation removes all funds from the source wallet."
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
             -- Restore a Byron wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureByronWallet ctx
 
@@ -1915,7 +1917,8 @@ spec = do
 
     it "BYRON_MIGRATE_03 - \
         \actual fee for migration is the same as the predicted fee."
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
             -- Restore a Byron wallet with funds.
             sourceWallet <- fixtureByronWallet ctx
 
@@ -1945,7 +1948,8 @@ spec = do
             actualFee `shouldBe` predictedFee
 
     it "BYRON_MIGRATE_04 - migration fails with a wrong passphrase"
-        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet] $ \fixtureByronWallet -> do
+        $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
+        $ \fixtureByronWallet -> do
         -- Restore a Byron wallet with funds, to act as a source wallet:
         sourceWallet <- fixtureByronWallet ctx
 

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -662,6 +662,8 @@ encodeTx (inps, outs) = mempty
 encodeSignedTx :: ([TxIn], [TxOut]) -> [ByteString] -> CBOR.Encoding
 encodeSignedTx tx witnesses = mempty
     <> CBOR.encodeListLen 2
+    <> CBOR.encodeWord8 0
+    <> CBOR.encodeListLen 2
     <> encodeTx tx
     <> CBOR.encodeListLen (fromIntegral $ length witnesses)
     <> mconcat (map encodeTxWitness witnesses)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -54,7 +54,9 @@ module Cardano.Wallet.Api
         , ForceResyncByronWallet
 
     , ByronTransactions
+        , CreateByronTransaction
         , ListByronTransactions
+        , PostByronTransactionFee
         , DeleteByronTransaction
 
     , ByronMigrations
@@ -389,8 +391,17 @@ type ForceResyncByronWallet = "byron-wallets"
 -------------------------------------------------------------------------------}
 
 type ByronTransactions n =
-         ListByronTransactions n
+    CreateByronTransaction n
+    :<|> ListByronTransactions n
+    :<|> PostByronTransactionFee n
     :<|> DeleteByronTransaction
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronTransaction
+type CreateByronTransaction n = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "transactions"
+    :> ReqBody '[JSON] (PostTransactionData n)
+    :> PostAccepted '[JSON] (ApiTransaction n)
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronTransactions
 type ListByronTransactions n = "byron-wallets"
@@ -400,6 +411,13 @@ type ListByronTransactions n = "byron-wallets"
     :> QueryParam "end" Iso8601Time
     :> QueryParam "order" (ApiT SortOrder)
     :> Get '[JSON] [ApiTransaction n]
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronTransactionFee
+type PostByronTransactionFee n = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "payment-fees"
+    :> ReqBody '[JSON] (PostTransactionFeeData n)
+    :> PostAccepted '[JSON] ApiFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteByronTransaction
 type DeleteByronTransaction = "byron-wallets"

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -296,13 +296,15 @@ selectCoins w =
 --
 
 createTransaction
-    :: forall w.
+    :: forall style w.
         ( HasType (ApiT WalletId) w
+        , Discriminate style
         )
     => w
     -> (Method, Text)
-createTransaction w =
-    endpoint @(Api.CreateTransaction Net) (wid &)
+createTransaction w = discriminate @style
+    (endpoint @(Api.CreateTransaction Net) (wid &))
+    (endpoint @(Api.CreateByronTransaction Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 
@@ -334,13 +336,15 @@ listTransactions' w inf sup order = discriminate @style
     mkURL mk = mk wid inf sup (ApiT <$> order)
 
 getTransactionFee
-    :: forall w.
+    :: forall style w.
         ( HasType (ApiT WalletId) w
+        , Discriminate style
         )
     => w
     -> (Method, Text)
-getTransactionFee w =
-    endpoint @(Api.PostTransactionFee Net) (wid &)
+getTransactionFee w = discriminate @style
+    (endpoint @(Api.PostTransactionFee Net) (wid &))
+    (endpoint @(Api.PostByronTransactionFee Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1527,7 +1527,10 @@ instance NFData StartTime
 
 -- | Magic constant associated to a given network
 newtype ProtocolMagic = ProtocolMagic { getProtocolMagic :: Int32 }
-    deriving (Generic, Show)
+    deriving (Generic, Show, Eq)
+
+instance ToText ProtocolMagic where
+    toText (ProtocolMagic pm) = T.pack (show pm)
 
 -- | Hard-coded protocol magic for the Byron TestNet
 testnetMagic :: ProtocolMagic

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -459,7 +459,7 @@ prop_changeIsOnlyKnownAfterGeneration (intPool, extPool) =
         s0 :: SeqState 'Mainnet ShelleyKey
         s0 = SeqState intPool extPool emptyPendingIxs rewardAccount
         addrs0 = knownAddresses s0
-        (change, s1) = genChange mempty s0
+        (change, s1) = genChange (delegationAddress @'Mainnet) s0
         addrs1 = knownAddresses s1
     in conjoin
         [ prop_addrsNotInInternalPool addrs0
@@ -579,7 +579,7 @@ changeAddresses
     -> SeqState 'Mainnet ShelleyKey
     -> ([Address], SeqState 'Mainnet ShelleyKey)
 changeAddresses as s =
-    let (a, s') = genChange mempty s
+    let (a, s') = genChange (\k _ -> paymentAddress @'Mainnet k) s
     in if a `elem` as then (as, s) else changeAddresses (a:as) s'
 
 unsafeMkAddressPoolGap :: (Integral a, Show a) => a -> AddressPoolGap

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -226,7 +226,8 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         wSrc <- fixtureWallet ctx
         let pass = "cardano-wallet" :: Text
 
-        replicateM_ batchSize (postTx ctx (wSrc, Link.createTransaction, pass) wDest amtToSend)
+        replicateM_ batchSize
+            (postTx ctx (wSrc, Link.createTransaction @'Shelley, pass) wDest amtToSend)
         eventually "repeatPostTx: wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet ctx (Link.getWallet @'Shelley wDest) Default Empty
             verify rWal1
@@ -262,7 +263,8 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         wSrc <- fixtureWalletWith ctx (replicate batchSize 1000)
         let pass = "Secure Passphrase" :: Text
 
-        postMultiTx ctx (wSrc, Link.createTransaction, pass) wDest amtToSend batchSize
+        postMultiTx ctx
+            (wSrc, Link.createTransaction @'Shelley, pass) wDest amtToSend batchSize
         eventually "repeatPostMultiTx: wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
@@ -343,18 +345,18 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
                     }
                 }]
             }|]
-        t6 <- measureApiLogs tvar
-            (request @ApiFee ctx (Link.getTransactionFee wal1) Default payload)
+        t6 <- measureApiLogs tvar $ request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wal1) Default payload
 
         fmtResult "postTransactionFee " t6
 
-        t7 <- measureApiLogs tvar
-            (request @[ApiStakePool] ctx Link.listStakePools Default Empty)
+        t7 <- measureApiLogs tvar $ request @[ApiStakePool] ctx
+            Link.listStakePools Default Empty
 
         fmtResult "listStakePools     " t7
 
-        t8 <- measureApiLogs tvar
-            (request @ApiNetworkInformation ctx Link.getNetworkInfo Default Empty)
+        t8 <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
+            Link.getNetworkInfo Default Empty
 
         fmtResult "getNetworkInfo     " t8
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -29,7 +29,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Jormungandr.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant (..), Passphrase (..), fromMnemonic )
+    ( DelegationAddress (..)
+    , NetworkDiscriminant (..)
+    , Passphrase (..)
+    , fromMnemonic
+    )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( KnownNetwork (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
@@ -433,7 +437,7 @@ fixtureExternalTx ctx toSend = do
     let (AddressAmount ((ApiT addrSrc),_) (Quantity amt)):_ = outs
     let (rootXPrv, pwd, st) = getSeqState mnemonicFaucet password
     -- we create change address
-    let (addrChng, st') = genChange () st
+    let (addrChng, st') = genChange (delegationAddress @n) st
     -- we generate address private keys for all source wallet addresses
     let (Just keysAddrSrc) = isOwned st' (rootXPrv, pwd) addrSrc
     let (Just keysAddrChng) = isOwned st' (rootXPrv, pwd) addrChng

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -121,12 +121,14 @@ spec = do
 
     it "TRANS_CREATE_09 - 0 amount transaction is accepted on single output tx" $ \ctx -> do
         (wSrc, payload) <- fixtureZeroAmtSingle ctx
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 r
 
     it "TRANS_CREATE_09 - 0 amount transaction is accepted on multi-output tx" $ \ctx -> do
         (wSrc, payload) <- fixtureZeroAmtMulti ctx
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 r
 
     it "TRANS_CREATE_10 - 'account' outputs" $ \ctx -> do
@@ -158,7 +160,8 @@ spec = do
                 "passphrase": #{fixturePassphrase}
             }|]
 
-        r <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
+        r <- request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
@@ -197,13 +200,15 @@ spec = do
     it "TRANS_ESTIMATE_09 - \
         \a fee can be estimated for a tx with an output of amount 0 (single)" $ \ctx -> do
         (wSrc, payload) <- fixtureZeroAmtSingle ctx
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 r
 
     it "TRANS_ESTIMATE_09 - \
         \a fee can be estimated for a tx with an output of amount 0 (multi)" $ \ctx -> do
         (wSrc, payload) <- fixtureZeroAmtMulti ctx
-        r <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+        r <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 r
 
     it "TRANS_LIST_?? - List transactions of a fixture wallet" $ \ctx -> do

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -127,43 +127,10 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."directory" or (buildDepError "directory"))
             (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
             (hsPkgs."http-client" or (buildDepError "http-client"))
-            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
-            (hsPkgs."network" or (buildDepError "network"))
-            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
-            (hsPkgs."process" or (buildDepError "process"))
-            (hsPkgs."temporary" or (buildDepError "temporary"))
-            (hsPkgs."text" or (buildDepError "text"))
-            (hsPkgs."time" or (buildDepError "time"))
-            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
-            (hsPkgs."yaml" or (buildDepError "yaml"))
-            ];
-          build-tools = [
-            (hsPkgs.buildPackages.cardano-wallet-byron or (pkgs.buildPackages.cardano-wallet-byron or (buildToolDepError "cardano-wallet-byron")))
-            ];
-          buildable = true;
-          };
-        };
-      tests = {
-        "integration" = {
-          depends = [
-            (hsPkgs."base" or (buildDepError "base"))
-            (hsPkgs."aeson" or (buildDepError "aeson"))
-            (hsPkgs."async" or (buildDepError "async"))
-            (hsPkgs."bytestring" or (buildDepError "bytestring"))
-            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
-            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
-            (hsPkgs."cardano-wallet-byron" or (buildDepError "cardano-wallet-byron"))
-            (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
-            (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
-            (hsPkgs."cardano-wallet-core-integration" or (buildDepError "cardano-wallet-core-integration"))
-            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
-            (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
-            (hsPkgs."directory" or (buildDepError "directory"))
-            (hsPkgs."filepath" or (buildDepError "filepath"))
-            (hsPkgs."hspec" or (buildDepError "hspec"))
-            (hsPkgs."http-client" or (buildDepError "http-client"))
+            (hsPkgs."http-types" or (buildDepError "http-types"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."network" or (buildDepError "network"))
             (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -145,5 +145,40 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           buildable = true;
           };
         };
+      tests = {
+        "integration" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-wallet-byron" or (buildDepError "cardano-wallet-byron"))
+            (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."http-client" or (buildDepError "http-client"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."network" or (buildDepError "network"))
+            (hsPkgs."ouroboros-network" or (buildDepError "ouroboros-network"))
+            (hsPkgs."process" or (buildDepError "process"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."time" or (buildDepError "time"))
+            (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
+            (hsPkgs."yaml" or (buildDepError "yaml"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-wallet-byron or (pkgs.buildPackages.cardano-wallet-byron or (buildToolDepError "cardano-wallet-byron")))
+            ];
+          buildable = true;
+          };
+        };
       };
     } // rec { src = (pkgs.lib).mkDefault ../.././lib/byron; }

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1924,6 +1924,41 @@ paths:
         - *parametersSortOrder
       responses: *responsesListTransactions
 
+    post:
+      operationId: postByronTransaction
+      tags: ["Byron Transactions"]
+      summary: Create
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Create and send transaction from the wallet.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+          required: true
+          content:
+            application/json:
+              schema: *ApiPostTransactionData
+      responses: *responsesPostTransaction
+
+  /byron-wallets/{walletId}/payment-fees:
+    post:
+      operationId: postByronTransactionFee
+      tags: ["Byron Transactions"]
+      summary: Estimate Fee
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Estimate fee for the transaction.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: *ApiPostTransactionFeeData
+      responses: *responsesPostTransactionFee
+
   /byron-wallets/{walletId}/transactions/{transactionId}:
     delete:
       operationId: deleteByronTransaction


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1347 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->
- e04b67cf47ec471231497ae3b8864962cc0e6ba6
  re-generate nix machinery
  
- f554ea41c49ecc58922682e6280f51a85039aa70
  extend swagger API specifications byron transactions to support payment
  
- bbe3d0303b3b2fb7c7aeff8bf7dc27ac94f17b33
  implement postTransaction (& fee) for byron endpoints
  
- ae8f84ccbaf96a25e99ef7da8b7e87395598649e
  review fixture functions to also return mnemonic
  And add two helper function to derive addresses from mnemonic sentences

- 3b3045cfeee7ab956cadc03d61efab74f0c3a80b
  extend Link.createTransaction and Link.postTransactionFee for Byron style
  
- 2ec53ee4c596953e73f07bb439f7206e1c099245
  implement basic integration scenario for byron txs
  
- 8a301bed9052eb3052e6cffa3ea6a46e3701217a
  implement protocol magic prefix in Byron transaction signing
  
- 36773806e34412b00d4148212de71f44452b0401
  Fix missing header bytes on byron transactions
  
- e6924c5f0d68abf160cdfa86b1e48ba10d02261e
  implement proper fee estimator for Byron
  
- 45e9927064b8e681d9b8100f1d6ee0e83503b123
  Cover multi-output transactions in cardano-node Byron scenarios
  
- e7511cebce9e050cbe488dc8531b891c3a3ab3b0
  move network discriminant choice up to integration/Main
  
- f1cb42293cbd47077691a268d0254eb8b0bbff55
  add remaining TRANS_CREATE and TRANS_ESTIMATE scenarios for byron w/ cardano-node
  
- dd8859eb6f2398b5a98eb4ac4e8cc570237cebb2
  re-generate nix machinery
  
- 3f4be72ca480a1312672610b9d919416554780a8
  log network magic with the network name
  
- ca1d3348bd862e0c4d8d9833e10ff89589a1d2f0
  fixup missing updates to create and fees endpoints in Latency benchmarks

# Comments

<!-- Additional comments or screenshots to attach if any -->

- I am starting to really believe that the `server` declaration should live in the target-specific packages (resp. cardano-wallet-jormungandr and cardano-wallet-byron) since the shape of the API is highly depending on them. Will do in another PR

- This closes the loop of the necessary things needed in the app for testing, now I need to investigate how to setup integration tests for the byron rewritten nodes to test that out!

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
