### PR TITLE
ChainSync Pipelined: moar speed. 

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -68,6 +68,7 @@ library
     , text-class
     , time
     , transformers
+    , typed-protocols
     , typed-protocols-examples
     , unordered-containers
     , warp

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -53,7 +53,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.DB.Sqlite.Delete
     ( DeleteSqliteDatabaseLog )
 import Control.Concurrent.MVar
-    ( newMVar, withMVar )
+    ( newMVar, withMVarMasked )
 import Control.Exception
     ( Exception, bracket_, tryJust )
 import Control.Monad
@@ -222,7 +222,7 @@ startSqliteBackend manualMigration autoMigration trace fp = do
     let observe :: IO a -> IO a
         observe = bracket_ (traceRun False) (traceRun True)
     let runQuery :: SqlPersistT IO a -> IO a
-        runQuery cmd = withMVar lock $ const $ observe $ runSqlConn cmd backend
+        runQuery cmd = withMVarMasked lock $ const $ observe $ runSqlConn cmd backend
     autoMigrationResult <-
         withForeignKeysDisabled trace connection
             $ runQuery (runMigrationQuiet autoMigration)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -248,6 +248,7 @@ import Fmt
     , fixedF
     , fmt
     , indentF
+    , listF'
     , ordinalF
     , padRightF
     , prefixF
@@ -1340,9 +1341,9 @@ data TxParameters = TxParameters
 instance NFData TxParameters
 
 instance Buildable TxParameters where
-    build txp = blockListF' "" id
-        [ "Fee policy:         " <> feePolicyF (txp ^. #getFeePolicy)
-        , "Tx max size:        " <> txMaxSizeF (txp ^. #getTxMaxSize)
+    build txp = listF' id
+        [ "Fee policy: " <> feePolicyF (txp ^. #getFeePolicy)
+        , "Tx max size: " <> txMaxSizeF (txp ^. #getTxMaxSize)
         ]
       where
         feePolicyF = build . toText

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -96,6 +96,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."text-class" or (buildDepError "text-class"))
           (hsPkgs."time" or (buildDepError "time"))
           (hsPkgs."transformers" or (buildDepError "transformers"))
+          (hsPkgs."typed-protocols" or (buildDepError "typed-protocols"))
           (hsPkgs."typed-protocols-examples" or (buildDepError "typed-protocols-examples"))
           (hsPkgs."unordered-containers" or (buildDepError "unordered-containers"))
           (hsPkgs."warp" or (buildDepError "warp"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-270

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 441eaf179d344d8c82e4f07204a0087017733038
  :round_pushpin: **replace the chain sync client with its pipelined version**
  No pipeline is done yet, this still uses the standard sequential way for sending requests,
but now using the 'ChainSyncClientPipelined' which has extra constructor we can now use
for pipelining

- 178b0dbe42f9b687f02e10c47b2fe00332af7632
  :round_pushpin: **implementing pipelining, pipeline by batches of 1000 requests. It's fast.**
  This is still work in progress for the 'edge' cases aren't properly handled. Rollbacks are just ignored
and, the area near the tip shouldn't be pipelined but is. Yet, this is a starter that gives some idea.

I haven't tweaked it much, nor tried different settings but so far, I've restored a wallet in ~6:30 minutes
on Mainnet, so more than 10k blocks per second.

- 37cdeb5bf210a72517494f86f0be9de5c64ad6d4
  :round_pushpin: **only pipeline when it's safe**
    This also makes sure to properly handle the starting and terminating
  conditions. This is a bit tricky because, ideally, to know whether we
  can safely pipeline, we want to check whether any of the pipelined
  request would be made within k blocks from the tip. The tricky part is
  "blocks". During rollbacks, we have access to points on the chain which
  are only referencing slots yet, we need to compare block height!

  To solve this, I've adopted two strategies: pipeline and one-by-one,
  defaulting to the latter and only using the former when we have enough
  information to make a sound decision. This means that the client always
  starts by restoring a single block from which it can now figure out a
  blockheight and compare this with the node's tip. In case it's far
  enough, we go full speed, in steps; checking at each step whether it is
  still safe to proceed with the next step.

  The last `k` blocks are therefore fetched one-by-one, which is quite
  slow but, it's `k` blocks out of millions. We _could_ possibly make this
  last part even faster by using the same batching strategy as before
  (where we would basically check after each request whether the node has
  rolled back or not) but it comes with some added complexity I am not
  necessarily fond of introducing. This new approach already cuts the
  overall restoration time by 2.5!

  e.g. on Mainnet:

  ```
  -- pipelined -----------------
  - [2020-05-06 12:12:34.40 UTC] 87a2d760: syncProgress: still restoring (0.00%)
  - [2020-05-06 12:15:12.80 UTC] 87a2d760: syncProgress: still restoring (50.01%)
  -- one by one ----------------
  - [2020-05-06 12:18:20.34 UTC] 87a2d760: syncProgress: still restoring (99.94%)
  - [2020-05-06 12:18:37.38 UTC] 87a2d760: syncProgress: restored
  ------------------------------
  6 minutes 3s / ~11366 block/s

  ```

- 485a324d48fa180bcd21721b29ce653bbe87d90a
  :round_pushpin: **Regenerate nix**
  
- 62d47077ba36b78ba78a718240079558b943a98c
  :round_pushpin: **adjust log outputs for MsgNodeTip and MsgTxParameters**
    Going from:

  ```
  [cardano-wallet.network:Debug:16] [2020-05-07 09:44:29.79 UTC] Network node tip block height is 4129973 at hash 3cf1a60a
  [cardano-wallet.network:Info:17] [2020-05-07 09:31:03.66 UTC] TxParams for tip are:  Fee policy:         155381.0 + 43.0x + 0.0y
   Tx max size:        8192
  ``` 

  to:
  ```
  [cardano-wallet.network:Debug:17] [2020-05-07 09:40:30.88 UTC] Network node tip is fe158920-[191.6466#4129961]
  [cardano-wallet.network:Info:17] [2020-05-07 09:40:30.88 UTC] TxParams for tip are: [Fee policy: 155381.0 + 43.0x + 0.0y, Tx max size: 8192]
  ```

  a) avoid multi-line log output with akward structure for tx params
  b) Show tip in a consistent way with other loggers (for instance, in the wallet engine).

- feb1ecff96403b91a9a38fcc44c68a260b38f254
  :round_pushpin: **fix asynchronous exception handling**
    There are two sides to this commit:

  a) It fixes the asynchronous exception "catcher" in 'follow' that would
     fail to catch any exception that occurs while the thread is sleeping. I
     noticed that sometimes the logs wouldn't display a proper error.

  b) It also fixes the 'runQuery' combinator for our SQLite implementation
     to make sure that asynchronous exceptions are masked while executing
     sql queries. I falsy thought this was already properly handled by
     'runSqlConn' from persistent but it seems to be source of most of our
     'ErrorBusy' / 'statementAlreadyFinalized' issues.

  :finger_crossed:

# Comments

<!-- Additional comments or screenshots to attach if any -->

It's fast :man_shrugging: 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
