### PR TITLE
Add unXPrvStripPub (& inverse) that matches jcli

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -346,7 +346,7 @@ toChimericAccount =
 -- readability in function signatures.
 newtype Passphrase (purpose :: Symbol) = Passphrase ScrubbedBytes
     deriving stock (Eq, Show)
-    deriving newtype (Semigroup, Monoid, NFData)
+    deriving newtype (Semigroup, Monoid, NFData, ByteArrayAccess)
 
 type role Passphrase phantom
 

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -251,10 +251,11 @@ test-suite integration
       Test.Integration.Jormungandr.Scenario.API.StakePools
       Test.Integration.Jormungandr.Scenario.API.Transactions
       Test.Integration.Jormungandr.Scenario.CLI.Launcher
+      Test.Integration.Jormungandr.Scenario.CLI.Keys
+      Test.Integration.Jormungandr.Scenario.CLI.Mnemonics
       Test.Integration.Jormungandr.Scenario.CLI.Server
       Test.Integration.Jormungandr.Scenario.CLI.StakePools
       Test.Integration.Jormungandr.Scenario.CLI.Transactions
-      Test.Integration.Jormungandr.Scenario.CLI.Mnemonics
       Test.Utils.Ports
 
 benchmark latency

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -84,6 +84,7 @@ import qualified Cardano.Wallet.Jormungandr.NetworkSpec as NetworkLayer
 import qualified Data.Text as T
 import qualified Test.Integration.Jormungandr.Scenario.API.StakePools as StakePoolsApiJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.API.Transactions as TransactionsApiJormungandr
+import qualified Test.Integration.Jormungandr.Scenario.CLI.Keys as KeysCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Launcher as LauncherCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Mnemonics as MnemonicsJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Server as ServerCLI
@@ -117,6 +118,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
             describe "Launcher CLI tests" $ parallel (LauncherCLI.spec @t)
             describe "Stake Pool Metrics" MetricsSpec.spec
