### PR TITLE
Import legacy Byron addresses

### DIFF
--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -184,6 +184,7 @@ test-suite integration
     , command
     , generic-lens
     , hspec
+    , http-api-data
     , http-client
     , http-types
     , iohk-monitoring

--- a/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
@@ -65,6 +65,7 @@ import Cardano.Wallet.Api.Server
     , postTransactionFee
     , postTrezorWallet
     , putByronWalletPassphrase
+    , putRandomAddress
     , putWallet
     , rndStateChange
     , withLegacyLayer
@@ -198,6 +199,10 @@ server byron icarus ntp =
     byronAddresses =
              (\wid s -> withLegacyLayer wid
                 (byron, postRandomAddress byron wid s)
+                (icarus, liftHandler $ throwE ErrCreateAddressNotAByronWallet)
+             )
+        :<|> (\wid addr -> withLegacyLayer wid
+                (byron, putRandomAddress byron wid addr)
                 (icarus, liftHandler $ throwE ErrCreateAddressNotAByronWallet)
              )
         :<|> (\wid s -> withLegacyLayer wid

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Addresses.hs
@@ -96,10 +96,10 @@ spec = do
         scenario_ADDRESS_CREATE_05 @n
         scenario_ADDRESS_CREATE_06 @n
 
-        scenario_ADDRESS_RESTORE_01 @n emptyRandomWalletMws
-        scenario_ADDRESS_RESTORE_02 @n emptyIcarusWalletMws
-        scenario_ADDRESS_RESTORE_03 @n emptyRandomWalletMws
-        scenario_ADDRESS_RESTORE_04 @n fixtureRandomWallet
+        scenario_ADDRESS_IMPORT_01 @n emptyRandomWalletMws
+        scenario_ADDRESS_IMPORT_02 @n emptyIcarusWalletMws
+        scenario_ADDRESS_IMPORT_03 @n emptyRandomWalletMws
+        scenario_ADDRESS_IMPORT_04 @n fixtureRandomWallet
 
 scenario_ADDRESS_LIST_01
     :: forall (n :: NetworkDiscriminant) t.
@@ -281,7 +281,7 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
   where
     title = "ADDRESS_CREATE_06 - Cannot create an address that already exists"
 
-scenario_ADDRESS_RESTORE_01
+scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , EncodeAddress n
@@ -289,7 +289,7 @@ scenario_ADDRESS_RESTORE_01
         )
     => (Context t -> IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith (Context t)
-scenario_ADDRESS_RESTORE_01 fixture = it title $ \ctx -> do
+scenario_ADDRESS_IMPORT_01 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
     -- Get an unused address
@@ -301,16 +301,16 @@ scenario_ADDRESS_RESTORE_01 fixture = it title $ \ctx -> do
         [ expectResponseCode @IO HTTP.status204
         ]
 
-    -- Restore it
+    -- Import it
     r1 <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
     verify r1
         [ expectListField 0 #state (`shouldBe` ApiT Unused)
         , expectListField 0 (#id . position @1) (`shouldBe` ApiT addr)
         ]
   where
-    title = "ADDRESS_RESTORE_01 - I can restore an address from my wallet"
+    title = "ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
-scenario_ADDRESS_RESTORE_02
+scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , EncodeAddress n
@@ -318,7 +318,7 @@ scenario_ADDRESS_RESTORE_02
         )
     => (Context t -> IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith (Context t)
-scenario_ADDRESS_RESTORE_02 fixture = it title $ \ctx -> do
+scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
     let addr = icarusAddresses @n mw !! 42
@@ -330,9 +330,9 @@ scenario_ADDRESS_RESTORE_02 fixture = it title $ \ctx -> do
         , expectErrorMessage errMsg403NotAByronWallet
         ]
   where
-    title = "ADDRESS_RESTORE_02 - I can't restore an address on an Icarus wallet"
+    title = "ADDRESS_IMPORT_02 - I can't import an address on an Icarus wallet"
 
-scenario_ADDRESS_RESTORE_03
+scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , EncodeAddress n
@@ -340,7 +340,7 @@ scenario_ADDRESS_RESTORE_03
         )
     => (Context t -> IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith (Context t)
-scenario_ADDRESS_RESTORE_03 fixture = it title $ \ctx -> do
+scenario_ADDRESS_IMPORT_03 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
     -- Get an unused address
@@ -354,9 +354,9 @@ scenario_ADDRESS_RESTORE_03 fixture = it title $ \ctx -> do
     r1 <- request @() ctx ("PUT", link) Default Empty
     verify r1 [ expectResponseCode @IO HTTP.status204 ]
   where
-    title = "ADDRESS_RESTORE_03 - I can restore an unused address multiple times"
+    title = "ADDRESS_IMPORT_03 - I can import an unused address multiple times"
 
-scenario_ADDRESS_RESTORE_04
+scenario_ADDRESS_IMPORT_04
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , EncodeAddress n
@@ -364,7 +364,7 @@ scenario_ADDRESS_RESTORE_04
         )
     => (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
-scenario_ADDRESS_RESTORE_04 fixture = it title $ \ctx -> do
+scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> do
     w <- fixture ctx
 
     -- Get a used address
@@ -383,4 +383,4 @@ scenario_ADDRESS_RESTORE_04 fixture = it title $ \ctx -> do
         (Link.listAddresses' @'Byron w (Just Used)) Default Empty
     verify r2 [ expectListField 0 id (`shouldBe` addr) ]
   where
-    title = "ADDRESS_RESTORE_04 - I can restore a used address (idempotence)"
+    title = "ADDRESS_IMPORT_04 - I can import a used address (idempotence)"

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -434,6 +434,10 @@ spec = do
             , "                           address index is optional, give none"
             , "                           to let the wallet generate a random"
             , "                           one."
+            , "  import                   Import a random address generated"
+            , "                           elsewhere. Only available for random"
+            , "                           wallets. The address must belong to"
+            , "                           the target wallet."
             ]
 
         ["address", "list", "--help"] `shouldShowUsage`
