### PR TITLE
Time and space optimization of address persistence

### DIFF
--- a/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
+++ b/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any.hs
@@ -43,7 +43,7 @@ import Data.Text
 import Data.Word
     ( Word32 )
 import Database.Persist.Sql
-    ( entityVal, insert_, selectFirst, (==.) )
+    ( deleteWhere, entityVal, insert_, selectFirst, (==.), (>.) )
 import GHC.Generics
     ( Generic )
 
@@ -99,6 +99,10 @@ instance PersistState AnyAddressState where
             , DB.AnyAddressStateCheckpointSlot ==. sl
             ] []
         return (AnyAddressState s)
+    deleteState (wid, sl) = deleteWhere
+        [ DB.AnyAddressStateWalletId ==. wid
+        , DB.AnyAddressStateCheckpointSlot >. sl
+        ]
 
 initAnyState :: Text -> Double -> (WalletId, WalletName, AnyAddressState)
 initAnyState wname p = (walletId cfg, WalletName wname, cfg)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -132,6 +132,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Set
+    ( Set )
 import Data.Text.Class
     ( ToText (..), fromText )
 import Data.Typeable
@@ -180,6 +182,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
 
@@ -509,6 +512,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile = do
                         [ TxMetaDirection ==. W.Incoming
                         , TxMetaSlot >. nearestPoint
                         ]
+                    deleteState @s (wid, nearestPoint)
                     pure (Right nearestPoint)
 
         , prune = \(PrimaryKey wid) -> ExceptT $ do
@@ -1115,6 +1119,8 @@ class PersistState s where
     insertState :: (W.WalletId, W.SlotId) -> s -> SqlPersistT IO ()
     -- | Load the state for a checkpoint.
     selectState :: (W.WalletId, W.SlotId) -> SqlPersistT IO (Maybe s)
+    -- | Delete any state beyond the given slot
+    deleteState :: (W.WalletId, W.SlotId) -> SqlPersistT IO ()
 
 {-------------------------------------------------------------------------------
                           Sequential address discovery
@@ -1160,16 +1166,26 @@ instance
         pendingChangeIxs <- lift $ selectSeqStatePendingIxs wid
         pure $ Seq.SeqState intPool extPool pendingChangeIxs rewardXPub
 
+    deleteState (wid, sl) = deleteWhere
+        [ SeqStateAddressWalletId ==. wid
+        , SeqStateAddressSlot >. sl
+        ]
+
 insertAddressPool
     :: forall n k c. (PaymentAddress n k, Typeable c)
     => W.WalletId
     -> W.SlotId
     -> Seq.AddressPool c k
     -> SqlPersistT IO ()
-insertAddressPool wid sl pool =
+insertAddressPool wid sl pool = do
+    maxIx <- fmap (seqStateAddressIndex . entityVal) <$> selectFirst
+        [ SeqStateAddressWalletId ==. wid
+        , SeqStateAddressAccountingStyle ==. Seq.accountingStyle @c
+        ] [Desc SeqStateAddressIndex]
     void $ dbChunked insertMany_
         [ SeqStateAddress wid sl addr ix (Seq.accountingStyle @c)
         | (ix, addr) <- zip [0..] (Seq.addresses (liftPaymentAddress @n) pool)
+        , Just ix > maxIx
         ]
 
 selectAddressPool
@@ -1187,7 +1203,7 @@ selectAddressPool
 selectAddressPool wid sl gap xpub = do
     addrs <- fmap entityVal <$> selectList
         [ SeqStateAddressWalletId ==. wid
-        , SeqStateAddressSlot ==. sl
+        , SeqStateAddressSlot <=. sl
         , SeqStateAddressAccountingStyle ==. Seq.accountingStyle @c
         ] [Asc SeqStateAddressIndex]
     pure $ addressPoolFromEntity addrs
@@ -1233,9 +1249,7 @@ instance PersistState (Rnd.RndState t) where
         insertRndStatePending wid (Rnd.pendingAddresses st)
 
     selectState (wid, sl) = runMaybeT $ do
-        st <- MaybeT $ selectFirst
-            [ RndStateWalletId ==. wid
-            ] []
+        st <- MaybeT $ selectFirst [ RndStateWalletId ==. wid ] []
         let (RndState _ ix gen (HDPassphrase pwd)) = entityVal st
         addresses <- lift $ selectRndStateAddresses wid sl
         pendingAddresses <- lift $ selectRndStatePending wid
@@ -1262,16 +1276,33 @@ instance PersistState (Rnd.RndState t) where
             , gen = gen
             }
 
