### PR TITLE
Missing tests for cardano node

### DIFF
--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -84,7 +84,7 @@ import Numeric.Natural
 import System.IO.Temp
     ( withSystemTempDirectory )
 import Test.Hspec
-    ( Spec, SpecWith, after, describe, hspec )
+    ( Spec, SpecWith, after, describe, hspec, parallel )
 import Test.Hspec.Extra
     ( aroundAll )
 import Test.Integration.Framework.DSL
@@ -109,6 +109,8 @@ import qualified Test.Integration.Byron.Scenario.CLI.Transactions as Transaction
 import qualified Test.Integration.Scenario.API.ByronTransactions as TransactionsCommon
 import qualified Test.Integration.Scenario.API.ByronWallets as WalletsCommon
 import qualified Test.Integration.Scenario.API.Network as Network
+import qualified Test.Integration.Scenario.CLI.Miscellaneous as MiscellaneousCLI
+import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
 
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Byron where
@@ -117,6 +119,11 @@ instance KnownCommand Byron where
 main :: forall t n. (t ~ Byron, n ~ 'Mainnet) => IO ()
 main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
     hspec $ do
+        describe "No backend required" $ do
+            -- describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec
+            describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
+            describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
+            -- describe "Key CLI tests" KeysCLI.spec
         describe "API Specifications" $ specWithServer tr $ do
             TransactionsCLI.spec @n
             WalletsCommon.spec @n

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -105,13 +105,13 @@ import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Test.Integration.Byron.Scenario.API.Addresses as AddressesByron
 import qualified Test.Integration.Byron.Scenario.API.Transactions as TransactionsByron
-import qualified Test.Integration.Byron.Scenario.CLI.Transactions as TransactionsCLI
-import qualified Test.Integration.Scenario.API.ByronTransactions as TransactionsCommon
-import qualified Test.Integration.Scenario.API.ByronWallets as WalletsCommon
+import qualified Test.Integration.Byron.Scenario.CLI.Transactions as TransactionsByronCLI
+import qualified Test.Integration.Scenario.API.ByronTransactions as TransactionsByronCommon
+import qualified Test.Integration.Scenario.API.ByronWallets as ByronWallets
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.CLI.Miscellaneous as MiscellaneousCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
-
+import qualified Test.Integration.Scenario.CLI.Port as PortCLI
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Byron where
     commandName = "cardano-wallet-byron"
@@ -120,17 +120,18 @@ main :: forall t n. (t ~ Byron, n ~ 'Mainnet) => IO ()
 main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
     hspec $ do
         describe "No backend required" $ do
-            -- describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec
             describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
-            -- describe "Key CLI tests" KeysCLI.spec
         describe "API Specifications" $ specWithServer tr $ do
-            TransactionsCLI.spec @n
-            WalletsCommon.spec @n
+            ByronWallets.spec @n
             AddressesByron.spec @n
             TransactionsByron.spec @n
-            TransactionsCommon.spec @n
+            TransactionsByronCommon.spec @n
             Network.spec
+        describe "CLI Specifications" $ specWithServer tr $ do
+            TransactionsByronCLI.spec @n
+            PortCLI.spec @t
+
 
 specWithServer
     :: Trace IO Text

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -111,7 +111,9 @@ import qualified Test.Integration.Scenario.API.ByronWallets as ByronWallets
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.CLI.Miscellaneous as MiscellaneousCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
+import qualified Test.Integration.Scenario.CLI.Network as NetworkCLI
 import qualified Test.Integration.Scenario.CLI.Port as PortCLI
+
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Byron where
     commandName = "cardano-wallet-byron"
@@ -131,6 +133,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
         describe "CLI Specifications" $ specWithServer tr $ do
             TransactionsByronCLI.spec @n
             PortCLI.spec @t
+            NetworkCLI.spec @t
 
 
 specWithServer

--- a/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/ByronWallets.hs
@@ -49,7 +49,7 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Test.Hspec
-    ( SpecWith, describe, it, runIO, shouldNotBe, shouldSatisfy )
+    ( SpecWith, describe, it, pendingWith, runIO, shouldNotBe, shouldSatisfy )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe )
 import Test.Integration.Framework.DSL
@@ -96,6 +96,8 @@ import Test.Integration.Framework.TestData
     , updatePassPayload
     , wildcardsWalletName
     )
