### PR TITLE
cardano-node: 1.10.0 -> 1.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet                                                                            | jörmungandr (compatible versions)                                              | cardano-node (compatible versions)
 > | ---                                                                                       | ---                                                                            | ---
-> | `master` branch                                                                           | [v0.8.15](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.15) | [1.9.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.9.3)
+> | `master` branch                                                                           | [v0.8.15](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.15) | [1.9.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.10.1)
+> | [v2020-04-07](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-04-07) | [v0.8.15](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.15) | [1.9.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.9.3)
+> | [v2020-04-01](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-04-01) | [v0.8.15](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.15) | [1.9.3](https://github.com/input-output-hk/cardano-node/releases/tag/1.9.3)
 > | [v2020-03-16](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-03-16) | [v0.8.14](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.14) | [1.6.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.6.0)
-> | [v2020-03-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-03-11) | [v0.8.13](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.13) | [1.6.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.6.0)
-> | [v2020-02-17](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-02-17) | [v0.8.9](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.9)   | N/A
-> | [v2020-01-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2020-01-27) | [v0.8.7](https://github.com/input-output-hk/jormungandr/releases/tag/v0.8.7)   | N/A
 
 ## How to build from sources
 

--- a/nix/.stack.nix/Win32-network.nix
+++ b/nix/.stack.nix/Win32-network.nix
@@ -105,8 +105,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/Win32-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-spec-chain.nix
+++ b/nix/.stack.nix/byron-spec-chain.nix
@@ -92,8 +92,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-spec-ledger.nix
+++ b/nix/.stack.nix/byron-spec-ledger.nix
@@ -113,8 +113,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "742a789a520387c6cd30a4ca28bc4fc8588a41c7";
-      sha256 = "0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6";
+      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
+      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -102,8 +102,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "742a789a520387c6cd30a4ca28bc4fc8588a41c7";
-      sha256 = "0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6";
+      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
+      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -90,8 +90,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "742a789a520387c6cd30a4ca28bc4fc8588a41c7";
-      sha256 = "0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6";
+      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
+      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "90b14c056059d0082cb2641f9c77cb1b097be329";
-      sha256 = "029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0";
+      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
+      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -100,8 +100,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "90b14c056059d0082cb2641f9c77cb1b097be329";
-      sha256 = "029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0";
+      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
+      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "90b14c056059d0082cb2641f9c77cb1b097be329";
-      sha256 = "029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0";
+      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
+      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -83,6 +83,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."megaparsec" or (buildDepError "megaparsec"))
           (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."mtl" or (buildDepError "mtl"))
+          (hsPkgs."quiet" or (buildDepError "quiet"))
           (hsPkgs."resourcet" or (buildDepError "resourcet"))
           (hsPkgs."streaming" or (buildDepError "streaming"))
           (hsPkgs."streaming-binary" or (buildDepError "streaming-binary"))
@@ -163,8 +164,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "90b14c056059d0082cb2641f9c77cb1b097be329";
-      sha256 = "029lqlf33a3vvy933fil8qglv3hjaprankllr80h0acspqjzahk0";
+      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
+      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "742a789a520387c6cd30a4ca28bc4fc8588a41c7";
-      sha256 = "0zqar90z7hdklxcimfxb2dmk0cq43bywa7p255hynn7ss0nxszz6";
+      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
+      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
       });
     postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -42,6 +42,7 @@
         "prometheus" = (((hackage.prometheus)."2.1.2").revisions).default;
         "quickcheck-instances" = (((hackage.quickcheck-instances)."0.3.19").revisions).default;
         "QuickCheck" = (((hackage.QuickCheck)."2.12.6.1").revisions).default;
+        "quiet" = (((hackage.quiet)."0.2").revisions).default;
         "snap-core" = (((hackage.snap-core)."1.0.4.1").revisions).default;
         "snap-server" = (((hackage.snap-server)."1.1.1.1").revisions).default;
         "statistics-linreg" = (((hackage.statistics-linreg)."0.3").revisions).default;
