### PR TITLE
Display Shelley migrations in Api doc

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -329,7 +329,7 @@ type DeleteTransaction = "wallets"
                                  Shelley Migrations
 
 See also:
-https://input-output-hk.github.io/cardano-wallet/api/#tag/Shelley-Migrations
+https://input-output-hk.github.io/cardano-wallet/api/#tag/Migrations
 -------------------------------------------------------------------------------}
 
 type ShelleyMigrations n =

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1987,10 +1987,12 @@ paths:
       description: |
         <p align="right">status: <strong>in development</strong></p>
 
-        Migrate all funds from a Shelley wallet to a specified set of addresses.
-        Create one or several transactions sending all funds from a Shelley wallet to set of addresses.
-        This operation tries to preserve as much as possible the current UTxO shape of a wallet (hence
-        why several transactions may be needed).
+        Submit one or more transactions which transfers all funds from a Shelley
+        wallet to a set of addresses.
+
+        This operation attempts to preserve the UTxO "shape" of a wallet as far as possible.
+        That is, coins will not be agglomerated. Therefore, if the wallet has
+        a large UTxO set, several transactions may be needed.
 
         A typical usage would be when one wants to move all funds from an old wallet to another
         by providing addresses coming from the new wallet.
@@ -2233,9 +2235,12 @@ paths:
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
-        Create one or several transactions sending all funds from a Byron wallet to set of addresses.
-        This operation tries to preserve as much as possible the current UTxO shape of a wallet (hence
-        why several transactions may be needed).
+        Submit one or more transactions which transfers all funds from a Byron
+        wallet to a set of addresses.
+
+        This operation attempts to preserve the UTxO "shape" of a wallet as far as possible.
+        That is, coins will not be agglomerated. Therefore, if the wallet has
+        a large UTxO set, several transactions may be needed.
 
         A typical usage would be when one wants to move all funds from an old wallet to another (Shelley
         or Byron) by providing addresses coming from the new wallet.

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1660,6 +1660,7 @@ x-tagGroups:
     - Addresses
     - Coin Selections
     - Transactions
+    - Migrations
     - Stake Pools
 
   - name: Byron (Random)
@@ -1967,13 +1968,13 @@ paths:
   /wallets/{walletId}/migrations:
     get:
       operationId: getShelleyWalletMigrationInfo
-      tags: ["Shelley Migrations"]
+      tags: ["Migrations"]
       summary: Calculate Cost
       description: |
-        <p align="right">status: <strong>stable</strong></p>
+        <p align="right">status: <strong>in development</strong></p>
 
-        Calculate the exact cost of migrating from a Shelley wallet to
-        the specified set of addresses.
+        Calculate the exact cost of sending all funds from particular Shelley wallet
+        to a set of addresses.
       parameters:
         - <<: *parametersWalletId
           name: walletId
@@ -1981,12 +1982,18 @@ paths:
 
     post:
       operationId: migrateShelleyWallet
-      tags: ["Shelley Migrations"]
+      tags: ["Migrations"]
       summary: Migrate
       description: |
-        <p align="right">status: <strong>stable</strong></p>
+        <p align="right">status: <strong>in development</strong></p>
 
         Migrate all funds from a Shelley wallet to a specified set of addresses.
+        Create one or several transactions sending all funds from a Shelley wallet to set of addresses.
+        This operation tries to preserve as much as possible the current UTxO shape of a wallet (hence
+        why several transactions may be needed).
+
+        A typical usage would be when one wants to move all funds from an old wallet to another
+        by providing addresses coming from the new wallet.
       parameters:
         - <<: *parametersWalletId
           name: walletId
@@ -2212,8 +2219,8 @@ paths:
       description: |
         <p align="right">status: <strong>stable</strong></p>
 
-        Calculate the exact cost of migrating from a Byron wallet to
-        the specified set of addresses.
+        Calculate the exact cost of sending all funds from particular Byron wallet to
+        a set of addresses.
       parameters:
         - <<: *parametersWalletId
           name: walletId


### PR DESCRIPTION
# Issue Number

#1675

# Overview

- 186726655c405149af9b3903dbf61c38b64be92e
  Display Shelley migrations in swagger spec.
  
- 508e41b4d94be8861ab9c8e407a1584975ad6dfa
  Reword migration description according to review suggestions



# Comments

Shelley migrations, although included in `swagger.yaml`, were not being displayed in the [API doc](https://input-output-hk.github.io/cardano-wallet/api/edge/). This pr fixes this. Also includes minor rewording of the migration endpoints descriptions.

![Screenshot from 2020-05-26 16-38-13](https://user-images.githubusercontent.com/42900201/82914129-6c934b00-9f6f-11ea-91e3-d92d336498f5.png)


