### PR TITLE
API endpoints for byron addresses endpoints 

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -189,5 +189,6 @@ test-suite cardano-node-integration
       Main.hs
   other-modules:
       Cardano.Wallet.Byron.Faucet
+      Test.Integration.Byron.Scenario.API.Addresses
       Test.Integration.Byron.Scenario.API.Transactions
       Test.Integration.Byron.Scenario.CLI.Transactions

--- a/lib/byron/exe/cardano-wallet-byron.hs
+++ b/lib/byron/exe/cardano-wallet-byron.hs
@@ -35,6 +35,7 @@ import Cardano.Chain.Genesis
 import Cardano.CLI
     ( LoggingOptions (..)
     , cli
+    , cmdAddress
     , cmdByronWalletCreate
     , cmdKey
     , cmdMnemonic
@@ -63,7 +64,11 @@ import Cardano.Startup
     , withUtf8Encoding
     )
 import Cardano.Wallet.Api.Client
-    ( byronTransactionClient, byronWalletClient, networkClient )
+    ( byronAddressClient
+    , byronTransactionClient
+    , byronWalletClient
+    , networkClient
+    )
 import Cardano.Wallet.Api.Server
     ( HostPreference, Listen (..) )
 import Cardano.Wallet.Byron
@@ -150,6 +155,7 @@ main = withUtf8Encoding $ do
         <> cmdMnemonic
         <> cmdKey
         <> cmdWallet cmdByronWalletCreate byronWalletClient
+        <> cmdAddress byronAddressClient
         <> cmdTransaction byronTransactionClient byronWalletClient
         <> cmdNetwork networkClient
         <> cmdVersion

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -103,6 +103,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
+import qualified Test.Integration.Byron.Scenario.API.Addresses as AddressesByron
 import qualified Test.Integration.Byron.Scenario.API.Transactions as TransactionsByron
 import qualified Test.Integration.Byron.Scenario.CLI.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.API.ByronTransactions as TransactionsCommon
@@ -119,6 +120,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
         describe "API Specifications" $ specWithServer tr $ do
             TransactionsCLI.spec @n
             WalletsCommon.spec @n
