### PR TITLE
Better error message when trying to generate address on icarus wallet.

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
@@ -172,9 +172,14 @@ scenario_ADDRESS_CREATE_02 = it title $ \ctx -> do
     w <- emptyIcarusWallet ctx
     let payload = Json [json| { "passphrase": "Secure Passphrase" }|]
     r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
-    verify r [ expectResponseCode @IO HTTP.status403 ]
+    verify r
+        [ expectResponseCode @IO HTTP.status403
+        , expectErrorMessage
+            "I cannot derive new address for this wallet type.\
+            \ Make sure to use Byron random wallet id."
+        ]
   where
-    title = "ADDRESS_CREATE_02 - Creation if forbidden on Icarus wallets"
+    title = "ADDRESS_CREATE_02 - Creation is forbidden on Icarus wallets"
 
 scenario_ADDRESS_CREATE_03
     :: forall (n :: NetworkDiscriminant) t.
@@ -250,6 +255,9 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     r0 <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
     verify r0 [ expectResponseCode @IO HTTP.status201 ]
     r1 <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
-    verify r1 [ expectResponseCode @IO HTTP.status409 ]
+    verify r1
+        [ expectResponseCode @IO HTTP.status409
+        , expectErrorMessage "I already know of such address."
+        ]
   where
     title = "ADDRESS_CREATE_06 - Cannot create an address that already exists"

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1764,6 +1764,7 @@ data ErrCreateRandomAddress
     = ErrIndexAlreadyExists (Index 'Hardened 'AddressK)
     | ErrCreateAddrNoSuchWallet ErrNoSuchWallet
     | ErrCreateAddrWithRootKey ErrWithRootKey
+    | ErrCreateAddressNotAByronWallet
     deriving (Generic, Eq, Show)
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -702,7 +702,7 @@ byronServer byron icarus ntp =
     byronAddresses =
              (\wid s -> withLegacyLayer wid
                 (byron, postRandomAddress byron wid s)
-                (icarus, throwError err403)
+                (icarus, liftHandler $ throwE ErrCreateAddressNotAByronWallet)
              )
         :<|> (\wid s -> withLegacyLayer wid
                 (byron , listAddresses byron (const pure) wid s)
@@ -2380,6 +2380,11 @@ instance LiftHandler ErrCreateRandomAddress where
             apiError err409 AddressAlreadyExists $ mconcat
                 [ "I cannot derive a new unused address #", pretty (fromEnum ix)
                 , " because I already know of such address."
+                ]
+        ErrCreateAddressNotAByronWallet ->
+            apiError err403 InvalidWalletType $ mconcat
+                [ "I cannot derive new address for this wallet type."
+                , " Make sure to use Byron random wallet id."
                 ]
 
 instance LiftHandler (Request, ServerError) where

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -629,6 +629,7 @@ data ApiErrorCode
     | NotImplemented
     | WalletNotResponding
     | AddressAlreadyExists
+    | InvalidWalletType
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- e3d60368faa266c9445c12edf329afe9e9ef05af
  Better error message when trying to generate address on icarus wallet.
# Comments

Was:
```
$ cardano-wallet-byron address create 3fe1acf86fefbf66b7481470ea81244eadde079d
Please enter your passphrase: *****************
It looks like something unexpected went wrong. Unfortunately I don't yet know how to handle this type of situation. Here's some information about what happened:
```

is:
```
$ cardano-wallet-byron address create 3fe1acf86fefbf66b7481470ea81244eadde079d
Please enter your passphrase: *****************
I cannot derive new unused address for this wallet type. Make sure to use Byron random wallet id.

