### PR TITLE
Bump version from 2020.4.7 to 2020.4.28

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-byron
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Wallet backend protocol-specific bits implemented using byron nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-jormungandr
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Wallet backend protocol-specific bits implemented using Jörmungandr
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2020.4.7
+version:             2020.4.28
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-byron"; version = "2020.4.7"; };
+      identifier = { name = "cardano-wallet-byron"; version = "2020.4.28"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2020.4.7"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2020.4.28"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2020.4.7";
+        version = "2020.4.28";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2020.4.7"; };
+      identifier = { name = "cardano-wallet-core"; version = "2020.4.28"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-jormungandr";
-        version = "2020.4.7";
+        version = "2020.4.28";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2020.4.7"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2020.4.28"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2020.4.7";
+        version = "2020.4.28";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { development = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2020.4.7"; };
+      identifier = { name = "text-class"; version = "2020.4.28"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -15,11 +15,11 @@
 
 ###############################################################
 # Release-specific parameters (Change when you bump the version)
-GIT_TAG="v2020-04-07"
-CABAL_VERSION="2020.4.7"
+GIT_TAG="v2020-04-28"
+CABAL_VERSION="2020.4.28"
 
-OLD_GIT_TAG="v2020-04-01"
-OLD_CABAL_VERSION="2020.4.1"
+OLD_GIT_TAG="v2020-04-07"
+OLD_CABAL_VERSION="2020.4.7"
 
 JORM_TAG="v0.8.15"
 CARDANO_NODE_TAG="1.9.3"


### PR DESCRIPTION
# Issue Number

None.

# Overview

This PR bumps the version from `2020.4.7` to `2020.4.28`.