### PR TITLE
Remove `epochId` argument from `getNetworkParameters`.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -158,7 +158,6 @@ import Cardano.Wallet.Api.Types
     , AllowedMnemonics
     , ApiAccountPublicKey
     , ApiByronWallet
-    , ApiEpochNumber
     , ApiMnemonicT (..)
     , ApiPostRandomAddressData (..)
     , ApiT (..)
@@ -1556,9 +1555,8 @@ cmdNetworkInformation mkClient =
         runClient wPort Aeson.encodePretty (networkInformation mkClient)
 
 -- | Arguments for 'network parameters' command
-data NetworkParametersArgs = NetworkParametersArgs
+newtype NetworkParametersArgs = NetworkParametersArgs
     { _port :: Port "Wallet"
-    , _epoch :: ApiEpochNumber
     }
 
 cmdNetworkParameters
@@ -1570,9 +1568,8 @@ cmdNetworkParameters mkClient =
   where
     cmd = fmap exec $ NetworkParametersArgs
         <$> portOption
-        <*> epochArgument
-    exec (NetworkParametersArgs wPort epoch) = do
-        runClient wPort Aeson.encodePretty $ networkParameters mkClient epoch
+    exec (NetworkParametersArgs wPort) = do
+        runClient wPort Aeson.encodePretty $ networkParameters mkClient
 
 -- | Arguments for 'network clock' command
 data NetworkClockArgs = NetworkClockArgs
@@ -1882,12 +1879,6 @@ tlsOption = TlsConfiguration
 walletIdArgument :: Parser WalletId
 walletIdArgument = argumentT $ mempty
     <> metavar "WALLET_ID"
-
--- | <epoch=EPOCH_NUMBER>
-epochArgument :: Parser ApiEpochNumber
-epochArgument = argumentT $ mempty
-    <> metavar "EPOCH_NUMBER"
-    <> help "epoch number parameter or 'latest'"
 
 -- | <transaction-id=TX_ID>
 transactionIdArgument :: Parser TxId

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -518,14 +518,13 @@ spec = do
             ]
 
         ["network", "parameters", "--help"] `shouldShowUsage`