+import Test.Integration.Scenario.API.Wallets
+    ( scenarioWalletResync01_happyPath, scenarioWalletResync02_notGenesis )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
@@ -542,6 +544,22 @@ spec = do
         verify r
             [ expectResponseCode @IO HTTP.status204
             ]
+
+    describe "BYRON_WALLETS_RESYNC_01" $ do
+        let title = "force resync eventually get us back to the same point"
+        it ("emptyRandomWallet - " ++ title) $ \ctx -> do
+            pendingWith "#1505 - Cannot force resync wallet and cardano-node crash as a result"
+            scenarioWalletResync01_happyPath @'Byron ctx emptyRandomWallet
+        it ("emptyIcarusWallet - " ++ title) $ \ctx -> do
+            pendingWith "#1505 - Cannot force resync wallet and cardano-node crash as a result"
+            scenarioWalletResync01_happyPath @'Byron ctx emptyIcarusWallet
+
+    describe "BYRON_WALLETS_RESYNC_02" $ do
+        let title = "force resync eventually get us back to the same point"
+        it ("emptyRandomWallet - " ++ title) $ \ctx -> do
+            scenarioWalletResync02_notGenesis @'Byron ctx emptyRandomWallet
+        it ("emptyIcarusWallet - " ++ title) $ \ctx -> do
+            scenarioWalletResync02_notGenesis @'Byron ctx emptyIcarusWallet
  where
      genMnemonics
         :: forall mw ent csz.

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Wallets.hs
@@ -12,6 +12,8 @@
 
 module Test.Integration.Scenario.API.Wallets
     ( spec
+    , scenarioWalletResync01_happyPath
+    , scenarioWalletResync02_notGenesis
     ) where
 
 import Prelude
@@ -1175,14 +1177,12 @@ spec = do
         expectErrorMessage (errMsg404NoWallet wid) ru
 
     describe "WALLETS_RESYNC_01" $ do
-        scenarioWalletResync01_happyPath @'Shelley emptyWallet
-        scenarioWalletResync01_happyPath @'Byron emptyRandomWallet
-        scenarioWalletResync01_happyPath @'Byron emptyIcarusWallet
+        it "force resync eventually get us back to the same point" $ \ctx -> do
+            scenarioWalletResync01_happyPath @'Shelley ctx emptyWallet
 
     describe "WALLETS_RESYNC_02" $ do
-        scenarioWalletResync02_notGenesis @'Shelley emptyWallet
-        scenarioWalletResync02_notGenesis @'Byron emptyRandomWallet
-        scenarioWalletResync02_notGenesis @'Byron emptyIcarusWallet
+        it "given point is not genesis (i.e. (0, 0))" $ \ctx -> do
+            scenarioWalletResync02_notGenesis @'Shelley ctx emptyWallet
 
     describe "BYRON_MIGRATE_05 -\
         \ migrating from/to inappropriate wallet types" $ do
@@ -1717,10 +1717,10 @@ scenarioWalletResync01_happyPath
         , Generic wallet
         , Show wallet
         )
-    => (Context t -> IO wallet)
-    -> SpecWith (Context t)
-scenarioWalletResync01_happyPath fixture = it
-  "force resync eventually get us back to the same point" $ \ctx -> do
+    => Context t
+    -> (Context t -> IO wallet)
+    -> IO ()
+scenarioWalletResync01_happyPath ctx fixture = do
     w <- fixture ctx
 
     -- 1. Wait for wallet to be synced
@@ -1748,10 +1748,10 @@ scenarioWalletResync02_notGenesis
         , Generic wallet
         , Show wallet
         )
