### PR TITLE
Store pool retirement certificates + fix stake distribution fetching & combining.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ See **Installation Instructions** for each available [release](https://github.co
 
 > ### Latest releases
 >
-> | cardano-wallet                                                                            | Jörmungandr (compatible versions)                                            |
-> | ---                                                                                       | ---                                                                          |
-> | `master` branch                                                                           | [v0.8.13](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.13) |
-> | [v2020-02-17](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-02-17) | [v0.8.9](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.9) |
-> | [v2020-01-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-01-27) | [v0.8.7](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.7) |
-> | [v2020-01-14](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-01-14) | [v0.8.5](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.5) |
+> | cardano-wallet                                                                            | jörmungandr (compatible versions)                                              | cardano-node (compatible versions)
+> | ---                                                                                       | ---                                                                            | ---
+> | `master` branch                                                                           | [v0.8.14](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.14) | [1.6.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.6.0)
+> | [v2020-03-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-03-11) | [v0.8.13](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.13) | [1.6.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.6.0)
+> | [v2020-02-17](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-02-17) | [v0.8.9](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.9)   | N/A
+> | [v2020-01-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-01-27) | [v0.8.7](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.7)   | N/A
+> | [v2020-01-14](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-01-14) | [v0.8.5](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.5)   | N/A
 
 ## How to build from sources
 

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -100,7 +100,7 @@ import Data.List
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Merge.Strict
-    ( traverseMissing, zipWithMatched )
+    ( dropMissing, traverseMissing, zipWithMatched )
 import Data.Map.Strict
     ( Map )
 import Data.Ord
@@ -445,9 +445,8 @@ combineMetrics
             )
         )
 combineMetrics mStake mProd mPerf = do
-    let errMissingLeft = ErrProducerNotInDistribution
-    mActivity <- zipWithRightDefault (,) errMissingLeft (Quantity 0) mStake mProd
-    zipWithRightDefault unzipZip3 errMissingLeft 0 mActivity mPerf
+    mActivity <- zipWithRightDefault (,) (Quantity 0) mStake mProd
+    zipWithRightDefault unzipZip3 0 mActivity mPerf
   where
     unzipZip3 :: (a,b) -> c -> (a,b,c)
     unzipZip3 (a,b) c = (a,b,c)
@@ -485,16 +484,15 @@ newtype ErrMetricsInconsistency
 zipWithRightDefault
     :: Ord k
     => (l -> r -> a)
-    -> (k -> errMissingLeft)
     -> r
     -> Map k l
     -> Map k r
     -> Either errMissingLeft (Map k a)
-zipWithRightDefault combine onMissing rZero =
+zipWithRightDefault combine rZero =
     Map.mergeA leftButNotRight rightButNotLeft bothPresent
   where
     leftButNotRight = traverseMissing $ \_k l -> pure (combine l rZero)
-    rightButNotLeft = traverseMissing $ \k _r -> Left (onMissing k)
+    rightButNotLeft = dropMissing
     bothPresent     = zipWithMatched  $ \_k l r -> (combine l r)
 
 -- | Given a mapping from 'PoolId' -> 'PoolOwner' and a mapping between

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -31,7 +31,6 @@ module Cardano.Pool.Metrics
     , monitorStakePools
 
       -- * Combining Metrics
-    , ErrMetricsInconsistency (..)
     , combineMetrics
 
       -- * Associating metadata
@@ -254,7 +253,6 @@ data StakePoolLayer m = StakePoolLayer
 
 data ErrListStakePools
      = ErrMetricsIsUnsynced (Quantity "percent" Percentage)
-     | ErrListStakePoolsMetricsInconsistency ErrMetricsInconsistency
      | ErrListStakePoolsCurrentNodeTip ErrCurrentNodeTip
      deriving (Show)
 
@@ -340,18 +338,16 @@ newStakePoolLayer tr block0H getEpCst db@DBLayer{..} nl metadataDir = StakePoolL
         liftIO $ do
             traceWith tr $ MsgUsingTotalStakeForRanking totalStake
             traceWith tr $ MsgUsingRankingEpochConstants epConstants
