### PR TITLE
Support bech32 encoding for CLI key derivation

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -551,6 +551,7 @@ spec = do
 
         ["key", "root", "--help"] `shouldShowUsage`
             [ "Usage:  key root [--wallet-style WALLET_STYLE] MNEMONIC_WORD..."
+            , "                 [--encoding KEY-ENCODING]"
             , "  Extract root extended private key from a mnemonic sentence."
             , ""
             , "Available options:"
@@ -563,7 +564,7 @@ spec = do
             ]
 
         ["key", "child", "--help"] `shouldShowUsage`
-            [ "Usage:  key child --path DER-PATH XPRV"
+            [ "Usage:  key child --path DER-PATH [XPRV]"
             , "  Derive child keys."
             , ""
             , "Available options:"
@@ -572,7 +573,7 @@ spec = do
             ]
 
         ["key", "public", "--help"] `shouldShowUsage`
-            [ "Usage:  key public XPRV"
+            [ "Usage:  key public [XPRV]"
             , "  Extract public key from a private key."
             , ""
             , "Available options:"
@@ -580,7 +581,7 @@ spec = do
             ]
 
         ["key", "inspect", "--help"] `shouldShowUsage`
-            [ "Usage:  key inspect XPRV"
+            [ "Usage:  key inspect [XPRV]"
             , "  Show information about a key."
             , ""
             , "Available options:"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -172,18 +172,15 @@ spec = do
                     expectation str
     describe "Specification / Usage Overview" $ do
 
-        let expectationFailure' = flip counterexample False
         let shouldShowUsage args expected = it (unwords args) $
                 case execParserPure defaultPrefs parser args of
-                    Success _ -> expectationFailure'
+                    Success _ -> expectationFailure
                         "expected parser to show usage but it has succeeded"
-                    CompletionInvoked _ -> expectationFailure'
+                    CompletionInvoked _ -> expectationFailure
                         "expected parser to show usage but it offered completion"
-                    Failure failure -> property $
+                    Failure failure -> do
                         let (usage, _) = renderFailure failure mempty
-                            msg = "*** Expected:\n" ++ (unlines expected)
-                                ++ "*** but actual usage is:\n" ++ usage
-                        in counterexample msg $ expected === lines usage
+                        (lines usage) `shouldBe` expected
 
         ["--help"] `shouldShowUsage`
             [ "The CLI is a proxy to the wallet server, which is required for"


### PR DESCRIPTION
## Issue Number

ADP-195. No issue yet.

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


## Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Added a `keyBech32Codec` abstraction for inferring the encoding automatically
- [x] Added support for reading input from stdin and chaining commands with `|`.

## Comments

Commands can be chained and work with both hex and bech32 encodings!

```
$ cardano-wallet-byron key root --wallet-style icarus --encoding bech32 -- express theme celery coral permit dizzy nothing stadium lemon tube olive brass dutch find mask \
    | cardano-wallet-byron key public
xpub1k365denpkmqhj9zj6qpaxat4dh0xetpz2qyneerrputtnwwq4jr5zyehhkjdt0qzzerzfq9cpxpyl76g79lq3k26h8cmj8fereywv6c0g4qe2

$ cardano-wallet-byron key root --wallet-style icarus -- express theme celery coral permit dizzy nothing stadium lemon tube olive brass dutch find mask \
     | cardano-wallet-byron key public
b47546e661b6c1791452d003d375756dde6cac2250093ce4630f16b9b9c0ac87411337bda4d5bc0216462480b809824ffb48f17e08d95ab9f1b91d391e48e66b
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
