### PR TITLE
Add latency benchmark for byron

### DIFF
--- a/.buildkite/bench-latency.sh
+++ b/.buildkite/bench-latency.sh
@@ -10,11 +10,14 @@ echo "--- Build"
 nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o $bench_name_jormungandr
 nix-build -A benchmarks.cardano-wallet-byron.latency -o $bench_name_byron
 
-echo "+++ Run benchmark"
-
 # Note: the tracing will not work if program output is piped
 # to another process (e.g. "tee").
 # It says "Error: Switchboard's queue full, dropping log items!"
 
-./$bench_name_jormungandr/bin/latency
+echo "+++ Run benchmark - byron"
+
 ./$bench_name_byron/bin/latency
+
+echo "+++ Run benchmark - jormungandr"
+
+./$bench_name_jormungandr/bin/latency

--- a/.buildkite/bench-latency.sh
+++ b/.buildkite/bench-latency.sh
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
-bench_name=bench-latency
+bench_name_jormungandr=bench-latency-jormungandr
+bench_name_byron=bench-latency-byron
 
 echo "--- Build"
-nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o $bench_name
+nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o $bench_name_jormungandr
+nix-build -A benchmarks.cardano-wallet-byron.latency -o $bench_name_byron
 
 echo "+++ Run benchmark"
 
@@ -14,4 +16,5 @@ echo "+++ Run benchmark"
 # to another process (e.g. "tee").
 # It says "Error: Switchboard's queue full, dropping log items!"
 
-./$bench_name/bin/latency
+./$bench_name_jormungandr/bin/latency
+./$bench_name_byron/bin/latency

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -10,6 +10,12 @@
           - AnyAddressStateId
           - AnyAddressStateKey
           - AnyAddressStateProportion
+  - section:
+    - name: test:integration bench:latency
+    - message:
+      - name: Module reused between components
+      - module:
+        - Cardano.Wallet.Byron.Faucet
 - package:
   - name: cardano-wallet-core
   - section:
@@ -136,4 +142,3 @@
     - message:
       - name: Module not compiled
       - module: Cardano.Startup.Windows
-

--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import Prelude
+
+main :: IO ()
+main = putStrLn "----------Latency"

--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -1,6 +1,267 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Main where
 
 import Prelude
 
