### PR TITLE
Fix Input resolution for inputs only present in db

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -285,6 +285,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletPassphraseInfo (..)
     , computeUtxoStatistics
     , dlgCertPoolId
+    , fromTransactionInfo
     , log10
     , slotParams
     , slotRangeFromTimeRange
@@ -366,7 +367,6 @@ import qualified Cardano.Wallet.Primitive.CoinSelection.Random as CoinSelection
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -599,7 +599,7 @@ readWallet ctx wid = db & \DBLayer{..} -> mapExceptT atomically $ do
     cp <- withNoSuchWallet wid $ readCheckpoint pk
     meta <- withNoSuchWallet wid $ readWalletMeta pk
     txs <- lift $ readTxHistory pk Descending wholeRange (Just Pending)
-    pure (cp, meta, Set.fromList (fst <$> txs))
+    pure (cp, meta, Set.fromList (fromTransactionInfo <$> txs))
   where
     db = ctx ^. dbLayer @s @k
 
@@ -907,10 +907,11 @@ listAddresses ctx wid normalize = db & \DBLayer{..} -> do
     let maybeIsOurs (TxOut a _) = if fst (isOurs a s)
             then normalize s a
             else Nothing
-    let usedAddrs = Set.fromList $
-            concatMap (mapMaybe maybeIsOurs . outputs') txs
-          where
-            outputs' (tx, _) = W.outputs tx
+    let usedAddrs
+            = Set.fromList
+            $ concatMap
+                (mapMaybe maybeIsOurs . W.outputs)
+                (fromTransactionInfo <$> txs)
     let knownAddrs =
             L.sortBy (compareDiscovery s) (mapMaybe (normalize s) $ knownAddresses s)
     let withAddressState addr =
@@ -1471,12 +1472,11 @@ listTransactions ctx wid mStart mEnd order = db & \DBLayer{..} -> do
         cp <- withExceptT ErrListTransactionsNoSuchWallet $
             withNoSuchWallet wid $ readCheckpoint pk
 
-        let tip = currentTip cp
         let sp = slotParams (blockchainParameters cp)
 
         mapExceptT liftIO (getSlotRange sp) >>= maybe
             (pure [])
-            (\r -> assemble sp tip <$> lift (readTxHistory pk order r Nothing))
+            (\r -> lift (readTxHistory pk order r Nothing))
   where
     db = ctx ^. dbLayer @s @k
 
@@ -1492,45 +1492,6 @@ listTransactions ctx wid mStart mEnd order = db & \DBLayer{..} -> do
             throwE (ErrListTransactionsStartTimeLaterThanEndTime err)
         _ ->
             pure $ slotRangeFromTimeRange sp $ Range mStart mEnd
-
-    -- This relies on DB.readTxHistory returning all necessary transactions
-    -- to assemble coin selection information for outgoing payments.
-    -- To reliably provide this information, it should be looked up when
-    -- applying blocks, but that is future work (issue #573).
-    assemble
-        :: SlotParameters
-        -> BlockHeader
-        -> [(Tx, TxMeta)]
-        -> [TransactionInfo]
-    assemble sp tip txs = map mkTxInfo txs
-      where
-        mkTxInfo (tx, meta) = TransactionInfo
-            { txInfoId = W.txId tx
-            , txInfoInputs =
-                [(txIn, lookupOutput txIn) | txIn <- W.inputs tx]
-            , txInfoOutputs = W.outputs tx
-            , txInfoMeta = meta
-            , txInfoDepth =
-                Quantity $ fromIntegral $ if tipH > txH then tipH - txH else 0
-            , txInfoTime = txTime (meta ^. #slotId)
-            }
-          where
-            txH = getQuantity (meta ^. #blockHeight)
-            tipH = getQuantity (tip ^. #blockHeight)
-        txOuts = Map.fromList
-            [ (W.txId tx, W.outputs tx)
-            | ((tx, _)) <- txs
-            ]
-        -- Because we only track the UTxO of this wallet, we can only
-        -- return this information for outgoing payments.
-        lookupOutput (TxIn txid index) =
-            Map.lookup txid txOuts >>= atIndex (fromIntegral index)
-        atIndex i xs = if i < length xs then Just (xs !! i) else Nothing
-        -- Get the approximate time of a transaction, given its 'SlotId'.
-        -- We assume that the transaction "happens" at the start of the
-        -- slot. This is purely arbitrary and in practice, any time between
-        -- the start of a slot and its end could be a valid candidate.
-        txTime = slotStartTime sp
 
 {-------------------------------------------------------------------------------
                                   Delegation

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -598,8 +598,8 @@ readWallet ctx wid = db & \DBLayer{..} -> mapExceptT atomically $ do
     let pk = PrimaryKey wid
     cp <- withNoSuchWallet wid $ readCheckpoint pk
     meta <- withNoSuchWallet wid $ readWalletMeta pk
-    txs <- lift $ readTxHistory pk Descending wholeRange (Just Pending)
-    pure (cp, meta, Set.fromList (fromTransactionInfo <$> txs))
+    pending <- lift $ readTxHistory pk Descending wholeRange (Just Pending)
+    pure (cp, meta, Set.fromList (fromTransactionInfo <$> pending))
   where
     db = ctx ^. dbLayer @s @k
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1159,7 +1159,8 @@ listTransactions ctx (ApiT wid) mStart mEnd mOrder = do
             Pending  -> apiTx
             InLedger -> apiTx { depth = Just depth  }
       where
-        apiTx = mkApiTransaction txid ins outs (meta, txtime) $
+        drop2nd (a,_,c) = (a,c)
+        apiTx = mkApiTransaction txid (drop2nd <$> ins) outs (meta, txtime) $
             case meta ^. #status of
                 Pending  -> #pendingSince
                 InLedger -> #insertedAt

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -42,6 +42,7 @@ import Cardano.Wallet.Primitive.Types
     , Range (..)
     , SlotId (..)
     , SortOrder (..)
+    , TransactionInfo
     , Tx (..)
     , TxMeta
     , TxParameters
@@ -199,7 +200,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> SortOrder
         -> Range SlotId
         -> Maybe TxStatus
-        -> stm [(Tx, TxMeta)]
+        -> stm [TransactionInfo]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
         -- descending slot number.
         --

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -121,8 +121,7 @@ newDBLayer = do
             txh `deepseq` alterDB errNoSuchWallet db (mPutTxHistory pk txh)
 
         , readTxHistory = \pk order range mstatus ->
-                error "TODO: readTxHistory"
-                -- readDB db (mReadTxHistory pk order range mstatus)
+            readDB db (mReadTxHistory pk order range mstatus)
 
         {-----------------------------------------------------------------------
                                        Keystore

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -121,7 +121,8 @@ newDBLayer = do
             txh `deepseq` alterDB errNoSuchWallet db (mPutTxHistory pk txh)
 
         , readTxHistory = \pk order range mstatus ->
-                readDB db (mReadTxHistory pk order range mstatus)
+                error "TODO: readTxHistory"
+                -- readDB db (mReadTxHistory pk order range mstatus)
 
         {-----------------------------------------------------------------------
                                        Keystore

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1031,6 +1031,15 @@ selectUTxO cp = fmap entityVal <$>
         , UtxoSlot ==. checkpointSlot cp
         ] []
 
+-- This relies on available information from the database to reconstruct
+-- coin selection information for __outgoing__ payments. We can't however guarantee
+-- that we have such information for __incoming__ payments (we usually don't
+-- have it).
+--
+-- To reliably provide this information for incoming payment, it should be looked
+-- up when applying blocks from the global Ledger, but that is future work
+--
+-- See also: issue #573.
 selectTxs
     :: [TxId]
     -> SqlPersistT IO ([(TxIn, Maybe TxOut)], [TxOut])

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Primitive.Types
     , txIns
     , isPending
     , inputs
+    , fromTransactionInfo
 
     -- * Address
     , Address (..)
@@ -931,7 +932,7 @@ isPending = (== Pending) . (status :: TxMeta -> TxStatus)
 data TransactionInfo = TransactionInfo
     { txInfoId :: !(Hash "Tx")
     -- ^ Transaction ID of this transaction
-    , txInfoInputs :: ![(TxIn, Maybe TxOut)]
+    , txInfoInputs :: ![(TxIn, Coin, Maybe TxOut)]
     -- ^ Transaction inputs and (maybe) corresponding outputs of the
     -- source. Source information can only be provided for outgoing payments.
     , txInfoOutputs :: ![TxOut]
@@ -943,6 +944,14 @@ data TransactionInfo = TransactionInfo
     , txInfoTime :: UTCTime
     -- ^ Creation time of the block including this transaction.
     } deriving (Show, Eq, Ord)
+
+-- | Reconstruct a transaction info from a transaction.
+fromTransactionInfo :: TransactionInfo -> Tx
+fromTransactionInfo info = Tx
+    { txId = txInfoId info
+    , resolvedInputs = (\(a,b,_) -> (a,b)) <$> txInfoInputs info
+    , outputs = txInfoOutputs info
+    }
 
 -- | A linear equation of a free variable `x`. Represents the @\x -> a + b*x@
 -- function where @x@ can be the transaction size in bytes or, a number of

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -50,6 +50,7 @@ module Cardano.Wallet.Primitive.Types
     , isPending
     , inputs
     , fromTransactionInfo
+    , toTxHistory
 
     -- * Address
     , Address (..)
@@ -952,6 +953,11 @@ fromTransactionInfo info = Tx
     , resolvedInputs = (\(a,b,_) -> (a,b)) <$> txInfoInputs info
     , outputs = txInfoOutputs info
     }
+
+-- | Drop time-specific information
+toTxHistory :: TransactionInfo -> (Tx, TxMeta)
+toTxHistory info =
+    (fromTransactionInfo info, txInfoMeta info)
 
 -- | A linear equation of a free variable `x`. Represents the @\x -> a + b*x@
 -- function where @x@ can be the transaction size in bytes or, a number of

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -944,7 +944,9 @@ data TransactionInfo = TransactionInfo
     -- ^ Number of slots since the transaction slot.
     , txInfoTime :: UTCTime
     -- ^ Creation time of the block including this transaction.
-    } deriving (Show, Eq, Ord)
+    } deriving (Generic, Show, Eq, Ord)
+
+instance NFData TransactionInfo
 
 -- | Reconstruct a transaction info from a transaction.
 fromTransactionInfo :: TransactionInfo -> Tx

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -85,6 +85,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (unSlotNo)
     , SortOrder (..)
+    , TransactionInfo
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
@@ -387,7 +388,7 @@ benchReadTxHistory
     -> (Maybe Word64, Maybe Word64)
     -> Maybe TxStatus
     -> DBLayerBench
-    -> IO [(Tx, TxMeta)]
+    -> IO [TransactionInfo]
 benchReadTxHistory sortOrder (inf, sup) mstatus DBLayer{..} =
     atomically $ readTxHistory testPk sortOrder range mstatus
   where

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -120,6 +120,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
+    , TransactionInfo (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
@@ -299,7 +300,7 @@ data Success s wid
     | WalletIds [wid]
     | Checkpoint (Maybe (Wallet s))
     | Metadata (Maybe WalletMetadata)
-    | TxHistory TxHistory
+    | TxHistory [TransactionInfo]
     | PrivateKey (Maybe MPrivKey)
     | TxParams (Maybe TxParameters)
     | BlockHeaders [BlockHeader]
@@ -996,7 +997,7 @@ tag = Foldl.fold $ catMaybes <$> sequenceA
             | otherwise = Nothing
 
     readTxHistory
-        :: (TxHistory -> Bool)
+        :: ([TransactionInfo] -> Bool)
         -> Tag
         -> Fold (Event s Symbolic) (Maybe Tag)
     readTxHistory check res = Fold update False (extractf res)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1670

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 1502136da13c0f9e6ba47b74c12c31912099da62
  :round_pushpin: **add regression test illustrating the issue**
  Input that should be resolved aren't. In order to resolve inputs, we are actually wrongly using
the transactions available from the history that was fetched from the database, instead of using
the entire database! So, giving different query parameters restricting the set of outputs has an
influence on something it shouldn't.

- 8ec012359e5faaeeec9f73f255184575b6b5d0c1
  :round_pushpin: **resolve transaction inputs from db when fetching the history**
  Before, this was done in the application layer, from the available history ('assemble' in 'Cardano.Wallet'). This requires exactly two extra lookups. One in the TxOut table, and one in the Checkpoint table so the performance impact should be quite small. It simplifies the application logic quite a bit and doesn't much impact the database logic, so it's almost a win-win. Plus, it fixes the issue where resolvable inputs would appear as non resolved

- 64bf4db742dc029ea3a18b1c4e957e22f612ab47
  :round_pushpin: **fix DB model to also return full 'TransactionInfo' when fetching the tx history**
  
- 21d75d20ae9b11707d16a4115159ef617e6bcdb0
  :round_pushpin: **Fix db benchmark build**
  Benchmarks may produce higher timings after this change, but it's OK
since the answers are more correct now, and the work has just shifted
from the wallet layer into the db layer.

- fffe476a58673fcb23a3c43136d8eded2d46f999
  :round_pushpin: **re-add lost comment about input resolution for incoming/outgoing transactions**
  
- 67adc07a71a3e8c3e5430654b0845173e4d189e2
  :round_pushpin: **rename 'txs' -> 'pending' to better match context**


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
