### PR TITLE
Revise exception handling in the chain follower to be more resilient

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -231,7 +231,8 @@ withNetworkLayer tr bp addrInfo versionData action = do
     -- NOTE: We keep a client connection running just for accessing the node tip.
     nodeTipQ <- atomically newTQueue
     let nodeTipClient = const $ mkNetworkClient tr bp nodeTipQ localTxSubmissionQ
-    link =<< async (connectClient tr nodeTipClient versionData addrInfo)
+    let handlers = retryOnConnectionLost tr
+    link =<< async (connectClient tr handlers nodeTipClient versionData addrInfo)
 
     action
         NetworkLayer
@@ -252,7 +253,8 @@ withNetworkLayer tr bp addrInfo versionData action = do
     _initCursor localTxSubmissionQ headers = do
         chainSyncQ <- atomically newTQueue
         let client = const $ mkNetworkClient tr bp chainSyncQ localTxSubmissionQ
-        link =<< async (connectClient tr client versionData addrInfo)
+        let handlers = failOnConnectionLost tr
+        link =<< async (connectClient tr handlers client versionData addrInfo)
         let points = reverse $ genesisPoint : (toPoint getEpochLength <$> headers)
         let policy = constantDelay 500
         let findIt = chainSyncQ `send` CmdFindIntersection points
@@ -424,11 +426,12 @@ mkNetworkClient tr bp chainSyncQ localTxSubmissionQ =
 -- >>> connectClient (mkNetworkClient tr bp queue) mainnetVersionData addrInfo
 connectClient
     :: Tracer IO NetworkLayerLog
+    -> [RetryStatus -> Handler IO Bool]
     -> (ConnectionId LocalAddress -> NetworkClient IO)
     -> (NodeToClientVersionData, CodecCBORTerm Text NodeToClientVersionData)
     -> FilePath
     -> IO ()
-connectClient tr client (vData, vCodec) addr = withIOManager $ \iocp -> do
+connectClient tr handlers client (vData, vCodec) addr = withIOManager $ \iocp -> do
     let vDict = DictVersion vCodec
     let versions = simpleSingletonVersions NodeToClientV_1 vData vDict client
     let tracers = NetworkConnectTracers
@@ -436,42 +439,77 @@ connectClient tr client (vData, vCodec) addr = withIOManager $ \iocp -> do
             , nctHandshakeTracer = contramap MsgHandshakeTracer tr
             }
     let socket = localSnocket iocp addr
-    recovering policy
-        [ const $ Handler handleIOException
-        , const $ Handler handleMuxError
-        ] $ \status -> do
-            traceWith tr $ MsgCouldntConnect (rsIterNumber status)
-            connectTo socket tracers versions addr
+    recovering policy handlers $ \status -> do
+        traceWith tr $ MsgCouldntConnect (rsIterNumber status)
+        connectTo socket tracers versions addr
   where
     -- .25s -> .25s -> .5s → .75s → 1.25s → 2s
     policy :: RetryPolicyM IO
     policy = fibonacciBackoff 250_000 & capDelay 2_000_000
 
-    -- There's a race-condition when starting the wallet and the node at the
-    -- same time: the socket might not be there yet when we try to open it.
-    -- In such case, we simply retry a bit later and hope it's there.
-    handleIOException :: IOException -> IO Bool
-    handleIOException e
-        | isDoesNotExistError e     = pure True
-        | isResourceVanishedError e = do
-            traceWith tr $ MsgConnectionLost (Just e)
-            pure True
-        | otherwise = pure False
-      where
-        isResourceVanishedError = isInfixOf "resource vanished" . show
+-- | Handlers that are retrying on every connection lost.
+retryOnConnectionLost
+    :: Tracer IO NetworkLayerLog
+    -> [RetryStatus -> Handler IO Bool]
+retryOnConnectionLost tr =
+    [ const $ Handler $ handleIOException tr' True
+    , const $ Handler $ handleMuxError tr' True
+    ]
+  where
+    tr' = contramap MsgConnectionLost tr
 
