### PR TITLE
Mock metadata aggregation server

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -216,7 +216,6 @@ test-suite unit
     , safe
     , scrypt
     , servant
-    , servant-client
     , servant-server
     , servant-swagger
     , stm

--- a/lib/core/src/Cardano/Pool/Metadata.hs
+++ b/lib/core/src/Cardano/Pool/Metadata.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -55,6 +56,8 @@ import Data.Time.Clock
     ( NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime )
 import Fmt
     ( pretty )
+import GHC.Generics
+    ( Generic )
 import Network.HTTP.Client
     ( Manager, defaultManagerSettings, newManager )
 import Network.HTTP.Types
@@ -183,7 +186,7 @@ data MetadataRegistryLog
     = MsgUsingCached PoolId UTCTime
     | MsgRefreshingMetadata PoolId (Maybe StakePoolOffChainMetadata, UTCTime)
     | MsgUnexpectedError ClientError
-    deriving (Show, Eq)
+    deriving (Generic, Show, Eq)
 
 instance HasPrivacyAnnotation MetadataRegistryLog
 instance HasSeverityAnnotation MetadataRegistryLog where

--- a/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
@@ -19,7 +19,7 @@ import Cardano.Pool.Metadata
     , Client (..)
     , Scheme (..)
     , defaultManagerSettings
-    , mkClient
+    , mkClientIO
     , newManager
     )
 import Cardano.Wallet.Api.Server
@@ -129,7 +129,7 @@ spec = describe "Metadata - MockServer" $
 -- | Run a server in a separate thread. Block until the server is ready, and
 -- returns the TCP port on which the server is listening, and a handle to the
 -- server thread.
-withMockServer :: (Client Api -> IO ()) -> IO ()
+withMockServer :: (Client Api IO -> IO ()) -> IO ()
 withMockServer action = do
     bracket acquire release inBetween
   where
@@ -149,7 +149,7 @@ withMockServer action = do
             Right port -> do
                 mngr <- newManager defaultManagerSettings
                 let baseUrl = BaseUrl Http host port ""
-                pure (mkClient mngr baseUrl, thread)
+                pure (mkClientIO mngr baseUrl, thread)
     release = cancel . snd
     inBetween = action . fst
 

--- a/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/MetadataSpec.hs
@@ -138,7 +138,7 @@ spec = describe "Metadata - MockServer" $ do
 
     around (withMockServer inMemoryCache)
         $ it "Cache metadata when called twice within the TTL"
-        $ \mkClient -> withMaxSuccess 10 $ property $ \pid -> monadicIO $ do
+        $ \mkClient -> withMaxSuccess 4 $ property $ \pid -> monadicIO $ do
             (logs, _) <- run $ captureLogging $ \tr -> do
                 let Client{getStakePoolMetadata} = mkClient tr
                 void $ getStakePoolMetadata pid
@@ -149,7 +149,7 @@ spec = describe "Metadata - MockServer" $ do
 
     around (withMockServer inMemoryCache)
         $ it "Fetch them again when fetching outside of the TTL"
-        $ \mkClient -> withMaxSuccess 10 $ property $ \pid -> monadicIO $ do
+        $ \mkClient -> withMaxSuccess 4 $ property $ \pid -> monadicIO $ do
             (logs, _) <- run $ captureLogging $ \tr -> do
                 let Client{getStakePoolMetadata} = mkClient tr
                 void $ getStakePoolMetadata pid
@@ -172,9 +172,9 @@ spec = describe "Metadata - MockServer" $ do
 -- Mock Storage
 --
 
--- | A default value for the cache, 10ms.
+-- | A default value for the cache, 1s
 defaultCacheTTL :: NominalDiffTime
-defaultCacheTTL = 0.01
+defaultCacheTTL = 1
 
 -- | Default dummy caching, callbacks are NoOps.
 noCache :: IO (ClientCallbacks IO)

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -34,6 +34,7 @@ library
     , contra-tracer
     , filepath
     , file-embed
+    , generic-lens
     , hspec
     , hspec-core
     , hspec-expectations

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -176,7 +176,6 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."safe" or (buildDepError "safe"))
             (hsPkgs."scrypt" or (buildDepError "scrypt"))
             (hsPkgs."servant" or (buildDepError "servant"))
