### PR TITLE
Latency benchmarks second look

### DIFF
--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -146,6 +146,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar ->
              fmtLn "\n"
              fmtLn walletName
 
+             fmtTitle "Non-cached run"
              runBareScenario logging tvar
 
              fmtTitle "Latencies for 2 fixture wallets scenario"
@@ -326,7 +327,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar ->
         -- in runScenario
         t <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
-        fmtResult "getNetworkInfo without cache    " t
+        fmtResult "getNetworkInfo     " t
         pure ()
 
 meanAvg :: [NominalDiffTime] -> Double

--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -146,6 +146,8 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar ->
              fmtLn "\n"
              fmtLn walletName
 
+             runBareScenario logging tvar
+
              fmtTitle "Latencies for 2 fixture wallets scenario"
              runScenario logging tvar (nFixtureWallet 2 fixtureByronWallet)
 
@@ -313,15 +315,18 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar ->
             (Link.getTransactionFee @'Byron wal1) Default payload
         fmtResult "postTransactionFee " t6
 
-        -- this one is to have comparable results from first to last measurement
-        -- otherwise the first one would be without cashing in contrast to other
-        -- measurements
-        _t7bare <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
-            Link.getNetworkInfo Default Empty
         t7 <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
         fmtResult "getNetworkInfo     " t7
 
+        pure ()
+
+    runBareScenario logging tvar  = benchWithServer logging $ \ctx -> do
+        -- this one is to have comparable results from first to last measurement
+        -- in runScenario
+        t <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
+            Link.getNetworkInfo Default Empty
+        fmtResult "getNetworkInfo without cache    " t
         pure ()
 
 meanAvg :: [NominalDiffTime] -> Double

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -135,6 +135,7 @@ import qualified Network.HTTP.Types.Status as HTTP
 main :: forall t n. (t ~ Jormungandr, n ~ 'Testnet 0) => IO ()
 main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
 
+    fmtLn "Non-cached run"
     runBareScenario logging tvar
 
     fmtLn "Latencies for 2 fixture wallets scenario"
@@ -370,7 +371,7 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         -- in runScenario
         t <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
-        fmtResult "getNetworkInfo without cache    " t
+        fmtResult "getNetworkInfo     " t
         pure ()
 
 meanAvg :: [NominalDiffTime] -> Double

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -134,6 +134,9 @@ import qualified Network.HTTP.Types.Status as HTTP
 
 main :: forall t n. (t ~ Jormungandr, n ~ 'Testnet 0) => IO ()
 main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
+
+    runBareScenario logging tvar
+
     fmtLn "Latencies for 2 fixture wallets scenario"
     runScenario logging tvar (nFixtureWallet 2)
 
@@ -365,6 +368,15 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
 
         fmtResult "getNetworkInfo     " t8
 
+        pure ()
+
+    runBareScenario logging tvar  = benchWithServer logging $ \ctx -> do
+        -- this one is to have comparable results from first to last measurement
+        -- in runScenario
+        t <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
+            Link.getNetworkInfo Default Empty
+        fmtResult "getNetworkInfo without cache    " t
+        fmtLn ""
         pure ()
 
 meanAvg :: [NominalDiffTime] -> Double

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -358,11 +358,6 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
 
         fmtResult "listStakePools     " t7
 
-        -- this one is to have comparable results from first to last measurement
-        -- otherwise the first one would be without cashing in contrast to other
-        -- measurements
-        _t8bare <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
-            Link.getNetworkInfo Default Empty
         t8 <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
 
@@ -376,7 +371,6 @@ main = withUtf8Encoding $ withLatencyLogging $ \logging tvar -> do
         t <- measureApiLogs tvar $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
         fmtResult "getNetworkInfo without cache    " t
-        fmtLn ""
         pure ()
 
 meanAvg :: [NominalDiffTime] -> Double


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have revised latency benchmarking once again. There is only one additional call for Jormungandr, two for Byron (one for random, one for Icarus).


# Comments

<!-- Additional comments or screenshots to attach if any -->
@piotr-iohk  when it concerns your latency plotting, now you should expect output like that (`getNetworkInfo without cache` added):
```
Random wallets                    
getNetworkInfo without cache     - 2.1 ms
    Latencies for 2 fixture wallets scenario
        listWallets         - 1.6 ms
        getWallet           - 0.7 ms
        getUTxOsStatistics  - 0.7 ms
        listAddresses       - 1.1 ms
        listTransactions    - 1.3 ms
        postTransactionFee  - 0.8 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 10 txs scenario
        listWallets         - 4.5 ms
        getWallet           - 2.5 ms
        getUTxOsStatistics  - 2.4 ms
        listAddresses       - 5.4 ms
        listTransactions    - 2.4 ms
        postTransactionFee  - 1.0 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 100 utxos scenario
        listWallets         - 3.3 ms
        getWallet           - 1.6 ms
        getUTxOsStatistics  - 1.6 ms
        listAddresses       - 5.8 ms
        listTransactions    - 11.2 ms
        postTransactionFee  - 7.5 ms
        getNetworkInfo      - 0.0 ms
 .....................                                 
                                  
Icarus wallets                    
getNetworkInfo without cache     - 1.5 ms
    Latencies for 2 fixture wallets scenario
        listWallets         - 2.5 ms
        getWallet           - 1.3 ms
        getUTxOsStatistics  - 1.3 ms
        listAddresses       - 18.6 ms
        listTransactions    - 1.8 ms
        postTransactionFee  - 1.5 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 10 txs scenario
        listWallets         - 2.8 ms
        getWallet           - 1.5 ms
        getUTxOsStatistics  - 1.5 ms
        listAddresses       - 15.2 ms
        listTransactions    - 2.9 ms
        postTransactionFee  - 1.7 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 2 fixture wallets with 100 utxos scenario
        listWallets         - 5.0 ms
        getWallet           - 2.5 ms
        getUTxOsStatistics  - 2.4 ms
        listAddresses       - 8.1 ms
        listTransactions    - 8.6 ms
        postTransactionFee  - 7.4 ms
        getNetworkInfo      - 0.0 ms
.......
Benchmark latency: FINISH         
Completed 2 action(s). 
``` 
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
