### PR TITLE
Mark wallet as "not_responding" when underlying workers die

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -374,7 +374,14 @@ data DBLog
     | MsgManualMigrationNeeded DBField Text
     | MsgManualMigrationNotNeeded DBField
     | MsgUpdatingForeignKeysSetting ForeignKeysSetting
+    | MsgFoundDatabase FilePath Text
+    | MsgUnknownDBFile FilePath
     deriving (Generic, Show, Eq, ToJSON)
+
+
+{-------------------------------------------------------------------------------
+                                    Logging
+-------------------------------------------------------------------------------}
 
 data DBField where
     DBField
@@ -442,6 +449,8 @@ instance DefineSeverity DBLog where
         MsgManualMigrationNeeded{} -> Notice
         MsgManualMigrationNotNeeded{} -> Debug
         MsgUpdatingForeignKeysSetting{} -> Debug
+        MsgFoundDatabase _ _ -> Info
+        MsgUnknownDBFile _ -> Notice
 
 instance ToText DBLog where
     toText = \case
@@ -493,6 +502,12 @@ instance ToText DBLog where
             [ "Updating the foreign keys setting to: "
             , T.pack $ show value
             , "."
+            ]
+        MsgFoundDatabase _file wid ->
+            "Found existing wallet: " <> wid
+        MsgUnknownDBFile file -> mconcat
+            [ "Found something other than a database file in "
+            , "the database folder: ", T.pack file
             ]
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -84,7 +84,7 @@ module Cardano.Wallet
     , ErrUpdatePassphrase (..)
     , ErrFetchRewards (..)
     , ErrCheckWalletIntegrity (..)
-    , ErrDeadWallet (..)
+    , ErrWalletNotResponding (..)
 
     -- ** Address
     , listAddresses
@@ -1679,8 +1679,8 @@ data ErrCannotQuit
     deriving (Generic, Eq, Show)
 
 -- | Can't perform given operation because the wallet died.
-newtype ErrDeadWallet
-    = ErrDeadWallet WalletId
+newtype ErrWalletNotResponding
+    = ErrWalletNotResponding WalletId
     deriving (Eq, Show)
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -84,6 +84,7 @@ module Cardano.Wallet
     , ErrUpdatePassphrase (..)
     , ErrFetchRewards (..)
     , ErrCheckWalletIntegrity (..)
+    , ErrDeadWallet (..)
 
     -- ** Address
     , listAddresses
@@ -1677,7 +1678,10 @@ data ErrCannotQuit
     = ErrNotDelegatingOrAboutTo
     deriving (Generic, Eq, Show)
 
-
+-- | Can't perform given operation because the wallet died.
+newtype ErrDeadWallet
+    = ErrDeadWallet WalletId
+    deriving (Eq, Show)
 
 {-------------------------------------------------------------------------------
                                    Utils

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -229,7 +229,7 @@ import Control.Exception
 import Control.Exception.Lifted
     ( finally )
 import Control.Monad
-    ( forM, forM_, unless, void, when )
+    ( forM, unless, void, when )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Monad.Trans.Except
@@ -1720,12 +1720,11 @@ newApiLayer
     -> NetworkLayer IO t Block
     -> TransactionLayer t k
     -> DBFactory IO s k
-    -> [WalletId]
     -> IO ctx
-newApiLayer tr g0 nw tl df wids = do
+newApiLayer tr g0 nw tl df = do
     re <- Registry.empty
     let ctx = ApiLayer tr g0 nw tl df re
-    forM_ wids (registerWorker ctx)
+    listDatabases df >>= mapM_ (registerWorker ctx)
     return ctx
 
 -- | Register a restoration worker to the registry.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -571,6 +571,7 @@ data ApiErrorCode
     | NoSuchEpochNo
     | InvalidDelegationDiscovery
     | NotImplemented
+    | WalletIsDead
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -571,7 +571,7 @@ data ApiErrorCode
     | NoSuchEpochNo
     | InvalidDelegationDiscovery
     | NotImplemented
-    | WalletIsDead
+    | WalletNotResponding
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -67,6 +67,9 @@ data DBFactory m s k = DBFactory
 
     , removeDatabase :: WalletId -> IO ()
         -- ^ Erase any trace of the database
+
+    , listDatabases :: IO [WalletId]
+        -- ^ List existing wallet database found on disk.
     }
 
 -- | A Database interface for storing various things in a DB. In practice,

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1283,11 +1283,14 @@ data SlotParameters = SlotParameters
 data SyncProgress
     = Ready
     | Syncing !(Quantity "percent" Percentage)
+    | Dead
     deriving (Generic, Eq, Show)
 
 instance NFData SyncProgress
 
 instance Ord SyncProgress where
+    Dead <= _ = True
+    _ <= Dead = False
     Ready <= Ready = True
     Ready <= Syncing _ = False
     Syncing _ <= Ready = True
@@ -1299,6 +1302,8 @@ instance Buildable SyncProgress where
             "restored"
         Syncing (Quantity p) ->
             "still restoring (" <> build (toText p) <> ")"
