### PR TITLE
Fix prop_guardQuitJoin not to use precondition for filtering pools.

### DIFF
--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -286,17 +286,16 @@ prop_guardJoinQuit knownPools dlg pid =
             label "ErrAlreadyDelegating" (W.guardQuit dlg === Right ())
 
 prop_guardQuitJoin
-    :: [PoolId]
+    :: NonEmptyList PoolId
     -> WalletDelegation
-    -> PoolId
     -> Property
-prop_guardQuitJoin knownPools dlg pid =
-    pid `elem` knownPools ==> case W.guardQuit dlg of
+prop_guardQuitJoin (NonEmpty knownPools) dlg =
+    case W.guardQuit dlg of
         Right () ->
             label "I can quit" $ property True
         Left W.ErrNotDelegatingOrAboutTo ->
             label "ErrNotDelegatingOrAboutTo"
-                (W.guardJoin knownPools dlg pid === Right ())
+                (W.guardJoin knownPools dlg (last knownPools) === Right ())
 
 walletCreationProp
     :: (WalletId, WalletName, DummyState)


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/pull/1392#discussion_r386260363

# Overview

- 278ed5402c876c546cadba81c8d897909bda1474
  Fix prop_guardQuitJoin not to use precondition for filtering pools.

# Comments

```
    You can join if you cannot quit
      +++ OK, passed 1000000 tests:
      50.0319% I can quit
      49.9681% ErrNotDelegatingOrAboutTo
```