-    => (Context t -> IO wallet)
-    -> SpecWith (Context t)
-scenarioWalletResync02_notGenesis fixture = it
-  "given point is not genesis (i.e. (0, 0))" $ \ctx -> do
+    => Context t
+    -> (Context t -> IO wallet)
+    -> IO ()
+scenarioWalletResync02_notGenesis ctx fixture = do
     w <- fixture ctx
 
     -- 1. Force a resync on an invalid point (/= from genesis)

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
@@ -189,12 +189,6 @@ spec = do
         let tests =
                 [ ("serve", "--port", getPort minBound - 14)
                 , ("serve", "--port", getPort maxBound + 42)
-                , ("serve", "--node-port", getPort minBound - 6)
-                , ("serve", "--node-port", getPort maxBound + 523)
-                , ("launch", "--port", getPort minBound - 1)
-                , ("launch", "--port", getPort maxBound + 59375)
-                , ("launch", "--node-port", getPort minBound - 5621)
-                , ("launch", "--node-port", getPort maxBound + 1)
                 ]
         forM_ tests $ \(cmd, opt, port) -> let args = [cmd, opt, show port] in
             it (unwords args) $ \_ -> do

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -256,6 +256,7 @@ test-suite jormungandr-integration
       Test.Integration.Jormungandr.Scenario.CLI.Server
       Test.Integration.Jormungandr.Scenario.CLI.StakePools
       Test.Integration.Jormungandr.Scenario.CLI.Transactions
+      Test.Integration.Jormungandr.Scenario.CLI.Port
       Test.Utils.Ports
 
 benchmark latency

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -101,6 +101,7 @@ import qualified Test.Integration.Jormungandr.Scenario.API.Transactions as Trans
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Keys as KeysCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Launcher as LauncherCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Mnemonics as MnemonicsJormungandr
+import qualified Test.Integration.Jormungandr.Scenario.CLI.Port as PortCLIJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Server as ServerCLI
 import qualified Test.Integration.Jormungandr.Scenario.CLI.StakePools as StakePoolsCliJormungandr
 import qualified Test.Integration.Jormungandr.Scenario.CLI.Transactions as TransactionsCliJormungandr
@@ -154,6 +155,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             withCtxOnly $ WalletsCLI.spec @n @t
             withCtxOnly $ HWWalletsCLI.spec @n @t
             withCtxOnly $ PortCLI.spec @t
+            withCtxOnly $ PortCLIJormungandr.spec @t
             withCtxOnly $ NetworkCLI.spec @t
             withCtxOnly $ StakePoolsCliJormungandr.spec @t
             ServerCLI.spec @t

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Port.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Port.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Jormungandr.Scenario.CLI.Port
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.CLI
+    ( Port (..), getPort )
+import Control.Monad
+    ( forM_ )
+import Data.Generics.Product.Typed
+    ( HasType )
+import System.Command
+    ( Stderr (..), Stdout (..) )
+import System.Exit
+    ( ExitCode (..) )
+import Test.Hspec
+    ( SpecWith, describe, it )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe, shouldContain )
+import Test.Integration.Framework.DSL
+    ( KnownCommand (..), cardanoWalletCLI )
+
+spec
+    :: forall t s. (HasType (Port "wallet") s, KnownCommand t)
+    => SpecWith s
+spec = do
+    describe "PORT_04_JORM - Fail nicely when port is out-of-bounds" $ do
+        let tests =
+                [ ("serve", "--node-port", getPort minBound - 6)
+                , ("serve", "--node-port", getPort maxBound + 523)
+                , ("launch", "--port", getPort minBound - 1)
+                , ("launch", "--port", getPort maxBound + 59375)
+                , ("launch", "--node-port", getPort minBound - 5621)
+                , ("launch", "--node-port", getPort maxBound + 1)
+                ]
+        forM_ tests $ \(cmd, opt, port) -> let args = [cmd, opt, show port] in
+            it (unwords args) $ \_ -> do
+                (exit, Stdout (_ :: String), Stderr err) <- cardanoWalletCLI @t args
+                exit `shouldBe` ExitFailure 1
+                err `shouldContain`
+                    (  "expected a TCP port number between "
+                    <> show (getPort minBound)
+                    <> " and "
+                    <> show (getPort maxBound)
+                    )


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- d8b98ef949920d47638cb27c106727e8001045fc
  CLI tests with no backend
  
- d2995a17ff50b47158e0aa464e5d565beba49593
  Byron resync tests
  
- 1ad5ff8d0c4a808abf4449cda24e531a3f2aedbf
  Port CLI tests for Byron
  
- c4c51ba3bb41a4f07ab808c3bcc928680d98944b
  Network CLI tests
  



# Comments

Still outstanding are Byron wallets CRUD CLI and  Byron address CLI.