+            describe "Key CLI tests" KeysCLI.spec
 
         describe "API Specifications" $ specWithServer tr $ do
             Addresses.spec

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Test.Integration.Jormungandr.Scenario.CLI.Keys
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , Passphrase (..)
+    , SomeMnemonic (..)
+    , WalletKey (..)
+    , XPrv
+    , hex
+    , unXPrv
+    , unXPrvStripPub
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( ConsistentEntropy, EntropySize, Mnemonic, entropyToMnemonic )
+import Cardano.Wallet.Unsafe
+    ( unsafeMkEntropy )
+import Data.Proxy
+    ( Proxy (..) )
+import GHC.TypeLits
+    ( natVal )
+import System.Process
+    ( readProcessWithExitCode )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Property
+    , counterexample
+    , frequency
+    , property
+    , vectorOf
+    )
+import Test.QuickCheck.Monadic
+    ( assert, monadicIO, monitor, run )
+
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
+import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+
+spec :: Spec
+spec =
+    describe "unXPrvStripPub" $ do
+        it "is compatible with jcli (Shelley)" $
+            property $ prop_keyToHexTextJcliCompatible @ShelleyKey
+        it "is compatible with jcli (Icarus)" $
+            property $ prop_keyToHexTextJcliCompatible @IcarusKey
+        it "is compatible with jcli (Byron)" $
+            property $ prop_keyToHexTextJcliCompatible @ByronKey
+
+prop_keyToHexTextJcliCompatible
+    :: WalletKey k
+    => k 'RootK XPrv
+    -> Property
+prop_keyToHexTextJcliCompatible k = monadicIO $ do
+    let Right hexXPrv = fmap (B8.unpack . hex) . unXPrvStripPub . getRawKey $ k
+    monitor (counterexample $ "\nkey bytes = " ++ hexXPrv)
+    (code, stdout, stderr) <- run $ jcliKeyFromHex hexXPrv
+    monitor (counterexample $ "\n" ++ show code)
+    monitor (counterexample $ "Stdout: " ++ show stdout)
+    monitor (counterexample $ "Stderr: " ++ show stderr)
+    assert (stderr == "")
+  where
+    jcliKeyFromHex = readProcessWithExitCode
+        "jcli"
+        ["key", "from-bytes", "--type", "ed25519bip32"]
+
+instance Arbitrary (ShelleyKey 'RootK XPrv) where
+    shrink _ = []
+    arbitrary = do
+        s <- SomeMnemonic <$> genMnemonic @15
+        g <- fmap SomeMnemonic <$> genSecondFactor
+        return $ Shelley.unsafeGenerateKeyFromSeed (s, g) encryptionPass
+      where
+        encryptionPass = Passphrase ""
+        genSecondFactor = frequency
+            [ (30, return Nothing)
+            , (70, Just <$> genMnemonic @12)
+            ]
+
+instance Arbitrary (ByronKey 'RootK XPrv) where
+    shrink _ = []
+    arbitrary = Byron.unsafeGenerateKeyFromSeed ()
+        <$> (SomeMnemonic <$> genMnemonic @12)
+        <*> (pure mempty)
+
+instance Arbitrary (IcarusKey 'RootK XPrv) where
+    shrink _ = []
+    arbitrary = Icarus.unsafeGenerateKeyFromSeed
+        <$> (SomeMnemonic <$> genMnemonic @12)
+        <*> (pure mempty)
+
+instance Show XPrv where
+    show = show . unXPrv
+
+instance Eq XPrv where
+    a == b = unXPrv a == unXPrv b
+
+-- | Generates an arbitrary mnemonic of a size according to the type parameter.
+--
+-- E.g:
+-- >>> arbitrary = SomeMnemonic <$> genMnemonic @12
+--
+-- NOTE: Duplicated with "Cardano.Wallet.Gen".
+genMnemonic
+    :: forall mw ent csz.
+     ( ConsistentEntropy ent mw csz
+     , EntropySize mw ~ ent
+     )
+    => Gen (Mnemonic mw)
+genMnemonic = do
+        let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
+        bytes <- BS.pack <$> vectorOf n arbitrary
+        let ent = unsafeMkEntropy @(EntropySize mw) bytes
+        return $ entropyToMnemonic ent


### PR DESCRIPTION
# Issue Number

#1316 

# Overview

- [x] Added
```haskell
unXPrvStripPub :: XPrv -> Either ErrUnXPrvStripPub ByteString
xPrvFromStrippedPubXPrv :: ByteString -> Either ErrXPrvFromStrippedPubXPrv XPrv
```

To convert `XPrv` (`prv <> pub <> cc`) to a 96-byte bytestring of the form `prv <> cc`, and back.

Unusually, _both_ functions may fail. `unXPrvStripPub` fails if the resulting byte string cannot be converted back to the _same_ `XPrv` using `xPrvFromStrippedPubXPrv` (i.e. roundtrip)

- [x] Roundtrip properties.
    - `either roundtrips or fails (if xprv is encrypted)`
    - `(xPrvFromStrippedPubXPrv bs) fails if (BS.length bs) /= 96`
- [x] Integration test verifying that this format works with jcli

# Comments

- We need to convert between 96-byte long hex-encoded bytestrings and
XPrvs when implementing the `key root` and `key child` CLI commands.

Example showing that we cannot `unXPrvStripPub` encrypted XPrvs:
```haskell
λ> bytes = "(\134\242|I\141L\EM\NUL\128\173\252q\191\172\167>f \218\222\167.\136\DC4\216\191\253r8cD8&I\STX;\185&\177\172E\241\185\241\157\226\r\163+\EM\GS\232-\188\250[E^N\129J\158\STX\242s\215\149\142\217;\168P\DLE\159jHO\149'\ENQ\ETX!\129\CAN\140\176\221\DEL'*\DC4=<B\226\134\188!\241\DLEzt\222\199\247U\143\ETB\128,\226Q\"\230\234\"\191\177\250\230\167\n\214X\244z\\" :: BS.ByteString

λ> unXPrvStripPub k
Right "(\134\242|I\141L\EM\NUL\128\173\252q\191\172\167>f \218\222\167.\136\DC4\216\191\253r8cD8&I\STX;\185&\177\172E\241\185\241\157\226\r\163+\EM\GS\232-\188\250[E^N\129J\158\STX\134\188!\241\DLEzt\222\199\247U\143\ETB\128,\226Q\"\230\234\"\191\177\250\230\167\n\214X\244z\\"

λ> unXPrvStripPub $ CC.xPrvChangePass (""::BS.ByteString) ("newpass"::BS.ByteString) k
Left ErrNoRoundtripMismatch
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
