### PR TITLE
Use less verbose QuickCheck helpers in tests

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -103,7 +103,7 @@ import Test.QuickCheck
     , genericShrink
     , oneof
     , property
-    , vectorOf
+    , vector
     , (.&&.)
     , (===)
     )
@@ -848,7 +848,7 @@ genMnemonic
     => Gen (Mnemonic mw)
 genMnemonic = do
         let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         let ent = unsafeMkEntropy @(EntropySize mw) bytes
         return $ entropyToMnemonic ent
 

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -51,7 +51,7 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , conjoin
     , property
-    , vectorOf
+    , vector
     , (===)
     , (==>)
     )
@@ -196,7 +196,7 @@ prop_derivationPathRoundTrip pwd pwd' acctIx addrIx =
 instance {-# OVERLAPS #-} Arbitrary (Passphrase "addr-derivation-payload") where
     arbitrary = do
         -- TODO n <- choose (minSeedLengthBytes, 32)
-        bytes <- BS.pack <$> vectorOf 32 arbitrary
+        bytes <- BS.pack <$> vector 32
         return $ Passphrase $ BA.convert bytes
 
 instance Arbitrary (Index 'WholeDomain 'AddressK) where

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -46,6 +46,7 @@ import Data.Word.Odd
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
+    , applyArbitrary2
     , arbitrarySizedBoundedIntegral
     , choose
     , elements
@@ -54,7 +55,7 @@ import Test.QuickCheck
     , shrinkIntegral
     , shrinkList
     , shuffle
-    , vectorOf
+    , vector
     )
 
 import qualified Data.ByteString.Char8 as B8
@@ -76,7 +77,7 @@ data StakePoolsFixture = StakePoolsFixture
 instance Arbitrary SlotId where
     shrink (SlotId ep sl) =
         uncurry SlotId <$> shrink (ep, sl)
-    arbitrary = SlotId <$> arbitrary <*> arbitrary
+    arbitrary = applyArbitrary2 SlotId
 
 instance Arbitrary SlotNo where
     shrink (SlotNo x) = SlotNo <$> shrink x
@@ -103,7 +104,7 @@ arbitraryChainLength = 10
 -- NOTE Expected to have a high entropy
 instance Arbitrary PoolId where
     arbitrary = do
-        bytes <- vectorOf 32 arbitrary
+        bytes <- vector 32
         return $ PoolId $ B8.pack bytes
 
 -- NOTE Excepted to have a reasonnably small entropy
@@ -125,7 +126,7 @@ instance Arbitrary PoolRegistrationCertificate where
 instance Arbitrary StakePoolsFixture where
     arbitrary = do
         poolsNumber <- choose (1, 100)
-        pools <- vectorOf poolsNumber arbitrary
+        pools <- vector poolsNumber
         slotsNumber <- choose (0, 200)
         firstSlot <- arbitrary
         slotsGenerated <-

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -108,8 +108,10 @@ import Test.QuickCheck
     , Property
     , checkCoverage
     , choose
+    , applyArbitrary4
     , counterexample
     , elements
+    , vector
     , frequency
     , property
     , scale
@@ -347,11 +349,7 @@ getEpConsts _ _ = EpochConstants
 -------------------------------------------------------------------------------}
 
 instance Arbitrary BlockHeader where
-    arbitrary = BlockHeader
-        <$> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
+    arbitrary = applyArbitrary4 BlockHeader
     shrink = genericShrink
 
 instance Arbitrary SlotId where
@@ -410,7 +408,7 @@ instance Arbitrary (LowEntropy PoolId) where
         <$> elements [ "ares", "athena", "hades", "hestia", "nemesis" ]
 
 instance Arbitrary PoolId where
-    arbitrary = fmap (PoolId . B8.pack) (vectorOf 32 arbitrary)
+    arbitrary = fmap (PoolId . B8.pack) (vector 32)
 
 instance Arbitrary PoolOwner where
     shrink _  = []

--- a/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetricsSpec.hs
@@ -106,15 +106,15 @@ import Test.QuickCheck
     , NonEmptyList (..)
     , Positive (..)
     , Property
+    , applyArbitrary4
     , checkCoverage
     , choose
-    , applyArbitrary4
     , counterexample
     , elements
-    , vector
     , frequency
     , property
     , scale
