### PR TITLE
Buildkite nightly: Remove cache clean jobs

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -44,24 +44,3 @@ steps:
     timeout_in_minutes: 60
     agents:
       system: x86_64-linux
-
-  - block: 'Delete CI Caches'
-
-  - label: 'Clean up CI cache'
-    command:
-      - "nix-build .buildkite/default.nix -o sr"
-      - "./sr/bin/rebuild cleanup-cache --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
-    agents:
-      system: x86_64-linux
-
-  - label: 'Purge CI cache'
-    command:
-      - "nix-build .buildkite/default.nix -o sr"
-      - "./sr/bin/rebuild purge-cache --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
-    agents:
-      system: x86_64-linux
-
-  - wait
-
-  - label: "Rebuild master branch"
-    trigger: "cardano-wallet"


### PR DESCRIPTION
The cache cleaning is now done with a cron job on the buildkite agents. These pipeline steps never worked well anyway because it was not possible to run them on all buildkite agents at the same time.
