### PR TITLE
Fix latency benchmarking

### DIFF
--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -190,7 +190,8 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
                     [x*batchSize | x<-[1..whole10Rounds]] ++ [lastBit]
                 else
                     [lastBit]
-        mapM_ (repeatPostTx ctx wal1 amt batchSize . amtExp) expInflows
+        let expInflows' = filter (/=0) expInflows
+        mapM_ (repeatPostTx ctx wal1 amt batchSize . amtExp) expInflows'
 
         pure (wal1, wal2)
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#1356 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have fixed latency benchmarking


# Comments

<!-- Additional comments or screenshots to attach if any -->
When running : 
```
stack bench cardano-wallet-jormungandr
```
we have 
```
Error: Switchboard's queue full, dropping log items!
```
It seems it is due to `ineffactuate` call which point to https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs#L118
and here we have 
https://github.com/input-output-hk/iohk-monitoring-framework/blob/master/iohk-monitoring/src/Cardano/BM/Backend/Switchboard.lhs#L203
so I tried to set this flag but end up with the same error
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
