### PR TITLE
Update to redoc@2.0.0-rc.23

### DIFF
--- a/specifications/api/index.html
+++ b/specifications/api/index.html
@@ -14,7 +14,6 @@
 </head>
 <body>
   <redoc spec-url="./swagger.yaml"></redoc>
-  <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.2/bundles/redoc.standalone.js" async defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.23/bundles/redoc.standalone.js" async defer></script>
 </body>
 </html>
-


### PR DESCRIPTION
# Issue Number


# Overview

- b0456eeb648b0d004b095e52b2b6d22d4894dc88
  Update to redoc@2.0.0-rc.23


# Comments

It appears to fix misbehavior of API doc on Chrome after recent swagger.yaml updates. 
