### PR TITLE
read protocol magic from genesis file instead of command-line option

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -41,6 +41,7 @@ module Cardano.Wallet.Byron.Compatibility
     , fromChainHash
     , fromGenesisData
     , fromNetworkMagic
+    , fromProtocolMagicId
     , fromSlotNo
     , fromTip
     , fromTxAux
@@ -66,6 +67,8 @@ import Cardano.Chain.UTxO
     ( Tx (..), TxAux, TxIn (..), TxOut (..), taTx, unTxPayload )
 import Cardano.Crypto
     ( AbstractHash (..), hash )
+import Cardano.Crypto.ProtocolMagic
+    ( ProtocolMagicId, unProtocolMagicId )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Unsafe
@@ -389,3 +392,6 @@ fromGenesisData (genesisData, genesisHash) =
 fromNetworkMagic :: NetworkMagic -> W.ProtocolMagic
 fromNetworkMagic (NetworkMagic magic) =
     W.ProtocolMagic (fromIntegral magic)
+
+fromProtocolMagicId :: ProtocolMagicId -> W.ProtocolMagic
+fromProtocolMagicId = W.ProtocolMagic . fromIntegral . unProtocolMagicId


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

There's no point passing the protocol magic as an command-line option
for it can be read directly from the genesis file. This turns the serve
command into a very minimal and neat interface:

```
$ cardano-wallet serve --mainnet --node-socket /data/node.socket
$ cardano-wallet serve --testnet /config/genesis.json --node-socket /data/node.socket
```