### PR TITLE
Fix non-terminating fromPParams

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -356,7 +356,7 @@ fromPParams pp = W.TxParameters
     }
   where
     naturalToDouble :: Natural -> Double
-    naturalToDouble = naturalToDouble
+    naturalToDouble = fromIntegral
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData


### PR DESCRIPTION
# Issue Number

#1657 

# Overview

- [x] I made `fromPParams` not loop indefinitely and break the tip-following.

# Comments

The node tip now updates correctly:
```
$ cardano-wallet-shelley network information
Ok.
{
    "network_tip": {
        "epoch_number": 22,
        "slot_number": 8397
    },
    "node_tip": {
        "height": {
            "quantity": 12738,
            "unit": "block"
        },
        "epoch_number": 22,
        "slot_number": 8360
    },
    "sync_progress": {
        "status": "ready"
    },
    "next_epoch": {
        "epoch_start_time": "2020-05-18T14:15:00Z",
        "epoch_number": 23
    }
}
 $ cardano-wallet-shelley network information
Ok.
{
    "network_tip": {
        "epoch_number": 22,
        "slot_number": 8398
    },
    "node_tip": {
        "height": {
            "quantity": 12739,
            "unit": "block"
        },
        "epoch_number": 22,
        "slot_number": 8398
    },
    "sync_progress": {
        "status": "ready"
    },
    "next_epoch": {
        "epoch_start_time": "2020-05-18T14:15:00Z",
        "epoch_number": 23
    }
}
```

 - Could have added a test that `fromPParams` terminates/doesn't throw, but that seemed a bit too specific. When we add `Test.Integration.Scenario.API.Shelley.Wallets` I think those scenarios will cover this.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
