### PR TITLE
[ADP-286] Enable tagging latest container

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Post Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+    test-job:
+      name: "Tag / Build / Push Container"
+      runs-on: ubuntu-latest
+      steps:
+      - name: Trigger Buildkite Pipeline
+        uses: buildkite/trigger-pipeline-action@v1.2.0
+        env:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.Buildkite_Token }}
+          PIPELINE: ${{ github.repository }}
+          COMMIT: "HEAD"
+          BRANCH: "master"
+          MESSAGE: ":github: Triggered from a GitHub Action"
+          BUILD_ENV_VARS: "{\"GITHUB_REF\": \"${{ github.ref }}\", \"GITHUB_EVENT_NAME\": \"${{ github.event_name }}\" }"


### PR DESCRIPTION
# Issue Number

[ADP-286](https://jira.iohk.io/browse/ADP-286)

# Overview

- Adds a GitHub action that triggers the "docker-build-push.nix"
  script on release.
- Modified the "docker-build-push.nix" script:
    On release:
      - upload byron image as "latest"
      - upload images: "<version>-byron" and "<version>-jormungandr"
      - upload images: "byron" and "jormungandr"
    On master branch:
      - upload "dev-master-byron" and "dev-master-jormungandr"
    On every commit:
      - upload "<COMMIT_ID>-byron" and "<COMMIT_ID>-jormungandr"
- The difference here is that we're using a release workflow
  consistent with the other repo's addressed under [ADP-286].
- Additionally, we're uploading a image with the commit ID on every
  build.
- Note I've also added a "Buildkite_Token" GitHub secret so the action
  can talk to BuildKite.

# Comments

- The idea behind this was to bring this repo's
  "docker-build-push.nix" further into aligment with the rest of the
  repo's under [ADP-286], but I'm not particularly sure I've achieved
  that. This repo has quite different image requirements, namely:
    - "dev-master" images
    - "date-backend" images