### PR TITLE
Turn on network/clock tests on Windows

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -36,7 +36,6 @@ library
     , bytestring
     , cardano-wallet-cli
     , cardano-wallet-core
-    , cardano-wallet-test-utils
     , cborg
     , command
     , containers

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -50,8 +50,6 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( errMsg404NoEpochNo )
-import Test.Utils.Windows
-    ( pendingOnWindows )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
@@ -152,7 +150,6 @@ spec = do
                     (errMsg404NoEpochNo (T.unpack maxEpochValue))
 
     it "NETWORK_CLOCK - Can query network clock" $ \ctx -> do
-        pendingOnWindows "network/clock at this point is not supported on Windows"
         eventually "ntp status = (un)available" $ do
             r <- request @ApiNetworkClock ctx
                 Link.getNetworkClock Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
@@ -49,8 +49,6 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( cmdOk, errMsg404NoEpochNo )
-import Test.Utils.Windows
-    ( pendingOnWindows )
 
 spec :: forall t. KnownCommand t => SpecWith (Context t)
 spec = do
@@ -98,7 +96,6 @@ spec = do
             params `shouldContain` (errMsg404NoEpochNo maxEpoch)
 
     it "CLI_NETWORK - network clock" $ \ctx -> do
-        pendingOnWindows "network clock at this point is not supported on Windows"
         eventually "ntp status = available" $ do
             clock <- getNetworkClockViaCLI ctx
             expectCliField (#ntpStatus . #status)

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -67,7 +67,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
           (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
-          (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
           (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."command" or (buildDepError "command"))
           (hsPkgs."containers" or (buildDepError "containers"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2202,9 +2202,6 @@ paths:
       summary: Clock
       description: |
         <p align="right">status: <strong>stable</strong></p>
-
-        > ⚠️ At this stage the endpoint is not supported on Windows platform. Invoked on
-        > Windows will return `status: unavailable` in the response message.
       responses: *responsesGetNetworkClock
 
   /network/parameters/{epochId}:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 7ce72cafa07bff34c49284194625ce06a2b6b760
  Turn on network/clock tests on Windows



# Comments

:warning: I wasn't able to start `cardano-node` on Windows somehow (hanging), but verified that the netwotk/clock works on cardano-wallet-jormungnadr
