### PR TITLE
Make sure to only generate addresses using the Hardened index convention

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
@@ -225,7 +225,7 @@ scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
     let payload = Json [json|
             { "passphrase": "Secure Passphrase"
-            , "address_index": 14
+            , "address_index": 2147483662
             }|]
     r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
     verify r
@@ -245,7 +245,7 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
     let payload = Json [json|
             { "passphrase": "Secure Passphrase"
-            , "address_index": 14
+            , "address_index": 2147483662
             }|]
     r0 <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
     verify r0 [ expectResponseCode @IO HTTP.status201 ]

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1302,7 +1302,7 @@ cmdAddressList mkClient =
 -- | Arguments for 'address create' command
 data AddressCreateArgs = AddressCreateArgs
     { _port :: Port "Wallet"
-    , _addressIndex :: Maybe (Index 'WholeDomain 'AddressK)
+    , _addressIndex :: Maybe (Index 'Hardened 'AddressK)
     , _id :: WalletId
     }
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -586,7 +586,7 @@ newtype ApiNetworkClock = ApiNetworkClock
 
 data ApiPostRandomAddressData = ApiPostRandomAddressData
     { passphrase :: !(ApiT (Passphrase "raw"))
-    , addressIndex :: !(Maybe (ApiT (Index 'WholeDomain 'AddressK)))
+    , addressIndex :: !(Maybe (ApiT (Index 'Hardened 'AddressK)))
     } deriving (Eq, Generic, Show)
 
 -- | Error codes returned by the API, in the form of snake_cased strings

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1183,7 +1183,22 @@ instance PersistState (Rnd.RndState t) where
         pendingAddresses <- lift $ selectRndStatePending wid
         pure $ Rnd.RndState
             { hdPassphrase = pwd
-            , accountIndex = W.Index ix
+            , accountIndex =
+                -- FIXME
+                -- In the early days when Daedalus Flight was shipped, the
+                -- wallet backend was generating addresses indexes across the
+                -- whole domain which was causing a great deal of issues with
+                -- the legacy cardano-sl:wallet ...
+                --
+                -- We later changed that to instead use "hardened indexes". Yet,
+                -- for the few wallets which were already created, we revert
+                -- this dynamically by replacing the index here.
+                --
+                -- This ugly hack could / should be removed eventually, in a few
+                -- releases from 2020-04-06.
+                if ix == 0
+                then minBound
+                else W.Index ix
             , addresses = addresses
             , pendingAddresses = pendingAddresses
             , gen = gen

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -41,6 +41,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , HardDerivation (..)
     , SoftDerivation (..)
+    , liftIndex
 
     -- * Delegation
     , ChimericAccount (..)
@@ -288,6 +289,16 @@ instance
             , "and"
             , show (maxBound @(Index derivation level))
             ]
+
+-- Safe coercion to WholeDomain from smaller domains.
+class LiftIndex derivation where
+    liftIndex :: Index derivation level -> Index 'WholeDomain level
+
+instance LiftIndex 'Hardened where
+    liftIndex (Index ix) = Index ix
+
+instance LiftIndex 'Soft where
+    liftIndex (Index ix) = Index ix
 
 -- | Type of derivation that should be used with the given indexes.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -44,6 +44,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Passphrase (..)
     , PaymentAddress (..)
     , XPrv
