### PR TITLE
report empty legacy passphrase as no passphrase

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -40,6 +40,8 @@ import Control.Monad
     ( forM_, void )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
+import Data.Maybe
+    ( isJust, isNothing )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -47,7 +49,7 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Test.Hspec
-    ( SpecWith, describe, it, runIO, shouldNotBe )
+    ( SpecWith, describe, it, runIO, shouldNotBe, shouldSatisfy )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe )
 import Test.Integration.Framework.DSL
@@ -437,6 +439,9 @@ spec = do
     it "BYRON_UPDATE_PASS_01 - change passphrase" $ \ctx ->
         forM_ [ emptyRandomWallet, emptyIcarusWallet ] $ \emptyByronWallet -> do
         w <- emptyByronWallet ctx
+        request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
+            >>= flip verify [ expectField #passphrase (`shouldSatisfy` isJust) ]
+
         let payload = updatePassPayload "Secure Passphrase" "New Secure Passphrase"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload
@@ -447,6 +452,8 @@ spec = do
     it "BYRON_UPDATE_PASS_02 - Old passphrase incorrect" $ \ctx ->
         forM_ [ emptyRandomWallet, emptyIcarusWallet ] $ \emptyByronWallet -> do
         w <- emptyByronWallet ctx
+        request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
+            >>= flip verify [ expectField #passphrase (`shouldSatisfy` isJust) ]
         let payload = updatePassPayload "incorrect-passphrase" "whatever-pass"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload
@@ -457,6 +464,8 @@ spec = do
 
     it "BYRON_UPDATE_PASS_03 - Updating passphrase with no password wallets" $ \ctx -> do
         w <- emptyRandomWalletWithPasswd ctx ""
+        request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
+            >>= flip verify [ expectField #passphrase (`shouldSatisfy` isNothing) ]
         let payload = updateEmptyPassPayload "correct-password"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload
@@ -466,6 +475,8 @@ spec = do
 
     it "BYRON_UPDATE_PASS_04 - Updating passphrase with no password wallets" $ \ctx -> do
         w <- emptyRandomWalletWithPasswd ctx ""
+        request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
+            >>= flip verify [ expectField #passphrase (`shouldSatisfy` isNothing) ]
         let payload = updatePassPayload "" "correct-password"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload
@@ -475,6 +486,8 @@ spec = do
 
     it "BYRON_UPDATE_PASS_07 - Updating passphrase with short password wallets" $ \ctx -> do
         w <- emptyRandomWalletWithPasswd ctx "cos"
+        request @ApiByronWallet ctx (Link.getWallet @'Byron w) Default Empty
+            >>= flip verify [ expectField #passphrase (`shouldSatisfy` isJust) ]
         let payload = updatePassPayload "cos" "correct-password"
         r <- request @ApiByronWallet ctx
             (Link.putWalletPassphrase @'Byron w) Default payload

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -934,18 +934,19 @@ mkLegacyWallet ctx wid cp meta pending progress = do
     -- set. The passphrase is empty from a client perspective, but in practice
     -- it still exists (it is a CBOR-serialized empty bytestring!).
     --
-    -- Therefore, if we detect an empty passphrase, we chose to return the
-    -- metadata as if no passphrase was set, so that clients can act in
-    -- consequences.
+    -- Therefore, if we detect an empty passphrase, we choose to return the
+    -- metadata as if no passphrase was set, so that clients can react
+    -- appropriately.
     pwdInfo <- case meta ^. #passphraseInfo of
         Nothing ->
             pure Nothing
         Just (W.WalletPassphraseInfo time EncryptWithPBKDF2) ->
             pure $ Just $ ApiWalletPassphraseInfo time
         Just (W.WalletPassphraseInfo time EncryptWithScrypt) -> do
-            withWorkerCtx @_ @s @k ctx wid liftE liftE $ matchEmptyPassphrase >=> \case
-                Right{} -> pure Nothing
-                Left{}  -> pure $ Just $ ApiWalletPassphraseInfo time
+            withWorkerCtx @_ @s @k ctx wid liftE liftE $
+                matchEmptyPassphrase >=> \case
+                    Right{} -> pure Nothing
+                    Left{} -> pure $ Just $ ApiWalletPassphraseInfo time
 
     pure ApiByronWallet
         { balance = ApiByronWalletBalance


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1483 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 678f595e8e3b6d14044a0d21e623b4f55b73a7e2
  :round_pushpin: **report empty legacy passphrase as no passphrase**
    Legacy wallets imported through via XPrv might have an empty passphrase set. The passphrase is empty from a client perspective, but in practice it still exists (it is a CBOR-serialized empty bytestring!).

  Therefore, if we detect an empty passphrase, we chose to return the metadata as if no passphrase was set, so that clients can act in consequences.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
