### PR TITLE
Distinguish (internally) between legacy and new passphrase encryptions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -323,8 +323,8 @@ spec = do
             ]
 
     describe "BYRON_RESTORE_06 - Passphrase" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -424,8 +424,8 @@ spec = do
             verify r expectations
 
     describe "WALLETS_CREATE_07 - Passphrase" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')
@@ -790,8 +790,8 @@ spec = do
         expectField #passphrase (`shouldNotBe` originalPassUpdateDateTime) rg
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')
@@ -837,8 +837,8 @@ spec = do
 
     describe "WALLETS_UPDATE_PASS_03 - Can update pass from pass that's boundary\
     \ value" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź') )
@@ -858,7 +858,7 @@ spec = do
                      } |]
             (_, w) <- unsafeRequest @ApiWallet ctx
                 (Link.postWallet @'Shelley) createPayload
-            let len = passphraseMaxLength (Proxy @"encryption")
+            let len = passphraseMaxLength (Proxy @"raw")
             let newPass = T.pack $ replicate len '💘'
             let payload = updatePassPayload oldPass newPass
             rup <- request @ApiWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Wallets.hs
@@ -332,7 +332,7 @@ spec = do
             e `shouldBe` cmdOk
 
     describe "WALLETS_CREATE_07 - Passphrase is valid" $ do
-        let proxy_ = Proxy @"encryption"
+        let proxy_ = Proxy @"raw"
         let passphraseMax = replicate (passphraseMaxLength proxy_) 'ą'
         let passBelowMax = replicate (passphraseMaxLength proxy_ - 1) 'ć'
         let passphraseMin = replicate (passphraseMinLength proxy_) 'ń'
@@ -355,7 +355,7 @@ spec = do
             expectCliField #passphrase (`shouldNotBe` Nothing) j
 
     describe "WALLETS_CREATE_07 - When passphrase is invalid" $ do
-        let proxy_ = Proxy @"encryption"
+        let proxy_ = Proxy @"raw"
         let passAboveMax = replicate (passphraseMaxLength proxy_ + 1) 'ą'
         let passBelowMin = replicate (passphraseMinLength proxy_ - 1) 'ń'
         let passMinWarn = "passphrase is too short: expected at \
@@ -524,8 +524,8 @@ spec = do
             expectCliField #passphrase (`shouldNotBe` initPassUpdateTime) j
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , replicate minLength 'ź'
@@ -582,8 +582,8 @@ spec = do
             exitCode `shouldBe` ExitFailure 1
 
     describe "WALLETS_UPDATE_PASS_03 - Old passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show (minLength - 1) ++ " char long"
                   , replicate (minLength - 1) 'ź'
@@ -615,8 +615,8 @@ spec = do
 
     describe "WALLETS_UPDATE_PASS_03 - \
         \Can update pass from pass that's boundary value" $ do
-        let minLength = passphraseMinLength (Proxy @"encryption")
-        let maxLength = passphraseMaxLength (Proxy @"encryption")
+        let minLength = passphraseMinLength (Proxy @"raw")
+        let maxLength = passphraseMaxLength (Proxy @"raw")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , replicate minLength 'ź'

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -78,6 +78,7 @@ library
     , retry
     , safe
     , scientific
+    , scrypt
     , servant
     , servant-client
     , servant-server

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -181,6 +181,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , checkPassphrase
     , deriveRewardAccount
     , encryptPassphrase
+    , preparePassphrase
     , toChimericAccount
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -611,13 +612,20 @@ updateWalletPassphrase
         )
     => ctx
     -> WalletId
-    -> (Passphrase "encryption-old", Passphrase "encryption-new")
+    -> (Passphrase "raw", Passphrase "raw")
     -> ExceptT ErrUpdatePassphrase IO ()
 updateWalletPassphrase ctx wid (old, new) =
     withRootKey @ctx @s @k ctx wid (coerce old) ErrUpdatePassphraseWithRootKey
