### PR TITLE
cardano-node: 1.10.1 -> 1.11.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,7 +77,7 @@ let
     inherit pkgs commonLib src haskellPackages stackNixRegenerate;
     inherit (jmPkgs) jormungandr jormungandr-cli;
     # expose cardano-node, so daedalus can ship it without needing to pin cardano-node
-    inherit (pkgs) cardano-node;
+    inherit (pkgs) cardano-node cardano-cli;
     inherit (haskellPackages.cardano-wallet-core.identifier) version;
     # expose db-converter, so daedalus can ship it without needing to pin a ouroborus-network rev
     inherit (haskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
@@ -133,6 +133,7 @@ let
           jormungandr
           jormungandr-cli
           cardano-node
+          cardano-cli
         ]) ++ (with pkgs; [
           stack
           cabal-install

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -130,10 +130,10 @@ import Network.Wai.Handler.Warp
     ( setBeforeMainLoop )
 import Network.Wai.Middleware.Logging
     ( ApiLog )
+import Ouroboros.Network.CodecCBORTerm
+    ( CodecCBORTerm )
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..) )
-import Ouroboros.Network.Protocol.Handshake.Version
-    ( CodecCBORTerm )
 import System.Exit
     ( ExitCode (..) )
 import System.IOManager

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -108,14 +108,14 @@ import Ouroboros.Network.Block
     )
 import Ouroboros.Network.ChainFragment
     ( HasHeader (..) )
+import Ouroboros.Network.CodecCBORTerm
+    ( CodecCBORTerm )
 import Ouroboros.Network.Magic
     ( NetworkMagic (..) )
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..), nodeToClientCodecCBORTerm )
 import Ouroboros.Network.Point
     ( WithOrigin (..) )
-import Ouroboros.Network.Protocol.Handshake.Version
-    ( CodecCBORTerm )
 
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types as W

--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -103,7 +103,7 @@ trMessage tr = Tracer $ \arg ->
        <*> pure (LogMessage arg)
 
 instance forall m a. (MonadIO m, ToText a, HasPrivacyAnnotation a, HasSeverityAnnotation a) => Transformable Text m a where
-    trTransformer _fmt _verb = Tracer . traceWith . trMessageText
+    trTransformer _verb = Tracer . traceWith . trMessageText
 
 -- | Tracer transformer which removes tracing below the qgiven severity limit.
 filterTraceSeverity

--- a/nix/.stack.nix/Win32-network.nix
+++ b/nix/.stack.nix/Win32-network.nix
@@ -105,8 +105,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/Win32-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-spec-chain.nix
+++ b/nix/.stack.nix/byron-spec-chain.nix
@@ -92,8 +92,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-spec-ledger.nix
+++ b/nix/.stack.nix/byron-spec-ledger.nix
@@ -113,8 +113,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
-      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
+      rev = "2cc27584bb19bd5be9f1721fd4a2393bb99c6119";
+      sha256 = "1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -102,8 +102,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
-      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
+      rev = "2cc27584bb19bd5be9f1721fd4a2393bb99c6119";
+      sha256 = "1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -65,7 +65,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
           (hsPkgs."deepseq" or (buildDepError "deepseq"))
           (hsPkgs."memory" or (buildDepError "memory"))
-          (hsPkgs."reflection" or (buildDepError "reflection"))
           (hsPkgs."vector" or (buildDepError "vector"))
           ];
         buildable = true;
@@ -90,8 +89,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
-      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
+      rev = "2cc27584bb19bd5be9f1721fd4a2393bb99c6119";
+      sha256 = "1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -75,8 +75,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
-      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
+      rev = "9ee8a6630a8719ba54554c3ce10c555bf5dff4cc";
+      sha256 = "0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4";
       });
     postUnpack = "sourceRoot+=/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -100,8 +100,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
-      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
+      rev = "9ee8a6630a8719ba54554c3ce10c555bf5dff4cc";
+      sha256 = "0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4";
       });
     postUnpack = "sourceRoot+=/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -96,8 +96,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
