### PR TITLE
Buildkite all-tests-pass branch

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -73,14 +73,14 @@ in
     branch="''${BUILDKITE_BRANCH:-}"
     tag="''${BUILDKITE_TAG:-}"
     extra_tag=""
-    if [[ -n "$tag" ]]; then
+    if [[ "$tag" =~ ^v20 ]]; then
       tag="${image.imageTag}"
       extra_tag="${image.backend}"
     elif [[ "$branch" = master ]]; then
       tag="$(echo ${image.imageTag} | sed -e s/${image.version}/''${BUILDKITE_COMMIT:-dev-$branch}/)"
       extra_tag="$(echo ${image.imageTag} | sed -e s/${image.version}/dev-$branch/)"
     else
-      echo "Not pushing docker image because this is not a master branch or tag build."
+      echo "Not pushing docker image because this is not a master branch or v20* tag build."
       exit 0
     fi
     echo "Loading ${image}"

--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -55,4 +55,10 @@ steps:
       message: "Nightly build with jormungandr integration tests"
       env:
         NIGHTLY_BUILD: "yes"
-    # async: true
+    # Run the jormungandr integration tests, but don't worry about them failing.
+    async: true
+
+  - label: "Advance all-tests-pass branch"
+    command: "./.buildkite/push-branch.sh all-tests-pass"
+    agents:
+      system: x86_64-linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ env:
 steps:
   - label: 'hydra-eval-errors'
     command: 'nix-build ./nix -A iohkNix.hydraEvalErrors && ./result/bin/hydra-eval-errors.py'
+    if: 'build.tag == null'
     agents:
       system: x86_64-linux
 

--- a/.buildkite/push-branch.sh
+++ b/.buildkite/push-branch.sh
@@ -1,0 +1,41 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils git
+
+########################################################################
+# This script creates/updates a branch in the cardano-wallet git repo
+# to match the current HEAD revision.
+#
+# It's used to mark which revision has had all nightly tests
+# successfully run.
+#
+#########################################################################
+
+set -euo pipefail
+
+branch="${1:-}"
+
+if [ -z "$branch" ]; then
+  echo "usage: $0 TARGET_BRANCH"
+  exit 1
+fi
+
+: "${sshkey:=/run/keys/buildkite-cardano-wallet-ssh-private}"
+remote="git@github.com:input-output-hk/cardano-wallet.git"
+
+git fetch origin "$branch" || true
+
+from=$(git show-ref -s "origin/$branch" || echo "-")
+to=$(git show-ref -s HEAD)
+
+echo "Advancing $branch from $from to $to"
+
+if [ -e $sshkey ]; then
+  echo "Authenticating using SSH with $sshkey"
+  export GIT_SSH_COMMAND="ssh -i $sshkey -F /dev/null"
+  git push $remote HEAD:refs/heads/$branch
+  exit 0
+else
+  echo "There is no SSH key at $sshkey"
+  echo "The update can't be pushed."
+  exit 2
+fi

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -301,9 +301,7 @@ titled heading action = do
 -- Weeder - uses contents of .stack-work to determine unused dependencies
 
 weederStep :: DryRun -> IO ExitCode
-weederStep dryRun = do
-    echo "--- Weeder"
-    run dryRun "weeder" []
+weederStep dryRun = titled "Weeder" $ run dryRun "weeder" []
 
 ----------------------------------------------------------------------------
 -- Stack Haskell Program Coverage and upload to Coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 # Every night at 00:00UTC
 # Download the latest master branch build of windows testing bundle
 # and run it.
+# After that passes, hand over to the Buildkite nightly pipeline.
 
 name: cardano-wallet Windows Tests
 
@@ -41,3 +42,17 @@ jobs:
         run: '.\\cardano-wallet-jormungandr-test-jormungandr-integration.exe --color'
         continue-on-error: true
         timeout-minutes: 60
+
+  trigger-buildkite-nightly:
+    needs: tests
+    name: 'Trigger cardano-wallet-nightly pipeline on Buildkite'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Trigger Buildkite Pipeline
+      uses: buildkite/trigger-pipeline-action@v1.2.0
+      env:
+        BUILDKITE_API_ACCESS_TOKEN: '${{ secrets.Buildkite_Token }}'
+        PIPELINE: '${{ github.repository }}-nightly'
+        COMMIT: 'HEAD'
+        BRANCH: 'master'
+        MESSAGE: ':github: Triggered from a GitHub Action'

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "13a88d15f3bbcfd61d89dfe2dade093393d8c9e2",
-        "sha256": "0ccn14c82f0yf7jals8jhr7yq9fm8fxfjmnrw2n54w58jjpxr2s8",
+        "rev": "0b1381b88d3eeb9652d9b998a3d979184e34c9aa",
+        "sha256": "1sk8aqx94ww5nrbhdq74byi794lwk98hxa5pwax853qqnygb0fkh",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/13a88d15f3bbcfd61d89dfe2dade093393d8c9e2.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/0b1381b88d3eeb9652d9b998a3d979184e34c9aa.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {


### PR DESCRIPTION
### Overview

- Some buildkite fixes.
- Trigger buildkite nightly pipeline from github actions, after the windows tests pass.
- Push the `all-tests-pass` branch after the nightly job successfully completes.
- Add a github tag filter to the docker image push script. Otherwise, if the buildkite ref filter were removed, and someone pushed any tag, then the "latest" docker tags would be updated to that tag.
- Bump haskell.nix revision while we're at it.