### PR TITLE
Fix remaining fee calculation

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
@@ -108,6 +108,7 @@ newTransactionLayer _proxy protocolMagic = TransactionLayer
     , estimateSize = _estimateSize
     , estimateMaxNumberOfInputs = _estimateMaxNumberOfInputs
     , validateSelection = _validateSelection
+    , allowUnbalancedTx = True
     }
   where
     _mkStdTx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -220,6 +220,7 @@ import Cardano.Wallet.Primitive.Fee
     ( ErrAdjustForFee (..)
     , Fee (..)
     , FeeOptions (..)
+    , OnDanglingChange (..)
     , adjustForFee
     , computeCertFee
     , computeFee
@@ -955,6 +956,7 @@ feeOpts
 feeOpts tl feeCompute feePolicy = FeeOptions
     { estimateFee = feeCompute feePolicy . estimateSize tl
     , dustThreshold = minBound
+    , onDanglingChange = if allowUnbalancedTx tl then SaveMoney else PayAndBalance
     }
 
 -- | Prepare a transaction and automatically select inputs from the

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -29,7 +29,9 @@ module Cardano.Wallet.Primitive.Fee
       -- * Fee Adjustment
     , FeeOptions (..)
     , ErrAdjustForFee(..)
+    , OnDanglingChange(..)
     , adjustForFee
+    , rebalanceChangeOutputs
     ) where
 
 import Prelude
@@ -128,7 +130,25 @@ data FeeOptions = FeeOptions
       -- ^ Change addresses below the given threshold will be evicted
       -- from the created transaction. Setting 'dustThreshold' to 0
       -- removes output equal to 0
+
+    , onDanglingChange
+      :: OnDanglingChange
+      -- ^ What do to when we encouter a dangling change output.
+      -- See 'OnDanglingChange'
     } deriving (Generic)
+
+-- | We call 'dangling' a change output that would be too expensive to add. This
+-- can happen when a change output is small, but adding it generate more fees
+-- than not having it.
+--
+-- In case where nodes accept slightly unbalanced transactions, we may choose to
+-- save money and keep the transaction slightly unbalanced. In case where node
+-- demands exactly balanced transaction, we have no choice but to add the extra
+-- dangling change output and pay for the extra cost induced.
+data OnDanglingChange
+    = PayAndBalance
+    | SaveMoney
+    deriving (Generic, Show, Eq)
 
 newtype ErrAdjustForFee
     = ErrCannotCoverFee Word64
@@ -189,14 +209,9 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         => CoinSelection
         -> StateT UTxO (ExceptT ErrAdjustForFee m) CoinSelection
     go coinSel@(CoinSelection inps outs chgs) = do
-        -- 1/
-        -- We compute fees using all inputs, outputs and changes since
-        -- all of them have an influence on the fee calculation.
-        let upperBound = estimateFee opt coinSel
-        -- 2/
         -- Substract fee from change outputs, proportionally to their value.