+        Dead ->
+            "dead"
 
 newtype SyncTolerance = SyncTolerance NominalDiffTime
     deriving stock (Generic, Eq, Show)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1283,14 +1283,14 @@ data SlotParameters = SlotParameters
 data SyncProgress
     = Ready
     | Syncing !(Quantity "percent" Percentage)
-    | Dead
+    | NotResponding
     deriving (Generic, Eq, Show)
 
 instance NFData SyncProgress
 
 instance Ord SyncProgress where
-    Dead <= _ = True
-    _ <= Dead = False
+    NotResponding <= _ = True
+    _ <= NotResponding = False
     Ready <= Ready = True
     Ready <= Syncing _ = False
     Syncing _ <= Ready = True
@@ -1302,8 +1302,8 @@ instance Buildable SyncProgress where
             "restored"
         Syncing (Quantity p) ->
             "still restoring (" <> build (toText p) <> ")"
-        Dead ->
-            "dead"
+        NotResponding ->
+            "not responding"
 
 newtype SyncTolerance = SyncTolerance NominalDiffTime
     deriving stock (Generic, Eq, Show)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -155,6 +155,7 @@ x-syncProgress: &syncProgress
       enum:
         - ready
         - syncing
+        - dead
     progress:
       <<: *percentage
       description: |

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -155,7 +155,7 @@ x-syncProgress: &syncProgress
       enum:
         - ready
         - syncing
-        - dead
+        - not_responding
     progress:
       <<: *percentage
       description: |


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1292 (in particular, last comment: https://github.com/input-output-hk/cardano-wallet/issues/1292#issuecomment-581822625)

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->
- 732c6f4ad76ebef0c595beb78cea589567f9c5d0
  :round_pushpin:**move list databases to enable server calling it from API handlers**
  When a wallet worker dies, it is removed from the registry and therefore, is no longer
available for listing. Yet, the file might still exist on disk, so looking at the database
files is more reliable than looking at the registered workers. Should a worker be dead
however, operation on a wallet should be degraded

- b5f560be8667267144f0a75b4a70c8c58626af4b
  :round_pushpin:**create a new 'ErrDeadWallet' to capture dead workers**
  
- da31d825a2d35402b36483c6053fc8c951170972
  :round_pushpin:**list workers through known databases and allow recovering from a dead worker**
  With this, we could still return wallet as degraded when listing and fetching them independently. At
least, it indicates client that something went wrong and despite being stuck, wallets remains accessible.

- 3e499186bc2e0e94762fec82480b88062db5bf11
  :round_pushpin:**marks wallets as 'dead' when fetching them despite a worker being dead**
  
- 33ce4bbfd189e9df1f2c79b39fe952058133747a
  :round_pushpin:**rename 'dead' to 'not_responding'**
  Because 'dead' is a bad word.
 
# Comments

<!-- Additional comments or screenshots to attach if any -->

Kinda hard to test because workers ain't supposed to die in practice :grimacing: ...
So, I injected a temporary fault in the restoration loop to make the worker dies immediately and it works as expected:

<details>
    <summary>curl http://localhost:8090/v2/byron-wallets | jq</summary>

```json
[
  {
    "passphrase": {
      "last_updated_at": "2020-03-23T11:36:12.582891065Z"
    },
    "state": {
      "status": "dead"
    },
    "balance": {
      "total": {
        "quantity": 0,
        "unit": "lovelace"
      },
      "available": {
        "quantity": 0,
        "unit": "lovelace"
      }
    },
    "name": "MyWallet",
    "id": "adc78398110d92af3132488546c6977f61dc0c7e",
    "tip": {
      "height": {
        "quantity": 0,
        "unit": "block"
      },
      "epoch_number": 0,
      "slot_number": 0
    }
  }
]
```
</details>

<details>
    <summary>curl http://localhost:8090/v2/byron-wallets/{walletId} | jq</summary>

```json
{
  "passphrase": {
    "last_updated_at": "2020-03-23T11:36:12.582891065Z"
  },
  "state": {
    "status": "dead"
  },
  "balance": {
    "total": {
      "quantity": 0,
      "unit": "lovelace"
    },
    "available": {
      "quantity": 0,
      "unit": "lovelace"
    }
  },
  "name": "MyWallet",
  "id": "adc78398110d92af3132488546c6977f61dc0c7e",
  "tip": {
    "height": {
      "quantity": 0,
      "unit": "block"
    },
    "epoch_number": 0,
    "slot_number": 0
  }
}
```
</details>

<details>
    <summary>Anything else</summary>

```json
{
  "code": "wallet_is_dead",
  "message": "That's embarassing. My associated worker for adc78398110d92af3132488546c6977f61dc0c7e is no longer responding. This is not something that is supposed to happen. The worker must have left a trace in the logs of severity 'Error' when it died which might explain the cause. Said differently, this wallet won't be accessible until the server is restarted but there are good chances it'll recover itself upon restart."
}
```
</details>

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
