### PR TITLE
nix: Add fully static build of cardano-wallet-byron

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -133,9 +133,9 @@ let
                     "--disable-shared"
           ];
         });
-      in {
-        # Add GHC flags and libraries for fully static build
-        packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr = {
+
+        # Module options which adds GHC flags and libraries for a fully static build
+        fullyStaticOptions = {
           configureFlags =
              lib.optionals hostPlatform.isMusl ([
                "--disable-executable-dynamic"
@@ -144,6 +144,12 @@ let
                "--ghc-option=-optl=-static"
              ] ++ map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs);
         };
+      in {
+        # Apply fully static options to our Haskell executables
+        packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr = fullyStaticOptions;
+        packages.cardano-wallet-byron.components.exes.cardano-wallet-byron = fullyStaticOptions;
+        packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
+
         # Packages we wish to ignore version bounds of.
         # This is similar to jailbreakCabal, however it
         # does not require any messing with cabal files.

--- a/nix/linux-release.nix
+++ b/nix/linux-release.nix
@@ -1,0 +1,32 @@
+############################################################################
+# Linux release
+#
+# This bundles up the fully static Linux build of the given exes and
+# sets up the Hydra build artifact.
+#
+############################################################################
+
+{ pkgs
+, exes ? []
+}:
+
+with pkgs.lib;
+
+assert (assertMsg (builtins.length exes > 0) "empty list of exes");
+
+let
+  name = (head exes).meta.name;
+  tarname = "${name}-linux64.tar.gz";
+
+in pkgs.runCommand name {
+  buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
+} ''
+  mkdir ${name}
+  cp -R ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
+  chmod -R 755 ${name}
+  strip ${name}/*
+
+  mkdir -p $out/nix-support
+  tar -czf $out/${tarname} ${name}
+  echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
+''

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -1,0 +1,31 @@
+############################################################################
+# macOS release
+#
+# This bundles up the fully darwin build of the given exes, with their
+# dependencies, and sets up the Hydra build artifact.
+#
+############################################################################
+
+{ pkgs
+, exes ? []
+}:
+
+with pkgs.lib;
+
+assert (assertMsg (builtins.length exes > 0) "empty list of exes");
+
+let
+  name = (head exes).meta.name;
+  tarname = "${name}-macos64.tar.gz";
+
+in pkgs.runCommand name {
+  buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
+} ''
+  mkdir ${name}
+  cp -R ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
+  chmod -R 755 ${name}
+
+  mkdir -p $out/nix-support
+  tar -czf $out/${tarname} ${name}
+  echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
+''

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  name = "${exe.name}-win64";
+  name = "${exe.meta.name}-win64";
 
 in pkgs.runCommand name { buildInputs = [ pkgs.buildPackages.zip ]; } ''
   mkdir -p $out/nix-support release

--- a/release.nix
+++ b/release.nix
@@ -149,21 +149,19 @@ let
       migration-tests = jobs.x86_64-w64-mingw32.migration-tests.x86_64-linux;
     };
 
-    # Fully-static linux binary (placeholder - does not build)
-    cardano-wallet-jormungandr-linux64 = let
-      name = "cardano-wallet-jormungandr-${project.version}";
-      tarname = "${name}-linux64.tar.gz";
-    in pkgs.runCommand "${name}-linux64" {
-      buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
-    } ''
-      cp -R ${jobs.musl64.cardano-wallet-jormungandr.x86_64-linux}/bin ${name}
-      chmod -R 755 ${name}
-      strip ${name}/*
-
-      mkdir -p $out/nix-support
-      tar -czf $out/${tarname} ${name}
-      echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
-    '';
+    # Fully-static linux binaries
+    cardano-wallet-jormungandr-linux64 = import ./nix/linux-release.nix {
+      inherit pkgs;
+      exes = [ jobs.musl64.cardano-wallet-jormungandr.x86_64-linux ];
+    };
+    cardano-wallet-byron-linux64 = import ./nix/linux-release.nix {
+      inherit pkgs;
+      exes = [
+        jobs.musl64.cardano-wallet-byron.x86_64-linux
+        # SRE-83 dependencies fail to build
+        # jobs.musl64.cardano-node.x86_64-linux
+      ];
+    };
 
     # macOS binary and dependencies in tarball
     cardano-wallet-jormungandr-macos64 = let

--- a/release.nix
+++ b/release.nix
@@ -164,19 +164,17 @@ let
     };
 
     # macOS binary and dependencies in tarball
-    cardano-wallet-jormungandr-macos64 = let
-      name = "cardano-wallet-jormungandr-${project.version}";
-      tarname = "${name}-macos64.tar.gz";
-    in pkgs.runCommand "${name}-macos64" {
-      buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils nix ];
-    } ''
-      cp -R ${jobs.native.cardano-wallet-jormungandr.x86_64-darwin}/bin ${name}
-      chmod -R 755 ${name}
-
-      mkdir -p $out/nix-support
-      tar -czf $out/${tarname} ${name}
-      echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
-    '';
+    cardano-wallet-jormungandr-macos64 = import ./nix/macos-release.nix {
+      inherit pkgs;
+      exes = [ jobs.native.cardano-wallet-jormungandr.x86_64-darwin ];
+    };
+    cardano-wallet-byron-macos64 = import ./nix/macos-release.nix {
+      inherit pkgs;
+      exes = [
+        jobs.native.cardano-wallet-byron.x86_64-darwin
+        jobs.native.cardano-node.x86_64-darwin
+      ];
+    };
 
     # Build and cache the build script used on Buildkite
     buildkiteScript = import ./.buildkite/default.nix {


### PR DESCRIPTION
### Overview

I saw the musl static build of `cardano-wallet-byron` was failing and it's pretty simple to fix.

# Comments

Download links:
- https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1526/cardano-wallet-byron-linux64/latest-finished
- https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1526/cardano-wallet-byron-macos64/latest-finished