### PR TITLE
nix: Provide deployment info in $CARDANO_NODE_CONFIGS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -154,7 +154,7 @@ let
           sqlite-interactive
           pythonPackages.openapi-spec-validator
         ]);
-      CARDANO_NODE_CONFIGS = cardano-node.configs;
+      CARDANO_NODE_CONFIGS = cardano-node.deployments;
       meta.platforms = lib.platforms.unix;
     };
     stackShell = import ./nix/stack-shell.nix {

--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -181,7 +181,8 @@ import qualified Data.Text.Encoding as T
 
 main :: IO ()
 main = do
-    testnetGenesis <- getEnv "TESTNET_GENESIS"
+    configs <- getEnv "CARDANO_NODE_CONFIGS"
+    let testnetGenesis = configs </> "testnet" </> "genesis.json"
     let opts = info (fmap exec (networkConfigurationOption testnetGenesis)) mempty
     join $ execParser opts
 
@@ -215,12 +216,13 @@ exec c = do
 
     ----------------------------------------------------------------------------
     -- Environment variables set by nix/haskell.nix (or manually)
-    topology <- case c of
-        MainnetConfig _ -> getEnv "MAINNET_TOPOLOGY"
-        TestnetConfig _ -> getEnv "TESTNET_TOPOLOGY"
-    config <- case c of
-        MainnetConfig _ -> getEnv "MAINNET_NODE_CONFIG"
-        TestnetConfig _ -> getEnv "TESTNET_NODE_CONFIG"
+    configs <- getEnv "CARDANO_NODE_CONFIGS"
+    let networkDir = case c of
+            MainnetConfig _ -> "mainnet"
+            TestnetConfig _ -> "testnet"
+        topology = configs </> networkDir </> "topology.json"
+        config = configs </> networkDir </> "configuration.json"
+
     ----------------------------------------------------------------------------
     -- Environment variables set by ./buildkite/bench-restore.sh (or manually)
     nodeDB <- getEnv "NODE_DB"

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -150,11 +150,7 @@ let
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/restore \
-                --set TESTNET_NODE_CONFIG ${pkgs.cardano-node.testnet.configFile} \
-                --set TESTNET_TOPOLOGY ${pkgs.cardano-node.topologyFiles.testnet} \
-                --set TESTNET_GENESIS ${pkgs.cardano-node.testnet.genesisFile} \
-                --set MAINNET_NODE_CONFIG ${pkgs.cardano-node.mainnet.configFile} \
-                --set MAINNET_TOPOLOGY ${pkgs.cardano-node.topologyFiles.mainnet} \
+                --set CARDANO_NODE_CONFIGS ${pkgs.cardano-node.deployments} \
                 --prefix PATH : ${pkgs.cardano-node}/bin
             '';
           };

