### PR TITLE
Fix wrong key fingerprint for Icarus addresses on Testnet

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -530,13 +530,13 @@ createIcarusWallet
     -> (k 'RootK XPrv, Passphrase "encryption")
     -> ExceptT ErrWalletAlreadyExists IO WalletId
 createIcarusWallet ctx wid wname credentials = db & \DBLayer{..} -> do
-    let s = mkSeqStateFromRootXPrv credentials (mkUnboundedAddressPoolGap 10000)
+    let s = mkSeqStateFromRootXPrv @n credentials (mkUnboundedAddressPoolGap 10000)
     let (hist, cp) = initWallet block0 bp s
     let addrs = map address . concatMap (view #outputs . fst) $ hist
     let g  = defaultAddressPoolGap
     let s' = SeqState
-            (shrinkPool (liftPaymentAddress @n) addrs g (internalPool s))
-            (shrinkPool (liftPaymentAddress @n) addrs g (externalPool s))
+            (shrinkPool @n (liftPaymentAddress @n) addrs g (internalPool s))
+            (shrinkPool @n (liftPaymentAddress @n) addrs g (externalPool s))
             (pendingChangeIxs s)
             (rewardAccountKey s)
     now <- lift getCurrentTime

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -401,14 +401,16 @@ instance MkKeyFingerprint IcarusKey Address where
             Just _  -> Right $ KeyFingerprint bytes
             Nothing -> Left $ ErrInvalidAddress addr (Proxy @IcarusKey)
 
-instance MkKeyFingerprint IcarusKey (IcarusKey 'AddressK XPub) where
-    paymentKeyFingerprint k =
+instance PaymentAddress n IcarusKey
+    => MkKeyFingerprint IcarusKey (Proxy (n :: NetworkDiscriminant), IcarusKey 'AddressK XPub)
+  where
+    paymentKeyFingerprint (proxy, k) =
         bimap (const err) coerce
         . paymentKeyFingerprint @IcarusKey
-        . paymentAddress @'Mainnet
+        . paymentAddress @n
         $ k
       where
-        err = ErrInvalidAddress k Proxy
+        err = ErrInvalidAddress (proxy, k) Proxy
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -423,9 +423,9 @@ instance MkKeyFingerprint ShelleyKey Address where
         | otherwise =
             Left $ ErrInvalidAddress addr (Proxy @ShelleyKey)
 
-instance MkKeyFingerprint ShelleyKey (ShelleyKey 'AddressK XPub) where
+instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyKey 'AddressK XPub) where
     paymentKeyFingerprint =
-        Right . KeyFingerprint . xpubPublicKey . getRawKey
+        Right . KeyFingerprint . xpubPublicKey . getRawKey . snd
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -167,6 +167,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Char
     ( isAlphaNum, toLower )
+import Data.Either
+    ( isRight )
 import Data.FileEmbed
     ( embedFile, makeRelativeToProject )
 import Data.Function
@@ -247,7 +249,15 @@ import Test.Aeson.Internal.RoundtripSpecs
 import Test.Aeson.Internal.Utils
     ( TypeName (..), TypeNameInfo (..), mkTypeNameInfo )
 import Test.Hspec
-    ( Spec, SpecWith, describe, expectationFailure, it, runIO, shouldBe )
+    ( Spec
+    , SpecWith
+    , describe
+    , expectationFailure
+    , it
+    , runIO
+    , shouldBe
+    , shouldSatisfy
+    )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
@@ -644,6 +654,30 @@ spec = do
             ]
             "addr1sn0e7zr89gafgauz9xu3m25cz5ugs0s4xhtxdhqsuca58r6ycclr\
             \7sp2hlmqvhyywy266ghldvxn4p0adxn0esew6a423jkmxpdsc5d8fke02m"
+
+    describe "Golden test addresses" $ do
+        it "Byron / Random (Mainnet)" $
+            decodeAddress @'Mainnet
+                "DdzFFzCqrhstkaXBhux3ALL9wqvP3Nkz8QE5qKwFbqkmTL6zyKpc\
+                \FpqXJLkgVhRTYkf5F7mh3q6bAv5hWYjhSV1gekjEJE8XFeZSganv"
+            `shouldSatisfy` isRight
+
+        it "Byron / Icarus (Mainnet)" $
+            decodeAddress @'Mainnet
+                "Ae2tdPwUPEZ9mpZBa3pN4CJH3xRA4cPr1HTUE1dVBF5JKNvkAKUxdK8f5L9"
+              `shouldSatisfy` isRight
+
+        it "Byron / Random (Testnet)" $
+            decodeAddress @('Testnet 1097911063)
+                "37btjrVyb4KFg2FzVkfmBWgue1qqC7oHmFNVTWYgLTHEE9wGC6xizioGw\
+                \sYPAtPbDTrvtnV7vUXAsmP7pTMx7X95AcwfUAqoLJpGJ4eaosUHGBjta4"
+              `shouldSatisfy` isRight
+
+        it "Byron / Icarus (Testnet)" $
+            decodeAddress @('Testnet 1097911063)
+                "2cWKMJemoBajA7ji3xQvAnrSESRyceRVnj\
+                \5j9kj1Tb9pzGoY5jPc142iPXfaix1DbbDF7"
+              `shouldSatisfy` isRight
 
     describe "pointless tests to trigger coverage for record accessors" $ do
         it "ApiAddress" $ property $ \x ->

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -471,7 +471,7 @@ instance Arbitrary (Seq.PendingIxs) where
     arbitrary = pure Seq.emptyPendingIxs
 
 instance Typeable chain => Arbitrary (AddressPool chain ShelleyKey) where
-    arbitrary = pure $ mkAddressPool arbitrarySeqAccount minBound mempty
+    arbitrary = pure $ mkAddressPool @'Mainnet arbitrarySeqAccount minBound mempty
 
 -- Properties are quite heavy on the generation of values, although for
 -- private keys, it isn't particularly useful / relevant to generate many of


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1535

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 942f536017be58222b1008dbede17dd3c27e83ad
  :round_pushpin: **repair fingerprint conversion for Icarus addresses**
  This was forcing 'Mainnet by default because of how we consider Icarus addresses
on the ITN. However, now that we have integrated with cardano-node, this exception
is no longer valid.

Note that we can't really take anything else than the full address for a
fingerprint on Byron addresses because both the public key and the
network discriminant gets hashed in the address root! Thus there's no
way to recover them from a raw address. This also forces us to provide a
network discriminant in order to compute the fingerprint!

- f73322046afbf77b282a404cc9751d11a2ec0ca3
  :round_pushpin: **add simple golden tests on address decoding**
  We had 0 so far and it's always good to check that we can at least decode existing addresses..
These addresses were taken from the mainnet and testnet explorers