### PR TITLE
Buildkite: don't cache stack logs

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -446,7 +446,8 @@ saveStackWork cfg = saveZippedCache stackWorkCache cfg tar
   where
     nullTerminate = (<> "\0") . FP.encode
     dirs = nullTerminate <$> find (ends ".stack-work") "."
-    tar = TB.inproc "tar" ["--null", "-T", "-", "-c"] dirs
+    tar = TB.inproc "tar" (exclude ++ ["--null", "-T", "-", "-c"]) dirs
+    exclude = ["--exclude", ".stack-work/logs"]
 
 saveZippedCache :: FilePath -> CICacheConfig -> Shell ByteString -> IO ()
 saveZippedCache ext cfg@CICacheConfig{..} tar = case putCacheName cfg ext of


### PR DESCRIPTION
### Overview

The stack build/test logs from old builds were cluttering up the buildkite artifacts list.

### Comments

Tested with using `ghci` in the `.buildkite` directory then inspecting archive contents.

```
λ> :l rebuild.hs
[1 of 1] Compiling Main             ( rebuild.hs, interpreted )
Ok, one module loaded.
Collecting type info for 1 module(s) ... 
λ> cd ".."
λ> saveStackWork (CICacheConfig "/tmp/cache" "/home/rodney/.stack" ["master"])
Saving cache /tmp/cache/master/stack-work.tar.lz4 ... wrote 2.135 GB.
λ> 
```