-      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
+      rev = "9ee8a6630a8719ba54554c3ce10c555bf5dff4cc";
+      sha256 = "0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4";
       });
     postUnpack = "sourceRoot+=/cardano-ledger/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -164,8 +164,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger";
-      rev = "357ed656ad81fcddb401ceb656d6c2a6a177a0fa";
-      sha256 = "1fw87n0cvi4asyhv8x2spqhp90a460r47vcahmdl9pvjs913syvv";
+      rev = "9ee8a6630a8719ba54554c3ce10c555bf5dff4cc";
+      sha256 = "0ycd751rd7952amrmq1q7i84ic2xwc3xipvqvd3zcy6xyncqdxk4";
       });
     postUnpack = "sourceRoot+=/cardano-ledger; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -83,8 +83,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3";
-      sha256 = "1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4";
+      rev = "91f357abae16099858193b999807323ca9a7c63c";
+      sha256 = "11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -116,7 +116,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3";
-      sha256 = "1qlmz3alrlzx6fzsxc5zp9qqx15qapywrc7a9bvxz70yfzc7b5j4";
+      rev = "91f357abae16099858193b999807323ca9a7c63c";
+      sha256 = "11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b";
       });
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "42c57fed487b61c13a68a1600a6675ad987822d0";
-      sha256 = "0iab9bwa7my1qb3nnwml8zv4g4zxi5rrypkfmdjs558yh00ykskq";
+      rev = "2cc27584bb19bd5be9f1721fd4a2393bb99c6119";
+      sha256 = "1zjrjh6hr2v4vsr9yj3vr73q1358mymi0ri1kl4cy4i54b4iwbfv";
       });
     postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -65,8 +65,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim-classes.nix
+++ b/nix/.stack.nix/io-sim-classes.nix
@@ -70,8 +70,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/io-sim-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/io-sim; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -88,6 +88,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."transformers" or (buildDepError "transformers"))
           (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           (hsPkgs."vector" or (buildDepError "vector"))
+          (hsPkgs."Win32-network" or (buildDepError "Win32-network"))
           (hsPkgs."yaml" or (buildDepError "yaml"))
           (hsPkgs."libyaml" or (buildDepError "libyaml"))
           ] ++ (if system.isWindows
@@ -138,8 +139,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -78,8 +78,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -78,8 +78,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -114,8 +114,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-scribe-systemd.nix
+++ b/nix/.stack.nix/lobemo-scribe-systemd.nix
@@ -79,8 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -127,8 +127,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ntp-client.nix
+++ b/nix/.stack.nix/ntp-client.nix
@@ -98,8 +98,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ntp-client; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byron.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byron.nix
@@ -165,8 +165,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-byron; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byronspec.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byronspec.nix
@@ -83,8 +83,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-byronspec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-cardano.nix
+++ b/nix/.stack.nix/ouroboros-consensus-cardano.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-cardano; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-mock.nix
+++ b/nix/.stack.nix/ouroboros-consensus-mock.nix
@@ -106,8 +106,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus/ouroboros-consensus-mock; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-shelley.nix
+++ b/nix/.stack.nix/ouroboros-consensus-shelley.nix
@@ -91,12 +91,14 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
             (hsPkgs."cardano-crypto-class" or (buildDepError "cardano-crypto-class"))
             (hsPkgs."cardano-crypto-wrapper" or (buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-prelude" or (buildDepError "cardano-prelude"))
             (hsPkgs."cardano-slotting" or (buildDepError "cardano-slotting"))
             (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."containers" or (buildDepError "containers"))
             (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
             (hsPkgs."generic-random" or (buildDepError "generic-random"))
             (hsPkgs."hedgehog-quickcheck" or (buildDepError "hedgehog-quickcheck"))
+            (hsPkgs."mtl" or (buildDepError "mtl"))
             (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
             (hsPkgs."time" or (buildDepError "time"))
             (hsPkgs."tasty" or (buildDepError "tasty"))
@@ -116,8 +118,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus-shelley; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-test-infra.nix
+++ b/nix/.stack.nix/ouroboros-consensus-test-infra.nix
@@ -111,8 +111,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus/ouroboros-consensus-test-infra; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -189,8 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-framework.nix
+++ b/nix/.stack.nix/ouroboros-network-framework.nix
@@ -147,8 +147,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-framework; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-testing.nix
+++ b/nix/.stack.nix/ouroboros-network-testing.nix
@@ -69,8 +69,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-network-testing; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -189,6 +189,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."containers" or (buildDepError "containers"))
             (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (buildDepError "directory"))
+            (hsPkgs."filepath" or (buildDepError "filepath"))
             (hsPkgs."fingertree" or (buildDepError "fingertree"))
             (hsPkgs."hashable" or (buildDepError "hashable"))
             (hsPkgs."io-sim" or (buildDepError "io-sim"))
@@ -213,8 +215,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger-test.nix
+++ b/nix/.stack.nix/shelley-spec-ledger-test.nix
@@ -86,8 +86,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/executable-spec/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger.nix
+++ b/nix/.stack.nix/shelley-spec-ledger.nix
@@ -115,8 +115,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-non-integral.nix
+++ b/nix/.stack.nix/shelley-spec-non-integral.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/dependencies/non-integer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -119,8 +119,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "5c5854be017f75c703b11c1aad4b765f511ee70e";
-      sha256 = "0bbwjba0jdsvc1w1dzli6yrsrh7k3jh6j9swfv767nwx9j37gmw8";
+      rev = "52afaab4fe99df8fff1e7666e665a923118cfc53";
+      sha256 = "1ldgpw37lnrgd09hhv2zxak9vc0kxbysmpsn7qd74zg3vli5z66j";
       });
     postUnpack = "sourceRoot+=/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/tracer-transformers.nix
+++ b/nix/.stack.nix/tracer-transformers.nix
@@ -88,8 +88,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "10877fbae54aa7a4c04ae3b5d87c825a4019e9e9";
-      sha256 = "17brigssa3yjys75izczpwh10m1ai4rja2wgkx95nvm6krizrkh7";
+      rev = "8f7d2a4ba4288e528fea62946b525f493c26ae7a";
+      sha256 = "12slplsvvf1hywddzsissza4sb85j4r0xhx44nv2icmhp4hp83cc";
       });
     postUnpack = "sourceRoot+=/tracer-transformers; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-examples.nix
