### PR TITLE
make NETWORK_BYRON work on cardano-node and jormungandr

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -47,7 +47,6 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , request
     , verify
-    , waitForNextEpoch
     , (.>)
     )
 import Test.Integration.Framework.TestData
@@ -99,20 +98,17 @@ spec = do
             let getNetworkInfo = request @ApiNetworkInformation ctx
                     Link.getNetworkInfo Default Empty
             w <- emptyRandomWallet ctx
-            waitForNextEpoch ctx
-            r <- eventually "Network info enpoint shows syncProgress = Ready" $ do
+            eventually "Wallet has the same tip as network/information" $ do
                 sync <- getNetworkInfo
                 expectField (#syncProgress . #getApiT) (`shouldBe` Ready) sync
-                return sync
 
-            let epochNum =
-                    getFromResponse (#nodeTip . #epochNumber . #getApiT) r
-            let slotNum =
-                    getFromResponse (#nodeTip . #slotNumber . #getApiT) r
-            let blockHeight =
-                    getFromResponse (#nodeTip . #height) r
+                let epochNum =
+                        getFromResponse (#nodeTip . #epochNumber . #getApiT) sync
+                let slotNum =
+                        getFromResponse (#nodeTip . #slotNumber . #getApiT) sync
+                let blockHeight =
+                        getFromResponse (#nodeTip . #height) sync
 
-            eventually "Wallet has the same tip as network/information" $ do
                 res <- request @ApiByronWallet ctx
                     (Link.getWallet @'Byron w) Default Empty
                 verify res


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 791bc1960b1952577a271084e3be2d150c725dba
  remove waitForNextEpoch from NETWORK_BYRON to make it work on cardano-node


# Comments

The test was failing on cardano-node as it was using `waitForNextEpoch`. I removed it and put the whole action + verification into `eventually`, so hopefully it is not flaky on neither cardano-node nor jormungandr.
