### PR TITLE
Protect against syncProgress division by zero

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1362,7 +1362,8 @@ syncProgress (SyncTolerance timeTolerance) sp tip slotNow =
         ActiveSlotCoefficient f = sp ^. #getActiveSlotCoefficient
         remainingBlocks = round (remainingSlots * f)
 
-        progress = bhTip % (bhTip + remainingBlocks)
+        -- Using (max 1) to avoid division by 0.
+        progress = bhTip % (max 1 (bhTip + remainingBlocks))
     in if distance n1 n0 < tolerance || n0 >= n1 || progress >= 1 then
         Ready
     else

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -339,6 +339,21 @@ spec = do
                 syncProgress syncTolerance slotParams nodeTip ntwkTip
                     `shouldBe` progress
 
+        it "unit test #6 - block height 0" $ do
+            let slotParams = mockSlotParams 0.5
+            let ntwkTip = SlotId 1 0
+            let plots =
+                    [ (mockBlockHeader (SlotId 0 8) 0, 0)
+                    , (mockBlockHeader (SlotId 0 9) 0, 0)
+                    , (mockBlockHeader (SlotId 1 0) 0, 1)
+                    ]
+            forM_ plots $ \(nodeTip, p) -> do
+                let progress = if p == 1
+                        then Ready
+                        else Syncing (Quantity $ unsafeMkPercentage p)
+                syncProgress syncTolerance slotParams nodeTip ntwkTip
+                    `shouldBe` progress
+
         it "syncProgress should never crash" $ withMaxSuccess 10000
             $ property $ \f netSlot wSlot bh -> monadicIO $ do
                 let slotParams = mockSlotParams f

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -339,7 +339,7 @@ spec = do
                 syncProgress syncTolerance slotParams nodeTip ntwkTip
                     `shouldBe` progress
 
-        it "syncProgress should never crash"
+        it "syncProgress should never crash" $ withMaxSuccess 10000
             $ property $ \f netSlot wSlot bh -> monadicIO $ do
                 let slotParams = mockSlotParams f
                 let nodeTip = mockBlockHeader wSlot bh


### PR DESCRIPTION
# Issue Number

#1431 

# Overview

- [x] I added a `max 1` to make sure the denominator cannot be 0.
- [x] I increased `withMaxSuccess` of the test making sure this cannot happen. Test fails reliably without fix, and passes with fix.

# Comments

- In practice it should be very unlikely to have both `bhTip` and `remainingBlocks` 0. (The current time would have to be the genesis block date, or be close, to have remainingBlocks 0)

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
