### PR TITLE
Clarify the description of `getNetworkParameters` in the API and CLI.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1564,7 +1564,7 @@ cmdNetworkParameters
     -> Mod CommandFields (IO ())
 cmdNetworkParameters mkClient =
     command "parameters" $ info (helper <*> cmd) $ mempty
-        <> progDesc "View network parameters."
+        <> progDesc "View network parameters for the current epoch."
   where
     cmd = fmap exec $ NetworkParametersArgs
         <$> portOption

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -503,7 +503,8 @@ spec = do
             , ""
             , "Available commands:"
             , "  information              View network information."
-            , "  parameters               View network parameters."
+            , "  parameters               View network parameters for the"
+            , "                           current epoch."
             , "  clock                    View NTP offset."
             ]
 
@@ -519,7 +520,7 @@ spec = do
 
         ["network", "parameters", "--help"] `shouldShowUsage`
             [ "Usage:  network parameters [--port INT]"
-            , "  View network parameters."
+            , "  View network parameters for the current epoch."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2298,6 +2298,8 @@ paths:
       summary: Parameters
       description: |
         <p align="right">status: <strong>stable</strong></p>
+
+        Returns the set of network parameters for the current epoch.
       responses: *responsesGetNetworkParameters
 
   /proxy/transactions:


### PR DESCRIPTION
# Related Issues

#1690

# Overview

This PR clarifies the descriptions of the `getNetworkParameters` API endpoint and the associated `network parameters` CLI command, in response to [review feedback](https://github.com/input-output-hk/cardano-wallet/pull/1694/files#r431011565) for #1694, 