-        case combineMetrics distr prod perfs of
-            Left e ->
-                throwE $ ErrListStakePoolsMetricsInconsistency e
-            Right ps -> lift $ do
-                let len = fromIntegral (length ps)
-                let avg = if null ps
-                        then 0
-                        else sum ((\(_,_,c) -> c) <$> (Map.elems ps)) / len
-                ns <- readNewcomers db (Map.keys ps) avg
-                pools <- atomically $
-                    Map.traverseMaybeWithKey mergeRegistration (ps <> ns)
-                sortResults $ Map.elems pools
+        let ps = combineMetrics distr prod perfs
+        lift $ do
+            let len = fromIntegral (length ps)
+            let avg = if null ps
+                    then 0
+                    else sum ((\(_,_,c) -> c) <$> (Map.elems ps)) / len
+            ns <- readNewcomers db (Map.keys ps) avg
+            pools <- atomically $
+                Map.traverseMaybeWithKey mergeRegistration (ps <> ns)
+            sortResults $ Map.elems pools
       where
         totalStake =
             Quantity $ Map.foldl' (\a (Quantity b) -> a + b) 0 distr
@@ -419,16 +415,8 @@ readNewcomers DBLayer{..} elders avg = do
 -- 2. A pool-production map
 -- 3. A pool-performance map
 --
--- If a pool has produced a block without existing in the stake-distribution,
--- i.e it exists in (2) but not (1), this function will return
--- @Left ErrMetricsInconsistency@.
---
--- If a pool is in (1) but not (2), it simply means it has produced 0 blocks so
--- far.
---
--- Similarly, if we do have metrics about a pool in (3), but this pool is
--- unknown from (1) & (2), this function also returns
--- @Left ErrMetricsInconsistency@.
+-- If a pool is in 2 or 3 but not in 1, it means that the pool has been
+-- de-registered.
 --
 -- If a pool is in (1+2) but not in (3), it simply means it has produced 0
 -- blocks so far.
@@ -436,38 +424,23 @@ combineMetrics
     :: Map PoolId (Quantity "lovelace" Word64)
     -> Map PoolId (Quantity "block" Word64)
     -> Map PoolId Double
-    -> Either
-        ErrMetricsInconsistency
-        ( Map PoolId
-            ( Quantity "lovelace" Word64
-            , Quantity "block" Word64
-            , Double
-            )
+    -> Map PoolId
+        ( Quantity "lovelace" Word64
+        , Quantity "block" Word64
+        , Double
         )
-combineMetrics mStake mProd mPerf = do
-    mActivity <- zipWithRightDefault (,) (Quantity 0) mStake mProd
-    zipWithRightDefault unzipZip3 0 mActivity mPerf
+combineMetrics mStake mProd mPerf =
+    let
+        mActivity = zipWithRightDefault (,) (Quantity 0) mStake mProd
+    in
+        zipWithRightDefault unzipZip3 0 mActivity mPerf
   where
     unzipZip3 :: (a,b) -> c -> (a,b,c)
     unzipZip3 (a,b) c = (a,b,c)
 
--- | Possible errors returned by 'combineMetrics'.
-newtype ErrMetricsInconsistency
-    = ErrProducerNotInDistribution PoolId
-        -- ^ Somehow, we tried to combine invalid metrics together and passed
-        -- a passed a block production that doesn't match the producers found in
-        -- the stake activity.
-        --
-        -- Note that the opposite case is okay as we only observe pools that
-        -- have produced blocks. So it could be the case that a pool exists in
-        -- the distribution but not in the production! (In which case, we'll
-        -- assign it a production of '0').
-    deriving (Show, Eq)
-
 -- | Combine two maps with the given zipping function. It defaults when elements
--- of the first map (left) are not present in the second (right), but returns an
--- error when elements of the second (right) map are not present in the first
--- (left).
+-- of the first map (left) are not present in the second (right), and discards
+-- elements in the second (right) map are not present in the first (left).
 --
 -- Example:
 --
@@ -476,20 +449,17 @@ newtype ErrMetricsInconsistency
 -- let m2 = Map.fromList [(2, True)]
 -- @
 --
--- >>> zipWithRightDefault (,) ErrMissing False m1 m2
--- Right (Map.fromList [(1, ('a', False)), (2, ('b', True)), (3, ('c', False))])
---
--- >>> zipWithRightDefault (,) ErrMissing False m2 m1
--- Left (ErrMissing 1)
+-- >>> zipWithRightDefault (,) False m1 m2
+-- Map.fromList [(1, ('a', False)), (2, ('b', True)), (3, ('c', False))])
 zipWithRightDefault
     :: Ord k
     => (l -> r -> a)
     -> r
     -> Map k l
     -> Map k r
-    -> Either errMissingLeft (Map k a)
+    -> Map k a
 zipWithRightDefault combine rZero =
-    Map.mergeA leftButNotRight rightButNotLeft bothPresent
+    Map.merge leftButNotRight rightButNotLeft bothPresent
   where
     leftButNotRight = traverseMissing $ \_k l -> pure (combine l rZero)
     rightButNotLeft = dropMissing

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -40,11 +40,7 @@ import Prelude
 import Cardano.Pool.Metadata
     ( StakePoolMetadata )
 import Cardano.Pool.Metrics
