### PR TITLE
nix: Fix build caching

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,42 @@
+############################################################################
+#
+# Cardano Wallet Nix build
+#
+# Derivation attributes of this file can be build with "nix-build -A ..."
+# Discover attribute names using tab-completion in your shell.
+#
+# Interesting top-level attributes:
+#
+#   - cardano-wallet-jormungandr - cli executable
+#   - cardano-wallet-byron - cli executable
+#   - tests - attrset of test-suite executables
+#     - cardano-wallet-core.unit
+#     - cardano-wallet-jormungandr.integration
+#     - etc (layout is PACKAGE.COMPONENT)
+#   - checks - attrset of test-suite results
+#     - cardano-wallet-core.unit
+#     - cardano-wallet-jormungandr.integration
+#     - etc
+#   - benchmarks - attret of benchmark executables
+#     - cardano-wallet-core.db
+#     - cardano-wallet-jormungandr.latency
+#     - etc
+#   - migration-tests - tests db migrations from previous versions
+#   - dockerImage - tarball of the docker image
+#   - shell - imported by shell.nix
+#   - haskellPackages - a Haskell.nix package set of all packages and their dependencies
+#     - cardano-wallet-core.components.library
+#     - etc (layout is PACKAGE-NAME.components.COMPONENT-TYPE.COMPONENT-NAME)
+#
+# The attributes of this file are imported by the Hydra jobset and
+# mapped into the layout TARGET-SYSTEM.ATTR-PATH.BUILD-SYSTEM.
+# See release.nix for more info about that.
+#
+# Other documentation:
+#   https://github.com/input-output-hk/cardano-wallet/wiki/Building#nix-build
+#
+############################################################################
+
 { system ? builtins.currentSystem
 , crossSystem ? null
 , config ? {}
@@ -5,17 +44,18 @@
 , pkgs ? import ./nix/default.nix { inherit system crossSystem config sourcesOverride; }
 # Use this git revision for stamping executables
 , gitrev ? pkgs.commonLib.commitIdFromGitRepoOrZero ./.git
-# Use this to reference local sources rather than the pinned versions (see nix/default.nix)
+# Use this to reference local sources rather than the niv pinned versions (see nix/default.nix)
 , sourcesOverride ? {}
 }:
 
+# commonLib includes iohk-nix utilities, our util.nix and nixpkgs lib.
 with pkgs; with commonLib; with pkgs.haskell-nix.haskellLib;
 
 let
   haskellPackages = cardanoWalletHaskellPackages;
 
-  filterCardanoPackages = pkgs.lib.filterAttrs (_: package: isCardanoWallet package);
-  getPackageChecks = pkgs.lib.mapAttrs (_: package: package.checks);
+  filterCardanoPackages = lib.filterAttrs (_: package: isCardanoWallet package);
+  getPackageChecks = lib.mapAttrs (_: package: package.checks);
 
   self = {
     inherit pkgs commonLib src haskellPackages stackNixRegenerate;
@@ -64,7 +104,7 @@ let
         ++ [ self.jormungandr self.jormungandr-cli
              pkgs.pkgconfig pkgs.sqlite-interactive
              pkgs.cabal-install pkgs.pythonPackages.openapi-spec-validator ];
-      meta.platforms = pkgs.lib.platforms.unix;
+      meta.platforms = lib.platforms.unix;
     };
     stackShell = import ./nix/stack-shell.nix {
       walletPackages = self;

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 , crossSystem ? null
 , config ? {}
 # Import pinned Nixpkgs with iohk-nix and Haskell.nix overlays
-, pkgs ? import ./nix { inherit system crossSystem config sourcesOverride; }
+, pkgs ? import ./nix/default.nix { inherit system crossSystem config sourcesOverride; }
 # Use this git revision for stamping executables
 , gitrev ? pkgs.commonLib.commitIdFromGitRepoOrZero ./.git
 # Use this to reference local sources rather than the pinned versions (see nix/default.nix)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,12 @@
+
 { system ? builtins.currentSystem
 , crossSystem ? null
+# Lets you customise ghc and profiling (see ./haskell.nix):
 , config ? {}
+# Lets you override niv dependencies of the project without
+# modifications to the source.
+# eg. to test build against a local checkout of cardano-node:
+#   nix-build default.nix -A cardano-wallet-byron --arg sourcesOverride '{ cardano-node = ../cardano-node; }'
 , sourcesOverride ? {}
 }:
 let

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,7 @@
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohKNix = import sources.iohk-nix {};
+  iohkNix = import sources.iohk-nix {};
   haskellNix = import sources."haskell.nix";
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
@@ -14,16 +14,16 @@ let
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
     else (builtins.trace "Using IOHK default nixpkgs"
-      iohKNix.nixpkgs);
+      iohkNix.nixpkgs);
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohKNix.overlays.haskell-nix-extra
+    ++ iohkNix.overlays.haskell-nix-extra
     # iohkNix: nix utilities and niv:
-    ++ iohKNix.overlays.iohkNix
+    ++ iohkNix.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {
@@ -34,7 +34,7 @@ let
           # also expose our sources and overlays
           // { inherit overlays sources; };
       })
-      # And, of course, our haskell-nix-ified cabal project:
+      # And, of course, our haskell-nix-ified stack project:
       (import ./pkgs.nix)
     ];
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -7,9 +7,6 @@
 , haskell-nix
 , buildPackages
 , config ? {}
-# GHC attribute name
-## fixme: what is this for?
-, compiler ? config.haskellNix.compiler or "ghc865"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 }:

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -28,14 +28,15 @@ let
 
   # Chop out a subdirectory of the source, so that the package is only
   # rebuilt when something in the subdirectory changes.
-  filterSubDir = dir:  with pkgs.lib; let
+  filterSubDir = dir: with pkgs.lib; let
       isFiltered = src ? _isLibCleanSourceWith;
       origSrc = if isFiltered then src.origSrc else src;
+      hasPathPrefix = prefix: hasPrefix (toString origSrc + toString prefix);
     in cleanSourceWith {
       inherit src;
       filter = path: type:
-        type == "directory" ||
-        hasPrefix (toString origSrc + toString dir) path;
+        (type == "directory" && hasPathPrefix (dirOf dir) path) ||
+        hasPathPrefix dir path;
     } + dir;
 
   pkgSet = haskell.mkStackPkgSet {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -8,6 +8,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
+## fixme: what is this for?
 , compiler ? config.haskellNix.compiler or "ghc865"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -18,7 +18,11 @@ let
   haskell = pkgs.haskell-nix;
   jmPkgs = pkgs.jmPkgs;
 
-  src = ../.;
+  src = haskell.cleanSourceHaskell {
+    src = ../.;
+    name = "cardano-wallet-src";
+  };
+
   # our packages
   stack-pkgs = import ./.stack.nix/default.nix;
 

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -30,7 +30,7 @@
 ############################################################################
 
 let
-  commonLib' = import ./. {};
+  commonLib' = import ./default.nix {};
 
 in { commonLib ? commonLib'.commonLib
 , pkgs ? commonLib'.pkgs

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -1,6 +1,6 @@
 # This is the derivation used by "stack --nix".
 # It provides the system dependencies required for a stack build.
-{ walletPackages ? import ./.. {}
+{ walletPackages ? import ../default.nix {}
 , pkgs ? walletPackages.pkgs
 }:
 with pkgs;

--- a/release.nix
+++ b/release.nix
@@ -5,6 +5,26 @@
 # The purpose of this file is to select jobs defined in default.nix and map
 # them to all supported build platforms.
 #
+# The layout is TARGET-SYSTEM.ATTR-PATH.BUILD-SYSTEM where
+#
+#   * TARGET-SYSTEM is one of
+#     - native - build the job for BUILD-SYSTEM
+#     - x86_64-w64-mingw32 - build the job for windows
+#     - musl64 - build the job for Linux, but statically linked with musl libc
+#
+#   * ATTR-PATH is an attribute from default.nix
+#
+#   * BUILD-SYSTEM is the system where the derivation is built. Hydra
+#     uses this to distribute builds to its build slaves. If building
+#     locally then it must reflect your local system. The value is one of:
+#     - x86_64-linux - Linux
+#     - x86_64-darwin - macOS
+#
+# Discover jobs by using tab completion in your shell:
+#   nix-build release.nix -A <TAB>
+# ... or by looking at the jobset evaluated by Hydra:
+#   https://hydra.iohk.io/jobset/Cardano/cardano-wallet#tabs-jobs
+#
 ############################################################################
 
 # The project sources


### PR DESCRIPTION
### Issue number

None

### Overview

I noticed in input-output-hk/cardano-launcher#15 that the cache was not being used for nix builds, because source filtering and naming was removed in #1351.

This puts back and improves source filtering, and adds a few source comments to the nix code.