### PR TITLE
Better bech32 error messages

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -631,18 +631,14 @@ spec = do
 
             describe "bech32" $ do
                 decodeKeyGoldenErr "xprv1hs" "xprv1hs"
-                    "StringToDecodeTooShort"
+                    "Bech32 error: string is too short"
                 decodeKeyGoldenErr "xpub1hs" "xpubhs"
-                    "StringToDecodeTooShort"
-
-                -- TODO: We really have an opportunity to render nice error
-                -- messages here!
-                --
-                -- We should underline the invalid character!
-                decodeKeyGoldenErr (xprv1Bech32 <> "ö") "trailing \"ö\" char"
-                    "StringToDecodeContainsInvalidChars [CharPosition 165]"
+                    "Bech32 error: string is too short"
+                decodeKeyGoldenErr (xprv1Bech32 <> "ö") "trailing \"ö\" char" $
+                    "Bech32 error: Invalid character(s) in string:\n"
+                    <> T.unpack xprv1Bech32 <> "\ESC[91m\246\ESC[0m\ESC[0m"
                 decodeKeyGoldenErr (xprv1Bech32 <> "n") "trailing \"n\" char"
-                    "StringToDecodeContainsInvalidChars []"
+                    "Bech32 error: Invalid character(s) in string"
 
                 -- We should /perhaps/ return a bech32 specific error here
                 decodeKeyGoldenErr xprv1Bech32FooHrp "wrong hrp"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1603 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Addded custom error messages for bech32 errors
- [x] Mark invalid characters red <s>and underline them with `^`</s>


# Comments

- Not sure if/how we should test
- Not sure if the (non-IO) ANSI red works on windows
- <s>Not sure if the `^` underlining is a great idea considering line wrapping is likely</s> removed

<img width="1536" alt="Skärmavbild 2020-05-04 kl  12 02 28" src="https://user-images.githubusercontent.com/304423/80955366-7a85fe00-8dff-11ea-8563-c1b5ffe20a02.png">

<img width="296" alt="Skärmavbild 2020-05-04 kl  12 02 49" src="https://user-images.githubusercontent.com/304423/80955372-7f4ab200-8dff-11ea-9178-a7095f922c40.png">




<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
