### PR TITLE
Re-enable integration tests on Hydra

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -71,7 +71,7 @@ let
   };
 
   filterCardanoPackages = lib.filterAttrs (_: package: isCardanoWallet package);
-  getPackageChecks = lib.mapAttrs (_: package: package.checks);
+  getPackageChecks = mapAttrs (_: package: package.checks);
 
   self = {
     inherit pkgs commonLib src haskellPackages stackNixRegenerate;

--- a/default.nix
+++ b/default.nix
@@ -105,10 +105,12 @@ let
     # `migration-tests` build previous releases then check if the database successfully upgrades.
     migration-tests = import ./nix/migration-tests.nix { inherit system crossSystem config pkgs; };
 
-    dockerImage = mapAttrs (backend: exe: pkgs.callPackage ./nix/docker.nix { inherit backend exe; }) {
+    dockerImage = let
+      mkDockerImage = backend: exe: pkgs.callPackage ./nix/docker.nix { inherit backend exe; };
+    in recurseIntoAttrs (mapAttrs mkDockerImage {
       jormungandr = self.cardano-wallet-jormungandr;
       byron = self.cardano-wallet-byron;
-    };
+    });
 
     shell = haskellPackages.shellFor {
       name = "cardano-wallet-shell";

--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -56,7 +56,9 @@ import System.Directory
 import System.Environment
     ( lookupEnv )
 import System.FilePath
-    ( (</>) )
+    ( takeFileName, (</>) )
+import System.Info
+    ( os )
 import System.IO.Temp
     ( createTempDirectory, getCanonicalTemporaryDirectory )
 
@@ -153,8 +155,11 @@ withConfig tdir action =
         let nodeDlgCertFile  = dir </> "node.cert"
         let nodeGenesisFile  = dir </> "genesis.json"
         let nodeSignKeyFile  = dir </> "node.key"
-        let nodeSocketFile   = dir </> "node.socket"
         let nodeTopologyFile = dir </> "node.topology"
+        let nodeSocketFile =
+                if os == "mingw32"
+                then "\\\\.\\pipe\\" ++ takeFileName dir
+                else dir </> "node.socket"
 
         -- we need to specify genesis file location every run in tmp
         Yaml.decodeFileThrow (source </> "node.config")

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -81,6 +81,8 @@ import Network.HTTP.Client
     )
 import Numeric.Natural
     ( Natural )
+import System.IO
+    ( BufferMode (..), hSetBuffering, stdout )
 import System.IO.Temp
     ( withSystemTempDirectory )
 import Test.Hspec
@@ -120,6 +122,7 @@ instance KnownCommand Byron where
 
 main :: forall t n. (t ~ Byron, n ~ 'Mainnet) => IO ()
 main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
+    hSetBuffering stdout LineBuffering
     hspec $ do
         describe "No backend required" $ do
             describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
@@ -52,7 +52,14 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldContain, shouldSatisfy )
+    ( SpecWith
+    , describe
+    , it
+    , pendingWith
+    , shouldBe
+    , shouldContain
+    , shouldSatisfy
+    )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)
@@ -335,8 +342,13 @@ spec = describe "BYRON_TXS_CLI" $ do
               length <$> [oJson1, oJson2] `shouldSatisfy` all (== 0)
 
     it "TRANS_DELETE_01a - Can forget pending tx, still it resolves when it is OK"
-        $ \ctx -> forM_ [fixtureRandomWalletAddrs @n, fixtureRandomWalletAddrs @n]
+        $ \ctx ->forM_ [fixtureRandomWalletAddrs @n, fixtureRandomWalletAddrs @n]
         $ \fixtureByronWallet -> do
+        pendingWith
+            "This test is built on a race-condition. Should the transaction be \
+            \inserted and discovered before the forget request is sent, it \
+            \fails. There are probably better ways of testing this..."
+
         --SETUP
         let amnt = 100_000 :: Natural
         (wSrc, addrs) <- fixtureByronWallet ctx

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -36,6 +36,7 @@ library
     , bytestring
     , cardano-wallet-cli
     , cardano-wallet-core
