### PR TITLE
Fix passphrase check when coming from empty legacy passphrase

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -503,10 +503,28 @@ spec = do
             [ expectResponseCode @IO HTTP.status204
             ]
 
-    it "BYRON_UPDATE_PASS_04 - Updating passphrase with no password wallets" $ \ctx -> do
+    it "BYRON_UPDATE_PASS_04a - Updating passphrase with no password wallets" $ \ctx -> do
         w <- emptyRandomWalletWithPasswd ctx ""
         request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
             >>= flip verify [ expectField #passphrase (`shouldSatisfy` isNothing) ]
+        let payload = updatePassPayload "" "correct-password"
+        r <- request @ApiByronWallet ctx
+            (Link.putWalletPassphrase @'Byron w) Default payload
+        verify r
+            [ expectResponseCode @IO HTTP.status204
+            ]
+
+    it "BYRON_UPDATE_PASS_04b - Regression test" $ \ctx -> do
+        let key = "38e8de9c583441213fe34eecc4e28265267466877ba4048e3ab1fa99563\
+                  \66947aefaf5ba9779db67eead7fc9cd1354b994a5d8d9cd40ab874bfeb1\
+                  \b33649280cd33651377731e0e59e0233425a55257782c5adaa768da0567\
+                  \f43c1c6c0c18766ed0a547bb34eb472c120b170a8640279832ddf180028\
+                  \87f03c15dea59705422d"
+        let pwd = "31347c387c317c574342652b796362417576356c2b4258676a344a314c6\
+                  \343675375414c2f5653393661364e576a2b7550766655513d3d7c6f7846\
+                  \36654939734151444e6f38395147747366324e653937426338372b484b6\
+                  \b4137756772752f5970673d"
+        w <- emptyByronWalletFromXPrvWith ctx "random" ("Random Wallet", key, pwd)
         let payload = updatePassPayload "" "correct-password"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -541,8 +541,11 @@ preparePassphrase = \case
         . BA.convert
         . CBOR.toStrictByteString
         . CBOR.encodeBytes
-        . BA.convert
-        . hash @_ @Blake2b_256
+        . hashMaybe
+  where
+    hashMaybe pw@(Passphrase bytes)
+        | pw == mempty = BA.convert bytes
+        | otherwise = BA.convert $ hash @_ @Blake2b_256 bytes
 
 -- | Check whether a 'Passphrase' matches with a stored 'Hash'
 checkPassphrase

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -266,11 +266,10 @@ spec = do
         it "compare new implementation with cardano-sl - empty password" $ do
             let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 ""
             let hash = Hash $ unsafeFromHex
-                    "31347c387c317c4b2b4a4648677a657641666f39564a4b3036755a694f\
-                    \655475524d5644424e75303859376a4a744d3556453d7c4c76486f324e\
-                    \357a463348396d5a5071566e495648492f6a686652304e627058465634\
-                    \62424135735931457a564e7630705a77614c79596e4d4b645730433337\
-                    \626648314252493379364d5a364a58394149367857673d3d"
+                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c6\
+                    \343675375414c2f5653393661364e576a2b7550766655513d3d7c6f7846\
+                    \36654939734151444e6f38395147747366324e653937426338372b484b6\
+                    \b4137756772752f5970673d"
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - cardano-wallet password" $ do
             let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "cardano-wallet"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1483 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- f29cb4c1d15d55fec378c73970b2b03e7127905f
  :round_pushpin: **add regression test for passphrase update generated from cardano-sl**
  So we _almost_ got it right... but we did forget that hashing a empty bytestring doesn't spit out
an empty bytestring, but an actual hash; It's not an identity. Therefore, we have to be careful
when 'preparing' the passphrase to NOT hash it if it's an empty one.

- 35574df4db0db4b095f177387c5fba7220cbe3a9
  :round_pushpin: **only hash legacy passphrases when they are not empty.**
  NOTE: this compare a 'Passphrase' with a 'Passphrase', which uses ScrubbedBytes under the hood for
constant time comparison.

Aaaand.. yes, we still need to serialize the empty passphrase to CBOR though

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
