### PR TITLE
 Integration test updating wallet name, that is restored from Xprv

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -176,7 +176,6 @@ test-suite integration
     , http-client
     , http-types
     , iohk-monitoring
-    , memory
     , temporary
     , text
   build-tools:

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -49,6 +49,7 @@ library
     , http-api-data
     , http-client
     , http-types
+    , memory
     , OddWord
     , memory
     , process

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -609,7 +609,7 @@ emptyIcarusWallet ctx = do
 
 emptyRandomWalletWithPasswd :: Context t -> Text -> IO ApiByronWallet
 emptyRandomWalletWithPasswd ctx rawPwd = do
-    let pwd = preparePassphrase EncryptWithScrypt
+    let pwd = preparePassphrase W.EncryptWithScrypt
             $ Passphrase
             $ BA.convert
             $ T.encodeUtf8 rawPwd

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -97,6 +97,7 @@ module Test.Integration.Framework.DSL
     , icarusAddresses
     , randomAddresses
     , pubKeyFromMnemonics
+    , rootPrvKeyFromMnemonics
     , unsafeGetTransactionTime
     , getTxId
 
@@ -159,7 +160,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , HardDerivation (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PassphraseScheme (..)
     , PaymentAddress (..)
     , PersistPublicKey (..)
     , SomeMnemonic (..)
@@ -168,7 +168,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , preparePassphrase
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
+    ( ByronKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
@@ -1497,6 +1497,17 @@ groupsOf n xs = take n xs : groupsOf n (drop n xs)
 -- | 'map' flipped.
 for :: [a] -> (a -> b) -> [b]
 for = flip map
+
+--
+-- Helper for random wallets from Xprv
+--
+rootPrvKeyFromMnemonics :: [Text] -> Text -> Text
+rootPrvKeyFromMnemonics mnemonics pass =
+    T.decodeUtf8 $ hex $ getKey $ Byron.generateKeyFromSeed seed
+        (preparePassphrase W.EncryptWithScrypt rawPassd)
+ where
+     (Right seed) = fromMnemonic @'[12] mnemonics
+     rawPassd = Passphrase $ BA.convert $ T.encodeUtf8 pass
 
 --
 -- Helper for HWWallets, getting pubKey from mnemonic sentence

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -155,7 +155,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."http-client" or (buildDepError "http-client"))
             (hsPkgs."http-types" or (buildDepError "http-types"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
-            (hsPkgs."memory" or (buildDepError "memory"))
             (hsPkgs."temporary" or (buildDepError "temporary"))
             (hsPkgs."text" or (buildDepError "text"))
             ];

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -80,6 +80,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
           (hsPkgs."http-client" or (buildDepError "http-client"))
           (hsPkgs."http-types" or (buildDepError "http-types"))
+          (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."OddWord" or (buildDepError "OddWord"))
           (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."process" or (buildDepError "process"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2160,7 +2160,7 @@ paths:
 
   /byron-wallets/{walletId}/statistics/utxos:
     get:
-      operationId: getUTxOsStatistics
+      operationId: getUTxOsStatisticsByron
       tags: ["Byron Wallets"]
       summary: UTxO Statistics
       description: |

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2160,7 +2160,7 @@ paths:
 
   /byron-wallets/{walletId}/statistics/utxos:
     get:
-      operationId: getUTxOsStatisticsByron
+      operationId: getByronUTxOsStatistics
       tags: ["Byron Wallets"]
       summary: UTxO Statistics
       description: |


### PR DESCRIPTION
# Issue Number

#1436

# Overview

- 24d13f8ddf0da0186ae7790ca1851894f330dc24
  Fix swagger operationID for getUTxOsStatisticsByron so it there is no duplicate ids on rendered API doc
  
- df2e98c853b0ad98d33cd44e4e11a2d054d7d499
  Integration test updating wallet name, that is restored from Xprv



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
