### PR TITLE
Modify docker-compose.yml example so it is possible to run mainnet and testnet interchangeably

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ start with Daedalus.
 > [cardano-sl](https://github.com/input-output-hk/cardano-sl)
 > repository.
 
-## Getting Started 
+## Getting Started
 
 ```
 wget https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/docker-compose.yml
@@ -52,6 +52,12 @@ Fantastic! The server is up-and-running, waiting for HTTP requests on `localhost
 
 ```
 curl http://localhost:8090/v2/network/information
+```
+
+or to be accessed via CLI, e.g.:
+
+```
+docker run --network host --rm inputoutput/cardano-wallet network information
 ```
 
 See also [Wiki - Docker](https://github.com/input-output-hk/cardano-wallet/wiki/Docker) for more information about using docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       NETWORK:
     volumes:
-      - node-db:/data
+      - node-${NETWORK}-db:/data
       - node-ipc:/ipc
       - node-config:/nix/store
     restart: on-failure
@@ -14,7 +14,7 @@ services:
   cardano-wallet:
     image: inputoutput/cardano-wallet:latest
     volumes:
-      - wallet-db:/wallet-db
+      - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc
       - node-config:/config
     ports:
@@ -30,7 +30,9 @@ services:
     restart: on-failure
 
 volumes:
-  node-db:
+  node-mainnet-db:
+  node-testnet-db:
+  wallet-mainnet-db:
+  wallet-testnet-db:
   node-ipc:
   node-config:
-  wallet-db:


### PR DESCRIPTION

# Issue Number

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have modified docker-compose.yml example so one can run it for `testnet` and `mainnet` interchangeably.


# Comments

With current docker-compose.yml if one starts:
```
NETWORK=testnet docker-compose up
```
...runs it for a while and then starts:

```
NETWORK=mainnet docker-compose up
```
then she will get failure:
```
cardano-node_1    | Shutting down..
cardano-node_1    | ProtocolMagicIdMismatch "/data/db/protocolMagicId" (ProtocolMagicId {unProtocolMagicId = 764824073}) (ProtocolMagicId {unProtocolMagicId = 1097911063})
cardano-node_1    |
```
as the volumes will interfere with each other. 

After this change one can run it for `testnet` and `mainnet` interchangeably...
