### PR TITLE
HW wallets tests

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -70,6 +70,7 @@ library
       Test.Integration.Scenario.API.Network
       Test.Integration.Scenario.API.Transactions
       Test.Integration.Scenario.API.Wallets
+      Test.Integration.Scenario.API.HWWallets
       Test.Integration.Scenario.CLI.Addresses
       Test.Integration.Scenario.CLI.Miscellaneous
       Test.Integration.Scenario.CLI.Mnemonics

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1219,16 +1219,16 @@ getSlotParams
     :: (Context t)
     -> IO (EpochNo, SlotParameters)
 getSlotParams ctx = do
-    r2 <- request @ApiNetworkInformation ctx
+    r1 <- request @ApiNetworkInformation ctx
           Link.getNetworkInfo Default Empty
-    let (ApiT currentEpoch) = getFromResponse (#networkTip . #epochNumber) r2
+    let (ApiT currentEpoch) = getFromResponse (#networkTip . #epochNumber) r1
 
     let endpoint = ( "GET", "v2/network/parameters/latest" )
-    r3 <- request @ApiNetworkParameters ctx endpoint Default Empty
-    let (Quantity slotL) = getFromResponse #slotLength r3
-    let (Quantity epochL) = getFromResponse #epochLength r3
-    let (Quantity coeff) = getFromResponse #activeSlotCoefficient r3
-    let (ApiT genesisBlockDate) = getFromResponse #blockchainStartTime r3
+    r2 <- request @ApiNetworkParameters ctx endpoint Default Empty
+    let (Quantity slotL) = getFromResponse #slotLength r2
+    let (Quantity epochL) = getFromResponse #epochLength r2
+    let (Quantity coeff) = getFromResponse #activeSlotCoefficient r2
+    let (ApiT genesisBlockDate) = getFromResponse #blockchainStartTime r2
     let sp = SlotParameters (EpochLength epochL) (SlotLength slotL) genesisBlockDate (ActiveSlotCoefficient coeff)
 
     return (currentEpoch, sp)

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -56,7 +56,7 @@ module Test.Integration.Framework.TestData
     , errMsg403NothingToMigrate
     , errMsg404NoEndpoint
     , errMsg404CannotFindTx
-    , errMsg410NoRootKey
+    , errMsg403NoRootKey
     , errMsg404NoWallet
     , errMsg404NoEpochNo
     , errMsg403InputsDepleted
@@ -360,8 +360,8 @@ errMsg404CannotFindTx :: Text -> String
 errMsg404CannotFindTx tid = "I couldn't find a transaction with the given id: "
     ++ unpack tid
 
-errMsg410NoRootKey :: Text -> String
-errMsg410NoRootKey wid = "I couldn't find a root private key for the given\
+errMsg403NoRootKey :: Text -> String
+errMsg403NoRootKey wid = "I couldn't find a root private key for the given\
     \ wallet: " ++ unpack wid ++ ". However, this operation requires that I do\
     \ have such a key. Either there's no such wallet, or I don't fully own it."
 

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -56,7 +56,7 @@ module Test.Integration.Framework.TestData
     , errMsg403NothingToMigrate
     , errMsg404NoEndpoint
     , errMsg404CannotFindTx
-    , errMsg404NoRootKey
+    , errMsg410NoRootKey
     , errMsg404NoWallet
     , errMsg404NoEpochNo
     , errMsg403InputsDepleted
@@ -360,8 +360,8 @@ errMsg404CannotFindTx :: Text -> String
 errMsg404CannotFindTx tid = "I couldn't find a transaction with the given id: "
     ++ unpack tid
 
-errMsg404NoRootKey :: Text -> String
-errMsg404NoRootKey wid = "I couldn't find a root private key for the given\
+errMsg410NoRootKey :: Text -> String
+errMsg410NoRootKey wid = "I couldn't find a root private key for the given\
     \ wallet: " ++ unpack wid ++ ". However, this operation requires that I do\
     \ have such a key. Either there's no such wallet, or I don't fully own it."
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Integration.Scenario.API.HWWallets
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiTransaction, ApiWallet, WalletStyle (..) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( FromMnemonic (..)
+    , HardDerivation (..)
+    , NetworkDiscriminant (..)
+    , PersistPublicKey (..)
+    , WalletKey (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( generateKeyFromSeed )
+import Cardano.Wallet.Primitive.Mnemonic
+    ( entropyToMnemonic, genEntropy, mnemonicToText )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Quantity
+    ( Quantity (..) )
+import Test.Hspec
+    ( SpecWith, it, shouldBe )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , eventually
+    , expectField
+    , expectResponseCode
+    , fixtureWallet
+    , getFromResponse
+    , json
+    , listAddresses
+    , request
+    , verify
+    )
+import Test.Integration.Framework.TestData
+    ( payloadWith )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Text.Encoding as T
+import qualified Network.HTTP.Types.Status as HTTP
+
+
+spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
+spec = do
+    it "HW_WALLETS_01 - Restoration from account public key preserve funds" $ \ctx -> do
+        wSrc <- fixtureWallet ctx
+        -- create wallet
+        mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+        let wName = "!st created"
+        let payldCrt = payloadWith wName mnemonics
+        rInit <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default payldCrt
+        verify rInit
+            [ expectResponseCode @IO HTTP.status201
+            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+            , expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+            ]
+
+        --send funds
+        let wDest = getFromResponse id rInit
+        addrs <- listAddresses ctx wDest
+        let destination = (addrs !! 1) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": 1,
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": "cardano-wallet"
+            }|]
+        rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
+            Default payload
+        expectResponseCode @IO HTTP.status202 rTrans
+
+        eventually "Wallet balance is as expected" $ do
+            rGet <- request @ApiWallet ctx
+                (Link.getWallet @'Shelley wDest) Default Empty
+            verify rGet
+                [ expectField
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                , expectField
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                ]
+
+        -- delete wallet
+        rDel <-
+            request @ApiWallet ctx (Link.deleteWallet @'Shelley wDest) Default Empty
+        expectResponseCode @IO HTTP.status204 rDel
+
+        -- restore from account public key and make sure funds are there
+        let (Right seed) = fromMnemonic @'[15] mnemonics
+        let rootXPrv = generateKeyFromSeed (seed, Nothing) mempty
+        let accXPub = T.decodeUtf8 $ serializeXPub $
+                publicKey $ deriveAccountPrivateKey mempty rootXPrv minBound
+        print mnemonics
+        print accXPub
+        let payloadRestore = Json [json| {
+                "name": #{wName},
+                "account_public_key": #{accXPub}
+            }|]
+        rRestore <-
+            request @ApiWallet ctx (Link.postWallet @'Shelley) Default payloadRestore
+        let wDest' = getFromResponse id rRestore
+        expectResponseCode @IO HTTP.status201 rRestore
+
+        eventually "Balance of restored wallet is as expected" $ do
+            rGet <- request @ApiWallet ctx
+                (Link.getWallet @'Shelley wDest') Default Empty
+            verify rGet
+                [ expectField
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                , expectField
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
@@ -84,7 +84,7 @@ import Test.Integration.Framework.DSL
     , walletId
     )
 import Test.Integration.Framework.TestData
-    ( errMsg410NoRootKey, payloadWith, updateNamePayload, updatePassPayload )
+    ( errMsg403NoRootKey, payloadWith, updateNamePayload, updatePassPayload )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text.Encoding as T
@@ -191,8 +191,8 @@ spec = do
 
         -- cannot quit stake pool
         rQuit <- quitStakePool ctx (wRestored, fixturePassphrase)
-        expectResponseCode @IO HTTP.status410 rQuit
-        expectErrorMessage (errMsg410NoRootKey $ wRestored ^. walletId) rQuit
+        expectResponseCode @IO HTTP.status403 rQuit
+        expectErrorMessage (errMsg403NoRootKey $ wRestored ^. walletId) rQuit
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
         it "Cannot send tx" $ \ctx -> do
@@ -218,8 +218,8 @@ spec = do
                 }|]
             rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
                 Default payload
-            expectResponseCode @IO HTTP.status410 rTrans
-            expectErrorMessage (errMsg410NoRootKey $ wSrc ^. walletId) rTrans
+            expectResponseCode @IO HTTP.status403 rTrans
+            expectErrorMessage (errMsg403NoRootKey $ wSrc ^. walletId) rTrans
 
         it "Cannot join SP" $ \ctx -> do
             (w, mnemonics) <- fixtureWalletWithMnemonics ctx
@@ -232,8 +232,8 @@ spec = do
             (_, p:_) <- eventually "Stake pools are listed" $
                 unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
             rJoin <- joinStakePool ctx (p ^. #id) (wk, fixturePassphrase)
-            expectResponseCode @IO HTTP.status410 rJoin
-            expectErrorMessage (errMsg410NoRootKey $ wk ^. walletId) rJoin
+            expectResponseCode @IO HTTP.status403 rJoin
+            expectErrorMessage (errMsg403NoRootKey $ wk ^. walletId) rJoin
 
         it "Cannot update pass" $ \ctx -> do
             mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
@@ -244,8 +244,8 @@ spec = do
             let payload = updatePassPayload fixturePassphrase "new-wallet-passphrase"
             rup <- request @ApiWallet ctx
                 (Link.putWalletPassphrase wk) Default payload
-            expectResponseCode @IO HTTP.status410 rup
-            expectErrorMessage (errMsg410NoRootKey $ wk ^. walletId) rup
+            expectResponseCode @IO HTTP.status403 rup
+            expectErrorMessage (errMsg403NoRootKey $ wk ^. walletId) rup
 
     describe "HW_WALLETS_04 - Can manage HW wallet the same way as others" $ do
         it "Can update name" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
@@ -16,7 +16,15 @@ module Test.Integration.Scenario.API.HWWallets
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiTransaction, ApiWallet, WalletStyle (..) )
+    ( AddressAmount (..)
+    , ApiAddress
+    , ApiFee
+    , ApiStakePool
+    , ApiTransaction
+    , ApiUtxoStatistics
+    , ApiWallet
+    , WalletStyle (..)
+    )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( FromMnemonic (..)
     , HardDerivation (..)
@@ -26,30 +34,57 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( generateKeyFromSeed )
+import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+    ( defaultAddressPoolGap, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Mnemonic
     ( entropyToMnemonic, genEntropy, mnemonicToText )
+import Cardano.Wallet.Primitive.Types
+    ( AddressState (..), SyncProgress (..) )
+import Control.Monad
+    ( forM_ )
 import Data.Generics.Internal.VL.Lens
-    ( (^.) )
+    ( view, (^.) )
+import Data.List.NonEmpty
+    ( NonEmpty ((:|)) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
 import Test.Hspec
-    ( SpecWith, it, shouldBe )
+    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
+    , emptyWallet
     , eventually
+    , expectErrorMessage
     , expectField
+    , expectListField
+    , expectListSize
     , expectResponseCode
+    , expectWalletUTxO
+    , fixturePassphrase
     , fixtureWallet
+    , fixtureWalletWithMnemonics
     , getFromResponse
+    , getSlotParams
+    , joinStakePool
     , json
     , listAddresses
+    , mkEpochInfo
+    , notDelegating
+    , quitStakePool
     , request
+    , selectCoins
+    , unsafeRequest
     , verify
+    , waitAllTxsInLedger
+    , waitForNextEpoch
+    , walletId
     )
 import Test.Integration.Framework.TestData
-    ( payloadWith )
+    ( errMsg410NoRootKey, payloadWith, updateNamePayload, updatePassPayload )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text.Encoding as T
@@ -58,7 +93,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall t n. (n ~ 'Testnet) => SpecWith (Context t)
 spec = do
-    it "HW_WALLETS_01 - Restoration from account public key preserve funds" $ \ctx -> do
+    it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
         -- create wallet
         mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
@@ -105,20 +140,8 @@ spec = do
         expectResponseCode @IO HTTP.status204 rDel
 
         -- restore from account public key and make sure funds are there
-        let (Right seed) = fromMnemonic @'[15] mnemonics
-        let rootXPrv = generateKeyFromSeed (seed, Nothing) mempty
-        let accXPub = T.decodeUtf8 $ serializeXPub $
-                publicKey $ deriveAccountPrivateKey mempty rootXPrv minBound
-        print mnemonics
-        print accXPub
-        let payloadRestore = Json [json| {
-                "name": #{wName},
-                "account_public_key": #{accXPub}
-            }|]
-        rRestore <-
-            request @ApiWallet ctx (Link.postWallet @'Shelley) Default payloadRestore
-        let wDest' = getFromResponse id rRestore
-        expectResponseCode @IO HTTP.status201 rRestore
+        let accXPub = pubKeyFromMnemonics mnemonics
+        wDest' <- restoreWalletFromPubKey ctx accXPub
 
         eventually "Balance of restored wallet is as expected" $ do
             rGet <- request @ApiWallet ctx
@@ -129,3 +152,282 @@ spec = do
                 , expectField
                         (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
                 ]
+
+    it "HW_WALLETS_02 - Restoration from account public key preserves delegation\
+        \ but I cannot quit" $ \ctx -> do
+        -- create wallet and get acc pub key from mnemonics
+        (w, mnemonics) <- fixtureWalletWithMnemonics ctx
+        let accPub = pubKeyFromMnemonics mnemonics
+
+        --make sure you are at the beginning of the epoch
+        waitForNextEpoch ctx
+        (currentEpoch, sp) <- getSlotParams ctx
+
+        -- join stake pool
+        (_, p:_) <- eventually "Stake pools are listed" $
+            unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
+        r <- joinStakePool ctx (p ^. #id) (w, fixturePassphrase)
+        expectResponseCode @IO HTTP.status202 r
+        waitAllTxsInLedger ctx w
+        let expectedDelegation =
+                [ expectField #delegation
+                    (`shouldBe` notDelegating
+                        [ (Just (p ^. #id), mkEpochInfo (currentEpoch + 2) sp)
+                        ]
+                    )
+                ]
+        request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty >>= flip verify
+            expectedDelegation
+
+        -- delete wallet
+        rDel <-
+            request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
+        expectResponseCode @IO HTTP.status204 rDel
+
+        -- restore from pub key and make sure delegation preserved
+        wRestored <- restoreWalletFromPubKey ctx accPub
+        request @ApiWallet ctx (Link.getWallet @'Shelley wRestored) Default Empty >>= flip verify
+            expectedDelegation
+
+        -- cannot quit stake pool
+        rQuit <- quitStakePool ctx (wRestored, fixturePassphrase)
+        expectResponseCode @IO HTTP.status410 rQuit
+        expectErrorMessage (errMsg410NoRootKey $ wRestored ^. walletId) rQuit
+
+    describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
+        it "Cannot send tx" $ \ctx -> do
+            (w, mnemonics) <- fixtureWalletWithMnemonics ctx
+            let pubKey = pubKeyFromMnemonics mnemonics
+            r <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
+            expectResponseCode @IO HTTP.status204 r
+
+            wSrc <- restoreWalletFromPubKey ctx pubKey
+            wDest <- emptyWallet ctx
+
+            addrs <- listAddresses ctx wDest
+            let destination = (addrs !! 1) ^. #id
+            let payload = Json [json|{
+                    "payments": [{
+                        "address": #{destination},
+                        "amount": {
+                            "quantity": 1,
+                            "unit": "lovelace"
+                        }
+                    }],
+                    "passphrase": "cardano-wallet"
+                }|]
+            rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
+                Default payload
+            expectResponseCode @IO HTTP.status410 rTrans
+            expectErrorMessage (errMsg410NoRootKey $ wSrc ^. walletId) rTrans
+
+        it "Cannot join SP" $ \ctx -> do
+            (w, mnemonics) <- fixtureWalletWithMnemonics ctx
+            let pubKey = pubKeyFromMnemonics mnemonics
+            r <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
+            expectResponseCode @IO HTTP.status204 r
+
+            wk <- restoreWalletFromPubKey ctx pubKey
+            -- cannot join stake pool
+            (_, p:_) <- eventually "Stake pools are listed" $
+                unsafeRequest @[ApiStakePool] ctx Link.listStakePools Empty
+            rJoin <- joinStakePool ctx (p ^. #id) (wk, fixturePassphrase)
+            expectResponseCode @IO HTTP.status410 rJoin
+            expectErrorMessage (errMsg410NoRootKey $ wk ^. walletId) rJoin
+
+        it "Cannot update pass" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wk <- restoreWalletFromPubKey ctx pubKey
+
+            -- cannot update pass
+            let payload = updatePassPayload fixturePassphrase "new-wallet-passphrase"
+            rup <- request @ApiWallet ctx
+                (Link.putWalletPassphrase wk) Default payload
+            expectResponseCode @IO HTTP.status410 rup
+            expectErrorMessage (errMsg410NoRootKey $ wk ^. walletId) rup
+
+    describe "HW_WALLETS_04 - Can manage HW wallet the same way as others" $ do
+        it "Can update name" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wk <- restoreWalletFromPubKey ctx pubKey
+
+            -- cannot update wallet name
+            let newName = "new name"
+            let payload = updateNamePayload newName
+            rup <- request @ApiWallet ctx (Link.putWallet wk) Default payload
+            expectResponseCode @IO HTTP.status200 rup
+
+            rGet <- request @ApiWallet ctx
+                (Link.getWallet @'Shelley wk) Default Empty
+            expectField
+                (#name . #getApiT . #getWalletName)
+                (`shouldBe` newName)
+                rGet
+
+        it "Can get tx fee" $ \ctx -> do
+            (w, mnemonics) <- fixtureWalletWithMnemonics ctx
+            let pubKey = pubKeyFromMnemonics mnemonics
+            r <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
+            expectResponseCode @IO HTTP.status204 r
+
+            wSrc <- restoreWalletFromPubKey ctx pubKey
+            wDest <- emptyWallet ctx
+
+            addrs <- listAddresses ctx wDest
+            let destination = (addrs !! 1) ^. #id
+            let payload = Json [json|{
+                    "payments": [{
+                        "address": #{destination},
+                        "amount": {
+                            "quantity": 1,
+                            "unit": "lovelace"
+                        }
+                    }]
+                }|]
+
+            rFee <- request @ApiFee ctx (Link.getTransactionFee wSrc) Default payload
+            expectResponseCode @IO HTTP.status202 rFee
+
+        it "Can delete" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+            r <- request @ApiWallet ctx
+                (Link.deleteWallet @'Shelley wPub) Default Empty
+            expectResponseCode @IO HTTP.status204 r
+
+        it "Can see utxo" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+            rStat <- request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics wPub) Default Empty
+            expectResponseCode @IO HTTP.status200 rStat
+            expectWalletUTxO [] (snd rStat)
+
+        it "Can list addresses" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+
+            let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
+            r <- request @[ApiAddress n] ctx
+                (Link.listAddresses wPub) Default Empty
+            expectResponseCode @IO HTTP.status200 r
+            expectListSize g r
+            forM_ [0..(g-1)] $ \addrNum -> do
+                expectListField addrNum (#state . #getApiT) (`shouldBe` Unused) r
+
+        it "Can have address pool gap" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            let addrPoolGap = 55 --arbitraty but known
+            let payloadRestore = Json [json| {
+                    "name": #{restoredWalletName},
+                    "account_public_key": #{pubKey},
+                    "address_pool_gap": #{addrPoolGap}
+                }|]
+            rRestore <- request @ApiWallet ctx (Link.postWallet @'Shelley)
+                    Default payloadRestore
+            expectResponseCode @IO HTTP.status201 rRestore
+
+            let wPub = getFromResponse id rRestore
+
+            r <- request @[ApiAddress n] ctx
+                (Link.listAddresses wPub) Default Empty
+            expectResponseCode @IO HTTP.status200 r
+            expectListSize addrPoolGap r
+            forM_ [0..(addrPoolGap-1)] $ \addrNum -> do
+                expectListField addrNum (#state . #getApiT) (`shouldBe` Unused) r
+
+        it "Can list transactions" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+
+            rt <- request @([ApiTransaction n]) ctx
+                (Link.listTransactions @'Shelley wPub) Default Empty
+            expectResponseCode HTTP.status200 rt
+            expectListSize 0 rt
+
+        it "Can force resync" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+
+            let payload = Json [json|{ "epoch_number": 0, "slot_number": 0 }|]
+            r <- request @ApiWallet ctx (Link.forceResyncWallet @'Shelley wPub)
+                    Default payload
+            expectResponseCode @IO HTTP.status204 r
+
+        it "Can get coin selection" $ \ctx -> do
+            (w, mnemonics) <- fixtureWalletWithMnemonics ctx
+            let pubKey = pubKeyFromMnemonics mnemonics
+            r <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
+            expectResponseCode @IO HTTP.status204 r
+
+            source <- restoreWalletFromPubKey ctx pubKey
+            target <- emptyWallet ctx
+            targetAddress : _ <- fmap (view #id) <$> listAddresses ctx target
+
+            let amount = Quantity 1
+            let payment = AddressAmount targetAddress amount
+            selectCoins ctx source (payment :| []) >>= flip verify
+                [ expectResponseCode HTTP.status200
+                , expectField #inputs (`shouldSatisfy` (not . null))
+                , expectField #outputs (`shouldSatisfy` ((> 1) . length))
+                , expectField #outputs (`shouldSatisfy` (payment `elem`))
+                ]
+
+    describe "HW_WALLETS_05 - Wallet from pubKey is available" $ do
+        it "Can get wallet" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            wPub <- restoreWalletFromPubKey ctx pubKey
+            rGet <- request @ApiWallet ctx
+                (Link.getWallet @'Shelley wPub) Default Empty
+            expectField
+                (#name . #getApiT . #getWalletName)
+                (`shouldBe` restoredWalletName)
+                rGet
+
+        it "Can list wallet" $ \ctx -> do
+            mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
+            let pubKey = pubKeyFromMnemonics mnemonics
+            _ <- restoreWalletFromPubKey ctx pubKey
+            rl <- request @[ApiWallet] ctx
+                (Link.listWallets @'Shelley) Default Empty
+            expectListField 0
+                (#name . #getApiT . #getWalletName)
+                (`shouldBe` restoredWalletName)
+                rl
+
+ where
+     pubKeyFromMnemonics :: [Text] -> Text
+     pubKeyFromMnemonics mnemonics =
+         T.decodeUtf8 $ serializeXPub $ publicKey
+            $ deriveAccountPrivateKey mempty rootXPrv minBound
+      where
+          (Right seed) = fromMnemonic @'[15] mnemonics
+          rootXPrv = generateKeyFromSeed (seed, Nothing) mempty
+
+     restoredWalletName :: Text
+     restoredWalletName = "Wallet from pub key"
+
+     restoreWalletFromPubKey :: Context t -> Text -> IO ApiWallet
+     restoreWalletFromPubKey ctx pubKey = do
+         let payloadRestore = Json [json| {
+                 "name": #{restoredWalletName},
+                 "account_public_key": #{pubKey}
+             }|]
+         r <- request @ApiWallet ctx (Link.postWallet @'Shelley)
+                Default payloadRestore
+         expectResponseCode @IO HTTP.status201 r
+         let wid = getFromResponse id r
+         eventually "restoreWalletFromPubKey: wallet is 100% synced " $ do
+             rg <- request @ApiWallet ctx
+                 (Link.getWallet @'Shelley wid) Default Empty
+             expectField (#state . #getApiT) (`shouldBe` Ready) rg
+         return wid

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -27,16 +27,10 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( FromMnemonic (..)
-    , HardDerivation (..)
-    , NetworkDiscriminant (..)
+    ( NetworkDiscriminant (..)
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
-    , PersistPublicKey (..)
-    , WalletKey (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..) )
 import Cardano.Wallet.Primitive.Mnemonic
@@ -121,7 +115,6 @@ import Test.Integration.Framework.TestData
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Network.HTTP.Types.Status as HTTP
 
 
@@ -255,76 +248,6 @@ spec = do
         eventually "Wallet balance is ok on restored wallet" $ do
             rGet <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
-            verify rGet
-                [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
-                , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
-                ]
-
-    it "WALLETS_CREATE_03 - Restoration from account public key" $ \ctx -> do
-        wSrc <- fixtureWallet ctx
-        -- create wallet
-        mnemonics <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
-        let wName = "!st created"
-        let payldCrt = payloadWith wName mnemonics
-        rInit <- request @ApiWallet ctx (Link.postWallet @'Shelley) Default payldCrt
-        verify rInit
-            [ expectResponseCode @IO HTTP.status201
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
-            ]
-
-        --send funds
-        let wDest = getFromResponse id rInit
-        addrs <- listAddresses ctx wDest
-        let destination = (addrs !! 1) ^. #id
-        let payload = Json [json|{
-                "payments": [{
-                    "address": #{destination},
-                    "amount": {
-                        "quantity": 1,
-                        "unit": "lovelace"
-                    }
-                }],
-                "passphrase": "cardano-wallet"
-            }|]
-        rTrans <- request @(ApiTransaction n) ctx (Link.createTransaction wSrc)
-            Default payload
-        expectResponseCode @IO HTTP.status202 rTrans
-
-        eventually "Wallet balance is as expected" $ do
-            rGet <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest) Default Empty
-            verify rGet
-                [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
-                , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
-                ]
-
-        -- delete wallet
-        rDel <-
-            request @ApiWallet ctx (Link.deleteWallet @'Shelley wDest) Default Empty
-        expectResponseCode @IO HTTP.status204 rDel
-
-        -- restore from account public key and make sure funds are there
-        let (Right seed) = fromMnemonic @'[15] mnemonics
-        let rootXPrv = generateKeyFromSeed (seed, Nothing) mempty
-        let accXPub = T.decodeUtf8 $ serializeXPub $
-                publicKey $ deriveAccountPrivateKey mempty rootXPrv minBound
-        let payloadRestore = Json [json| {
-                "name": #{wName},
-                "account_public_key": #{accXPub}
-            }|]
-        rRestore <-
-            request @ApiWallet ctx (Link.postWallet @'Shelley) Default payloadRestore
-        let wDest' = getFromResponse id rRestore
-        expectResponseCode @IO HTTP.status201 rRestore
-
-        eventually "Balance of restored wallet is as expected" $ do
-            rGet <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wDest') Default Empty
             verify rGet
                 [ expectField
                         (#balance . #getApiT . #total) (`shouldBe` Quantity 1)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -916,7 +916,7 @@ spec = do
         _ <- request @ApiWallet ctx ("DELETE", endpoint) Default Empty
 
         let newName = updateNamePayload "new name"
-        ru <- request @ApiWallet ctx ("GET", endpoint) Default newName
+        ru <- request @ApiWallet ctx ("PUT", endpoint) Default newName
         expectResponseCode @IO HTTP.status404 ru
         expectErrorMessage (errMsg404NoWallet wid) ru
 
@@ -1457,7 +1457,7 @@ spec = do
         let wid = w ^. walletId
         let endpoint = "v2/wallets" </> wid
         let newName = updateNamePayload "new name"
-        ru <- request @ApiWallet ctx ("GET", endpoint) Default newName
+        ru <- request @ApiWallet ctx ("PUT", endpoint) Default newName
         expectResponseCode @IO HTTP.status404 ru
         expectErrorMessage (errMsg404NoWallet wid) ru
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1808,7 +1808,7 @@ instance LiftHandler ErrCreateWallet where
 instance LiftHandler ErrWithRootKey where
     handler = \case
         ErrWithRootKeyNoRootKey wid ->
-            apiError err404 NoRootKey $ mconcat
+            apiError err403 NoRootKey $ mconcat
                 [ "I couldn't find a root private key for the given wallet: "
                 , toText wid, ". However, this operation requires that I do "
                 , "have such a key. Either there's no such wallet, or I don't "
@@ -1914,8 +1914,8 @@ instance LiftHandler ErrSignPayment where
             , errReasonPhrase = errReasonPhrase err410
             }
         ErrSignPaymentWithRootKey e@ErrWithRootKeyNoRootKey{} -> (handler e)
-            { errHTTPCode = 410
-            , errReasonPhrase = errReasonPhrase err410
+            { errHTTPCode = 403
+            , errReasonPhrase = errReasonPhrase err403
             }
         ErrSignPaymentWithRootKey e@ErrWithRootKeyWrongPassphrase{} -> handler e
 
@@ -2082,8 +2082,8 @@ instance LiftHandler ErrSignDelegation where
             , errReasonPhrase = errReasonPhrase err410
             }
         ErrSignDelegationWithRootKey e@ErrWithRootKeyNoRootKey{} -> (handler e)
-            { errHTTPCode = 410
-            , errReasonPhrase = errReasonPhrase err410
+            { errHTTPCode = 403
+            , errReasonPhrase = errReasonPhrase err403
             }
         ErrSignDelegationWithRootKey e@ErrWithRootKeyWrongPassphrase{} -> handler e
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -698,7 +698,9 @@ instance FromJSON AccountPublicKey where
         bs <- T.encodeUtf8 <$> parseJSON bytes
         case xpubFromText bs of
             Left _ ->
-                fail "AccountPublicKey: unable to deserialize ShelleyKey from json"
+                fail $
+                "AccountPublicKey: unable to deserialize ShelleyKey from json. "
+                <> "Expecting hex-encoded string of 128 characters."
             Right pubkey ->
                 pure $ AccountPublicKey $ ApiT $ ShelleyKey pubkey
 instance ToJSON AccountPublicKey where

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -95,6 +95,7 @@ import qualified Test.Integration.Jormungandr.Scenario.CLI.Transactions as Trans
 import qualified Test.Integration.Scenario.API.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.ByronTransactions as ByronTransactions
 import qualified Test.Integration.Scenario.API.ByronWallets as ByronWallets
+import qualified Test.Integration.Scenario.API.HWWallets as HWWallets
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.API.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Wallets as Wallets
@@ -129,6 +130,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             TransactionsApiJormungandr.spec @t
             TransactionsCliJormungandr.spec @t
             Wallets.spec
+            HWWallets.spec
             ByronWallets.spec
             ByronTransactions.spec
             Network.spec


### PR DESCRIPTION
# Issue Number

#1355

# Overview

- c8a33b989375d26d1b0897b92a609d2d091299a9
  Move HW wallets integration tests into separate module
  
- c0dc735d77839d910cd25bd006d3b71523f13c98
  Move waitAllTxsInLedger and getSlotParams to DSL.hs
  
- f2f8f96d4750888700bae945b45f530c3763a151
  HW wallets integration tests
  
- 399e9280513343711b34e554891ee55912406969
  return 403 when operation on HW wallet requires private key
  
- 9197fbd769c69811dc285cfa33a9de1c79032ff5
  add tests for malformed account_public_key and make error message more informative.
  
- 2d096cfb9376eebd9761e17c36d9d350b45b8f62
  add test that the same account and mnemonic wallet can live side-by-side
  
- 4e1eb0ec59929d49be0cdc30a6d35ce4e7f0d883
  small fix to Wallet.hs tests
  
- d45edd7d15ddc745dc25dc058b77999bc78d0c37
  refactor param names in getSlotParams



# Comments
- integration tests `HW_WALLETS` added
```
Finished in 13.3691 seconds
16 examples, 0 failures
```
 - ~still to test -> HW_WALLETS_06 https://github.com/input-output-hk/cardano-wallet/issues/1355#issuecomment-591430246~ -> done in 9197fbd769c69811dc285cfa33a9de1c79032ff5
