### PR TITLE
Add cli `key child` command

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1370,10 +1370,11 @@ walletStyleOption = option (eitherReader fromTextS)
     ( long "wallet-style"
     <> metavar "WALLET_STYLE"
     <> helpDoc (Just (vsep typeOptions))
+    <> value Icarus -- NOTE: Remember to update help text when updating!
     )
   where
     typeOptions = string <$>
-        [ "Any of the following:"
+        [ "Any of the following (default: icarus)"
         , "  icarus (" ++ allowedWords Icarus ++ ")"
         , "  trezor (" ++ allowedWords Trezor ++ ")"
         , "  ledger (" ++ allowedWords Ledger ++ ")"

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -405,7 +405,7 @@ xPrvToTextTransform = (xPrvToHexText, hexTextToXPrv)
 
     hexTextToXPrv :: Text -> Either String XPrv
     hexTextToXPrv txt = do
-        bytes <- fromHex $ B8.pack $ T.unpack txt
+        bytes <- fromHex $ B8.pack $ T.unpack . T.strip $ txt
         left showErr $ xPrvFromStrippedPubXPrv bytes
       where
         showErr (ErrInputLengthMismatch expected actual) = mconcat

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -406,8 +406,7 @@ xPrvToTextTransform = (xPrvToHexText, hexTextToXPrv)
       where
         -- NOTE: This error should never happen from using the CLI.
         showErr ErrCannotRoundtripToSameXPrv =
-            "The private key I'm trying to encode looks wierd. \
-            \Is it encrypted? Or an old Byron key?"
+            "Internal error: Failed to safely encode an extended private key"
 
     hexTextToXPrv :: Text -> Either String XPrv
     hexTextToXPrv txt = do
@@ -422,8 +421,8 @@ xPrvToTextTransform = (xPrvToHexText, hexTextToXPrv)
             , " bytes."
             ]
         showErr (ErrCannotRoundtripToSameBytes) = mconcat
-            [ "Couldn't decode that extended private key while making sure it "
-            , "can be encoded back again. Is it an old Byron key?"
+            [ "That extended private key looks weird. "
+            , "Is it encrypted? Or is it an old Byron key?"
             ]
         fromHex = left (const "Invalid hex.")
             . convertFromBase Base16

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1455,7 +1455,7 @@ walletStyleOption = option (eitherReader fromTextS)
          formatEnglishEnumerationRev xs = intercalate ", " (reverse xs)
 
 keyArgument :: Parser Text
-keyArgument = T.pack <$> (argument str (metavar "HEX-XPRV"))
+keyArgument = T.pack <$> (argument str (metavar "XPRV"))
 
 pathOption :: Parser DerivationPath
 pathOption = option (eitherReader fromTextS) $

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -490,15 +490,16 @@ instance FromText DerivationIndex where
 
         mkDerivationIndex :: Int -> Either TextDecodingError DerivationIndex
         mkDerivationIndex =
-            indexInv >=> (return . DerivationIndex . toEnum . fromEnum)
+            fmap (DerivationIndex . toEnum . fromEnum) . indexInv
 
-        parseSoftIndex =
-            parseWord >=> softIndexInv >=> mkDerivationIndex
+        parseSoftIndex txt = do
+            num <- parseWord txt >>= softIndexInv
+            mkDerivationIndex num
 
-        parseHardenedIndex =
-            parseWord
-            >=> (return . (+ fromIntegral firstHardenedIndex))
-            >=> mkDerivationIndex
+        parseHardenedIndex txt = do
+            num <- parseWord txt
+            let i = num + fromIntegral firstHardenedIndex
+            mkDerivationIndex i
 
         softIndexInv a = do
             idx <- mkDerivationIndex a

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -476,7 +476,7 @@ instance FromText DerivationIndex where
         "An empty string is not a derivation index!"
     fromText x = do
        -- NOTE: T.takeEnd will not throw, but may return "".
-       if T.takeEnd 1 x == "\'"
+       if T.takeEnd 1 x == "H"
        then do
            let x' = T.dropEnd 1 x
            parseHardenedIndex x'
@@ -506,7 +506,7 @@ instance FromText DerivationIndex where
             then Left . TextDecodingError $ mconcat
                 [ show a
                 , " is too high to be a soft derivation index. "
-                , "Please use \"'\" to denote hardened indexes. "
+                , "Please use \"H\" to denote hardened indexes. "
                 , "Did you mean \""
                 , T.unpack $ toText idx
                 , "\"?"
@@ -525,7 +525,7 @@ instance ToText DerivationIndex where
     toText (DerivationIndex i) = do
         T.pack $
             if i >= firstHardenedIndex
-            then show (i - firstHardenedIndex) ++ "'"
+            then show (i - firstHardenedIndex) ++ "H"
             else show i
 
 newCliKeyScheme :: CliWalletStyle -> CliKeyScheme XPrv (Either String)
@@ -1462,7 +1462,7 @@ pathOption = option (eitherReader fromTextS) $
     mempty
     <> long "path"
     <> metavar "DER-PATH"
-    <> help "Derivation path e.g. \"44'/1815'/0'/0\""
+    <> help "Derivation path e.g. 44H/1815H/0H/0"
 
 -- | <wallet-id=WALLET_ID>
 walletIdArgument :: Parser WalletId

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -359,7 +359,7 @@ cmdKey = command "key" $ info (helper <*> cmds) $ mempty
     <> progDesc "Derive keys from mnemonics."
   where
     cmds = subparser $ mempty
-        <> cmdRootKey
+        <> cmdKeyRoot
         <> cmdKeyPublic
         <> cmdKeyInspect
 
@@ -578,8 +578,8 @@ data KeyRootArgs = KeyRootArgs
     , _mnemonicWords :: [Text]
     }
 
-cmdRootKey :: Mod CommandFields (IO ())
-cmdRootKey =
+cmdKeyRoot :: Mod CommandFields (IO ())
+cmdKeyRoot =
     command "root" $ info (helper <*> cmd) $ mempty
         <> progDesc "Extract root extended private key from a mnemonic sentence."
   where

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -423,7 +423,7 @@ xPrvToTextTransform = (xPrvToHexText, hexTextToXPrv)
             ]
         showErr (ErrCannotRoundtripToSameBytes) = mconcat
             [ "Couldn't decode that extended private key while making sure it "
-            , " can be encoded back again. Is it an old Byron key?"
+            , "can be encoded back again. Is it an old Byron key?"
             ]
         fromHex = left (const "Invalid hex.")
             . convertFromBase Base16
@@ -698,6 +698,7 @@ cmdKeyInspect =
       where
         toHex :: ByteString -> Text
         toHex = T.pack . B8.unpack . hex
+
 {-------------------------------------------------------------------------------
                             Commands - 'mnemonic'
 -------------------------------------------------------------------------------}

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -483,7 +483,7 @@ spec = do
             ]
 
         ["key", "child", "--help"] `shouldShowUsage`