+    , liftIndex
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -81,7 +82,7 @@ import qualified Data.Set as Set
 data RndState (network :: NetworkDiscriminant) = RndState
     { hdPassphrase :: Passphrase "addr-derivation-payload"
     -- ^ The HD derivation passphrase
-    , accountIndex :: Index 'WholeDomain 'AccountK
+    , accountIndex :: Index 'Hardened 'AccountK
     -- ^ The account index used for address _generation_ in this wallet. Note
     -- that addresses will be _discovered_ from any and all account indices,
     -- regardless of this value.
@@ -186,18 +187,18 @@ unavailablePaths st = Map.keysSet $ addresses st <> pendingAddresses st
 -- account's address space is used up. We may have to improve it later.
 findUnusedPath
     :: StdGen
-    -> Index 'WholeDomain 'AccountK
+    -> Index 'Hardened 'AccountK
     -> Set DerivationPath
     -> (DerivationPath, StdGen)
 findUnusedPath g accIx used
     | Set.notMember path used = (path, gen')
     | otherwise = findUnusedPath gen' accIx used
   where
-    path = (accIx, addrIx)
+    path = (liftIndex accIx, liftIndex addrIx)
     (addrIx, gen') = randomIndex g
 
 randomIndex
-    :: forall ix g. (RandomGen g, ix ~ Index 'WholeDomain 'AddressK)
+    :: forall ix g. (RandomGen g, ix ~ Index 'Hardened 'AddressK)
     => g
     -> (ix, g)
 randomIndex g = (Index ix, g')

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiPostRandomAddressData.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiPostRandomAddressData.json
@@ -1,40 +1,42 @@
 {
-    "seed": -1497831599329803574,
+    "seed": 1057336814512791865,
     "samples": [
         {
-            "passphrase": "YEo3Vh%tK4sjc7`LL)RMἡPTxZZ{QBJ7ZNY?ZPdy)saUx ",
-            "address_index": 3479812113
+            "passphrase": ",xX\"&럮=u|C>alA49k&95j\\$>>Ci'{aJ9cqK啗++vEyNS|8;@Z<G𠎽$.ze*\\vRQ+o/-cwqP8iy=AFB)V;!",
+            "address_index": 2409257139
         },
         {
-            "passphrase": "3=^e)0cVgYy|Q#oH\"SR<t^~bO)oc}ClBgA𧛇E5YpO*5d[Ax𤣣)l]lo<p+;8#=1u[z0#)𢯷w}$[8WiU;<O}2/ORl_y4GgK/-ㅙNGq4<w눤*jE+s/jN#USR?'c9Hx\",i'TH~CXE𠪌EOP=mF噑vO\\O/h#x=6}𤶴𨢃9戉W3{'x|I%]&;,plydo8u-fMt1"
+            "passphrase": "`is*C&mI&r8_i\"Uz𐄇to3`3sO庮X",
+            "address_index": 4174614133
         },
         {
-            "passphrase": "u1mk0`ZLc-*(Xg[c^HvX12W1z^:ㄽJT:x@.FQ-$+.qk`G5WVmJAR-6`$f3C;'1||+QeeB䳱:_bISm_%EBFmW&VOR𦽏n2𠵠JJ|e:s< r RPlu/W;dZo<SO!|V`w]>ZVdD葊[8)tCZ{@M<jd&왯f)Ha}j7^_~Fl4t.AJh𥃆",
-            "address_index": 3089404203
+            "passphrase": ":zCy&Hf2〽iFX'8]F8@A3%-Wq+`~0ZNp[]bI+s-)LD[9>WoI,by}<feSZwdՏ5Pm8#UU`+^iJeBb<fv.0p#k𛰂r5Wre]?u'i_f",
+            "address_index": 2951403462
         },
         {
-            "passphrase": "|z&hG뎜Kmd$6b)!:p교O1U|tb𧣸X&}#\"'@LWG(WbA,},^`|쐘.W[A~^ht99\"=A𧋭LOY[Er&@D~_k?$-,_flwPt-SFP3ye')7sCf.UzM'1t\\iES*tWB|&N=+jlPmMB 𦴨|*K+j7V;X*7Q:#(T?:*^e&d6L(Y-M/y.-嵐.(oxb[&]\"<me!葔+~5럨2cTxh!;(KFj\"{|JA^2B_Z8b)]Bq[1<c;`1?^~e$6u!k;gU(W^T)V-u[9j-Wk%dfNgX\"b;AI",
-            "address_index": 1785310246
+            "passphrase": "𖽐7/k~Fum\"Xl>bk$,m+:'=,@(x0痓Nx@C{Ba99>]M!T4Vr2v1~4 G'bF,EPwHN9L4-h5AF\\cU9GFDS2Vso5ujM%t!Bli"
         },
         {
-            "passphrase": "𦂺G+]-ZS'%)vshF:tJS*Cd,H㯶]*yfYA:j,V479}wfNJ&*6m!{NXShkjT]+8",
-            "address_index": 330114776
+            "passphrase": "6T*G]6\":88p2wBfu3lO ^1pi/J9,^p/%)q,>,𐦪&^c'Pd\\1tdP@0qYa.\"c)\"",
+            "address_index": 3759281734
         },
         {
-            "passphrase": "U_E0,:bB(3홫d9N@dxR:TL:s0>|4n{/+lo3P\"(#yabl`.\\?w@k"
+            "passphrase": "\"`:A'c0({{q|#$sG2v]g=\\jI>p{?<w p3P8B>tfi7ahncrZK(VOj9E:",
+            "address_index": 3854767076
         },
         {
-            "passphrase": "XY@GvD2 6KG$EupOD':X!dfdL3u=zh1VcFqkD@W=Ap\\~i*jo1YImbf\")*8UL='%jBlYY.`**3 a?9b𠿇'UW=:3c*7P}I?dLnp"
+            "passphrase": "M(wIByaF䫟DX+MA딿/&`PO::gvM[$U>R_\"NI -aPrMTmuW@8^Gf/G's/~Gfii}N1Lq79;V30)RHUVeO[\\MQoH/VI-emD'!a$x:h5UleUH:𠊭<.'LB{\\s%Mll%_HQgP's$?Z8Cn'1?2/O3#YF6;5u@zpp⾅V&qᙝ-\\a=%i1𤼕T-!!9䂊B*5𣡉Q9PVL6$ZО.!RA\\.TkQn^%^*]]WQ%*m",
+            "address_index": 3838992962
         },
         {
-            "passphrase": ")c{c1}((U#aGtast$Y{'7XTp.𥳂.$!bgTI`/Oo@hL]7gUds^E𣈥냣7𤴎au~_EV𒈸$K=bGK6\".p9A𪓣coNv6k|uw𢝌?%mZczETu-}6emnr%=tSx𫗧fC09gs^=y)tWcEXS:Dc0 CFRs!(WYi[SP4IH:s/p2imTdQlE$op"
+            "passphrase": "JZ\" IMlA=]NiGniy2\"n)p=\"gE(OCui;2E\\X)mpB`CNT俑/H!Neub.bC!Ahx u?7efA3.&e)7Gx!2JEsto%\\Nz=->!gGWn<&.U𤤓$9𠫚+x\\TUMk${8p+H4SxyWN=!=Ass/Mm烐:ƱpSaAI3|3tBhk6@;Xn7G{^P,SF+'}n:9I=EkMS`zvn,zI&L3Ip =^`~erx&uP911g'Hldt ]K>EQR=9>;N3XJ-.%\\ley\"Gz_푧"
         },
         {
-            "passphrase": "T'/n_Os8^KeFX::A#W`By4T\\G/gna9\\wmspjA\\"
+            "passphrase": "LJ\\k4;;veDFGt^6"
         },
         {
-            "passphrase": "*}/{Sr*YyI\"&鸉^h<W퓡V}A*{mo1oNj9\"*r[9(v>u,^Q2>v>W_ypTN*H9𠌂 ~屝'!=2A7Ntu76ivb&G(&S즲ᗵ{㼆c4zl쨣1-v3b>=zGW5X(xZ^}f2K{V-Cv;BbO8aBNg0&sgrp抗'bsru~k;O%XwUe~P.[U}53[nW--s.𡵛O'JOI2IUr%m枻Y*'G}E",
-            "address_index": 3416170945
+            "passphrase": "#q쭩U7j:,g2Hqᡂ/P`eTF8V9{uo]@~_bO[[yU P.?Omf u(nr{OtvF8A`F)TF7WvMI𤂇=Emv+vc@㉆h鋃52#kh9m@1{N0ZzSJMIm8}]%^Kx93%\\qF[TJG2딉y;<5qJeVC~!9u2BizS@}5bC^7)Ts?Ag\",G긲uzy8𠀛e~7eJEq\\2W6P",
+            "address_index": 2346090214
         }
     ]
 }

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -424,7 +424,15 @@ instance Arbitrary (Index 'Soft 'AddressK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
+instance Arbitrary (Index 'Hardened 'AccountK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
 instance Arbitrary (Index 'WholeDomain 'AccountK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary (Index 'Hardened 'AddressK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -462,6 +462,10 @@ instance Arbitrary (Index 'Hardened 'AccountK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum
 
+instance Arbitrary (Index 'Hardened 'AddressK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum
+
 instance Arbitrary (Index 'WholeDomain 'AddressK) where
     shrink _ = []
     arbitrary = arbitraryBoundedEnum


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->
- be2cd3d3b2b921db2d674cc031ff3c9c2ace536c
  :round_pushpin: **Make sure to only generate addresses using the Hardened index convention**
  It seems that the old / legacy wallet has trouble digesting addresses that are using indexes in the
soft convention. Note that the derivation is always hardened, regardless of the index value but
the convention was switched a while ago on -sl to use only indexes beyond 2^32...

Note that there are still many addresses on the current Mainnet that do not abide by this convention
and these addresses seems to break legacy wallet. So, if we can avoid generating potentially
problematic addresses in the new version, that's good :) ...

We still recognize address and account indexes across the whole domain though

- 91ecb305093549121ebca03c30eb6b0292789dd2
  :round_pushpin: **hack, hopefully temporarily, rnd state reading from the database**
  See comment in DB/Sqlite.

- 5e7a6041610918d9df41d0d3a15940422de5b010
  :round_pushpin: **re-generate API golden test for PostRandomAddressData**
  This now contains indexes that are considered invalid :)...

- b93c623486ddc26edd3415d74c6e82b2be632162
  :round_pushpin: **remove soft derivation index addresses from known addresses**
    smoke tested with wallet made from the previous release:

  ```
  $ cardano-wallet address list aef25f56c818fc31494183702016b82227cd4702
  Ok.
  [
    {
        "state": "unused",
        "id": "2w1sdSJu3GVfRsedS1xiTkpHAg8DuBZZdEXVY971uAdebdmyD75c271fMdj2j33dndqKchWis5Leaxzkxc6ksi2uupu68Ykk7V1"
    },
    {
        "state": "unused",
        "id": "2w1sdSJu3GVix5rkaLKd4fNMbUsY9ufWz1A6zWq6nyG3QFcris1rW9yaipuHDfrL8NgBWStDmAwm7TdSpqbcsMYo333tudcQYcV"
    }
  ]

  -- Restarting the server using the new version, migration applies automatically.

  $ ./cardano-wallet address list aef25f56c818fc31494183702016b82227cd4702
  Ok.
  []
  ```


# Comments

<!-- Additional comments or screenshots to attach if any -->

```
$ cardano-wallet-byron address create 924e219963cfcb5e36e56447bf63848a21134c75
Please enter your passphrase: **********
Ok.
{
    "state": "unused",
    "id": "DdzFFzCqrhsv6mq5SVNwaUkkFXBAcVpss3tmWXhxMLRgQ17iMRWEMik3a1bDYuymnQ8cgP7N4uCa5BFFBXK2raAPzqsEVZdPNKxNU5H9"
}
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
