### PR TITLE
Fix nightly DB migration tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,16 @@
 with pkgs; with commonLib; with pkgs.haskell-nix.haskellLib;
 
 let
-  haskellPackages = cardanoWalletHaskellPackages;
+  src = pkgs.haskell-nix.cleanSourceHaskell {
+    src = ./.;
+    name = "cardano-wallet-src";
+  };
+
+  haskellPackages = import ./nix/haskell.nix {
+    inherit config lib stdenv pkgs buildPackages;
+    inherit (pkgs) haskell-nix;
+    inherit src;
+  };
 
   filterCardanoPackages = lib.filterAttrs (_: package: isCardanoWallet package);
   getPackageChecks = lib.mapAttrs (_: package: package.checks);

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -9,16 +9,13 @@
 , config ? {}
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
+# Project top-level source tree
+, src
 }:
 
 let
   haskell = pkgs.haskell-nix;
   jmPkgs = pkgs.jmPkgs;
-
-  src = haskell.cleanSourceHaskell {
-    src = ../.;
-    name = "cardano-wallet-src";
-  };
 
   # our packages
   stack-pkgs = import ./.stack.nix/default.nix;

--- a/nix/launch-migration-test.sh
+++ b/nix/launch-migration-test.sh
@@ -5,8 +5,8 @@
 # Environment variables you can set:
 #   PATH - You should have all necessary programs on the PATH.
 #   stateDir - suitable temporary location for databases.
-#   src - top of source tree, defaults to parent directory of this script.
-
+#   genesisDataDir - where block0.bin and secret.yaml are
+#   configFile - path to config.yaml
 
 set -euo pipefail
 
@@ -20,12 +20,17 @@ if [ -z "${stateDir:-}" ]; then
   exit 1
 fi
 
-: "${src:=$(cd `dirname $0`/..; pwd)}"
+if [ -z "${genesisDataDir:-}" ]; then
+  echo "$0: set the genesisDataDir environment variable before running this script."
+  exit 1
+fi
 
-data=$src/lib/jormungandr/test/data/jormungandr
-echo "data is $data"
+if [ -z "${configFile:-}" ]; then
+  echo "$0: set the configFile environment variable before running this script."
+  exit 1
+fi
 
 cardano-wallet-jormungandr version
 jormungandr --version
 
-exec migration-test $1 launch --state-dir $stateDir --genesis-block $data/block0.bin -- --secret $data/secret.yaml --config $data/config.yaml
+exec migration-test $1 launch --state-dir $stateDir --genesis-block $genesisDataDir/block0.bin -- --secret $genesisDataDir/secret.yaml --config $configFile

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -113,7 +113,8 @@ let
           pkgs.bash
           pkgs.coreutils
         ]}
-        export src=${latestRelease.src}
+        export genesisDataDir=${latestRelease.src}/lib/jormungandr/test/data/jormungandr
+        export configFile=${targetRelease.src}/lib/jormungandr/test/data/jormungandr/config.yaml
 
         exec ${./launch-migration-test.sh} "$@"
       '' // { inherit (latestRelease) cardano-wallet-jormungandr; };

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -27,7 +27,7 @@
 { system ? builtins.currentSystem
 , crossSystem ? null
 , config ? {}
-, pkgs ? import ./nixpkgs-haskell.nix {}
+, pkgs ? import ./default.nix {}
 }:
 
 with pkgs.lib;

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -4,13 +4,4 @@ let
 in pkgs: _: with pkgs; {
   jmPkgs = import ./jormungandr.nix { inherit (pkgs) commonLib; inherit pkgs; };
   inherit (pkgs1903) stack;
-  cardanoWalletHaskellPackages = import ./haskell.nix {
-    inherit config
-      lib
-      stdenv
-      pkgs
-      haskell-nix
-      buildPackages
-      ;
-  };
 }


### PR DESCRIPTION
# Issue Number

Fixes #1367.

# Overview

1. The nightly DB migration tests stopped working after #1351 was merged. There are two fixes to solve that.
2. The jormungandr `config.yaml` format has changed in a backwards incompatible-way. I changed the migration test script to keep using the latest genesis config, but use the jormungandr config which matches the jormungandr version.

# Comments

[Buildkite nightly pipeline](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=rvl%2F1367%2Ffix-nightly-tests)