-main :: IO ()
-main = putStrLn "----------Latency"
+import Cardano.BM.Backend.Switchboard
+    ( effectuate )
+import Cardano.BM.Configuration.Static
+    ( defaultConfigStdout )
+import Cardano.BM.Data.LogItem
+    ( LOContent (..), LOMeta (..), LogObject (..) )
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.BM.Data.Tracer
+    ( ToObject (..), contramap, nullTracer )
+import Cardano.BM.Setup
+    ( setupTrace_, shutdown )
+import Cardano.BM.Trace
+    ( traceInTVarIO )
+import Cardano.CLI
+    ( Port (..) )
+import Cardano.Launcher
+    ( ProcessHasExited (..) )
+import Cardano.Startup
+    ( withUtf8Encoding )
+import Cardano.Wallet.Api.Server
+    ( Listen (..) )
+import Cardano.Wallet.Api.Types
+    ( ApiByronWallet, WalletStyle (..) )
+import Cardano.Wallet.Byron
+    ( SomeNetworkDiscriminant (..)
+    , Tracers
+    , Tracers' (..)
+    , nullTracers
+    , serveWallet
+    )
+import Cardano.Wallet.Byron.Compatibility
+    ( Byron )
+import Cardano.Wallet.Byron.Faucet
+    ( initFaucet )
+import Cardano.Wallet.Byron.Launch
+    ( withCardanoNode )
+import Cardano.Wallet.Logging
+    ( trMessage )
+import Cardano.Wallet.Network.Ports
+    ( unsafePortNumber )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.Types
+    ( SyncTolerance (..) )
+import Control.Concurrent.Async
+    ( race )
+import Control.Concurrent.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
+import Control.Concurrent.STM.TVar
+    ( TVar, newTVarIO, readTVarIO, writeTVar )
+import Control.Exception
+    ( bracket, onException, throwIO )
+import Control.Monad
+    ( mapM_, replicateM, replicateM_ )
+import Control.Monad.STM
+    ( atomically )
+import Data.Aeson
+    ( FromJSON (..), ToJSON (..) )
+import Data.Maybe
+    ( mapMaybe )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text.Class
+    ( toText )
+import Data.Time
+    ( NominalDiffTime )
+import Data.Time.Clock
+    ( diffUTCTime )
+import Fmt
+    ( Builder, build, fixedF, fmtLn, padLeftF, (+|), (|+) )
+import Network.HTTP.Client
+    ( defaultManagerSettings
+    , managerResponseTimeout
+    , newManager
+    , responseTimeoutMicro
+    )
+import Network.Wai.Middleware.Logging
+    ( ApiLog (..), HandlerLog (..) )
+import System.IO.Temp
+    ( withSystemTempDirectory )
+import Test.Integration.Framework.DSL
+    ( Context (..), Headers (..), Payload (..), fixtureRandomWallet, request )
+import Test.Utils.Paths
+    ( getTestData )
+
+import qualified Cardano.BM.Configuration.Model as CM
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Text as T
+
+main :: forall t n. (t ~ Byron, n ~ 'Mainnet) => IO ()
+main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
+    fmtLn "Latencies for 2 fixture wallets scenario"
+    runScenario logging tvar (nFixtureWallet 2)
+  where
+    -- Creates n fixture wallets and return two of them
+    nFixtureWallet n ctx = do
+        wal1 : wal2 : _ <- replicateM n (fixtureRandomWallet ctx)
+        pure (wal1, wal2)
+
+    runScenario logging tvar scenario = benchWithServer logging $ \ctx -> do
+        (_wal1, _wal2) <- scenario ctx
+
+        t1 <- measureApiLogs tvar
+            (request @[ApiByronWallet] ctx (Link.listWallets @'Byron) Default Empty)
+
+        fmtResult "listWallets        " t1
+
+        pure ()
+
+meanAvg :: [NominalDiffTime] -> Double
+meanAvg ts = sum (map realToFrac ts) * 1000 / fromIntegral (length ts)
+
+buildResult :: [NominalDiffTime] -> Builder
+buildResult [] = "ERR"
+buildResult ts = build $ fixedF 1 $ meanAvg ts
+
+fmtResult :: String -> [NominalDiffTime] -> IO ()
+fmtResult title ts =
+    let titleExt = title|+" - " :: String
+        titleF = padLeftF 25 ' ' titleExt
+    in fmtLn (titleF+|buildResult ts|+" ms")
+
+isLogRequestStart :: ApiLog -> Bool
+isLogRequestStart = \case
+    ApiLog _ LogRequestStart -> True
+    _ -> False
+
+isLogRequestFinish :: ApiLog -> Bool
+isLogRequestFinish = \case
+    ApiLog _ LogRequestFinish -> True
+    _ -> False
+
+measureApiLogs
+    :: TVar [LogObject ApiLog] -- ^ Log message variable.
+    -> IO a -- ^ Action to run
+    -> IO [NominalDiffTime]
+measureApiLogs = measureLatency isLogRequestStart isLogRequestFinish
+
+-- | Run tests for at least this long to get accurate timings.
+sampleTimeSeconds :: Int
+sampleTimeSeconds = 5
+
+-- | Run tests for at least this long to get accurate timings.
+sampleNTimes :: Int
+sampleNTimes = 10
+
+-- | Measure how long an action takes based on trace points and taking an
+-- average of results over a short time period.
+measureLatency
+    :: (msg -> Bool) -- ^ Predicate for start message
+    -> (msg -> Bool) -- ^ Predicate for end message
+    -> TVar [LogObject msg] -- ^ Log message variable.
+    -> IO a -- ^ Action to run
+    -> IO [NominalDiffTime]
+measureLatency start finish tvar action = do
+    atomically $ writeTVar tvar []
+    replicateM_ sampleNTimes action
+    extractTimings start finish . reverse <$> readTVarIO tvar
+
+-- | Scan through iohk-monitoring logs and extract time differences between
+-- start and end messages.
+extractTimings
+    :: (a -> Bool) -- ^ Predicate for start message
+    -> (a -> Bool) -- ^ Predicate for end message
+    -> [LogObject a] -- ^ Log messages
+    -> [NominalDiffTime]
+extractTimings isStart isFinish msgs = map2 mkDiff filtered
+  where
+    map2 _ [] = []
+    map2 f (a:b:xs) = (f a b:map2 f xs)
+    map2 _ _ = error "start trace without matching finish trace"
+
+    mkDiff (False, start) (True, finish) = diffUTCTime finish start
+    mkDiff (False, _) _ = error "missing finish trace"
+    mkDiff (True, _) _ = error "missing start trace"
+
+    filtered = mapMaybe filterMsg msgs
+    filterMsg logObj = case loContent logObj of
+        LogMessage msg | isStart msg -> Just (False, getTimestamp logObj)
+        LogMessage msg | isFinish msg -> Just (True, getTimestamp logObj)
+        _ -> Nothing
+    getTimestamp = tstamp . loMeta
+
+withLatencyLogging
+    ::(Tracers IO -> TVar [LogObject ApiLog] -> IO a)
+    -> IO a
+withLatencyLogging action = do
+    tvar <- newTVarIO []
+    cfg <- defaultConfigStdout
+    CM.setMinSeverity cfg Debug
+    bracket (setupTrace_ cfg "bench-latency") (shutdown . snd) $ \(_, sb) -> do
+        action (setupTracers tvar) tvar `onException` do
+            fmtLn "Action failed. Here are the captured logs:"
+            readTVarIO tvar >>= mapM_ (effectuate sb) . reverse
+
+setupTracers :: TVar [LogObject ApiLog] -> Tracers IO
+setupTracers tvar = nullTracers
+    { apiServerTracer = trMessage $ contramap snd (traceInTVarIO tvar) }
+
+benchWithServer
+    :: Tracers IO
+    -> (Context Byron -> IO ())
+    -> IO ()
+benchWithServer tracers action = do
+    ctx <- newEmptyMVar
+    let setupContext bp wAddr = do
+            let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
+            let sixtySeconds = 60*1000*1000 -- 60s in microseconds
+            manager <- (baseUrl,) <$> newManager (defaultManagerSettings
+                { managerResponseTimeout =
+                    responseTimeoutMicro sixtySeconds
+                })
+            faucet <- initFaucet
+            putMVar ctx $ Context
+                { _cleanup = pure ()
+                , _manager = manager
+                , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
+                , _faucet = faucet
+                , _feeEstimator = \_ -> error "feeEstimator not available"
+                , _blockchainParameters = bp
+                , _target = Proxy
+                }
+    race (takeMVar ctx >>= action) (withServer setupContext) >>=
+        either pure (throwIO . ProcessHasExited "integration")
+  where
+    withServer act =
+        withCardanoNode nullTracer $(getTestData) $ \socketPath block0 (bp,vData) ->
+        withSystemTempDirectory "cardano-wallet-databases" $ \db -> do
+            serveWallet
+                (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                tracers
+                (SyncTolerance 10)
+                (Just db)
+                "127.0.0.1"
+                ListenOnRandomPort
+                Nothing
+                socketPath
+                block0
+                (bp, vData)
+                (act bp)
+
+instance ToJSON ApiLog where
+    toJSON = toJSON . toText
+
+instance FromJSON ApiLog where
+    parseJSON _ = fail "FromJSON ApiLog stub"
+
+instance ToObject ApiLog

--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -130,12 +130,17 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar ->
     forM_ [ (fixtureRandomWallet, "Random wallets")
           , (fixtureIcarusWallet, "Icarus wallets")] $
     \(fixtureByronWallet, walletName) -> do
-
              fmtLn "\n"
              fmtLn walletName
 
              fmtLn "  Latencies for 2 fixture wallets scenario"
              runScenario logging tvar (nFixtureWallet 2 fixtureByronWallet)
+
+             fmtLn "  Latencies for 10 fixture wallets scenario"
+             runScenario logging tvar (nFixtureWallet 10 fixtureByronWallet)
+
+             fmtLn "  Latencies for 100 fixture wallets scenario"
+             runScenario logging tvar (nFixtureWallet 100 fixtureByronWallet)
   where
     -- Creates n fixture wallets and return two of them
     nFixtureWallet n fixtureWallet ctx = do

--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -439,7 +439,7 @@ benchWithServer tracers action = do
         either pure (throwIO . ProcessHasExited "integration")
   where
     withServer act =
-        withCardanoNode nullTracer $(getTestData) $ \socketPath block0 (bp,vData) ->
+        withCardanoNode nullTracer $(getTestData) Error $ \socketPath block0 (bp,vData) ->
         withSystemTempDirectory "cardano-wallet-databases" $ \db -> do
             serveWallet
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)

--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -243,3 +243,25 @@ benchmark restore
    other-modules:
        Cardano.Wallet.Primitive.AddressDiscovery.Any
        Cardano.Wallet.Primitive.AddressDiscovery.Any.TH
+
+benchmark latency
+   default-language:
+       Haskell2010
+   default-extensions:
+       NoImplicitPrelude
+       OverloadedStrings
+   ghc-options:
+       -threaded -rtsopts
+       -Wall
+       -O2
+   if (!flag(development))
+     ghc-options:
+       -Werror
+   build-depends:
+       base
+   type:
+      exitcode-stdio-1.0
+   hs-source-dirs:
+       bench
+   main-is:
+       Latency.hs

--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -260,7 +260,6 @@ benchmark latency
    build-depends:
       base
     , aeson
-    , aeson-qq
     , async
     , bech32
     , bech32-th

--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -258,10 +258,42 @@ benchmark latency
      ghc-options:
        -Werror
    build-depends:
-       base
-   type:
-      exitcode-stdio-1.0
-   hs-source-dirs:
-       bench
-   main-is:
-       Latency.hs
+      base
+    , aeson
+    , aeson-qq
+    , async
+    , bech32
+    , bech32-th
+    , bytestring
+    , cardano-wallet-cli
+    , cardano-wallet-core
+    , cardano-wallet-core-integration
+    , cardano-wallet-byron
+    , cardano-wallet-launcher
+    , cardano-wallet-test-utils
+    , command
+    , directory
+    , filepath
+    , fmt
+    , generic-lens
+    , http-client
+    , http-types
+    , hspec
+    , iohk-monitoring
+    , memory
+    , stm
+    , temporary
+    , text
+    , text-class
+    , time
+  build-tools:
+      cardano-wallet-byron
+  type:
+     exitcode-stdio-1.0
+  hs-source-dirs:
+      bench
+      test/integration
+  main-is:
+      Latency.hs
+  other-modules:
+      Cardano.Wallet.Byron.Faucet

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.Byron
     , tracerDescriptions
     , setupTracers
     , tracerSeverities
+    , nullTracers
 
       -- * Logs
     , ApplicationLog (..)
@@ -440,3 +441,14 @@ tracerDescriptions =
     ]
   where
     lbl f = T.unpack . getConst . f $ tracerLabels
+
+-- | Use a 'nullTracer' for each of the 'Tracer's in 'Tracers'
+nullTracers :: Monad m => Tracers m
+nullTracers = Tracers
+    { applicationTracer  = nullTracer
+    , apiServerTracer    = nullTracer
+    , walletEngineTracer = nullTracer
+    , walletDbTracer     = nullTracer
+    , ntpClientTracer    = nullTracer
+    , networkTracer      = nullTracer
+    }

--- a/lib/byron/test/data/cardano-node/node.config
+++ b/lib/byron/test/data/cardano-node/node.config
@@ -39,9 +39,6 @@ LastKnownBlockVersion-Alt: 0
 #    |_____\___/ \__, |\__, |_|_| |_|\__, |
 #                |___/ |___/         |___/
 
-# global filter; messages must have at least this severity to pass:
-minSeverity: Info
-
 # if not indicated otherwise, then messages are passed to these backends:
 defaultBackends:
   - KatipBK

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -170,7 +170,7 @@ specWithServer tr = aroundAll withContext . after tearDown
             either pure (throwIO . ProcessHasExited "integration")
 
     withServer action =
-        withCardanoNode tr $(getTestData) $ \socketPath block0 (bp,vData) ->
+        withCardanoNode tr $(getTestData) Info $ \socketPath block0 (bp,vData) ->
         withSystemTempDirectory "cardano-wallet-databases" $ \db -> do
             serveWallet
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -202,7 +202,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."aeson" or (buildDepError "aeson"))
-            (hsPkgs."aeson-qq" or (buildDepError "aeson-qq"))
             (hsPkgs."async" or (buildDepError "async"))
             (hsPkgs."bech32" or (buildDepError "bech32"))
             (hsPkgs."bech32-th" or (buildDepError "bech32-th"))

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -198,6 +198,42 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             ];
           buildable = true;
           };