-            [ "Usage:  key child --path DER-PATH HEX-XPRV"
+            [ "Usage:  key child --path DER-PATH XPRV"
             , "  Derive child keys."
             , ""
             , "Available options:"
@@ -492,7 +492,7 @@ spec = do
             ]
 
         ["key", "public", "--help"] `shouldShowUsage`
-            [ "Usage:  key public HEX-XPRV"
+            [ "Usage:  key public XPRV"
             , "  Extract public key from a private key."
             , ""
             , "Available options:"
@@ -500,7 +500,7 @@ spec = do
             ]
 
         ["key", "inspect", "--help"] `shouldShowUsage`
-            [ "Usage:  key inspect HEX-XPRV"
+            [ "Usage:  key inspect XPRV"
             , "  Show information about a key."
             , ""
             , "Available options:"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -518,8 +518,14 @@ spec = do
         fromTextGolden @DerivationIndex "" "should fail" $
             Left "An empty string is not a derivation index!"
 
+        fromTextGolden @DerivationIndex "0'" "should fail" $
+            Left "\"0'\" is not a number."
+
         fromTextGolden @DerivationIndex "4294967295H" "should fail" $
             Left "6442450943 is too high to be a derivation index."
+
+        fromTextGolden @DerivationPath "" "should fail" $
+            Left "An empty string is not a derivation index!"
 
         fromTextGolden @DerivationPath "44H/0H/0" "" $
             Right . DerivationPath . map DerivationIndex $

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -722,12 +722,10 @@ spec = do
                 (newCliKeyScheme s)
                 (newCliKeyScheme s)
 
-        -- This tests provides a stronger guarantee than merely knowing that
-        -- unsafeHexTextToXPrv and xPrvToHexText roundtrips.
         it "scheme == mapKey (fromHex . toHex) scheme"
             $ property prop_roundtripCliKeySchemeKeyViaHex
 
-        it "random /= icarus" $ do
+        it "ledger /= icarus" $ do
             expectFailure $ propCliKeySchemeEquality
                 (newCliKeyScheme Ledger)
                 (newCliKeyScheme Icarus)

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -696,6 +696,10 @@ spec = do
             ["key", "child", "--path", "0", encryptedKey]
                 `expectStdErr` (`shouldBe` "That extended private key looks \
                        \weird. Is it encrypted? Or is it an old Byron key?\n")
+        describe "fails when key is not 96 bytes" $ do
+            ["key", "child", "--path", "0", "5073"]
+                `expectStdErr` (`shouldBe` "Expected extended private key to be \
+                                           \96 bytes but got 2 bytes.\n")
 
     describe "key public" $ do
         let prv1 = "588102383ed9ecc5c44e1bfa18d1cf8ef19a7cf806a20bb4cbbe4e51166\

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -701,6 +701,17 @@ spec = do
                 , cc
                 , "\n"
                 ]
+        describe "bryon keys fail" $ do
+            -- This key does not have the "tweak" that newer keys are expected
+            -- to have.
+            let byronKey = "464f3a1316a3849a1ca49a7e3a8b9ab35379598ac4fbcd0ba2b\
+                \c3a165185150a5c56ebf6d6d39fd6c070731a44133ebb083c42b949046d79a\
+                \ac48b7a1f52787ca5078d2194b78ccb6116d64f4d5a3fad3cd41e4748c20fc\
+                \589d87a0e69583357"
+            ["key", "child", "--path", "0", byronKey]
+                `expectStdErr` (`shouldBe` "Couldn't decode that extended \
+				\private key while making sure it can be encoded back again. \
+				\Is it an old Byron key?\n")
 
     describe "CliKeyScheme" $ do
         it "all allowedWordLengths are supported"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -677,6 +677,26 @@ spec = do
             \59c46d040abb4b3e0623bb151362233e75cf1f923b6d5964780ebbcf3a2d7a3d90\
             \78e802011f1580465c80e7040f1e4d8e24f978d23f01c1d2cf18fcf741a7\n"
 
+        -- This key does not have the "tweak" that newer keys are expected
+        -- to have.
+        let byronKey =
+              "464f3a1316a3849a1ca49a7e3a8b9ab35379598ac4fbcd0ba2bc3a165185150a\
+              \5c56ebf6d6d39fd6c070731a44133ebb083c42b949046d79aac48b7a1f52787c\
+              \a5078d2194b78ccb6116d64f4d5a3fad3cd41e4748c20fc589d87a0e69583357"
+        let encryptedKey =
+              "9d41c6c66a0aaac73b31bfbf2522c63eea4e16e7df63ccf43e012b20a4606cbb\
+              \e99a00cfed56e9516bc947f327a73e0849882a32a682932c51b42156055abb0b\
+              \5d3661deb9064f2d0e03fe85d68070b2fe33b4916059658e28ac7f7f91ca4b12"
+
+        describe "bryon keys fail" $ do
+            ["key", "child", "--path", "0", byronKey]
+                `expectStdErr` (`shouldBe` "That extended private key looks \
+                       \weird. Is it encrypted? Or is it an old Byron key?\n")
+        describe "encrypted keys fail" $ do
+            ["key", "child", "--path", "0", encryptedKey]
+                `expectStdErr` (`shouldBe` "That extended private key looks \
+                       \weird. Is it encrypted? Or is it an old Byron key?\n")
+
     describe "key public" $ do
         let prv1 = "588102383ed9ecc5c44e1bfa18d1cf8ef19a7cf806a20bb4cbbe4e51166\
                    \6cf48d6fd7bec908e4c6ced5f0c4f0798b1b619d6b61e6110492b5ebb43\
@@ -702,17 +722,6 @@ spec = do
                 , cc
                 , "\n"
                 ]
-        describe "bryon keys fail" $ do
-            -- This key does not have the "tweak" that newer keys are expected
-            -- to have.
-            let byronKey = "464f3a1316a3849a1ca49a7e3a8b9ab35379598ac4fbcd0ba2b\
-                \c3a165185150a5c56ebf6d6d39fd6c070731a44133ebb083c42b949046d79a\
-                \ac48b7a1f52787ca5078d2194b78ccb6116d64f4d5a3fad3cd41e4748c20fc\
-                \589d87a0e69583357"
-            ["key", "child", "--path", "0", byronKey]
-                `expectStdErr` (`shouldBe` "Couldn't decode that extended \
-				\private key while making sure it can be encoded back again. \
-				\Is it an old Byron key?\n")
 
     describe "CliKeyScheme" $ do
         it "all allowedWordLengths are supported"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -488,7 +488,7 @@ spec = do
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
-            , "  --path DER-PATH          Derivation path e.g. \"44'/1815'/0'/0\""
+            , "  --path DER-PATH          Derivation path e.g. 44H/1815H/0H/0"
             ]
 
         ["key", "public", "--help"] `shouldShowUsage`
@@ -518,26 +518,26 @@ spec = do
         fromTextGolden @DerivationIndex "" "should fail" $
             Left "An empty string is not a derivation index!"
 
-        fromTextGolden @DerivationIndex "4294967295'" "should fail" $
+        fromTextGolden @DerivationIndex "4294967295H" "should fail" $
             Left "6442450943 is too high to be a derivation index."
 
-        fromTextGolden @DerivationPath "44'/0'/0" "" $
+        fromTextGolden @DerivationPath "44H/0H/0" "" $
             Right . DerivationPath . map DerivationIndex $
                 [0x80000000 + 44, 0x80000000 + 0, 0]
 
         fromTextGolden
             @DerivationPath "2147483692" "hardened index without ' notation" $
                 Left "2147483692 is too high to be a soft derivation index. \
-                     \Please use \"'\" to denote hardened indexes. Did you \
-                     \mean \"44'\"?"
+                     \Please use \"H\" to denote hardened indexes. Did you \
+                     \mean \"44H\"?"
 
-        fromTextGolden @DerivationPath "44'/0'/0/" "should fail (trailing /)" $
+        fromTextGolden @DerivationPath "44H/0H/0/" "should fail (trailing /)" $
             Left "An empty string is not a derivation index!"
 
-        fromTextGolden @DerivationPath "ö'/0'/0/" "should fail" $
-            Left "\"ö'\" is not a number."
+        fromTextGolden @DerivationPath "öH/0H/0/" "should fail" $
+            Left "\"öH\" is not a number."
 
-        fromTextGolden @DerivationPath "0x80000000/0'/0/" "should fail" $
+        fromTextGolden @DerivationPath "0x80000000/0H/0/" "should fail" $
             Left "\"0x80000000\" is not a number."
 
     describe "Transaction ID decoding from text" $ do
@@ -664,7 +664,7 @@ spec = do
                        \11666cf48d6fd7bec908e4c6ced5f0c4f0798b1b619d6b61e611049\
                        \2b5ebb430f570488f074a9fc9a22f0a61b2ab9b1f1a990e3f8dd6fb\
                        \ed4ad474371095c74db3d9c743a\n"
-        ["key", "child", "--path", "1852'/1815'/0'/0/0", rootXPrv]
+        ["key", "child", "--path", "1852H/1815H/0H/0/0", rootXPrv]
             `shouldStdOut`
             "5073cbc3e3f85b0099c67ed5b0344bfc0f15861ef05f41cde2a797352f66cf48ab\
             \59c46d040abb4b3e0623bb151362233e75cf1f923b6d5964780ebbcf3a2d7a3d90\

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -469,13 +469,13 @@ spec = do
             ]
 
         ["key", "root", "--help"] `shouldShowUsage`
