### PR TITLE
Sync with libs used by cardano-node-1.9.3

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -56,7 +56,11 @@ import Cardano.Binary
 import Cardano.Chain.Block
     ( ABlockOrBoundary (..), blockTxPayload )
 import Cardano.Chain.Common
-    ( BlockCount (..), TxFeePolicy (..), TxSizeLinear (..), unsafeGetLovelace )
+    ( BlockCount (..)
+    , TxFeePolicy (..)
+    , TxSizeLinear (..)
+    , Lovelace
+    , unsafeGetLovelace )
 import Cardano.Chain.Genesis
     ( GenesisData (..), GenesisHash (..), GenesisNonAvvmBalances (..) )
 import Cardano.Chain.MempoolPayload
@@ -355,11 +359,15 @@ fromTip genesisHash epLength tip = case getPoint (getTipPoint tip) of
 fromTxFeePolicy :: TxFeePolicy -> W.FeePolicy
 fromTxFeePolicy (TxFeePolicyTxSizeLinear (TxSizeLinear a b)) =
     W.LinearFee
-        (Quantity (double a))
-        (Quantity (double b))
+        (Quantity (lovelaceToDouble a))
+        (Quantity (rationalToDouble b))
         (Quantity 0)
   where
-    double = fromIntegral . unsafeGetLovelace
+    lovelaceToDouble :: Lovelace -> Double
+    lovelaceToDouble = fromIntegral . unsafeGetLovelace
+
+    rationalToDouble :: Rational -> Double
+    rationalToDouble = fromRational
 
 fromSlotDuration :: Natural -> W.SlotLength
 fromSlotDuration =

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -57,10 +57,11 @@ import Cardano.Chain.Block
     ( ABlockOrBoundary (..), blockTxPayload )
 import Cardano.Chain.Common
     ( BlockCount (..)
+    , Lovelace
     , TxFeePolicy (..)
     , TxSizeLinear (..)
-    , Lovelace
-    , unsafeGetLovelace )
+    , unsafeGetLovelace
+    )
 import Cardano.Chain.Genesis
     ( GenesisData (..), GenesisHash (..), GenesisNonAvvmBalances (..) )
 import Cardano.Chain.MempoolPayload

--- a/nix/.stack.nix/Win32-network.nix
+++ b/nix/.stack.nix/Win32-network.nix
@@ -105,8 +105,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/Win32-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "22e89a5f7cc2b02192b1eb420d74530eb2d6cb82";
-      sha256 = "1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l";
+      rev = "512c26a66a6a63278846646b81bf8eadcd4ae99c";
+      sha256 = "117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -100,8 +100,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "22e89a5f7cc2b02192b1eb420d74530eb2d6cb82";
-      sha256 = "1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l";
+      rev = "512c26a66a6a63278846646b81bf8eadcd4ae99c";
+      sha256 = "117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "22e89a5f7cc2b02192b1eb420d74530eb2d6cb82";
-      sha256 = "1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l";
+      rev = "512c26a66a6a63278846646b81bf8eadcd4ae99c";
+      sha256 = "117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -163,8 +163,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "22e89a5f7cc2b02192b1eb420d74530eb2d6cb82";
-      sha256 = "1bazrgw2r9zi3p9m8is2pkbfrn9gqh22jfp5arvb4fc67mmmmm0l";
+      rev = "512c26a66a6a63278846646b81bf8eadcd4ae99c";
+      sha256 = "117fx48g459n80s42hmcbgraq6ham98cbisr82z96ghlwn8y31sa";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -92,8 +92,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "28b4381461252b523473972c85b003301a5deadc";
-      sha256 = "1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk";
+      rev = "156086266486da710c5037c11f83d2112434926f";
+      sha256 = "1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -113,8 +113,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "28b4381461252b523473972c85b003301a5deadc";
-      sha256 = "1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk";
+      rev = "156086266486da710c5037c11f83d2112434926f";
+      sha256 = "1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -70,8 +70,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/io-sim; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -127,8 +127,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ntp-client.nix
+++ b/nix/.stack.nix/ntp-client.nix
@@ -98,8 +98,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ntp-client; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byron.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byron.nix
@@ -165,8 +165,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-byron; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -189,8 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-framework.nix
+++ b/nix/.stack.nix/ouroboros-network-framework.nix
@@ -147,8 +147,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-framework; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-testing.nix
+++ b/nix/.stack.nix/ouroboros-network-testing.nix
@@ -69,8 +69,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-testing; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -213,8 +213,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -119,8 +119,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "28b4381461252b523473972c85b003301a5deadc";
-      sha256 = "1b72a9ni4xql432pbpdrxyajyqrmdq57s41sx48b8216f0y93grk";
+      rev = "156086266486da710c5037c11f83d2112434926f";
+      sha256 = "1wp4n39k4i3rnkn0cnhwlfkdj73zml58957mjrxb40q2ngjl4ydw";
       });
     postUnpack = "sourceRoot+=/byron/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-examples.nix
+++ b/nix/.stack.nix/typed-protocols-examples.nix
@@ -88,8 +88,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/typed-protocols-examples; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -66,8 +66,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "ffcc4fad05ef888a7c0ed8ff662ee4478484d1da";
-      sha256 = "1sa8fks5i1sya3qxfl97cagl2w9hjjbfk3s3ghr0fprrgv3ls2lf";
+      rev = "7e89518148ebb11d9ee6b973c394a69713961de6";
+      sha256 = "06mhpn3kmlk9siiki2rn3cmq4v7lz6rvxzmll1zdf5lhrh3ixks2";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -87,7 +87,7 @@ extra-deps:
     - slotting
 
 - git: https://github.com/input-output-hk/cardano-ledger
-  commit: 22e89a5f7cc2b02192b1eb420d74530eb2d6cb82
+  commit: 512c26a66a6a63278846646b81bf8eadcd4ae99c
   subdirs:
     - cardano-ledger
     - cardano-ledger/test
@@ -95,7 +95,7 @@ extra-deps:
     - crypto/test
 
 - git: https://github.com/input-output-hk/cardano-ledger-specs
-  commit: 28b4381461252b523473972c85b003301a5deadc
+  commit: 156086266486da710c5037c11f83d2112434926f
   subdirs:
     - byron/semantics/executable-spec # small-steps
     - byron/ledger/executable-spec    # cs-ledger
@@ -111,7 +111,7 @@ extra-deps:
     - test
 
 - git: https://github.com/input-output-hk/ouroboros-network
-  commit: ffcc4fad05ef888a7c0ed8ff662ee4478484d1da
+  commit: 7e89518148ebb11d9ee6b973c394a69713961de6
   subdirs:
     - io-sim
     - io-sim-classes


### PR DESCRIPTION
This includes the various fixes to the Windows named pipe support.

Most of those fixes were only relevant for the server side, i.e. the node, but one of them is relevant for the client side too.

https://github.com/input-output-hk/ouroboros-network/pull/1881

In particular this changes how we connect to a named pipe so that if the pipe instance is not initially available then it'll wait and retry. This is genuinely the MSDN recommended way to do it :man_facepalming:. Otherwise there's a race condition when multiple clients connect, or a client established multiple connections quickly after each other.