### PR TITLE
[ADP-286] Enable tagging latest container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Latest Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+    test-job:
+      name: "Tag / Build / Push Container"
+      runs-on: ubuntu-latest
+      steps:
+      - name: Trigger Buildkite Pipeline
+        uses: buildkite/trigger-pipeline-action@v1.2.0
+        env:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.Buildkite_Token }}
+          PIPELINE: ${{ github.repository }}
+          COMMIT: "HEAD"
+          BRANCH: "master"
+          MESSAGE: ":github: Triggered from a GitHub Action"
+          BUILD_ENV_VARS: "{\"BUILDKITE_TAG\": \"latest\"}"


### PR DESCRIPTION
# Issue Number

ADP-286

# Overview

- https://jira.iohk.io/browse/ADP-286
- Adds a GitHub action that, on release, triggers a Buildkite action
  to tag the latest docker image with the "latest" tag.
- Note I've also added a "Buildkite_Token" GitHub secret so the action
  can talk to BuildKite.
- Note I've also added the pattern "latest" to the Branch Filter
  Pattern of this repo's Buildkite pipeline. This is so when Buildkite
  receives the tag "latest", it triggers a build.
