### PR TITLE
Remove reward-credentials option from `cardano-wallet-byron mnemonic` CLI

### DIFF
--- a/lib/byron/exe/cardano-wallet-byron.hs
+++ b/lib/byron/exe/cardano-wallet-byron.hs
@@ -38,7 +38,7 @@ import Cardano.CLI
     , cmdAddress
     , cmdByronWalletCreate
     , cmdKey
-    , cmdMnemonic
+    , cmdMnemonicByron
     , cmdNetwork
     , cmdTransaction
     , cmdVersion
@@ -153,7 +153,7 @@ main = withUtf8Encoding $ do
     enableWindowsANSI
     runCli $ cli $ mempty
         <> cmdServe
-        <> cmdMnemonic
+        <> cmdMnemonicByron
         <> cmdKey
         <> cmdWallet cmdByronWalletCreate byronWalletClient
         <> cmdAddress byronAddressClient

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -33,6 +33,7 @@ module Cardano.CLI
 
     -- * Commands
     , cmdMnemonic
+    , cmdMnemonicByron
     , cmdWallet
     , cmdWalletCreate
     , cmdByronWalletCreate
@@ -715,6 +716,13 @@ cmdMnemonic = command "mnemonic" $ info (helper <*> cmds) $ mempty
     cmds = subparser $ mempty
         <> cmdMnemonicGenerate
         <> cmdMnemonicRewardCredentials
+
+cmdMnemonicByron :: Mod CommandFields (IO ())
+cmdMnemonicByron = command "mnemonic" $ info (helper <*> cmds) $ mempty
+    <> progDesc "Manage mnemonic phrases."
+  where
+    cmds = subparser $ mempty
+        <> cmdMnemonicGenerate
 
 -- | Arguments for 'mnemonic generate' command
 newtype MnemonicGenerateArgs = MnemonicGenerateArgs


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 124cdeb58f6450ede9b97322c536d65d2ccfbc8e
  Remove reward-credentials option from `cardano-wallet-byron mnemonic` CLI
  


# Comments
Because the option was only for ITN.
Now:
```
$ cardano-wallet-byron mnemonic
Usage: cardano-wallet-byron mnemonic COMMAND
  Manage mnemonic phrases.

Available options:
  -h,--help                Show this help text

Available commands:
  generate                 Generate English BIP-0039 compatible mnemonic words.
```