-        let (coinSel', remFee) = rebalanceChangeOutputs opt upperBound coinSel
-        -- 3.1/
+        let (coinSel', remFee) = rebalanceChangeOutputs opt coinSel
+
         -- Should the change cover the fee, we're (almost) good. By removing
         -- change outputs, we make them smaller and may reduce the size of the
         -- transaction, and the fee. Thus, we end up paying slightly more than
@@ -205,7 +220,6 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         if remFee == Fee 0
         then pure coinSel'
         else do
-            -- 3.2/
             -- Otherwise, we need an extra entries from the available utxo to
             -- cover what's left. Note that this entry may increase our change
             -- because we may not consume it entirely. So we will just split
@@ -246,37 +260,57 @@ coverRemainingFee (Fee fee) = go [] where
 -- any output:change ratio as unchanged as possible
 rebalanceChangeOutputs
     :: FeeOptions
-    -> Fee
     -> CoinSelection
     -> (CoinSelection, Fee)
-rebalanceChangeOutputs opts totalFee sel@(CoinSelection _ _ chgs) =
-    let
-        chgs' = case removeDust (dustThreshold opts) chgs of
-            [] -> []
-            xs -> removeDust (dustThreshold opts)
+rebalanceChangeOutputs opts s
+    -- selection is now balanced, nothing to do.
+    | φ_original == δ_original =
+        (s, Fee 0)
+
+    -- some fee left to pay, but we've depleted all change outputs
+    | φ_original > δ_original && null (change s) =
+        (s, Fee (φ_original - δ_original))
+
+    -- some fee left to pay, and we've haven't depleted all change yet
+    | φ_original > δ_original && not (null (change s)) = do
+        let chgs' = removeDust (Coin 0)
                 $ map reduceSingleChange
-                $ divvyFee totalFee xs
-    in
-        remainingFee (sel { change = chgs' })
+                $ divvyFee (Fee $ φ_original - δ_original) (change s)
+        rebalanceChangeOutputs opts (s { change = chgs' })
+
+    -- we've left too much, but adding a change output would be more
+    -- expensive than not having it. Here we have two choices:
+    --
+    -- a) If the node allows unbalanced transaction, we can stop here and do
+    -- nothing. We'll leave slightly more than what's needed for fees, but
+    -- having an extra change output isn't worth it anyway.
+    --
+    -- b) If we __must__ balance the transaction, then we can choose to pay
+    -- the extra cost by adding the change output and pick a new input to
+    -- pay for the fee.
+    | φ_dangling >= δ_original && φ_dangling > δ_dangling =
+        case onDanglingChange opts of
+            SaveMoney ->
+                (s, Fee 0)
+            PayAndBalance ->
+                (sDangling, Fee (φ_dangling - δ_dangling))
+
+    -- So, we can simply add the change output, and iterate.
+    | otherwise =
+        rebalanceChangeOutputs opts sDangling
   where
-    -- | Computes how much is left to pay given a particular selection
-    remainingFee :: CoinSelection -> (CoinSelection, Fee)
-    remainingFee s
-        | φ_original >= δ_original = (s, Fee (φ_original - δ_original))
-        | otherwise = (sDangling, Fee (φ_dangling - δ_dangling))
-      where
-        -- The original requested fee amount
-        Fee φ_original = estimateFee opts s
-        -- The initial amount left for fee (i.e. inputs - outputs)
-        δ_original = inputBalance s - (outputBalance s + changeBalance s)
+    -- The original requested fee amount
+    Fee φ_original = estimateFee opts s
+    -- The initial amount left for fee (i.e. inputs - outputs)
+    δ_original = inputBalance s - (outputBalance s + changeBalance s)
 
-        -- The new amount left after balancing (i.e. φ_original)
-        Fee φ_dangling = estimateFee opts sDangling
-        -- The new requested fee after adding the output.
-        δ_dangling = φ_original -- by construction of the change output
+    -- The new amount left after balancing (i.e. φ_original)
+    Fee φ_dangling = estimateFee opts sDangling
+    -- The new requested fee after adding the output.
+    δ_dangling = φ_original -- by construction of the change output
 
-        extraChng = Coin (δ_original - φ_original)
-        sDangling = s { change = splitChange extraChng (change s) }
+    extraChng = Coin (δ_original - φ_original)
+    sDangling = s { change = splitChange extraChng (change s) }
 
 -- | Reduce single change output by a given fee amount. If fees are too big for
 -- a single coin, returns a `Coin 0`.

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -255,7 +255,7 @@ rebalanceChangeOutputs
     -> (CoinSelection, Fee)
 rebalanceChangeOutputs opts totalFee sel@(CoinSelection _ _ chgs) =
     let
-        chgs' = case removeDust (Coin 0) chgs of
+        chgs' = case removeDust (dustThreshold opts) chgs of
             [] -> []
             xs -> removeDust (dustThreshold opts)
                 $ map reduceSingleChange

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -114,6 +114,10 @@ data TransactionLayer t k = TransactionLayer
       -- For example, Byron nodes do not allow null output amounts. Jörmungandr
       -- on its side doesn't support more than 255 inputs or outputs.
 
+    , allowUnbalancedTx
+      :: Bool
+      -- ^ Whether the transaction layer accepts unbalanced transactions.
+
     , decodeSignedTx
         :: ByteString -> Either ErrDecodeSignedTx (Tx, SealedTx)
         -- ^ Decode an externally-signed transaction to the chain producer

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -15,7 +15,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Migration
 import Cardano.Wallet.Primitive.CoinSelectionSpec
     ()
 import Cardano.Wallet.Primitive.Fee
-    ( Fee (..), FeeOptions (..) )
+    ( Fee (..), FeeOptions (..), OnDanglingChange (..) )
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types
@@ -121,6 +121,7 @@ spec = do
                     , estimateFee = \s -> Fee
                         $ fromIntegral
                         $ 5 * (length (inputs s) + length (outputs s))
+                    , onDanglingChange = PayAndBalance
                     }
             let batchSize = 1
             let utxo = UTxO $ Map.fromList
@@ -241,6 +242,7 @@ genFeeOptions (Coin dust) = do
             let x = fromIntegral (length (inputs s) + length (outputs s))
             in Fee $ (dust `div` 100) * x + dust
         , dustThreshold = Coin dust
+        , onDanglingChange = PayAndBalance
         }
 
 -- | Generate a given UTxO with a particular percentage of dust

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -161,7 +161,7 @@ spec = do
             }) (Right $ FeeOutput
             { csInps = [20,20,20]
             , csOuts = [14,18,19]
-            , csChngs = [6]
+            , csChngs = [4,2]
             })
 
         -- Cannot cover fee, no extra inputs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -17,7 +17,13 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.Fee