-    -- Recover frmo error when the connection with the node is lost.
-    handleMuxError :: MuxError -> IO Bool
-    handleMuxError = pure . errorType >=> \case
-        MuxUnknownMiniProtocol -> pure False
-        MuxDecodeError -> pure False
-        MuxIngressQueueOverRun -> pure False
-        MuxInitiatorOnly -> pure False
-        MuxIOException e -> handleIOException e
-        MuxBearerClosed -> do
-            traceWith tr $ MsgConnectionLost Nothing
-            pure True
+-- | Handlers that are failing if the connection is lost
+failOnConnectionLost
+    :: Tracer IO NetworkLayerLog
+    -> [RetryStatus -> Handler IO Bool]
+failOnConnectionLost tr =
+    [ const $ Handler $ handleIOException tr' False
+    , const $ Handler $ handleMuxError tr' False
+    ]
+  where
+    tr' = contramap MsgConnectionLost tr
 
+-- There's a race-condition when starting the wallet and the node at the
+-- same time: the socket might not be there yet when we try to open it.
+-- In such case, we simply retry a bit later and hope it's there.
+--
+-- When the node's connection vanished, we may also want to handle things in a
+-- slightly different way depending on whether we are a waller worker or just
+-- the node's tip thread.
+handleIOException
+    :: Tracer IO (Maybe IOException)
+    -> Bool -- ^ 'True' = retry on 'ResourceVanishedError'
+    -> IOException
+    -> IO Bool
+handleIOException tr onResourceVanished e
+    | isDoesNotExistError e =
+        pure True
+
+    | isResourceVanishedError e = do
+        traceWith tr $ Just e
+        pure onResourceVanished
+
+    | otherwise =
+        pure False
+  where
+    isResourceVanishedError = isInfixOf "resource vanished" . show
+
+-- Recover from error when the connection with the node is lost.
+handleMuxError
+    :: Tracer IO (Maybe IOException)
+    -> Bool
+    -> MuxError
+    -> IO Bool
+handleMuxError tr onResourceVanished = pure . errorType >=> \case
+    MuxUnknownMiniProtocol -> pure False
+    MuxDecodeError -> pure False
+    MuxIngressQueueOverRun -> pure False
+    MuxInitiatorOnly -> pure False
+    MuxIOException e ->
+        handleIOException tr onResourceVanished e
+    MuxBearerClosed -> do
+        traceWith tr Nothing
+        pure onResourceVanished
 
 -- | Client for the 'Chain Sync' mini-protocol.
 --

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -64,6 +64,7 @@ import Cardano.Wallet.Network
     ( ErrCurrentNodeTip
     , ErrNetworkUnavailable
     , FollowAction (..)
+    , FollowExit (..)
     , FollowLog
     , NetworkLayer (currentNodeTip, stakeDistribution)
     , follow
@@ -171,8 +172,11 @@ monitorStakePools tr (block0, Quantity k) nl db@DBLayer{..} = do
     cursor <- initCursor
     traceWith tr $ MsgStartMonitoring cursor
     follow nl trFollow cursor forward header >>= \case
-        Nothing    -> pure ()
-        Just point -> do
+        FollowInterrupted -> pure ()
+        FollowFatal -> pure ()
+        FollowException ->
+            monitorStakePools tr (block0, Quantity k) nl db
+        FollowRollback point -> do
             traceWith tr $ MsgRollingBackTo point
             liftIO . atomically $ rollbackTo point
             monitorStakePools tr (block0, Quantity k) nl db

--- a/lib/core/src/Cardano/Pool/Metrics.hs
+++ b/lib/core/src/Cardano/Pool/Metrics.hs
@@ -173,8 +173,7 @@ monitorStakePools tr (block0, Quantity k) nl db@DBLayer{..} = do
     traceWith tr $ MsgStartMonitoring cursor
     follow nl trFollow cursor forward header >>= \case
         FollowInterrupted -> pure ()
-        FollowFatal -> pure ()
-        FollowException ->
+        FollowFailure ->
             monitorStakePools tr (block0, Quantity k) nl db
         FollowRollback point -> do
             traceWith tr $ MsgRollingBackTo point

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -662,8 +662,7 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
     let forward bs h = run $ restoreBlocks @ctx @s @k ctx wid bs h
     liftIO (follow nw tr cps forward (view #header)) >>= \case
         FollowInterrupted -> pure ()
-        FollowFatal -> pure ()
-        FollowException ->
+        FollowFailure ->
             restoreWallet @ctx @s @t @k ctx wid
         FollowRollback point -> do
             rollbackBlocks @ctx @s @k ctx wid point

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -164,6 +164,7 @@ import Cardano.Wallet.Network
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
     , FollowAction (..)
+    , FollowExit (..)
     , FollowLog (..)
     , NetworkLayer (..)
     , follow
@@ -342,6 +343,7 @@ import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Text as T
 
 -- $Development
 -- __Naming Conventions__
@@ -659,8 +661,11 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
     cps <- liftIO $ atomically $ listCheckpoints (PrimaryKey wid)
     let forward bs h = run $ restoreBlocks @ctx @s @k ctx wid bs h
     liftIO (follow nw tr cps forward (view #header)) >>= \case
-        Nothing -> pure ()
-        Just point -> do
+        FollowInterrupted -> pure ()
+        FollowFatal -> pure ()
+        FollowException ->
+            restoreWallet @ctx @s @t @k ctx wid
+        FollowRollback point -> do
             rollbackBlocks @ctx @s @k ctx wid point
             restoreWallet @ctx @s @t @k ctx wid
   where
@@ -708,6 +713,14 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
         <$> withNoSuchWallet wid (readCheckpoint $ PrimaryKey wid)
         <*> withNoSuchWallet wid (readWalletMeta $ PrimaryKey wid)
     let bp = blockchainParameters cp
+
+    unless (cp `isParentOf` NE.head blocks) $ fail $ T.unpack $ T.unwords
+        [ "restoreBlocks: given chain isn't a valid continuation."
+        , "Wallet is at:", pretty (currentTip cp)
+        , "but the given chain continues starting from:"
+        , pretty (header (NE.head blocks))
+        ]
+
     let (filteredBlocks, cps) = NE.unzip $ applyBlocks @s blocks cp
     let slotPoolDelegations =
             [ (slotId, cert)
@@ -756,6 +769,10 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
 
     logDelegation :: (SlotId, DelegationCertificate) -> IO ()
     logDelegation (slotId, cert) = traceWith tr $ MsgDelegation slotId cert
+
+    isParentOf :: Wallet s -> Block -> Bool
+    isParentOf cp = (== parent) . parentHeaderHash . header
+      where parent = headerHash $ currentTip cp
 
 
 -- | Remove an existing wallet. Note that there's no particular work to


### PR DESCRIPTION
The main idea is simply restart the block restoration, so we get to resync from a known state, as if the
wallet was restarted. If this doesn't work, nothing will.

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1468 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->
- d6615e9013e213ce7c74034d058c109337c66238
  :round_pushpin: **revise exception handling in the chain follower to be more resilient**
  The main idea is simply restart the block restoration, so we get to resync from a known state, as if the wallet was restarted. If this doesn't work, nothing will.

- c6bae5acf19877542e8d3e3f0be673fe33411292
  :round_pushpin: **distinguish handlers between wallet workers and node tip workers**
  We let wallet workers die so that they can restart and re-set a new intersection. This is not needed for the node tip worker which can simply keep on retrying (this worker only look for intersection with the genesis point anyway).

- 5d71c302d103d990ae1a116fca47dd5c8c3cc0d4
  :round_pushpin: **remove now network layer test now obsolete**
  The follow loop doesn't automatically retry on exception anymore but leave that decision to the caller. So, there's no need to test that it doesn't retry _too often_ anymore.




# Comments

<!-- Additional comments or screenshots to attach if any -->

Here's what changes in this PR: 

- If we encounter an exception, instead of restarting the chain follower where it was at (which was a faulty state anyway...), we exit it with a special exit value, then it's up to caller to decide what to do.

- On fatal exception or interruption, we let the worker exits and die, as before. 

- On exception however, we'll now restart the entire restore loop; which starts by fetching the latest checkpoints and therefore, can re-init a cursor with the node's network layer and, continue the following where it stopped. This is pretty much equivalent to restarting the server, but on a per-wallet basis. 

Here are a few scenarios I tested manually with this, turning the node's off and on:

<details> 
  <summary>Only node's tip worker</summary>

```
[cardano-wallet.network:Warning:11] [2020-03-26 10:04:12.26 UTC] Connection lost with the node.
[cardano-wallet.network:Notice:11] [2020-03-26 10:04:12.52 UTC] Couldn't connect to node (x2). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:04:12.77 UTC] Couldn't connect to node (x3). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:04:13.27 UTC] Couldn't connect to node (x4). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:04:14.02 UTC] Couldn't connect to node (x5). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:04:15.27 UTC] Couldn't connect to node (x6). Retrying in a bit...
[cardano-wallet.network:Info:11] [2020-03-26 10:04:15.27 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Send MsgProposeVersions (fromList [(NodeToClientV_1,TInt 764824073)])
[cardano-wallet.network:Info:11] [2020-03-26 10:04:15.27 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Recv MsgAcceptVersion NodeToClientV_1 (TInt 764824073)
```
</details>

<details>
  <summary>With a wallet, interruption shorter than message timeout</summary>

```
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.52 UTC] adc78398: Applying blocks [0.14999 ... 0.15998]
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.53 UTC] adc78398: Creating checkpoint at c287feed-[0.15998#15999]
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.53 UTC] adc78398: MyWallet, created at 2020-03-26 10:05:07 UTC, delegating to ∅
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.53 UTC] adc78398: syncProgress: still restoring (0.40%)
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.53 UTC] adc78398: discovered 0 new transaction(s)
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:09.53 UTC] adc78398: local tip: c287feed-[0.15998#15999]
[cardano-wallet.network:Warning:11] [2020-03-26 10:05:10.55 UTC] Connection lost with the node.
[cardano-wallet.wallet-engine:Error:40] [2020-03-26 10:05:10.55 UTC] adc78398: Recoverable error following the chain: ExceptionInLinkedThread ThreadId 41 (MuxError {errorType = MuxBearerClosed, errorMsg = "<socket: 16> closed when reading data, waiting on next header True", errorStack = []})
[cardano-wallet.network:Info:40] [2020-03-26 10:05:10.55 UTC] Looking for an intersection with the node's local chain with: 89d9b5a5-[0.0#0], c287feed-[0.15998#15999]
[cardano-wallet.network:Info:144] [2020-03-26 10:05:13.56 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Send MsgProposeVersions (fromList [(NodeToClientV_1,TInt 764824073)])
[cardano-wallet.network:Info:144] [2020-03-26 10:05:13.56 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Recv MsgAcceptVersion NodeToClientV_1 (TInt 764824073)
[cardano-wallet.network:Info:40] [2020-03-26 10:05:13.60 UTC] Intersection found: c287feed
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.70 UTC] adc78398: Applying blocks [0.15999 ... 0.16998]
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.71 UTC] adc78398: Creating checkpoint at abb4798e-[0.16998#16999]
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.71 UTC] adc78398: MyWallet, created at 2020-03-26 10:05:07 UTC, delegating to ∅
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.71 UTC] adc78398: syncProgress: still restoring (0.43%)
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.71 UTC] adc78398: discovered 0 new transaction(s)
[cardano-wallet.wallet-engine:Info:40] [2020-03-26 10:05:13.71 UTC] adc78398: local tip: abb4798e-[0.16998#16999]
```
</details>

<details>
  <summary>With a wallet, interruption longer than message timeout</summary>

```
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.25 UTC] adc78398: Applying blocks [0.13999 ... 0.14998]
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.26 UTC] adc78398: Creating checkpoint at 97576228-[0.14998#14999]
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.26 UTC] adc78398: MyWallet, created at 2020-03-26 10:06:46 UTC, delegating to ∅
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.26 UTC] adc78398: syncProgress: still restoring (0.38%)
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.26 UTC] adc78398: discovered 0 new transaction(s)
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:06:48.26 UTC] adc78398: local tip: 97576228-[0.14998#14999]
[cardano-wallet.network:Warning:33] [2020-03-26 10:06:49.28 UTC] Connection lost with the node.
[cardano-wallet.wallet-engine:Error:32] [2020-03-26 10:06:49.28 UTC] adc78398: Recoverable error following the chain: ExceptionInLinkedThread ThreadId 33 (MuxError {errorType = MuxBearerClosed, errorMsg = "<socket: 17> closed when reading data, waiting on next header True", errorStack = []})
[cardano-wallet.network:Info:32] [2020-03-26 10:06:49.28 UTC] Looking for an intersection with the node's local chain with: 89d9b5a5-[0.0#0], 97576228-[0.14998#14999]
[cardano-wallet.network:Notice:131] [2020-03-26 10:06:49.54 UTC] Couldn't connect to node (x2). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:06:49.78 UTC] Couldn't connect to node (x3). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:06:50.29 UTC] Couldn't connect to node (x4). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:06:51.04 UTC] Couldn't connect to node (x5). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:06:52.29 UTC] Couldn't connect to node (x6). Retrying in a bit...
[cardano-wallet.network:Warning:131] [2020-03-26 10:06:54.29 UTC] Couldn't connect to node (x7). Retrying in a bit...
[cardano-wallet.network:Warning:131] [2020-03-26 10:06:56.29 UTC] Couldn't connect to node (x8). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:06:58.29 UTC] Couldn't connect to node (x9). Retrying in a bit...
[cardano-wallet.network:Warning:32] [2020-03-26 10:06:59.29 UTC] Couldn't find an intersection in a timely manner. Retrying...
[cardano-wallet.network:Warning:131] [2020-03-26 10:07:00.30 UTC] Couldn't connect to node (x10). Retrying in a bit...
[cardano-wallet.network:Warning:131] [2020-03-26 10:07:02.30 UTC] Couldn't connect to node (x11). Retrying in a bit...
[cardano-wallet.network:Warning:11] [2020-03-26 10:07:04.30 UTC] Couldn't connect to node (x12). Retrying in a bit...
[cardano-wallet.network:Info:11] [2020-03-26 10:07:04.30 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Send MsgProposeVersions (fromList [(NodeToClientV_1,TInt 764824073)])
[cardano-wallet.network:Info:11] [2020-03-26 10:07:04.30 UTC] Mux ConnectionId {localAddress = LocalAddress {getFilePath = ""}, remoteAddress = LocalAddress {getFilePath = "state-node-mainnet/node.socket"}} Recv MsgAcceptVersion NodeToClientV_1 (TInt 764824073)
[cardano-wallet.network:Info:32] [2020-03-26 10:07:04.36 UTC] Intersection found: 97576228
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.48 UTC] adc78398: Applying blocks [0.14999 ... 0.15998]
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.49 UTC] adc78398: Creating checkpoint at c287feed-[0.15998#15999]
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.49 UTC] adc78398: MyWallet, created at 2020-03-26 10:06:46 UTC, delegating to ∅
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.49 UTC] adc78398: syncProgress: still restoring (0.40%)
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.49 UTC] adc78398: discovered 0 new transaction(s)
[cardano-wallet.wallet-engine:Info:32] [2020-03-26 10:07:04.49 UTC] adc78398: local tip: c287feed-[0.15998#15999]
```
</details>

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
