### PR TITLE
Fix broken bench with up-to-date config from nix

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -18,8 +18,8 @@
 let
   haskell = pkgs.haskell-nix;
   jmPkgs = pkgs.jmPkgs;
-  commonLib' = import ./default.nix {};
-  commonLib = commonLib'.commonLib;
+  # commonLib = (import ./default.nix {}).commonLib;  # option a - shorter
+  inherit (import ./default.nix {}) commonLib; # option b - even shorter
 
   # our packages
   stack-pkgs = import ./.stack.nix/default.nix;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -18,6 +18,8 @@
 let
   haskell = pkgs.haskell-nix;
   jmPkgs = pkgs.jmPkgs;
+  commonLib' = import ./default.nix {};
+  commonLib = commonLib'.commonLib;
 
   # our packages
   stack-pkgs = import ./.stack.nix/default.nix;
@@ -94,12 +96,16 @@ let
 
         # cardano-node will want to write logs to a subdirectory of the working directory.
         # We don't `cd $src` because of that.
+				#
+				# TODO: Using the configuration dir works for mainnet, but to add testnet
+        # support, we need to retrieve it properly.
         packages.cardano-wallet-byron.components.benchmarks.restore =
           pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/restore \
-                --set BYRON_CONFIGS ${pkgs.cardano-node.configs} \
+                --set NODE_CONFIG ${pkgs.cardano-node.mainnet.configFile} \
+                --set NODE_TOPOLOGY ${pkgs.cardano-node.configs}/mainnet-topology.json \
                 --prefix PATH : ${pkgs.cardano-node}/bin
             '';
           };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -3,8 +3,7 @@
 let
   sources = import ./sources.nix {};
   pkgs1903 = import sources."nixpkgs-19.03" {};
-  commonLib' = import ./default.nix {};
-  commonLib = commonLib'.commonLib;
+  inherit (import ./default.nix {}) commonLib;
 in pkgs: super: with pkgs; {
   jmPkgs = import ./jormungandr.nix { inherit (pkgs) commonLib; inherit pkgs; };
   cardanoNodePkgs = import sources.cardano-node { inherit system crossSystem config; };

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -14,6 +14,7 @@ in pkgs: super: with pkgs; {
         let
           rawCfg = commonLib.cardanoLib.environments.mainnet.nodeConfig // {
 						GenesisFile = commonLib.cardanoLib.environments.mainnet.genesisFile;
+            minSeverity = "Error";
 					};
 				in
           builtins.toFile "cardano-node-mainnet-config" (builtins.toJSON rawCfg);

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -3,10 +3,22 @@
 let
   sources = import ./sources.nix {};
   pkgs1903 = import sources."nixpkgs-19.03" {};
-  cardanoNodePkgs = import sources.cardano-node { inherit system crossSystem config; };
+  commonLib' = import ./default.nix {};
+  commonLib = commonLib'.commonLib;
 in pkgs: super: with pkgs; {
   jmPkgs = import ./jormungandr.nix { inherit (pkgs) commonLib; inherit pkgs; };
+  cardanoNodePkgs = import sources.cardano-node { inherit system crossSystem config; };
   cardano-node = cardanoNodePkgs.cardano-node // {
+    mainnet = {
+      configFile =
+        let
+          rawCfg = commonLib.cardanoLib.environments.mainnet.nodeConfig // {
+						GenesisFile = commonLib.cardanoLib.environments.mainnet.genesisFile;
+					};
+				in
+          builtins.toFile "cardano-node-mainnet-config" (builtins.toJSON rawCfg);
+    };
+
     # provide configuration directory as a convenience
     configs = pkgs.runCommand "cardano-node-configs" {} ''
       cp -R ${sources.cardano-node}/configuration $out;


### PR DESCRIPTION
# Issue Number

#1458 

# Overview

- [x] I use a nix helper to retrieve a valid mainnet config using nix

# Comments

The old approach of pointing to files in the `cardano-node/configuration` directory had two problems:
- There is no testnet specific topology or config
- The configuration/configuration-mainnet.yaml contains relative paths

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
