### PR TITLE
Fix migration error on checkpoint table

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -748,6 +748,8 @@ mkCheckpointEntity wid wal =
         , checkpointEpochStability = coerce (bp ^. #getEpochStability)
         , checkpointActiveSlotCoeff =
             W.unActiveSlotCoefficient (bp ^. #getActiveSlotCoefficient)
+        , checkpointFeePolicyUnused = ""
+        , checkpointTxMaxSizeUnused = 0
         }
     utxo =
         [ UTxO wid sl (TxId input) ix addr coin
@@ -776,8 +778,10 @@ checkpointFromEntity cp utxo s =
         bh
         (BlockId genesisHash)
         genesisStart
+        _feePolicyUnused
         slotLength
         epochLength
+        _txMaxSizeUnused
         epochStability
         activeSlotCoeff
         ) = cp

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -133,8 +133,10 @@ Checkpoint
     checkpointBlockHeight       Word32       sql=block_height
     checkpointGenesisHash       BlockId      sql=genesis_hash
     checkpointGenesisStart      UTCTime      sql=genesis_start
+    checkpointFeePolicyUnused   Text         sql=fee_policy
     checkpointSlotLength        Word64       sql=slot_length
     checkpointEpochLength       Word32       sql=epoch_length
+    checkpointTxMaxSizeUnused   Word16       sql=tx_max_size
     checkpointEpochStability    Word32       sql=epoch_stability
     checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 


### PR DESCRIPTION
### Issue Number

Relates to #1577 / ADP-83 and  #1621.

### Overview

Fix migration error on checkpoint table found in nightly tests.

SQLite doesn't support removing columns, so we put them back as "unused" fields (https://www.sqlite.org/lang_altertable.html#altertableishard).
