### PR TITLE
Update test node config for 1.8

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -153,7 +153,7 @@ withConfig tdir action =
               )
     setupConfig = do
         dir <- getCanonicalTemporaryDirectory
-            >>= \tmpRoot -> createTempDirectory tmpRoot "cardano-wallet-byron"
+            >>= \tmpRoot -> createTempDirectory tmpRoot "cw-byron"
 
         let nodeConfigFile   = dir </> "node.config"
         let nodeDatabaseDir  = dir </> "node.db"

--- a/lib/byron/test/data/cardano-node/node.config
+++ b/lib/byron/test/data/cardano-node/node.config
@@ -10,8 +10,9 @@
 
 NodeId:
 NumCoreNodes: 1
-PBftSignatureThreshold: 1000000000000000
+PBftSignatureThreshold: 1
 Protocol: RealPBFT
+GenesisFile: genesis.json
 RequiresNetworkMagic: RequiresNoMagic
 TurnOnLogMetrics: False
 TurnOnLogging: True
@@ -61,6 +62,9 @@ options:
     cardano.node.metrics.ChainDB: []
     cardano.node.metrics: []
     cardano.node.metrics: []
+  mapSubtrace:
+    cardano.node.Forge.metrics:
+      subtrace: NoTrace
 
 # these backends are initialized:
 setupBackends:


### PR DESCRIPTION
# Issue Number

None.


# Overview

- Pass in relative path to the genesis file in the node config
- use shorter tmp dirs to avoid a unix 108 char limit on socket paths
- Disable node forge metric logs which are "critical", but fine.
- set PBftSignatureThreshold: 1, which is the max value according to Duncan

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