@@ -460,6 +464,17 @@ spec = do
             , "  --port INT               port used for serving the wallet"
             , "                           API. (default: 8090)"
             , "  --address-index INDEX    A derivation index for the address"
+            ]
+
+        ["address", "import", "--help"] `shouldShowUsage`
+            [ "Usage:  address import [--port INT] WALLET_ID ADDRESS"
+            , "  Import a random address generated elsewhere. Only available for"
+            , "  random wallets. The address must belong to the target wallet."
+            , ""
+            , "Available options:"
+            , "  -h,--help                Show this help text"
+            , "  --port INT               port used for serving the wallet"
+            , "                           API. (default: 8090)"
             ]
 
         ["stake-pool", "list", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -50,8 +50,10 @@ module Test.Integration.Framework.DSL
     , (</>)
     , (!!)
     , emptyRandomWallet
+    , emptyRandomWalletMws
     , emptyRandomWalletWithPasswd
     , emptyIcarusWallet
+    , emptyIcarusWalletMws
     , emptyByronWalletWith
     , emptyWallet
     , emptyWalletWith
@@ -608,11 +610,23 @@ emptyRandomWallet ctx = do
     emptyByronWalletWith ctx "random"
         ("Random Wallet", mnemonic, "Secure Passphrase")
 
+emptyRandomWalletMws :: Context t -> IO (ApiByronWallet, Mnemonic 12)
+emptyRandomWalletMws ctx = do
+    mnemonic <- entropyToMnemonic <$> genEntropy
+    (,mnemonic) <$> emptyByronWalletWith ctx "random"
+        ("Random Wallet", mnemonicToText @12 mnemonic, "Secure Passphrase")
+
 emptyIcarusWallet :: Context t -> IO ApiByronWallet
 emptyIcarusWallet ctx = do
     mnemonic <- mnemonicToText @15 . entropyToMnemonic <$> genEntropy
     emptyByronWalletWith ctx "icarus"
         ("Icarus Wallet", mnemonic, "Secure Passphrase")
+
+emptyIcarusWalletMws :: Context t -> IO (ApiByronWallet, Mnemonic 15)
+emptyIcarusWalletMws ctx = do
+    mnemonic <- entropyToMnemonic <$> genEntropy
+    (,mnemonic) <$> emptyByronWalletWith ctx "icarus"
+        ("Icarus Wallet",mnemonicToText @15 mnemonic, "Secure Passphrase")
 
 emptyRandomWalletWithPasswd :: Context t -> Text -> IO ApiByronWallet
 emptyRandomWalletWithPasswd ctx rawPwd = do

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -119,6 +119,7 @@ module Test.Integration.Framework.DSL
     , getWalletUtxoStatisticsViaCLI
     , getWalletViaCLI
     , createAddressViaCLI
+    , importAddressViaCLI
     , listAddressesViaCLI
     , listStakePoolsViaCLI
     , listWalletsViaCLI
@@ -1397,6 +1398,16 @@ createAddressViaCLI ctx args pass = do
             out <- TIO.hGetContents stdout
             err <- TIO.hGetContents stderr
             pure (c, out, err)
+
+importAddressViaCLI
+    :: forall t r s. (CmdResult r, KnownCommand t, HasType (Port "wallet") s)
+    => s
+    -> [String]
+        -- ^ Args
+    -> IO r
+        -- ^ (ExitCode, StdOut, StdErr)
+importAddressViaCLI ctx args = cardanoWalletCLI @t $
+    ["address", "import", "--port", show (ctx ^. typed @(Port "wallet"))] ++ args
 
 listAddressesViaCLI
     :: forall t r s. (CmdResult r, KnownCommand t, HasType (Port "wallet") s)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -94,7 +94,8 @@ import Prelude
 import Cardano.Wallet
     ( WalletLayer (..), WalletLog )
 import Cardano.Wallet.Api.Types
-    ( ApiAddressT
+    ( ApiAddressIdT
+    , ApiAddressT
     , ApiByronWallet
     , ApiByronWalletMigrationInfo
     , ApiCoinSelectionT
@@ -418,14 +419,22 @@ type PutByronWalletPassphrase = "byron-wallets"
 
 type ByronAddresses n =
     PostByronAddress n
+    :<|> PutByronAddress n
     :<|> ListByronAddresses n
 
--- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronAddress
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/createAddress
 type PostByronAddress n = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> ReqBody '[JSON] ApiPostRandomAddressData
     :> PostCreated '[JSON] (ApiAddressT n)
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/restoreAddress
+type PutByronAddress n = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "addresses"
+    :> Capture "addressId" (ApiAddressIdT n)
+    :> PutNoContent
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronAddresses
 type ListByronAddresses n = "byron-wallets"

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -57,7 +57,8 @@ import Cardano.Wallet.Api
     , Wallets
     )
 import Cardano.Wallet.Api.Types
-    ( ApiAddressT
+    ( ApiAddressIdT
+    , ApiAddressT
     , ApiByronWallet
     , ApiCoinSelectionT
     , ApiEpochNumber
@@ -95,6 +96,8 @@ import Data.Generics.Labels
     ()
 import Data.Proxy
     ( Proxy (..) )
+import Data.Text
+    ( Text )
 import Servant
     ( (:<|>) (..), (:>), NoContent )
 import Servant.Client
@@ -166,6 +169,10 @@ data AddressClient = AddressClient
         :: ApiT WalletId
         -> ApiPostRandomAddressData
         -> ClientM (ApiAddressT Aeson.Value)
+    , putRandomAddress
+        :: ApiT WalletId
+        -> ApiAddressIdT Aeson.Value
+        -> ClientM NoContent
     }
 
 data StakePoolClient = StakePoolClient
@@ -299,6 +306,7 @@ addressClient =
         AddressClient
             { listAddresses = _listAddresses
             , postRandomAddress = \_ _ -> fail "feature unavailable."
+            , putRandomAddress  = \_ _ -> fail "feature unavailable."
             }
 
 
@@ -308,12 +316,14 @@ byronAddressClient
 byronAddressClient =
     let
         _postRandomAddress
+            :<|> _putRandomAddress
             :<|> _listAddresses
             = client (Proxy @("v2" :> ByronAddresses Aeson.Value))
     in
         AddressClient
             { listAddresses = _listAddresses
             , postRandomAddress = _postRandomAddress
+            , putRandomAddress = _putRandomAddress
             }
 
 -- | Produces an 'StakePoolsClient n' working against the /stake-pools API
@@ -354,6 +364,7 @@ networkClient =
 --
 
 type instance ApiAddressT Aeson.Value = Aeson.Value
+type instance ApiAddressIdT Aeson.Value = Text
 type instance ApiCoinSelectionT Aeson.Value = Aeson.Value
 type instance ApiSelectCoinsDataT Aeson.Value = Aeson.Value
 type instance ApiTransactionT Aeson.Value = Aeson.Value

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -93,6 +93,7 @@ import Cardano.Wallet
     , ErrCreateRandomAddress (..)
     , ErrDecodeSignedTx (..)
     , ErrFetchRewards (..)
+    , ErrImportRandomAddress (..)
     , ErrJoinStakePool (..)
     , ErrListTransactions (..)
     , ErrListUTxOStatistics (..)
@@ -1034,7 +1035,9 @@ putRandomAddress
     -> ApiT WalletId
     -> (ApiT Address, Proxy n)
     -> Handler NoContent
-putRandomAddress ctx wid (ApiT addr, _proxy)  = do
+putRandomAddress ctx (ApiT wid) (ApiT addr, _proxy)  = do
+    withWorkerCtx ctx wid liftE liftE
+        $ \wrk -> liftHandler $ W.importRandomAddress @_ @s @k wrk wid addr
     pure NoContent
 
 listAddresses
@@ -2093,6 +2096,20 @@ instance LiftHandler ErrCreateRandomAddress where
             apiError err403 InvalidWalletType $ mconcat
                 [ "I cannot derive new address for this wallet type."
                 , " Make sure to use Byron random wallet id."
+                ]
+
+instance LiftHandler ErrImportRandomAddress where
+    handler = \case
+        ErrImportAddrNoSuchWallet e -> handler e
+        ErrImportAddressNotAByronWallet ->
+            apiError err403 InvalidWalletType $ mconcat
+                [ "I cannot derive new address for this wallet type."
+                , " Make sure to use Byron random wallet id."
+                ]
+        ErrImportAddrDoesNotBelong ->
+            apiError err403 KeyNotFoundForAddress $ mconcat
+                [ "I couldn't identify this address as one of mine. It likely "
+                , "belongs to another wallet and I will therefore not import it."
                 ]
 
 instance LiftHandler (Request, ServerError) where

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -65,6 +65,7 @@ module Cardano.Wallet.Api.Server
     , postTrezorWallet
     , postWallet
     , putByronWalletPassphrase
+    , putRandomAddress
     , putWallet
     , putWalletPassphrase
     , quitStakePool
@@ -1021,6 +1022,20 @@ postRandomAddress ctx (ApiT wid) body = do
     pure $ coerceAddress (addr, Unused)
   where
     coerceAddress (a, s) = ApiAddress (ApiT a, Proxy @n) (ApiT s)
+
+putRandomAddress
+    :: forall ctx s t k n.
+        ( s ~ RndState n
+        , k ~ ByronKey
+        , ctx ~ ApiLayer s t k
+        , PaymentAddress n ByronKey
+        )
+    => ctx
+    -> ApiT WalletId
+    -> (ApiT Address, Proxy n)
+    -> Handler NoContent
+putRandomAddress ctx wid (ApiT addr, _proxy)  = do
+    pure NoContent
 
 listAddresses
     :: forall ctx s t k n.

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -70,13 +70,15 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( WalletId, walletNameMaxLength )
+    ( Address, WalletId, walletNameMaxLength )
 import Control.Arrow
     ( first )
 import Data.Aeson.QQ
     ( aesonQQ )
 import Data.ByteString.Lazy
     ( ByteString )
+import Data.Proxy
+    ( Proxy (..) )
 import Data.String
     ( IsString )
 import Data.Text
@@ -172,6 +174,17 @@ instance Malformed (PathParam ApiEpochNumber) where
         ]
       where
         msg = "I couldn't parse the given epoch number. I am expecting either the word 'latest' or, an integer from 0 to 2147483647."
+
+instance Wellformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
+    wellformed = PathParam
+        "FHnt4NL7yPY7JbfJYSadQVSGJG7EKkN4kpVJMhJ8CN3uDNymGnJuuwcHmyP4ouZ"
+
+instance Malformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
+    malformed = first PathParam <$>
+        [ ( "NOT-AN-ADDRESS"
+          , "Unable to decode Address: encoding is neither Bech32 nor Base58."
+          )
+        ]
 
 --
 -- Class instances (BodyParam)

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -211,6 +211,7 @@ server byron icarus shelley spl ntp =
     byronAddresses =
              (\_ _ -> throwError err501)
         :<|> (\_ _ -> throwError err501)
+        :<|> (\_ _ -> throwError err501)
 
     byronTransactions :: Server (ByronTransactions n)
     byronTransactions =

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -168,6 +168,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
             (hsPkgs."command" or (buildDepError "command"))
             (hsPkgs."generic-lens" or (buildDepError "generic-lens"))
             (hsPkgs."hspec" or (buildDepError "hspec"))
+            (hsPkgs."http-api-data" or (buildDepError "http-api-data"))
             (hsPkgs."http-client" or (buildDepError "http-client"))
             (hsPkgs."http-types" or (buildDepError "http-types"))
             (hsPkgs."iohk-monitoring" or (buildDepError "iohk-monitoring"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1144,6 +1144,15 @@ x-parametersStakePoolId: &parametersStakePoolId
     maxLength: 64
     minLength: 64
 
+x-parametersAddressId:  &parametersAddressId
+  in: path
+  name: addressId
+  required: true
+  schema:
+    type: string
+    format: base58
+    example: DdzFFzCqrhtCNjPk5Lei7E1FxnoqMoAYtJ8VjAWbFmDb614nNBWBwv3kt6QHJa59cGezzf6piMWsbK7sWRB5sv325QqWdRuusMqqLdMt
+
 x-parametersStartDate: &parametersStartDate
   in: query
   name: start
@@ -1597,6 +1606,13 @@ x-responsesPostRandomAddress: &responsesPostRandomAddress
       application/json:
         schema: *ApiAddress
 
+x-responsesPutRandomAddress: &responsesPutRandomAddress
+  <<: *responsesErr400
+  <<: *responsesErr403
+  <<: *responsesErr405
+  204:
+    description: No Content
+
 #############################################################################
 #                                                                           #
 #                                  PATHS                                    #
@@ -2030,6 +2046,22 @@ paths:
             application/json:
               schema: *ApiPostRandomAddressData
         responses: *responsesPostRandomAddress
+
+  /byron-wallets/{walletId}/addresses/{addressId}:
+      put:
+        operationId: restoreAddress
+        tags: ["Byron Addresses"]
+        summary: Restore Address
+        description: |
+          <p align="right">status: <strong>stable</strong></p>
+
+          ⚠️  This endpoint is available for `random` wallets only. Any
+          attempt to call this endpoint on another type of wallet will result in
+          a `403 Forbidden` error from the server.
+        parameters:
+          - *parametersWalletId
+          - *parametersAddressId
+        responses: *responsesPutRandomAddress
 
   /byron-wallets/{walletId}/transactions:
     get:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2049,9 +2049,9 @@ paths:
 
   /byron-wallets/{walletId}/addresses/{addressId}:
       put:
-        operationId: restoreAddress
+        operationId: importAddress
         tags: ["Byron Addresses"]
-        summary: Restore Address
+        summary: Import Address
         description: |
           <p align="right">status: <strong>stable</strong></p>
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-292

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- f71d8a890417cc0d029dbebba43337a3951d979b
  :round_pushpin: **add 'putRandomAddress' to the swagger specifications and API servant definition**
  
- db29babc7fdeff92133a48ed40196b04aa81affe
  :round_pushpin: **write dummy server implementation for 'putRandomAddress' and fill the gap in various APIs**
  
- 46aa7c5c14dfa0a8865eda0fab7575805f4c6309
  :round_pushpin: **add integration tests for byron address restoration**
  
- 3f255e77a21b5ea4d2635a6378fa020531be1860
  :round_pushpin: **implement server and application handlers for importing an address**
  
- f7ba8fb485946175ca85775e675c7989c0eafed8
  :round_pushpin: **add command for 'address import' mapping to the newly introduced endpoint**
  
- 2ae81f6049425cdfa8892cd6c0ada71306cc2f62
  :round_pushpin: **add some integration tests scenario for 'address import'**

- 73294aeb92297b890e0a67d9848dbdaf7c359fae
  :round_pushpin: **fix non-atomic checkpoint modification in {import,create}RandomAddress**
    This is subtle but, everytime we are tempted to write:

  ```hs
  cp <- atomically $ readCheckpoint wid
  {- Do some stuff... -}
  atomically $ putCheckpoint wid cp'
  ```

  we should in reality really go for:

  ```hs
  atomically $ do
    cp <- readCheckpoint wid
    {- Do some stuff... -}
    putCheckpoint wid cp'
  ```

  because there's no guarantee that the checkpoint hasn't already
  changed between the moment we fetched it, and the moment we insert a
  modification. This could have disastreous effects like actually
  updating a checkpoint in the past while a new one has already been
  created with now oudated data; or worse, in the case of EBB, it'll
  simply override the newly written checkpoint and makes the database
  silently roll back of exactly 1 block!

# Comments

<!-- Additional comments or screenshots to attach if any -->

![Screenshot from 2020-05-08 18-05-25](https://user-images.githubusercontent.com/5680256/81424623-89014c00-9156-11ea-9a33-a4e6fb3fcd50.png)

```
$ cardano-wallet-byron address import --help
Usage: cardano-wallet-byron address import [--port INT] WALLET_ID ADDRESS
  Import a random address generated elsewhere. Only available for random
  wallets. The address must belong to the target wallet.

Available options:
  -h,--help                Show this help text
  --port INT               port used for serving the wallet API. (default: 8090)
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
