### PR TITLE
nix: Update test-suite name to jormungandr-integration

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,11 +11,11 @@
 #   - cardano-wallet-byron - cli executable
 #   - tests - attrset of test-suite executables
 #     - cardano-wallet-core.unit
-#     - cardano-wallet-jormungandr.integration
+#     - cardano-wallet-jormungandr.jormungandr-integration
 #     - etc (layout is PACKAGE.COMPONENT)
 #   - checks - attrset of test-suite results
 #     - cardano-wallet-core.unit
-#     - cardano-wallet-jormungandr.integration
+#     - cardano-wallet-jormungandr.jormungandr-integration
 #     - etc
 #   - benchmarks - attret of benchmark executables
 #     - cardano-wallet-core.db

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -58,6 +58,11 @@ let
       # Add dependencies
       {
         packages.cardano-wallet-byron.components.tests = {
+          # Only run integration tests on non-PR jobsets. Note that
+          # the master branch jobset will just re-use the cached Bors
+          # staging build and test results.
+          cardano-node-integration.doCheck = !isHydraPRJobset;
+
           # provide cardano-node command to test suites
           cardano-node-integration.build-tools = [ pkgs.cardano-node ];
         };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -49,7 +49,7 @@ let
         packages.cardano-wallet-byron.components.tests.cardano-node-integration.keepSource = true;
         packages.cardano-wallet-jormungandr.src = filterSubDir /lib/jormungandr;
         packages.cardano-wallet-jormungandr.components.tests.unit.keepSource = true;
-        packages.cardano-wallet-jormungandr.components.tests.integration.keepSource = true;
+        packages.cardano-wallet-jormungandr.components.tests.jormungandr-integration.keepSource = true;
         packages.cardano-wallet-test-utils.src = filterSubDir /lib/test-utils;
         packages.text-class.src = filterSubDir /lib/text-class;
         packages.text-class.components.tests.unit.keepSource = true;
@@ -65,11 +65,11 @@ let
           # Only run integration tests on non-PR jobsets. Note that
           # the master branch jobset will just re-use the cached Bors
           # staging build and test results.
-          integration.doCheck = !isHydraPRJobset;
+          jormungandr-integration.doCheck = !isHydraPRJobset;
           # Some tests want to write ~/.local/share/cardano-wallet
-          integration.preCheck = "export HOME=`pwd`";
+          jormungandr-integration.preCheck = "export HOME=`pwd`";
           # provide jormungandr command to test suites
-          integration.build-tools = [
+          jormungandr-integration.build-tools = [
             jmPkgs.jormungandr
             jmPkgs.jormungandr-cli
           ];

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -58,10 +58,13 @@ let
       # Add dependencies
       {
         packages.cardano-wallet-byron.components.tests = {
-          # Only run integration tests on non-PR jobsets. Note that
-          # the master branch jobset will just re-use the cached Bors
-          # staging build and test results.
-          cardano-node-integration.doCheck = !isHydraPRJobset;
+          # # Only run integration tests on non-PR jobsets. Note that
+          # # the master branch jobset will just re-use the cached Bors
+          # # staging build and test results.
+          # cardano-node-integration.doCheck = !isHydraPRJobset;
+
+          # fixme: test suite disabled - they are timing out
+          cardano-node-integration.doCheck = false;
 
           # provide cardano-node command to test suites
           cardano-node-integration.build-tools = [ pkgs.cardano-node ];

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -46,7 +46,7 @@ let
         packages.cardano-wallet-cli.src = filterSubDir /lib/cli;
         packages.cardano-wallet-launcher.src = filterSubDir /lib/launcher;
         packages.cardano-wallet-byron.src = filterSubDir /lib/byron;
-        packages.cardano-wallet-byron.components.tests.cardano-node-integration.keepSource = true;
+        packages.cardano-wallet-byron.components.tests.integration.keepSource = true;
         packages.cardano-wallet-jormungandr.src = filterSubDir /lib/jormungandr;
         packages.cardano-wallet-jormungandr.components.tests.unit.keepSource = true;
         packages.cardano-wallet-jormungandr.components.tests.jormungandr-integration.keepSource = true;
@@ -61,13 +61,13 @@ let
           # # Only run integration tests on non-PR jobsets. Note that
           # # the master branch jobset will just re-use the cached Bors
           # # staging build and test results.
-          # cardano-node-integration.doCheck = !isHydraPRJobset;
+          # integration.doCheck = !isHydraPRJobset;
 
           # fixme: test suite disabled - they are timing out
-          cardano-node-integration.doCheck = false;
+          integration.doCheck = false;
 
           # provide cardano-node command to test suites
-          cardano-node-integration.build-tools = [ pkgs.cardano-node ];
+          integration.build-tools = [ pkgs.cardano-node ];
         };
         packages.cardano-wallet-jormungandr.components.tests = {
           # Next releases are going to be about cardano-node and we

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -62,10 +62,9 @@ let
           cardano-node-integration.build-tools = [ pkgs.cardano-node ];
         };
         packages.cardano-wallet-jormungandr.components.tests = {
-          # Only run integration tests on non-PR jobsets. Note that
-          # the master branch jobset will just re-use the cached Bors
-          # staging build and test results.
-          jormungandr-integration.doCheck = !isHydraPRJobset;
+          # Next releases are going to be about cardano-node and we
+          # aren't touching jormungandr a lot more these days.
+          jormungandr-integration.doCheck = false;
           # Some tests want to write ~/.local/share/cardano-wallet
           jormungandr-integration.preCheck = "export HOME=`pwd`";
           # provide jormungandr command to test suites


### PR DESCRIPTION
### Issue Number

Relates to #1508

### Overview

- Update the jormungandr integration test-suite name in the nix config. This fixes the failing windows test bundle build.
- Stop running jormungandr integration tests on hydra.
- Temporarily disable cardano-node integration tests on hydra until the timeout problem can be debugged. This means we are no longer wasting build slots on hydra. :-)