+    deleteState (wid, sl) = deleteWhere
+        [ RndStateAddressWalletId ==. wid
+        , RndStateAddressSlot >. sl
+        ]
+
 insertRndStateAddresses
     :: W.WalletId
     -> W.SlotId
     -> RndStateAddresses
     -> SqlPersistT IO ()
 insertRndStateAddresses wid sl addresses = do
+    known <- pack . fmap entityVal <$> selectList
+        [ RndStateAddressWalletId ==. wid ]
+        []
+    let unknown = addresses `Map.withoutKeys` known
     dbChunked insertMany_
         [ RndStateAddress wid sl accIx addrIx addr
-        | ((W.Index accIx, W.Index addrIx), addr) <- Map.assocs addresses
+        | ((Index accIx, Index addrIx), addr) <- Map.assocs unknown
         ]
+  where
+    pack :: [RndStateAddress] -> Set Rnd.DerivationPath
+    pack = foldr (Set.insert . toDerivationPath) Set.empty
+      where
+        toDerivationPath x =
+            ( Index $ rndStateAddressAccountIndex x
+            , Index $ rndStateAddressIndex x
+            )
 
 insertRndStatePending
     :: W.WalletId
@@ -1291,7 +1322,7 @@ selectRndStateAddresses
 selectRndStateAddresses wid sl = do
     addrs <- fmap entityVal <$> selectList
         [ RndStateAddressWalletId ==. wid
-        , RndStateAddressSlot ==. sl
+        , RndStateAddressSlot <=. sl
         ] []
     pure $ Map.fromList $ map assocFromEntity addrs
   where

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -211,7 +211,7 @@ SeqStateAddress
         seqStateAddressAddress
         seqStateAddressIndex
         seqStateAddressAccountingStyle
-    Foreign Checkpoint seq_state_address seqStateAddressWalletId seqStateAddressSlot ! ON DELETE CASCADE
+    Foreign Wallet seq_state_address seqStateAddressWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Sequential address discovery scheme -- pending change indexes
@@ -249,7 +249,7 @@ RndStateAddress
         rndStateAddressAccountIndex
         rndStateAddressIndex
         rndStateAddressAddress
-    Foreign Checkpoint rnd_state_address rndStateAddressWalletId rndStateAddressSlot ! ON DELETE CASCADE
+    Foreign Wallet rnd_state_address rndStateAddressWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- The set of pending change addresses.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -24,6 +24,7 @@ module Cardano.Wallet.Primitive.AddressDiscovery.Random
     (
     -- ** State
       RndState (..)
+    , DerivationPath
     , mkRndState
 
     -- ** Low-level API

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -103,6 +103,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , WalletPassphraseInfo (..)
     , flatSlot
+    , fromFlatSlot
     , isPending
     , rangeIsValid
     , slotSucc
@@ -148,7 +149,7 @@ import GHC.Generics
 import System.IO.Unsafe
     ( unsafePerformIO )
 import System.Random
-    ( mkStdGen )
+    ( mkStdGen, random, randoms )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
@@ -164,9 +165,11 @@ import Test.QuickCheck
     , generate
     , genericShrink
     , oneof
+    , resize
     , scale
     , shrinkIntegral
     , shrinkList
+    , sized
     , vector
     , vectorOf
     )
@@ -295,7 +298,7 @@ instance Arbitrary MockChain where
 instance GenState s => Arbitrary (InitialCheckpoint s) where
     shrink (InitialCheckpoint cp) = InitialCheckpoint <$> shrink cp
     arbitrary = do
-        cp <- arbitrary @(Wallet s)
+        cp <- resize 0 $ arbitrary @(Wallet s)
         pure $ InitialCheckpoint $ unsafeInitWallet
             (utxo cp)
             (block0 ^. #header)
@@ -342,9 +345,9 @@ instance Arbitrary PassphraseScheme where
 -------------------------------------------------------------------------------}
 
 instance Arbitrary BlockHeader where
