### PR TITLE
Enable `key` cli commands for cardano-wallet-byron executable

### DIFF
--- a/lib/byron/exe/cardano-wallet-byron.hs
+++ b/lib/byron/exe/cardano-wallet-byron.hs
@@ -32,6 +32,7 @@ import Cardano.CLI
     ( LoggingOptions (..)
     , cli
     , cmdAddress
+    , cmdKey
     , cmdMnemonic
     , cmdNetwork
     , cmdTransaction
@@ -126,6 +127,7 @@ main = withUtf8Encoding $ do
         <> cmdAddress @'Mainnet
         <> cmdNetwork @'Mainnet
         <> cmdVersion
+        <> cmdKey
 
 beforeMainLoop
     :: Trace IO MainLog


### PR DESCRIPTION
# Issue Number

#1316 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] enable `key` cli commands for cardano-wallet-byron

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
