### PR TITLE
Disable running integration tests on Hydra CI

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,8 @@
 , gitrev ? pkgs.commonLib.commitIdFromGitRepoOrZero ./.git
 # Use this to reference local sources rather than the niv pinned versions (see nix/default.nix)
 , sourcesOverride ? {}
+# GitHub PR number (as a string), set when building a Hydra PR jobset.
+, pr ? null
 }:
 
 # commonLib includes iohk-nix utilities, our util.nix and nixpkgs lib.
@@ -60,7 +62,7 @@ let
   haskellPackages = import ./nix/haskell.nix {
     inherit config lib stdenv pkgs buildPackages;
     inherit (pkgs) haskell-nix;
-    inherit src;
+    inherit src pr;
   };
 
   filterCardanoPackages = lib.filterAttrs (_: package: isCardanoWallet package);


### PR DESCRIPTION
# Overview

Reduces the load on Hydra by not running integration tests for PR builds. The test executables are still built however.

This uses the `pr` input which was added to [ci-ops/jobsets/default.nix](https://github.com/input-output-hk/ci-ops/blob/30d4685beded3e54caff4a22718aa6acde48d367/jobsets/default.nix#L326).

# Comments

Tested with:

    rodney@blue:~/iohk/cardano-wallet % nix-build --argstr pr 1234 release.nix -A native.checks.cardano-wallet-jormungandr.integration.x86_64-linux
    error: attribute 'integration' in selection path 'native.checks.cardano-wallet-jormungandr.integration.x86_64-linux' not found

    rodney@blue:~/iohk/cardano-wallet % nix-build release.nix -A native.checks.cardano-wallet-jormungandr.integration.x86_64-linux
    ...

[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1422#tabs-jobs)