+            AddressesByron.spec @n
             TransactionsByron.spec @n
             TransactionsCommon.spec @n
             Network.spec

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Integration.Byron.Scenario.API.Addresses
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiAddress
+    , ApiByronWallet
+    , ApiT (..)
+    , DecodeAddress
+    , EncodeAddress
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant )
+import Cardano.Wallet.Primitive.Types
+    ( AddressState (..) )
+import Control.Monad
+    ( forM_ )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Test.Hspec
+    ( SpecWith, describe, it, shouldBe )
+import Test.Integration.Framework.DSL
+    ( Context
+    , Headers (..)
+    , Payload (..)
+    , emptyIcarusWallet
+    , emptyRandomWallet
+    , expectErrorMessage
+    , expectListField
+    , expectListSize
+    , expectResponseCode
+    , fixtureIcarusWallet
+    , fixtureRandomWallet
+    , getFromResponse
+    , request
+    , verify
+    , walletId
+    )
+import Test.Integration.Framework.TestData
+    ( errMsg404NoWallet )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall n t.
+    ( DecodeAddress n
+    , EncodeAddress n
+    ) => SpecWith (Context t)
+spec = do
+    describe "BYRON_ADDRESSES" $ do
+        scenario_ADDRESS_LIST_01 @n emptyRandomWallet
+        scenario_ADDRESS_LIST_01 @n emptyIcarusWallet
+
+        scenario_ADDRESS_LIST_02 @n fixtureRandomWallet
+        scenario_ADDRESS_LIST_02 @n fixtureIcarusWallet
+
+        scenario_ADDRESS_LIST_04 @n emptyRandomWallet
+        scenario_ADDRESS_LIST_04 @n emptyIcarusWallet
+
+scenario_ADDRESS_LIST_01
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        )
+    => (Context t -> IO ApiByronWallet)
+    -> SpecWith (Context t)
+scenario_ADDRESS_LIST_01 fixture = it title $ \ctx -> do
+    w <- fixture ctx
+    r <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    verify r [ expectResponseCode @IO HTTP.status200 ]
+    let n = length $ getFromResponse id r
+    forM_ [0..n-1] $ \addrIx -> do
+        expectListField addrIx #state (`shouldBe` ApiT Unused) r
+  where
+    title = "ADDRESS_LIST_01 - Can list known addresses on a default wallet"
+
+scenario_ADDRESS_LIST_02
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        )
+    => (Context t -> IO ApiByronWallet)
+    -> SpecWith (Context t)
+scenario_ADDRESS_LIST_02 fixture = it title $ \ctx -> do
+    w <- fixture ctx
+
+    -- filtering ?state=used
+    rUsed <- request @[ApiAddress n] ctx
+        (Link.listAddresses' @'Byron w (Just Used)) Default Empty
+    verify rUsed
+        [ expectResponseCode @IO HTTP.status200
+        , expectListSize 10 -- NOTE fixture wallets have 10 faucet UTxOs
+        ]
+    let nUsed = length $ getFromResponse id rUsed
+    forM_ [0..nUsed-1] $ \addrIx -> do
+        expectListField addrIx #state (`shouldBe` ApiT Used) rUsed
+
+    -- filtering ?state=unused
+    rUnused <- request @[ApiAddress n] ctx
+        (Link.listAddresses' @'Byron w (Just Unused)) Default Empty
+    let nUnused = length $ getFromResponse id rUnused
+    forM_ [0..nUnused-1] $ \addrIx -> do
+        expectListField addrIx #state (`shouldBe` ApiT Unused) rUnused
+  where
+    title = "ADDRESS_LIST_02 - Can filter used and unused addresses"
+
+scenario_ADDRESS_LIST_04
+    :: forall (n :: NetworkDiscriminant) t.
+        ( DecodeAddress n
+        , EncodeAddress n
+        )
+    => (Context t -> IO ApiByronWallet)
+    -> SpecWith (Context t)
+scenario_ADDRESS_LIST_04 fixture = it title $ \ctx -> do
+    w <- fixture ctx
+    _ <- request @() ctx (Link.deleteWallet @'Byron w) Default Empty
+    r <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    verify r
+        [ expectResponseCode @IO HTTP.status404
+        , expectErrorMessage $ errMsg404NoWallet $ w ^. walletId
+        ]
+  where
+    title = "ADDRESS_LIST_04 - Delete wallet"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -440,6 +440,11 @@ spec = do
             , "Available commands:"
             , "  list                     List all known addresses of a given"
             , "                           wallet."
+            , "  create                   Create a new random address. Only"
+            , "                           available for random wallets. The"
+            , "                           address index is optional, give none"
+            , "                           to let the wallet generate a random"
+            , "                           one."
             ]
 
         ["address", "list", "--help"] `shouldShowUsage`
@@ -452,6 +457,20 @@ spec = do
             , "                           API. (default: 8090)"
             , "  --state STRING           only addresses with the given state:"
             , "                           either 'used' or 'unused'."
