### PR TITLE
stdoutTextTracer: Use line-buffered print statements

### DIFF
--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -41,7 +41,8 @@ import Data.Text
 import Data.Text.Class
     ( ToText (..) )
 
-import qualified Data.Text.IO as T
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text.Encoding as T
 
 -- | Converts a 'Text' trace into any other type of trace that has a 'ToText'
 -- instance.
@@ -125,4 +126,4 @@ filterNonEmpty tr = Tracer $ \arg -> do
 -- | Creates a tracer that prints any 'ToText' log message. This is useful for
 -- debugging functions in the REPL, when you need a 'Tracer' object.
 stdoutTextTracer :: (MonadIO m, ToText a) => Tracer m a
-stdoutTextTracer = Tracer $ liftIO . T.putStrLn . toText
+stdoutTextTracer = Tracer $ liftIO . B8.putStrLn . T.encodeUtf8 . toText


### PR DESCRIPTION
### Issue number

Found while reviewing #1394.

### Summary

Use `B8.putStrLn`, which seems to be line-buffered, whereas `T.putStrLn` is character-buffered.

So rather than

    Starting ntp client
    quernyt pt oc lnitepn tc liise nttr iigngveorkeedd

we get

    Starting ntp client
    query to ntp client invoked
    ntp client is triggered

