### PR TITLE
Add docker image for cardano-wallet-byron

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -42,7 +42,8 @@ with hostPkgs.lib;
 
 let
   images = map impureCreated [
-    walletPackages.dockerImage
+    walletPackages.dockerImage.jormungandr
+    walletPackages.dockerImage.byron
   ];
 
   # Override Docker image, setting its creation date to the current time rather than the unix epoch.

--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -21,6 +21,10 @@
 # 3. After pushing the image to the repo, the "latest" tag is updated.
 #
 #    - "inputoutput/cardano-wallet:latest" should point to the most
+#      recent VERSION-byron tag build.
+#    - "inputoutput/cardano-wallet:byron" should point to the most
+#      recent VERSION-byron tag build.
+#    - "inputoutput/cardano-wallet:jormungandr" should point to the most
 #      recent VERSION-jormungandr tag build.
 #    - "inputoutput/cardano-wallet:dev-master-jormungandr" should
 #      point to the most recent master branch build.
@@ -47,7 +51,7 @@ let
   ];
 
   # Override Docker image, setting its creation date to the current time rather than the unix epoch.
-  impureCreated = image: image.overrideAttrs (oldAttrs: { created = "now"; }) // { inherit (image) version; };
+  impureCreated = image: image.overrideAttrs (oldAttrs: { created = "now"; }) // { inherit (image) version backend; };
 
 in
   writeScript "docker-build-push" (''
@@ -71,7 +75,7 @@ in
     extra_tag=""
     if [[ -n "$tag" ]]; then
       tag="${image.imageTag}"
-      extra_tag="latest"
+      extra_tag="${image.backend}"
     elif [[ "$branch" = master ]]; then
       tag="$(echo ${image.imageTag} | sed -e s/${image.version}/''${BUILDKITE_COMMIT:-dev-$branch}/)"
       extra_tag="$(echo ${image.imageTag} | sed -e s/${image.version}/dev-$branch/)"
@@ -91,5 +95,11 @@ in
       echo "Pushing $fullrepo:$extra_tag"
       docker tag "$tagged" "$fullrepo:$extra_tag"
       docker push "$fullrepo:$extra_tag"
+
+      ${optionalString (image.backend == "byron") ''
+      echo "Pushing $fullrepo:latest"
+      docker tag "$tagged" "$fullrepo:latest"
+      docker push "$fullrepo:latest"
+      ''}
     fi
   '') images)

--- a/default.nix
+++ b/default.nix
@@ -12,17 +12,22 @@
 #   - tests - attrset of test-suite executables
 #     - cardano-wallet-core.unit
 #     - cardano-wallet-jormungandr.jormungandr-integration
+#     - cardano-wallet-byron.integration
 #     - etc (layout is PACKAGE.COMPONENT)
 #   - checks - attrset of test-suite results
 #     - cardano-wallet-core.unit
 #     - cardano-wallet-jormungandr.jormungandr-integration
+#     - cardano-wallet-byron.integration
 #     - etc
 #   - benchmarks - attret of benchmark executables
 #     - cardano-wallet-core.db
 #     - cardano-wallet-jormungandr.latency
+#     - cardano-wallet-byron.restore
 #     - etc
 #   - migration-tests - tests db migrations from previous versions
-#   - dockerImage - tarball of the docker image
+#   - dockerImage - tarballs of the docker images
+#     - jormungandr
+#     - byron
 #   - shell - imported by shell.nix
 #   - haskellPackages - a Haskell.nix package set of all packages and their dependencies
 #     - cardano-wallet-core.components.library
@@ -100,8 +105,9 @@ let
     # `migration-tests` build previous releases then check if the database successfully upgrades.
     migration-tests = import ./nix/migration-tests.nix { inherit system crossSystem config pkgs; };
 
-    dockerImage = pkgs.callPackage ./nix/docker.nix {
-      inherit (self) cardano-wallet-jormungandr;
+    dockerImage = mapAttrs (backend: exe: pkgs.callPackage ./nix/docker.nix { inherit backend exe; }) {
+      jormungandr = self.cardano-wallet-jormungandr;
+      byron = self.cardano-wallet-byron;
     };
 
     shell = haskellPackages.shellFor {

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -3,15 +3,17 @@
 #
 # To test it out, use:
 #
-#   docker load -i $(nix-build -A dockerImage --no-out-link)
-#   docker run cardano-wallet-jormungandr
+#   docker load -i $(nix-build -A dockerImage.byron --no-out-link)
+#   docker run cardano-wallet-byron
 #
 ############################################################################
 
 { runtimeShell, writeScriptBin, runCommand, dockerTools
 
 # The main contents of the image.
-, cardano-wallet-jormungandr
+, exe
+# Short name of the backend, e.g. jormungandr or byron
+, backend
 
 # Other things to include in the image.
 , glibcLocales, iana-etc, cacert
@@ -25,7 +27,7 @@ let
   defaultPort = "8090";
   dataDir = "/data";
 
-  startScript = writeScriptBin "start-cardano-wallet-jormungandr" ''
+  startScript = writeScriptBin "start-cardano-wallet-${backend}" ''
     #!${runtimeShell}
     set -euo pipefail
 
@@ -35,7 +37,7 @@ let
     ln -s ${dataDir} /cardano-wallet
 
     export LOCALE_ARCHIVE="${glibcLocales}/lib/locale/locale-archive"
-    exec ${cardano-wallet-jormungandr}/bin/cardano-wallet-jormungandr "$@"
+    exec ${exe}/bin/cardano-wallet-${backend} "$@"
   '';
 
   # Layer of tools which aren't going to change much between versions.
@@ -52,17 +54,17 @@ let
 in
   dockerTools.buildImage {
     name = repoName;
-    tag = "${cardano-wallet-jormungandr.version}-jormungandr";
+    tag = "${exe.version}-${backend}";
     fromImage = baseImage;
     contents = [
-      cardano-wallet-jormungandr
+      exe
       startScript
     ];
     config = {
-      EntryPoint = [ "start-cardano-wallet-jormungandr" ];
+      EntryPoint = [ "start-cardano-wallet-${backend}" ];
       ExposedPorts = {
         "${defaultPort}/tcp" = {}; # wallet api
       };
       Volume = [ dataDir ];
     };
-  } // { inherit (cardano-wallet-jormungandr) version; }
+  } // { inherit (exe) version; }

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -67,4 +67,4 @@ in
       };
       Volume = [ dataDir ];
     };
-  } // { inherit (exe) version; }
+  } // { inherit (exe) version; inherit backend; }


### PR DESCRIPTION
# Issue Number

None

# Overview

- Adds a docker image build for cardano-wallet-byron in addition to the build for cardano-wallet-jormungandr.
- Adjusts the tagging scheme so that "latest" is the latest tagged release of cardano-wallet-byron.
