### PR TITLE
remove passphrase validations on endpoints using passphrase

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -714,7 +714,7 @@ byronServer byron icarus ntp =
     byronTransactions =
              (\wid tx -> withLegacyLayer wid
                  (byron , do
-                    let pwd = getApiT $ tx ^. #passphrase
+                    let pwd = coerce (getApiT $ tx ^. #passphrase)
                     genChange <- rndStateChange byron wid pwd
                     postTransaction byron genChange wid tx
                  )
@@ -1329,7 +1329,7 @@ postRandomAddress
     -> ApiPostRandomAddressData
     -> Handler (ApiAddress n)
 postRandomAddress ctx (ApiT wid) body = do
-    let pwd = getApiT (body ^. #passphrase)
+    let pwd = coerce $ getApiT $ body ^. #passphrase
     let mix = getApiT <$> (body ^. #addressIndex)
     addr <- withWorkerCtx ctx wid liftE liftE
         $ \wrk -> liftHandler $ W.createRandomAddress @_ @s @k wrk wid pwd mix
@@ -1381,7 +1381,7 @@ postTransaction
     -> Handler (ApiTransaction n)
 postTransaction ctx genChange (ApiT wid) body = do
     let outs = coerceCoin <$> (body ^. #payments)
-    let pwd = getApiT $ body ^. #passphrase
+    let pwd = coerce $ getApiT $ body ^. #passphrase
 
     selection <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.selectCoinsForPayment @_ @s @t wrk wid outs
@@ -1507,7 +1507,9 @@ joinStakePool
     -> ApiT WalletId
     -> ApiWalletPassphrase
     -> Handler (ApiTransaction n)
-joinStakePool ctx spl apiPoolId (ApiT wid) (ApiWalletPassphrase (ApiT pwd)) = do
+joinStakePool ctx spl apiPoolId (ApiT wid) body = do
+    let pwd = coerce $ getApiT $ body ^. #passphrase
+
     pid <- case apiPoolId of
         ApiPoolIdPlaceholder -> liftE ErrUnexpectedPoolIdPlaceholder
         ApiPoolId pid -> pure pid
@@ -1551,7 +1553,9 @@ quitStakePool
     -> ApiT WalletId
     -> ApiWalletPassphrase
     -> Handler (ApiTransaction n)
-quitStakePool ctx (ApiT wid) (ApiWalletPassphrase (ApiT pwd)) = do
+quitStakePool ctx (ApiT wid) body = do
+    let pwd = coerce $ getApiT $ body ^. #passphrase
+
     (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.quitStakePool @_ @s @t @k wrk wid (delegationAddress @n) pwd
 
@@ -1631,7 +1635,7 @@ migrateWallet srcCtx sheCtx (ApiT srcWid) (ApiT sheWid) migrateData = do
             (meta, time)
             #pendingSince
   where
-    pwd = getApiT $ migrateData ^. #passphrase
+    pwd = coerce $ getApiT $ migrateData ^. #passphrase
 
 {-------------------------------------------------------------------------------
                                     Network

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -394,7 +394,7 @@ data ApiWalletDelegationStatus
     deriving (Eq, Generic, Show)
 
 newtype ApiWalletPassphrase = ApiWalletPassphrase
-    { passphrase :: ApiT (Passphrase "raw")
+    { passphrase :: ApiT (Passphrase "lenient")
     } deriving (Eq, Generic, Show)
 
 data ApiStakePool = ApiStakePool
@@ -478,13 +478,13 @@ data WalletPutPassphraseData = WalletPutPassphraseData
     } deriving (Eq, Generic, Show)
 
 data ByronWalletPutPassphraseData = ByronWalletPutPassphraseData
-    { oldPassphrase :: !(Maybe (ApiT (Passphrase "byron-raw")))
+    { oldPassphrase :: !(Maybe (ApiT (Passphrase "lenient")))
     , newPassphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
 data PostTransactionData (n :: NetworkDiscriminant) = PostTransactionData
     { payments :: !(NonEmpty (AddressAmount (ApiT Address, Proxy n)))
-    , passphrase :: !(ApiT (Passphrase "raw"))
+    , passphrase :: !(ApiT (Passphrase "lenient"))
     } deriving (Eq, Generic, Show)
 
 newtype PostTransactionFeeData (n :: NetworkDiscriminant) = PostTransactionFeeData
@@ -589,7 +589,7 @@ newtype ApiNetworkClock = ApiNetworkClock
     } deriving (Eq, Generic, Show)
 
 data ApiPostRandomAddressData = ApiPostRandomAddressData
-    { passphrase :: !(ApiT (Passphrase "raw"))
+    { passphrase :: !(ApiT (Passphrase "lenient"))
     , addressIndex :: !(Maybe (ApiT (Index 'Hardened 'AddressK)))
     } deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -404,8 +404,8 @@ class PassphraseMaxLength (purpose :: Symbol) where
 instance PassphraseMinLength "raw" where passphraseMinLength _ = 10
 instance PassphraseMaxLength "raw" where passphraseMaxLength _ = 255
 
-instance PassphraseMinLength "byron-raw" where passphraseMinLength _ = 0
-instance PassphraseMaxLength "byron-raw" where passphraseMaxLength _ = 255
+instance PassphraseMinLength "lenient" where passphraseMinLength _ = 0
+instance PassphraseMaxLength "lenient" where passphraseMaxLength _ = 255
 
 instance
     ( PassphraseMaxLength purpose

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTPassphraselenient.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTPassphraselenient.json
@@ -1,0 +1,15 @@
+{
+    "seed": -196504461830298285,
+    "samples": [
+        "o23UW1몥;\"L=_Dyt^#KI%?b<`w#P<^[oI𩖦d'3,&,Rlzn/{B&(2eJ^4콑LAYB/𪐈36>ⷡ}j#𖠡@6}fCHxgj 9voH-{𠍍ZY`>f#4;PX)_D)wo\\kz9V03D'Qd\"|Xw?G6𢘘wIPNxReK1Z.oM(NW(OE",
+        "SG6YmwI듁=wwT𦸽f/1v3<?<B7↟goTSy50jbyF/6T%/2J`Ee^_?{zj@T7f]r5ViZQ $vcGz%䵒^Zc[9T~;^%\\l𓅞-pa/ꬉk[w;ꑸT9,~^k+",
+        "+}:<WUisVTxT7c-(mO-m:Bw]Nn+kQ//L?t(7<b/C[3䞓kb𣒳`^_:b1r汊)Xy\\C#TP 2i(Gz:ggK\\",
+        "z%9D;\\!;Z𦮸S%dA,,}]y\\ 1cQ3 &:ijk3t?p}8U.TyL`$yrlB}론-5Mt4L(yP'𩃌l^\\crXoua@5k$:5815.XOy<>R_b9Ba{!h\"3x-{W=8CFV4<(vb%+tmm쁄'f싦Wo7-M_v\"#joLhP歶y (^+b.3>Jc5Ps:)$Sr^AU<=v274=X$xaN$9`S$/+1wMOjfR)襉R~ ^5k\"/@\"m1/SAtS@W;N;i5-^dP?CBOEd)[𪷆A.Hm𦾦Z;4ni辰KeS=,)}q#",
+        "%^0$alz7[6u`벗'+%>tYFG%(y3RA+a'OS6jN*7#tAz镾 BB$Ia'K/[!5GJU<<Bu2<gZATI8 S<G-#+>{*EM/UlOw?5\"#bMv`*M~O(relYp'ix'bsL<3FP?$ .Dy^^늿rM|gX>|;sv3,:#N.饜[}<>VL/窽zB*(dk`𖩅;RLnn(TN",
+        "4𥠴>y>@\"Z=Ej昛@9\\|WC}&\"Yc𤻜#",
+        "1<#8v?xXfh6i>F\\5o{/}u=2k.1(r(o\\lg6!TUE+qQ!f*cD*;Rm,f(r-$/$T%=4#Gk[;E_c",
+        "=@~P@@EopeAB[",
+        "2%K𣷭v࠵^5",
+        "/YrdiHD𦷽j6C)XmjoJj%*:{4ju,_AE7T+c\"^Y7U(7DDcv\"oV'#QpTy<O]W{ISt\\2j22?bE둊CfL>yj|bh5[fꏒK}<Dg#jmpm}PUfq{69Ft&𧮉o',=xh0=k_'khD@r<fIj!7c`0s%Pf~_-D*fb6[%HtTE9eYLLkCXu풮Xk,L$Ud60𡗏`$xIXw)T+WWb|/"
+    ]
+}

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -828,13 +828,7 @@ instance Malformed (BodyParam ApiWalletPassphrase) where
             , ("{\"name : \"random\"}", msgJsonInvalid)
             ]
          jsonValid = first (BodyParam . Aeson.encode) <$>
-            [ ( [aesonQQ| { "passphrase": "" }|]
-              , "Error in $.passphrase: passphrase is too short: expected at least 10 characters"
-              )
-            , ( [aesonQQ| { "passphrase": "123456789" }|]
-              , "Error in $.passphrase: passphrase is too short: expected at least 10 characters"
-              )
-            , ( [aesonQQ| { "passphrase": #{nameTooLong} }|]
+            [ ( [aesonQQ| { "passphrase": #{nameTooLong} }|]
               , "Error in $.passphrase: passphrase is too long: expected at most 255 characters"
               )
             , ( [aesonQQ| { "passphrase": 123 }|]
@@ -881,20 +875,6 @@ instance Malformed (BodyParam (PostTransactionData ('Testnet pm))) where
                    ]
                 }|]
               , "Error in $: parsing Cardano.Wallet.Api.Types.PostTransactionData(PostTransactionData) failed, key 'passphrase' not found"
-              )
-            , ( [aesonQQ|
-               { "payments": [
-                   {
-                       "address": #{addrValid},
-                       "amount": {
-                           "quantity": 42000000,
-                           "unit": "lovelace"
-                       }
-                   }
-                  ],
-                  "passphrase": "123"
-               }|]
-               , "Error in $.passphrase: passphrase is too short: expected at least 10 characters"
               )
             , ( [aesonQQ|
                { "payments": [

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -347,7 +347,7 @@ spec = do
             jsonRoundtripAndGolden $ Proxy @ByronWalletPutPassphraseData
             jsonRoundtripAndGolden $ Proxy @(ApiT (Hash "Tx"))
             jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "raw"))
-            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "byron-raw"))
+            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "lenient"))
             jsonRoundtripAndGolden $ Proxy @(ApiT Address, Proxy ('Testnet 0))
             jsonRoundtripAndGolden $ Proxy @(ApiT AddressPoolGap)
             jsonRoundtripAndGolden $ Proxy @(ApiT Direction)
@@ -422,13 +422,13 @@ spec = do
                 #{replicate (2*maxLength) '*'}
             |] `shouldBe` (Left @String @(ApiT (Passphrase "raw")) msg)
 
-        it "ApiT (Passphrase \"byron-raw\") (too long)" $ do
-            let maxLength = passphraseMaxLength (Proxy :: Proxy "byron-raw")
+        it "ApiT (Passphrase \"lenient\") (too long)" $ do
+            let maxLength = passphraseMaxLength (Proxy :: Proxy "lenient")
             let msg = "Error in $: passphrase is too long: \
                     \expected at most " <> show maxLength <> " characters"
             Aeson.parseEither parseJSON [aesonQQ|
                 #{replicate (2*maxLength) '*'}
-            |] `shouldBe` (Left @String @(ApiT (Passphrase "byron-raw")) msg)
+            |] `shouldBe` (Left @String @(ApiT (Passphrase "lenient")) msg)
 
         it "ApiT WalletName (too short)" $ do
             let msg = "Error in $: name is too short: \
@@ -1211,12 +1211,12 @@ instance Arbitrary ApiWalletDelegationNext where
             <*> fmap Just arbitrary
         ]
 
-instance Arbitrary (Passphrase "byron-raw") where
+instance Arbitrary (Passphrase "lenient") where
     arbitrary = do
         n <- choose (passphraseMinLength p, passphraseMaxLength p)
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes
-      where p = Proxy :: Proxy "byron-raw"
+      where p = Proxy :: Proxy "lenient"
 
     shrink (Passphrase bytes)
         | BA.length bytes <= passphraseMinLength p = []
@@ -1226,7 +1226,7 @@ instance Arbitrary (Passphrase "byron-raw") where
             $ B8.take (passphraseMinLength p)
             $ BA.convert bytes
             ]
-      where p = Proxy :: Proxy "byron-raw"
+      where p = Proxy :: Proxy "lenient"
 
 instance Arbitrary ApiWalletDelegation where
     arbitrary = ApiWalletDelegation

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -277,7 +277,7 @@ x-walletPassphrase: &walletPassphrase
   maxLength: 255
   example: Secure Passphrase
 
-x-byronWalletPassphrase: &byronWalletPassphrase
+x-lenientPassphrase: &lenientPassphrase
   description: A master passphrase to lock and protect the wallet for sensitive operation (e.g. sending funds)
   type: string
   minLength: 0
@@ -883,7 +883,7 @@ components:
         - passphrase
       properties:
         passphrase:
-          <<: *walletPassphrase
+          <<: *lenientPassphrase
           description: The source Byron wallet's master passphrase.
 
     ApiWalletUTxOsStatistics: &ApiWalletUTxOsStatistics
@@ -1063,7 +1063,7 @@ components:
         - new_passphrase
       properties:
         old_passphrase:
-          <<: *byronWalletPassphrase
+          <<: *lenientPassphrase
           description: The current passphrase if present.
         new_passphrase:
           <<: *walletPassphrase
@@ -1077,7 +1077,7 @@ components:
       properties:
         payments: *transactionOutputs
         passphrase:
-          <<: *walletPassphrase
+          <<: *lenientPassphrase
           description: The wallet's master passphrase.
 
     ApiPostTransactionFeeData: &ApiPostTransactionFeeData
@@ -1092,7 +1092,7 @@ components:
       required:
         - passphrase
       properties:
-        passphrase: *walletPassphrase
+        passphrase: *lenientPassphrase
         address_index: *addressIndex
 
 #############################################################################


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 0364e701cbc0f3bcb7eee740f59137ae377de701
  :round_pushpin: **remove passphrase validations on endpoints using passphrase**
  It is still required to provide a valid and "strong" passphrase
  when creating a wallet though. But if a wallet has been created
  with a passphrase that is shorter than the expected validation,
  then the API won't reject it and simply go forward trying to use it.

  This only use-case and possible way for introducing a shorter
  passphrase is by importing a legacy wallet from an already encrypted
  private key. In this case, we can't control rules regarding the
  passphrase and, the passphrase might as well be one single character.

# Comments

<!-- Additional comments or screenshots to attach if any -->

:warning: I am expecting some CI failures here, i haven't particularly look at the integration tests. Most should be fine because it won't impact current behavior, but maybe we have some scenario that are precisely checking that we can't use a short passphrase on legacy wallets.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