@@ -52,7 +53,6 @@
         "th-lift-instances" = (((hackage.th-lift-instances)."0.1.14").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "transformers-except" = (((hackage.transformers-except)."0.1.1").revisions).default;
-        "quiet" = (((hackage.quiet)."0.2").revisions).default;
         "Unique" = (((hackage.Unique)."0.4.7.6").revisions).default;
         "websockets" = (((hackage.websockets)."0.12.6.1").revisions).default;
         "Win32" = (((hackage.Win32)."2.6.2.0").revisions).default;

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -52,6 +52,7 @@
         "th-lift-instances" = (((hackage.th-lift-instances)."0.1.14").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;
         "transformers-except" = (((hackage.transformers-except)."0.1.1").revisions).default;
+        "quiet" = (((hackage.quiet)."0.2").revisions).default;
         "Unique" = (((hackage.Unique)."0.4.7.6").revisions).default;
         "websockets" = (((hackage.websockets)."0.12.6.1").revisions).default;
         "Win32" = (((hackage.Win32)."2.6.2.0").revisions).default;

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -70,8 +70,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/io-sim; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -127,8 +127,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ntp-client.nix
+++ b/nix/.stack.nix/ntp-client.nix
@@ -98,8 +98,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ntp-client; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byron.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byron.nix
@@ -165,8 +165,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-byron; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-cardano.nix
+++ b/nix/.stack.nix/ouroboros-consensus-cardano.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-cardano; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-mock.nix
+++ b/nix/.stack.nix/ouroboros-consensus-mock.nix
@@ -106,8 +106,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus/ouroboros-consensus-mock; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-shelley.nix
+++ b/nix/.stack.nix/ouroboros-consensus-shelley.nix
@@ -116,8 +116,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-shelley; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -189,8 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-framework.nix
+++ b/nix/.stack.nix/ouroboros-network-framework.nix
@@ -147,8 +147,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-framework; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-testing.nix
+++ b/nix/.stack.nix/ouroboros-network-testing.nix
@@ -69,8 +69,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-testing; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -213,8 +213,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger-test.nix
+++ b/nix/.stack.nix/shelley-spec-ledger-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/executable-spec/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger.nix
+++ b/nix/.stack.nix/shelley-spec-ledger.nix
@@ -115,8 +115,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-non-integral.nix
+++ b/nix/.stack.nix/shelley-spec-non-integral.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/dependencies/non-integer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -119,8 +119,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "f1d5ddb25531b2512796d34e9cfd803f7af76567";
-      sha256 = "1nxqdi8vbx3mg1qdbvj7v6ngfjbgbf9i7yxc3ijac2mqb4fn5b4f";
+      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
+      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
       });
     postUnpack = "sourceRoot+=/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-examples.nix
+++ b/nix/.stack.nix/typed-protocols-examples.nix
@@ -88,8 +88,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/typed-protocols-examples; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -66,8 +66,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "3d89fa475bc740473e5ffe947572c19f9b91d26d";
-      sha256 = "0v1mfsamjh3c93m0bqqdflg89iy6wvfq0l1ji66m4xgvrj0ilzds";
+      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
+      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "tags/1.10.0",
+        "branch": "tags/1.10.1",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "76d321b7cb217795e78620eede4ffc239727bcb1",
-        "sha256": "1xyax2i7wb1a2kh1x3q81n1ay1fvq651innaxx3n2q1grl88s4zi",
+        "rev": "99e1a85b4a3f6d13ddf89e6ea471df18b65fd31a",
+        "sha256": "0gsv06hzrlqziaxdaj925gd15y6yhc4zw90r9818qvz6nvsym2y1",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/76d321b7cb217795e78620eede4ffc239727bcb1.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/99e1a85b4a3f6d13ddf89e6ea471df18b65fd31a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.10.0.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/rvl/cardano-node-1.10.1-snapshot/snapshots/cardano-1.10.1.yaml
 
 packages:
 - lib/core

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/rvl/cardano-node-1.10.1-snapshot/snapshots/cardano-1.10.1.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.10.1.yaml
 
 packages:
 - lib/core


### PR DESCRIPTION
### Overview

- 834ed309d9cc3897cb25b4880bf5fbd9769b2794
  :round_pushpin: **Update stack resolver to cardano-1.10.1.yaml**
  
- 5e466538e48567d02d6c47f24129b729ce84e48d
  :round_pushpin: **cardano-node: 1.10.0 -> 1.10.1**
  https://github.com/input-output-hk/cardano-node/releases/tag/1.10.1

- ffbdfe9505588262def60cd4824149216c933dba
  :round_pushpin: **Regenerate nix**
  
- 8c93e3f858559170e34a7119d164caf57dcc4c3c
  :round_pushpin: **use 'master' revision from cardano-haskell's snapshots**
  
- 7fb5a9accf1f137b9e901f523c6cadb035654b1c
  :round_pushpin: **bump versions in the compatibility matrix on the README**

# Comments

Depends on input-output-hk/cardano-haskell#11 being merged first.
