### PR TITLE
eventually with description for better identification when action inside eventually fails

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -34,7 +34,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , emptyWalletWith
-    , eventually_
+    , eventually
     , expectErrorMessage
     , expectField
     , expectListField
@@ -184,7 +184,7 @@ spec = do
             expectResponseCode @IO HTTP.status202 rTrans
 
         -- make sure all transactions are in ledger
-        eventually_ $ do
+        eventually "Wallet balance = 10" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             expectField

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -71,7 +71,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , emptyWalletWith
-    , eventually_
+    , eventually
     , expectErrorMessage
     , expectField
     , expectListField
@@ -251,7 +251,7 @@ spec = do
 
             -- Check that funds become available in the target wallet:
             let expectedBalance = originalBalance - expectedFee
-            eventually_ $ do
+            eventually "Wallet has expectedBalance" $ do
                 r2 <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley targetWallet) Default Empty
                 verify r2
@@ -284,7 +284,7 @@ spec = do
                 } |]
         (_, wOld) <- unsafeRequest @ApiByronWallet ctx
             (Link.postWallet @'Random) payloadRestore
-        eventually_ $ do
+        eventually "wallet balance greater than 0" $ do
             request @ApiByronWallet ctx
                 (Link.getWallet @'Byron wOld)
                 Default
@@ -317,7 +317,7 @@ spec = do
 
         -- Check that funds become available in the target wallet:
         let expectedBalance = originalBalance - expectedFee
-        eventually_ $ do
+        eventually "wallet balance = expectedBalance" $ do
             request @ApiWallet ctx
                 (Link.getWallet @'Shelley wNew)
                 Default
@@ -396,7 +396,7 @@ spec = do
                     } |]
             (_, sourceWallet) <- unsafeRequest @ApiByronWallet ctx
                 (Link.postWallet @'Random) payloadRestore
-            eventually_ $ do
+            eventually "wallet balance greater than 0" $ do
                 request @ApiByronWallet ctx
                     (Link.getWallet @'Byron sourceWallet)
                     Default
@@ -843,7 +843,7 @@ spec = do
                 verify r expectations
                 let w = getFromResponse id r
 
-                eventually_ $ do
+                eventually "wallet is available and ready" $ do
                     -- get
                     rg <- request @ApiByronWallet ctx
                         (Link.getWallet @'Byron w) Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -58,7 +58,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 spec :: forall t. SpecWith (Context t)
 spec = do
     it "NETWORK - Can query network information" $ \ctx -> do
-        r <- eventually $ do
+        r <- eventually "wallet's syncProgress = Ready" $ do
             now <- liftIO getCurrentTime
             r <- request @ApiNetworkInformation ctx
                 Link.getNetworkInfo Default Empty
@@ -81,7 +81,7 @@ spec = do
         let calculatedNextEpoch = getFromResponse (#nextEpoch . #epochNumber) r1
         let nextEpochStartTime = getFromResponse (#nextEpoch . #epochStartTime) r1
 
-        eventuallyUsingDelay 100 $ do
+        eventuallyUsingDelay 100 "nextEpochStartTime passes" $ do
             now <- liftIO getCurrentTime
             now `shouldSatisfy` (>= nextEpochStartTime)
 
@@ -95,9 +95,8 @@ spec = do
             let getNetworkInfo = request @ApiNetworkInformation ctx
                     Link.getNetworkInfo Default Empty
             w <- emptyWallet ctx
-            -- make sure you're at the beginning of the epoch
             waitForNextEpoch ctx
-            r <- eventually $ do
+            r <- eventually "Network info enpoint shows syncProgress = Ready" $ do
                 sync <- getNetworkInfo
                 expectField (#syncProgress . #getApiT) (`shouldBe` Ready) sync
                 return sync
@@ -109,7 +108,7 @@ spec = do
             let blockHeight =
                     getFromResponse (#nodeTip . #height) r
 
-            eventually $ do
+            eventually "Wallet has the same tip as network/information" $ do
                 res <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley w) Default Empty
                 verify res
@@ -126,9 +125,8 @@ spec = do
             let getNetworkInfo = request @ApiNetworkInformation ctx
                     Link.getNetworkInfo Default Empty
             w <- emptyRandomWallet ctx
-            -- make sure you're at the beginning of the epoch
             waitForNextEpoch ctx
-            r <- eventually $ do
+            r <- eventually "Network info enpoint shows syncProgress = Ready" $ do
                 sync <- getNetworkInfo
                 expectField (#syncProgress . #getApiT) (`shouldBe` Ready) sync
                 return sync
@@ -140,7 +138,7 @@ spec = do
             let blockHeight =
                     getFromResponse (#nodeTip . #height) r
 
-            eventually $ do
+            eventually "Wallet has the same tip as network/information" $ do
                 res <- request @ApiByronWallet ctx
                     (Link.getWallet @'Byron w) Default Empty
                 verify res

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Transactions.hs
@@ -65,7 +65,7 @@ import Test.Integration.Framework.DSL
     , between
     , emptyRandomWallet
     , emptyWallet
-    , eventually_
+    , eventually
     , expectErrorMessage
     , expectField
     , expectListField
@@ -149,7 +149,7 @@ spec = do
             , expectField (#status . #getApiT) (`shouldBe` Pending)
             ]
 
-        eventually_ $ do
+        eventually "Tx is in ledger" $ do
             rt <- request @([ApiTransaction n]) ctx
                 (Link.listTransactions @'Shelley wSrc) Default Empty
             verify rt
@@ -167,7 +167,7 @@ spec = do
         wSrc <- fixtureWalletWith ctx [5_000_000]
         wDest <- emptyWallet ctx
 
-        eventually_ $ do
+        eventually "Pending tx has pendingSince field" $ do
             -- Post Tx
             let amt = (1 :: Natural)
             r <- postTx ctx (wSrc, Link.createTransaction ,"Secure Passphrase") wDest amt
@@ -222,7 +222,7 @@ spec = do
                     (`shouldBe` Quantity (faucetAmt - faucetUtxoAmt))
             ]
 
-        eventually_ $ do
+        eventually "wa and wb balances are as expected" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wb) Default Empty
             expectField
@@ -285,7 +285,7 @@ spec = do
                     (#balance . #getApiT . #available)
                     (`shouldBe` Quantity (faucetAmt - 2 * faucetUtxoAmt))
             ]
-        eventually_ $ do
+        eventually "wDest balance is as expected" $ do
             rd <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rd
@@ -351,7 +351,7 @@ spec = do
                     (#balance . #getApiT . #available)
                     (`shouldBe` Quantity (faucetAmt - 2 * faucetUtxoAmt))
             ]
-        eventually_ $ forM_ [wDest1, wDest2] $ \wDest -> do
+        eventually "Balances are as expected" $ forM_ [wDest1, wDest2] $ \wDest -> do
             rd <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default payload
             verify rd
@@ -429,7 +429,7 @@ spec = do
             , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
             ]
 
-        eventually_ $ do
+        eventually "Wallet balance is as expected" $ do
             rd <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rd
@@ -1175,7 +1175,7 @@ spec = do
 
         tx <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc) Default payload
         expectResponseCode HTTP.status202 tx
-        eventually_ $ do
+        eventually "Wallet balance is as expected" $ do
             rGet <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
@@ -1638,8 +1638,7 @@ spec = do
                     (`shouldBe` Quantity faucetAmt)
             ]
 
-        -- transaction eventually is in source wallet
-        eventually_ $ do
+        eventually "transaction eventually is in source wallet" $ do
             let ep = Link.listTransactions @'Shelley wSrc
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListField 0
@@ -1648,8 +1647,7 @@ spec = do
                     (#status . #getApiT) (`shouldBe` InLedger)
                 ]
 
-        -- transaction eventually is in target wallet
-        eventually_ $ do
+        eventually "transaction eventually is in target wallet" $ do
             let ep = Link.listTransactions @'Shelley wDest
             request @[ApiTransaction n] ctx ep Default Empty >>= flip verify
                 [ expectListField 0
@@ -1683,8 +1681,7 @@ spec = do
             postTx ctx (wSrc, Link.createTransaction, "cardano-wallet") wDest (1 :: Natural)
         let txid = getFromResponse #id rTx
 
-        -- Wait for the transaction to be accepted
-        eventually_ $ do
+        eventually "Transaction is accepted" $ do
             let ep = Link.listTransactions @'Shelley wSrc
             request @([ApiTransaction n]) ctx ep Default Empty >>= flip verify
                 [ expectListField 0

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Addresses.hs
@@ -43,7 +43,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , emptyWalletWith
-    , eventually_
+    , eventually
     , expectCliField
     , expectCliListField
     , expectValidJSON
@@ -175,8 +175,7 @@ spec = do
             (cTx, _, _) <- postTransactionViaCLI @t ctx "cardano-wallet" args
             cTx `shouldBe` ExitSuccess
 
-        -- make sure all transactions are in ledger
-        eventually_ $ do
+        eventually "all transactions are in ledger" $ do
             Stdout o2 <- getWalletViaCLI @t ctx $ T.unpack (wDest ^. walletId)
             w <- expectValidJSON (Proxy @ApiWallet) o2
             expectCliField

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Transactions.hs
@@ -65,7 +65,7 @@ import Test.Integration.Framework.DSL
     , deleteWalletViaCLI
     , emptyRandomWallet
     , emptyWallet
-    , eventually_
+    , eventually
     , expectCliField
     , expectCliListField
     , expectValidJSON
@@ -135,8 +135,7 @@ spec = do
                     , Quantity $ faucetAmt - feeMax - amt)
             ]
 
-        -- verify balance on dest wallet
-        eventually_ $ do
+        eventually "balance on dest wallet is OK" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -190,8 +189,7 @@ spec = do
                         ))
             ]
 
-        -- verify balance on dest wallet
-        eventually_ $ do
+        eventually "balance on dest wallet is OK" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -246,8 +244,7 @@ spec = do
                     )
             ]
 
-        eventually_ $ forM_ [wDest1, wDest2] $ \wDest -> do
-            -- verify balance on dest wallets
+        eventually "balance on dest wallets is OK" $ forM_ [wDest1, wDest2] $ \wDest -> do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -305,7 +302,7 @@ spec = do
             , expectCliField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
             ]
 
