### PR TITLE
Fix port selection in the db migration tests

### DIFF
--- a/nix/launch-migration-test.sh
+++ b/nix/launch-migration-test.sh
@@ -30,7 +30,14 @@ if [ -z "${configFile:-}" ]; then
   exit 1
 fi
 
+# Find an unused TCP port to run the test on.
+# Source: https://unix.stackexchange.com/a/132524
+find_unused_port() {
+  python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'
+}
+
+# Sanity-check versions
 cardano-wallet-jormungandr version
 jormungandr --version
 
-exec migration-test $1 launch --port 9090 --state-dir $stateDir --genesis-block $genesisDataDir/block0.bin -- --secret $genesisDataDir/secret.yaml --config $configFile
+exec migration-test $1 launch --port "$(find_unused_port)" --state-dir $stateDir --genesis-block $genesisDataDir/block0.bin -- --secret $genesisDataDir/secret.yaml --config $configFile

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -112,6 +112,7 @@ let
           migrationTest
           pkgs.bash
           pkgs.coreutils
+          pkgs.python3
         ]}
         export genesisDataDir=${latestRelease.src}/lib/jormungandr/test/data/jormungandr
         export configFile=${targetRelease.src}/lib/jormungandr/test/data/jormungandr/config.yaml


### PR DESCRIPTION
### Issue number

Relates to #1649

### Overview

Each migration test running in turn was using the same port.

However due to the `SO_LINGER` TCP socket option, the port remains in use for a short time after the wallet server process exits.

So use a different port for each test.

### Comments

Tested with:

    nix-build -A migration-tests -o migration-tests && ./migration-tests/runall.sh
