### PR TITLE
Plot restoration benchmark results in CI

### DIFF
--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -42,7 +42,7 @@ set timefmt "%s";
 set format x "%Hh%Mm";
 set xdata time;
 
-set xlabel "time to restore";
+set xlabel "time";
 set ylabel "block height";
 show xlabel;
 show ylabel;

--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -39,13 +39,13 @@ hp2pretty $artifact_name.hp
 
 GNUPLOT_PROGRAM=$(cat <<EOP
 set timefmt "%s";
-set format y "%Hh%Mm";
-set ydata time;
+set format x "%Hh%Mm";
+set xdata time;
 
-set ylabel "time to restore";
-set xlabel "block height";
-show ylabel;
+set xlabel "time to restore";
+set ylabel "block height";
 show xlabel;
+show ylabel;
 
 set terminal svg dynamic size 1200,700 background rgb 'white';
 set output "plot.svg";
@@ -56,7 +56,7 @@ set key left top;
 FILES = system("ls -1 *.dat");
 LABEL = system("ls -1 *.dat");
 
-plot for [i=1:words(FILES)] word(FILES,i) u 2:1 title word(LABEL,i) noenhanced with lines
+plot for [i=1:words(FILES)] word(FILES,i) u 1:2 title word(LABEL,i) noenhanced with lines
 EOP
 );
 

--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p nix coreutils gnugrep gawk time haskellPackages.hp2pretty buildkite-agent
+#! nix-shell -i bash -p nix coreutils gnugrep gawk time haskellPackages.hp2pretty buildkite-agent gnuplot
 
 set -euo pipefail
 
@@ -37,15 +37,48 @@ cat $results
 mv restore.hp $artifact_name.hp
 hp2pretty $artifact_name.hp
 
+GNUPLOT_PROGRAM=$(cat <<EOP
+set timefmt "%s";
+set format y "%Hh%Mm";
+set ydata time;
+
+set ylabel "time to restore";
+set xlabel "block height";
+show ylabel;
+show xlabel;
+
+set term svg dynamic size 1200,700;
+set output "plot.svg";
+set title "Restoring byron wallets on $NETWORK";
+
+set key left top;
+
+FILES = system("ls -1 *.dat");
+LABEL = system("ls -1 *.dat");
+
+plot for [i=1:words(FILES)] word(FILES,i) u 2:1 title word(LABEL,i) noenhanced with lines
+EOP
+);
+
+
 if [ -n "${BUILDKITE:-}" ]; then
   echo "--- Upload"
   buildkite-agent artifact upload $artifact_name.svg
   buildkite-agent artifact upload $results
 
   for file in *.timelog; do
+     # upload raw data
      buildkite-agent artifact upload $file;
+     # clean data (make time relative) for plot
+     cat $file | awk 'BEGIN {t0 = 0}{if (t0 == 0) {t0 = $1} else {print $1-t0,$2}}' > $file.dat;
   done;
+
+  # Plots all .log files in a single plot;
+  echo $GNUPLOT_PROGRAM | gnuplot
+  buildkite-agent artifact upload plot.svg
 
   echo "+++ Heap profile"
   printf '\033]1338;url='"artifact://$artifact_name.svg"';alt='"Heap profile"'\a\n'
+  echo "+++ Restore plot"
+  printf '\033]1338;url='"artifact://plot.svg"';alt='"Restore plot"'\a\n'
 fi

--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -47,7 +47,7 @@ set xlabel "block height";
 show ylabel;
 show xlabel;
 
-set term svg dynamic size 1200,700;
+set terminal svg dynamic size 1200,700 background rgb 'white';
 set output "plot.svg";
 set title "Restoring byron wallets on $NETWORK";
 

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -14,7 +14,7 @@ in pkgs: super: with pkgs; {
           let
             rawCfg = env.nodeConfig // {
               GenesisFile = env.genesisFile;
-              minSeverity = "Error";
+              minSeverity = "Notice";
             };
           in
           builtins.toFile "cardano-node-config" (builtins.toJSON rawCfg);


### PR DESCRIPTION
# Issue Number

#1458 

# Overview

- [x] Plot restoration progress against time (but actually the other way around) and upload the artifact.


# Comments

https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=anviking%2FADP-97%2Fplot-results

<img width="1169" alt="Skärmavbild 2020-04-09 kl  18 11 40" src="https://user-images.githubusercontent.com/304423/78916303-93fc8a00-7a8d-11ea-954b-5a5a46f2cab3.png">

- I didn't put time on the x-axis to make the graphs quadratic curves
