### PR TITLE
Better response example in api doc for network/clock

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -581,7 +581,6 @@ x-networkInformationNtpStatus: &networkInformationNtpStatus
       properties:
         quantity:
           type: integer
-          minimum: 0
           example: 14
         unit:
           type: string

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -565,10 +565,10 @@ x-networkInformationNtpStatus: &networkInformationNtpStatus
     status:
       type: string
       enum:
-        - unavailable
         - available
+        - unavailable
         - pending
-    drift:
+    offset:
       type: object
       description: |
         <span style="position: relative; left: 35px; top: -21px; vertical-align: middle; background-color: rgba(142, 142, 220, 0.05); color: rgba(50, 50, 159, 0.9); margin: 0 5px; padding: 0 5px; border: 1px solid rgba(50, 50, 159, 0.1); line-height: 20px; font-size: 13px; border-radius: 2px;">
@@ -586,7 +586,7 @@ x-networkInformationNtpStatus: &networkInformationNtpStatus
         unit:
           type: string
           enum:
-            - microseconds
+            - microsecond
 
 x-networkInformationNodeTip: &networkInformationNodeTip
   <<: *blockReference
@@ -661,7 +661,7 @@ components:
         next_epoch: *ApiEpochInfo
 
     ApiNetworkClock: &ApiNetworkClock
-      <<: *networkClockSyncProgress
+      <<: *networkInformationNtpStatus
 
     ApiNetworkParameters: &ApiNetworkParameters
       type: object


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 62128be5b54998fdc014f82d2fc606cc3fb10411
  Better response example in api doc for network/clock
  
- e632629f8a5f3818d4b49689482603185b88f596
  Fix for failng validateEveryToJSON test: "Cardano.Wallet.Api.Types, verify that every type used with JSON content type in a servant API has compatible ToJSON and ToSchema instances using validateToJSON., ApiNetworkClock"


# Comments

| Before | After  |
|--|--|
|![Screenshot from 2020-03-13 13-13-39](https://user-images.githubusercontent.com/42900201/76620020-8e626180-652c-11ea-9516-64c71cc18a30.png) | ![Screenshot from 2020-03-13 13-13-57](https://user-images.githubusercontent.com/42900201/76620104-b356d480-652c-11ea-97c4-425a9bd6c5c4.png)|
