### PR TITLE
Fix macos release tarballs in Hydra

### DIFF
--- a/nix/package-cardano-node.nix
+++ b/nix/package-cardano-node.nix
@@ -30,7 +30,9 @@ pkgs.stdenv.mkDerivation rec {
     cp --remove-destination -v ${cardano-node}/bin/* $out/bin
     cp -Rv ${cardano-node.configs} $out/configuration
   '' else (if pkgs.stdenv.hostPlatform.isDarwin then ''
-    rewrite-libs $out/bin $out/bin/${exe.identifier.name}
+    cp -v ${cardano-node}/bin/cardano-node $out/bin
+    chmod -R +w $out
+    rewrite-libs $out/bin $out/bin/${exe.identifier.name} $out/bin/cardano-node
   '' else ''
     $STRIP $out/bin/${exe.identifier.name}
   ''));

--- a/nix/package-jormungandr.nix
+++ b/nix/package-jormungandr.nix
@@ -53,7 +53,6 @@ let
       chmod -R +w $out
       rewrite-libs $out/bin $out/bin/cardano-wallet-jormungandr
       ${setGitRev}
-      cp ${jormungandr}/bin/* $out/bin
     '';
 
     windows = buildCommand [] ''

--- a/release.nix
+++ b/release.nix
@@ -178,10 +178,7 @@ let
     };
     cardano-wallet-byron-macos64 = import ./nix/macos-release.nix {
       inherit pkgs;
-      exes = [
-        jobs.native.cardano-wallet-byron.x86_64-darwin
-        jobs.native.cardano-node.x86_64-darwin
-      ];
+      exes = [ jobs.native.cardano-wallet-byron.x86_64-darwin ];
     };
 
     # Build and cache the build script used on Buildkite


### PR DESCRIPTION
# Issue Number

Relates to #1553.

# Overview

- 32dbf3df9e0711eaab794746251968a08abeebed
  nix: Remove jormungandr from cardano-wallet-jormungandr.x86_64-darwin

  For some reason, a Linux jormungandr binary is getting included. So just remove it altogether because there are macos binary releases of jormungandr available.

- 07619bfbf93f60af9605b07d48682a3770cd3b4d
  nix: Rewrite dylibs of cardano-node in cardano-wallet-byron-macos64


# Comments

* [cardano-wallet-byron-macos64](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1554/cardano-wallet-byron-macos64/latest)
* [cardano-wallet-jormungandr-macos64](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-1554/cardano-wallet-jormungandr-macos64/latest)