-    ( ErrListStakePools (..)
-    , ErrMetricsInconsistency (..)
-    , StakePool (..)
-    , StakePoolLayer (..)
-    )
+    ( ErrListStakePools (..), StakePool (..), StakePoolLayer (..) )
 import Cardano.Wallet
     ( ErrAdjustForFee (..)
     , ErrCannotJoin (..)
@@ -2089,7 +2085,6 @@ instance LiftHandler ErrCurrentNodeTip where
 
 instance LiftHandler ErrListStakePools where
      handler = \case
-         ErrListStakePoolsMetricsInconsistency e -> handler e
          ErrListStakePoolsCurrentNodeTip e -> handler e
          ErrMetricsIsUnsynced p ->
              apiError err503 NotSynced $ mconcat
@@ -2097,16 +2092,6 @@ instance LiftHandler ErrListStakePools where
                  , "blockchain for metrics first. I'm at "
                  , toText p
                  ]
-
-instance LiftHandler ErrMetricsInconsistency where
-    handler = \case
-        ErrProducerNotInDistribution producer ->
-            apiError err500 UnexpectedError $ mconcat
-                [ "Something is terribly wrong with the metrics I collected. "
-                , "I recorded that some blocks were produced by "
-                , toText producer
-                , " but the node doesn't know about this stake pool!"
-                ]
 
 instance LiftHandler ErrSelectForDelegation where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -122,10 +122,9 @@ data NetworkLayer m target block = NetworkLayer
         -- ^ Broadcast a transaction to the chain producer
 
     , stakeDistribution
-        :: ExceptT ErrNetworkUnavailable m
-            ( EpochNo
-            , Map PoolId (Quantity "lovelace" Word64)
-            )
+        :: EpochNo
+        -> ExceptT ErrNetworkUnavailable m
+            (Map PoolId (Quantity "lovelace" Word64))
 
     , getAccountBalance
         :: ChimericAccount

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1202,6 +1202,9 @@ newtype EpochNo = EpochNo { unEpochNo :: Word31 }
     deriving stock (Show, Read, Eq, Ord, Generic)
     deriving newtype (Num, Bounded, Enum)
 
