### PR TITLE
Add LocalStateQuery to byron network layer

### DIFF
--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncTolerance (..) )
+    ( GenesisBlockParameters (..), SyncTolerance (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar
@@ -418,7 +418,7 @@ benchWithServer
     -> IO ()
 benchWithServer tracers action = do
     ctx <- newEmptyMVar
-    let setupContext bp wAddr = do
+    let setupContext gbp wAddr = do
             let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
             let sixtySeconds = 60*1000*1000 -- 60s in microseconds
             manager <- (baseUrl,) <$> newManager (defaultManagerSettings
@@ -432,7 +432,7 @@ benchWithServer tracers action = do
                 , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
                 , _faucet = faucet
                 , _feeEstimator = \_ -> error "feeEstimator not available"
-                , _blockchainParameters = bp
+                , _blockchainParameters = staticParameters gbp
                 , _target = Proxy
                 }
     race (takeMVar ctx >>= action) (withServer setupContext) >>=

--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -379,7 +379,7 @@ bench_restoration _proxy tracer socketPath gbp vData progressLogFile (wid, wname
                         hFlush h
                 let w = WalletLayer
                         (traceProgressForPlotting fileTr)
-                        (emptyGenesis bp, bp, mkSyncTolerance 3600)
+                        (emptyGenesis bp, gbp, mkSyncTolerance 3600)
                         nw
                         tl
                         db

--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -103,6 +103,7 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , BlockchainParameters (..)
     , ChimericAccount
+    , GenesisBlockParameters (..)
     , SlotId (..)
     , SyncProgress (..)
     , WalletId (..)
@@ -209,7 +210,7 @@ exec c = do
     (_logCfg, tr) <- initBenchmarkLogging Info
     installSignalHandlers (return ())
 
-    (SomeNetworkDiscriminant networkProxy, bp, vData, _b)
+    (SomeNetworkDiscriminant networkProxy, gbp, vData, _b)
         <- unsafeRunExceptT $ parseGenesisData c
 
     ----------------------------------------------------------------------------
@@ -247,14 +248,14 @@ exec c = do
     sayErr $ pretty cmd
 
     void $ withBackendProcess nullTracer cmd $ do
-            prepareNode networkProxy socketPath bp vData
+            prepareNode networkProxy socketPath gbp vData
             runBenchmarks
                 [ bench ("restore " <> network <> " seq")
                     (bench_restoration @_ @ByronKey
                         networkProxy
                         tr
                         socketPath
-                        bp
+                        gbp
                         vData
                         "seq.timelog"
                         (walletRnd))
@@ -264,7 +265,7 @@ exec c = do
                         networkProxy
                         tr
                         socketPath
-                        bp
+                        gbp
                         vData
                         "1-percent.timelog"
                         (initAnyState "Benchmark 1% Wallet" 0.01))
@@ -274,7 +275,7 @@ exec c = do
                         networkProxy
                         tr
                         socketPath
-                        bp
+                        gbp
                         vData
                         "2-percent.timelog"
                         (initAnyState "Benchmark 2% Wallet" 0.02))
@@ -352,17 +353,18 @@ bench_restoration
     -> Trace IO Text
     -> FilePath
        -- ^ Socket path
-    -> BlockchainParameters
+    -> GenesisBlockParameters
     -> NodeVersionData
     -> FilePath
        -- ^ Log output
     -> (WalletId, WalletName, s)
     -> IO ()
-bench_restoration _proxy tracer socketPath bp vData progressLogFile (wid, wname, s) = do
+bench_restoration _proxy tracer socketPath gbp vData progressLogFile (wid, wname, s) = do
     let networkText = networkDiscriminantVal @n
     let pm = fromNetworkMagic $ networkMagic $ fst vData
     let tl = newTransactionLayer @n @k @(IO Byron) (Proxy) pm
-    withNetworkLayer nullTracer bp socketPath vData $ \nw' -> do
+    withNetworkLayer nullTracer gbp socketPath vData $ \nw' -> do
+        let bp = staticParameters gbp
         let convert = fromByronBlock (getGenesisBlockHash bp) (getEpochLength bp)
         let nw = convert <$> nw'
         withBenchDBLayer @s @k tracer $ \db -> do
@@ -434,12 +436,13 @@ prepareNode
     :: forall n. (NetworkDiscriminantVal n)
     => Proxy n
     -> FilePath
-    -> BlockchainParameters
+    -> GenesisBlockParameters
     -> NodeVersionData
     -> IO ()
-prepareNode _ socketPath bp vData = do
+prepareNode _ socketPath gbp vData = do
     sayErr . fmt $ "Syncing "+|networkDiscriminantVal @n|+" node... "
-    sl <- withNetworkLayer nullTracer bp socketPath vData $ \nw' -> do
+    sl <- withNetworkLayer nullTracer gbp socketPath vData $ \nw' -> do
+        let bp = staticParameters gbp
         let convert = fromByronBlock (getGenesisBlockHash bp) (getEpochLength bp)
         let nw = convert <$> nw'
         waitForNodeSync nw logQuiet bp

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -269,7 +269,7 @@ serveWallet
         -> NetworkLayer IO t ByronBlock
         -> IO (ApiLayer s t k)
     apiLayer tl nl = do
-        let params = (block0, bp, sTolerance)
+        let params = (block0, gbp, sTolerance)
         db <- Sqlite.newDBFactory
             walletDbTracer
             (DefaultFieldValues $ getActiveSlotCoefficient bp)

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -136,24 +136,28 @@ type NodeVersionData =
 -- Chain Parameters
 
 
-mainnetBlockchainParameters :: W.BlockchainParameters
-mainnetBlockchainParameters = W.BlockchainParameters
-    { getGenesisBlockHash = W.Hash $ unsafeFromHex
-        "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-    , getGenesisBlockDate =
-        W.StartTime $ posixSecondsToUTCTime 1506203091
-    , getFeePolicy =
-        W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
-    , getSlotLength =
-        W.SlotLength 20
-    , getEpochLength =
-        W.EpochLength 21600
-    , getTxMaxSize =
-        Quantity 8192
-    , getEpochStability =
-        Quantity 2160
-    , getActiveSlotCoefficient =
-        W.ActiveSlotCoefficient 1.0
+mainnetBlockchainParameters :: W.GenesisBlockParameters
+mainnetBlockchainParameters = W.GenesisBlockParameters
+    { staticParameters = W.BlockchainParameters
+        { getGenesisBlockHash = W.Hash $ unsafeFromHex
+            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+        , getGenesisBlockDate =
+            W.StartTime $ posixSecondsToUTCTime 1506203091
+        , getSlotLength =
+            W.SlotLength 20
+        , getEpochLength =
+            W.EpochLength 21600
+        , getEpochStability =
+            Quantity 2160
+        , getActiveSlotCoefficient =
+            W.ActiveSlotCoefficient 1.0
+        }
+    , txParameters = W.TxParameters
+        { getFeePolicy =
+            W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
+        , getTxMaxSize =
+            Quantity 8192
+        }
     }
 
 -- NOTE
@@ -392,25 +396,29 @@ fromNonAvvmBalances (GenesisNonAvvmBalances m) =
     fromTxOut . uncurry TxOut <$> Map.toList m
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
-fromGenesisData :: (GenesisData, GenesisHash) -> (W.BlockchainParameters, [W.TxOut])
+fromGenesisData :: (GenesisData, GenesisHash) -> (W.GenesisBlockParameters, [W.TxOut])
 fromGenesisData (genesisData, genesisHash) =
-    ( W.BlockchainParameters
-        { getGenesisBlockHash =
-            W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
-        , getGenesisBlockDate =
-            W.StartTime . gdStartTime $ genesisData
-        , getFeePolicy =
-            fromTxFeePolicy . ppTxFeePolicy . gdProtocolParameters $ genesisData
-        , getSlotLength =
-            fromSlotDuration . ppSlotDuration . gdProtocolParameters $ genesisData
-        , getEpochLength =
-            fromBlockCount . gdK $ genesisData
-        , getTxMaxSize =
-            fromMaxTxSize . ppMaxTxSize . gdProtocolParameters $ genesisData
-        , getEpochStability =
-            Quantity . fromIntegral . unBlockCount . gdK $ genesisData
-        , getActiveSlotCoefficient =
-            W.ActiveSlotCoefficient 1.0
+    ( W.GenesisBlockParameters
+        { staticParameters = W.BlockchainParameters
+            { getGenesisBlockHash =
+                W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
+            , getGenesisBlockDate =
+                W.StartTime . gdStartTime $ genesisData
+            , getSlotLength =
+                fromSlotDuration . ppSlotDuration . gdProtocolParameters $ genesisData
+            , getEpochLength =
+                fromBlockCount . gdK $ genesisData
+            , getEpochStability =
+                Quantity . fromIntegral . unBlockCount . gdK $ genesisData
+            , getActiveSlotCoefficient =
+                W.ActiveSlotCoefficient 1.0
+            }
+        , txParameters = W.TxParameters
+            { getFeePolicy =
+                fromTxFeePolicy . ppTxFeePolicy . gdProtocolParameters $ genesisData
+            , getTxMaxSize =
+                fromMaxTxSize . ppMaxTxSize . gdProtocolParameters $ genesisData
+            }
         }
     , fromNonAvvmBalances . gdNonAvvmBalances $ genesisData
     )

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -161,7 +161,7 @@ mainnetBlockchainParameters = W.GenesisBlockParameters
         { getFeePolicy =
             W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
         , getTxMaxSize =
-            Quantity 8192
+            Quantity 4096
         }
     }
 

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -52,12 +52,13 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , BlockchainParameters (..)
     , FeePolicy (..)
+    , GenesisBlockParameters (..)
     , Hash (..)
     , SyncTolerance (..)
     , TxIn (..)
     , TxOut (..)
+    , TxParameters (..)
     )
 import Control.Concurrent.Async
     ( race )
@@ -154,7 +155,7 @@ specWithServer tr = aroundAll withContext . after tearDown
     withContext :: (Context Byron -> IO ()) -> IO ()
     withContext action = do
         ctx <- newEmptyMVar
-        let setupContext bp wAddr = do
+        let setupContext gbp wAddr = do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
                 logInfo tr baseUrl
                 let sixtySeconds = 60*1000*1000 -- 60s in microseconds
@@ -168,8 +169,8 @@ specWithServer tr = aroundAll withContext . after tearDown
                     , _manager = manager
                     , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
                     , _faucet = faucet
-                    , _feeEstimator = mkFeeEstimator (getFeePolicy bp)
-                    , _blockchainParameters = bp
+                    , _feeEstimator = mkFeeEstimator (getFeePolicy (txParameters gbp))
+                    , _blockchainParameters = staticParameters gbp
                     , _target = Proxy
                     }
         race (takeMVar ctx >>= action) (withServer setupContext) >>=

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -262,6 +262,7 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
+    , TxParameters (..)
     , TxStatus (..)
     , UTxOStatistics
     , UnsignedTx (..)
@@ -589,6 +590,18 @@ readWallet ctx wid = db & \DBLayer{..} -> mapExceptT atomically $ do
   where
     db = ctx ^. dbLayer @s @k
 
+readWalletTxParameters
+    :: forall ctx s k. HasDBLayer s k ctx
+    => ctx
+    -> WalletId
+    -> ExceptT ErrNoSuchWallet IO TxParameters
+readWalletTxParameters ctx wid = db & \DBLayer{..} ->
+    mapExceptT atomically $
+        withNoSuchWallet wid $
+            readTxParameters (PrimaryKey wid)
+  where
+    db = ctx ^. dbLayer @s @k
+
 walletSyncProgress
     :: forall ctx s.
         ( HasGenesisData ctx
@@ -672,7 +685,9 @@ restoreWallet
     -> ExceptT ErrNoSuchWallet IO ()
 restoreWallet ctx wid = db & \DBLayer{..} -> do
     cps <- liftIO $ atomically $ listCheckpoints (PrimaryKey wid)
-    let forward bs h = run $ restoreBlocks @ctx @s @k ctx wid bs h
+    let forward bs (h, ps) = run $ do
+            restoreBlocks @ctx @s @k ctx wid bs h
+            saveParams @ctx @s @k ctx wid ps
     liftIO (follow nw tr cps forward (view #header)) >>= \case
         FollowInterrupted -> pure ()
         FollowFailure ->
@@ -788,6 +803,20 @@ restoreBlocks ctx wid blocks nodeTip = db & \DBLayer{..} -> do
     isParentOf cp = (== parent) . parentHeaderHash . header
       where parent = headerHash $ currentTip cp
 
+-- | Store the node tip params into the wallet database
+saveParams
+    :: forall ctx s k.
+        ( HasLogger WalletLog ctx
+        , HasDBLayer s k ctx
+        )
+    => ctx
+    -> WalletId
+    -> TxParameters
+    -> ExceptT ErrNoSuchWallet IO ()
+saveParams ctx wid params = db & \DBLayer{..} ->
+   mapExceptT atomically $ putTxParameters (PrimaryKey wid) params
+  where
+    db = ctx ^. dbLayer @s @k
 
 -- | Remove an existing wallet. Note that there's no particular work to
 -- be done regarding the restoration worker as it will simply terminate
@@ -982,13 +1011,14 @@ selectCoinsForPayment
 selectCoinsForPayment ctx wid recipients = do
     (wal, _, pending) <- withExceptT ErrSelectForPaymentNoSuchWallet $
         readWallet @ctx @s @k ctx wid
-    let bp = blockchainParameters wal
+    txp <- withExceptT ErrSelectForPaymentNoSuchWallet $
+        readWalletTxParameters @ctx @s @k ctx wid
     let utxo = availableUTxO @s pending wal
     (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
-        let opts = coinSelOpts tl (bp ^. #getTxMaxSize)
+        let opts = coinSelOpts tl (txp ^. #getTxMaxSize)
         CoinSelection.random opts recipients utxo
     lift . traceWith tr $ MsgPaymentCoinSelection sel
-    let feePolicy = feeOpts tl computeFee (bp ^. #getFeePolicy)
+    let feePolicy = feeOpts tl computeFee (txp ^. #getFeePolicy)
     withExceptT ErrSelectForPaymentFee $ do
         balancedSel <- adjustForFee feePolicy utxo' sel
         lift . traceWith tr $ MsgPaymentCoinSelectionAdjusted balancedSel
@@ -1011,10 +1041,11 @@ selectCoinsForDelegation
 selectCoinsForDelegation ctx wid = do
     (wal, _, pending) <- withExceptT ErrSelectForDelegationNoSuchWallet $
         readWallet @ctx @s @k ctx wid
-    let bp = blockchainParameters wal
+    txp <- withExceptT ErrSelectForDelegationNoSuchWallet $
+        readWalletTxParameters @ctx @s @k ctx wid
     let utxo = availableUTxO @s pending wal
     let sel = CoinSelection [] [] []
-    let feePolicy = feeOpts tl (computeCertFee 1) (bp ^. #getFeePolicy)
+    let feePolicy = feeOpts tl (computeCertFee 1) (txp ^. #getFeePolicy)
     withExceptT ErrSelectForDelegationFee $ do
         balancedSel <- adjustForFee feePolicy utxo sel
         lift $ traceWith tr $ MsgDelegationCoinSelection balancedSel
@@ -1042,12 +1073,13 @@ selectCoinsForMigration
 selectCoinsForMigration ctx wid = do
     (cp, _, pending) <- withExceptT ErrSelectForMigrationNoSuchWallet $
         readWallet @ctx @s @k ctx wid
-    let bp = blockchainParameters cp
+    txp <- withExceptT ErrSelectForMigrationNoSuchWallet $
+        readWalletTxParameters @ctx @s @k ctx wid
     let utxo = availableUTxO @s pending cp
-    let feePolicy@(LinearFee (Quantity a) _ _) = bp ^. #getFeePolicy
+    let feePolicy@(LinearFee (Quantity a) _ _) = txp ^. #getFeePolicy
     let feeOptions = (feeOpts tl computeFee feePolicy)
             { dustThreshold = Coin $ ceiling a }
-    let selOptions = coinSelOpts tl (bp ^. #getTxMaxSize)
+    let selOptions = coinSelOpts tl (txp ^. #getTxMaxSize)
     case depleteUTxO feeOptions (idealBatchSize selOptions) utxo of
         cs | not (null cs) -> pure cs
         _ -> throwE (ErrSelectForMigrationEmptyWallet wid)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -132,7 +132,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( AddressState
     , Block
-    , BlockchainParameters
+    , GenesisBlockParameters
     , SortOrder (..)
     , SyncTolerance
     , WalletId (..)
@@ -547,7 +547,7 @@ type PostExternalTransaction = "proxy"
 data ApiLayer s t (k :: Depth -> * -> *)
     = ApiLayer
         (Tracer IO (WorkerLog WalletId WalletLog))
-        (Block, BlockchainParameters, SyncTolerance)
+        (Block, GenesisBlockParameters, SyncTolerance)
         (NetworkLayer IO t (Block))
         (TransactionLayer t k)
         (DBFactory IO s k)

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -112,10 +112,11 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> Wallet s
         -> WalletMetadata
         -> [(Tx, TxMeta)]
+        -> TxParameters
         -> ExceptT ErrWalletAlreadyExists stm ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
-        -- 'putWalletMeta' or 'putTxHistory' will actually all fail if they are
-        -- called _first_ on a wallet.
+        -- 'putWalletMeta', 'putTxHistory' or 'putTxParameters' will actually
+        -- all fail if they are called _first_ on a wallet.
 
     , removeWallet
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -42,6 +42,7 @@ import Cardano.Wallet.Primitive.Types
     , SortOrder (..)
     , Tx (..)
     , TxMeta
+    , TxParameters
     , TxStatus
     , WalletId
     , WalletMetadata
@@ -221,6 +222,17 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> stm (Maybe (k 'RootK XPrv, Hash "encryption"))
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
+
+    , putTxParameters
+        :: PrimaryKey WalletId
+        -> TxParameters
+        -> ExceptT ErrNoSuchWallet stm ()
+        -- ^ Store blockchain parameters for the node tip.
+
+    , readTxParameters
+        :: PrimaryKey WalletId
+        -> stm (Maybe TxParameters)
+        -- ^ Read the previously stored node tip blockchain parameters.
 
     , rollbackTo
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -36,10 +36,12 @@ import Cardano.Wallet.DB.Model
     , mPutDelegationCertificate
     , mPutPrivateKey
     , mPutTxHistory
+    , mPutTxParameters
     , mPutWalletMeta
     , mReadCheckpoint
     , mReadPrivateKey
     , mReadTxHistory
+    , mReadTxParameters
     , mReadWalletMeta
     , mRemovePendingTx
     , mRemoveWallet
@@ -134,6 +136,15 @@ newDBLayer = do
 
         , removePendingTx = \pk tid -> ExceptT $ do
             alterDB errCannotRemovePendingTx db (mRemovePendingTx pk tid)
+
+        {-----------------------------------------------------------------------
+                                 Blockchain Parameters
+        -----------------------------------------------------------------------}
+
+        , putTxParameters = \pk txp -> ExceptT $ do
+            txp `deepseq` alterDB errNoSuchWallet db (mPutTxParameters pk txp)
+
+        , readTxParameters = readDB db . mReadTxParameters
 
         {-----------------------------------------------------------------------
                                       Execution

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -74,9 +74,9 @@ newDBLayer = do
                                       Wallets
         -----------------------------------------------------------------------}
 
-        { initializeWallet = \pk cp meta txs -> ExceptT $ do
+        { initializeWallet = \pk cp meta txs txp -> ExceptT $ do
             cp `deepseq` meta `deepseq`
-                alterDB errWalletAlreadyExists db (mInitializeWallet pk cp meta txs)
+                alterDB errWalletAlreadyExists db (mInitializeWallet pk cp meta txs txp)
 
         , removeWallet = ExceptT . alterDB errNoSuchWallet db . mRemoveWallet
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -728,10 +728,8 @@ mkCheckpointEntity wid wal =
         , checkpointBlockHeight = bh
         , checkpointGenesisHash = BlockId (coerce (bp ^. #getGenesisBlockHash))
         , checkpointGenesisStart = coerce (bp ^. #getGenesisBlockDate)
-        , checkpointFeePolicy = bp ^. #getFeePolicy
         , checkpointSlotLength = coerceSlotLength $ bp ^. #getSlotLength
         , checkpointEpochLength = coerce (bp ^. #getEpochLength)
-        , checkpointTxMaxSize = coerce (bp ^. #getTxMaxSize)
         , checkpointEpochStability = coerce (bp ^. #getEpochStability)
         , checkpointActiveSlotCoeff =
             W.unActiveSlotCoefficient (bp ^. #getActiveSlotCoefficient)
@@ -763,10 +761,8 @@ checkpointFromEntity cp utxo s =
         bh
         (BlockId genesisHash)
         genesisStart
-        feePolicy
         slotLength
         epochLength
-        txMaxSize
         epochStability
         activeSlotCoeff
         ) = cp
@@ -778,10 +774,8 @@ checkpointFromEntity cp utxo s =
     bp = W.BlockchainParameters
         { getGenesisBlockHash = coerce genesisHash
         , getGenesisBlockDate = W.StartTime genesisStart
-        , getFeePolicy = feePolicy
         , getSlotLength = W.SlotLength (toEnum (fromEnum slotLength))
         , getEpochLength = W.EpochLength epochLength
-        , getTxMaxSize = Quantity txMaxSize
         , getEpochStability = Quantity epochStability
         , getActiveSlotCoefficient = W.ActiveSlotCoefficient activeSlotCoeff
         }

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -133,15 +133,20 @@ Checkpoint
     checkpointBlockHeight       Word32       sql=block_height
     checkpointGenesisHash       BlockId      sql=genesis_hash
     checkpointGenesisStart      UTCTime      sql=genesis_start
-    checkpointFeePolicy         W.FeePolicy  sql=fee_policy
     checkpointSlotLength        Word64       sql=slot_length
     checkpointEpochLength       Word32       sql=epoch_length
-    checkpointTxMaxSize         Word16       sql=tx_max_size
     checkpointEpochStability    Word32       sql=epoch_stability
     checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
+    deriving Show Generic
+
+TxParameters
+    txParametersWalletId          W.WalletId  sql=wallet_id
+    txParametersFeePolicy         W.FeePolicy sql=fee_policy
+    txParametersTxMaxSize         Word16      sql=tx_max_size
+    Primary txParametersWalletId
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -147,6 +147,7 @@ TxParameters
     txParametersFeePolicy         W.FeePolicy sql=fee_policy
     txParametersTxMaxSize         Word16      sql=tx_max_size
     Primary txParametersWalletId
+    Foreign Wallet fk_wallet_tx_parameters txParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.Network
     , ErrNetworkUnavailable (..)
     , ErrCurrentNodeTip (..)
     , ErrGetBlock (..)
+    , ErrGetTxParameters (..)
     , ErrPostTx (..)
     , ErrGetAccountBalance (..)
 
@@ -47,6 +48,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , SealedTx
     , SlotId
+    , TxParameters
     )
 import Control.Concurrent
     ( threadDelay )
@@ -118,6 +120,9 @@ data NetworkLayer m target block = NetworkLayer
         :: ExceptT ErrCurrentNodeTip m BlockHeader
         -- ^ Get the current tip from the chain producer
 
+    , getTxParameters
+        :: ExceptT ErrGetTxParameters m TxParameters
+
     , postTx
         :: SealedTx -> ExceptT ErrPostTx m ()
         -- ^ Broadcast a transaction to the chain producer
@@ -164,6 +169,15 @@ data ErrGetBlock
     = ErrGetBlockNetworkUnreachable ErrNetworkUnavailable
     | ErrGetBlockNotFound (Hash "BlockHeader")
     deriving (Generic, Show, Eq)
+
+-- | Error while querying local parameters state.
+data ErrGetTxParameters
+    = ErrGetTxParametersTip ErrCurrentNodeTip
+    | ErrGetTxParametersNetworkUnreachable ErrNetworkUnavailable
+    | ErrGetTxParametersNotFound
+    deriving (Generic, Show, Eq)
+
+instance Exception ErrGetTxParameters
 
 -- | Error while trying to send a transaction
 data ErrPostTx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1333,15 +1333,6 @@ instance Buildable TxParameters where
         feePolicyF = build . toText
         txMaxSizeF (Quantity s) = build s
 
-{-
--- | Get transaction-specific parameters from the chain parameters.
-txParams :: BlockchainParameters -> TxParameters
-txParams bp =
-    TxParameters
-        (bp ^. #getFeePolicy)
-        (bp ^. #getTxMaxSize)
--}
-
 {-------------------------------------------------------------------------------
                                    Slotting
 -------------------------------------------------------------------------------}

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -82,6 +82,7 @@ module Cardano.Wallet.Primitive.Types
     , log10
 
     -- * BlockchainParameters
+    , GenesisBlockParameters (..)
     , BlockchainParameters (..)
     , TxParameters (..)
     , ActiveSlotCoefficient (..)
@@ -93,7 +94,6 @@ module Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , StartTime (..)
     , slotParams
-    , txParams
 
     -- * Slotting
     , SyncProgress(..)
@@ -1245,19 +1245,32 @@ computeUtxoStatistics btype utxos =
                              Blockchain Parameters
 -------------------------------------------------------------------------------}
 
+-- | Initial blockchain parameters loaded from the application configuration and
+-- genesis block.
+data GenesisBlockParameters = GenesisBlockParameters
+    { staticParameters :: BlockchainParameters
+       -- ^ These parameters are defined by the configuration and genesis
+       -- block. At present, none of these are covered by the update system.
+    , txParameters :: TxParameters
+       -- ^ These parameters may be changed through update proposals. Currently
+       -- the only dynamic blockchain parameters that the wallet needs are
+       -- related to creating transactions.
+    } deriving (Generic, Show, Eq)
+
+instance NFData GenesisBlockParameters
+
+instance Buildable GenesisBlockParameters where
+    build (GenesisBlockParameters bp txp) = build bp <> build txp
+
 data BlockchainParameters = BlockchainParameters
     { getGenesisBlockHash :: Hash "Genesis"
         -- ^ Hash of the very first block
     , getGenesisBlockDate :: StartTime
         -- ^ Start time of the chain.
-    , getFeePolicy :: FeePolicy
-        -- ^ Policy regarding transaction fee.
     , getSlotLength :: SlotLength
         -- ^ Length, in seconds, of a slot.
     , getEpochLength :: EpochLength
         -- ^ Number of slots in a single epoch.
-    , getTxMaxSize :: Quantity "byte" Word16
-        -- ^ Maximum size of a transaction (soft or hard limit).
     , getEpochStability :: Quantity "block" Word32
         -- ^ Length of the suffix of the chain considered unstable
     , getActiveSlotCoefficient :: ActiveSlotCoefficient
@@ -1272,22 +1285,18 @@ instance Buildable BlockchainParameters where
         [ "Genesis block hash: " <> genesisF (getGenesisBlockHash bp)
         , "Genesis block date: " <> startTimeF (getGenesisBlockDate
             (bp :: BlockchainParameters))
-        , "Fee policy:         " <> feePolicyF (bp ^. #getFeePolicy)
         , "Slot length:        " <> slotLengthF (getSlotLength
             (bp :: BlockchainParameters))
         , "Epoch length:       " <> epochLengthF (getEpochLength
             (bp :: BlockchainParameters))
-        , "Tx max size:        " <> txMaxSizeF (bp ^. #getTxMaxSize)
         , "Epoch stability:    " <> epochStabilityF (getEpochStability bp)
         , "Active slot coeff:  " <> build (bp ^. #getActiveSlotCoefficient)
         ]
       where
         genesisF = build . T.decodeUtf8 . convertToBase Base16 . getHash
         startTimeF (StartTime s) = build s
-        feePolicyF = build . toText
         slotLengthF (SlotLength s) = build s
         epochLengthF (EpochLength s) = build s
-        txMaxSizeF (Quantity s) = build s
         epochStabilityF (Quantity s) = build s
 
 newtype ActiveSlotCoefficient
@@ -1308,7 +1317,7 @@ slotParams bp =
 -- | Blockchain parameters relating to constructing transactions.
 data TxParameters = TxParameters
     { getFeePolicy :: FeePolicy
-        -- ^ Policy regarding transaction fee.
+        -- ^ Formula for calculating the transaction fee.
     , getTxMaxSize :: Quantity "byte" Word16
         -- ^ Maximum size of a transaction (soft or hard limit).
     } deriving (Generic, Show, Eq)
@@ -1316,20 +1325,22 @@ data TxParameters = TxParameters
 instance NFData TxParameters
 
 instance Buildable TxParameters where
-    build bp = blockListF' "" id
-        [ "Fee policy:         " <> feePolicyF (bp ^. #getFeePolicy)
-        , "Tx max size:        " <> txMaxSizeF (bp ^. #getTxMaxSize)
+    build txp = blockListF' "" id
+        [ "Fee policy:         " <> feePolicyF (txp ^. #getFeePolicy)
+        , "Tx max size:        " <> txMaxSizeF (txp ^. #getTxMaxSize)
         ]
       where
         feePolicyF = build . toText
         txMaxSizeF (Quantity s) = build s
 
+{-
 -- | Get transaction-specific parameters from the chain parameters.
 txParams :: BlockchainParameters -> TxParameters
 txParams bp =
     TxParameters
         (bp ^. #getFeePolicy)
         (bp ^. #getTxMaxSize)
+-}
 
 {-------------------------------------------------------------------------------
                                    Slotting

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -52,7 +52,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Sqlite
     ( DefaultFieldValues (..), newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( block0, genesisParameters, mkTxId )
+    ( block0, genesisParameters, genesisTxParameters, mkTxId )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (..)
     , Depth (..)
@@ -363,7 +363,8 @@ withCleanDB db = perRunEnv (walletFixture db $> db)
 walletFixture :: DBLayerBench -> IO ()
 walletFixture db@DBLayer{..} = do
     cleanDB db
-    atomically $ unsafeRunExceptT $ initializeWallet testPk testCp testMetadata mempty
+    atomically $ unsafeRunExceptT $
+        initializeWallet testPk testCp testMetadata mempty genesisTxParameters
 
 ----------------------------------------------------------------------------
 -- TxHistory benchmarks

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -6,8 +6,9 @@
 module Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget
     , block0
+    , genesisBlockParameters
     , genesisParameters
-    , txParameters
+    , genesisTxParameters
     , genesisHash
     , mockHash
     , mkTxId
@@ -24,6 +25,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , EpochLength (..)
     , FeePolicy (..)
+    , GenesisBlockParameters (..)
     , Hash (..)
     , SlotLength (..)
     , StartTime (..)
@@ -79,10 +81,16 @@ genesisParameters = BlockchainParameters
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     }
 
-txParameters :: TxParameters
-txParameters = TxParameters
+genesisTxParameters :: TxParameters
+genesisTxParameters = TxParameters
     { getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
     , getTxMaxSize = Quantity 8192
+    }
+
+genesisBlockParameters :: GenesisBlockParameters
+genesisBlockParameters = GenesisBlockParameters
+    { staticParameters = genesisParameters
+    , txParameters = genesisTxParameters
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -7,6 +7,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     ( DummyTarget
     , block0
     , genesisParameters
+    , txParameters
     , genesisHash
     , mockHash
     , mkTxId
@@ -29,6 +30,7 @@ import Cardano.Wallet.Primitive.Types
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
+    , TxParameters (..)
     , slotMinBound
     )
 import Crypto.Hash
@@ -67,18 +69,21 @@ block0 = Block
     , delegations = []
     }
 
-genesisParameters  :: BlockchainParameters
+genesisParameters :: BlockchainParameters
 genesisParameters = BlockchainParameters
     { getGenesisBlockHash = genesisHash
     , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-    , getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
     , getSlotLength = SlotLength 1
     , getEpochLength = EpochLength 21600
-    , getTxMaxSize = Quantity 8192
     , getEpochStability = Quantity 2160
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     }
 
+txParameters :: TxParameters
+txParameters = TxParameters
+    { getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
+    , getTxMaxSize = Quantity 8192
+    }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.
 mkTx :: [(TxIn, Coin)] -> [TxOut] -> Tx

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -79,6 +79,7 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochLength (..)
     , EpochNo (..)
+    , FeePolicy (..)
     , Hash (..)
     , PassphraseScheme (..)
     , PoolId (..)
@@ -92,6 +93,7 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
+    , TxParameters (..)
     , TxStatus (..)
     , UTxO (..)
     , WalletDelegation (..)
@@ -558,6 +560,21 @@ genPassphrase range = do
 rootKeysRnd :: [ByronKey 'RootK XPrv]
 rootKeysRnd = unsafePerformIO $ generate (vectorOf 10 genRootKeysRnd)
 {-# NOINLINE rootKeysRnd #-}
+
+{-------------------------------------------------------------------------------
+                             Blockchain Parameters
+-------------------------------------------------------------------------------}
+
+instance Arbitrary TxParameters where
+    arbitrary = TxParameters <$> arbitrary <*> arbitrary
+    shrink (TxParameters fp mx) =
+        [TxParameters fp' mx' | (fp', mx') <- shrink (fp, mx)]
+
+instance Arbitrary FeePolicy where
+    arbitrary = LinearFee <$> arbitrary <*> arbitrary <*> pure (Quantity 0)
+    shrink (LinearFee a b c) = [LinearFee a' b' c | (a', b') <- shrink (a, b)]
+
+deriving instance Arbitrary a => Arbitrary (Quantity n a)
 
 {-------------------------------------------------------------------------------
                                  Miscellaneous

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -109,6 +109,7 @@ import Cardano.Wallet.Primitive.Types
     , DelegationCertificate
     , Direction (..)
     , EpochNo (..)
+    , FeePolicy
     , Hash (..)
     , Hash (..)
     , PoolId (..)
@@ -120,6 +121,7 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
+    , TxParameters
     , TxStatus
     , UTxO (..)
     , WalletId (..)
@@ -779,6 +781,12 @@ instance ToExpr Address where
     toExpr = genericToExpr
 
 instance ToExpr TxMeta where
+    toExpr = genericToExpr
+
+instance ToExpr TxParameters where
+    toExpr = genericToExpr
+
+instance ToExpr FeePolicy where
     toExpr = genericToExpr
 
 instance ToExpr Direction where

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -34,7 +34,7 @@ import Cardano.Wallet
 import Cardano.Wallet.DB
     ( DBLayer (..), ErrNoSuchWallet (..), PrimaryKey (..), putTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( DummyTarget, block0, genesisParameters, mkTxId )
+    ( DummyTarget, block0, genesisBlockParameters, mkTxId )
 import Cardano.Wallet.Gen
     ( genMnemonic )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -66,6 +66,7 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochNo (..)
+    , GenesisBlockParameters (..)
     , Hash (..)
     , PoolId (..)
     , SealedTx (..)
@@ -522,16 +523,16 @@ setupFixture (wid, wname, wstate) = do
     let nl = error "NetworkLayer"
     let tl = dummyTransactionLayer
     db <- MVar.newDBLayer
-    let wl = WalletLayer nullTracer (block0, bp, st) nl tl db
+    let wl = WalletLayer nullTracer (block0, gbp, st) nl tl db
     res <- runExceptT $ W.createWallet wl wid wname wstate
     let wal = case res of
             Left _ -> []
             Right walletId -> [walletId]
     pure $ WalletLayerFixture db wl wal slotIdTime
   where
-    slotNo = flatSlot (getEpochLength bp)
+    slotNo = flatSlot $ getEpochLength $ staticParameters gbp
     slotIdTime = posixSecondsToUTCTime . fromIntegral . slotNo
-    bp = genesisParameters
+    gbp = genesisBlockParameters
     st = SyncTolerance 10
 
 -- | A dummy transaction layer to see the effect of a root private key. It

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -98,7 +98,7 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockchainParameters, Hash (..), SyncTolerance )
+    ( GenesisBlockParameters, Hash (..), SyncTolerance )
 import Cardano.Wallet.Version
     ( GitRevision, Version, gitRevision, showFullVersion, version )
 import Control.Applicative
@@ -187,7 +187,7 @@ beforeMainLoop
     :: Trace IO MainLog
     -> SockAddr
     -> Port "node"
-    -> BlockchainParameters
+    -> GenesisBlockParameters
     -> IO ()
 beforeMainLoop tr addr _ _ = logInfo tr $ MsgListenAddress addr
 

--- a/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
+++ b/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
@@ -73,6 +73,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId
     , StakePool (..)
     , StakePoolMetadata (..)
+    , TxParameters
     , sameStakePoolMetadata
     )
 import Cardano.Wallet.Unsafe
@@ -180,9 +181,9 @@ monitorStakePools tr (block0, Quantity k) nl db@DBLayer{..} = do
 
     forward
         :: NonEmpty Block
-        -> BlockHeader
+        -> (BlockHeader, TxParameters)
         -> IO (FollowAction ErrMonitorStakePools)
-    forward blocks nodeTip = handler $ do
+    forward blocks (nodeTip, _params) = handler $ do
         let epochs = NE.nub $ view (#header . #slotId . #epochNumber) <$> blocks
         distributions <- forM epochs $ \ep -> do
             liftIO $ traceWith tr $ MsgStakeDistribution ep

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -231,9 +231,9 @@ serveWallet Tracers{..} sTolerance databaseDir hostPref listen backend beforeMai
                 withWalletNtpClient io ntpClientTracer $ \ntpClient -> do
                     link $ ntpThread ntpClient
                     poolApi <- stakePoolLayer (block0, bp) nl db md
-                    byronApi   <- apiLayer (block0, bp) byronTl nl
-                    icarusApi  <- apiLayer (block0, bp) icarusTl nl
-                    shelleyApi <- apiLayer (block0, bp) shelleyTl nl
+                    byronApi   <- apiLayer (block0, gbp) byronTl nl
+                    icarusApi  <- apiLayer (block0, gbp) icarusTl nl
+                    shelleyApi <- apiLayer (block0, gbp) shelleyTl nl
                     startServer socket nPort gbp
                         byronApi
                         icarusApi
@@ -270,17 +270,17 @@ serveWallet Tracers{..} sTolerance databaseDir hostPref listen backend beforeMai
             , PersistPrivateKey (k 'RootK)
             , WalletKey k
             )
-        => (J.Block, BlockchainParameters)
+        => (J.Block, GenesisBlockParameters)
         -> TransactionLayer t k
         -> NetworkLayer IO t J.Block
         -> IO (ApiLayer s t k)
-    apiLayer (block0, bp) tl nl = do
+    apiLayer (block0, gbp) tl nl = do
         db <- Sqlite.newDBFactory
             walletDbTracer
-            (DefaultFieldValues $ getActiveSlotCoefficient bp)
+            (DefaultFieldValues $ getActiveSlotCoefficient $ staticParameters gbp)
             databaseDir
         Server.newApiLayer
-            walletEngineTracer (toWLBlock block0, bp, sTolerance) nl' tl db
+            walletEngineTracer (toWLBlock block0, gbp, sTolerance) nl' tl db
       where
         nl' = toWLBlock <$> nl
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -79,9 +79,11 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , BlockchainParameters (..)
     , EpochNo (..)
+    , GenesisBlockParameters (..)
     , Hash (..)
     , SealedTx
     , SlotLength (..)
+    , TxParameters (..)
     )
 import Control.Arrow
     ( left )
@@ -152,7 +154,7 @@ data JormungandrClient m = JormungandrClient
         -> ExceptT ErrPostTx m ()
     , getInitialBlockchainParameters
         :: Hash "Genesis"
-        -> ExceptT ErrGetBlockchainParams m (J.Block, BlockchainParameters)
+        -> ExceptT ErrGetBlockchainParams m (J.Block, GenesisBlockParameters)
     , getStakeDistribution
         :: EpochNo
         -> ExceptT ErrNetworkUnavailable m StakeApiResponse
@@ -289,17 +291,21 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
             ([policy],[duration],[block0T], [epLength], [stability],[coeff]) ->
                 return
                     ( jblock
-                    , BlockchainParameters
-                        { getGenesisBlockHash = block0
-                        , getGenesisBlockDate = block0T
-                        , getFeePolicy = case mperCertFee of
-                            [override] -> overrideFeePolicy policy override
-                            _ -> policy
-                        , getEpochLength = epLength
-                        , getSlotLength = SlotLength duration
-                        , getTxMaxSize = softTxMaxSize
-                        , getEpochStability = stability
-                        , getActiveSlotCoefficient = coeff
+                    , GenesisBlockParameters
+                        { staticParameters = BlockchainParameters
+                            { getGenesisBlockHash = block0
+                            , getGenesisBlockDate = block0T
+                            , getEpochLength = epLength
+                            , getSlotLength = SlotLength duration
+                            , getEpochStability = stability
+                            , getActiveSlotCoefficient = coeff
+                            }
+                        , txParameters = TxParameters
+                            { getFeePolicy = case mperCertFee of
+                                [override] -> overrideFeePolicy policy override
+                                _ -> policy
+                            , getTxMaxSize = softTxMaxSize
+                            }
                         }
                     )
             _ ->

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -64,7 +64,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockchainParameters (..), SyncTolerance (..) )
+    ( GenesisBlockParameters (..), SyncTolerance (..), TxParameters (..) )
 import Control.Concurrent.Async
     ( race_ )
 import Control.Concurrent.MVar
@@ -462,20 +462,20 @@ benchWithServer tracers action = withConfig $ \jmCfg -> do
         res <- serveWallet @('Testnet 0)
             tracers (SyncTolerance 10)
             Nothing "127.0.0.1"
-            ListenOnRandomPort (Launch jmCfg) $ \wAddr _ bp -> do
+            ListenOnRandomPort (Launch jmCfg) $ \wAddr _ gbp -> do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
                 let sixtySeconds = 60*1000*1000 -- 60s in microseconds
                 manager <- (baseUrl,) <$> newManager (defaultManagerSettings
                     { managerResponseTimeout =
                         responseTimeoutMicro sixtySeconds
                     })
-                faucet <- initFaucet (getFeePolicy bp)
+                faucet <- initFaucet (getFeePolicy (txParameters gbp))
                 putMVar ctx $ Context
                     { _cleanup = pure ()
                     , _manager = manager
                     , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
                     , _faucet = faucet
-                    , _blockchainParameters = bp
+                    , _blockchainParameters = staticParameters gbp
                     , _feeEstimator = \_ -> error "feeEstimator not available"
                     , _target = Proxy
                     }

--- a/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -19,7 +19,11 @@ import Cardano.Wallet.Jormungandr.Launch
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..), withJormungandr, withNetworkLayer )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), BlockchainParameters (..), SlotId )
+    ( BlockHeader (..)
+    , BlockchainParameters (..)
+    , GenesisBlockParameters (..)
+    , SlotId
+    )
 import Control.Concurrent
     ( forkIO, killThread )
 import Control.Exception
@@ -113,9 +117,9 @@ spec = around setup $ do
         let tr = nullTracer
         e <- withJormungandr tr cfg $ \cp ->
             withNetworkLayer tr (UseRunning cp) $ \case
-                Right (_, (b0, bp), nl) -> withDB "reference.sqlite" $ \db -> do
+                Right (_, (b0, gbp), nl) -> withDB "reference.sqlite" $ \db -> do
                     let nl' = toSPBlock <$> nl
-                    let k = getEpochStability bp
+                    let k = getEpochStability (staticParameters gbp)
                     let block0 = toSPBlock b0
                     withMonitorStakePoolsThread (block0, k) nl' db $ \_workerThread ->
                         cb (nl', (block0, k), db)

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -53,7 +53,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( BlockchainParameters (..), SyncTolerance (..) )
+    ( GenesisBlockParameters (..), SyncTolerance (..), TxParameters (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar
@@ -180,7 +180,7 @@ specWithServer tr = aroundAll withContext . after (tearDown . thd3)
   where
     withContext action = do
         ctx <- newEmptyMVar
-        let setupContext wAddr nPort bp = do
+        let setupContext wAddr nPort gbp = do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
                 logInfo tr baseUrl
                 let sixtySeconds = 60*1000*1000 -- 60s in microseconds
@@ -188,7 +188,7 @@ specWithServer tr = aroundAll withContext . after (tearDown . thd3)
                     { managerResponseTimeout =
                         responseTimeoutMicro sixtySeconds
                     })
-                let feePolicy = getFeePolicy bp
+                let feePolicy = getFeePolicy (txParameters gbp)
                 faucet <- initFaucet feePolicy
                 putMVar ctx (nPort, feePolicy, Context
                     { _cleanup = pure ()
@@ -196,7 +196,7 @@ specWithServer tr = aroundAll withContext . after (tearDown . thd3)
                     , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
                     , _faucet = faucet
                     , _feeEstimator = mkFeeEstimator feePolicy
-                    , _blockchainParameters = bp
+                    , _blockchainParameters = staticParameters gbp
                     , _target = Proxy
                     })
         race

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -266,7 +266,7 @@ prop_trackRegistrations test = monadicIO $ do
                 pure mempty
             , currentNodeTip =
                 pure header0
-            , getTxParameters = pure txParameters
+            , getTxParameters = pure genesisTxParameters
             }
 
 data instance Cursor RegistrationsTest = Cursor BlockHeader

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -63,6 +63,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , StakePoolMetadata (..)
     , StartTime (..)
+    , TxParameters (..)
     , flatSlot
     , flatSlot
     , fromFlatSlot
@@ -265,6 +266,7 @@ prop_trackRegistrations test = monadicIO $ do
                 pure mempty
             , currentNodeTip =
                 pure header0
+            , getTxParameters = pure txParameters
             }
 
 data instance Cursor RegistrationsTest = Cursor BlockHeader
@@ -323,6 +325,8 @@ mockNetworkLayer = NetworkLayer
         \_ -> error "mockNetworkLayer: cursorSlotId"
     , currentNodeTip =
         error "mockNetworkLayer: currentNodeTip"
+    , getTxParameters =
+        error "mockNetworkLayer: getTxParameters"
     , postTx =
         \_ -> error "mockNetworkLayer: postTx"
     , stakeDistribution =
@@ -478,16 +482,20 @@ genPercentage = unsafeMkPercentage . fromRational . toRational <$> genDouble
     genDouble :: Gen Double
     genDouble = choose (0, 1)
 
-genesisParameters  :: BlockchainParameters
+genesisParameters :: BlockchainParameters
 genesisParameters = BlockchainParameters
     { getGenesisBlockHash = genesisHash
     , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-    , getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
     , getSlotLength = SlotLength 1
     , getEpochLength = EpochLength 21600
-    , getTxMaxSize = Quantity 8192
     , getEpochStability = Quantity 2160
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
+    }
+
+genesisTxParameters :: TxParameters
+genesisTxParameters = TxParameters
+    { getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
+    , getTxMaxSize = Quantity 8192
     }
 
 genesisHash :: Hash "Genesis"

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -342,7 +342,7 @@ mockNetworkLayer logLine = do
     st <- newMVar emptyBlockHeaders
     Right (_b0, gbp) <- runExceptT $ getInitialBlockchainParameters jm genesisHash
     pure
-        ( fromJBlock <$> mkRawNetworkLayer (staticParameters gbp) (fromIntegral k) st jm
+        ( fromJBlock <$> mkRawNetworkLayer gbp (fromIntegral k) st jm
         , findIntersection st
         )
   where

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -33,7 +33,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (unSlotNo)
     , TxParameters (..)
-    , TxParameters (..)
     )
 import Control.Concurrent.MVar.Lifted
     ( MVar, newMVar, readMVar )


### PR DESCRIPTION
### Issue Number

Relates to #1577 / [ADP-83](https://jira.iohk.io/projects/ADP/issues/ADP-83).

### Overview

- [x] Updates ouroboros-network and cardano-node to latest master versions
- [x] Initial try at LocalStateQuery client in network layer.
- [x] Get latest tx parameters when fetching the block tip.
- [x] Store tx parameters in database while following the chain.
- [x] Use tx parameters from database when creating transactions.

### Comments

The TRANS_CREATE integration tests which check the fee should cover this. The only way the wallet can get TxParameters is through the node protocol parameters state.

### Next PRs
- [ ] Marcin says to use `defaultCodecs` or `clientCodecs` rather than constructing our own codecs. These functions require a `BlockConfig ByronBlock`. Which means that we would need to modify parseGenesisData, etc, etc. So this can be another PR ⇒ #1606.
- [ ] Integration test where new protocol parameters are proposed and accepted. It should test that the new tx max size and fee policy apply. This will require cardano-cli to update the node's parameters. However the update proposal function of cardano-cli is not yet complete.
