### PR TITLE
SRE-49 - fix windows wallet tests in hydra

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -141,7 +141,7 @@ buildStep dryRun bk =
     titled "Build"
         (build Fast ["--test", "--no-run-tests"]) .&&.
     titled "Test"
-        (timeout 30 (test Fast Serial .&&. test Fast Parallel)) .&&.
+        (timeout 45 (test Fast Serial .&&. test Fast Parallel)) .&&.
     titled "Checking golden test files"
         (checkUnclean dryRun "lib/core/test/data")
   where

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -73,6 +73,7 @@ test-suite unit
   build-depends:
       base
     , bytestring
+    , cardano-wallet-launcher
     , cardano-wallet-cli
     , cardano-wallet-core
     , filepath

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -36,6 +36,8 @@ import Cardano.CLI
     , newCliKeyScheme
     , xPrvToTextTransform
     )
+import Cardano.Startup
+    ( setUtf8EncodingHandles )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), XPrv, unXPrv )
 import Cardano.Wallet.Primitive.Mnemonic
@@ -45,8 +47,6 @@ import Cardano.Wallet.Primitive.Mnemonic
     , entropyToMnemonic
     , mnemonicToText
     )
-import Cardano.Startup
-    ( setUtf8EncodingHandles )
 import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy )
 import Control.Arrow

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -45,6 +45,8 @@ import Cardano.Wallet.Primitive.Mnemonic
     , entropyToMnemonic
     , mnemonicToText
     )
+import Cardano.Startup
+    ( setUtf8EncodingHandles )
 import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy )
 import Control.Arrow
@@ -127,14 +129,16 @@ spec = do
             <> cmdKey
 
 
-    let shouldStdOut args expected = it (unwords args) $
+    let shouldStdOut args expected = it (unwords args) $ do
+            setUtf8EncodingHandles
             case execParserPure defaultPrefs parser args of
                 Success x -> capture_ x >>= (`shouldBe` expected)
                 CompletionInvoked _ -> expectationFailure
                     "expected parser to show usage but it offered completion"
                 Failure failure ->
                     expectationFailure $ "parser failed with: " ++ show failure
-    let expectStdErr args expectation = it (unwords args) $
+    let expectStdErr args expectation = it (unwords args) $ do
+            setUtf8EncodingHandles
             case execParserPure defaultPrefs parser args of
                 Success x ->
                     hCapture_ [stderr] (try @SomeException x) >>= (expectation)

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -209,6 +209,7 @@ test-suite unit
     , QuickCheck
     , quickcheck-state-machine >= 0.6.0
     , random
+    , retry
     , safe
     , servant
     , servant-server
@@ -238,6 +239,7 @@ test-suite unit
       Main.hs
   other-modules:
       Cardano.Byron.Codec.CborSpec
+      Cardano.DB.Sqlite.DeleteSpec
       Cardano.Pool.DB.Arbitrary
       Cardano.Pool.DB.Properties
       Cardano.Pool.DB.SqliteSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -99,6 +99,7 @@ library
   exposed-modules:
       Cardano.Byron.Codec.Cbor
       Cardano.DB.Sqlite
+      Cardano.DB.Sqlite.Delete
       Cardano.Pool.DB
       Cardano.Pool.DB.MVar
       Cardano.Pool.DB.Model

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -50,6 +50,8 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
+import Cardano.DB.Sqlite.Delete
+    ( DeleteSqliteDatabaseLog )
 import Control.Concurrent.MVar
     ( newMVar, withMVar )
 import Control.Exception
@@ -366,6 +368,7 @@ data DBLog
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
     | MsgRemoving Text
+    | MsgRemovingDatabaseFile Text DeleteSqliteDatabaseLog
     | MsgManualMigrationNeeded DBField Text
     | MsgManualMigrationNotNeeded DBField
     | MsgUpdatingForeignKeysSetting ForeignKeysSetting
