### PR TITLE
Testing Support bech32 encoding

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -233,7 +233,7 @@ spec = do
             , ""
             , "Keys are read from standard input for convenient chaining of commands."
             , ""
-            , "Bech32- and hexadecimal encodings are supported."
+            , "Bech32 and hexadecimal encodings are supported."
             , ""
             , "Example:"
             , "$ " ++ name ++ " key root --wallet-style icarus --encoding bech32 -- express theme celery coral permit ... \\"
@@ -542,8 +542,8 @@ spec = do
             ]
 
         ["key", "root", "--help"] `shouldShowUsage`
-            [ "Usage:  key root [--wallet-style WALLET_STYLE] MNEMONIC_WORD..."
-            , "                 [--encoding KEY-ENCODING]"
+            [ "Usage:  key root [--wallet-style WALLET_STYLE]"
+            , "                 [--encoding KEY-ENCODING] MNEMONIC_WORD..."
             , "  Extract root extended private key from a mnemonic sentence."
             , ""
             , "Available options:"
@@ -553,6 +553,8 @@ spec = do
             , "                             icarus (15 mnemonic words)"
             , "                             trezor (12, 15, 18, 21 or 24 mnemonic words)"
             , "                             ledger (12, 15, 18, 21 or 24 mnemonic words)"
+            , "  --encoding KEY-ENCODING  Either 'hex' or 'bech32' (default:"
+            , "                           hex)"
             ]
 
         ["key", "child", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Keys.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Keys.hs
@@ -23,6 +23,15 @@ spec  = do
         let childPub = "xpub12vr8xuljuc0z4snfjjq6hcnx02t5qkegku6ygncqy7xkhx4s7gwq3ulfrded8x7n5ykegc3u2cvlenjpl5y35k0633m8yluke5fu8cg3dfa0p"
         let childPubHex = "53067373f2e61e2ac2699481abe2667a97405b28b734444f00278d6b9ab0f21c08f3e91b72d39bd3a12d94623c5619fcce41fd091a59fa8c76727f96cd13c3e1"
 
+        let expectedInspect = mconcat
+                [ "extended public key: "
+                , "53067373f2e61e2ac2699481abe2667a97405b28b734444f00278d6b9ab0f21c"
+                , "\n"
+                , "chain code: "
+                , "08f3e91b72d39bd3a12d94623c5619fcce41fd091a59fa8c76727f96cd13c3e1"
+                , "\n"
+                ]
+
         it "derive bech32 public child key from mnemonic" $ do
             res <- key (["root", "--encoding", "bech32", "--"] ++ mw) ""
                 >>= key ["child", "--path", "0H/0H"]
@@ -35,20 +44,20 @@ spec  = do
                 >>= key ["public"]
                 >>= key ["child", "--path", "0"]
             res `shouldBe` (childPubHex ++ "\n")
-        it "inspect the final result" $ do
+        it "inspect the final hex result" $ do
             res <- key (["root", "--"] ++ mw) ""
                 >>= key ["child", "--path", "0H/0H"]
                 >>= key ["public"]
                 >>= key ["child", "--path", "0"]
                 >>= key ["inspect"]
-            res `shouldBe` (mconcat
-                [ "extended public key: "
-                , "53067373f2e61e2ac2699481abe2667a97405b28b734444f00278d6b9ab0f21c"
-                , "\n"
-                , "chain code: "
-                , "08f3e91b72d39bd3a12d94623c5619fcce41fd091a59fa8c76727f96cd13c3e1"
-                , "\n"
-                ])
+            res `shouldBe` expectedInspect
+        it "inspect the final bech32 result" $ do
+            res <- key (["root", "--encoding", "bech32", "--"] ++ mw) ""
+                >>= key ["child", "--path", "0H/0H"]
+                >>= key ["public"]
+                >>= key ["child", "--path", "0"]
+                >>= key ["inspect"]
+            res `shouldBe` expectedInspect
 
     describe "key child" $ do
         let rootXPrv = "588102383ed9ecc5c44e1bfa18d1cf8ef19a7cf806a20bb4cbbe4e5\


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/1603

# Overview

- 00306f0fc1993c2379f2c7789db50da58837c2f2
  Polish key CLI help
  
- 285add3b45023b92a93812a10bcc37ad153d82ab
  Additional integration test for inspecting bech32 result

# Comments

Before:

```
$ cardano-wallet-jormungandr key root
Usage: cardano-wallet-jormungandr key root [--wallet-style WALLET_STYLE]
                                           MNEMONIC_WORD...
                                           [--encoding KEY-ENCODING]
  Extract root extended private key from a mnemonic sentence.

Available options:
  -h,--help                Show this help text
  --wallet-style WALLET_STYLE
                           Any of the following (default: icarus)
                             icarus (15 mnemonic words)
                             trezor (12, 15, 18, 21 or 24 mnemonic words)
                             ledger (12, 15, 18, 21 or 24 mnemonic words)
```


After:

```
$ cardano-wallet-jormungandr key root
Usage: cardano-wallet-jormungandr key root [--wallet-style WALLET_STYLE]
                                           [--encoding KEY-ENCODING]
                                           MNEMONIC_WORD...
  Extract root extended private key from a mnemonic sentence.

Available options:
  -h,--help                Show this help text
  --wallet-style WALLET_STYLE
                           Any of the following (default: icarus)
                             icarus (15 mnemonic words)
                             trezor (12, 15, 18, 21 or 24 mnemonic words)
                             ledger (12, 15, 18, 21 or 24 mnemonic words)
  --encoding KEY-ENCODING  Either 'hex' or 'bech32' (default: hex)

```

Also updated:
 - https://github.com/input-output-hk/cardano-wallet/wiki/Wallet-command-line-interface#key-root
 - https://github.com/input-output-hk/cardano-wallet/wiki/Wallet-Command-Line-Interface-(cardano-wallet-byron)#key-root