### PR TITLE
Connect a default client for querying tip when instantiating the network layer

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -55,16 +55,12 @@ import Control.Monad.Class.MonadST
     ( MonadST )
 import Control.Monad.Class.MonadSTM
     ( MonadSTM
-    , TMVar
     , TQueue
     , atomically
     , newEmptyTMVarM
-    , newTMVarM
     , newTQueue
     , putTMVar
-    , readTMVar
     , readTQueue
-    , swapTMVar
     , takeTMVar
     , writeTQueue
     )
@@ -194,7 +190,7 @@ withNetworkLayer tr bp addrInfo versionData action = do
 
     -- NOTE: We keep a client connection running just for accessing the node tip.
     nodeTipQ <- atomically newTQueue
-    let nodeTipClient = mkNetworkClient tr bp nodeTipQ localTxSubmissionQ
+    let nodeTipClient = const $ mkNetworkClient tr bp nodeTipQ localTxSubmissionQ
     link =<< async (connectClient nodeTipClient versionData addrInfo)
 
     action


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1452 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->


  Otherwise, the API would fail to access the node tip unless at least one
  wallet exists in the database! :facepalm:

  It happens that "NETWORK - Can query network information" was actually
  failing so far and this scenario tests precisely this. It now passes
  without issue.

  ```hs
  it "NETWORK - Can query network information" $ \ctx -> do
      r <- eventually "wallet's syncProgress = Ready" $ do
          now <- liftIO getCurrentTime
          r <- request @ApiNetworkInformation ctx
              Link.getNetworkInfo Default Empty
          expectResponseCode @IO HTTP.status200 r
          verify r
              [ expectField #nextEpoch ((.> now) . epochStartTime)
              , expectField (#syncProgress . #getApiT) (`shouldBe` Ready)
              ]
          return r

      let currentEpochNum =
              getFromResponse (#networkTip . #epochNumber . #getApiT) r
      let nextEpochNum =
              getFromResponse (#nextEpoch . #epochNumber . #getApiT) r
      nextEpochNum `shouldBe` currentEpochNum + 1
  ```

# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: We need automated CI for cardano-wallet-byron.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
