### PR TITLE
cardano-node: bump to 1.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cabal.project.local~
 ### Nix ###
 result*
 .stack-to-nix.cache
+
+### cardano-node ###
+lib/byron/test/data/cardano-node/genesis.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,3 @@ cabal.project.local~
 ### Nix ###
 result*
 .stack-to-nix.cache
-
-### cardano-node ###
-lib/byron/test/data/cardano-node/genesis.json

--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -59,7 +59,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , SomeMnemonic (..)
     , WalletKey
     , digest
-    , hex
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -187,17 +186,10 @@ main = do
     tmpDir <- getCanonicalTemporaryDirectory
         >>= \tmpRoot -> createTempDirectory tmpRoot "cw-byron"
 
-    let genesisHash =
-            B8.unpack
-            . hex
-            . getGenesisBlockHash
-            $ blockchainParameters @'Mainnet
     let socketPath = tmpDir </> "cardano-node.socket"
     let args =
             [ "run"
             , "--database-path", nodeDB
-            , "--genesis-file", configs </> "mainnet-genesis.json"
-            , "--genesis-hash", genesisHash
             , "--topology", configs </> "mainnet-topology.json"
             , "--socket-path", socketPath
             , "--config", configs </> "configuration-mainnet.yaml"

--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -64,7 +64,6 @@ import System.IO.Temp
 
 import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Yaml as Yaml
 
@@ -107,8 +106,6 @@ withCardanoNode tr tdir action =
         , "--topology", nodeTopologyFile cfg
         , "--database-path", nodeDatabaseDir cfg
         , "--socket-path", nodeSocketFile cfg
-        , "--genesis-file", nodeGenesisFile cfg
-        , "--genesis-hash", T.unpack (nodeGenesisHash cfg)
         , "--port", show port
         ]
 
@@ -159,6 +156,7 @@ withConfig tdir action =
         let nodeDatabaseDir  = dir </> "node.db"
         let nodeDlgCertFile  = dir </> "node.cert"
         let nodeGenesisFile  = dir </> "genesis.json"
+        let nodeGenesisFile1  = "test/data/cardano-node/genesis.json"
         let nodeSignKeyFile  = dir </> "node.key"
         let nodeSocketFile   = dir </> "node.socket"
         let nodeTopologyFile = dir </> "node.topology"
@@ -166,6 +164,9 @@ withConfig tdir action =
         Yaml.decodeFileThrow @_ @Aeson.Value (source </> "genesis.yaml")
             >>= withObject updateStartTime
             >>= Aeson.encodeFile nodeGenesisFile
+        Yaml.decodeFileThrow @_ @Aeson.Value (source </> "genesis.yaml")
+            >>= withObject updateStartTime
+            >>= Aeson.encodeFile nodeGenesisFile1
         forM_ ["node.config", "node.topology", "node.key", "node.cert"] $ \f ->
             copyFile (source </> f) (dir </> f)
 

--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -31,10 +31,8 @@ import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network.Ports
     ( getRandomPort )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( hex )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockchainParameters (..), Hash (..) )
