### PR TITLE
Fix listByronAddresses swagger operation id

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2047,7 +2047,7 @@ paths:
 
   /byron-wallets/{walletId}/addresses:
       get:
-        operationId: listAddresses
+        operationId: listByronAddresses
         tags: ["Byron Addresses"]
         summary: List
         description: |


### PR DESCRIPTION
# Issue Number

#1609

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] Fix listByronAddresses swagger operation id


# Comments

Linking to listByronAddresses in spec should be possible...
