### PR TITLE
Provide clear error message when $GITHUB_API_TOKEN is not set

### DIFF
--- a/scripts/make_changelog
+++ b/scripts/make_changelog
@@ -11,9 +11,11 @@
 #     make_changelog 2019-08-15
 
 # NOTE:
-# You need to set $API_TOKEN before running this script
+# You need to set $GITHUB_API_TOKEN before running this script
 
 REPO="input-output-hk/cardano-wallet"
+
+: ${GITHUB_API_TOKEN?"Please provide a Github Api Token for fetching pull requests"}
 
 PULL_REQUESTS=$(curl -X GET \
   -H "Authorization: token $GITHUB_API_TOKEN" \


### PR DESCRIPTION

# Issue Number

None.


# Overview

- [x] Check that token is set in `./scripts/make_changelog`


# Comments

```
$ ./scripts/make_changelog "2020-04-01"
./scripts/make_changelog: line 18: GITHUB_API_TOKEN: Please provide a Github Api Token for fetching pull requests
```
Note that when running
```
$ ./scripts/make_release.sh
```
the script will still mostly succeed, but the error will be printed
and the changelog will not be generated.

ℹ️ We could fail immediately in `./scripts/make_release.sh` too, but as it is one can run the script without the token set if desired. 

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
