### PR TITLE
nix: remove socket files from source trees before building

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,9 +59,10 @@
 with pkgs; with commonLib; with pkgs.haskell-nix.haskellLib;
 
 let
-  src = pkgs.haskell-nix.cleanSourceHaskell {
-    src = ./.;
+  src = cleanSourceWith {
+    src = pkgs.haskell-nix.cleanSourceHaskell { src = ./.; };
     name = "cardano-wallet-src";
+    filter = removeSocketFilesFilter;
   };
 
   haskellPackages = import ./nix/haskell.nix {

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -15,4 +15,10 @@ with lib; with haskell-nix.haskellLib;
     (package.isHaskell or false) &&
       ((hasPrefix "cardano-wallet" package.identifier.name) ||
        (elem package.identifier.name [ "text-class" ]));
+
+  # lib.cleanSourceWith filter function which removes socket files
+  # from a source tree. This files can be created by cardano-node and
+  # cause errors when nix attempts to copy them into the store.
+  removeSocketFilesFilter = _path: type:
+    elem type ["regular" "directory" "symlink" ];
 }


### PR DESCRIPTION
## Overview

Any `cardano-node.socket` files present in the source tree will cause an error in the nix build.

This happened in the nightly build. I do not know why the `git clean` command that Buildkite ran did not remove `cardano-node.socket` from the git checkout directory. But this change will prevent the error.