-        $ \xprv -> withExceptT ErrUpdatePassphraseNoSuchWallet $ do
-            let xprv' = changePassphrase old new xprv
-            attachPrivateKeyFromPwd @ctx @s @k ctx wid (xprv', coerce new)
+        $ \xprv scheme -> withExceptT ErrUpdatePassphraseNoSuchWallet $ do
+            -- NOTE
+            -- /!\ Important /!\
+            -- attachPrivateKeyFromPwd does use 'EncryptWithPBKDF2', so
+            -- regardless of the passphrase current scheme, we'll re-encrypt
+            -- it using the new scheme, always.
+            let oldP = preparePassphrase scheme old
+            let newP = preparePassphrase EncryptWithPBKDF2 new
+            let xprv' = changePassphrase oldP newP xprv
+            attachPrivateKeyFromPwd @ctx @s @k ctx wid (xprv', newP)
 
 -- | List the wallet's UTxO statistics.
 listUtxoStatistics
@@ -1038,11 +1046,11 @@ signPayment
     => ctx
     -> WalletId
     -> ArgGenChange s
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> CoinSelection
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 signPayment ctx wid argGenChange pwd (CoinSelection ins outs chgs) = db & \DBLayer{..} -> do
-    withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv -> do
+    withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
         mapExceptT atomically $ do
             cp <- withExceptT ErrSignPaymentNoSuchWallet $ withNoSuchWallet wid $
                 readCheckpoint (PrimaryKey wid)
@@ -1051,7 +1059,7 @@ signPayment ctx wid argGenChange pwd (CoinSelection ins outs chgs) = db & \DBLay
             withExceptT ErrSignPaymentNoSuchWallet $
                 putCheckpoint (PrimaryKey wid) (updateState s' cp)
 
-            let keyFrom = isOwned (getState cp) (xprv, pwd)
+            let keyFrom = isOwned (getState cp) (xprv, preparePassphrase scheme pwd)
             (tx, sealedTx) <- withExceptT ErrSignPaymentMkTx $ ExceptT $ pure $
                 mkStdTx tl keyFrom ins allOuts
 
@@ -1073,16 +1081,16 @@ signTx
         )
     => ctx
     -> WalletId
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> UnsignedTx
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 signTx ctx wid pwd (UnsignedTx inpsNE outsNE) = db & \DBLayer{..} -> do
-    withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv -> do
+    withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
         mapExceptT atomically $ do
             cp <- withExceptT ErrSignPaymentNoSuchWallet $ withNoSuchWallet wid $
                 readCheckpoint (PrimaryKey wid)
 
-            let keyFrom = isOwned (getState cp) (xprv, pwd)
+            let keyFrom = isOwned (getState cp) (xprv, preparePassphrase scheme pwd)
             (tx, sealedTx) <- withExceptT ErrSignPaymentMkTx $ ExceptT $ pure $
                 mkStdTx tl keyFrom inps outs
 
@@ -1158,13 +1166,14 @@ signDelegation
     => ctx
     -> WalletId
     -> ArgGenChange s
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> CoinSelection
     -> DelegationAction
     -> ExceptT ErrSignDelegation IO (Tx, TxMeta, UTCTime, SealedTx)
 signDelegation ctx wid argGenChange pwd coinSel action = db & \DBLayer{..} -> do
     let (CoinSelection ins outs chgs) = coinSel
-    withRootKey @_ @s ctx wid pwd ErrSignDelegationWithRootKey $ \xprv -> do
+    withRootKey @_ @s ctx wid pwd ErrSignDelegationWithRootKey $ \xprv scheme -> do
+        let pwdP = preparePassphrase scheme pwd
         mapExceptT atomically $ do
             cp <- withExceptT ErrSignDelegationNoSuchWallet $ withNoSuchWallet wid $
                 readCheckpoint (PrimaryKey wid)
@@ -1173,14 +1182,14 @@ signDelegation ctx wid argGenChange pwd coinSel action = db & \DBLayer{..} -> do
             withExceptT ErrSignDelegationNoSuchWallet $
                 putCheckpoint (PrimaryKey wid) (updateState s' cp)
 
-            let rewardAcc = deriveRewardAccount @k pwd xprv
-            let keyFrom = isOwned (getState cp) (xprv, pwd)
+            let rewardAcc = deriveRewardAccount @k pwdP xprv
+            let keyFrom = isOwned (getState cp) (xprv, pwdP)
             (tx, sealedTx) <- withExceptT ErrSignDelegationMkTx $ ExceptT $ pure $
                 case action of
                     Join poolId ->
-                        mkDelegationJoinTx tl poolId (rewardAcc, pwd) keyFrom ins allOuts
+                        mkDelegationJoinTx tl poolId (rewardAcc, pwdP) keyFrom ins allOuts
                     Quit ->
-                        mkDelegationQuitTx tl (rewardAcc, pwd) keyFrom ins allOuts
+                        mkDelegationQuitTx tl (rewardAcc, pwdP) keyFrom ins allOuts
 
             let bp = blockchainParameters cp
             let (time, meta) = mkTxMeta bp (currentTip cp) s' ins allOuts
@@ -1375,7 +1384,7 @@ joinStakePool
     -> WalletId
     -> (PoolId, [PoolId])
     -> ArgGenChange s
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> ExceptT ErrJoinStakePool IO (Tx, TxMeta, UTCTime)
 joinStakePool ctx wid (pid, pools) argGenChange pwd = db & \DBLayer{..} -> do
     walMeta <- mapExceptT atomically $ withExceptT ErrJoinStakePoolNoSuchWallet $
@@ -1414,7 +1423,7 @@ quitStakePool
     => ctx
     -> WalletId
     -> ArgGenChange s
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> ExceptT ErrQuitStakePool IO (Tx, TxMeta, UTCTime)
 quitStakePool ctx wid argGenChange pwd = db & \DBLayer{..} -> do
     walMeta <- mapExceptT atomically $ withExceptT ErrQuitStakePoolNoSuchWallet $
@@ -1450,11 +1459,23 @@ attachPrivateKeyFromPwd
     -> (k 'RootK XPrv, Passphrase "encryption")
     -> ExceptT ErrNoSuchWallet IO ()
 attachPrivateKeyFromPwd ctx wid (xprv, pwd) = db & \DBLayer{..} -> do
+    hpwd <- liftIO $ encryptPassphrase pwd
     -- NOTE Only new wallets are constructed through this function, so the
     -- passphrase is encrypted with the new scheme (i.e. PBKDF2)
-    let scheme = EncryptWithPBKDF2
-    hpwd <- liftIO $ encryptPassphrase scheme pwd
-    attachPrivateKey db wid (xprv, hpwd) scheme
+    --
+    -- We do an extra sanity check after having encrypted the passphrase: we
+    -- tried to avoid some programmer mistakes with the phantom types on
+    -- Passphrase, but it's still possible that someone would inadvertently call
+    -- this function with a 'Passphrase' that wasn't prepared for
+    -- 'EncryptWithPBKDF2', if this happens, this is a programmer error and we
+    -- must fail hard for this would have dramatic effects later on.
+    case checkPassphrase EncryptWithPBKDF2 (coerce pwd) hpwd of
+        Right () -> attachPrivateKey db wid (xprv, hpwd) EncryptWithPBKDF2
+        Left{} -> fail
+            "Awe crap! The passphrase given to 'attachPrivateKeyFromPwd' wasn't \
+            \rightfully constructed. This is a programmer error. Look for calls \
+            \to this function and make sure that the given Passphrase wasn't not \
+            \prepared using 'EncryptWithScrypt'!"
   where
     db = ctx ^. dbLayer @s @k
 
@@ -1498,16 +1519,31 @@ attachPrivateKey db wid (xprv, hpwd) scheme = db & \DBLayer{..} -> do
         putWalletMeta (PrimaryKey wid) (modify meta)
 
 -- | Execute an action which requires holding a root XPrv.
+--
+-- 'withRootKey' takes a callback function with two arguments:
+--
+--  - The encrypted root private key itself
+--  - The underlying passphrase scheme (legacy or new)
+--
+-- Caller are then expected to use 'preparePassphrase' with the given scheme in
+-- order to "prepare" the passphrase to be used by other function. This does
+-- nothing for the new encryption, but for the legacy encryption with Scrypt,
+-- passphrases needed to first be CBOR serialized and blake2b_256 hashed.
+--
+-- @@@
+--     withRootKey @ctx @s @k ctx wid pwd OnError $ \xprv scheme ->
+--         changePassphrase (preparePassphrase scheme pwd) newPwd xprv
+-- @@@
 withRootKey
     :: forall ctx s k e a. HasDBLayer s k ctx
     => ctx
     -> WalletId
-    -> Passphrase "encryption"
+    -> Passphrase "raw"
     -> (ErrWithRootKey -> e)
-    -> (k 'RootK XPrv -> ExceptT e IO a)
+    -> (k 'RootK XPrv -> PassphraseScheme -> ExceptT e IO a)
     -> ExceptT e IO a
 withRootKey ctx wid pwd embed action = db & \DBLayer{..} -> do
-    xprv <- withExceptT embed $ mapExceptT atomically $ do
+    (xprv, scheme) <- withExceptT embed $ mapExceptT atomically $ do
         mScheme <- (>>= (fmap passphraseScheme . passphraseInfo)) <$>
             lift (readWalletMeta $ PrimaryKey wid)
         mXPrv <- lift $ readPrivateKey $ PrimaryKey wid
@@ -1515,10 +1551,10 @@ withRootKey ctx wid pwd embed action = db & \DBLayer{..} -> do
             (Just (xprv, hpwd), Just scheme) -> do
                 withExceptT (ErrWithRootKeyWrongPassphrase wid) $ ExceptT $
                     return $ checkPassphrase scheme pwd hpwd
-                return xprv
+                return (xprv, scheme)
             _ ->
                 throwE $ ErrWithRootKeyNoRootKey wid
-    action xprv
+    action xprv scheme
   where
     db = ctx ^. dbLayer @s @k
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -128,6 +128,7 @@ import Cardano.Wallet.Api.Types
     , ApiWalletDelegationNext (..)
     , ApiWalletDelegationStatus (..)
     , ApiWalletPassphrase (..)
+    , ApiWalletPassphraseInfo (..)
     , ByronWalletFromXPrvPostData
     , ByronWalletPostData (..)
     , Iso8601Time (..)
@@ -240,7 +241,7 @@ import Data.Function
 import Data.Functor
     ( ($>), (<&>) )
 import Data.Generics.Internal.VL.Lens
-    ( Lens', (.~), (^.) )
+    ( Lens', view, (.~), (^.) )
 import Data.Generics.Labels
     ()
 import Data.List
@@ -777,7 +778,8 @@ mkShelleyWallet ctx wid cp meta pending progress = do
         , delegation = toApiWalletDelegation (meta ^. #delegation)
         , id = ApiT wid
         , name = ApiT $ meta ^. #name
-        , passphrase = ApiT <$> meta ^. #passphraseInfo
+        , passphrase = ApiWalletPassphraseInfo
+            <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
         , state = ApiT progress
         , tip = getWalletTip cp
         }
@@ -845,7 +847,8 @@ mkLegacyWallet _ctx wid cp meta pending progress =
             }
         , id = ApiT wid
         , name = ApiT $ meta ^. #name
-        , passphrase = ApiT <$> meta ^. #passphraseInfo
+        , passphrase = ApiWalletPassphraseInfo
+            <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
         , state = ApiT progress
         , tip = getWalletTip cp
         }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -48,6 +48,7 @@ module Cardano.Wallet.Api.Types
     , ApiStakePoolMetrics (..)
     , ApiWallet (..)
     , ApiWalletPassphrase (..)
+    , ApiWalletPassphraseInfo (..)
     , ApiUtxoStatistics (..)
     , WalletBalance (..)
     , WalletPostData (..)
@@ -148,7 +149,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletBalance (..)
     , WalletId (..)
     , WalletName (..)
-    , WalletPassphraseInfo (..)
     , hashFromText
     , isValidCoin
     , unsafeEpochNo
@@ -318,9 +318,13 @@ data ApiWallet = ApiWallet
     , balance :: !(ApiT WalletBalance)
     , delegation :: !ApiWalletDelegation
     , name :: !(ApiT WalletName)
-    , passphrase :: !(Maybe (ApiT WalletPassphraseInfo))
+    , passphrase :: !(Maybe ApiWalletPassphraseInfo)
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
+    } deriving (Eq, Generic, Show)
+
+data ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
+    { lastUpdatedAt :: UTCTime
     } deriving (Eq, Generic, Show)
 
 data ApiWalletDelegation = ApiWalletDelegation
@@ -690,7 +694,7 @@ data ApiByronWallet = ApiByronWallet
     { id :: !(ApiT WalletId)
     , balance :: !(ApiByronWalletBalance)
     , name :: !(ApiT WalletName)
-    , passphrase :: !(Maybe (ApiT WalletPassphraseInfo))
+    , passphrase :: !(Maybe ApiWalletPassphraseInfo)
     , state :: !(ApiT SyncProgress)
     , tip :: !ApiBlockReference
     } deriving (Eq, Generic, Show)
@@ -989,10 +993,10 @@ instance FromJSON (ApiT WalletName) where
 instance ToJSON (ApiT WalletName) where
     toJSON = toJSON . toText . getApiT
 
-instance FromJSON (ApiT WalletPassphraseInfo) where
-    parseJSON = fmap ApiT . genericParseJSON defaultRecordTypeOptions
-instance ToJSON (ApiT WalletPassphraseInfo) where
-    toJSON = genericToJSON defaultRecordTypeOptions . getApiT
+instance FromJSON ApiWalletPassphraseInfo where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiWalletPassphraseInfo where
+    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON (ApiT SyncProgress) where
     parseJSON = fmap ApiT . genericParseJSON syncProgressOptions

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -344,7 +344,7 @@ data ApiWalletDelegationStatus
     deriving (Eq, Generic, Show)
 
 newtype ApiWalletPassphrase = ApiWalletPassphrase
-    { passphrase :: ApiT (Passphrase "encryption")
+    { passphrase :: ApiT (Passphrase "raw")
     } deriving (Eq, Generic, Show)
 
 data ApiStakePool = ApiStakePool
@@ -374,7 +374,7 @@ data WalletPostData = WalletPostData
     , mnemonicSentence :: !(ApiMnemonicT (AllowedMnemonics 'Shelley))
     , mnemonicSecondFactor :: !(Maybe (ApiMnemonicT (AllowedMnemonics 'SndFactor)))
     , name :: !(ApiT WalletName)
-    , passphrase :: !(ApiT (Passphrase "encryption"))
+    , passphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
 data SomeByronWalletPostData
@@ -388,7 +388,7 @@ data SomeByronWalletPostData
 data ByronWalletPostData mw = ByronWalletPostData
     { mnemonicSentence :: !(ApiMnemonicT mw)
     , name :: !(ApiT WalletName)
-    , passphrase :: !(ApiT (Passphrase "encryption"))
+    , passphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
 data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
@@ -423,13 +423,13 @@ newtype WalletPutData = WalletPutData
     } deriving (Eq, Generic, Show)
 
 data WalletPutPassphraseData = WalletPutPassphraseData
-    { oldPassphrase :: !(ApiT (Passphrase "encryption-old"))
-    , newPassphrase :: !(ApiT (Passphrase "encryption-new"))
+    { oldPassphrase :: !(ApiT (Passphrase "raw"))
+    , newPassphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
 data PostTransactionData n = PostTransactionData
     { payments :: !(NonEmpty (AddressAmount n))
-    , passphrase :: !(ApiT (Passphrase "encryption"))
+    , passphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
 newtype PostTransactionFeeData n = PostTransactionFeeData

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -633,8 +633,8 @@ mkWalletEntity wid meta = Wallet
     { walId = wid
     , walName = meta ^. #name . coerce
     , walCreationTime = meta ^. #creationTime
-    , walPassphraseLastUpdatedAt =
-        W.lastUpdatedAt <$> meta ^. #passphraseInfo
+    , walPassphraseLastUpdatedAt = W.lastUpdatedAt <$> meta ^. #passphraseInfo
+    , walPassphraseScheme = W.passphraseScheme <$> meta ^. #passphraseInfo
     }
 
 mkWalletMetadataUpdate :: W.WalletMetadata -> [Update Wallet]
@@ -657,8 +657,9 @@ metadataFromEntity :: W.WalletDelegation -> Wallet -> W.WalletMetadata
 metadataFromEntity walDelegation wal = W.WalletMetadata
     { name = W.WalletName (walName wal)
     , creationTime = walCreationTime wal
-    , passphraseInfo = W.WalletPassphraseInfo <$>
-        walPassphraseLastUpdatedAt wal
+    , passphraseInfo = W.WalletPassphraseInfo
+        <$> walPassphraseLastUpdatedAt wal
+        <*> walPassphraseScheme wal
     , delegation = walDelegation
     }
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -57,10 +57,11 @@ share
 
 -- Wallet IDs, address discovery state, and metadata.
 Wallet
-    walId                       W.WalletId     sql=wallet_id
-    walCreationTime             UTCTime        sql=creation_time
-    walName                     Text           sql=name
-    walPassphraseLastUpdatedAt  UTCTime Maybe  sql=passphrase_last_updated_at
+    walId                       W.WalletId                sql=wallet_id
+    walCreationTime             UTCTime                   sql=creation_time
+    walName                     Text                      sql=name
+    walPassphraseLastUpdatedAt  UTCTime Maybe             sql=passphrase_last_updated_at
+    walPassphraseScheme         W.PassphraseScheme Maybe  sql=passphrase_scheme
 
     Primary walId
     deriving Show Generic

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -21,7 +21,7 @@ module Cardano.Wallet.DB.Sqlite.Types where
 import Prelude
 
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( AccountingStyle (..), Passphrase (..) )
+    ( AccountingStyle (..), Passphrase (..), PassphraseScheme (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), getAddressPoolGap, mkAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
@@ -430,3 +430,14 @@ instance PersistFieldSql HDPassphrase where
 
 instance Read HDPassphrase where
     readsPrec _ = error "readsPrec stub needed for persistent"
+
+----------------------------------------------------------------------------
+-- PassphraseScheme
+--
+
+instance PersistField PassphraseScheme where
+    toPersistValue = toPersistValue . show
+    fromPersistValue = fromPersistValue >=> pure . read
+
+instance PersistFieldSql PassphraseScheme where
+    sqlType _ = sqlType (Proxy @String)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -296,8 +296,8 @@ unsafeMkByronKeyFromMasterKey derivationPath masterKey = ByronKey
 -- expected to have already checked that. Using an incorrect passphrase here
 -- will lead to very bad thing.
 changePassphraseRnd
-    :: Passphrase "encryption-old"
-    -> Passphrase "encryption-new"
+    :: Passphrase "encryption"
+    -> Passphrase "encryption"
     -> ByronKey depth XPrv
     -> ByronKey depth XPrv
 changePassphraseRnd (Passphrase oldPwd) (Passphrase newPwd) key = ByronKey

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -276,8 +276,8 @@ digestSeq (ShelleyKey k) =
 -- expected to have already checked that. Using an incorrect passphrase here
 -- will lead to very bad thing.
 changePassphraseSeq
-    :: Passphrase "encryption-old"
-    -> Passphrase "encryption-new"
+    :: Passphrase "encryption"
+    -> Passphrase "encryption"
     -> ShelleyKey depth XPrv
     -> ShelleyKey depth XPrv
 changePassphraseSeq (Passphrase oldPwd) (Passphrase newPwd) (ShelleyKey prv) =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -126,6 +126,7 @@ module Cardano.Wallet.Primitive.Types
     , WalletDelegationStatus (..)
     , WalletDelegationNext (..)
     , WalletPassphraseInfo(..)
+    , PassphraseScheme(..)
     , WalletBalance(..)
     , IsDelegatingTo (..)
 
@@ -410,11 +411,22 @@ instance IsDelegatingTo WalletDelegation where
     isDelegatingTo predicate WalletDelegation{active,next} =
         isDelegatingTo predicate active || any (isDelegatingTo predicate) next
 
-newtype WalletPassphraseInfo = WalletPassphraseInfo
-    { lastUpdatedAt :: UTCTime }
-    deriving (Generic, Eq, Ord, Show)
+data WalletPassphraseInfo = WalletPassphraseInfo
+    { lastUpdatedAt :: UTCTime
+    , passphraseScheme :: PassphraseScheme
+    } deriving (Generic, Eq, Ord, Show)
 
 instance NFData WalletPassphraseInfo
+
+-- | A type to capture which encryption scheme should be used
+data PassphraseScheme
+    = EncryptWithScrypt
+        -- ^ Legacy encryption scheme for passphrases
+    | EncryptWithPBKDF2
+        -- ^ Encryption scheme used since cardano-wallet
+    deriving (Generic, Eq, Ord, Show, Read)
+
+instance NFData PassphraseScheme
 
 data WalletBalance = WalletBalance
     { available :: !(Quantity "lovelace" Natural)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -60,6 +60,7 @@ import Cardano.Wallet.Api.Types
     , ApiWalletDelegationNext (..)
     , ApiWalletDelegationStatus (..)
     , ApiWalletPassphrase (..)
+    , ApiWalletPassphraseInfo (..)
     , ByronWalletFromXPrvPostData (..)
     , ByronWalletPostData (..)
     , ByronWalletStyle (..)
@@ -137,7 +138,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletDelegationStatus (..)
     , WalletId (..)
     , WalletName (..)
-    , WalletPassphraseInfo (..)
     , computeUtxoStatistics
     , log10
     , walletNameMaxLength
@@ -335,7 +335,7 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletBalance)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletId)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletName)
-            jsonRoundtripAndGolden $ Proxy @(ApiT WalletPassphraseInfo)
+            jsonRoundtripAndGolden $ Proxy @ApiWalletPassphraseInfo
             jsonRoundtripAndGolden $ Proxy @(ApiT SyncProgress)
             jsonRoundtripAndGolden $ Proxy @StakePoolMetadata
 
@@ -1204,8 +1204,8 @@ instance Arbitrary WalletName where
         | T.length t <= walletNameMinLength = []
         | otherwise = [WalletName $ T.take walletNameMinLength t]
 
-instance Arbitrary WalletPassphraseInfo where
-    arbitrary = WalletPassphraseInfo <$> genUniformTime
+instance Arbitrary ApiWalletPassphraseInfo where
+    arbitrary = ApiWalletPassphraseInfo <$> genUniformTime
 
 instance Arbitrary SyncProgress where
     arbitrary = genericArbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -327,7 +327,7 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @WalletPutData
             jsonRoundtripAndGolden $ Proxy @WalletPutPassphraseData
             jsonRoundtripAndGolden $ Proxy @(ApiT (Hash "Tx"))
-            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "encryption"))
+            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "raw"))
             jsonRoundtripAndGolden $ Proxy @(ApiT Address, Proxy ('Testnet 0))
             jsonRoundtripAndGolden $ Proxy @(ApiT AddressPoolGap)
             jsonRoundtripAndGolden $ Proxy @(ApiT Direction)
@@ -390,20 +390,20 @@ spec = do
             Aeson.parseEither parseJSON [aesonQQ|"-----"|]
                 `shouldBe` (Left @String @(ApiT Address, Proxy ('Testnet 0)) msg)
 
-        it "ApiT (Passphrase \"encryption\") (too short)" $ do
-            let minLength = passphraseMinLength (Proxy :: Proxy "encryption")
+        it "ApiT (Passphrase \"raw\") (too short)" $ do
+            let minLength = passphraseMinLength (Proxy :: Proxy "raw")
             let msg = "Error in $: passphrase is too short: \
                     \expected at least " <> show minLength <> " characters"
             Aeson.parseEither parseJSON [aesonQQ|"patate"|]
-                `shouldBe` (Left @String @(ApiT (Passphrase "encryption")) msg)
+                `shouldBe` (Left @String @(ApiT (Passphrase "raw")) msg)
 
-        it "ApiT (Passphrase \"encryption\") (too long)" $ do
-            let maxLength = passphraseMaxLength (Proxy :: Proxy "encryption")
+        it "ApiT (Passphrase \"raw\") (too long)" $ do
+            let maxLength = passphraseMaxLength (Proxy :: Proxy "raw")
             let msg = "Error in $: passphrase is too long: \
                     \expected at most " <> show maxLength <> " characters"
             Aeson.parseEither parseJSON [aesonQQ|
                 #{replicate (2*maxLength) '*'}
-            |] `shouldBe` (Left @String @(ApiT (Passphrase "encryption")) msg)
+            |] `shouldBe` (Left @String @(ApiT (Passphrase "raw")) msg)
 
         it "ApiT WalletName (too short)" $ do
             let msg = "Error in $: name is too short: \

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -79,6 +79,7 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , Hash (..)
+    , PassphraseScheme (..)
     , PoolId (..)
     , ShowFmt (..)
     , SlotId (..)
@@ -156,13 +157,14 @@ import Test.QuickCheck
     , frequency
     , generate
     , genericShrink
-    , liftArbitrary
     , oneof
     , scale
     , shrinkIntegral
     , shrinkList
     , vectorOf
     )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary )
 import Test.Utils.Time
     ( genUniformTime )
 
@@ -318,8 +320,15 @@ instance Arbitrary WalletMetadata where
     arbitrary =  WalletMetadata
         <$> (WalletName <$> elements ["bulbazaur", "charmander", "squirtle"])
         <*> genUniformTime
-        <*> (fmap WalletPassphraseInfo <$> liftArbitrary genUniformTime)
+        <*> oneof
+            [ pure Nothing
+            , Just <$> (WalletPassphraseInfo <$> genUniformTime <*> arbitrary)
+            ]
         <*> pure (WalletDelegation NotDelegating [])
+
+instance Arbitrary PassphraseScheme where
+    arbitrary = genericArbitrary
+
 
 {-------------------------------------------------------------------------------
                                    Blocks

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -94,6 +94,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Hash (..)
+    , PassphraseScheme (..)
     , Range
     , SlotId (..)
     , SortOrder (..)
@@ -396,7 +397,7 @@ fileModeSpec =  do
             (ctx, DBLayer{..}) <- newDBLayer' (Just f)
             now <- getCurrentTime
             let meta = testMetadata
-                   { passphraseInfo = Just $ WalletPassphraseInfo now }
+                   { passphraseInfo = Just $ WalletPassphraseInfo now EncryptWithPBKDF2 }
             atomically $ unsafeRunExceptT $
                 initializeWallet testPk testCp meta mempty
             destroyDBLayer ctx
@@ -622,7 +623,7 @@ attachPrivateKey DBLayer{..} wid = do
     let Right pwd = fromText "simplevalidphrase"
     seed <- liftIO $ generate $ SomeMnemonic <$> genMnemonic @15
     let k = generateKeyFromSeed (seed, Nothing) pwd
-    h <- liftIO $ encryptPassphrase pwd
+    h <- liftIO $ encryptPassphrase EncryptWithPBKDF2 pwd
     mapExceptT atomically $ putPrivateKey wid (k, h)
     return (k, h)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -56,6 +56,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( KnownNetwork (..), ShelleyKey (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..), Hash (..), PassphraseScheme (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
 import Control.Arrow
     ( left )
 import Control.Monad
@@ -238,6 +240,16 @@ spec = do
 
         it "(xPrvFromStrippedPubXPrv bs) fails if (BS.length bs) /= 96"
             (property prop_xPrvFromStrippedPubXPrvLengthRequirement)
+
+    describe "golden test legacy passphrase encryption" $ do
+        it "compare new implementation with cardano-sl" $ do
+            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "patate"
+            let hash = Hash $ unsafeFromHex
+                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
+                    \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
+                    \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
+                    \414941366a515867386539493d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
 
 {-------------------------------------------------------------------------------
                                Properties

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -121,7 +121,7 @@ instance Show XPrv where
 
 instance {-# OVERLAPS #-} Arbitrary (Passphrase "encryption") where
     arbitrary = do
-        let p = Proxy :: Proxy "encryption"
+        let p = Proxy :: Proxy "raw"
         n <- choose (passphraseMinLength p, passphraseMaxLength p)
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -371,7 +371,7 @@ walletUpdateNameNoSuchWallet wallet@(wid', _, _) wid wName =
 
 walletUpdatePassphrase
     :: (WalletId, WalletName, DummyState)
-    -> Passphrase "encryption-new"
+    -> Passphrase "raw"
     -> Maybe (ShelleyKey 'RootK XPrv, Passphrase "encryption")
     -> Property
 walletUpdatePassphrase wallet new mxprv = monadicIO $ liftIO $ do
@@ -381,7 +381,7 @@ walletUpdatePassphrase wallet new mxprv = monadicIO $ liftIO $ do
         Just (xprv, pwd) -> prop_withPrivateKey wl wid (xprv, pwd)
   where
     prop_withoutPrivateKey wl wid = do
-        attempt <- runExceptT $ W.updateWalletPassphrase wl wid (coerce new, new)
+        attempt <- runExceptT $ W.updateWalletPassphrase wl wid (new, new)
         let err = ErrUpdatePassphraseWithRootKey $ ErrWithRootKeyNoRootKey wid
         attempt `shouldBe` Left err
 
@@ -393,7 +393,7 @@ walletUpdatePassphrase wallet new mxprv = monadicIO $ liftIO $ do
 walletUpdatePassphraseWrong
     :: (WalletId, WalletName, DummyState)
     -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
-    -> (Passphrase "encryption-old", Passphrase "encryption-new")
+    -> (Passphrase "raw", Passphrase "raw")
     -> Property
 walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
     pwd /= coerce old ==> monadicIO $ liftIO $ do
@@ -408,7 +408,7 @@ walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
 walletUpdatePassphraseNoSuchWallet
     :: (WalletId, WalletName, DummyState)
     -> WalletId
-    -> (Passphrase "encryption-old", Passphrase "encryption-new")
+    -> (Passphrase "raw", Passphrase "raw")
     -> Property
 walletUpdatePassphraseNoSuchWallet wallet@(wid', _, _) wid (old, new) =
     wid /= wid' ==> monadicIO $ liftIO $ do
@@ -441,7 +441,7 @@ walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
 walletKeyIsReencrypted
     :: (WalletId, WalletName)
     -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
-    -> Passphrase "encryption-new"
+    -> Passphrase "raw"
     -> Property
 walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
     monadicIO $ liftIO $ do
@@ -449,10 +449,11 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
         let wallet = (wid, wname, DummyState state)
         (WalletLayerFixture _ wl _ _) <- liftIO $ setupFixture wallet
         unsafeRunExceptT $ W.attachPrivateKeyFromPwd wl wid (xprv, pwd)
-        (_,_,_,txOld) <- unsafeRunExceptT $ W.signPayment @_ @_ @DummyTarget wl wid () pwd selection
+        (_,_,_,txOld) <-
+            unsafeRunExceptT $ W.signPayment @_ @_ @DummyTarget wl wid () (coerce pwd) selection
         unsafeRunExceptT $ W.updateWalletPassphrase wl wid (coerce pwd, newPwd)
         (_,_,_,txNew) <-
-            unsafeRunExceptT $ W.signPayment @_ @_ @DummyTarget wl wid () (coerce newPwd) selection
+            unsafeRunExceptT $ W.signPayment @_ @_ @DummyTarget wl wid () newPwd selection
         txOld `shouldBe` txNew
   where
     selection = CoinSelection

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -487,8 +487,8 @@ spec = do
     describe "STAKE_POOLS_JOIN/QUIT_02 -\
         \ Passphrase must have appropriate length" $ do
 
-        let pMax = passphraseMaxLength (Proxy @"encryption")
-        let pMin = passphraseMinLength (Proxy @"encryption")
+        let pMax = passphraseMaxLength (Proxy @"raw")
+        let pMin = passphraseMinLength (Proxy @"raw")
         let tooShort =
                 "passphrase is too short: expected at least 10 characters"
         let tooLong =


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1436 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- c433d811172cf0983ceb741a304ea9785958e7f5
  Augment passphrase metadata info with encryptiohttps://github.com/input-output-hk/cardano-wallet/compare/paweljakubas/1436/byron-wallet-restoration-from-xprv-endpoint-impl...KtorZ/1436/encrypt-with-scrypt?expand=1n scheme
  This to allow distinguish legacy passphrase hashes imported from Daedalus that are
encrypted through Scrypt and the new passphrases that we now encrypt with PBKDF2.

- 413498eb1aa0d389ec2877465d243daaa76743a7
  Actually implement 'checkPassphrase' and 'encryptPassphrase' for Scrypt
  This still misses some test vectors to compare with the legacy implementation. I'll
produce that soon using both Daedalus + cardano-sl code.

# Comments

<!-- Additional comments or screenshots to attach if any -->



<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