+    , cardano-wallet-test-utils
     , cborg
     , command
     , containers

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -23,7 +23,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..), SyncProgress (..) )
 import Control.Monad
-    ( forM_ )
+    ( forM_, when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Data.Generics.Internal.VL.Lens
@@ -33,7 +33,7 @@ import Data.Time.Clock
 import Data.Word.Odd
     ( Word31 )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe )
+    ( SpecWith, describe, it, pendingWith, shouldBe )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
@@ -50,6 +50,8 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( errMsg404NoEpochNo )
+import Test.Utils.Paths
+    ( inNixBuild )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
@@ -150,6 +152,9 @@ spec = do
                     (errMsg404NoEpochNo (T.unpack maxEpochValue))
 
     it "NETWORK_CLOCK - Can query network clock" $ \ctx -> do
+        sandboxed <- inNixBuild
+        when sandboxed $
+            pendingWith "Internet NTP servers unavailable in build sandbox"
         eventually "ntp status = (un)available" $ do
             r <- request @ApiNetworkClock ctx
                 Link.getNetworkClock Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
@@ -21,6 +21,8 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..), epochPred )
+import Control.Monad
+    ( when )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Product.Typed
@@ -36,7 +38,7 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe, it, pendingWith )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
 import Test.Integration.Framework.DSL
@@ -49,6 +51,8 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( cmdOk, errMsg404NoEpochNo )
+import Test.Utils.Paths
+    ( inNixBuild )
 
 spec :: forall t. KnownCommand t => SpecWith (Context t)
 spec = do
@@ -96,6 +100,9 @@ spec = do
             params `shouldContain` (errMsg404NoEpochNo maxEpoch)
 
     it "CLI_NETWORK - network clock" $ \ctx -> do
+        sandboxed <- inNixBuild
+        when sandboxed $
+            pendingWith "Internet NTP servers unavailable in build sandbox"
         eventually "ntp status = available" $ do
             clock <- getNetworkClockViaCLI ctx
             expectCliField (#ntpStatus . #status)

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -67,6 +67,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
           (hsPkgs."cardano-wallet-cli" or (buildDepError "cardano-wallet-cli"))
           (hsPkgs."cardano-wallet-core" or (buildDepError "cardano-wallet-core"))
+          (hsPkgs."cardano-wallet-test-utils" or (buildDepError "cardano-wallet-test-utils"))
           (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."command" or (buildDepError "command"))
           (hsPkgs."containers" or (buildDepError "containers"))

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -69,6 +69,9 @@ let
           # because ouroboros-network doesn't fully work under Wine.
           integration.testWrapper = lib.mkIf pkgs.stdenv.hostPlatform.isWindows ["echo"];
 
+          # cardano-node socket path becomes too long otherwise
+          integration.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
+
           # provide cardano-node command to test suites
           integration.build-tools = [ pkgs.cardano-node ];
         };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -63,10 +63,11 @@ let
           # Only run integration tests on non-PR jobsets. Note that
           # the master branch jobset will just re-use the cached Bors
           # staging build and test results.
-          #
+          integration.doCheck = !isHydraPRJobset;
+
           # Running Windows integration tests under Wine is disabled
           # because ouroboros-network doesn't fully work under Wine.
-          integration.doCheck = !isHydraPRJobset && !pkgs.stdenv.hostPlatform.isWindows;
+          integration.testWrapper = lib.mkIf pkgs.stdenv.hostPlatform.isWindows ["echo"];
 
           # provide cardano-node command to test suites
           integration.build-tools = [ pkgs.cardano-node ];

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -156,7 +156,8 @@ let
         # Apply fully static options to our Haskell executables
         packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr = fullyStaticOptions;
         packages.cardano-wallet-byron.components.exes.cardano-wallet-byron = fullyStaticOptions;
