### PR TITLE
Unit tests delegation transition

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1621,14 +1621,14 @@ guardJoin
     -> PoolId
     -> Either ErrCannotJoin ()
 guardJoin knownPools WalletDelegation{active,next} pid = do
+    when (pid `notElem` knownPools) $
+        Left (ErrNoSuchPool pid)
+
     when ((null next) && isDelegatingTo (== pid) active) $
         Left (ErrAlreadyDelegating pid)
 
     when (not (null next) && isDelegatingTo (== pid) (last next)) $
         Left (ErrAlreadyDelegating pid)
-
-    when (pid `notElem` knownPools) $
-        Left (ErrNoSuchPool pid)
 
 guardQuit
     :: WalletDelegation


### PR DESCRIPTION
# Issue Number

#1386

# Overview

- 6902ac2bfae0e85991e27549b072006644e388f9
  expose guardQuit and guardJoin for unit testing
  
- 7c6761b0adbc8796a33f813debb4262af926d514
  guardJoin - check if pool is known at first
  
- 3e0b82430f37edee61e91bbe89fc6fa48bcaf51f
  Integration tests for next/active delegation
  
- f617302842774bc87bcf6559ec68cd4306f11447
  guardJoin, guardQuit properties and unit tests


# Comments

I have cherry-picked integration tests from #1374 on top of 718f931ef53846a325b816a09169adb927b987be. 

Integration tests that I kept.
```
STAKE_POOL_NEXT_01 - Can join/re-join another/quit stake pool
STAKE_POOL_NEXT_02/STAKE_POOLS_QUIT_01 - Cannot quit when active: not_delegating
STAKE_POOL_NEXT_02 - Override join with join in the same epoch => delegating to the last one in the end
STAKE_POOL_NEXT_03 - Join 2 in two subsequent epochs => delegating to 1st in epoch X + 2 and 2nd in epoch X + 3
```

removed, covered by unit tests and properties
```
TO_REMOVE - STAKE_POOL_NEXT_02 - Override join with quit in the same epoch => not_delegating in the end
TO_REMOVE - STAKE_POOL_NEXT_02 - Override quit with join in the same epoch => delegating to the last one in the end
TO_REMOVE - STAKE_POOL_NEXT_03 - Join and quit in two subsequent epochs => delegating in epoch X + 2, not_delegating in epoch X + 3
TO_REMOVE - STAKE_POOL_NEXT_04 - Cannot quit when most recent delegation next: not_delegating
TO_REMOVE - STAKE_POOL_NEXT_04 - Cannot quit when 'next 1': not_delegating, 'next 2': not_delegating
TO_REMOVE - STAKE_POOL_NEXT_05/STAKE_POOLS_JOIN_01 - Cannot join A, when active: A
TO_REMOVE - STAKE_POOL_NEXT_05/STAKE_POOLS_JOIN_01 - Cannot join A, when 'next 1': A and there is no 'next 2'
TO_REMOVE - STAKE_POOL_NEXT_05/STAKE_POOLS_JOIN_01 - Cannot join A, when 'active' : A, 'next 1': B and 'next 2': A
```