-        eventually_ $ do
+        eventually "Balance on dest wallet is OK" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -689,7 +686,7 @@ spec = do
         -- post transaction
         (c, _, _) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         c `shouldBe` ExitSuccess
-        eventually_ $ do
+        eventually "Balance on wallet is as expected" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -917,7 +914,7 @@ spec = do
             ]
         let txId =  getTxId txJson
 
-        eventually_ $ do
+        eventually "Tx is in ledger" $ do
             (fromStdout <$> listTransactionsViaCLI @t ctx [wSrcId])
                 >>= expectValidJSON (Proxy @([ApiTransaction n]))
                 >>= flip verify

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -54,7 +54,7 @@ import Test.Integration.Framework.DSL
     , emptyRandomWallet
     , emptyWallet
     , emptyWalletWith
-    , eventually_
+    , eventually
     , expectCliField
     , expectCliListField
     , expectValidJSON
@@ -162,7 +162,7 @@ spec = do
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
 
-        eventually_ $ do
+        eventually "Wallet state = Ready" $ do
             Stdout og <- getWalletViaCLI @t ctx $ T.unpack (j ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
             expectCliField (#state . #getApiT) (`shouldBe` Ready) jg
@@ -197,7 +197,7 @@ spec = do
         _ <- expectValidJSON (Proxy @(ApiTransaction n)) op
         cp `shouldBe` ExitSuccess
 
-        eventually_ $ do
+        eventually "Wallet balance is as expected" $ do
             Stdout og <- getWalletViaCLI @t ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
             expectCliField (#balance . #getApiT . #available)
@@ -215,7 +215,7 @@ spec = do
         T.unpack e2 `shouldContain` cmdOk
         wRestored <- expectValidJSON (Proxy @ApiWallet) o2
         expectCliField walletId (`shouldBe` wDest ^. walletId) wRestored
-        eventually_ $ do
+        eventually "Wallet is fully restored" $ do
             Stdout og2 <- getWalletViaCLI @t ctx $ T.unpack (wDest ^. walletId)
             jg2 <- expectValidJSON (Proxy @ApiWallet) og2
             expectCliField (#state . #getApiT) (`shouldBe` Ready) jg2
@@ -429,7 +429,7 @@ spec = do
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
 
-        eventually_ $ do
+        eventually "Wallet state = Ready" $ do
             Stdout og <- getWalletViaCLI @t ctx walId
             jg <- expectValidJSON (Proxy @ApiWallet) og
             expectCliField (#state . #getApiT) (`shouldBe` Ready) jg
@@ -717,7 +717,7 @@ spec = do
             _ <- expectValidJSON (Proxy @(ApiTransaction n)) op
             cp `shouldBe` ExitSuccess
             let coinsSent = map fromIntegral $ take alreadyAbsorbed coins
-            eventually_ $ do
+            eventually "Wallet balance is as expected" $ do
                 Stdout og <- getWalletViaCLI @t ctx $ T.unpack (wDest ^. walletId)
                 jg <- expectValidJSON (Proxy @ApiWallet) og
                 expectCliField (#balance . #getApiT . #available)

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -107,7 +107,7 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
-    , eventually_
+    , eventually
     , expectField
     , expectResponseCode
     , expectSuccess
@@ -221,7 +221,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         let pass = "cardano-wallet" :: Text
 
         replicateM_ batchSize (postTx ctx (wSrc, Link.createTransaction, pass) wDest amtToSend)
-        eventually_ $ do
+        eventually "repeatPostTx: wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet ctx (Link.getWallet @'Shelley wDest) Default Empty
             verify rWal1
                 [ expectSuccess
@@ -257,7 +257,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         let pass = "Secure Passphrase" :: Text
 
         postMultiTx ctx (wSrc, Link.createTransaction, pass) wDest amtToSend batchSize
-        eventually_ $ do
+        eventually "repeatPostMultiTx: wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rWal1

--- a/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/MetricsSpec.hs
@@ -47,17 +47,18 @@ spec = around setup $ do
         \ with one that stays running" $ \(nl, referenceDB) ->
         withDB "db.sqlite" $ \db ->
             withMonitorStakePoolsThread nl db $ \worker -> do
-                eventually $ do
+                eventually "db `shouldContainSameSlotsAs` referenceDB and db shouldNotBeEmpty" $ do
                     db `shouldContainSameSlotsAs` referenceDB
                     shouldNotBeEmpty db
 
                 killThread worker
 
-                eventually $
+                eventually "shouldBeBehindBy 3 db referenceDB" $
                     shouldBeBehindBy 3 db referenceDB
 
                 withMonitorStakePoolsThread nl db $ \_ ->
-                    eventually $ db `shouldContainSameSlotsAs` referenceDB
+                    eventually "db `shouldContainSameSlotsAs` referenceDB" $
+                        db `shouldContainSameSlotsAs` referenceDB
   where
     shouldBeBehindBy n db ref = do
         refSlots <- readSlots ref

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -78,7 +78,7 @@ import Test.Integration.Framework.DSL as DSL
     , TxDescription (..)
     , emptyRandomWallet
     , emptyWallet
-    , eventually_
+    , eventually
     , expectErrorMessage
     , expectField
     , expectListField
@@ -171,7 +171,7 @@ spec = do
             , expectField (#status . #getApiT) (`shouldBe` Pending)
             ]
 
-        eventually_ $ do
+        eventually "Tx is in ledger and wDest balance = utxoAmt" $ do
             request @([ApiTransaction n]) ctx
                 (Link.listTransactions @'Shelley wSrc)
                 Default
@@ -230,7 +230,7 @@ spec = do
         request @ApiTxId ctx Link.postExternalTransaction headers (NonJson payload)
             >>= expectResponseCode HTTP.status202
 
-        eventually_ $ do
+        eventually ("Wallet balance = " ++ show amt) $ do
             r <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley w) Default Empty
             expectField (#balance . #getApiT . #available)
@@ -266,7 +266,7 @@ spec = do
                 expectErrorMessage (errMsg404CannotFindTx txid) ra
 
                 -- tx eventually gets into ledger (funds are on the target wallet)
-                eventually_ $ do
+                eventually ("Wallet balance = " ++ show amt) $ do
                     rg <- request @ApiWallet ctx
                         (Link.getWallet @'Shelley wal) Default Empty
                     expectField (#balance . #getApiT . #available)
@@ -295,7 +295,7 @@ spec = do
             , expectResponseCode HTTP.status202
             ]
 
-        eventually_ $ do
+        eventually "wDest and wSrc balance is as expected" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rb
@@ -503,7 +503,7 @@ fixtureExternalTx ctx toSend = do
     expectField
             (#name . #getApiT . #getWalletName) (`shouldBe` "Destination Wallet") r1
     let wid = getFromResponse Prelude.id r1
-    eventually_ $ do
+    eventually "Wallet state is Ready" $ do
         r <- request @ApiWallet ctx (Link.getWallet @'Shelley wid) Default Empty
         expectField (#state . #getApiT) (`shouldBe` Ready) r
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -56,7 +56,7 @@ import Test.Integration.Framework.DSL
     ( KnownCommand (..)
     , cardanoWalletCLI
     , createWalletViaCLI
-    , eventually_
+    , eventually
     , expectCliField
     , expectPathEventuallyExist
     , expectValidJSON
@@ -213,7 +213,7 @@ spec = do
                 TIO.hGetContents e >>= TIO.putStrLn
             withCreateProcess process $ \_ (Just o) (Just e) ph -> do
                 waitForServer @t ctx
-                eventually_ $ do
+                eventually "Wallet state = Ready" $ do
                     Stdout og <- getWalletViaCLI @t ctx $ T.unpack (wallet ^. walletId)
                     jg <- expectValidJSON (Proxy @ApiWallet) og
                     expectCliField (#state . #getApiT) (`shouldBe` Ready) jg

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/StakePools.hs
@@ -23,7 +23,7 @@ spec
     => SpecWith (Context t)
 spec = do
     it "STAKE_POOLS_LIST_01 - List stake pools" $ \ctx -> do
-        eventually $ do
+        eventually "Stake pools are listed" $ do
             (Exit c, Stdout _, Stderr e) <- listStakePoolsViaCLI @t ctx
             e `shouldBe` "Ok.\n"
             c `shouldBe` ExitSuccess

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
@@ -39,7 +39,7 @@ import Test.Integration.Framework.DSL
     , KnownCommand
     , deleteTransactionViaCLI
     , emptyWallet
-    , eventually_
+    , eventually
     , expectCliField
     , expectValidJSON
     , fixtureRawTx
@@ -81,7 +81,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         out `shouldContain` "id"
         code `shouldBe` ExitSuccess
-        eventually_ $ do
+        eventually ("Wallet's balance is as expected = " ++ show amt) $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (w ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -111,7 +111,7 @@ spec = do
         out `shouldBe` "{\n    \"id\": " ++ show expectedTxId ++ "\n}\n"
         code `shouldBe` ExitSuccess
 
-        eventually_ $ do
+        eventually "Wallet balance is as expected" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (wDest ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
@@ -174,7 +174,7 @@ spec = do
         let txid = T.unpack $ toUrlPiece (txJson ^. #id)
 
         -- funds eventually are on target wallet
-        eventually_ $ do
+        eventually "Wallet balance is as expected" $ do
             Stdout gOutDest <- getWalletViaCLI @t ctx
                 (T.unpack (w ^. walletId))
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 86ffd6b15f2cc505b4bac790b95e11638ac40c3b
  eventually with description for better identification when action inside eventually fails
  

# Comments

```
        eventually "Wallet balance = 10" $ do
            rb <- request @ApiWallet ctx
                (Link.getWallet @'Shelley wDest) Default Empty
            expectField
                (#balance . #getApiT . #available) (`shouldBe` Quantity 10) rb
```

in case of failure:
```
  src/Test/Integration/Scenario/API/Addresses.hs:153:5: 
  1) API Specifications ADDRESS_LIST_03 - Generates new address pool gap
       uncaught exception: IOException of type UserError
       Worker has exited: main action is over.
       user error (waited more than 3min for action to eventually resolve. Action: "Wallet balance = 10")
```
