### PR TITLE
Fix launcher unit tests on windows

### DIFF
--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -106,7 +106,7 @@ spec = describe "withShutdownHandler" $ do
 
 withPipe :: ((Handle, Handle) -> IO a) -> IO a
 withPipe = bracket createPipe closePipe
-    where closePipe (a, b) = hClose a >> hClose b
+    where closePipe (a, b) = hClose b >> hClose a
 
 captureLogging' :: (Tracer IO msg -> IO a) -> IO [msg]
 captureLogging' = fmap fst . captureLogging

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -20,9 +22,8 @@ import Control.Exception
     ( bracket, throwIO )
 import Control.Tracer
     ( Tracer, nullTracer )
-import qualified Data.ByteString as BS
 import System.IO
-    ( Handle, IOMode (..), hClose, stdin, withFile )
+    ( Handle, IOMode (..), hClose, hWaitForInput, stdin, withFile )
 import System.IO.Error
     ( isUserError )
 import System.Process
@@ -32,19 +33,55 @@ import Test.Hspec
 import Test.Utils.Trace
     ( captureLogging )
 import Test.Utils.Windows
-    ( nullFileName )
+    ( nullFileName, pendingOnWindows )
+
+#if defined(mingw32_HOST_OS)
+import Control.Concurrent
+    ( forkIO )
+import Control.Concurrent.MVar
+    ( MVar, newEmptyMVar, putMVar, takeMVar )
+import Control.Exception
+    ( IOException, catch )
+#endif
+
+import qualified Data.ByteString as BS
 
 spec :: Spec
 spec = describe "withShutdownHandler" $ do
     let decisecond = 100000
 
     describe "sanity tests" $ do
+        -- check file handle for input, allowing interruptions on windows
+        -- example
+        -- https://github.com/input-output-hk/ouroboros-network/blob/69d62063e59f966dc90bda5b4d0ac0a11efd3657/Win32-network/src/System/Win32/Async/Socket.hs#L46-L59
+        let hWait :: Handle -> IO Bool
+#if defined(mingw32_HOST_OS)
+            hWait h = do
+                v <- newEmptyMVar :: IO (MVar (Either IOException Bool))
+                _ <- forkIO ((hWaitForInput h (-1) >>= putMVar v . Right) `catch` (putMVar v . Left))
+                takeMVar v >>= either throwIO pure
+#else
+            hWait h = hWaitForInput h (-1)
+#endif
+        it "race hWaitForInput stdin" $ do
+            res <- race (hWait stdin) (threadDelay decisecond)
+            res `shouldBe` Right ()
+
+        it "race hWaitForInput pipe" $ withPipe $ \(a, _) -> do
+            res <- race (hWait a) (threadDelay decisecond)
+            res `shouldBe` Right ()
+
+        let getChunk :: Handle -> IO BS.ByteString
+            getChunk h = BS.hGet h 1000
+
         it "race stdin" $ do
-            res <- race (BS.hGet stdin 1000) (threadDelay decisecond)
+            pendingOnWindows "deadlocks on windows"
+            res <- race (getChunk stdin) (threadDelay decisecond)
             res `shouldBe` Right ()
 
         it "race pipe" $ withPipe $ \(a, _) -> do
-            res <- race (BS.hGet a 1000) (threadDelay decisecond)
+            pendingOnWindows "deadlocks on windows"
+            res <- race (getChunk a) (threadDelay decisecond)
             res `shouldBe` Right ()
 
     it "action completes immediately" $ withPipe $ \(a, _) -> do
@@ -84,6 +121,7 @@ spec = describe "withShutdownHandler" $ do
         logs `shouldBe` [MsgShutdownHandler True]
 
     it ("handle is " ++ nullFileName ++ " (immediate EOF)") $ do
+        pendingOnWindows $ "Can't open " ++ nullFileName ++ " for reading"
         logs <- captureLogging' $ \tr ->
             withFile nullFileName ReadMode $ \h -> do
                 res <- withShutdownHandler' tr h $ do


### PR DESCRIPTION
### Overview

- Fixes a hang in the test cases (happened on Linux and Windows).
- Add integration test for case where parent process sets stdin to `/dev/null`.
- Make `Cardano.Startup.withShutdownHandler` work on Windows without hanging.

### Comment

- [x] [cardano-wallet-launcher.unit](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1425/x86_64-w64-mingw32.checks.cardano-wallet-launcher.unit.x86_64-linux)