### PR TITLE
release.nix: Add tests to required job

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,6 @@
 status = [
   "buildkite/cardano-wallet",
+  "ci/hydra:Cardano:cardano-wallet:required",
 ]
 timeout_sec = 3600
 required_approvals = 1

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -77,6 +77,8 @@ test-suite unit
     , contra-tracer
     , fmt
     , hspec
+    , hspec-core
+    , hspec-expectations
     , iohk-monitoring
     , process
     , retry

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -38,6 +38,7 @@ library
     , hspec-core
     , hspec-expectations
     , iohk-monitoring
+    , process
     , QuickCheck
     , stm
     , template-haskell

--- a/lib/test-utils/src/Test/Utils/Paths.hs
+++ b/lib/test-utils/src/Test/Utils/Paths.hs
@@ -6,6 +6,7 @@
 
 module Test.Utils.Paths
     ( getTestData
+    , inNixBuild
     ) where
 
 import Prelude

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -85,6 +85,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
             (hsPkgs."fmt" or (buildDepError "fmt"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (buildDepError "hspec-core"))
+            (hsPkgs."hspec-expectations" or (buildDepError "hspec-expectations"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
             (hsPkgs."process" or (buildDepError "process"))
             (hsPkgs."retry" or (buildDepError "retry"))

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -69,6 +69,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."hspec-core" or (buildDepError "hspec-core"))
           (hsPkgs."hspec-expectations" or (buildDepError "hspec-expectations"))
           (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+          (hsPkgs."process" or (buildDepError "process"))
           (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
           (hsPkgs."stm" or (buildDepError "stm"))
           (hsPkgs."template-haskell" or (buildDepError "template-haskell"))


### PR DESCRIPTION
### Issue Number

Relates to #1283.


### Overview

- Adds hydra to the Bors config so that it must pass for PRs to be merged.
- Adds native build test execution jobs to "required".
- Adds windows cross-build test execution jobs to "required".
- Makes some of the tests pass.

### Comments

* [Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1467#tabs-jobs)
* Constituents of [`required` job](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1467/required/latest-finished#tabs-constituents)

- [x] `native.checks.cardano-wallet-byron.cardano-node-integration.x86_64-linux` - test execution times out after 7200s - it's stuck somewhere ⇒ disabled in #1524, but needs to be investigated.
- [x] `native.checks.cardano-wallet-byron.cardano-node-integration.x86_64-darwin` - as above.
- [x] `x86_64-w64-mingw32.checks.cardano-wallet-byron.cardano-node-integration.x86_64-linux` - also timing out, but may be for a different reason ⇒ disabled in #1524.
- [x] `native.checks.cardano-wallet-jormungandr.integration.x86_64-linux` - has regressed - internet ntp servers not accessible from sandbox  ⇒ disabled in #1524, but needs to be fixed.
- [x] `native.checks.cardano-wallet-jormungandr.integration.x86_64-darwin` - as above.
- [x] `x86_64-w64-mingw32.checks.cardano-wallet-jormungandr.integration.x86_64-linux` ⇒ #1466
- [x] `native.checks.cardano-wallet-launcher.unit.x86_64-linux` - unit test issue StartupSpec fails because stdin is EOF ⇒ fixed here.
- [x] `native.checks.cardano-wallet-launcher.unit.x86_64-darwin` - as above.
- [x] `x86_64-w64-mingw32.checks.cardano-wallet-launcher.unit.x86_64-linux` - wine environment difference ⇒ skip these tests on wine.

#### New failures

- [x] renaming of Cabal test suites ⇒ #1524.
- [x] `native.checks.cardano-wallet-launcher.unit.x86_64-darwin` - started failing after adding tls support ⇒ #1525.