+        "latency" = {
+          depends = [
+            (hsPkgs."base" or (buildDepError "base"))
+            (hsPkgs."aeson" or (buildDepError "aeson"))
+            (hsPkgs."aeson-qq" or (buildDepError "aeson-qq"))
+            (hsPkgs."async" or (buildDepError "async"))
+            (hsPkgs."bech32" or (buildDepError "bech32"))
+            (hsPkgs."bech32-th" or (buildDepError "bech32-th"))
+            (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-byron" or (buildDepError "cardano-wallet-byron"))
+            (hsPkgs."cardano-wallet-launcher" or (buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."command" or (buildDepError "command"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
+            (hsPkgs."fmt" or (buildDepError "fmt"))
+            (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
+            (hsPkgs."http-client" or (buildDepError "http-client"))
+            (hsPkgs."http-types" or (buildDepError "http-types"))
+            (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))
+            (hsPkgs."memory" or (buildDepError "memory"))
+            (hsPkgs."stm" or (buildDepError "stm"))
+            (hsPkgs."temporary" or (buildDepError "temporary"))
+            (hsPkgs."text" or (buildDepError "text"))
+            (hsPkgs."text-class" or (buildDepError "text-class"))
+            (hsPkgs."time" or (buildDepError "time"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-wallet-byron or (pkgs.buildPackages.cardano-wallet-byron or (buildToolDepError "cardano-wallet-byron")))
+            ];
+          buildable = true;
+          };
         };
       };
     } // rec { src = (pkgs.lib).mkDefault ../.././lib/byron; }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -104,6 +104,7 @@ let
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/latency \
+                --run "cd $src" \
                 --prefix PATH : ${pkgs.cardano-node}/bin
             '';
           };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -98,6 +98,16 @@ let
             '';
           };
 
+        # Add cardano-node to the PATH of the byron latency benchmark
+        packages.cardano-wallet-byron.components.benchmarks.latency =
+          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+            build-tools = [ pkgs.makeWrapper ];
+            postInstall = ''
+              wrapProgram $out/bin/latency \
+                --prefix PATH : ${pkgs.cardano-node}/bin
+            '';
+          };
+
         # cardano-node will want to write logs to a subdirectory of the working directory.
         # We don't `cd $src` because of that.
 				#


### PR DESCRIPTION
# Issue Number

#1527 

# Overview

- [x] I have added first benchmark that works with just one scenario inside
- [x] I have extended scenario with all endpoints to be tested
- [x] I have enabled testing for both icarus and random wallets
- [x] I have added more benchmarks conditions (txs and utxos)
- [x] I have added the benchmark to nightly


# Comments

- Manual build on Buildkite: [cardano-wallet-nightly](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=paweljakubas%2F1527%2Fadd-latency-benchmark-for-byron)