-    arbitrary = do
-        sid@(SlotId (EpochNo ep) (SlotNo sl)) <- arbitrary
-        let h = fromIntegral sl + fromIntegral ep * arbitraryEpochLength
+    arbitrary = sized $ \n -> do
+        let h = fromIntegral n
+        let sid = fromFlatSlot (EpochLength arbitraryEpochLength) (fromIntegral h)
         blockH <- arbitrary
         pure $ BlockHeader sid (Quantity h) blockH (coerce blockH)
 
@@ -530,17 +533,31 @@ arbitraryRewardAccount =
                                  Random State
 -------------------------------------------------------------------------------}
 
+{- HLINT ignore "Use !!" -}
 instance Arbitrary (RndState 'Mainnet) where
     shrink (RndState k ix addrs pending g) =
         [ RndState k ix' addrs' pending' g
         | (ix', addrs', pending') <- shrink (ix, addrs, pending)
         ]
-    arbitrary = RndState
-        <$> pure (Passphrase "passphrase")
-        <*> pure minBound
-        <*> arbitrary
-        <*> (pure mempty) -- FIXME: see comment on 'Arbitrary Seq.PendingIxs'
-        <*> pure (mkStdGen 42)
+    -- Addresses are generate based on the size parameter, so that property
+    -- tests can actually expect addresses to not be totally random, but
+    -- instead, be an ever growing map, much more like they are actually
+    -- generated in practice.
+    arbitrary = sized $ \n -> do
+        let stdgen = mkStdGen 42
+        let newAddress (m, g0) = (Map.insert k v m, g2)
+              where
+                (acctIx, g1) = random g0
+                (addrIx, g2) = random g1
+                k = (Index acctIx, Index addrIx)
+                v = Address $ B8.pack $ take 32 $ randoms g2
+        let addrs = fst $ head $ drop n $ iterate newAddress (mempty, stdgen)
+        pure $ RndState
+            (Passphrase "passphrase")
+            minBound
+            addrs
+            mempty -- FIXME: see comment on 'Arbitrary Seq.PendingIxs'
+            stdgen
 
 instance Arbitrary (ByronKey 'RootK XPrv) where
     shrink _ = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -174,6 +174,7 @@ import Test.QuickCheck
     , frequency
     , labelledExamplesWith
     , property
+    , resize
     , (===)
     )
 import Test.QuickCheck.Monadic
@@ -474,19 +475,19 @@ type WidRefs r =
     RefEnv WalletId MWid r
 
 data Model s r
-    = Model (Mock s) (WidRefs r)
+    = Model Int (Mock s) (WidRefs r)
     deriving (Generic)
 
 deriving instance (Show1 r, Show s) => Show (Model s r)
 
 initModel :: Model s r
-initModel = Model emptyDatabase []
+initModel = Model 0 emptyDatabase []
 
 toMock :: (Functor (f s), Eq1 r) => Model s r -> f s :@ r -> f s MWid
-toMock (Model _ wids) (At fr) = fmap (wids !) fr
+toMock (Model _ _ wids) (At fr) = fmap (wids !) fr
 
 step :: Eq1 r => Model s r -> Cmd s :@ r -> (Resp s MWid, Mock s)
-step m@(Model mock _) c = runMock (toMock m c) mock
+step m@(Model _ mock _) c = runMock (toMock m c) mock
 
 {-------------------------------------------------------------------------------
   Events
@@ -507,10 +508,10 @@ lockstep
     -> Cmd s  :@ r
     -> Resp s :@ r
     -> Event s   r
-lockstep m@(Model _ ws) c (At resp) = Event
+lockstep m@(Model n _ ws) c (At resp) = Event
     { before = m
     , cmd = c
-    , after = Model mock' (ws <> ws')
+    , after = Model (n + 1) mock' (ws <> ws')
     , mockResp = resp'
     }
   where
@@ -527,7 +528,7 @@ generator
     :: forall s. (Arbitrary (Wallet s), GenState s)
     => Model s Symbolic
     -> Maybe (Gen (Cmd s :@ Symbolic))
-generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
+generator (Model n _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
     [ withoutWid
     , if null wids then [] else withWid
     ]
@@ -546,7 +547,7 @@ generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
     withWid =
         [ (3, RemoveWallet <$> genId')
         , (5, pure ListWallets)
-        , (5, PutCheckpoint <$> genId' <*> arbitrary)
+        , (5, PutCheckpoint <$> genId' <*> resize n arbitrary)
         , (5, ReadCheckpoint <$> genId')
         , (5, ListCheckpoints <$> genId')
         , (5, PutWalletMeta <$> genId' <*> arbitrary)
@@ -582,7 +583,7 @@ shrinker
     :: (Arbitrary (Wallet s))
     => Model s Symbolic
     -> Cmd s :@ Symbolic -> [Cmd s :@ Symbolic]
-shrinker (Model _ _) (At cmd) = case cmd of
+shrinker Model{} (At cmd) = case cmd of
     PutCheckpoint wid wal ->
         [ At $ PutCheckpoint wid wal'
         | wal' <- shrink wal ]
@@ -616,7 +617,7 @@ transition :: Eq1 r => Model s r -> Cmd s :@ r -> Resp s :@ r -> Model s r
 transition m c = after . lockstep m c
 
 precondition :: Model s Symbolic -> Cmd s :@ Symbolic -> Logic
-precondition (Model _ wids) (At c) =
+precondition (Model _ _ wids) (At c) =
     forall (toList c) (`elem` map fst wids)
 
 postcondition
@@ -873,7 +874,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
   where
     isRollbackSuccess :: Event s Symbolic -> Maybe MWid
     isRollbackSuccess ev = case (cmd ev, mockResp ev, before ev) of
-        (At (RollbackTo wid _), Resp (Right Point{}), Model _ wids ) ->
+        (At (RollbackTo wid _), Resp (Right Point{}), Model _ _ wids ) ->
             Just (wids ! wid)
         _otherwise ->
             Nothing
@@ -889,7 +890,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
                 (Nothing
                     , At (RemoveWallet wid)
                     , Resp (Right _)
-                    , Model _ wids) ->
+                    , Model _ _ wids) ->
                         Map.insert (wids ! wid) 0 created
                 _otherwise ->
                     created
@@ -900,7 +901,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
 
     isReadTxHistory :: Event s Symbolic -> Maybe MWid
     isReadTxHistory ev = case (cmd ev, mockResp ev, before ev) of
-        (At (ReadTxHistory wid _ _ _), Resp (Right (TxHistory _)), Model _ wids)
+        (At (ReadTxHistory wid _ _ _), Resp (Right (TxHistory _)), Model _ _ wids)
             -> Just (wids ! wid)
         _otherwise
             -> Nothing
@@ -970,7 +971,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
     isReadPrivateKeySuccess ev = case (cmd ev, mockResp ev, before ev) of
         (At (ReadPrivateKey wid)
             , Resp (Right (PrivateKey (Just _)))
-            , Model _ wids )
+            , Model _ _ wids )
                 -> Just (wids ! wid)
         _otherwise
             -> Nothing
@@ -1040,7 +1041,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
     isPutCheckpointSuccess ev = case (cmd ev, mockResp ev, before ev) of
         (At (PutCheckpoint wid _wal)
             , Resp (Right (Unit ()))
-            , Model _ wids )
+            , Model _ _ wids )
                 -> Just (wids ! wid)
         _otherwise
             -> Nothing
@@ -1056,7 +1057,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
                 ( Nothing
                   , At (PutDelegationCertificate wid _ _)
                   , Resp (Right _)
-                  , Model _ wids
+                  , Model _ _ wids
                   ) ->
                     Map.insert (wids ! wid) 0 acc
                 _ ->
@@ -1069,7 +1070,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
 
     isReadWalletMetadata :: Event s Symbolic -> Maybe MWid
     isReadWalletMetadata ev = case (cmd ev, mockResp ev, before ev) of
-        (At (ReadWalletMeta wid), Resp Right{}, Model _ wids) ->
+        (At (ReadWalletMeta wid), Resp Right{}, Model _ _ wids) ->
             Just (wids ! wid)
         _ ->
             Nothing

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -578,7 +578,8 @@ newtype DummyState
 
 instance Sqlite.PersistState DummyState where
     insertState _ _ = error "DummyState.insertState: not implemented"
-    selectState _ = error "DummyState.selectState: not implemented"
+    selectState _   = error "DummyState.selectState: not implemented"
+    deleteState _   = error "DummyState.deleteState: not implemented"
 
 instance NFData DummyState
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A (was working on debugging #1644 and noticed this so I gave it a shot).

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 2fa27f78213361d9054675467f06af4a641192e5
  :round_pushpin: **time and space optimization of address persistence**
    We currently re-write the entire address state for each checkpoint, whereas the address state is by essence, an ever growing list of addresses. Unlike UTxOs, used addresses aren't disappearing from the state, so an easy win to avoid inserting the same addresses over and over is to actually make a diff and only store the diff, if necessary.

  Analyzing our 2 cases:

  ##### Sequential addresses

  Since addresses are derived sequentially, it suffices to look at the higher index stored in the database, and only store addresses with indexes beyond that.

  Benchmark                     | Before  | After
  ----------------------------- | ------- | -------
  SeqState/10  CP x 10    addr  | 14.86ms | 10.94ms
  SeqState/10  CP x 10000 addr  | 2.019s  | 485.5ms
  SeqState/100 CP x 10    addr  | 78.60ms | 55.99ms
  SeqState/100 CP x 10000 addr  | 21.53s  | 3.814s

  ##### Random addresses

  These are a bit more complicated. To make a proper diff, we need to first lookup all known indexes from the database, and remove them from the in-memory map representing currently known addresses. And, store the diff. It isn't necessarily faster to select all indexes, make a diff in memory, and store the result, but it isn't significantly slower either. Random wallets are already deprecated so this is simply another good reason to stop using them. 

  Incidentally, this approach still optimizes the space needed to store these addresses, so it's still a win!

  Benchmark                     | Before  | After
  ----------------------------- | ------- | -------
  RndState/10  CP x 10    addr  | 6.812ms | 8.987ms
  RndState/10  CP x 10000 addr  | 754.2ms | 819.9ms
  RndState/100 CP x 10    addr  | 44.57ms | 44.35ms
  RndState/100 CP x 10000 addr  | 7.529s  | 8.281s

  Now, this introduces a fundamental change in how we manage this address state. Before, we would have a set of rows for each slot at which a checkpoint was created; These rows would be ALL the addresses known at this particular slot. Now, we only store the newly discovered addresses at that slot!

  ```
        s0 s1 s2 s3 s4                     s0 s1 s2 s3 s4
       ┌──┬──┬──┬──┬──┐                   ┌──┬──┬──┬──┬──┐
       │a0│a0│a0│a0│a0│    __   _____     │a0│  │  │  │  │
       │  │a1│a1│a1│a1│    \ \ / / __|    │  │a1│  │  │  │
       │  │  │  │a2│a2│     \ V /\__ \    │  │  │  │a2│  │
       │  │  │  │a3│a3│      \_/ |___/    │  │  │  │a3│  │
       │  │  │  │  │a4│                   │  │  │  │  │a4│
       └──┴──┴──┴──┴──┘                   └──┴──┴──┴──┴──┘
  ```

  This requires thereby some changes:

  a. Remove the foreign key to the checkpoint table with cascade delete
  b. Remove address state manually when relevant (rollbacks)
  c. Do not prune the address state, it is pruned by construction
  d. To reconstruct the state, select not only addresses from a slot S
     but also all the addresses from previous slots.

- a8faeb13aaa99a301eb820b0d32ffc150d5bf79f
  :round_pushpin: **Resize QSM checkpoints generator in terms of the number of steps**
    The main effect of this change is to make sure that checkpoints
  generated in by the QSM tests have increasing slot numbers, and
  that they also generate address states that are bigger and bigger.

  Before this change, we would see commands such as:

  - putCheckpoint (RndState [addr1, addr2, addr3])
  - putCheckpoint (RndState [])

  Which is basically not possible in practice; addresses don't disappear. Another approach could have been to adjust a bit our database model to keep track of address state in a sparse way as
  well. Ideally, we should also decrease the "size" factor with rollbacks although, to do it well, we need to have a coupling between the generator and the transition function advancing the model (to make sure to shrink the size by the right factor).

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
