### PR TITLE
Allow serving wallet w/ cardano-node on either testnet or mainnet 

### DIFF
--- a/lib/byron/exe/cardano-wallet-byron.hs
+++ b/lib/byron/exe/cardano-wallet-byron.hs
@@ -122,7 +122,7 @@ main = withUtf8Encoding $ do
         <> cmdServe
         <> cmdMnemonic
         <> cmdKey
-        <> cmdNetwork @'Mainnet
+        <> cmdNetwork
         <> cmdVersion
 
 beforeMainLoop

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
@@ -63,6 +63,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Either.Combinators
     ( maybeToRight )
+import Data.Proxy
+    ( Proxy )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -89,9 +91,10 @@ newTransactionLayer
         , WalletKey k
         , MaxSizeOf Address n k
         )
-    => ProtocolMagic
+    => Proxy n
+    -> ProtocolMagic
     -> TransactionLayer t k
-newTransactionLayer protocolMagic = TransactionLayer
+newTransactionLayer _proxy protocolMagic = TransactionLayer
     { mkStdTx = _mkStdTx
     , mkDelegationJoinTx = _mkDelegationJoinTx
     , mkDelegationQuitTx = _mkDelegationQuitTx

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -28,7 +28,11 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Api.Types
     ( ApiByronWallet, WalletStyle (..) )
 import Cardano.Wallet.Byron
-    ( serveWallet, setupTracers, tracerSeverities )
+    ( SomeNetworkDiscriminant (..)
+    , serveWallet
+    , setupTracers
+    , tracerSeverities
+    )
 import Cardano.Wallet.Byron.Compatibility
     ( Byron )
 import Cardano.Wallet.Byron.Config
@@ -147,7 +151,8 @@ specWithServer tr = aroundAll withContext . after tearDown
     withServer action =
         withCardanoNode tr $ \addrInfo block0 (bp,vData) ->
         withSystemTempDirectory "cardano-wallet-databases" $ \db -> do
-            serveWallet @'Mainnet
+            serveWallet
+                (SomeNetworkDiscriminant $ Proxy @'Mainnet)
                 (setupTracers (tracerSeverities (Just Info)) tr)
                 (SyncTolerance 10)
                 (Just db)

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -46,6 +46,7 @@ library
     , http-client
     , iohk-monitoring
     , memory
+    , servant-server
     , servant-client
     , servant-client-core
     , text

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -123,7 +123,7 @@ spec = do
             <> cmdTransaction @'Testnet
             <> cmdAddress @'Testnet
             <> cmdStakePool @'Testnet
-            <> cmdNetwork @'Testnet
+            <> cmdNetwork
             <> cmdKey
 
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -71,7 +71,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
 import Cardano.Wallet.Primitive.Mnemonic
     ( entropyToBytes, mnemonicToEntropy, mnemonicToText )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), invariant )
+    ( Address (..), Hash (..), invariant, testnetMagic )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq
@@ -383,6 +383,15 @@ instance PaymentAddress 'Mainnet IcarusKey where
     paymentAddress k = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k) []
+    liftPaymentAddress (KeyFingerprint bytes) =
+        Address bytes
+
+instance PaymentAddress 'Testnet IcarusKey where
+    paymentAddress k = Address
+        $ CBOR.toStrictByteString
+        $ CBOR.encodeAddress (getKey k)
+            [ CBOR.encodeProtocolMagicAttr testnetMagic
+            ]
     liftPaymentAddress (KeyFingerprint bytes) =
         Address bytes
 

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -169,7 +169,7 @@ main = withUtf8Encoding $ do
         <> cmdTransaction @'Testnet
         <> cmdAddress @'Testnet
         <> cmdStakePool @'Testnet
-        <> cmdNetwork @'Testnet
+        <> cmdNetwork
         <> cmdVersion
         <> cmdKey
 

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -74,6 +74,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."http-client" or (buildDepError "http-client"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
           (hsPkgs."memory" or (buildDepError "memory"))
+          (hsPkgs."servant-server" or (buildDepError "servant-server"))
           (hsPkgs."servant-client" or (buildDepError "servant-client"))
           (hsPkgs."servant-client-core" or (buildDepError "servant-client-core"))
           (hsPkgs."text" or (buildDepError "text"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A (some debts regarding the cardano-wallet-byron command-line)

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 839135bc2c6fd7c91fe427e0201c1c71b704fbf9
  remove network discriminant type parameter for cmdNetwork
  The same approach (i.e. using clients based on sub-part of the API,
instead of the global 'Api t' type) could be used for a few other
commands that are actually fairly agnostic to what the network
discriminant is.

- 57ca08ceca6f7e1a475a892f34dbe27b463d3a16
  allow serving cardano-wallet-byron on either testnet or mainnet
  There's no particular requirement as of _now_ about being able to serve custom networks from the
CLI. So, the command-line serve only so-called 'known networks', with pre-defined configuration.
Note that, to things working fine at the type-level, some extra type machinery was needed, mostly
playing around with proxies. The command-line now expects a flag, either '--testnet' or '--mainnet'
to be provided, or fails, e.g.:

    cardano-wallet serve --node-socket node.socket
    Missing: (--mainnet | --testnet)

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