+            ]
+
+        ["address", "create", "--help"] `shouldShowUsage`
+            [ "Usage:  address create [--port INT] [--address-index INDEX]"
+            , "                       WALLET_ID"
+            , "  Create a new random address. Only available for random wallets."
+            , "  The address index is optional, give none to let the wallet"
+            , "  generate a random one."
+            , ""
+            , "Available options:"
+            , "  -h,--help                Show this help text"
+            , "  --port INT               port used for serving the wallet"
+            , "                           API. (default: 8090)"
+            , "  --address-index INDEX    A derivation index for the address"
             ]
 
         ["stake-pool", "list", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -914,7 +914,7 @@ fixtureWalletWith ctx coins0 = do
                     (Link.getWallet @'Shelley dest) Default Empty
         addrs <- fmap (view #id) . getFromResponse id
             <$> request @[ApiAddress n] ctx
-                    (Link.listAddresses dest) Default Empty
+                    (Link.listAddresses @'Shelley dest) Default Empty
         let payments = for (zip coins addrs) $ \(amt, addr) -> [aesonQQ|{
                 "address": #{addr},
                 "amount": {
@@ -1134,7 +1134,7 @@ listAddresses
     -> ApiWallet
     -> IO [ApiAddress n]
 listAddresses ctx w = do
-    let link = Link.listAddresses w
+    let link = Link.listAddresses @'Shelley w
     (_, addrs) <- unsafeRequest @[ApiAddress n] ctx link Empty
     return addrs
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Addresses.hs
@@ -76,7 +76,7 @@ spec = do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
         w <- emptyWallet ctx
         r <- request @[ApiAddress n] ctx
-            (Link.listAddresses w) Default Empty
+            (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status200 r
         expectListSize g r
         forM_ [0..(g-1)] $ \addrNum -> do
@@ -86,7 +86,7 @@ spec = do
         let g = 15
         w <- emptyWalletWith ctx ("Wallet", "cardano-wallet", g)
         r <- request @[ApiAddress n] ctx
-            (Link.listAddresses w) Default Empty
+            (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status200 r
         expectListSize g r
         forM_ [0..(g-1)] $ \addrNum -> do
@@ -96,14 +96,14 @@ spec = do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
         w <- fixtureWallet ctx
         rUsed <- request @[ApiAddress n] ctx
-            (Link.listAddresses' w (Just Used)) Default Empty
+            (Link.listAddresses' @'Shelley w (Just Used)) Default Empty
         expectResponseCode @IO HTTP.status200 rUsed
         expectListSize 10 rUsed
         forM_ [0..9] $ \addrNum -> do
             expectListField
                 addrNum (#state . #getApiT) (`shouldBe` Used) rUsed
         rUnused <- request @[ApiAddress n] ctx
-            (Link.listAddresses' w (Just Unused)) Default Empty
+            (Link.listAddresses' @'Shelley w (Just Unused)) Default Empty
         expectResponseCode @IO HTTP.status200 rUnused
         expectListSize g rUnused
         forM_ [10..(g-1)] $ \addrNum -> do
@@ -114,9 +114,9 @@ spec = do
         $ \ctx -> do
         w <- emptyWallet ctx
         rUsed <- request @[ApiAddress n] ctx
-            (Link.listAddresses' w (Just Used)) Default Empty
+            (Link.listAddresses' @'Shelley w (Just Used)) Default Empty
         rUnused <- request @[ApiAddress n] ctx
-            (Link.listAddresses' w (Just Unused)) Default Empty
+            (Link.listAddresses' @'Shelley w (Just Unused)) Default Empty
         expectResponseCode @IO HTTP.status200 rUsed
         expectListSize 0 rUsed
         expectResponseCode @IO HTTP.status200 rUnused
@@ -143,7 +143,7 @@ spec = do
         let withQuery f (method, link) = (method, link <> "?state=" <> T.pack f)
         forM_ filters $ \fil -> it fil $ \ctx -> do
             w <- emptyWallet ctx
-            let link = withQuery fil $ Link.listAddresses w
+            let link = withQuery fil $ Link.listAddresses @'Shelley w
             r <- request @[ApiAddress n] ctx link Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status400
@@ -159,7 +159,7 @@ spec = do
 
         -- make sure all addresses in address_pool_gap are 'Unused'
         r <- request @[ApiAddress n] ctx
-            (Link.listAddresses wDest) Default Empty
+            (Link.listAddresses @'Shelley wDest) Default Empty
         verify r
             [ expectResponseCode @IO HTTP.status200
             , expectListSize 10
@@ -195,7 +195,7 @@ spec = do
 
         -- verify new address_pool_gap has been created
         rAddr <- request @[ApiAddress n] ctx
-            (Link.listAddresses wDest) Default Empty
+            (Link.listAddresses @'Shelley wDest) Default Empty
         verify rAddr
             [ expectResponseCode @IO HTTP.status200
             , expectListSize 20
@@ -212,6 +212,6 @@ spec = do
         _ <- request @ApiWallet ctx
             (Link.deleteWallet @'Shelley w) Default Empty
         r <- request @[ApiAddress n] ctx
-            (Link.listAddresses w) Default Empty
+            (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/HWWallets.hs
@@ -310,7 +310,7 @@ spec = do
 
             let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
             r <- request @[ApiAddress n] ctx
-                (Link.listAddresses wPub) Default Empty
+                (Link.listAddresses @'Shelley wPub) Default Empty
             expectResponseCode @IO HTTP.status200 r
             expectListSize g r
             forM_ [0..(g-1)] $ \addrNum -> do
@@ -332,7 +332,7 @@ spec = do
             let wPub = getFromResponse id rRestore
 
             r <- request @[ApiAddress n] ctx
-                (Link.listAddresses wPub) Default Empty
+                (Link.listAddresses @'Shelley wPub) Default Empty
             expectResponseCode @IO HTTP.status200 r
             expectListSize addrPoolGap r
             forM_ [0..(addrPoolGap-1)] $ \addrNum -> do

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -60,6 +60,10 @@ module Cardano.Wallet.Api
         , GetByronUTxOsStatistics
         , PutByronWalletPassphrase
 
+    , ByronAddresses
+        , PostByronAddress
+        , ListByronAddresses
+
     , ByronTransactions
         , CreateByronTransaction
         , ListByronTransactions
@@ -103,6 +107,7 @@ import Cardano.Wallet.Api.Types
     , ApiNetworkParameters
     , ApiNetworkTip
     , ApiPoolId
+    , ApiPostRandomAddressData
     , ApiSelectCoinsDataT
     , ApiStakePool
     , ApiT
@@ -172,6 +177,7 @@ type Api n =
     :<|> Transactions n
     :<|> StakePools n
     :<|> ByronWallets
+    :<|> ByronAddresses n
     :<|> ByronTransactions n
     :<|> ByronMigrations n
     :<|> Network
@@ -414,6 +420,30 @@ type PutByronWalletPassphrase = "byron-wallets"
     :> "passphrase"
     :> ReqBody '[JSON] ByronWalletPutPassphraseData
     :> PutNoContent
+
+{-------------------------------------------------------------------------------
+                                  Addresses
+
+  See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Addresses
+-------------------------------------------------------------------------------}
+
+type ByronAddresses n =
+    PostByronAddress n
+    :<|> ListByronAddresses n
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronAddress
+type PostByronAddress n = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "addresses"
+    :> ReqBody '[JSON] ApiPostRandomAddressData
+    :> PostCreated '[JSON] (ApiAddressT n)
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronAddresses
+type ListByronAddresses n = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "addresses"
+    :> QueryParam "state" (ApiT AddressState)
+    :> Get '[JSON] [ApiAddressT n]
 
 {-------------------------------------------------------------------------------
                                  Byron Transactions

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -51,7 +51,7 @@ module Cardano.Wallet.Api.Link
     , forceResyncWallet
 
       -- * Addresses
-    , postAddress
+    , postRandomAddress
     , listAddresses
     , listAddresses'
 
@@ -262,13 +262,13 @@ forceResyncWallet w = discriminate @style
 -- Addresses
 --
 
-postAddress
+postRandomAddress
     :: forall w.
         ( HasType (ApiT WalletId) w
         )
     => w
     -> (Method, Text)
-postAddress w =
+postRandomAddress w =
     endpoint @(Api.PostByronAddress Net) (wid &)
   where
     wid = w ^. typed @(ApiT WalletId)

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -51,6 +51,7 @@ module Cardano.Wallet.Api.Link
     , forceResyncWallet
 
       -- * Addresses
+    , postAddress
     , listAddresses
     , listAddresses'
 
@@ -261,24 +262,38 @@ forceResyncWallet w = discriminate @style
 -- Addresses
 --
 
-listAddresses
+postAddress
     :: forall w.
         ( HasType (ApiT WalletId) w
+        )
+    => w
+    -> (Method, Text)
+postAddress w =
+    endpoint @(Api.PostByronAddress Net) (wid &)
+  where
+    wid = w ^. typed @(ApiT WalletId)
+
+listAddresses
+    :: forall style w.
+        ( HasType (ApiT WalletId) w
+        , Discriminate style
         )
     => w
     -> (Method, Text)
 listAddresses w =
-    listAddresses' w Nothing
+    listAddresses' @style w Nothing
 
 listAddresses'
-    :: forall w.
+    :: forall style w.
         ( HasType (ApiT WalletId) w
+        , Discriminate style
         )
     => w
     -> Maybe AddressState
     -> (Method, Text)
-listAddresses' w mstate =
-    endpoint @(Api.ListAddresses Net) (\mk -> mk wid (ApiT <$> mstate))
+listAddresses' w mstate = discriminate @style
+    (endpoint @(Api.ListAddresses Net) (\mk -> mk wid (ApiT <$> mstate)))
+    (endpoint @(Api.ListByronAddresses Net) (\mk -> mk wid (ApiT <$> mstate)))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -693,7 +693,10 @@ byronServer byron icarus ntp =
 
     byronAddresses :: Server (ByronAddresses n)
     byronAddresses =
-             postRandomAddress byron
+             (\wid s -> withLegacyLayer wid
+                (byron, postRandomAddress byron wid s)
+                (icarus, throwError err403)
+             )
         :<|> (\wid s -> withLegacyLayer wid
                 (byron , listAddresses byron (const pure) wid s)
                 (icarus, listAddresses icarus (const pure) wid s)

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -15,9 +15,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
--- NOTE: Temporary
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -630,6 +630,7 @@ data ApiErrorCode
     | InvalidDelegationDiscovery
     | NotImplemented
     | WalletNotResponding
+    | AddressAlreadyExists
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -244,8 +244,6 @@ import GHC.TypeLits
     ( KnownNat, Nat, Symbol )
 import Numeric.Natural
     ( Natural )
-import Safe
-    ( toEnumMay )
 import Servant.API
     ( MimeRender (..), MimeUnrender (..), OctetStream )
 import Web.HttpApiData
@@ -1266,15 +1264,8 @@ instance
   , Bounded (Index derivation level)
   ) => FromJSON (ApiT (Index derivation level)) where
     parseJSON bytes = do
-        n <- parseJSON bytes
-        case toEnumMay n of
-            Just ix -> pure (ApiT ix)
-            Nothing -> fail $ unwords
-                [ "Couldn't parse derivation index. Expected an integer between"
-                , show (minBound @(Index derivation level))
-                , "and"
-                , show (maxBound @(Index derivation level))
-                ]
+        n <- parseJSON @Int bytes
+        eitherToParser . bimap ShowFmt ApiT . fromText . T.pack $ show n
 
 instance
   ( Enum (Index derivation level)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -25,8 +25,13 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Random
     -- ** State
       RndState (..)
     , mkRndState
-    ) where
 
+    -- ** Low-level API
+    , addDiscoveredAddress
+    , deriveRndStateAddress
+    , findUnusedPath
+    , unavailablePaths
+    ) where
 import Prelude
 
 import Cardano.Byron.Codec.Cbor

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -65,7 +65,6 @@ import Cardano.Crypto.Wallet
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..)
     , ChimericAccount (..)
-    , DelegationAddress (..)
     , Depth (..)
     , DerivationType (..)
     , HardDerivation (..)
@@ -74,6 +73,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
+    , PaymentAddress (..)
     , PersistPublicKey (..)
     , SoftDerivation (..)
     , WalletKey (..)
@@ -687,7 +687,7 @@ instance
                 (Just i1, Just i2) -> compare i1 i2
 
 instance
-    ( DelegationAddress n k
+    ( PaymentAddress n k
     ) => KnownAddresses (SeqState n k) where
     knownAddresses s =
         let
@@ -699,16 +699,11 @@ instance
                 take (length ixs) $ drop (length xs - internalGap) xs
             changeAddresses =
                 discardUndiscoveredChange $
-                    addresses mkAddress (internalPool s)
+                    addresses (liftPaymentAddress @n @k) (internalPool s)
             nonChangeAddresses =
-                addresses mkAddress (externalPool s)
+                addresses (liftPaymentAddress @n @k) (externalPool s)
         in
             nonChangeAddresses <> changeAddresses
-
-        where
-          mkAddress fingerprint = liftDelegationAddress @n @k
-              fingerprint
-              (rewardAccountKey s)
 
 instance forall n k. HasRewardAccount (SeqState n k) where
     type RewardAccountKey (SeqState n k) = k

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiPostRandomAddressData.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiPostRandomAddressData.json
@@ -1,0 +1,40 @@
+{
+    "seed": -1497831599329803574,
+    "samples": [
+        {
+            "passphrase": "YEo3Vh%tK4sjc7`LL)RMἡPTxZZ{QBJ7ZNY?ZPdy)saUx ",
+            "address_index": 3479812113
+        },
+        {
+            "passphrase": "3=^e)0cVgYy|Q#oH\"SR<t^~bO)oc}ClBgA𧛇E5YpO*5d[Ax𤣣)l]lo<p+;8#=1u[z0#)𢯷w}$[8WiU;<O}2/ORl_y4GgK/-ㅙNGq4<w눤*jE+s/jN#USR?'c9Hx\",i'TH~CXE𠪌EOP=mF噑vO\\O/h#x=6}𤶴𨢃9戉W3{'x|I%]&;,plydo8u-fMt1"
+        },
+        {
+            "passphrase": "u1mk0`ZLc-*(Xg[c^HvX12W1z^:ㄽJT:x@.FQ-$+.qk`G5WVmJAR-6`$f3C;'1||+QeeB䳱:_bISm_%EBFmW&VOR𦽏n2𠵠JJ|e:s< r RPlu/W;dZo<SO!|V`w]>ZVdD葊[8)tCZ{@M<jd&왯f)Ha}j7^_~Fl4t.AJh𥃆",
+            "address_index": 3089404203
+        },
+        {
+            "passphrase": "|z&hG뎜Kmd$6b)!:p교O1U|tb𧣸X&}#\"'@LWG(WbA,},^`|쐘.W[A~^ht99\"=A𧋭LOY[Er&@D~_k?$-,_flwPt-SFP3ye')7sCf.UzM'1t\\iES*tWB|&N=+jlPmMB 𦴨|*K+j7V;X*7Q:#(T?:*^e&d6L(Y-M/y.-嵐.(oxb[&]\"<me!葔+~5럨2cTxh!;(KFj\"{|JA^2B_Z8b)]Bq[1<c;`1?^~e$6u!k;gU(W^T)V-u[9j-Wk%dfNgX\"b;AI",
+            "address_index": 1785310246
+        },
+        {
+            "passphrase": "𦂺G+]-ZS'%)vshF:tJS*Cd,H㯶]*yfYA:j,V479}wfNJ&*6m!{NXShkjT]+8",
+            "address_index": 330114776
+        },
+        {
+            "passphrase": "U_E0,:bB(3홫d9N@dxR:TL:s0>|4n{/+lo3P\"(#yabl`.\\?w@k"
+        },
+        {
+            "passphrase": "XY@GvD2 6KG$EupOD':X!dfdL3u=zh1VcFqkD@W=Ap\\~i*jo1YImbf\")*8UL='%jBlYY.`**3 a?9b𠿇'UW=:3c*7P}I?dLnp"
+        },
+        {
+            "passphrase": ")c{c1}((U#aGtast$Y{'7XTp.𥳂.$!bgTI`/Oo@hL]7gUds^E𣈥냣7𤴎au~_EV𒈸$K=bGK6\".p9A𪓣coNv6k|uw𢝌?%mZczETu-}6emnr%=tSx𫗧fC09gs^=y)tWcEXS:Dc0 CFRs!(WYi[SP4IH:s/p2imTdQlE$op"
+        },
+        {
+            "passphrase": "T'/n_Os8^KeFX::A#W`By4T\\G/gna9\\wmspjA\\"
+        },
+        {
+            "passphrase": "*}/{Sr*YyI\"&鸉^h<W퓡V}A*{mo1oNj9\"*r[9(v>u,^Q2>v>W_ypTN*H9𠌂 ~屝'!=2A7Ntu76ivb&G(&S즲ᗵ{㼆c4zl쨣1-v3b>=zGW5X(xZ^}f2K{V-Cv;BbO8aBNg0&sgrp抗'bsru~k;O%XwUe~P.[U}53[nW--s.𡵛O'JOI2IUr%m枻Y*'G}E",
+            "address_index": 3416170945
+        }
+    ]
+}

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -53,6 +53,7 @@ import Cardano.Wallet.Api.Types
     ( ApiEpochNumber
     , ApiNetworkTip
     , ApiPoolId
+    , ApiPostRandomAddressData
     , ApiSelectCoinsData
     , ApiT (..)
     , ApiTxId
@@ -971,6 +972,21 @@ instance Malformed (BodyParam ApiNetworkTip) where
 instance Malformed (BodyParam PostExternalTransactionData)
 -- no cases here as all bad requests are served by ErrDecodeSignedTxWrongPayload
 -- in Server.hs. Tested by integration tests.
+
+instance Malformed (BodyParam ApiPostRandomAddressData) where
+    malformed = first (BodyParam . Aeson.encode) <$>
+        [ ( [aesonQQ|
+            { "passphrase": "Secure Passphrase"
+            , "address_index": "not_a_number"
+            }|]
+          , "Error in $['address_index']: parsing Int failed, expected Number, but encountered String"
+          )
+        , ( [aesonQQ|
+            { "address_index": 0
+            }|]
+          , "Error in $: parsing Cardano.Wallet.Api.Types.ApiPostRandomAddressData(ApiPostRandomAddressData) failed, key 'passphrase' not found"
+          )
+        ]
 
 --
 -- Class instances (Header)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -47,6 +47,7 @@ import Cardano.Wallet.Api.Types
     , ApiNetworkParameters (..)
     , ApiNetworkTip (..)
     , ApiNtpStatus (..)
+    , ApiPostRandomAddressData
     , ApiSelectCoinsData (..)
     , ApiStakePool (..)
     , ApiStakePoolMetrics (..)
@@ -346,6 +347,7 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @ApiWalletPassphraseInfo
             jsonRoundtripAndGolden $ Proxy @(ApiT SyncProgress)
             jsonRoundtripAndGolden $ Proxy @StakePoolMetadata
+            jsonRoundtripAndGolden $ Proxy @ApiPostRandomAddressData
 
     describe "Textual encoding" $ do
         describe "Can perform roundtrip textual encoding & decoding" $ do
@@ -1504,6 +1506,10 @@ instance Arbitrary TxStatus where
 instance Arbitrary (Quantity "block" Natural) where
     arbitrary = fmap (Quantity . fromIntegral) (arbitrary @Word32)
 
+instance Arbitrary ApiPostRandomAddressData where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery
 
@@ -1690,6 +1696,9 @@ instance ToSchema ApiWalletDelegationNext where
 
 instance ToSchema ApiWalletDelegation where
     declareNamedSchema _ = declareSchemaForDefinition "ApiWalletDelegation"
+
+instance ToSchema ApiPostRandomAddressData where
+    declareNamedSchema _ = declareSchemaForDefinition "ApiPostRandomAddressData"
 
 -- | Utility function to provide an ad-hoc 'ToSchema' instance for a definition:
 -- we simply look it up within the Swagger specification.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -459,7 +459,7 @@ prop_changeIsOnlyKnownAfterGeneration (intPool, extPool) =
         s0 :: SeqState 'Mainnet ShelleyKey
         s0 = SeqState intPool extPool emptyPendingIxs rewardAccount
         addrs0 = knownAddresses s0
-        (change, s1) = genChange (delegationAddress @'Mainnet) s0
+        (change, s1) = genChange (\k _ -> paymentAddress @'Mainnet k) s0
         addrs1 = knownAddresses s1
     in conjoin
         [ prop_addrsNotInInternalPool addrs0

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -324,7 +324,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         fmtResult "getUTxOsStatistics " t3
 
         t4 <- measureApiLogs tvar
-            (request @[ApiAddress n] ctx (Link.listAddresses wal1) Default Empty)
+            (request @[ApiAddress n] ctx (Link.listAddresses @'Shelley wal1) Default Empty)
 
         fmtResult "listAddresses      " t4
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -638,6 +638,13 @@ x-delegationTarget: &delegationTarget
   <<: *stakePoolId
   description: A unique Stake-Pool identifier (present only if status = `delegating`)
 
+x-addressIndex: &addressIndex
+  type: number
+  minimum: 0
+  maximum: 4294967296 # 2 ^ 32, whole range (soft and hard) for random addresses.
+  description: |
+    An optional address derivation index. Leave out to get an address
+    with a randomly generated index.
 
 #############################################################################
 #                                                                           #
@@ -941,7 +948,6 @@ components:
         - *ApiWalletPostData
 
     ApiByronWalletRandomPostData: &ApiByronWalletRandomPostData
-      description: test
       type: object
       required:
         - name
@@ -1071,6 +1077,13 @@ components:
       properties:
         payments: *transactionOutputs
 
+    ApiPostRandomAddressData: &ApiPostRandomAddressData
+      type: object
+      required:
+        - passphrase
+      properties:
+        passphrase: *walletPassphrase
+        address_index: *addressIndex
 
 #############################################################################
 #                                                                           #
@@ -1547,6 +1560,18 @@ x-responsesGetNetworkParameters: &responsesGetNetworkParameters
       application/json:
         schema: *ApiNetworkParameters
 
+x-responsesPostRandomAddress: &responsesPostRandomAddress
+  <<: *responsesErr400
+  <<: *responsesErr403
+  <<: *responsesErr405
+  <<: *responsesErr406
+  <<: *responsesErr415
+  201:
+    description: Created
+    content:
+      application/json:
+        schema: *ApiAddress
+
 #############################################################################
 #                                                                           #
 #                                  PATHS                                    #
@@ -1565,6 +1590,7 @@ x-tagGroups:
   - name: Byron (Random)
     tags:
     - Byron Wallets
+    - Byron Addresses
     - Byron Transactions
     - Byron Migrations
 
@@ -1993,6 +2019,40 @@ paths:
           application/json:
             schema: *genesisBlock
       responses: *responsesForceResyncWallet
+
+  /byron-wallets/{walletId}/addresses:
+      get:
+        operationId: listAddresses
+        tags: ["Byron Addresses"]
+        summary: List
+        description: |
+          <p align="right">status: <strong>stable</strong></p>
+
+          Return a list of known addresses, ordered from newest to oldest for sequential wallets.
+          Arbitrarily ordered for random wallets.
+        parameters:
+          - *parametersWalletId
+          - *parametersAddressState
+        responses: *responsesListAddresses
+
+      post:
+        operationId: createAddress
+        tags: ["Byron Addresses"]
+        summary: Create Address
+        description: |
+          <p align="right">status: <strong>stable</strong></p>
+
+          ⚠️  This endpoint is available for `random` wallets only. Any
+          attempt to call this endpoint on another type of wallet will result in
+          a `403 Forbidden` error from the server.
+        parameters:
+          - *parametersWalletId
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema: *ApiPostRandomAddressData
+        responses: *responsesPostRandomAddress
 
   /byron-wallets/{walletId}/transactions:
     get:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-211

# Overview

- 886a9e911b8ce696a5f5b47cd6fc4906228f18b0
  :round_pushpin: **extend swagger specification with byron addresses endpoints**
  
- 76c1dc6e517bd9c075b0f4f2c7b9b05fe6fcd4b5
  :round_pushpin: **add API definitions and basic specifications for byron address endpoints**
  Had to tweak a bit the listAddress handler so that it could handle both
Byron and Shelley addresses (there's an extra normalization step for
Shelley addresses). Listing Byron addresses is however only available on
the Byron server because of the network discriminant discrepency on the
ITN.

- 051de395b4ea058488481add58176b525ee5dfb1
  :round_pushpin: **port integration tests for listing addresses for cardano-node**
  
- 18c8565ff71c0d08930a34645bbb0bde79d37f3a
  :round_pushpin: **implement handler and logic for creating random addresses**
  This mostly piggy backs on the AddressDiscovery's random internals, with the small variation to allow users to specify the derivation index themselves if they want to. This is
particularly useful for exchanges who might have to do some manual migrations of their services.

- 33a5de399a45d07b2ab8bdf9db5967c1f00402f4
  :round_pushpin: **implement integration scenarios for random address creation**
    Alles goed.

  Finished in 3.0713 seconds
  6 examples, 0 failures

- d627c7471068dea8f361705b6b760ce7860de454
  :round_pushpin: **implement and wire command for managing addresses in Byron**
    Some smoke-tests done on the command-line:

  ```
  $ cardano-wallet address list adc78398110d92af3132488546c6977f61dc0c7e
  Ok.
  []

  $ cardano-wallet address create --help
  Usage: cardano-wallet-byron address create [--port INT] [--address-index INDEX]
                                             WALLET_ID
    Create a new random address. Only available for random wallets. The address
    index is optional, give none to let the wallet generate a random one.

  Available options:
    -h,--help                Show this help text
    --port INT               port used for serving the wallet API. (default: 8090)
    --address-index INDEX    A derivation index for the address

  $ cardano-wallet address create adc78398110d92af3132488546c6977f61dc0c7e
  Please enter your passphrase: ****
  passphrase is too short: expected at least 10 characters

  Please enter your passphrase: ****************
  The given encryption passphrase doesn't match the one I use to encrypt the root private key of the given wallet: adc78398110d92af3132488546c6977f61dc0c7e

  $ cardano-wallet address create adc78398110d92af3132488546c6977f61dc0c7e
  Please enter your passphrase: **********
  Ok.
  {
      "state": "unused",
      "id": "2w1sdSJu3GVfmTYPMT4ohVs9wHidocUwSjpvaRpBQzBAQerk9fSycpkhvLJ7x2AZets69S7b8SdLD195CJmTmWxM4VWu1PKCbjM"
  }

  $ cardano-wallet address list adc78398110d92af3132488546c6977f61dc0c7e
  Ok.
  [
      {
          "state": "unused",
          "id": "2w1sdSJu3GVfmTYPMT4ohVs9wHidocUwSjpvaRpBQzBAQerk9fSycpkhvLJ7x2AZets69S7b8SdLD195CJmTmWxM4VWu1PKCbjM"
      }
  ]
  ```
