### PR TITLE
actually identify output by their transaction AND output index...

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -847,6 +847,14 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
         Empty
 
     -- ASSERTIONS
+    let transaction = head $ getFromResponse id rTxs
+    let inputs = view (#inputs)
+    let outputs = view (#outputs)
+    let amounts = getQuantity . view #amount . fromJust . view #source
+    let inputAmounts = sum $ amounts <$> (inputs transaction)
+    let outputAmounts = sum $ (getQuantity . view #amount) <$> (outputs transaction)
+
+    inputAmounts `shouldSatisfy` (>= outputAmounts)
     verify rTxs
         [ expectListSize 1
         , expectListField 0 #inputs (`shouldSatisfy` (all (isJust . view #source)))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1670 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

The transaction id doesn't uniquely identify an output! So, if a transaction had several output, they'd all be conflated under the same key... :facepalm:

I wonder why the state machine didn't catch that though.. because the database model was doing it correctly by using the full `TxIn` as a key.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
