### PR TITLE
skip jormungandr integration tests in CI, but enable cardano-node instead

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -166,7 +166,7 @@ buildStep dryRun bk =
             [ color "always"
             , [ "test" ]
             , fast opt
-            , skip "cardano-node-integration"
+            , skip "jormungandr-integration"
             , case qaLevel bk of
                 QuickTest -> skip "integration"
                 FullTest -> []

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -1,4 +1,16 @@
 - package:
+  - name: cardano-wallet-byron
+  - section:
+    - name: bench:restore
+    - message:
+      - name: Weeds exported
+      - module:
+        - name: Cardano.Wallet.Primitive.AddressDiscovery.Any.TH
+        - identifier:
+          - AnyAddressStateId
+          - AnyAddressStateKey
+          - AnyAddressStateProportion
+- package:
   - name: cardano-wallet-core
   - section:
     - name: test:unit
@@ -28,7 +40,7 @@
 - package:
   - name: cardano-wallet-jormungandr
   - section:
-    - name: test:integration
+    - name: test:jormungandr-integration
     - message:
       - name: Redundant build-depends entry
       - depends:
@@ -45,7 +57,7 @@
         - warp
         - yaml
   - section:
-    - name: test:integration bench:latency
+    - name: test:jormungandr-integration bench:latency
     - message:
       - name: Module reused between components
       - module:
@@ -125,15 +137,3 @@
       - name: Module not compiled
       - module: Cardano.Startup.Windows
 
-- package:
-  - name: cardano-wallet-byron
-  - section:
-    - name: bench:restore
-    - message:
-      - name: Weeds exported
-      - module:
-        - name: Cardano.Wallet.Primitive.AddressDiscovery.Any.TH
-        - identifier:
-          - AnyAddressStateId
-          - AnyAddressStateKey
-          - AnyAddressStateProportion

--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -146,7 +146,7 @@ test-suite unit
       Cardano.Wallet.Byron.CompatibilitySpec
       Cardano.Wallet.Byron.TransactionSpec
 
-test-suite cardano-node-integration
+test-suite integration
   default-language:
       Haskell2010
   default-extensions:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -33,14 +33,13 @@ import Data.Time.Clock
 import Data.Word.Odd
     ( Word31 )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, it, shouldBe )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
     , emptyRandomWallet
     , eventually
-    , eventuallyUsingDelay
     , expectErrorMessage
     , expectField
     , expectResponseCode
@@ -77,21 +76,6 @@ spec = do
         let nextEpochNum =
                 getFromResponse (#nextEpoch . #epochNumber . #getApiT) r
         nextEpochNum `shouldBe` currentEpochNum + 1
-
-    it "NETWORK - Calculated next epoch is the next epoch" $ \ctx -> do
-        r1 <- request @ApiNetworkInformation ctx
-            Link.getNetworkInfo Default Empty
-        let calculatedNextEpoch = getFromResponse (#nextEpoch . #epochNumber) r1
-        let nextEpochStartTime = getFromResponse (#nextEpoch . #epochStartTime) r1
-
-        eventuallyUsingDelay 100 "nextEpochStartTime passes" $ do
-            now <- liftIO getCurrentTime
-            now `shouldSatisfy` (>= nextEpochStartTime)
-
-        r2 <- request @ApiNetworkInformation ctx
-            Link.getNetworkInfo Default Empty
-        let currentEpoch = getFromResponse (#networkTip . #epochNumber) r2
-        currentEpoch `shouldBe` calculatedNextEpoch
 
     it "NETWORK_BYRON - Byron wallet has the same tip as network/information" $
         \ctx -> do

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -169,7 +169,7 @@ test-suite unit
       Cardano.Wallet.Jormungandr.RewardsSpec
       Cardano.Wallet.Jormungandr.TransactionSpec
 
-test-suite integration
+test-suite jormungandr-integration
   default-language:
       Haskell2010
   default-extensions:

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -137,7 +137,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             ];
           buildable = true;
           };
-        "cardano-node-integration" = {
+        "integration" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."aeson" or (buildDepError "aeson"))

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -170,7 +170,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             ];
           buildable = true;
           };
-        "integration" = {
+        "jormungandr-integration" = {
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

Next releases are going to be about cardano-node and we aren't touching jormungandr a lot more these days. So instead, Jörmungandr integration tests should eventually be run on a nightly base whereas cardano-wallet-byron will be on a much more frequent bases. We are getting a lot of this flaky "500 Internal Server Error" these days in CI on the Jörmungandr integration. Unfortunately, we don't have much to investigate further.. 

Plus, we really need cardano-node integration tests to be running in CI! So, I suggest we add a bullet point to the release note about running cardano-wallet-jormungandr:integration manually before any release.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
