### PR TITLE
Run multiple coin selections to estimate fees

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -263,7 +263,7 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
             }
     verify r
         [ expectResponseCode HTTP.status202
-        , expectField #amount $ between (Quantity feeMin, Quantity feeMax)
+        , expectField #estimatedMin $ between (Quantity feeMin, Quantity feeMax)
         ]
   where
     title = "TRANS_ESTIMATE_01/02 - " ++ show (length fixtures) ++ " recipient(s)"
@@ -422,7 +422,7 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
             }
     verify r
         [ expectResponseCode HTTP.status202
-        , expectField #amount $ between (Quantity feeMin, Quantity feeMax)
+        , expectField #estimatedMin $ between (Quantity feeMin, Quantity feeMax)
         ]
   where
     title = "TRANS_ESTIMATE_04 - Can't cover fee"

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
@@ -582,7 +582,9 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
             , nChanges = length fixtures
             }
     verify r
-        [ expectCliField #amount $ between (Quantity feeMin, Quantity feeMax) ]
+        [ expectCliField #estimatedMin $
+            between (Quantity feeMin, Quantity feeMax)
+        ]
   where
     title = "CLI_TRANS_ESTIMATE_01/02 - " ++ show (length fixtures) ++ " recipient(s)"
 
@@ -751,7 +753,9 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
             , nChanges = 0
             }
     verify r
