### PR TITLE
fix LAUNCH - Restoration workers restart hanging infinitely

### DIFF
--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -79,6 +79,7 @@ spec = do
     let testData = $(getTestData) </> "jormungandr"
     let block0 = testData </> "block0.bin"
     let secret = testData </> "secret.yaml"
+    let config = testData </> "config.yaml"
     describe "LAUNCH - cardano-wallet launch [SERIAL]" $ do
         it "LAUNCH - Stop when --state-dir is an existing file" $ withTempFile $ \f _ -> do
             let args =
@@ -201,6 +202,7 @@ spec = do
                     , "--genesis-block", block0
                     , "--"
                     , "--secret", secret
+                    , "--config", config
                     ]
             let process = proc' (commandName @t) args
             wallet <- withCreateProcess process $ \_ (Just o) (Just e) ph -> do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- f7df783733bf6bfe6319d03a17435a2f9e329f09
  fix LAUNCH - Restoration workers restart hanging infinitely


# Comments

 Jormungandr needs to have `--config`, otherwise it complains and doesn't start:
```
Mar 12 15:05:53.564 ERRO trusted-peers cannot be empty. to avoid bootstrap use 'skip_bootstrap: true', task: bootstrap
```