-    ( ErrAdjustForFee (..), Fee (..), FeeOptions (..), adjustForFee, divvyFee )
+    ( ErrAdjustForFee (..)
+    , Fee (..)
+    , FeeOptions (..)
+    , OnDanglingChange (..)
+    , adjustForFee
+    , divvyFee
+    )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -161,7 +167,7 @@ spec = do
             }) (Right $ FeeOutput
             { csInps = [20,20,20]
             , csOuts = [14,18,19]
-            , csChngs = [4,2]
+            , csChngs = [4,1,1]
             })
 
         -- Cannot cover fee, no extra inputs
@@ -479,6 +485,8 @@ feeOptions fee dust = FeeOptions
         \_ -> Fee fee
     , dustThreshold =
         Coin dust
+    , onDanglingChange =
+        PayAndBalance
     }
 
 feeUnitTest
@@ -649,7 +657,8 @@ instance Arbitrary FeeOptions where
                     $ fromIntegral
                     $ c + a * (length (inputs s) + length (outputs s))
             , dustThreshold = Coin t
+            , onDanglingChange = PayAndBalance
             }
 
 instance Show FeeOptions where
-    show (FeeOptions _ dust) = show dust
+    show (FeeOptions _ dust onDangling) = show (dust, onDangling)

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -563,6 +563,8 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: validateSelection not implemented"
     , decodeSignedTx =
         error "dummyTransactionLayer: decodeSignedTx not implemented"
+    , allowUnbalancedTx =
+        False
     }
   where
     withEither :: e -> Maybe a -> Either e a

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -111,6 +111,8 @@ newTransactionLayer block0H = TransactionLayer
     , validateSelection = \(CoinSelection inps outs _) -> do
         when (length inps > maxNumberOfInputs || length outs > maxNumberOfOutputs)
             $ Left ErrExceededInpsOrOuts
+
+    , allowUnbalancedTx = False
     }
   where
     mkFragment details keyFrom rnps outs = do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1561 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->
- 938a3a034ca39ff2e821a109fb5ae8130667629a
  :round_pushpin: **add regression test triggering the unbalanced invariant**
    currently fails as expected with:

  ```
  Generated an unbalanced tx! Too much left for fees : fee (raw) = 164282 : fee (dangling) = 167722 , diff = 200000
  selection = inputs: - 1st 30 (~ 1000000 @ 66616b65...72657373)
  outputs: - 800000 @ 66616b65...72657373
  change: []

  CallStack (from HasCallStack):
    error, called at src/Cardano/Wallet/Primitive/Fee.hs:330:18 in cardano-wallet-core-2020.4.7-Be8Kf2A2Kpl7z2pVyjHPdZ:Cardano.Wallet.Primitive.Fee
    remainingFee, called at src/Cardano/Wallet/Primitive/Fee.hs:207:22 in cardano-wallet-core-2020.4.7-Be8Kf2A2Kpl7z2pVyjHPdZ:Cardano.Wallet.Primitive.Fee
  ```

- 1041fac37f0d87244d1a31dc90b8d1c62fa472e7
  :round_pushpin: **refactor: merge 'remainingFee' and 'rebalanceChangeOutput'**
  The former actually makes assumption based on the output of the later. Testing these
function in isolation makes little sense. Grouping them into one function makes it
easier to understand the surrounding context and what is happening.

Further refactoring is needed in order to now fix the issue with dangling fee

- 1758a306fbbeb234cbf48e43bcb7b9accc62aaca
  :round_pushpin: **use dustThreshold instead of 'Coin 0'**
  They should actually have the same semantic within this context.

- 7194126ca7933e08a9cd2528c94ef689623cb0f6
  :round_pushpin: **fix remaining fee calculation**
  
- a17462cf42a0e275d866d0bb7c2b001d5940ce42
  :round_pushpin: **fix unit test now correctly divying fee across change outputs**
  
- 15341246a634af562a4bf3984ecc147361f55e99
  :round_pushpin: **property test fee balancing**
  And allow transaction to be unbalanced if the node allows it


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
