### PR TITLE
nix: Fix unit tests build on macos

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
@@ -14,8 +14,6 @@ import Control.Concurrent.Async
     ( async, link )
 import Control.Exception
     ( fromException )
-import Control.Monad
-    ( when )
 import Control.Tracer
     ( nullTracer )
 import Data.ByteString.Lazy
@@ -62,12 +60,10 @@ import Network.Wai
     ( responseLBS )
 import System.FilePath
     ( FilePath, (</>) )
-import System.Info
-    ( os )
 import Test.Hspec
-    ( Spec, describe, it, pendingWith, shouldBe, shouldThrow )
+    ( Spec, describe, it, shouldBe, shouldThrow )
 import Test.Utils.Paths
-    ( getTestData, inNixBuild )
+    ( getTestData )
 
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Network.HTTP.Types.Status as Http
@@ -77,7 +73,6 @@ import qualified Network.Wai.Handler.Warp as Warp
 spec :: Spec
 spec = describe "TLS Client Authentication" $ do
     it "Respond to authenticated client if TLS is enabled" $ do
-        pendingOnMacOSNix
         withListeningSocket "*" ListenOnRandomPort $ \(Right (port, socket)) -> do
             let tlsSv = TlsConfiguration
                     { tlsCaCert = rootPKI 1 </> "ca.crt"
@@ -99,7 +94,6 @@ spec = describe "TLS Client Authentication" $ do
                 }
 
     it "Deny client with wrong certificate if TLS is enabled" $ do
-        pendingOnMacOSNix
         withListeningSocket "*" ListenOnRandomPort $ \(Right (port, socket)) -> do
             let tlsSv = TlsConfiguration
                     { tlsCaCert = rootPKI 1 </> "ca.crt"
@@ -136,11 +130,6 @@ spec = describe "TLS Client Authentication" $ do
                 { statusCode = 426
                 , statusMessage = "Upgrade Required"
                 }
-
-pendingOnMacOSNix :: IO ()
-pendingOnMacOSNix = when (os == "darwin") $ do
-    nix <- inNixBuild
-    when nix $ pendingWith "Issue #1525 - needs darwin security tool in PATH"
 
 --
 -- Test Application

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -111,8 +111,15 @@ let
           };
 
         packages.cardano-wallet-core.components.tests.unit.preBuild = ''
+          # Provide the swagger file in an environment variable
+          # because it is located outside of the Cabal package source
+          # tree.
           export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}
-        '';
+        '' + (pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
+          # Make the /usr/bin/security tool available because it's
+          # needed at runtime by the x509-system Haskell package.
+          export PATH=$PATH:/usr/bin
+        '');
 
         # Workaround for Haskell.nix issue
         packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -110,16 +110,17 @@ let
             '';
           };
 
+        # Provide the swagger file in an environment variable because
+        # it is located outside of the Cabal package source tree.
         packages.cardano-wallet-core.components.tests.unit.preBuild = ''
-          # Provide the swagger file in an environment variable
-          # because it is located outside of the Cabal package source
-          # tree.
           export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}
-        '' + (pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
-          # Make the /usr/bin/security tool available because it's
-          # needed at runtime by the x509-system Haskell package.
-          export PATH=$PATH:/usr/bin
-        '');
+        '';
+
+        # Make the /usr/bin/security tool available because it's
+        # needed at runtime by the x509-system Haskell package.
+        packages.x509-system.components.library.preBuild = pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
+          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
+        '';
 
         # Workaround for Haskell.nix issue
         packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";


### PR DESCRIPTION
The cardano-wallet-core unit tests are failing on macOS on Hydra.

Hydra job: [native.checks.cardano-wallet-core.unit.x86_64-darwin](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1525/native.checks.cardano-wallet-core.unit.x86_64-darwin)