@@ -431,6 +434,7 @@ instance DefineSeverity DBLog where
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
         MsgRemoving _ -> Info
+        MsgRemovingDatabaseFile _ msg -> defineSeverity msg
         MsgManualMigrationNeeded{} -> Notice
         MsgManualMigrationNotNeeded{} -> Debug
         MsgUpdatingForeignKeysSetting{} -> Debug
@@ -457,6 +461,8 @@ instance ToText DBLog where
             "Statement already finalized: " <> msg
         MsgRemoving wid ->
             "Removing wallet's database. Wallet id was " <> wid
+        MsgRemovingDatabaseFile wid msg ->
+            "Removing " <> wid <> ": " <> toText msg
         MsgManualMigrationNeeded field value -> mconcat
             [ tableName field
             , " table does not contain required field '"

--- a/lib/core/src/Cardano/DB/Sqlite/Delete.hs
+++ b/lib/core/src/Cardano/DB/Sqlite/Delete.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- A function to delete a SQLite database file, which isn't as straightforward
+-- as it sounds.
+
+module Cardano.DB.Sqlite.Delete
+    ( deleteSqliteDatabase
+    , DeleteSqliteDatabaseLog (..)
+    ) where
+
+import Prelude
+
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.BM.Data.Tracer
+    ( DefinePrivacyAnnotation (..), DefineSeverity (..) )
+import Data.Aeson
+    ( ToJSON )
+import Data.Text.Class
+    ( ToText (..) )
+import GHC.Generics
+    ( Generic )
+import System.Directory
+    ( removePathForcibly )
+
+#if defined(mingw32_HOST_OS)
+import Control.Retry
+    ( RetryPolicy
+    , RetryStatus (..)
+    , limitRetries
+    , logRetries
+    , recovering
+    , retryPolicy
+    )
+import Control.Tracer
+    ( Tracer, traceWith )
+import System.IO.Error
+    ( isPermissionError )
+#else
+import Control.Tracer
+    ( Tracer )
+#endif
+
+import qualified Data.Text as T
+
+-- | Remove a SQLite database file.
+--
+-- If <https://www.sqlite.org/tempfiles.html SQLite temporary files> are present
+-- (@-wal@ and @-shm@), we remove them as well. Normally, they would be removed
+-- when the SQLite connection is closed. But we attempt to remove them anyway,
+-- in case cardano-wallet was unable to close the SQLite connection.
+--
+-- Additionally, on Windows, the deletion operations will be retried for a short
+-- time if they fail.  The reason for this is that a FileDelete command just
+-- marks a file for deletion. The file is really only removed when the last
+-- handle to the file is closed. Unfortunately there are a lot of system
+-- services that can have a file temporarily opened using a shared read-only
+-- lock, such as the built in AV and search indexer.
+--
+-- We can't really guarantee that these are all off, so what we can do is
+-- whenever after an rm the file still exists to try again and wait a bit.
+--
+-- See <https://github.com/haskell/directory/issues/96> for more information
+-- about this issue.
+deleteSqliteDatabase :: Tracer IO DeleteSqliteDatabaseLog -> FilePath -> IO ()
+deleteSqliteDatabase tr db = mapM_ (handleErrors tr . removePathForcibly) files
+  where
+    files = [ db, db <> "-wal", db <> "-shm" ]
+
+handleErrors :: Tracer IO DeleteSqliteDatabaseLog -> IO () -> IO ()
+#if defined(mingw32_HOST_OS)
+handleErrors tr = recovering policy [check] . const
+  where
+    check = logRetries (pure . isPermissionError) logRetry
+    policy = linearBackoff 25000 <> limitRetries 10
+    logRetry True _ st = traceWith tr $ MsgRetryDelete $ rsIterNumber st
+    logRetry False e _ = traceWith tr $ MsgGaveUpDelete $ show e
+
+-- | Retry policy where delay increases linearly from base with each retry.
+-- (as <https://www.sqlite.org/src/info/89f1848d7f implemented by SQLite>)
+linearBackoff
+    :: Int
+    -- ^ Base delay in microseconds
+    -> RetryPolicy
+linearBackoff base = retryPolicy $ \ RetryStatus { rsIterNumber = n } ->
+  Just $! base * n
+
+#else
+handleErrors _ = id
+#endif
+
+-- | Log messages that may arise from 'deleteSqliteDatabase'.
+data DeleteSqliteDatabaseLog
+    = MsgRetryDelete Int
+    | MsgGaveUpDelete String
+    deriving (Generic, Show, Eq, ToJSON)
+
+instance ToText DeleteSqliteDatabaseLog where
+    toText msg = case msg of
+        MsgRetryDelete retryNum ->
+            "retry " <> T.pack (show retryNum) <> " for lock/sharing violation - probably due to antivirus software"
+        MsgGaveUpDelete e ->
+            "gave up on delete due to " <> T.pack e
+
+instance DefinePrivacyAnnotation DeleteSqliteDatabaseLog
+instance DefineSeverity DeleteSqliteDatabaseLog where
+    defineSeverity msg = case msg of
+        MsgRetryDelete _ -> Warning
+        MsgGaveUpDelete _ -> Error

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -58,7 +58,7 @@ import Cardano.DB.Sqlite
     , tableName
     )
 import Cardano.DB.Sqlite.Delete
-    ( deleteSqliteDatabase )
+    ( deleteSqliteDatabase, newRefCount, waitForFree, withRef )
 import Cardano.Wallet.DB
     ( DBFactory (..)
     , DBLayer (..)
@@ -112,7 +112,7 @@ import Control.DeepSeq
 import Control.Exception
     ( Exception, bracket, throwIO )
 import Control.Monad
-    ( forM, void, when )
+    ( forM, unless, void, when )
 import Control.Monad.IO.Class
     ( MonadIO (..) )
 import Control.Monad.Trans.Class
@@ -238,16 +238,16 @@ newDBFactory
     -> Maybe FilePath
        -- ^ Path to database directory, or Nothing for in-memory database
     -> IO (DBFactory IO s k)
-newDBFactory tr defaultFieldValues mDatabaseDir = do
-    mvar <- newMVar mempty
-    case mDatabaseDir of
+newDBFactory tr defaultFieldValues = \case
+    Nothing -> do
         -- NOTE
         -- For the in-memory database, we do actually preserve the database
         -- after the 'action' is done. This allows for calling 'withDatabase'
         -- several times within the same execution and get back the same
         -- database. The memory is only cleaned up when calling
         -- 'removeDatabase', to mimic the way the file database works!
-        Nothing -> pure DBFactory
+        mvar <- newMVar mempty
+        pure DBFactory
             { withDatabase = \wid action -> do
                 db <- modifyMVar mvar $ \m -> case Map.lookup wid m of
                     Just (_, db) -> pure (m, db)
@@ -260,24 +260,33 @@ newDBFactory tr defaultFieldValues mDatabaseDir = do
                 traceWith tr $ MsgRemoving (pretty wid)
                 modifyMVar_ mvar (pure . Map.delete wid)
             }
-        Just databaseDir -> pure DBFactory
-            { withDatabase = \wid action -> do
-                withDBLayer
-                    tr
-                    defaultFieldValues
-                    (Just $ databaseFile wid)
-                    (action . snd)
+
+    Just databaseDir -> do
+        refs <- newRefCount
+        pure DBFactory
+            { withDatabase = \wid action -> withRef refs wid $ withDBLayer
+                tr
+                defaultFieldValues
+                (Just $ databaseFile wid)
+                (action . snd)
             , removeDatabase = \wid -> do
-                traceWith tr $ MsgRemoving (pretty wid)
-                let tr' = contramap (MsgRemovingDatabaseFile (pretty wid)) tr
-                deleteSqliteDatabase tr' (databaseFile wid)
+                let widp = pretty wid
+                -- try to wait for all 'withDatabase' calls to finish before
+                -- deleting database file.
+                let trWait = contramap (MsgWaitingForDatabase widp) tr
+                waitForFree trWait refs wid $ \inUse -> do
+                    unless (inUse == 0) $
+                        traceWith tr $ MsgRemovingInUse widp inUse
+                    traceWith tr $ MsgRemoving widp
+                    let trDel = contramap (MsgRemovingDatabaseFile widp) tr
+                    deleteSqliteDatabase trDel (databaseFile wid)
             }
-          where
-            databaseFilePrefix = keyTypeDescriptor $ Proxy @k
-            databaseFile wid =
-                databaseDir </>
-                databaseFilePrefix <> "." <>
-                T.unpack (toText wid) <> ".sqlite"
+      where
+        databaseFilePrefix = keyTypeDescriptor $ Proxy @k
+        databaseFile wid =
+            databaseDir </>
+            databaseFilePrefix <> "." <>
+            T.unpack (toText wid) <> ".sqlite"
 
 -- | Return all wallet databases that match the specified key type within the
 --   specified directory.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -103,12 +104,20 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Control.Arrow
     ( (***) )
+#if defined(mingw32_HOST_OS)
+import Control.Concurrent
+    ( threadDelay )
+#endif
 import Control.Concurrent.MVar
     ( modifyMVar, modifyMVar_, newMVar )
 import Control.DeepSeq
     ( NFData )
 import Control.Exception
-    ( Exception, bracket, throwIO )
+    ( Exception, bracket, throwIO
+#if defined(mingw32_HOST_OS)
+    , try, throw
+#endif
+     )
 import Control.Monad
     ( forM, mapM_, void, when )
 import Control.Monad.IO.Class
@@ -178,6 +187,12 @@ import System.Directory
     ( doesFileExist, listDirectory, removePathForcibly )
 import System.FilePath
     ( (</>) )
+#if defined(mingw32_HOST_OS)
+import System.IO.Error
+    ( isPermissionError )
+import Debug.Trace
+    ( traceShow )
+#endif
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
@@ -272,7 +287,7 @@ newDBFactory tr defaultFieldValues mDatabaseDir = do
                         , databaseFile wid <> "-wal"
                         , databaseFile wid <> "-shm"
                         ]
-                mapM_ removePathForcibly files
+                mapM_ internalRemovePathForcibly files
             }
           where
             databaseFilePrefix = keyTypeDescriptor $ Proxy @k
@@ -280,6 +295,36 @@ newDBFactory tr defaultFieldValues mDatabaseDir = do
                 databaseDir </>
                 databaseFilePrefix <> "." <>
                 T.unpack (toText wid) <> ".sqlite"
+
+internalRemovePathForcibly :: FilePath -> IO ()
+internalRemovePathForcibly =
+#if defined(mingw32_HOST_OS)
+    -- On Windows we have to retry the delete a couple of times.
+    -- The reason for this is that a FileDelete command just marks a
+    -- file for deletion. The file is really only removed when the last
+    -- handle to the file is closed. Unfortunately there are a lot of
+    -- system services that can have a file temporarily opened using a shared
+    -- read-only lock, such as the built in AV and search indexer.
+    --
+    -- We can't really guarantee that these are all off, so what we can do is
+    -- whenever after an rm the file still exists to try again and wait a bit.
+    retryOnPermissionErrors 5 . removePathForcibly
+#else
+    removePathForcibly
+#endif
+
+#if defined(mingw32_HOST_OS)
+retryOnPermissionErrors :: Int -> IO a -> IO a
+retryOnPermissionErrors maxRetries io = do
+    res <- try io
+    case res of
+        Right a -> return a
+        Left ex | isPermissionError ex && maxRetries > 1 -> do
+                    let retries' = traceShow (ex, maxRetries) (maxRetries - 1)
+                    threadDelay ((maxRetries - retries') * 200)
+                    retryOnPermissionErrors retries' io
+                | otherwise -> traceShow ("OTHER ERROR" :: String) (throw ex)
+#endif
 
 -- | Return all wallet databases that match the specified key type within the
 --   specified directory.

--- a/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -1,0 +1,58 @@
+module Cardano.DB.Sqlite.DeleteSpec (spec) where
+
+import Prelude
+
+import Cardano.DB.Sqlite.Delete
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( concurrently )
+import Control.Concurrent.MVar
+    ( isEmptyMVar, newEmptyMVar, putMVar )
+import Control.Retry
+    ( RetryPolicy, constantDelay, limitRetries )
+import Control.Tracer
+    ( nullTracer )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe, shouldReturn )
+
+spec :: Spec
+spec = describe "RefCount" $ do
+    let testId = 1 :: Int
+        otherId = 2 :: Int
+        
+    it "resource can be allocated multiple times" $ do
+        ref <- newRefCount
+        withRef ref testId $ withRef ref testId $ pure ()
+        waitForFree' nullTracer testPol ref testId $ flip shouldBe 0
+        
+    it "waitForFree waits for withRef to finish" $ do
+        ref <- newRefCount
+        closed <- newEmptyMVar
+
+        let conn = withRef ref testId $ do
+                threadDelay 500000
+                putMVar closed ()
+        let rm = waitForFree' nullTracer testPol ref testId $ \n -> do
+                n `shouldBe` 0
+                isEmptyMVar closed
+
+        concurrently conn rm `shouldReturn` ((), False)
+
+    it "waitForFree uses correct id" $ do
+        ref <- newRefCount
+        withRef ref testId $
+            waitForFree' nullTracer testPol ref otherId $
+                flip shouldBe 0
+
+    it "waitForFree times out" $ do
+        ref <- newRefCount
+        withRef ref testId $
+            waitForFree' nullTracer quickPol ref testId $
+                flip shouldBe 1
+        
+testPol :: RetryPolicy
+testPol = constantDelay 50000 <> limitRetries 20
+
+quickPol :: RetryPolicy
+quickPol = constantDelay 1000 <> limitRetries 1

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -364,7 +364,7 @@ fileModeSpec =  do
                         removeDatabase testWid
                         isEmptyMVar closed
 
-                concurrently conn rm `shouldReturn` ((), False)
+                concurrently conn (threadDelay 10 >> rm) `shouldReturn` ((), False)
 
     describe "Sqlite database file" $ do
         let writeSomething DBLayer{..} = do

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -12,6 +12,7 @@ module Cardano.Startup
     (
     -- * Program startup
       withUtf8Encoding
+    , setUtf8EncodingHandles
 
     -- * Clean shutdown
     , withShutdownHandler

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -88,6 +88,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
             (hsPkgs."filepath" or (buildDepError "filepath"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -163,6 +163,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
             (hsPkgs."quickcheck-state-machine" or (buildDepError "quickcheck-state-machine"))
             (hsPkgs."random" or (buildDepError "random"))
+            (hsPkgs."retry" or (buildDepError "retry"))
             (hsPkgs."safe" or (buildDepError "safe"))
             (hsPkgs."servant" or (buildDepError "servant"))
             (hsPkgs."servant-server" or (buildDepError "servant-server"))

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -13,27 +13,27 @@
         "version": "47e3b30f0f8e5449aff54fab6eb2567fa4957649"
     },
     "haskell.nix": {
-        "branch": "master",
+        "branch": "jbgi/cardano-wallet-fix-windows",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2d1a60c0c7ff268e3cf6eea13b4f24420fc711d2",
-        "sha256": "0bd45g8sjl1g5ldk292xs57kxswwkh3nmq05hcsrs9chvzg5lhhd",
+        "rev": "d075abf4aebe8371b52e1f0c67e6af34ffff42e0",
+        "sha256": "051r6lhwg89hbciq67rf94snjs0nllwqrrm0zzbb5h00jy9rgi7k",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/2d1a60c0c7ff268e3cf6eea13b4f24420fc711d2.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/d075abf4aebe8371b52e1f0c67e6af34ffff42e0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
-        "branch": "master",
+        "branch": "nixpkgs-common-channels",
         "description": "nix scripts shared across projects",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "6b1a7cfddd351a7f42738c38a4b6ab761fa47944",
-        "sha256": "0a5lwvgqilph4gb5avx95xqqrvfwq4mim3s7zzd25xdc4hs14cby",
+        "rev": "bfc2df4f3a23cd0170df845bc2fae8cd30bdce2d",
+        "sha256": "0zwa0h2qmlffgqs55wk8h7kj94pzq1savnw9yfw997g2wq6x7lv8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/6b1a7cfddd351a7f42738c38a4b6ab761fa47944.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/bfc2df4f3a23cd0170df845bc2fae8cd30bdce2d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -25,15 +25,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
-        "branch": "nixpkgs-common-channels",
+        "branch": "master",
         "description": "nix scripts shared across projects",
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "bfc2df4f3a23cd0170df845bc2fae8cd30bdce2d",
-        "sha256": "0zwa0h2qmlffgqs55wk8h7kj94pzq1savnw9yfw997g2wq6x7lv8",
+        "rev": "beed8cdad910911d7ee65018d81893bb15df48f2",
+        "sha256": "1r68rqvvxn1fgw4z7caqp1pxxjqdsnr417jrwq0xzy7ks88g6qid",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/bfc2df4f3a23cd0170df845bc2fae8cd30bdce2d.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/beed8cdad910911d7ee65018d81893bb15df48f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -13,15 +13,15 @@
         "version": "47e3b30f0f8e5449aff54fab6eb2567fa4957649"
     },
     "haskell.nix": {
-        "branch": "jbgi/cardano-wallet-fix-windows",
+        "branch": "master",
         "description": "Alternative Haskell Infrastructure for Nixpkgs",
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d075abf4aebe8371b52e1f0c67e6af34ffff42e0",
-        "sha256": "051r6lhwg89hbciq67rf94snjs0nllwqrrm0zzbb5h00jy9rgi7k",
+        "rev": "0933c58908816bca525fbf8873abdbc3e072a87e",
+        "sha256": "1shgaaqj0j2d5f7967xssp69nn6dv34dfvkvqkiakb99ggycgdyg",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d075abf4aebe8371b52e1f0c67e6af34ffff42e0.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/0933c58908816bca525fbf8873abdbc3e072a87e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
### Issue

[SRE-49](https://jira.iohk.io/browse/SRE-49)

### Summary

Fixes windows tests under wine by:
1. Updating the [wine version to 3.2.1](https://github.com/input-output-hk/haskell.nix/pull/472) and the [windows testWrapper](https://github.com/input-output-hk/haskell.nix/pull/471) so that we can run jormungandr under wine (allows integration tests to run under wine).
2. Fix utf-8 encoding issue in cli specs.
3. Fix errors found when deleting a wallet while its database is currently open.
4. In `DBFactory.removeDatabase`, only delete the file once there are no `withDatabase` actions in progress.

### Comments

- [x] [cardano-wallet-cli.unit](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1373/x86_64-w64-mingw32.checks.cardano-wallet-cli.unit.x86_64-linux)
- [x] [cardano-wallet-core.unit](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1373/x86_64-w64-mingw32.checks.cardano-wallet-core.unit.x86_64-linux)
- [ ] [cardano-wallet-jormungandr.integration](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1373/x86_64-w64-mingw32.checks.cardano-wallet-jormungandr.integration.x86_64-linux)
- [ ] [cardano-wallet-launcher.unit](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1373/x86_64-w64-mingw32.checks.cardano-wallet-launcher.unit.x86_64-linux) ⇒ #1425