-            [ "Usage:  network parameters [--port INT] EPOCH_NUMBER"
+            [ "Usage:  network parameters [--port INT]"
             , "  View network parameters."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
             , "  --port INT               port used for serving the wallet"
             , "                           API. (default: 8090)"
-            , "  EPOCH_NUMBER             epoch number parameter or 'latest'"
             ]
 
         ["network", "clock", "--help"] `shouldShowUsage`

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -29,7 +29,8 @@ library
     ghc-options:
       -Werror
   build-depends:
-      aeson
+      QuickCheck
+    , aeson
     , aeson-qq
     , async
     , base
@@ -52,16 +53,13 @@ library
     , http-client
     , http-types
     , memory
-    , memory
     , process
     , retry
     , scrypt
-    , time
     , template-haskell
     , text
     , text-class
     , time
-    , QuickCheck
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -52,7 +52,6 @@ library
     , http-client
     , http-types
     , memory
-    , OddWord
     , memory
     , process
     , retry

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1590,7 +1590,7 @@ getSlotParams ctx = do
           Link.getNetworkInfo Default Empty
     let (ApiT currentEpoch) = getFromResponse (#networkTip . #epochNumber) r1
 
-    let endpoint = ( "GET", "v2/network/parameters/latest" )
+    let endpoint = ( "GET", "v2/network/parameters" )
     r2 <- request @ApiNetworkParameters ctx endpoint Default Empty
     let (Quantity slotL) = getFromResponse #slotLength r2
     let (Quantity epochL) = getFromResponse #epochLength r2

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1596,7 +1596,11 @@ getSlotParams ctx = do
     let (Quantity epochL) = getFromResponse #epochLength r2
     let (Quantity coeff) = getFromResponse #activeSlotCoefficient r2
     let (ApiT genesisBlockDate) = getFromResponse #blockchainStartTime r2
-    let sp = SlotParameters (EpochLength epochL) (SlotLength slotL) genesisBlockDate (ActiveSlotCoefficient coeff)
+    let sp = SlotParameters
+            (EpochLength epochL)
+            (SlotLength slotL)
+            (genesisBlockDate)
+            (ActiveSlotCoefficient coeff)
 
     return (currentEpoch, sp)
 

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -60,7 +60,6 @@ module Test.Integration.Framework.TestData
     , errMsg404CannotFindTx
     , errMsg403NoRootKey
     , errMsg404NoWallet
-    , errMsg404NoEpochNo
     , errMsg409WalletExists
     , errMsg403InputsDepleted
     , errMsg403TxTooBig
@@ -320,14 +319,6 @@ errMsg400ParseError = mconcat
     [ "I couldn't understand the content of your message. If your "
     , "message is intended to be in JSON format, please check that "
     , "the JSON is valid."
-    ]
-
-errMsg404NoEpochNo :: String -> String
-errMsg404NoEpochNo rEpochNo = concat
-    [ "I couldn't show blockchain parameters for epoch number later"
-    , " than current one. You requested "
-    , rEpochNo
-    , " epoch. "
     ]
 
 errMsg403ZeroAmtOutput :: String

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -102,7 +102,6 @@ import Cardano.Wallet.Api.Types
     , ApiAddressT
     , ApiByronWallet
     , ApiCoinSelectionT
-    , ApiEpochNumber
     , ApiFee
     , ApiNetworkClock
     , ApiNetworkInformation
@@ -555,7 +554,6 @@ type GetNetworkInformation = "network"
 
 type GetNetworkParameters = "network"
     :> "parameters"
-    :> Capture "epochId" ApiEpochNumber
     :> Get '[JSON] ApiNetworkParameters
 
 type GetNetworkClock = "network"

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -61,7 +61,6 @@ import Cardano.Wallet.Api.Types
     , ApiAddressT
     , ApiByronWallet
     , ApiCoinSelectionT
-    , ApiEpochNumber
     , ApiFee
     , ApiNetworkClock
     , ApiNetworkInformation (..)
@@ -194,8 +193,7 @@ data NetworkClient = NetworkClient
     { networkInformation
         :: ClientM ApiNetworkInformation
     , networkParameters
-        :: ApiEpochNumber
-        -> ClientM ApiNetworkParameters
+        :: ClientM ApiNetworkParameters
     , networkClock
         :: Bool -- When 'True', block and force NTP check
         -> ClientM ApiNetworkClock

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -88,8 +88,7 @@ import Prelude
 import Cardano.Wallet.Api
     ( Api )
 import Cardano.Wallet.Api.Types
-    ( ApiEpochNumber
-    , ApiPoolId (..)
+    ( ApiPoolId (..)
     , ApiT (..)
     , ApiTxId (ApiTxId)
     , Iso8601Time
@@ -426,15 +425,9 @@ getNetworkInfo =
     endpoint @Api.GetNetworkInformation id
 
 getNetworkParams
-    :: forall e.
-        ( HasType ApiEpochNumber e
-        )
-    => e
-    -> (Method, Text)
-getNetworkParams e =
-    endpoint @Api.GetNetworkParameters (epoch &)
-  where
-    epoch = e ^. typed @ApiEpochNumber
+    :: (Method, Text)
+getNetworkParams =
+    endpoint @Api.GetNetworkParameters id
 
 getNetworkClock
     :: (Method, Text)

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -147,7 +147,6 @@ import Cardano.Wallet.Api.Types
     , ApiCoinSelection (..)
     , ApiCoinSelectionInput (..)
     , ApiEpochInfo (..)
-    , ApiEpochNumber (..)
     , ApiErrorCode (..)
     , ApiFee (..)
     , ApiMnemonicT (..)
@@ -278,7 +277,7 @@ import Control.Arrow
 import Control.Exception
     ( IOException, bracket, throwIO, tryJust )
 import Control.Monad
-    ( forM, void, when, (>=>) )
+    ( forM, void, (>=>) )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Control.Monad.Trans.Except
@@ -1430,24 +1429,9 @@ getNetworkInformation (_block0, gbp, st) nl = do
 
 getNetworkParameters
     :: (Block, GenesisBlockParameters, SyncTolerance)
-    -> ApiEpochNumber
     -> Handler ApiNetworkParameters
-getNetworkParameters (_block0, gbp, _st) apiEpochNum = do
-    case apiEpochNum of
-        ApiEpochNumber epochNum -> do
-            now <- liftIO getCurrentTime
-            let slotParams = W.slotParams bp
-            let ntrkTip = fromMaybe slotMinBound (slotAt slotParams now)
-            let currentEpochNum = ntrkTip ^. #epochNumber
-            when (currentEpochNum < epochNum) $
-                liftHandler $ throwE $ ErrNoSuchEpoch
-                    { errGivenEpoch = epochNum
-                    , errCurrentEpoch = currentEpochNum
-                    }
-            pure (toApiNetworkParameters bp)
-
-        ApiEpochNumberLatest ->
-            pure (toApiNetworkParameters bp)
+getNetworkParameters (_block0, gbp, _st) =
+    pure $ toApiNetworkParameters bp
   where
     bp = gbp ^. #staticParameters
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1435,11 +1435,6 @@ getNetworkParameters (_block0, gbp, _st) =
   where
     bp = gbp ^. #staticParameters
 
-data ErrNoSuchEpoch = ErrNoSuchEpoch
-    { errGivenEpoch :: W.EpochNo
-    , errCurrentEpoch :: W.EpochNo
-    } deriving (Eq, Show)
-
 getNetworkClock :: NtpClient -> Bool -> Handler ApiNetworkClock
 getNetworkClock client = liftIO . getNtpStatus client
 
@@ -2095,18 +2090,6 @@ instance LiftHandler ErrQuitStakePool where
                     , "although you're not even delegating, nor won't be in an "
                     , "immediate future."
                     ]
-
-instance LiftHandler ErrNoSuchEpoch where
-    handler = \case
-        ErrNoSuchEpoch {errGivenEpoch,errCurrentEpoch}->
-            apiError err404 NoSuchEpochNo $ mconcat
-                [ "I couldn't show blockchain parameters for epoch number later"
-                , " than current one. You requested "
-                , pretty errGivenEpoch
-                , " epoch. Current one is "
-                , pretty errCurrentEpoch
-                , ". Use smaller epoch than current or 'latest'."
-                ]
 
 instance LiftHandler ErrCreateRandomAddress where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -624,7 +624,6 @@ data ApiErrorCode
     | NotDelegatingTo
     | InvalidRestorationParameters
     | RejectedTip
-    | NoSuchEpochNo
     | InvalidDelegationDiscovery
     | NotImplemented
     | WalletNotResponding

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -50,8 +50,7 @@ module Cardano.Wallet.Api.Malformed
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiEpochNumber
-    , ApiNetworkTip
+    ( ApiNetworkTip
     , ApiPoolId
     , ApiPostRandomAddressData
     , ApiSelectCoinsData
@@ -86,8 +85,6 @@ import Data.Text
     ( Text )
 import Data.Typeable
     ( Typeable )
-import Data.Word.Odd
-    ( Word31 )
 import GHC.TypeLits
     ( Symbol )
 import Servant
@@ -162,19 +159,6 @@ instance Malformed (PathParam ApiPoolId) where
         ]
       where
         msg = "Invalid stake pool id: expecting a hex-encoded value that is 32 bytes in length."
-
-instance Wellformed (PathParam ApiEpochNumber) where
-    wellformed = PathParam "latest"
-
-instance Malformed (PathParam ApiEpochNumber) where
-    malformed = first PathParam <$>
-        [ ("earliest", msg)
-        , (T.pack $ show $ (+1) $ fromIntegral @Word31 @Int maxBound, msg)
-        , ("invalid", msg)
-        , ("-1", msg)
-        ]
-      where
-        msg = "I couldn't parse the given epoch number. I am expecting either the word 'latest' or, an integer from 0 to 2147483647."
 
 instance Wellformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
     wellformed = PathParam

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -48,7 +48,6 @@ import Cardano.Wallet.Api.Types
     , ApiCoinSelection (..)
     , ApiCoinSelectionInput (..)
     , ApiEpochInfo (..)
-    , ApiEpochNumber (..)
     , ApiFee (..)
     , ApiMnemonicT (..)
     , ApiNetworkClock (..)
@@ -334,7 +333,6 @@ spec = do
         describe "Can perform roundtrip textual encoding & decoding" $ do
             textRoundtrip $ Proxy @Iso8601Time
             textRoundtrip $ Proxy @SortOrder
-            textRoundtrip $ Proxy @ApiEpochNumber
 
     describe "AddressAmount" $ do
         it "fromText \"22323\"" $
@@ -1177,16 +1175,6 @@ instance Arbitrary (Quantity "percent" Double) where
 instance Arbitrary ApiNetworkParameters where
     arbitrary = genericArbitrary
     shrink = genericShrink
-
-instance Arbitrary ApiEpochNumber where
-    arbitrary = do
-        let lowerBound = fromIntegral (minBound @Word31)
-        let upperBound = fromIntegral (maxBound @Word31)
-        epochN <- choose (lowerBound :: Int, upperBound)
-        elements
-            [ ApiEpochNumberLatest
-            , ApiEpochNumber (EpochNo (fromIntegral epochN))
-            ]
 
 instance Arbitrary SlotId where
     arbitrary = applyArbitrary2 SlotId

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -60,6 +60,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     components = {
       "library" = {
         depends = [
+          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
           (hsPkgs."aeson" or (buildDepError "aeson"))
           (hsPkgs."aeson-qq" or (buildDepError "aeson-qq"))
           (hsPkgs."async" or (buildDepError "async"))
@@ -83,17 +84,13 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."http-client" or (buildDepError "http-client"))
           (hsPkgs."http-types" or (buildDepError "http-types"))
           (hsPkgs."memory" or (buildDepError "memory"))
-          (hsPkgs."OddWord" or (buildDepError "OddWord"))
-          (hsPkgs."memory" or (buildDepError "memory"))
           (hsPkgs."process" or (buildDepError "process"))
           (hsPkgs."retry" or (buildDepError "retry"))
           (hsPkgs."scrypt" or (buildDepError "scrypt"))
-          (hsPkgs."time" or (buildDepError "time"))
           (hsPkgs."template-haskell" or (buildDepError "template-haskell"))
           (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."text-class" or (buildDepError "text-class"))
           (hsPkgs."time" or (buildDepError "time"))
-          (hsPkgs."QuickCheck" or (buildDepError "QuickCheck"))
           ];
         buildable = true;
         };

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1608,8 +1608,6 @@ x-responsesGetNetworkClock: &responsesGetNetworkClock
         schema: *ApiNetworkClock
 
 x-responsesGetNetworkParameters: &responsesGetNetworkParameters
-  <<: *responsesErr400
-  <<: *responsesErr404
   <<: *responsesErr405
   <<: *responsesErr406
   200:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1158,16 +1158,6 @@ x-parametersTransactionId: &parametersTransactionId
     maxLength: 64
     minLength: 64
 
-x-parametersEpochId: &parametersEpochId
-  in: path
-  name: epochId
-  required: true
-  description: |
-    Epoch parameter number as string or `latest`
-    Example: `latest`, `0`, `22`
-  schema:
-    type: string
-
 x-parametersStakePoolId: &parametersStakePoolId
   in: path
   name: stakePoolId
@@ -2303,16 +2293,13 @@ paths:
           name: forceNtpCheck
       responses: *responsesGetNetworkClock
 
-  /network/parameters/{epochId}:
+  /network/parameters:
     get:
       operationId: getNetworkParameters
       tags: ["Network"]
       summary: Parameters
       description: |
         <p align="right">status: <strong>stable</strong></p>
-      parameters:
-        - <<: *parametersEpochId
-          name: epochId
       responses: *responsesGetNetworkParameters
 
   /proxy/transactions:


### PR DESCRIPTION
# Issue Number

#1690 

# Overview

This PR:

- [x] Removes the `epochId` argument from the `getNetworkParameters` API function.
- [x] Removes the `epoch` argument from the `network parameters` CLI command.
- [x] Removes the now unused `ApiEpochNumber` type. (We can reinstate it later, if necessary.)
- [x] Removes the now unused `ErrNoSuchEpoch` type. (We can reinstate it later, if necessary.)
- [x] Updates the swagger specification.
- [x] Updates the CLI integration tests.
- [x] Updates the API integration tests.

# Comments

**:warning: This PR breaks API compatibility with older versions! :warning:** 

- [x] Before merging this PR, we should notify projects that consume `cardano-wallet`, and help them transition to the modified endpoint. (See https://input-output-rnd.slack.com/archives/C7PJ29FME/p1590569319044000)