+++ b/nix/.stack.nix/typed-protocols-examples.nix
@@ -88,8 +88,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/typed-protocols-examples; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -66,8 +66,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "dbc48d30c5e3a46d28b7c25a15141d3518982c70";
-      sha256 = "1d8959sdmpk9ijji2dqp3wdpl8pff4kbxqwnglafb347wwss7bi7";
+      rev = "ec4f3af58c13a4c20116e9e262b048fb2d27bdc3";
+      sha256 = "1p4z6br0vyvkd84f3a9ilb7sg7d6pgg3fx2aijlxx9x3v1lb1426";
       });
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -32,5 +32,6 @@ in pkgs: super: with pkgs; {
         cp -R ${sources.cardano-node}/configuration $out;
       '';
       };
+  inherit (cardanoNodePkgs.haskellPackages.cardano-cli.components.exes) cardano-cli;
   inherit (pkgs1903) stack;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "tags/1.10.1",
+        "branch": "tags/1.11.0",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "99e1a85b4a3f6d13ddf89e6ea471df18b65fd31a",
-        "sha256": "0gsv06hzrlqziaxdaj925gd15y6yhc4zw90r9818qvz6nvsym2y1",
+        "rev": "376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22",
+        "sha256": "0zg6f8dbgn3kaki7r1lbmb1hsqkiw1h0j443d338lrv2zk2ggicg",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/99e1a85b4a3f6d13ddf89e6ea471df18b65fd31a.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/376562b0cb6dfde4b9f41e9f3ccea45cbfb41c22.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.10.1.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.11.0.yaml
 
 packages:
 - lib/core


### PR DESCRIPTION
# Issue Number

Relates to #1577 / ADP-83.

# Overview

- Updates cardano-node version in nix.
- Updates the cardano-haskell stack snapshot.
- Adds `cardano-cli` to the shell. I am hoping to use this in the integration tests.
- Build fixes

# Comments

WIP until input-output-hk/cardano-haskell#13 is merged.
