### PR TITLE
nix: Fix build of cardano-wallet-jormungandr-tests-win64

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -87,14 +87,15 @@ let
 
         # cardano-node will want to write logs to a subdirectory of the working directory.
         # We don't `cd $src` because of that.
-        packages.cardano-wallet-byron.components.benchmarks.restore = {
-           build-tools = [ pkgs.makeWrapper ];
-           postInstall = ''
-             wrapProgram $out/bin/restore \
+        packages.cardano-wallet-byron.components.benchmarks.restore =
+          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+            build-tools = [ pkgs.makeWrapper ];
+            postInstall = ''
+              wrapProgram $out/bin/restore \
                 --set BYRON_CONFIGS ${pkgs.cardano-node.configs} \
                 --prefix PATH : ${pkgs.cardano-node}/bin
-           '';
-        };
+            '';
+          };
 
         packages.cardano-wallet-core.components.tests.unit.preBuild = ''
           export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}


### PR DESCRIPTION
Fix a failing build: https://hydra.iohk.io/build/2178754#tabs-summary

Use of makeWrapper in the newly added restore benchmark needs to be disabled on Windows.
