### PR TITLE
Bump version from 2020.4.28 to 2020.5.6

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-byron
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Wallet backend protocol-specific bits implemented using byron nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-jormungandr
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Wallet backend protocol-specific bits implemented using Jörmungandr
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2020.4.28
+version:             2020.5.6
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-byron"; version = "2020.4.28"; };
+      identifier = { name = "cardano-wallet-byron"; version = "2020.5.6"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2020.4.28"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2020.5.6"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2020.4.28";
+        version = "2020.5.6";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2020.4.28"; };
+      identifier = { name = "cardano-wallet-core"; version = "2020.5.6"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-jormungandr";
-        version = "2020.4.28";
+        version = "2020.5.6";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2020.4.28"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2020.5.6"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -44,7 +44,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2020.4.28";
+        version = "2020.5.6";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -42,7 +42,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2020.4.28"; };
+      identifier = { name = "text-class"; version = "2020.5.6"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -1,11 +1,13 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p nix coreutils gnugrep
+#! nix-shell -i bash -p nix coreutils gnugrep gnused
+
+set -euo pipefail
 
 # A handy utility for filling in the github RELEASE_TEMPLATE.
 # Since we are using nix, this script shoud work whether on linux or mac.
 #
-# NOTE: This script will target the LATEST wiki version. Make sure the wiki hasn't changed undesirably since
-# the release tag.
+# NOTE: This script will target the LATEST wiki version. Make sure the
+# wiki hasn't changed undesirably since the release tag.
 #
 # Usage:
 # cd cardano-wallet # (only works from here!)
@@ -13,7 +15,7 @@
 # ./scripts/make_release.sh
 #
 
-###############################################################
+################################################################################
 # Release-specific parameters (Change when you bump the version)
 GIT_TAG="v2020-04-28"
 CABAL_VERSION="2020.4.28"
@@ -23,51 +25,41 @@ OLD_CABAL_VERSION="2020.4.7"
 
 JORM_TAG="v0.8.15"
 CARDANO_NODE_TAG="1.9.3"
-###############################################################
-TMP_CWD=$(pwd)
+################################################################################
 OLD_DATE="${OLD_GIT_TAG//v}"
 CHANGELOG=GENERATED_CHANGELOG.md
 OUT=GENERATED_RELEASE_NOTES-$GIT_TAG.md
 REPO="input-output-hk/cardano-wallet"
-TMP_WIKI_DIR=/tmp/cardano-wallet-script
-rm -rf $TMP_WIKI_DIR
-mkdir $TMP_WIKI_DIR
-echo $TMP_WIKI_DIR
-cd $TMP_WIKI_DIR
-git clone https://github.com/$REPO.wiki.git
-cd cardano-wallet.wiki
-
-WIKI_COMMIT=$(git log -n 1 --pretty=format:%H)
-
-cd $TMP_CWD
-echo "cd $TMP_CWD"
+WIKI_COMMIT=$(git ls-remote https://github.com/$REPO.wiki.git HEAD | cut -f1)
 
 echo ""
 echo "Replacing $OLD_CABAL_VERSION with $CABAL_VERSION"
-find nix -name "*.nix" -type f | xargs sed -i "s/$OLD_CABAL_VERSION/$CABAL_VERSION/"
-find lib -name "*.cabal" -type f | xargs sed -i "s/$OLD_CABAL_VERSION/$CABAL_VERSION/"
+sed -i "s/$OLD_CABAL_VERSION/$CABAL_VERSION/" \
+    $(git ls-files '*.nix'; git ls-files '*.cabal')
 echo "Looking for remaining references to old version:"
-echo "$(git grep $OLD_CABAL_VERSION)"
+git grep $OLD_CABAL_VERSION
 echo ""
 
 echo "Generating changelog..."
 ./scripts/make_changelog $OLD_DATE > $CHANGELOG
 echo ""
 echo "Filling in template..."
-sed -e "
-s/{{GIT_TAG}}/$GIT_TAG/g
-s/{{JORM_TAG}}/$JORM_TAG/g
-s/{{CARDANO_NODE_TAG}}/$CARDANO_NODE_TAG/g
-s/{{CABAL_VERSION}}/$CABAL_VERSION/g
-s/{{DOCKER_WIKI_COMMIT}}/$WIKI_COMMIT/g
-s/{{JORM_CLI_WIKI_COMMIT}}/$WIKI_COMMIT/g
-s/{{BYRON_CLI_WIKI_COMMIT}}/$WIKI_COMMIT/g
-" .github/RELEASE_TEMPLATE.md | sed -e "/{{CHANGELOG}}/r $CHANGELOG" > $OUT
+sed -e "s/{{GIT_TAG}}/$GIT_TAG/g"                   \
+    -e "s/{{JORM_TAG}}/$JORM_TAG/g"                 \
+    -e "s/{{CARDANO_NODE_TAG}}/$CARDANO_NODE_TAG/g" \
+    -e "s/{{CABAL_VERSION}}/$CABAL_VERSION/g"       \
+    -e "s/{{DOCKER_WIKI_COMMIT}}/$WIKI_COMMIT/g"    \
+    -e "s/{{JORM_CLI_WIKI_COMMIT}}/$WIKI_COMMIT/g"  \
+    -e "s/{{BYRON_CLI_WIKI_COMMIT}}/$WIKI_COMMIT/g" \
+    -e "/{{CHANGELOG}}/r $CHANGELOG"                \
+    -e "/{{CHANGELOG}}/d"                           \
+    .github/RELEASE_TEMPLATE.md > $OUT
 
-read -p "Do you want to create a commit and release-tag? (y/n)" -n 1 -r
-echo    # (optional) move to a new line
+read -p "Do you want to create a commit and release-tag? (y/n) " -n 1 -r
+echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-	git commit -am "Bump version from $OLD_CABAL_VERSION to $CABAL_VERSION"
+  msg="Bump version from $OLD_CABAL_VERSION to $CABAL_VERSION"
+  git diff --quiet || git commit -am "$msg"
   git tag -s -m $GIT_TAG $GIT_TAG
 fi

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -17,14 +17,14 @@ set -euo pipefail
 
 ################################################################################
 # Release-specific parameters (Change when you bump the version)
-GIT_TAG="v2020-04-28"
-CABAL_VERSION="2020.4.28"
+GIT_TAG="v2020-05-06"
+CABAL_VERSION="2020.5.6"
 
-OLD_GIT_TAG="v2020-04-07"
-OLD_CABAL_VERSION="2020.4.7"
+OLD_GIT_TAG="v2020-04-28"
+OLD_CABAL_VERSION="2020.4.28"
 
-JORM_TAG="v0.8.15"
-CARDANO_NODE_TAG="1.9.3"
+JORM_TAG="v0.8.18"
+CARDANO_NODE_TAG="1.11.0"
 ################################################################################
 OLD_DATE="${OLD_GIT_TAG//v}"
 CHANGELOG=GENERATED_CHANGELOG.md


### PR DESCRIPTION
- Updates the cabal package versions from 2020.4.28 to 2020.5.6.
- A few shell script tweaks to the release script.