-            [ "Usage:  key root --wallet-style WALLET_STYLE MNEMONIC_WORD..."
+            [ "Usage:  key root [--wallet-style WALLET_STYLE] MNEMONIC_WORD..."
             , "  Extract root extended private key from a mnemonic sentence."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
             , "  --wallet-style WALLET_STYLE"
-            , "                           Any of the following:"
+            , "                           Any of the following (default: icarus)"
             , "                             icarus (15 words)"
             , "                             trezor (12, 15, 18, 21 or 24 words)"
             , "                             ledger (12, 15, 18, 21 or 24 words)"
@@ -620,7 +620,7 @@ spec = do
                      \analyst ladder such report capital produce"
     let mw12 = words "broccoli side goddess shaft alarm victory sheriff \
                      \combine birth deny train outdoor"
-    describe "key derivation from mnemonics" $ do
+    describe "key root" $ do
         (["key", "root", "--wallet-style", "icarus"] ++ mw15) `shouldStdOut`
             "00aa5f5f364980f4ac6295fd0fbf65643390d6bb1cf76536c2ebb02713c8ba50d8\
             \903bee774b7bf8678ea0d6fded6d876db3b42bef687640cc514eb73f767537a8c7\
@@ -634,7 +634,7 @@ spec = do
             \9eb7ad13f798d06ce550a9f6c48dd2151db4593e67dbd2821d75378c7350f1366b\
             \85e0be9cdec2213af2084d462cc11e85c215e0f003acbeb996567e371502\n"
 
-    describe "key derivation (negative tests)" $ do
+    describe "key root (negative tests)" $ do
         (["key", "root", "--wallet-style", "icarus"] ++ mw12) `expectStdErr`
             (`shouldBe` "Invalid number of words: 15 words are expected.\n")
 

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -527,9 +527,10 @@ spec = do
         fromTextGolden @DerivationPath "" "should fail" $
             Left "An empty string is not a derivation index!"
 
+        let firstHardenedIx = 0x80000000
         fromTextGolden @DerivationPath "44H/0H/0" "" $
             Right . DerivationPath . map DerivationIndex $
-                [0x80000000 + 44, 0x80000000 + 0, 0]
+                [firstHardenedIx + 44, firstHardenedIx + 0, 0]
 
         fromTextGolden
             @DerivationPath "2147483692" "hardened index without ' notation" $

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -60,7 +60,9 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , hex
     , fromHex
     , unXPrvStripPub
+    , unXPrvStripPubCheckRoundtrip
     , xPrvFromStrippedPubXPrv
+    , xPrvFromStrippedPubXPrvCheckRoundtrip
     , ErrXPrvFromStrippedPubXPrv (..)
     , ErrUnXPrvStripPub (..)
     , NatVals (..)
@@ -730,7 +732,7 @@ fromHex :: ByteArray bout => ByteString -> Either String bout
 fromHex = convertFromBase Base16
 
 data ErrUnXPrvStripPub
-    = ErrCannotRoundtrip
+    = ErrCannotRoundtripToSameXPrv
       -- ^ The resulting bytestring would have been unable to roundtrip using
       -- @xPrvFromStrippedPubXPrv@. Most likely because the input @XPrv@ was
       -- encrypted, or because it was an old (Byron) key.
@@ -747,17 +749,21 @@ data ErrUnXPrvStripPub
 -- - If the @XPrv@ was encrypted
 -- - If a DerivationScheme1 (Byron) key was used (that does not conform to the
 -- "tweak")
-unXPrvStripPub :: XPrv -> Either ErrUnXPrvStripPub ByteString
-unXPrvStripPub k = do
-    let res = stripPub . unXPrv $ k
+unXPrvStripPubCheckRoundtrip :: XPrv -> Either ErrUnXPrvStripPub ByteString
+unXPrvStripPubCheckRoundtrip k = do
+    let res = unXPrvStripPub k
 
     -- Check that it roundtrips.
     case (fmap unXPrv . xPrvFromStrippedPubXPrv $ res) of
         Right bytes
             | bytes == unXPrv k -> Right res
-            | otherwise         -> Left ErrCannotRoundtrip
+            | otherwise         -> Left ErrCannotRoundtripToSameXPrv
         Left  _                 -> error "unXPrvStripPub: this state cannot be \
             \reached from a rightfully crafted XPrv"
+
+unXPrvStripPub :: XPrv -> ByteString
+unXPrvStripPub k = do
+    stripPub . unXPrv $ k
   where
     -- Converts  xprv <> pub <> cc
     -- To        xprv <>        cc
@@ -769,8 +775,17 @@ unXPrvStripPub k = do
 
 data ErrXPrvFromStrippedPubXPrv
     = ErrInputLengthMismatch Int Int -- ^ Expected, Actual
-    | ErrInternalError String
+    | ErrCannotRoundtripToSameBytes
     deriving (Eq, Show)
+
+xPrvFromStrippedPubXPrvCheckRoundtrip
+    :: ByteString
+    -> Either ErrXPrvFromStrippedPubXPrv XPrv
+xPrvFromStrippedPubXPrvCheckRoundtrip bs = do
+        res <- xPrvFromStrippedPubXPrv bs
+        if unXPrvStripPub res == bs
+        then Right res
+        else Left ErrCannotRoundtripToSameBytes
 
 -- | Create a @XPrv@ from a 96-byte long extended private key
 --
@@ -781,7 +796,7 @@ xPrvFromStrippedPubXPrv :: ByteString -> Either ErrXPrvFromStrippedPubXPrv XPrv
 xPrvFromStrippedPubXPrv x = do
         when (BS.length x /= expectedInputLength) $
             Left $ ErrInputLengthMismatch expectedInputLength (BS.length x)
-        toXPrv $ CC.encryptedCreateDirectWithTweak x pass
+        return $ toXPrv $ CC.encryptedCreateDirectWithTweak x pass
   where
     pass :: ByteString
     pass = ""
@@ -790,5 +805,5 @@ xPrvFromStrippedPubXPrv x = do
 
     -- @xprv@ can fail. But because it is calling @encryptedKey@ internally,
     -- and we are feeding it the output of @unEncryptedKey@, it really shouldn't.
-    toXPrv :: CC.EncryptedKey -> Either ErrXPrvFromStrippedPubXPrv XPrv
-    toXPrv = left ErrInternalError . xprv . CC.unEncryptedKey
+    toXPrv :: CC.EncryptedKey -> XPrv
+    toXPrv = either (error . show) id . xprv . CC.unEncryptedKey

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -43,8 +43,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , checkPassphrase
     , encryptPassphrase
     , getIndex
-    , unXPrvStripPub
-    , xPrvFromStrippedPubXPrv
+    , unXPrvStripPubCheckRoundtrip
+    , xPrvFromStrippedPubXPrvCheckRoundtrip
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
@@ -308,12 +308,12 @@ prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
 -- we would not care.
 prop_unXPrvStripRoundtrip :: XPrvWithPass -> Property
 prop_unXPrvStripRoundtrip (XPrvWithPass k enc) = do
-    let res = unXPrvStripPub k
+    let res = unXPrvStripPubCheckRoundtrip k
     case res of
         Right k' ->
-            xPrvFromStrippedPubXPrv k' === Right k
+            xPrvFromStrippedPubXPrvCheckRoundtrip k' === Right k
                 & label "roundtrip"
-        Left ErrCannotRoundtrip ->
+        Left ErrCannotRoundtripToSameXPrv ->
             enc /= Passphrase ""
                 & label "mismatch"
                 & counterexample "XPrv should be encrypted for the roundtrip to\
@@ -334,8 +334,8 @@ prop_xPrvFromStrippedPubXPrvLengthRequirement (Unencrypted k) (NonNegative n) = 
         & classify (n == 96) "== 96"
         & classify (n < 96) "< 96"
   where
-    toStripped = left show . unXPrvStripPub
-    fromStripped = left show . xPrvFromStrippedPubXPrv
+    toStripped = left show . unXPrvStripPubCheckRoundtrip
+    fromStripped = left show . xPrvFromStrippedPubXPrvCheckRoundtrip
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -25,12 +25,10 @@ import Cardano.Wallet.Gen
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
-    , ErrUnXPrvStripPub (..)
     , ErrWrongPassphrase (..)
     , FromMnemonic (..)
     , FromMnemonicError (..)
     , Index
-    , NetworkDiscriminant (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
     , PassphraseMaxLength (..)
@@ -43,7 +41,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , checkPassphrase
     , encryptPassphrase
     , getIndex
+    , hex
+    , unXPrvStripPub
     , unXPrvStripPubCheckRoundtrip
+    , xPrvFromStrippedPubXPrv
     , xPrvFromStrippedPubXPrvCheckRoundtrip
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -225,8 +226,14 @@ spec = do
             (property $ prop_roundtripXPub @IcarusKey)
 
     describe "unXPrvStripPub & xPrvFromStrippedPubXPrv" $ do
-        it "either roundtrips or fails (if xprv is encrypted)"
-            (property prop_unXPrvStripRoundtrip)
+        it "xPrvFromStrippedPubXPrv and unXPrvStripPub"
+              (property prop_strippedPubXPrvRoundtrip1)
+        it "xPrvFromStrippedPubXPrv and unXPrvStripPubCheckRoundtrip"
+              (property prop_strippedPubXPrvRoundtrip2)
+        it "xPrvFromStrippedPubXPrvCheckRoundtrip and unXPrvStripPub"
+              (property prop_strippedPubXPrvRoundtrip3)
+        it "xPrvFromStrippedPubXPrvCheckRoundtrip and unXPrvStripPubCheckRoundtrip"
+              (property prop_strippedPubXPrvRoundtrip4)
 
         it "(xPrvFromStrippedPubXPrv bs) fails if (BS.length bs) /= 96"
             (property prop_xPrvFromStrippedPubXPrvLengthRequirement)
@@ -299,25 +306,67 @@ prop_passphraseHashMalformed
 prop_passphraseHashMalformed pwd = monadicIO $ liftIO $ do
     checkPassphrase pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
 
--- NOTE: Instead of testing
--- > encrypted => fails
--- we are testing
--- > fails => encrypted
---
--- This /should/ be enough. If a key were to be encrypted, but still roundtrip,
--- we would not care.
-prop_unXPrvStripRoundtrip :: XPrvWithPass -> Property
-prop_unXPrvStripRoundtrip (XPrvWithPass k enc) = do
-    let res = unXPrvStripPubCheckRoundtrip k
-    case res of
-        Right k' ->
-            xPrvFromStrippedPubXPrvCheckRoundtrip k' === Right k
-                & label "roundtrip"
-        Left ErrCannotRoundtripToSameXPrv ->
-            enc /= Passphrase ""
-                & label "mismatch"
-                & counterexample "XPrv should be encrypted for the roundtrip to\
-                                 \fail"
+-- | xPrvFromStrippedPubXPrv and unXPrvStripPub
+prop_strippedPubXPrvRoundtrip1 :: XPrvWithPass -> Property
+prop_strippedPubXPrvRoundtrip1 (XPrvWithPass k enc) = do
+    let bytes = unXPrvStripPub k
+    let Right res = xPrvFromStrippedPubXPrv bytes
+    counterexample (show . hex $ bytes) $
+        if enc == Passphrase ""
+        then label "no passphrase" (res === k)
+        else label "passphrase" $ do
+            counterexample "shoudn't roundtrip with passphrase"
+                $ property $ res /= k
+
+-- | xPrvFromStrippedPubXPrv and unXPrvStripPubCheckRoundtrip
+prop_strippedPubXPrvRoundtrip2 :: XPrvWithPass -> Property
+prop_strippedPubXPrvRoundtrip2 (XPrvWithPass k enc) = do
+    let bytes = left show $ unXPrvStripPubCheckRoundtrip k
+    let res = xPrvFromStrippedPubXPrv' <$> bytes
+    counterexample (either (const "") (show . hex) bytes) $
+        if enc == Passphrase ""
+        then label "no passphrase" (res === Right k)
+        else label "passphrase" $ do
+            case res of
+                Right _ ->
+                    counterexample "shoudn't roundtrip with passphrase"
+                        $ property False
+                Left _ ->
+                    label "error" True
+  where
+   -- The input cannot have wrong length, so we discard the possibility of
+   -- @Left@.
+    xPrvFromStrippedPubXPrv' = either (error . show) id . xPrvFromStrippedPubXPrv
+
+-- | xPrvFromStrippedPubXPrvCheckRoundtrip and unXPrvStripPub
+prop_strippedPubXPrvRoundtrip3 :: XPrvWithPass -> Property
+prop_strippedPubXPrvRoundtrip3 (XPrvWithPass k enc) = do
+    let bytes = unXPrvStripPub k
+    let res = xPrvFromStrippedPubXPrvCheckRoundtrip bytes
+    counterexample (show $ hex bytes) $
+        if enc == Passphrase ""
+        then label "no passphrase" (res === Right k)
+        else label "passphrase" $ do
+            case res of
+                Right k' -> label "false success" $ k' /= k
+                Left _ -> label "error" True
+
+-- | xPrvFromStrippedPubXPrvCheckRoundtrip and unXPrvStripPubCheckRoundtrip
+prop_strippedPubXPrvRoundtrip4 :: XPrvWithPass -> Property
+prop_strippedPubXPrvRoundtrip4 (XPrvWithPass k enc) = do
+    let bytes = left show $ unXPrvStripPubCheckRoundtrip k
+    let res = left show . xPrvFromStrippedPubXPrvCheckRoundtrip =<< bytes
+    counterexample (either (const "") (show . hex) bytes) $
+        if enc == Passphrase ""
+        then label "no passphrase" (res === Right k)
+        else label "passphrase" $ do
+            case res of
+                Right _ ->
+                    counterexample "shoudn't roundtrip with passphrase"
+                        $ property False
+                Left _ ->
+                    label "error" True
+
 prop_xPrvFromStrippedPubXPrvLengthRequirement
     :: Unencrypted XPrv
     -> NonNegative Int

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
@@ -71,7 +71,7 @@ prop_keyToHexTextJcliCompatible
     => k 'RootK XPrv
     -> Property
 prop_keyToHexTextJcliCompatible k = monadicIO $ do
-    let Right hexXPrv = fmap (B8.unpack . hex) . unXPrvStripPub . getRawKey $ k
+    let hexXPrv = (B8.unpack . hex) . unXPrvStripPub . getRawKey $ k
     monitor (counterexample $ "\nkey bytes = " ++ hexXPrv)
     (code, stdout, stderr) <- run $ jcliKeyFromHex hexXPrv
     monitor (counterexample $ "\n" ++ show code)


### PR DESCRIPTION
# Issue Number

#1353 

# Overview

- [x] Preparatory addition of CLI `DerivationIndex` and `DerivationPath` types
- [x] Make `mapKey` xprv to hex transformation bidirectional
- [x] Add `key child --path` command to cli
- [x] Confirming that we can derive an actual wallet address key using `key child` as a manual golden test.

# Comments
- [ ] Not here: Parsing hexadecimal indexes e.g `0x8000073c` (could be neat 🤷‍♂ )

Manual example. Note that `to-pub` is not functionality of `cardano-wallet` — yet.
```bash
$ cardano-wallet-jormungandr key child --path "2147485500/2147485463/0'/0/0" 588102383ed9ecc5c44e1bfa18d1cf8ef19a7cf806a20bb4cbbe4e511666cf48d6fd7bec908e4c6ced5f0c4f0798b1b619d6b61e6110492b5ebb430f570488f074a9fc9a22f0a61b2ab9b1f1a990e3f8dd6fbed4ad474371095c74db3d9c743a | to-pub
eb806fca3bfda11ae14dee52c5ad6564e68e7531c1a1d498a76172898d2841cb3d9078e802011f1580465c80e7040f1e4d8e24f978d23f01c1d2cf18fcf741a7

# Address comes from an actual empty wallet:
$ jcli address info addr1sn4cqm728076zxhpfhh993ddv4jwdrn4x8q6r4yc5ash9zvd9pqukyh6fnkrsrsz4w9jvu8hyre20xm7m78jf4kww4h2n5maytuhtflrax9duz
discrimination: testing
public key: ed25519_pk1awqxlj3mlks34c2daefvttt9vnnguaf3cxsafx98v9egnrfgg89s4y7wfm
group key:  ed25519_pk1ztayempcpcp2hzexwrmjpu48ndldlrey6m882m4f6d7j97t45l3s5h5gl4
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
