### PR TITLE
Remove xPrvFromStrippedPubXPrvCheckRoundtrip and related

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -675,13 +675,11 @@ spec = do
                     (Left "Expected extended private key to be 96 bytes \
                           \but got 64 bytes.")
 
-            -- TODO: Make the error message match the previous case.
-            -- This one currently comes from cardano-crypto.
             it "xprv pretending to be xpub fails" $ do
                 decodeAnyKey notAXPub
                     `shouldBe`
-                    (Left "error: xprv needs to be 64 bytes: \
-                          \got 96 bytes")
+                    (Left "Expected extended public key to be 64 bytes \
+                          \but got 96 bytes.")
 
     describe "Transaction ID decoding from text" $ do
 


### PR DESCRIPTION
# Issue Number

#1637, relates to PR #1640 

# Overview

- [x] `xPrvFromStrippedPubXPrvCheckRoundtrip` and related functions no longer serve any purpose and can be removed.


# Comments

- They were introduced do cope with the underlying function silently modifying the keys. `xprvFromBytes` in cardano-addresses will not modify the keys.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