-        packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
+        # SRE-83 dependencies fail to build
+        # packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
 
         # Packages we wish to ignore version bounds of.
         # This is similar to jailbreakCabal, however it

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -60,13 +60,13 @@ let
       # Add dependencies
       {
         packages.cardano-wallet-byron.components.tests = {
-          # # Only run integration tests on non-PR jobsets. Note that
-          # # the master branch jobset will just re-use the cached Bors
-          # # staging build and test results.
-          # integration.doCheck = !isHydraPRJobset;
-
-          # fixme: test suite disabled - they are timing out
-          integration.doCheck = false;
+          # Only run integration tests on non-PR jobsets. Note that
+          # the master branch jobset will just re-use the cached Bors
+          # staging build and test results.
+          #
+          # Running Windows integration tests under Wine is disabled
+          # because ouroboros-network doesn't fully work under Wine.
+          integration.doCheck = !isHydraPRJobset && !pkgs.stdenv.hostPlatform.isWindows;
 
           # provide cardano-node command to test suites
           integration.build-tools = [ pkgs.cardano-node ];

--- a/release.nix
+++ b/release.nix
@@ -77,7 +77,7 @@ let
     ) ds);
 
   # Remove build jobs for which cross compiling does not make sense.
-  filterJobsCross = filterAttrs (n: _: n != "dockerImage" && n != "shell" && n != "stackShell");
+  filterJobsCross = filterAttrs (n: _: !(elem n ["dockerImage" "shell" "stackShell" "stackNixRegenerate"]));
 
   inherit (systems.examples) mingwW64 musl64;
 


### PR DESCRIPTION
# Issue Number

Relates to #1283.

# Overview

- [x] Enable integration tests on Hydra for the Linux/macOS native builds. This marks the single failing test as pending.
- [x] Enable integration tests under wine on Hydra for the windows cross build.
- [x] Choose a unique pipe name acceptable to Windows.
- [x] Enable line buffering mode for stdout so that you can see the test case names as they are running. 
- [ ] ~Get `cardano-wallet-byron:test:integration` passing under wine.~
- [x] Tested manually on real windows, and in CI ⇒ #1411.
- [x] Remove a broken build job and put back others that I accidentally removed.

# Comments

- Hydra [required job](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1536/required/latest-finished#tabs-constituents)

- Note that integration tests are only ever run on non-PR builds (i.e. bors or master branch).

- On GitHub CI windows, all integration tests pass.
- On my Windows 10 VM, all integration tests pass except one:
  ```
  Failures:

    test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs:357:9:
    1) API Specifications, BYRON_TXS_CLI, TRANS_DELETE_01a - Can forget pending tx, still it resolves when it is OK
         expected: ExitSuccess
          but got: ExitFailure 1

    To rerun use: --match "/API Specifications/BYRON_TXS_CLI/TRANS_DELETE_01a - Can forget pending tx, still it resolves when it is OK/"
  ```

- On Wine they integration test suite never finishes and there are errors logged from cardano-node after every test case:
  ```
  [localhos:cardano.node.LocalErrorPolicy:Error:46] [2020-04-02 15:48:57.01 UTC] {"event":"ErrorPolicyUnhandledApplicationException (MuxError {errorType = MuxIOException withIODataPtr (writeHandle): invalid argument (Error 0x13d), errorMsg = \"(writeHandle errored)\", errorStack = []})","kind":"ErrorPolicyTrace","address":"LocalAddress {getFilePath = \"\\\\\\\\.\\\\pipe\\\\cw-byron-bd9df28726c96ffa\"}"}
  [cardano-wallet.network:Warning:691] [2020-04-02 15:48:57.01 UTC] Connection lost with the node. withIODataPtr (readHandle): resource vanished (Broken pipe.)
  [cardano-wallet.wallet-engine:Error:290] [2020-04-02 15:48:57.01 UTC] a2bd5324: Unexpected error following the chain: ExceptionInLinkedThread ThreadId 691 (MuxError {errorType = MuxIOException withIODataPtr (readHandle): resource vanished (Broken pipe.), errorMsg = "(readHandle errored)", errorStack = []})
  ```
  This is most likely due to `ouroboros-network` not fully working under Wine. So we have to skip these tests on Hydra.
