### PR TITLE
Make all hydra jobs green

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -57,7 +57,7 @@ let
         packages.text-class.components.tests.unit.keepSource = true;
       }
 
-      # Add dependencies
+      # Provide configuration and dependencies to cardano-wallet components
       {
         packages.cardano-wallet-byron.components.tests = {
           # Only run integration tests on non-PR jobsets. Note that
@@ -131,25 +131,37 @@ let
           export SWAGGER_YAML=${src + /specifications/api/swagger.yaml}
         '';
 
-        # Make the /usr/bin/security tool available because it's
-        # needed at runtime by the x509-system Haskell package.
-        packages.x509-system.components.library.preBuild = pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
-          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
-        '';
-
         # Workaround for Haskell.nix issue
         packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";
         packages.cardano-wallet-core.components.all.preBuild = pkgs.lib.mkForce "";
         packages.cardano-wallet-byron.components.all.postInstall = pkgs.lib.mkForce "";
       }
 
+      # Build fixes for library dependencies
+      {
+        # Make the /usr/bin/security tool available because it's
+        # needed at runtime by the x509-system Haskell package.
+        packages.x509-system.components.library.preBuild = pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
+          substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
+        '';
+
+        # Packages we wish to ignore version bounds of.
+        # This is similar to jailbreakCabal, however it
+        # does not require any messing with cabal files.
+        packages.katip.doExactConfig = true;
+
+        # split data output for ekg to reduce closure size
+        packages.ekg.components.library.enableSeparateDataOutput = true;
+        enableLibraryProfiling = profiling;
+      }
+
       # Musl libc fully static build
-      (with pkgs.stdenv; let
+      (lib.optionalAttrs stdenv.hostPlatform.isMusl (let
         staticLibs = [ zlib openssl libffi gmp6 ];
-        gmp6 = pkgs.gmp6.override { withStatic = true; };
-        zlib = pkgs.zlib.static;
-        openssl = (pkgs.openssl.override { static = true; }).out;
-        libffi = pkgs.libffi.overrideAttrs (oldAttrs: {
+        gmp6 = buildPackages.gmp6.override { withStatic = true; };
+        zlib = buildPackages.zlib.static;
+        openssl = (buildPackages.openssl.override { static = true; }).out;
+        libffi = buildPackages.libffi.overrideAttrs (oldAttrs: {
           dontDisableStatic = true;
           configureFlags = (oldAttrs.configureFlags or []) ++ [
                     "--enable-static"
@@ -159,13 +171,9 @@ let
 
         # Module options which adds GHC flags and libraries for a fully static build
         fullyStaticOptions = {
-          configureFlags =
-             lib.optionals hostPlatform.isMusl ([
-               "--disable-executable-dynamic"
-               "--disable-shared"
-               "--ghc-option=-optl=-pthread"
-               "--ghc-option=-optl=-static"
-             ] ++ map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs);
+          enableShared = false;
+          enableStatic = true;
+          configureFlags = map (drv: "--ghc-option=-optl=-L${drv}/lib") staticLibs;
         };
       in {
         # Apply fully static options to our Haskell executables
@@ -182,19 +190,7 @@ let
         packages.cardano-wallet-jormungandr.components.tests.jormungandr-integration = fullyStaticOptions;
         packages.cardano-wallet-jormungandr.components.tests.unit = fullyStaticOptions;
         packages.cardano-wallet-launcher.components.tests.unit = fullyStaticOptions;
-
-        # SRE-83 dependencies fail to build
-        # packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
-
-        # Packages we wish to ignore version bounds of.
-        # This is similar to jailbreakCabal, however it
-        # does not require any messing with cabal files.
-        packages.katip.doExactConfig = true;
-
-        # split data output for ekg to reduce closure size
-        packages.ekg.components.library.enableSeparateDataOutput = true;
-        enableLibraryProfiling = profiling;
-      })
+      }))
 
       # Allow installation of a newer version of Win32 than what is
       # included with GHC. The packages in this list are all those

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -169,8 +169,20 @@ let
         };
       in {
         # Apply fully static options to our Haskell executables
-        packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr = fullyStaticOptions;
+        packages.cardano-wallet-byron.components.benchmarks.latency = fullyStaticOptions;
+        packages.cardano-wallet-byron.components.benchmarks.restore = fullyStaticOptions;
         packages.cardano-wallet-byron.components.exes.cardano-wallet-byron = fullyStaticOptions;
+        packages.cardano-wallet-byron.components.tests.integration = fullyStaticOptions;
+        packages.cardano-wallet-byron.components.tests.unit = fullyStaticOptions;
+        packages.cardano-wallet-cli.components.tests.unit = fullyStaticOptions;
+        packages.cardano-wallet-core.components.benchmarks.db = fullyStaticOptions;
+        packages.cardano-wallet-core.components.tests.unit = fullyStaticOptions;
+        packages.cardano-wallet-jormungandr.components.benchmarks.latency = fullyStaticOptions;
+        packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr = fullyStaticOptions;
+        packages.cardano-wallet-jormungandr.components.tests.jormungandr-integration = fullyStaticOptions;
+        packages.cardano-wallet-jormungandr.components.tests.unit = fullyStaticOptions;
+        packages.cardano-wallet-launcher.components.tests.unit = fullyStaticOptions;
+
         # SRE-83 dependencies fail to build
         # packages.cardano-node.components.exes.cardano-node = fullyStaticOptions;
 

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -224,4 +224,6 @@ let
   mkTests = if pkgs.stdenv.hostPlatform.isWindows then mkTestsWindows else mkTestsBash;
 
 in
-  mkTests releases
+  if pkgs.stdenv.hostPlatform.isMusl
+    then pkgs.runCommand "migration-tests-disabled" {} "touch $out"
+    else mkTests releases

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -11,7 +11,8 @@ haskell.lib.buildStackProject rec {
 
   buildInputs =
     (with walletPackages; [ jormungandr jormungandr-cli cardano-node ]) ++
-    [ zlib gmp ncurses lzma openssl git systemd.dev ] ++
+    [ zlib gmp ncurses lzma openssl ] ++
+    (lib.optionals (!stdenv.isDarwin) [ git systemd.dev ]) ++
     (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));
 
   phases = ["nobuildPhase"];


### PR DESCRIPTION
# Issue Number

Relates to #1283

# Overview

Currently, all constituents of the [`required` job](https://hydra.iohk.io/job/Cardano/cardano-wallet/required/latest-finished#tabs-constituents) pass, but not all jobs in the main jobset pass.

This PR will either fix or disable the red jobs.

# Comments

[Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1566#tabs-jobs)

Failing jobs which depend on SRE-83 / input-output-hk/cardano-node#800:

- `musl64.benchmarks.cardano-wallet-byron.latency.x86_64-linux`
- `musl64.benchmarks.cardano-wallet-byron.restore.x86_64-linux`
- `musl64.tests.cardano-wallet-byron.integration.x86_64-linux`
- `musl64.cardano-node.x86_64-linux`
- `musl64.db-converter.x86_64-linux`

Fixed jobs:

- [x] `native.stackShell.x86_64-darwin`
- [x] `musl64.benchmarks.cardano-wallet-jormungandr.latency.x86_64-linux`
- [x] `musl64.tests.cardano-wallet-jormungandr.jormungandr-integration.x86_64-linux`
- [x] `musl64.tests.cardano-wallet*`
- [x] `musl64.benchmarks.cardano-wallet*`

Disabled jobs:

- [x] `musl64.migration-tests.x86_64-linux`
