### PR TITLE
Use port 9090 on migration tests not to interfere with any wallet tests that run on default port

### DIFF
--- a/lib/jormungandr/test/migration/migration-test.hs
+++ b/lib/jormungandr/test/migration/migration-test.hs
@@ -83,7 +83,7 @@ main = do
 
     cfg <- defaultConfigStdout
     withTrace cfg "migration-test" $ \tr ->
-        testMain @('Testnet 0) tr 8090 testAction launchArgs >>= exitWith
+        testMain @('Testnet 0) tr 9090 testAction launchArgs >>= exitWith
 
 -- | Something to do while the server is running.
 type TestAction (t :: NetworkDiscriminant) = Trace IO Text -> ApiBase -> IO ExitCode

--- a/nix/launch-migration-test.sh
+++ b/nix/launch-migration-test.sh
@@ -33,4 +33,4 @@ fi
 cardano-wallet-jormungandr version
 jormungandr --version
 
-exec migration-test $1 launch --state-dir $stateDir --genesis-block $genesisDataDir/block0.bin -- --secret $genesisDataDir/secret.yaml --config $configFile
+exec migration-test $1 launch --port 9090 --state-dir $stateDir --genesis-block $genesisDataDir/block0.bin -- --secret $genesisDataDir/secret.yaml --config $configFile


### PR DESCRIPTION


# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/1649#issuecomment-626641522

# Overview

- 9faa90bae1ef79d9866db89bf2028b199765cbff
  Use port 9090 on migration tests not to interfere with any wallet tests that run on default port
  


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
