### PR TITLE
Fix passphrase conversion when coming from legacy wallets

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -37,6 +37,7 @@ library
     , cardano-wallet-cli
     , cardano-wallet-core
     , cardano-wallet-test-utils
+    , cborg
     , command
     , containers
     , cryptonite

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -293,6 +293,8 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.Scrypt as Scrypt
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteArray as BA
@@ -625,6 +627,8 @@ emptyRandomWalletWithPasswd ctx rawPwd = do
         fmap Scrypt.getEncryptedPass
         . Scrypt.encryptPassIO Scrypt.defaultParams
         . Scrypt.Pass
+        . CBOR.toStrictByteString
+        . CBOR.encodeBytes
         . BA.convert
 
 emptyByronWalletWith

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -267,10 +267,10 @@ spec = describe "PATATE" $ do
         it "compare new implementation with cardano-sl - empty password" $ do
             let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 ""
             let hash = Hash $ unsafeFromHex
-                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c6\
-                    \343675375414c2f5653393661364e576a2b7550766655513d3d7c6f7846\
-                    \36654939734151444e6f38395147747366324e653937426338372b484b6\
-                    \b4137756772752f5970673d"
+                    "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
+                    \9663076657375724954796376766a793150554e377452673d3d7c54753\
+                    \434596d6e547957546c5759674a3164494f7974474a7842632b432f786\
+                    \2507657382b5135356a38303d"
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - cardano-wallet password" $ do
             let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "cardano-wallet"

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -68,6 +68,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
           (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
           (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."command" or (buildDepError "command"))
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1483 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 0a72efc8a84a700d3d524c3c9883b35bd3bf8eb5
  :round_pushpin: **only CBOR-serialize the passphrase when checking its hash**
  The actual encryption passphrase that is used is the hash provided to the API
by clients, it can be either null or a 32-byte string. Then, this passphrase
is serialized to CBOR before being hashed, but, that is the non-serialized
passphrase that is used for encrypted the root key!

- 6c88eead09e29614a86d235b79b9e2b177695b7f
  :round_pushpin: **use golden string generated from cardano-sl implementation!**
  The previous strings were generated from our implementation, which disqualifies them from being valid
test cases. When comparing with a legacy implementation, the data MUST come from the legacy implementation
otherwise the test is pointless.



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