+instance ToText EpochNo where
+    toText = T.pack . show . unEpochNo
+
 instance Buildable EpochNo where
     build (EpochNo e) = build $ fromIntegral @Word31 @Word32 e
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api.hs
@@ -22,6 +22,7 @@ import Prelude
 import Cardano.Wallet.Jormungandr.Api.Types
     ( AccountId
     , AccountState
+    , ApiT
     , BlockId
     , Hex
     , JormungandrBinary
@@ -30,7 +31,7 @@ import Cardano.Wallet.Jormungandr.Api.Types
 import Cardano.Wallet.Jormungandr.Binary
     ( Block )
 import Cardano.Wallet.Primitive.Types
-    ( SealedTx (..) )
+    ( EpochNo, SealedTx (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Servant.API
@@ -94,4 +95,5 @@ type PostMessage
 type GetStakeDistribution
     = "api" :> "v0"
     :> "stake"
+    :> Capture "epoch" (ApiT EpochNo)
     :> Get '[JSON] StakeApiResponse

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
@@ -36,6 +36,7 @@ import Cardano.Wallet.Jormungandr.Binary
     ( Block, eitherRunGet, getBlock )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
+    , EpochNo (..)
     , Hash (..)
     , PoolId (..)
     , SealedTx (..)
@@ -106,6 +107,9 @@ instance ToHttpApiData BlockId where
 
 instance ToHttpApiData AccountId where
     toUrlPiece = toText . getAccountId
+
+instance ToHttpApiData (ApiT EpochNo) where
+    toUrlPiece = toText . getApiT
 
 instance MimeUnrender JormungandrBinary [BlockId] where
     mimeUnrender _ =

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -98,7 +98,7 @@ import Cardano.Wallet.Jormungandr.Api.Types
     ( AccountState (currentBalance)
     , ApiStakeDistribution (pools)
     , ApiT (..)
-    , StakeApiResponse (epoch, stake)
+    , StakeApiResponse (stake)
     )
 import Cardano.Wallet.Jormungandr.Binary
     ( runGetOrFail )
@@ -346,15 +346,13 @@ mkRawNetworkLayer bp batchSize st j = NetworkLayer
         maybe (SlotId 0 0) slotId (blockHeadersTip unstable)
 
     _stakeDistribution
-        :: ExceptT ErrNetworkUnavailable m
-            ( EpochNo
-            , Map PoolId (Quantity "lovelace" Word64)
-            )
-    _stakeDistribution = do
-        r <- getStakeDistribution j
-        let epochNo = getApiT . epoch $ r
+        :: EpochNo
+        -> ExceptT ErrNetworkUnavailable m
+            (Map PoolId (Quantity "lovelace" Word64))
+    _stakeDistribution ep = do
+        r <- getStakeDistribution j ep
         let distr = map (\(ApiT a, ApiT b) -> (a,b)) . pools . stake $ r
-        return (epochNo, Map.fromList distr)
+        return $ Map.fromList distr
 
     _getAccountBalance (ChimericAccount acc) =
         liftE1

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -270,7 +270,7 @@ spec = do
                 (^? (_Ctor @"ErrGetDescendantsNetworkUnreachable"))
 
         describe "getStakeDistribution" $ do
-            let ep client () = Jormungandr.getStakeDistribution client
+            let ep client () = Jormungandr.getStakeDistribution client 0
             testInvalidUrlPath ep (error "should throw")
             testGetNetworkUnreachable ep pure
 

--- a/nix/jormungandr.nix
+++ b/nix/jormungandr.nix
@@ -38,19 +38,19 @@ in { commonLib ? commonLib'.commonLib
 
 let
   release = rec {
-    version = "0.8.13";
+    version = "0.8.14";
     # Git revision of input-output-hk/jormungandr repo.
     rev = "v${version}";
     # Hash of git repo and all of its submodules.
-    sha256 = "1r1dklwyadgnw69d6pyldzqwwms789jj9mg5rr729vxy999d9699";
+    sha256 = "06lrpwk653k8mgns9cip270iyarxfd8j1ny4qfrcfjmizm2d7yr2";
     # Hash of all Cargo dependencies.
-    cargoSha256 = "1pycc6i2ia8vl16qqxl2lsk686wafzg9xy1cc7ljywjb8nlf5cmi";
+    cargoSha256 = "17nyp5gpzc0j7cgqx5y6lg8jlvr5ryh2qyxcg8xscg00yfdzawdp";
   };
 
   windows = rec {
     # URL and hash of windows binary release
     url = "https://github.com/input-output-hk/jormungandr/releases/download/v${release.version}/jormungandr-v${release.version}-x86_64-pc-windows-msvc.zip";
-    sha256 = "0hspxfpc0iafg970kk9z8bz5axn5h72zkzq120jrirkzgiky490a";
+    sha256 = "03kalhiyxaacwwbf987zqa60ln7h5jvraypmygynad4lk6cwasrz";
   };
 
   jormungandr-win64 = pkgs.runCommand "jormungandr-win64-${release.version}" {


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1442

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- c74803733f4d84285f768a40c9b12f9c5614491c
  bump versions in README compatibility matrix
  
- ded40cc9f34dfddf79a840a5b50dc997435fe770
  add Jörmungandr binary deserialisers for pool retirement certificates
  
- 42e387d6d73bf796e249ed765072863dacf64448
  track 'PoolRetirementCertificate' in the stake pool worker
  The corresponding database function doesn't exist _yet_, coming in the next commit.
So far, this would simply add the retirement certificates into a new table but, do
nothing with them.

- 61203d457017d5b6bfffea007d2c6a50eef75a37
  implement initial behavior for 'putPoolRetirement' in the database layer
    Any pool that has submitted a retirement certificate will be removed
  from the list, regardless of the retirement time set by the pool.

  Ideally, we would prefer to only discard pool when they are actually
  retired (i.e. based on the time they set).

- 7c8623a1a75a427124846f8057e1e794702e130a
  Fetch stake distribution by epoch instead of latest one
  
- 9d2fd50c1d7d11ddc09772051ee658d2dd8d74ee
  Ignore blocks produced by pools not in the stake distribution.
  The erroring was originally a precaution.

While I haven't checked, it must be that jormungandr removes pools in
the stake-distribution... before they are retired?

This patch seems to solve the problem.

- 7f43e64350284fe0ad75e124bb5a023ce207d5e3
  cleanup ErrMetricsInconsistency now obsolete

- 0858080446eb9f0964a437a4e5f2e729be328e59
  update jormungandr.nix references for 0.8.14
  
# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: turns out that handling de-registration certificates was kinda useless. Problem was that we were trying to merge all-time production with stake distribution of the latest epoch which.. doesn't work.

On the way fixing this, I also implemented fetching the stake distribution based on the relevant epoch number, so this is now done as part of the forward loop and should automatically make the metrics & ranking much more stable. 

Also added code for managing retirement certificates. We still do nothing with that but.. it's there now :man_shrugging: ... when relevant, we can then think about notifying frontend applications about de-registered pools.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
