### PR TITLE
Buildkite: Only update all-tests-pass branch after other steps pass

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -58,6 +58,8 @@ steps:
     # Run the jormungandr integration tests, but don't worry about them failing.
     async: true
 
+  - wait
+
   - label: "Advance all-tests-pass branch"
     command: "./.buildkite/push-branch.sh all-tests-pass"
     agents:


### PR DESCRIPTION
In the [Buildkite nightly](https://buildkite.com/input-output-hk/cardano-wallet-nightly) pipeline, only update all-tests-pass branch after other steps pass. I forgot to add the dependency before.
