### PR TITLE
Next delegation integration tests => next delegation unit tests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -55,6 +55,7 @@ module Test.Integration.Framework.TestData
     , errMsg404NoSuchPool
     , errMsg403PoolAlreadyJoined
     , errMsg403NotDelegating
+    , errMsg403NotDelegatingNext
     , errMsg403NothingToMigrate
     , errMsg404NoEndpoint
     , errMsg404CannotFindTx
@@ -431,6 +432,11 @@ errMsg403NotDelegating :: String
 errMsg403NotDelegating = "It seems that you're trying to retire from \
     \delegation although you're not even delegating, nor won't be in an \
     \immediate future."
+
+errMsg403NotDelegatingNext :: String
+errMsg403NotDelegatingNext = "It seems that you're trying to retire from \
+    \delegation although you have already done so. Quiting again would \
+    \incur an unnecessary fee!"
 
 errMsg404CannotFindTx :: Text -> String
 errMsg404CannotFindTx tid = "I couldn't find a transaction with the given id: "


### PR DESCRIPTION
# Issue Number

Follow up to #1361 

# Overview

- afeee24084c3c417e1ee285a8ba3196c4e15da55
  I have reorganized a bit integration tests for "stake pool active/next" groupping them into 5 scenarios:
  - STAKE_POOL_NEXT_01 - Can join/re-join another/quit stake pool
  - STAKE_POOL_NEXT_02 - Join 2 sp in the same epoch => delegating to the 
last one in the end
  - STAKE_POOL_NEXT_02 - Join and quit in the same epoch => 
not_delegating in the end
  - STAKE_POOL_NEXT_03 - Join 2 in two subsequent epochs => delegating to 
1st in epoch X + 2 and 2nd in epoch X + 3
  - STAKE_POOL_NEXT_03 - Join and quit in two subsequent epochs => 
delegating in epoch X + 2, not_delegating in epoch X + 3

- 3241e1ff51020fccf07e5c23bd5f260d7b1bf8bc
  Further tests for join/quit active/next


# Comments

Additional integration tests for #1342 after changes made in #1361. The tests are somewhat comprehensive but at the same time they take ~9minutes, which made CI to timeout before...

The idea would be to turn some of them into unit tests...