+    , vector
     , vectorOf
     , (===)
     )

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -162,8 +162,8 @@ import Test.QuickCheck
     , scale
     , shrinkIntegral
     , shrinkList
-    , vectorOf
     , vector
+    , vectorOf
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary )

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
@@ -27,6 +27,7 @@ import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , applyArbitrary2
     , arbitrarySizedBoundedIntegral
     , property
     , shrinkIntegral
@@ -56,7 +57,7 @@ persistRoundtrip proxy = it
 -------------------------------------------------------------------------------}
 
 instance Arbitrary SlotId where
-    arbitrary = SlotId <$> arbitrary <*> arbitrary
+    arbitrary = applyArbitrary2 SlotId
     shrink (SlotId en sn) = uncurry SlotId <$> shrink (en, sn)
 
 instance Arbitrary EpochNo where

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -140,6 +140,7 @@ import Test.QuickCheck
     , Args (..)
     , Gen
     , Property
+    , applyArbitrary2
     , arbitraryBoundedEnum
     , collect
     , elements
@@ -531,7 +532,7 @@ generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
     genSortOrder = arbitraryBoundedEnum
 
     genRange :: Gen (Range SlotId)
-    genRange = Range <$> arbitrary <*> arbitrary
+    genRange = applyArbitrary2 Range
 
 isUnordered :: Ord x => [x] -> Bool
 isUnordered xs = xs /= L.sort xs

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -27,7 +27,7 @@ import Data.Ratio
 import GHC.TypeLits
     ( natVal )
 import Test.QuickCheck
-    ( Arbitrary (..), Gen, choose, vectorOf )
+    ( Arbitrary (..), Gen, choose, vector )
 
 import qualified Data.ByteString as BS
 
@@ -43,7 +43,7 @@ genMnemonic
     => Gen (Mnemonic mw)
 genMnemonic = do
         let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         let ent = unsafeMkEntropy @(EntropySize mw) bytes
         return $ entropyToMnemonic ent
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
@@ -47,7 +47,7 @@ import Data.Text
 import Test.Hspec
     ( Expectation, Spec, describe, it, shouldBe )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, choose, property, vectorOf )
+    ( Arbitrary (..), Property, choose, property, vector )
 
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -173,8 +173,8 @@ pp hex = Passphrase b
 instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
     arbitrary = do
         n <- choose (minSeedLengthBytes, 64)
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         return $ Passphrase $ BA.convert bytes
 
 instance Arbitrary XPrv where
-    arbitrary = unsafeXPrv . BS.pack <$> vectorOf 128 arbitrary
+    arbitrary = unsafeXPrv . BS.pack <$> vector 128

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -63,7 +63,7 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , choose
     , property
-    , vectorOf
+    , vector
     , (===)
     )
 
@@ -329,7 +329,7 @@ instance Arbitrary AccountingStyle where
 instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
     arbitrary = do
         n <- choose (minSeedLengthBytes, 64)
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         return $ Passphrase $ BA.convert bytes
 
 instance Arbitrary Address where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ShelleySpec.hs
@@ -61,7 +61,7 @@ import Test.QuickCheck
     , expectFailure
     , property
     , suchThat
-    , vectorOf
+    , vector
     , (===)
     , (==>)
     )