-        [ expectCliField #amount $ between (Quantity feeMin, Quantity feeMax) ]
+        [ expectCliField #estimatedMin $
+            between (Quantity feeMin, Quantity feeMax)
+        ]
   where
     title = "CLI_TRANS_ESTIMATE_04 - Can't cover fee"
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -626,7 +626,7 @@ spec = do
         verify r
             [ expectSuccess
             , expectResponseCode HTTP.status202
-            , expectField (#amount . #getQuantity) $
+            , expectField (#estimatedMin . #getQuantity) $
                 between (feeMin - amt, feeMax + amt)
             ]
 
@@ -664,7 +664,7 @@ spec = do
             (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
-            , expectField (#amount . #getQuantity) $
+            , expectField (#estimatedMin . #getQuantity) $
                 between (feeMin - (2*amt), feeMax + (2*amt))
             ]
 
@@ -706,7 +706,7 @@ spec = do
             (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
-            , expectField (#amount . #getQuantity) $
+            , expectField (#estimatedMin . #getQuantity) $
                 between (feeMin - (2*amt), feeMax + (2*amt))
             ]
 
@@ -764,7 +764,7 @@ spec = do
             (Link.getTransactionFee @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
-            , expectField (#amount . #getQuantity) $
+            , expectField (#estimatedMin . #getQuantity) $
                 between (feeMin - amt, feeMax + amt)
             ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -237,7 +237,7 @@ spec = do
             err `shouldBe` cmdOk
             txJson <- expectValidJSON (Proxy @ApiFee) out
             verify txJson
-                [ expectCliField (#amount . #getQuantity) $
+                [ expectCliField (#estimatedMin . #getQuantity) $
                     between (feeMin - amt, feeMax + amt)
                 ]
             code `shouldBe` ExitSuccess

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -485,7 +485,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliField (#amount . #getQuantity) $
+            [ expectCliField (#estimatedMin . #getQuantity) $
                 between (feeMin - amt, feeMax + amt)
             ]
         c `shouldBe` ExitSuccess
@@ -511,7 +511,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliField (#amount . #getQuantity) $
+            [ expectCliField (#estimatedMin . #getQuantity) $
                 between (feeMin, feeMax)
             ]
         c `shouldBe` ExitSuccess
@@ -540,7 +540,7 @@ spec = do
         err `shouldBe` "Ok.\n"
         txJson <- expectValidJSON (Proxy @ApiFee) out
         verify txJson
-            [ expectCliField (#amount . #getQuantity) $
+            [ expectCliField (#estimatedMin . #getQuantity) $
                 between (feeMin, feeMax)
             ]
         c `shouldBe` ExitSuccess

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -84,6 +84,7 @@ library
     , servant-client
     , servant-server
     , split
+    , statistics
     , stm
     , streaming-commons
     , template-haskell

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -95,6 +95,7 @@ module Cardano.Wallet
     -- ** Payment
     , selectCoinsExternal
     , selectCoinsForPayment
+    , estimateFeeForPayment
     , signPayment
     , ErrSelectCoinsExternal (..)
     , ErrSelectForPayment (..)
@@ -112,6 +113,7 @@ module Cardano.Wallet
     , joinStakePool
     , quitStakePool
     , selectCoinsForDelegation
+    , estimateFeeForDelegation
     , signDelegation
     , guardJoin
     , guardQuit
@@ -121,6 +123,10 @@ module Cardano.Wallet
     , ErrCannotQuit (..)
     , ErrSelectForDelegation (..)
     , ErrSignDelegation (..)
+
+    -- ** Fee Estimation
+    , FeeEstimation (..)
+    , estimateFeeForCoinSelection
 
     -- ** Transaction
     , forgetPendingTx
@@ -214,7 +220,11 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , shrinkPool
     )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
+    ( CoinSelection (..)
+    , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
+    , feeBalance
+    )
 import Cardano.Wallet.Primitive.CoinSelection.Migration
     ( depleteUTxO, idealBatchSize )
 import Cardano.Wallet.Primitive.Fee
@@ -292,7 +302,7 @@ import Cardano.Wallet.Transaction
 import Control.Exception
     ( Exception )
 import Control.Monad
-    ( forM, forM_, unless, when )
+    ( forM, forM_, replicateM, unless, when )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Monad.Trans.Class
@@ -309,6 +319,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Coerce
     ( coerce )
+import Data.Either
+    ( partitionEithers )
 import Data.Either.Extra
     ( eitherToMaybe )
 import Data.Foldable
@@ -347,6 +359,8 @@ import Numeric.Natural
     ( Natural )
 import Safe
     ( lastMay )
+import Statistics.Quantile
+    ( medianUnbiased, quantiles )
 
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
 import qualified Cardano.Wallet.Primitive.CoinSelection.Random as CoinSelection
@@ -356,6 +370,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
+import qualified Data.Vector as V
 
 -- $Development
 -- __Naming Conventions__
@@ -1068,6 +1083,20 @@ selectCoinsForDelegation ctx wid = do
     tl = ctx ^. transactionLayer @t @k
     tr = ctx ^. logger @WalletLog
 
+-- | Estimate fee for 'selectCoinsForDelegation'.
+estimateFeeForDelegation
+    :: forall ctx s t k.
+        ( HasTransactionLayer t k ctx
+        , HasLogger WalletLog ctx
+        , HasDBLayer s k ctx
+        )
+    => ctx
+    -> WalletId
+    -> ExceptT ErrSelectForDelegation IO FeeEstimation
+estimateFeeForDelegation ctx wid =
+    estimateFeeForCoinSelection $
+    selectCoinsForDelegation @_ @s @t @k ctx wid
+
 -- | Constructs a set of coin selections that select all funds from the given
 --   source wallet, returning them as change.
 --
@@ -1099,6 +1128,22 @@ selectCoinsForMigration ctx wid = do
         _ -> throwE (ErrSelectForMigrationEmptyWallet wid)
   where
     tl = ctx ^. transactionLayer @t @k
+
+-- | Estimate fee for 'selectCoinsForPayment'.
+estimateFeeForPayment
+    :: forall ctx s t k e.
+        ( HasTransactionLayer t k ctx
+        , HasLogger WalletLog ctx
+        , HasDBLayer s k ctx
+        , e ~ ErrValidateSelection t
+        )
+    => ctx
+    -> WalletId
+    -> NonEmpty TxOut
+    -> ExceptT (ErrSelectForPayment e) IO FeeEstimation
+estimateFeeForPayment ctx wid recipients =
+    estimateFeeForCoinSelection $
+    selectCoinsForPayment @_ @s @t @k ctx wid recipients
 
 -- | Augments the given outputs with new outputs. These new outputs corresponds
 -- to change outputs to which new addresses are being assigned to. This updates
@@ -1559,6 +1604,59 @@ quitStakePool ctx wid argGenChange pwd = db & \DBLayer{..} -> do
     pure (tx, txMeta, txTime)
   where
     db = ctx ^. dbLayer @s @k
+
+{-------------------------------------------------------------------------------
+                                 Fee Estimation
+-------------------------------------------------------------------------------}
+
+-- | Result of a fee estimation process given a wallet and payment order.
+data FeeEstimation = FeeEstimation
+    { estMinFee :: Word64
+    -- ^ Most coin selections will result in a fee higher than this.
+    , estMaxFee :: Word64
+    -- ^ Most coin selections will result in a fee lower than this.
+    } deriving (Show, Eq)
+
+-- | Estimate the transaction fee for a given coin selection algorithm by
+-- repeatedly running it (100 times) and collecting the results. In the returned
+-- 'FeeEstimation', the minimum fee is that which 90% of the sampled fees are
+-- greater than. The maximum fee is the highest fee observed in the samples.
+estimateFeeForCoinSelection
+    :: forall m err. Monad m
+    => ExceptT err m CoinSelection
+    -> ExceptT err m FeeEstimation
+estimateFeeForCoinSelection
+    = fmap deciles
+    . handleErrors
+    . replicateM repeats
+    . runExceptT
+    . fmap feeBalance
+  where
+    -- Use method R-8 from to get top 90%.
+    -- https://en.wikipedia.org/wiki/Quantile#Estimating_quantiles_from_a_sample
+    deciles = mkFeeEstimation
+        . map round
+        . V.toList
+        . quantiles medianUnbiased (V.fromList [1, 10]) 10
+        . V.fromList
+        . map fromIntegral
+    mkFeeEstimation [a,b] = FeeEstimation a b
+    mkFeeEstimation _ = error "estimateFeeForCoinSelection: impossible"
+
+    -- Remove failed coin selections from samples. Unless they all failed, in
+    -- which case pass on the error.
+    handleErrors :: m [Either err a] -> ExceptT err m [a]
+    handleErrors = ExceptT . fmap skipFailed
+      where
+        skipFailed samples = case partitionEithers samples of
+            ([], []) ->
+                error "estimateFeeForCoinSelection: impossible empty list"
+            ((e:_), []) ->
+                Left e
+            (_, samples') ->
+                Right samples'
+
+    repeats = 100 -- TODO: modify repeats based on data
 
 {-------------------------------------------------------------------------------
                                   Key Store

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -497,8 +497,9 @@ newtype PostExternalTransactionData = PostExternalTransactionData
     { payload :: ByteString
     } deriving (Eq, Generic, Show)
 
-newtype ApiFee = ApiFee
-    { amount :: (Quantity "lovelace" Natural)
+data ApiFee = ApiFee
+    { estimatedMin :: !(Quantity "lovelace" Natural)
+    , estimatedMax :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
 
 data ApiEpochNumber =

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiFee.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiFee.json
@@ -1,63 +1,103 @@
 {
-    "seed": 5688188066260266317,
+    "seed": 508417423620240746,
     "samples": [
         {
-            "amount": {
-                "quantity": 129,
+            "estimated_min": {
+                "quantity": 60,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 84,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 125,
+            "estimated_min": {
+                "quantity": 96,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 9,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
+            "estimated_min": {
                 "quantity": 10,
                 "unit": "lovelace"
-            }
-        },
-        {
-            "amount": {
-                "quantity": 208,
+            },
+            "estimated_max": {
+                "quantity": 58,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 1,
+            "estimated_min": {
+                "quantity": 66,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 41,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 24,
+            "estimated_min": {
+                "quantity": 31,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 48,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 47,
+            "estimated_min": {
+                "quantity": 4,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 55,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 171,
+            "estimated_min": {
+                "quantity": 40,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 180,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 225,
+            "estimated_min": {
+                "quantity": 88,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 228,
                 "unit": "lovelace"
             }
         },
         {
-            "amount": {
-                "quantity": 173,
+            "estimated_min": {
+                "quantity": 76,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 136,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "estimated_min": {
+                "quantity": 179,
+                "unit": "lovelace"
+            },
+            "estimated_max": {
+                "quantity": 67,
                 "unit": "lovelace"
             }
         }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -772,7 +772,8 @@ spec = do
         it "ApiFee" $ property $ \x ->
             let
                 x' = ApiFee
-                    { amount = amount (x :: ApiFee)
+                    { estimatedMin = estimatedMin (x :: ApiFee)
+                    , estimatedMax = estimatedMax (x :: ApiFee)
                     }
             in
                 x' === x .&&. show x' === show x

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/StakePools.hs
@@ -572,7 +572,7 @@ spec = do
         verify r
             [ expectResponseCode HTTP.status200
             ]
-        let fee = getFromResponse #amount r
+        let fee = getFromResponse #estimatedMin r
         joinStakePool @n ctx (p ^. #id) (w, fixturePassphrase) >>= flip verify
             [ expectField #amount (`shouldBe` fee)
             ]
@@ -584,7 +584,7 @@ spec = do
         let (fee, _) = ctx ^. #_feeEstimator $ DelegDescription 2 1 1
         verify r
             [ expectResponseCode HTTP.status200
-            , expectField #amount (`shouldBe` Quantity fee)
+            , expectField #estimatedMin (`shouldBe` Quantity fee)
             ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_02 - \

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -111,6 +111,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."servant-client" or (buildDepError "servant-client"))
           (hsPkgs."servant-server" or (buildDepError "servant-server"))
           (hsPkgs."split" or (buildDepError "split"))
+          (hsPkgs."statistics" or (buildDepError "statistics"))
           (hsPkgs."stm" or (buildDepError "stm"))
           (hsPkgs."streaming-commons" or (buildDepError "streaming-commons"))
           (hsPkgs."template-haskell" or (buildDepError "template-haskell"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -766,9 +766,11 @@ components:
     ApiFee: &ApiFee
       type: object
       required:
-        - amount
+        - estimated_min
+        - estimated_max
       properties:
-        amount: *transactionAmount
+        estimated_min: *transactionAmount
+        estimated_max: *transactionAmount
 
     ApiTxId: &ApiTxId
       type: object
@@ -1788,7 +1790,12 @@ paths:
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
-        Estimate fee for the transaction.
+        Estimate fee for the transaction. The estimate is made by
+        assembling multiple transactions and analyzing the
+        distribution of their fees. The estimated_max is the highest
+        fee observed, and the estimated_min is the fee which is lower
+        than at least 90% of the fees observed.
+
       parameters:
         - *parametersWalletId
       requestBody:


### PR DESCRIPTION
### Issue Number

Relates to ADP-283 / #1648.

### Overview

- Extends `POST /wallets/{id}/payment-fees` API endpoint with a "better" estimation. Adds fields for expected minimum and maximum fees.

### Comments

- [x] decide on whether the api change should be breaking or backwards compatible
- [x] also do similar fee estimation for delegation transactions
- [x] better handling of coin selection errors while sampling
- [ ] determine how many samples to take, or a criteria for stopping sampling.
- [x] decide on quantile calculation method (currently using median).
- [x] unit test `estimateFeeForCoinSelection`