-            (hsPkgs."servant-client" or (buildDepError "servant-client"))
             (hsPkgs."servant-server" or (buildDepError "servant-server"))
             (hsPkgs."servant-swagger" or (buildDepError "servant-swagger"))
             (hsPkgs."stm" or (buildDepError "stm"))

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -65,6 +65,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."contra-tracer" or (buildDepError "contra-tracer"))
           (hsPkgs."filepath" or (buildDepError "filepath"))
           (hsPkgs."file-embed" or (buildDepError "file-embed"))
+          (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
           (hsPkgs."hspec" or (buildDepError "hspec"))
           (hsPkgs."hspec-core" or (buildDepError "hspec-core"))
           (hsPkgs."hspec-expectations" or (buildDepError "hspec-expectations"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1597

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

-  64052c5449d21ef3002d6ddf21dc06669e4c9315
  :round_pushpin: **Basic skeleton for refreshing metadata.**
  Still requires proper log messages and error handling. But this already allows some level of testing.

- 7be9a83dd78c02cef31b1ba71d08c5838709e98c
  :round_pushpin: **log events while refreshing metadata**
  
- 566d95d9482dd32eb4098288ecca99ac994bb36f
  :round_pushpin: **handle 404 in the metadata client directly**
  So that the calling code needs not to worry about the 'ClientError'. Any error becomes unexpected and all errors can be treated consistently.

- 398bb7839e105fabeea062292d6cbfe40e01ed8b
  :round_pushpin: **merge 'refresh' and 'Client' so that the client is already caching results by itself.**
  This makes it slightly easier to use from a consumer perspective. Once one has a handle on a 'Client IO Api' it can makes requests without having to
worry about whether they get cached or not. Doing so, I also removed the 'ClientError' from the response. The client does handle error by itself and
log messages accordingly. A caller would likely not do anything more than relogging the error.
Plus, from the caller perspective, a metadata not being there and the request failing has pretty much the same end: no metadata.

- 98a499d1e5fdbf20361074a6fe30be7766747852
  :round_pushpin: **write small unit / property tests to exercise the client.**
    Written as property so we get some fuzzy testing and test cases with and without metadata
  Fails nicely with each log messages obtained in the run:
  ```
  Assertion failed (after 1 test):
    PoolId {getPoolId = "\SOH\NUL\SOH\NUL\NUL\NUL\NUL\NUL\NUL\SOH\SOH\NUL\SOH\SOH\SOH\SOH\NUL\SOH\NUL\SOH\SOH\SOH\NUL\SOH\NUL\SOH\NUL\NUL\NUL\SOH\SOH\NUL"}
    MsgRefreshingMetadata (PoolId {getPoolId = "\SOH\NUL\SOH\NUL\NUL\NUL\NUL\NUL\NUL\SOH\SOH\NUL\SOH\SOH\SOH\SOH\NUL\SOH\NUL\SOH\SOH\SOH\NUL\SOH\NUL\SOH\NUL\NUL\NUL\SOH\SOH\NUL"}) (Just (StakePoolOffChainMetadata {ticker = StakePoolTicker {unStakePoolTicker = "VUHQ"}, name = "_-NfdG\21785\&0?-wjm'\\.G{0MtJ4E", description = "_-NfdG\21785\&0?-wjm'\\.G{0MtJ4E", homepage = "https://\tXuP9h>v\ETXXM\FSUHd\ACKp\SOH\FS\SOHg\DEL$.io"}),2020-05-04 23:31:26.917183969 UTC)
    MsgUsingCached (PoolId {getPoolId = "\SOH\NUL\SOH\NUL\NUL\NUL\NUL\NUL\NUL\SOH\SOH\NUL\SOH\SOH\SOH\SOH\NUL\SOH\NUL\SOH\SOH\SOH\NUL\SOH\NUL\SOH\NUL\NUL\NUL\SOH\SOH\NUL"}) 2020-05-04 23:31:26.917183969 UTC
  ```

- 51cf00ad9c6391dcc1a600298150c35909b1cd3f
  :round_pushpin: **add an extra scenario illustrating a unhappy path**
    ```
  Cardano.Pool.Metadata
    Metadata - MockServer
      Mock Server works as intended
        +++ OK, passed 100 tests:
        51% Got Valid Metadata
        49% No Corresponding Metadata
      Cache metadata when called twice within the TTL
        +++ OK, passed 10 tests.
      Fetch them again when fetching outside of the TTL
        +++ OK, passed 10 tests.
      Returns 'Nothing' and a warning log message on failure
        +++ OK, passed 1 test.
  ```

- c76f29d7b3eb338e26889d9ec41f8ecb37cd08d3
  :round_pushpin: **move 'count' to 'Test.Util.Trace' with extra comments'**

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