@@ -208,7 +208,7 @@ instance Arbitrary AccountingStyle where
 instance {-# OVERLAPS #-} Arbitrary (Passphrase "seed") where
     arbitrary = do
         n <- choose (minSeedLengthBytes, 64)
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         return $ Passphrase $ BA.convert bytes
 
 newtype SingleAddress (n :: NetworkDiscriminant)
@@ -217,7 +217,7 @@ newtype SingleAddress (n :: NetworkDiscriminant)
 
 instance KnownNetwork n => Arbitrary (SingleAddress n) where
     arbitrary = SingleAddress . Address . BS.pack
-        <$> fmap ([addrSingle @n] <>) (vectorOf publicKeySize arbitrary)
+        <$> fmap ([addrSingle @n] <>) (vector publicKeySize)
 
 newtype GroupedAddress (n :: NetworkDiscriminant)
     = GroupedAddress Address
@@ -225,7 +225,7 @@ newtype GroupedAddress (n :: NetworkDiscriminant)
 
 instance KnownNetwork n => Arbitrary (GroupedAddress n) where
     arbitrary = GroupedAddress . Address . BS.pack
-        <$> fmap ([addrGrouped @n] <>) (vectorOf (2*publicKeySize) arbitrary)
+        <$> fmap ([addrGrouped @n] <>) (vector (2*publicKeySize))
 
 newtype InvalidAddress = InvalidAddress Address deriving (Eq, Show)
 
@@ -233,7 +233,7 @@ instance Arbitrary InvalidAddress where
     arbitrary = InvalidAddress . Address . BS.pack <$> do
         firstByte <- suchThat arbitrary (`notElem` validFirstBytes)
         len <- elements validSizes
-        ([firstByte]<>) <$> vectorOf len arbitrary
+        (firstByte:) <$> vector len
       where
         validSizes = [publicKeySize, 2*publicKeySize]
         validFirstBytes =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -87,7 +87,7 @@ import Test.QuickCheck
     , label
     , oneof
     , property
-    , vectorOf
+    , vector
     , (.&&.)
     , (===)
     , (==>)
@@ -556,11 +556,11 @@ genAddress
     => Gen Address
 genAddress = oneof
     [ (\bytes -> Address (BS.pack (addrSingle @network:bytes)))
-        <$> vectorOf Seq.publicKeySize arbitrary
+        <$> vector Seq.publicKeySize
     , (\bytes -> Address (BS.pack (addrGrouped @network:bytes)))
-        <$> vectorOf (2*Seq.publicKeySize) arbitrary
+        <$> vector (2*Seq.publicKeySize)
     , (\bytes -> Address (BS.pack (addrAccount @network:bytes)))
-        <$> vectorOf Seq.publicKeySize arbitrary
+        <$> vector Seq.publicKeySize
     ]
 
 genLegacyAddress :: (Int, Int) -> Gen Address
@@ -571,7 +571,7 @@ genLegacyAddress range = do
             , 216, 24   -- Tag 24
             , 88, fromIntegral n -- Bytes(n), n > 23 && n < 256
             ]
-    addrPayload <- BS.pack <$> vectorOf n arbitrary
+    addrPayload <- BS.pack <$> vector n
     let crc = BS.pack [26,1,2,3,4]
     return $ Address (prefix <> addrPayload <> crc)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -46,8 +46,8 @@ import Test.QuickCheck
     , frequency
     , label
     , property
-    , vectorOf
     , vector
+    , vectorOf
     , withMaxSuccess
     , (===)
     )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -38,8 +38,7 @@ import Numeric.Natural
 import Test.Hspec
     ( Spec, SpecWith, describe, it, shouldSatisfy )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , Gen
+    ( Gen
     , Property
     , choose
     , conjoin
@@ -48,6 +47,7 @@ import Test.QuickCheck
     , label
     , property
     , vectorOf
+    , vector
     , withMaxSuccess
     , (===)
     )
@@ -254,7 +254,7 @@ genUTxO r (Coin dust) = do
     genTxIn :: Int -> Gen [TxIn]
     genTxIn n = do
         ids <- vectorOf n (Hash <$> genBytes 8)
-        ixs <- vectorOf n arbitrary
+        ixs <- vector n
         pure $ zipWith TxIn ids ixs
 
     genTxOut :: Int -> Gen [TxOut]
@@ -264,7 +264,7 @@ genUTxO r (Coin dust) = do
         pure $ zipWith TxOut addrs coins
 
     genBytes :: Int -> Gen ByteString
-    genBytes n = B8.pack <$> vectorOf n arbitrary
+    genBytes n = B8.pack <$> vector n
 
     genCoin :: Gen Coin
     genCoin = Coin <$> frequency

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -64,7 +64,7 @@ import Test.QuickCheck
     , property
     , scale
     , tabulate
-    , vectorOf
+    , vector
     , withMaxSuccess
     , (===)
     , (==>)
@@ -549,20 +549,20 @@ deriving newtype instance Arbitrary a => Arbitrary (ShowFmt a)
 genUTxO :: [Coin] -> Gen UTxO
 genUTxO coins = do
     let n = length coins
-    inps <- vectorOf n arbitrary
+    inps <- vector n
     outs <- genTxOut coins
     return $ UTxO $ Map.fromList $ zip inps outs
 
 genTxOut :: [Coin] -> Gen [TxOut]
 genTxOut coins = do
     let n = length coins