--- a/nix/package-cardano-node.nix
+++ b/nix/package-cardano-node.nix
@@ -28,6 +28,7 @@ pkgs.stdenv.mkDerivation rec {
   '' + (if pkgs.stdenv.hostPlatform.isWindows then ''
     cp --remove-destination -v ${pkgs.libffi}/bin/libffi-6.dll $out/bin
     cp --remove-destination -v ${cardano-node}/bin/* $out/bin
+    cp -Rv ${cardano-node.deployments} $out/deployments
     cp -Rv ${cardano-node.configs} $out/configuration
   '' else (if pkgs.stdenv.hostPlatform.isDarwin then ''
     cp -v ${cardano-node}/bin/cardano-node $out/bin

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -7,31 +7,38 @@ let
 in pkgs: super: with pkgs; {
   jmPkgs = import ./jormungandr.nix { inherit (pkgs) commonLib; inherit pkgs; };
   cardanoNodePkgs = import sources.cardano-node { inherit system crossSystem config; };
-  cardano-node = cardanoNodePkgs.cardano-node
-    // commonLib.cardanoLib.forEnvironments (env:
-      env // {
-        configFile =
-          let
-            rawCfg = env.nodeConfig // {
-              GenesisFile = env.genesisFile;
-              minSeverity = "Notice";
-            };
-          in
-          builtins.toFile "cardano-node-config" (builtins.toJSON rawCfg);
-        })
-    // {
-      topologyFiles = {
-        # Note: It was easier to define as topologyFiles.testnet than testnet.topologyFile.
-        # TODO: Retrieve these from iohk-nix or cardano-node directly.
-        mainnet = builtins.toFile "topology" "{\"Producers\":[{\"addr\":\"relays-new.cardano-mainnet.iohk.io\",\"port\":3001,\"valency\":1}]}";
-        testnet = builtins.toFile "topology" "{\"Producers\":[{\"addr\":\"relays-new.cardano-testnet.iohkdev.io\",\"port\":3001,\"valency\":1}]}";
+  cardano-node = cardanoNodePkgs.cardano-node // {
+    # Provide real deployment configurations for use in dev/tests/benchmarks.
+    # https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1/index.html
+    deployments = let
+      environments = {
+        inherit (pkgs.commonLib.cardanoLib.environments) ff mainnet testnet;
       };
+      updateConfig = cfg: cfg // {
+        GenesisFile = "genesis.json";
+        minSeverity = "Notice";
+      };
+      mkTopology = env: pkgs.commonLib.cardanoLib.mkEdgeTopology {
+        edgeNodes = [ env.relaysNew ];
+        valency = 2;
+      };
+      mapAttrsToString = f: attrs:
+        pkgs.lib.concatStringsSep "\n" (pkgs.lib.mapAttrsToList f attrs);
+    in pkgs.runCommand "cardano-node-deployments" {
+      nativeBuildInputs = [ pkgs.buildPackages.jq ];
+    } (mapAttrsToString (name: env: ''
+      cfg=$out/${name}
+      mkdir -p $cfg
+      jq . < ${__toFile "${name}-config.json" (__toJSON (updateConfig env.nodeConfig))} > $cfg/configuration.json
+      jq . < ${env.genesisFile} > $cfg/genesis.json
+      jq . < ${mkTopology env} > $cfg/topology.json
+    '') environments);
 
-      # provide configuration directory as a convenience
-      configs = pkgs.runCommand "cardano-node-configs" {} ''
-        cp -R ${sources.cardano-node}/configuration $out;
-      '';
-      };
+    # Provide configuration directory as a convenience
+    configs = pkgs.runCommand "cardano-node-configs" {} ''
+      cp -R ${sources.cardano-node}/configuration $out;
+    '';
+  };
   inherit (cardanoNodePkgs.haskellPackages.cardano-cli.components.exes) cardano-cli;
   inherit (pkgs1903) stack;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "30cf81c421d7fca198660e1e995038dd8b6f3d13",
-        "sha256": "0sy9gza5gsrbqfbizp0dd98njnymigchj0aszswkfzxndskknarj",
+        "rev": "b11279c2441f737407c31792fa9c93c59e6ab347",
+        "sha256": "0b90hw5h3iwkzjyrc4zwd7987j30rsq6c0hwa7j9g29134v4fk98",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/30cf81c421d7fca198660e1e995038dd8b6f3d13.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/b11279c2441f737407c31792fa9c93c59e6ab347.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -32,4 +32,14 @@ in pkgs.runCommand name { buildInputs = [ pkgs.buildPackages.zip ]; } ''
     zip -r $out/${exe.name}-configuration.zip .
     echo "file binary-dist $out/${exe.name}-configuration.zip" >> $out/nix-support/hydra-build-products
   fi
+
+  # make a separate deployments configuration package if needed
+  if [ -d ${exe}/deployments ]; then
+    cp -R ${exe}/deployments ..
+    cd ../deployments
+    chmod -R +w .
+
+    zip -r $out/${exe.name}-deployments.zip .
+    echo "file binary-dist $out/${exe.name}-deployments.zip" >> $out/nix-support/hydra-build-products
+  fi
 ''


### PR DESCRIPTION
### Issue Number

ADP-289

### Overview

Provide deployment info in `$CARDANO_NODE_CONFIGS` in the nix-shell. For example:

```
rodney@blue:~/iohk/cardano-wallet % tree $CARDANO_NODE_CONFIGS
/nix/store/r7v7y9k88qgz7d18l3hy4ydgvx53z6pj-cardano-node-deployments
├── ff
│   ├── configuration.json
│   ├── genesis.json
│   └── topology.json
├── mainnet
│   ├── configuration.json
│   ├── genesis.json
│   └── topology.json
└── testnet
    ├── configuration.json
    ├── genesis.json
    └── topology.json

3 directories, 9 files
```

This can be used for the restore benchmark, and during development.

It will make it easier to support the shelley ff testnet in the restore benchmark/test.

It can also be used by cardano-launcher to provide configurations for its unit tests ⇒ input-output-hk/cardano-launcher#73.

### Comments

* There is a CI failure - needs input-output-hk/iohk-nix#385