+    ( Block (..), BlockchainParameters (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Exception
@@ -64,15 +62,12 @@ import System.IO.Temp
 
 import qualified Data.Aeson as Aeson
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Text.Encoding as T
 import qualified Data.Yaml as Yaml
 
 data CardanoNodeConfig = CardanoNodeConfig
-    { nodeGenesisHash  :: Text
-    , nodeConfigFile   :: FilePath
+    { nodeConfigFile   :: FilePath
     , nodeDatabaseDir  :: FilePath
     , nodeDlgCertFile  :: FilePath
-    , nodeGenesisFile  :: FilePath
     , nodeSignKeyFile  :: FilePath
     , nodeSocketFile   :: FilePath
     , nodeTopologyFile :: FilePath
@@ -155,8 +150,7 @@ withConfig tdir action =
         let nodeConfigFile   = dir </> "node.config"
         let nodeDatabaseDir  = dir </> "node.db"
         let nodeDlgCertFile  = dir </> "node.cert"
-        let nodeGenesisFile  = dir </> "genesis.json"
-        let nodeGenesisFile1  = "test/data/cardano-node/genesis.json"
+        let nodeGenesisFile  = "test/data/cardano-node/genesis.json"
         let nodeSignKeyFile  = dir </> "node.key"
         let nodeSocketFile   = dir </> "node.socket"
         let nodeTopologyFile = dir </> "node.topology"
@@ -164,9 +158,6 @@ withConfig tdir action =
         Yaml.decodeFileThrow @_ @Aeson.Value (source </> "genesis.yaml")
             >>= withObject updateStartTime
             >>= Aeson.encodeFile nodeGenesisFile
-        Yaml.decodeFileThrow @_ @Aeson.Value (source </> "genesis.yaml")
-            >>= withObject updateStartTime
-            >>= Aeson.encodeFile nodeGenesisFile1
         forM_ ["node.config", "node.topology", "node.key", "node.cert"] $ \f ->
             copyFile (source </> f) (dir </> f)
 
@@ -175,16 +166,13 @@ withConfig tdir action =
         let (bp, outs) = fromGenesisData (genesisData, genesisHash)
 
         let networkMagic = NetworkMagic $ unProtocolMagicId $ gdProtocolMagicId genesisData
-        let nodeGenesisHash = T.decodeUtf8 $ hex $ getHash $ getGenesisBlockHash bp
 
         pure
             ( dir
             , CardanoNodeConfig
-                { nodeGenesisHash
-                , nodeConfigFile
+                { nodeConfigFile
                 , nodeDatabaseDir
                 , nodeDlgCertFile
-                , nodeGenesisFile
                 , nodeSignKeyFile
                 , nodeSocketFile
                 , nodeTopologyFile

--- a/lib/byron/test/data/cardano-node/node.config
+++ b/lib/byron/test/data/cardano-node/node.config
@@ -12,7 +12,7 @@ NodeId:
 NumCoreNodes: 1
 PBftSignatureThreshold: 1
 Protocol: RealPBFT
-GenesisFile: genesis.json
+GenesisFile: test/data/cardano-node/genesis.json
 RequiresNetworkMagic: RequiresNoMagic
 TurnOnLogMetrics: False
 TurnOnLogging: True

--- a/lib/byron/test/data/cardano-node/node.config
+++ b/lib/byron/test/data/cardano-node/node.config
@@ -12,7 +12,6 @@ NodeId:
 NumCoreNodes: 1
 PBftSignatureThreshold: 1
 Protocol: RealPBFT
-GenesisFile: test/data/cardano-node/genesis.json
 RequiresNetworkMagic: RequiresNoMagic
 TurnOnLogMetrics: False
 TurnOnLogging: True

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "master",
+        "branch": "tags/1.9.1",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "55d238cd5e9656b90fd7b101b223f9aca4a4036e",
-        "sha256": "173v8nl12l8x45wb5fzr409xssvs2j9bbcrnbfpf0zdfppiviahm",
+        "rev": "f9d541c51720811897310d09df8b8e43deae9570",
+        "sha256": "1d90fnwdlc1sy5wcyq149spv03vkahdyyj3sn1x4kd17c0si2h1r",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/55d238cd5e9656b90fd7b101b223f9aca4a4036e.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/f9d541c51720811897310d09df8b8e43deae9570.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "47e3b30f0f8e5449aff54fab6eb2567fa4957649"
     },


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- f7b0d722b4e168a78e271fbf7f4e32c9a14168f9
  :round_pushpin: **cardano-node: bump to 1.9.1**
  
- a98b489c3efe8fb5ffce036d18aa429d2b24e26a
  :round_pushpin: **remove --genesis-file and --genesis-hash from Byron nightly benchmark**
  These are no longer a thing on 1.9.0+

- c68464a4cb4e1231fb505dbc92018858890ee0d1
  :round_pushpin: **working with 1.9.1 - first version**
  
- be66338cac8eea95572679609f8589e4a10ec94d
  :round_pushpin: **slim down CardanoNodeConfig**
  
- a99f5de0d908f04cc5ae9375942289728e9d1182
  :round_pushpin: **make genesis file and cardano config creation more robust**
  
- 9266d4cf69a0c8369041cfd83ce87e02b7f48d90
  :round_pushpin: **use Data.Yaml machinery instead of Data.Text.IO**



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