-    outs <- vectorOf n arbitrary
+    outs <- vector n
     return $ zipWith TxOut outs coins
 
 genSelection :: NonEmpty TxOut -> Gen CoinSelection
 genSelection outs = do
     let opts = CS.CoinSelectionOptions (const 100) (const $ pure ())
-    utxo <- vectorOf (NE.length outs * 3) arbitrary >>= genUTxO
+    utxo <- vector (NE.length outs * 3) >>= genUTxO
     case runIdentity $ runExceptT $ largestFirst opts outs utxo of
         Left _ -> genSelection outs
         Right (s,_) -> return s
@@ -595,7 +595,7 @@ instance Arbitrary FeeProp where
     arbitrary = do
         cs <- arbitrary
         utxo <- choose (0, 50)
-            >>= \n -> vectorOf n arbitrary
+            >>= vector
             >>= genUTxO
         fee <- choose (100000, 500000)
         dust <- choose (0, 10000)
@@ -604,7 +604,7 @@ instance Arbitrary FeeProp where
 instance Arbitrary (Hash "Tx") where
     shrink _ = []
     arbitrary = do
-        bytes <- BS.pack <$> vectorOf 32 arbitrary
+        bytes <- BS.pack <$> vector 32
         pure $ Hash bytes
 
 instance Arbitrary Address where
@@ -634,7 +634,7 @@ instance Arbitrary CoinSelection where
                     ]
     arbitrary = do
         outs <- choose (1, 10)
-            >>= \n -> vectorOf n arbitrary
+            >>= vector
             >>= genTxOut
         genSelection (NE.fromList outs)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/MnemonicSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/MnemonicSpec.hs
@@ -59,7 +59,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
-    ( Arbitrary, arbitrary, vectorOf, (===) )
+    ( Arbitrary, arbitrary, (===), vector )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Data.ByteArray as BA
@@ -287,7 +287,7 @@ instance
         let
             size = fromIntegral $ natVal @n Proxy
             entropy =
-                mkEntropy  @n . B8.pack <$> vectorOf (size `quot` 8) arbitrary
+                mkEntropy  @n . B8.pack <$> vector (size `quot` 8)
         in
             either (error . show . UnexpectedEntropyError) id <$> entropy
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/MnemonicSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/MnemonicSpec.hs
@@ -59,7 +59,7 @@ import Test.Hspec
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
-    ( Arbitrary, arbitrary, (===), vector )
+    ( Arbitrary, arbitrary, vector, (===) )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Data.ByteArray as BA

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -151,7 +151,6 @@ import Test.QuickCheck
     , NonNegative (..)
     , NonZero (..)
     , Property
-    , elements
     , Small (..)
     , applyArbitrary2
     , applyArbitrary4
@@ -163,13 +162,14 @@ import Test.QuickCheck
     , choose
     , counterexample
     , cover
+    , elements
     , forAll
     , infiniteList
     , oneof
     , property
     , scale
-    , vector
     , shrinkIntegral
+    , vector
     , withMaxSuccess
     , (.&&.)
     , (=/=)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -151,7 +151,10 @@ import Test.QuickCheck
     , NonNegative (..)
     , NonZero (..)
     , Property
+    , elements
     , Small (..)
+    , applyArbitrary2
+    , applyArbitrary4
     , arbitraryBoundedEnum
     , arbitraryBoundedIntegral
     , arbitraryPrintableChar
@@ -165,8 +168,8 @@ import Test.QuickCheck
     , oneof
     , property
     , scale
+    , vector
     , shrinkIntegral
-    , vectorOf
     , withMaxSuccess
     , (.&&.)
     , (=/=)
@@ -1170,35 +1173,35 @@ instance Arbitrary FeePolicy where
         f (x, y, z) = LinearFee (Quantity x) (Quantity y) (Quantity z)
 
 instance Arbitrary (Hash "Genesis") where
-    arbitrary = Hash . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . BS.pack <$> vector 32
 
 instance Arbitrary (Hash "Block") where
-    arbitrary = Hash . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . BS.pack <$> vector 32
 
 instance Arbitrary (Hash "Account") where
-    arbitrary = Hash . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . BS.pack <$> vector 32
 
 instance Arbitrary (Hash "BlockHeader") where
-    arbitrary = Hash . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . BS.pack <$> vector 32
 
 instance Arbitrary (Hash "Tx") where
     -- No Shrinking
-    arbitrary = oneof
-        [ pure $ Hash $ unsafeFromHex
+    arbitrary = elements
+        [ Hash $ unsafeFromHex
             "0000000000000000000000000000000000000000000000000000000000000001"
-        , pure $ Hash $ unsafeFromHex
+        , Hash $ unsafeFromHex
             "0000000000000000000000000000000000000000000000000000000000000002"
-        , pure $ Hash $ unsafeFromHex
+        , Hash $ unsafeFromHex
             "0000000000000000000000000000000000000000000000000000000000000003"
         ]
 
 -- Same for addresses
 instance Arbitrary Address where
     -- No Shrinking
-    arbitrary = oneof
-        [ pure $ Address "ADDR01"
-        , pure $ Address "ADDR02"
-        , pure $ Address "ADDR03"
+    arbitrary = elements
+        [ Address "ADDR01"
+        , Address "ADDR02"
+        , Address "ADDR03"
         ]
 
 instance Arbitrary AddressState where
@@ -1245,9 +1248,7 @@ makeNonSingletonRangeValid (NonSingletonRange r)
 
 instance Arbitrary TxOut where
     -- No Shrinking
-    arbitrary = TxOut
-        <$> arbitrary
-        <*> arbitrary
+    arbitrary = applyArbitrary2 TxOut
 
 instance Arbitrary TxIn where
     -- No Shrinking
@@ -1264,23 +1265,23 @@ instance Arbitrary UTxO where
     arbitrary = do
         n <- choose (0, 10)
         utxo <- zip
-            <$> vectorOf n arbitrary
-            <*> vectorOf n arbitrary
+            <$> vector n
+            <*> vector n
         return $ UTxO $ Map.fromList utxo
 
 instance Arbitrary Tx where
     shrink (Tx tid ins outs) =
         (flip (Tx tid) outs <$> shrink ins) <> ((Tx tid) ins <$> shrink outs)
     arbitrary = do
-        ins <- choose (1, 3) >>= flip vectorOf arbitrary
-        outs <- choose (1, 3) >>= flip vectorOf arbitrary
+        ins <- choose (1, 3) >>= vector
+        outs <- choose (1, 3) >>= vector
         tid <- genHash
         return $ Tx tid ins outs
       where
-        genHash = oneof
-          [ pure $ Hash "Tx1"
-          , pure $ Hash "Tx2"
-          , pure $ Hash "Tx3"
+        genHash = elements
+          [ Hash "Tx1"
+          , Hash "Tx2"
+          , Hash "Tx3"
           ]
 
 instance Arbitrary BlockHeader where
@@ -1292,10 +1293,10 @@ instance Arbitrary BlockHeader where
         mockBlockHeight :: SlotId -> Quantity "block" Word32
         mockBlockHeight = Quantity . fromIntegral . flatSlot (EpochLength 200)
 
-        genHash = oneof
-            [ pure $ Hash "BLOCK01"
-            , pure $ Hash "BLOCK02"
-            , pure $ Hash "BLOCK03"
+        genHash = elements
+            [ Hash "BLOCK01"
+            , Hash "BLOCK02"
+            , Hash "BLOCK03"
             ]
 
 instance Arbitrary EpochNo where
@@ -1331,7 +1332,7 @@ instance Arbitrary SlotId where
 instance Arbitrary Block where
     shrink (Block h txs _) = Block h <$> shrink txs <*> pure []
     arbitrary = do
-        txs <- choose (0, 500) >>= flip vectorOf arbitrary
+        txs <- choose (0, 500) >>= vector
         Block <$> arbitrary <*> pure txs <*> pure []
 
 instance Arbitrary WalletId where
@@ -1374,11 +1375,7 @@ instance Arbitrary ActiveSlotCoefficient where
         ActiveSlotCoefficient <$> choose (0.001, 1.0)
 
 instance Arbitrary SlotParameters where
-    arbitrary = SlotParameters
-        <$> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
+    arbitrary = applyArbitrary4 SlotParameters
     shrink = genericShrink
 
 instance Arbitrary SyncTolerance where
@@ -1415,7 +1412,7 @@ instance Arbitrary SlotParametersAndTimePoint where
         let timeB = toModifiedJulianDay $ utctDay $ epochStartTime sps minBound
         let timeC = toModifiedJulianDay $ utctDay $ epochStartTime sps maxBound
         let timeD = timeC * 2
-        (lowerBound, upperBound) <- oneof $ fmap pure
+        (lowerBound, upperBound) <- elements
             [ (timeA, timeB)
             , (timeB, timeC)
             , (timeC, timeD)
@@ -1445,7 +1442,7 @@ instance Arbitrary Word31 where
     shrink = shrinkIntegral
 
 instance Arbitrary PoolOwner where
-    arbitrary = PoolOwner . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = PoolOwner . BS.pack <$> vector 32
 
 {-------------------------------------------------------------------------------
                                   Test data

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -140,6 +140,7 @@ import Test.QuickCheck
     , NonEmptyList (..)
     , Positive (..)
     , Property
+    , applyArbitrary2
     , arbitraryBoundedEnum
     , arbitrarySizedBoundedIntegral
     , choose
@@ -149,7 +150,7 @@ import Test.QuickCheck
     , property
     , scale
     , shrinkIntegral
-    , vectorOf
+    , vector
     , withMaxSuccess
     , (===)
     , (==>)
@@ -493,7 +494,7 @@ instance Arbitrary WalletDelegation where
     shrink = genericShrink
     arbitrary = WalletDelegation
         <$> arbitrary
-        <*> oneof [ pure [], vectorOf 1 arbitrary, vectorOf 2 arbitrary ]
+        <*> oneof [ pure [], vector 1, vector 2 ]
 
 instance Arbitrary WalletDelegationStatus where
     shrink = genericShrink
@@ -637,7 +638,7 @@ instance {-# OVERLAPS #-} Arbitrary (ShelleyKey 'RootK XPrv, Passphrase "encrypt
 
 instance Arbitrary SlotId where
     shrink _ = []
-    arbitrary = SlotId <$> arbitrary <*> arbitrary
+    arbitrary = applyArbitrary2 SlotId
 
 instance Arbitrary SlotNo where
     shrink (SlotNo x) = SlotNo <$> shrink x
@@ -681,7 +682,7 @@ instance Arbitrary Tx where
 
 instance Arbitrary TxIn where
     arbitrary = TxIn
-        <$> (Hash . B8.pack <$> vectorOf 32 arbitrary)
+        <$> (Hash . B8.pack <$> vector 32)
         <*> scale (`mod` 3) arbitrary
 
 instance Arbitrary TxOut where

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -119,7 +119,7 @@ import Test.Hspec
     , shouldThrow
     )
 import Test.QuickCheck
-    ( Arbitrary (..), generate, vectorOf )
+    ( Arbitrary (..), generate, vector )
 import Test.Utils.Ports
     ( randomUnusedTCPPorts )
 
@@ -178,7 +178,7 @@ spec = do
             \(nw, _) -> do
                 -- NOTE There's a very little chance of hash clash here. But,
                 -- for what it's worth, I didn't bother retrying.
-                bytes <- BS.pack <$> generate (vectorOf 32 arbitrary)
+                bytes <- BS.pack <$> generate (vector 32)
                 let block = BlockHeader
                         { slotId = SlotId 42 14 -- Anything
                         , blockHeight = Quantity 0 -- Anything
@@ -481,7 +481,7 @@ instance Eq (NextBlocksResult (Cursor t) b) where
     a == b = show a == show b
 
 instance Arbitrary (Hash any) where
-    arbitrary = Hash . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . BS.pack <$> vector 32
 
 getRollForward :: NextBlocksResult (Cursor t) block -> Maybe [block]
 getRollForward AwaitReply = Nothing

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -102,7 +102,7 @@ import Test.Integration.Framework.TestData
 import Test.Integration.Jcli
     ( getBlock0H )
 import Test.QuickCheck
-    ( arbitrary, generate, vectorOf )
+    ( generate, vector )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Codec.Binary.Bech32 as Bech32
@@ -139,7 +139,7 @@ spec = do
         addrs <- listAddresses @n ctx wDest
 
         let hrp = [Bech32.humanReadablePart|addr|]
-        bytes <- generate (vectorOf 32 arbitrary)
+        bytes <- generate (vector 32)
         let (utxoAmt, utxoAddr) =
                 ( 14 :: Natural
                 , (addrs !! 1) ^. #id

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Keys.hs
@@ -45,7 +45,7 @@ import Test.QuickCheck
     , counterexample
     , frequency
     , property
-    , vectorOf
+    , vector
     )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
@@ -128,6 +128,6 @@ genMnemonic
     => Gen (Mnemonic mw)
 genMnemonic = do
         let n = fromIntegral (natVal $ Proxy @(EntropySize mw)) `div` 8
-        bytes <- BS.pack <$> vectorOf n arbitrary
+        bytes <- BS.pack <$> vector n
         let ent = unsafeMkEntropy @(EntropySize mw) bytes
         return $ entropyToMnemonic ent

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/ApiSpec.hs
@@ -48,7 +48,7 @@ import Test.Aeson.Internal.RoundtripSpecs
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldSatisfy )
 import Test.QuickCheck
-    ( Arbitrary (..) )
+    ( Arbitrary (..), applyArbitrary3 )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
@@ -160,10 +160,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 instance Arbitrary AccountState where
-    arbitrary = AccountState
-        <$> arbitrary
-        <*> arbitrary
-        <*> arbitrary
+    arbitrary = applyArbitrary3 AccountState
 
 instance Arbitrary PoolId where
     arbitrary = PoolId . BS.pack

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -95,7 +95,7 @@ import Test.QuickCheck as QC
     , label
     , oneof
     , property
-    , vectorOf
+    , vector
     , withMaxSuccess
     )
 import Test.QuickCheck.Arbitrary.Generic
@@ -296,9 +296,9 @@ instance Arbitrary TestFragment where
         block0H = Hash $ B8.replicate 32 '0'
 
         genSimpleTransactionFragment = do
-            inps <- choose (1, maxNumberOfInputs) >>= flip vectorOf arbitrary
-            creds <- map (,mempty) <$> vectorOf (length inps) arbitrary
-            outs <- choose (1, maxNumberOfOutputs) >>= flip vectorOf arbitrary
+            inps <- choose (1, maxNumberOfInputs) >>= vector
+            creds <- map (,mempty) <$> vector (length inps)
+            outs <- choose (1, maxNumberOfOutputs) >>= vector
             witTag <- elements [TxWitnessUTxO, TxWitnessLegacyUTxO]
             pure $ TestFragment
                 { fragmentGenesis = block0H
@@ -323,21 +323,21 @@ instance Arbitrary TestFragment where
                 }
 
 instance Arbitrary ChimericAccount where
-    arbitrary = ChimericAccount . BS.pack <$> vectorOf 32 arbitrary
+    arbitrary = ChimericAccount . BS.pack <$> vector 32
 
 instance Arbitrary XPrv where
-    arbitrary = unsafeXPrv . BS.pack <$> vectorOf 128 arbitrary
+    arbitrary = unsafeXPrv . BS.pack <$> vector 128
 
 instance Arbitrary Address where
     arbitrary = Address <$> oneof
-        [ BS.pack . ([3] <>) <$> vectorOf 32 arbitrary
-        , BS.pack . ([4] <>) <$> vectorOf 64 arbitrary
-        , BS.pack . ([5] <>) <$> vectorOf 32 arbitrary
-        , BS.pack . ([6] <>) <$> vectorOf 32 arbitrary
+        [ BS.pack . (3:) <$> vector 32
+        , BS.pack . (4:) <$> vector 64
+        , BS.pack . (5:) <$> vector 32
+        , BS.pack . (6:) <$> vector 32
         ]
 
 instance Arbitrary (Hash "Tx") where
-    arbitrary = Hash . B8.pack <$> vectorOf 32 arbitrary
+    arbitrary = Hash . B8.pack <$> vector 32
 
 instance Arbitrary Coin where
     arbitrary = do
@@ -360,7 +360,7 @@ instance Arbitrary TxOut where
     shrink = genericShrink
 
 instance Arbitrary PoolId where
-    arbitrary = PoolId . B8.pack <$> vectorOf 32 arbitrary
+    arbitrary = PoolId . B8.pack <$> vector 32
 
 -- Necessary unsound 'Show' and 'Eq' instances for QuickCheck failure reporting
 instance Show XPrv where


### PR DESCRIPTION
# Issue Number

N/A

# Overview

Using less verbose QuickCheck helpers where applicable. In particular:
- `vectorOf n arbitrary == vector n`
- `oneof [pure x, pure y, ..] == elements [x, y, ..]`
- `X <$> arbitrary <*> arbitrary <*> arbitrary == applyArbitrary3 X`
- other minor simplifications

# Comments
