### PR TITLE
Remove types for the greater good: Value-level NetworkDiscriminant

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -26,8 +26,7 @@
 -- "Cardano.Wallet.Byron.Transaction"
 
 module Cardano.Wallet.Byron
-    ( SomeNetworkDiscriminant (..)
-    , serveWallet
+    ( serveWallet
 
       -- * Tracing
     , Tracers' (..)
@@ -59,8 +58,11 @@ import Cardano.Wallet.Api
     ( ApiLayer, ApiV2 )
 import Cardano.Wallet.Api.Server
     ( HostPreference, Listen (..), ListenError (..), TlsConfiguration )
+<<<<<<< HEAD
 import Cardano.Wallet.Api.Types
     ( ApiStakePool, DecodeAddress, EncodeAddress, EncodeStakeAddress )
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Cardano.Wallet.Byron.Api.Server
     ( server )
 import Cardano.Wallet.Byron.Compatibility
@@ -69,8 +71,6 @@ import Cardano.Wallet.Byron.Network
     ( NetworkLayerLog, withNetworkLayer )
 import Cardano.Wallet.Byron.Transaction
     ( newTransactionLayer )
-import Cardano.Wallet.Byron.Transaction.Size
-    ( MaxSizeOf )
 import Cardano.Wallet.DB.Sqlite
     ( DefaultFieldValues (..), PersistState )
 import Cardano.Wallet.Logging
@@ -78,18 +78,16 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
+    ( AddressScheme
+    , Depth (..)
     , NetworkDiscriminant (..)
-    , NetworkDiscriminantVal
-    , PaymentAddress
     , PersistPrivateKey
     , WalletKey
-    , networkDiscriminantVal
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
+    ( ByronKey, byronScheme )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+    ( IcarusKey, icarusScheme )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
@@ -149,6 +147,7 @@ import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
 
+<<<<<<< HEAD
 -- | Encapsulate a network discriminant and the necessary constraints it should
 -- satisfy.
 data SomeNetworkDiscriminant where
@@ -169,6 +168,8 @@ data SomeNetworkDiscriminant where
 
 deriving instance Show SomeNetworkDiscriminant
 
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 -- | The @cardano-wallet-shelley@ main function. It takes the configuration
 -- which was passed from the CLI and environment and starts all components of
 -- the wallet.
@@ -176,7 +177,7 @@ serveWallet
     :: forall t.
         ( t ~ IO Byron
         )
-    => SomeNetworkDiscriminant
+    => NetworkDiscriminant
     -- ^ Proxy for the network discriminant
     -> Tracers IO
     -- ^ Logging config.
@@ -206,7 +207,7 @@ serveWallet
     -- ^ Callback to run before the main loop
     -> IO ExitCode
 serveWallet
-  (SomeNetworkDiscriminant proxy)
+  n
   Tracers{..}
   sTolerance
   databaseDir
@@ -217,9 +218,8 @@ serveWallet
   block0
   (np, vData)
   beforeMainLoop = do
-    let ntwrk = networkDiscriminantValFromProxy proxy
     traceWith applicationTracer $ MsgStarting socketPath
-    traceWith applicationTracer $ MsgNetworkName ntwrk
+    traceWith applicationTracer $ MsgNetworkName (toText n)
     Server.withListeningSocket hostPref listen $ \case
         Left e -> handleApiServerStartupError e
         Right (_, socket) -> serveApp socket
@@ -228,19 +228,13 @@ serveWallet
         withNetworkLayer networkTracer np socketPath vData $ \nl -> do
             withWalletNtpClient io ntpClientTracer $ \ntpClient -> do
                 let pm = fromNetworkMagic $ networkMagic $ fst vData
-                randomApi  <- apiLayer (newTransactionLayer proxy pm) nl
-                icarusApi  <- apiLayer (newTransactionLayer proxy pm) nl
-                startServer proxy socket randomApi icarusApi ntpClient
+                randomApi  <- apiLayer (newTransactionLayer n pm) nl (byronScheme n)
+                icarusApi  <- apiLayer (newTransactionLayer n pm) nl (icarusScheme n)
+                startServer socket randomApi icarusApi ntpClient
                 pure ExitSuccess
 
-    networkDiscriminantValFromProxy
-        :: forall n. (NetworkDiscriminantVal n)
-        => Proxy n
-        -> Text
-    networkDiscriminantValFromProxy _ =
-        networkDiscriminantVal @n
-
     startServer
+<<<<<<< HEAD
         :: forall n.
             ( PaymentAddress n IcarusKey
             , PaymentAddress n ByronKey
@@ -253,31 +247,43 @@ serveWallet
         -> Socket
         -> ApiLayer (RndState n) t ByronKey
         -> ApiLayer (SeqState n IcarusKey) t IcarusKey
+=======
+        :: Socket
+        -> ApiLayer RndState t ByronKey
+        -> ApiLayer (SeqState IcarusKey) t IcarusKey
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         -> NtpClient
         -> IO ()
-    startServer _proxy socket random icarus ntp = do
+    startServer socket random icarus ntp = do
         sockAddr <- getSocketName socket
         let settings = Warp.defaultSettings & setBeforeMainLoop
                 (beforeMainLoop sockAddr)
+<<<<<<< HEAD
         let application = Server.serve (Proxy @(ApiV2 n ApiStakePool)) $
                 server random icarus ntp
+=======
+        let application = Server.serve (Proxy @ApiV2) $
+                server n random icarus ntp
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         Server.start settings apiServerTracer tlsConfig socket application
 
     apiLayer
         :: forall s k.
             ( IsOurs s Address
             , IsOurs s ChimericAccount
-            , PersistState s
+            , PersistState s k
             , PersistPrivateKey (k 'RootK)
             , WalletKey k
             )
         => TransactionLayer t k
         -> NetworkLayer IO t ByronBlock
+        -> AddressScheme k
         -> IO (ApiLayer s t k)
-    apiLayer tl nl = do
+    apiLayer tl nl addrScheme = do
         let params = (block0, np, sTolerance)
         db <- Sqlite.newDBFactory
             walletDbTracer
+<<<<<<< HEAD
             (DefaultFieldValues
                 { defaultActiveSlotCoefficient =
                     getActiveSlotCoefficient gp
@@ -293,6 +299,12 @@ serveWallet
             databaseDir
         Server.newApiLayer walletEngineTracer params nl' tl db
             Server.idleWorker
+=======
+            (DefaultFieldValues $ getActiveSlotCoefficient gp)
+            addrScheme
+            databaseDir
+        Server.newApiLayer walletEngineTracer params nl' tl db addrScheme
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
       where
         gp = genesisParameters np
         nl' = fromByronBlock gp <$> nl

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- Orphan instances for {Encode,Decode}Address until we get rid of the
@@ -86,6 +85,7 @@ import Cardano.Crypto
     ( serializeCborHash )
 import Cardano.Crypto.ProtocolMagic
     ( ProtocolMagicId, unProtocolMagicId )
+<<<<<<< HEAD
 import Cardano.Wallet.Api.Types
     ( DecodeAddress (..)
     , DecodeStakeAddress (..)
@@ -98,32 +98,22 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( decodeLegacyAddress )
 import Cardano.Wallet.Primitive.Slotting
     ( flatSlot, fromFlatSlot )
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Cardano.Wallet.Unsafe
     ( unsafeDeserialiseCbor, unsafeFromHex )
-import Data.ByteString
-    ( ByteString )
-import Data.ByteString.Base58
-    ( bitcoinAlphabet, decodeBase58, encodeBase58 )
 import Data.Coerce
     ( coerce )
-import Data.Either.Extra
-    ( maybeToEither )
-import Data.Function
-    ( (&) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text
     ( Text )
-import Data.Text.Class
-    ( TextDecodingError (..) )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime )
 import Data.Word
     ( Word16, Word32 )
 import GHC.Stack
     ( HasCallStack )
-import GHC.TypeLits
-    ( KnownNat )
 import Numeric.Natural
     ( Natural )
 import Ouroboros.Consensus.Block.Abstract
@@ -165,7 +155,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import qualified Data.Text.Encoding as T
 import qualified Ouroboros.Network.Block as O
 import qualified Ouroboros.Network.Point as Point
 
@@ -507,6 +496,7 @@ fromProtocolMagicId = W.ProtocolMagic . fromIntegral . unProtocolMagicId
                       Address Encoding / Decoding
 -------------------------------------------------------------------------------}
 
+<<<<<<< HEAD
 instance {-# OVERLAPS #-} EncodeStakeAddress n where
     encodeStakeAddress = error
         "encodeStakeAddress: there's no such thing as stake address in Byron"
@@ -554,3 +544,5 @@ gDecodeAddress decodeByron text =
     tryBase58 :: Maybe ByteString
     tryBase58 =
         decodeBase58 bitcoinAlphabet (T.encodeUtf8 text)
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant

--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -38,8 +38,6 @@ import Cardano.Crypto.ProtocolMagic
     ( ProtocolMagicId (..) )
 import Cardano.Launcher
     ( Command (..), StdStream (..), withBackendProcess )
-import Cardano.Wallet.Byron
-    ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Byron.Compatibility
     ( NodeVersionData
     , emptyGenesis
@@ -73,16 +71,15 @@ import Control.Monad.Trans.Except
     ( ExceptT, withExceptT )
 import Data.Aeson
     ( toJSON )
-import Data.Function
-    ( (&) )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Text
     ( Text )
 import Data.Time.Clock.POSIX
     ( getPOSIXTime )
+<<<<<<< HEAD
 import GHC.TypeLits
     ( KnownNat, Nat, SomeNat (..), someNatVal )
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Options.Applicative
     ( Parser, flag', help, long, metavar )
 import Ouroboros.Network.Magic
@@ -107,7 +104,7 @@ import qualified Data.Yaml as Yaml
 
 data NetworkConfiguration where
     MainnetConfig
-        :: (SomeNetworkDiscriminant, NodeVersionData)
+        :: NodeVersionData
         -> NetworkConfiguration
 
     TestnetConfig
@@ -146,7 +143,7 @@ networkConfigurationOption =
   where
     -- --mainnet
     mainnetFlag = flag'
-        (MainnetConfig (SomeNetworkDiscriminant $ Proxy @'Mainnet, mainnetVersionData))
+        (MainnetConfig mainnetVersionData)
         (long "mainnet")
 
     customNetworkOption
@@ -157,6 +154,7 @@ networkConfigurationOption =
         <> metavar "FILE"
         <> help "Path to the genesis .json file."
 
+<<<<<<< HEAD
 someCustomDiscriminant
     :: (forall (pm :: Nat). KnownNat pm => Proxy pm -> SomeNetworkDiscriminant)
     -> ProtocolMagic
@@ -170,13 +168,14 @@ someCustomDiscriminant mkSomeNetwork pm@(ProtocolMagic n) =
         _ -> error "networkDiscriminantFlag: failed to convert \
             \ProtocolMagic to SomeNat."
 
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 parseGenesisData
     :: NetworkConfiguration
-    -> ExceptT String IO
-        (SomeNetworkDiscriminant, NetworkParameters, NodeVersionData, Block)
+    -> ExceptT String IO (NetworkDiscriminant, NetworkParameters, NodeVersionData, Block)
 parseGenesisData = \case
-    MainnetConfig (discriminant, vData) -> pure
-        ( discriminant
+    MainnetConfig vData -> pure
+        ( Mainnet
         , mainnetNetworkParameters
         , vData
         , emptyGenesis (genesisParameters mainnetNetworkParameters)
@@ -185,6 +184,7 @@ parseGenesisData = \case
         (genesisData, genesisHash) <-
             withExceptT show $ readGenesisData genesisFile
 
+<<<<<<< HEAD
         let mkSomeNetwork
                 :: forall (pm :: Nat). KnownNat pm
                 => Proxy pm
@@ -218,9 +218,13 @@ parseGenesisData = \case
                 & fromProtocolMagicId
                 & someCustomDiscriminant mkSomeNetwork
 
+=======
+        let pm = fromProtocolMagicId $ gdProtocolMagicId genesisData
+        let vData = testnetVersionData pm
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         let (np, outs) = fromGenesisData (genesisData, genesisHash)
         pure
-            ( discriminant
+            ( Testnet $ fromIntegral $ getProtocolMagic pm
             , np
             , vData
             , genesisBlockFromTxOuts (genesisParameters np) outs

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
@@ -125,14 +125,19 @@ sizeOfCoin = sizeOf . CBOR.encodeWord64 . getCoin
 sizeOf :: CBOR.Encoding -> Int
 sizeOf = fromIntegral . BL.length . CBOR.toLazyByteString
 
-class MaxSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
-    maxSizeOf :: Int
+class MaxSizeOf (t :: *) (k :: Depth -> * -> *) where
+    maxSizeOf :: NetworkDiscriminant -> Int
 
+<<<<<<< HEAD
 instance forall t k pm. (MaxSizeOf t 'Mainnet k) => MaxSizeOf t ('Staging pm) k where
     maxSizeOf = maxSizeOf @t @'Mainnet @k
 
 class MinSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
     minSizeOf :: Int
+=======
+class MinSizeOf (t :: *) (k :: Depth -> * -> *) where
+    minSizeOf :: NetworkDiscriminant -> Int
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
 instance forall t k pm. (MinSizeOf t 'Mainnet k) => MinSizeOf t ('Staging pm) k where
     minSizeOf = minSizeOf @t @'Mainnet @k
@@ -160,9 +165,9 @@ instance forall t k pm. (MinSizeOf t 'Mainnet k) => MinSizeOf t ('Staging pm) k 
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (Ø)       --     1 byte
 --             | U8                   --     1 bytes
-instance MaxSizeOf Address 'Mainnet IcarusKey where maxSizeOf = 43
-instance MinSizeOf Address 'Mainnet IcarusKey where minSizeOf = 39
-
+--
+--
+--
 -- ADDRESS (TestNet, Icarus)
 --     = CBOR-LIST-LEN (2)    --     1 byte
 --     | 46-50OCTET           -- 46-50 bytes #------*
@@ -186,8 +191,13 @@ instance MinSizeOf Address 'Mainnet IcarusKey where minSizeOf = 39
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (8)       --     8 bytes
 --             | U8                   --     1 bytes
-instance MaxSizeOf Address ('Testnet pm) IcarusKey where maxSizeOf = 50
-instance MinSizeOf Address ('Testnet pm) IcarusKey where minSizeOf = 46
+instance MaxSizeOf Address IcarusKey where
+    maxSizeOf Mainnet     = 43
+    maxSizeOf (Testnet _) = 50
+
+instance MinSizeOf Address IcarusKey where
+    minSizeOf Mainnet     = 39
+    minSizeOf (Testnet _) = 46
 
 -- ADDRESS (MainNet, Random)
 --     = CBOR-LIST-LEN (2)    --     1 byte
@@ -212,9 +222,8 @@ instance MinSizeOf Address ('Testnet pm) IcarusKey where minSizeOf = 46
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (34)      -- 30-34 bytes
 --             | U8                   --     1 bytes
-instance MaxSizeOf Address 'Mainnet ByronKey where maxSizeOf = 76
-instance MinSizeOf Address 'Mainnet ByronKey where minSizeOf = 68
-
+--
+--
 -- ADDRESS (TestNet, Random)
 --     = CBOR-LIST-LEN (2)    --     1 byte
 --     | 79-83OCTET           -- 79-83 bytes #------*
@@ -238,5 +247,10 @@ instance MinSizeOf Address 'Mainnet ByronKey where minSizeOf = 68
 --             | 28OCTET              --    28 bytes
 --             | ATTRIBUTES (37-41)   -- 37-41 bytes
 --             | U8                   --     1 bytes
-instance MaxSizeOf Address ('Testnet pm) ByronKey where maxSizeOf = 83
-instance MinSizeOf Address ('Testnet pm) ByronKey where minSizeOf = 75
+
+instance MaxSizeOf Address ByronKey where
+    maxSizeOf Mainnet     = 76
+    maxSizeOf (Testnet _) = 83
+instance MinSizeOf Address ByronKey where
+    minSizeOf Mainnet     = 68
+    minSizeOf (Testnet _) = 75

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -18,26 +18,27 @@ import Prelude
 import Cardano.Mnemonic
     ( entropyToMnemonic, genEntropy, mnemonicToText )
 import Cardano.Wallet.Api.Types
-    ( ApiByronWallet
+    ( ApiAddress (..)
+    , ApiByronWallet
     , ApiFee
     , ApiT (..)
     , ApiTransaction
     , ApiTxId (ApiTxId)
     , ApiUtxoStatistics
+<<<<<<< HEAD
     , DecodeAddress (..)
     , DecodeStakeAddress (..)
     , EncodeAddress (..)
+=======
+    , ApiWalletMigrationInfo
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     , Iso8601Time (..)
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant (..), PaymentAddress (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+    ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address, Direction (..), TxStatus (..) )
+    ( Direction (..), TxStatus (..) )
 import Control.Monad
     ( forM, forM_ )
 import Data.Generics.Internal.VL.Lens
@@ -105,7 +106,10 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
+-- TODO: Taking NetworkDiscriminant as an argument is superfluous when it already
+-- exists within @Context@.
 spec
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( PaymentAddress n IcarusKey
         , PaymentAddress n ByronKey
@@ -115,66 +119,101 @@ spec
         )
     => SpecWith (Context t)
 spec = do
+=======
+    :: forall t. NetworkDiscriminant -> SpecWith (Context t)
+spec n = do
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     describe "BYRON_TXS" $ do
         -- Random → Random
-        scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-            [ fixtureRandomWalletAddrs @n
+        scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+            [ fixtureRandomWalletAddrs n
             ]
 
         -- Random → [Random, Icarus]
-        scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-            [ fixtureRandomWalletAddrs @n
-            , fixtureIcarusWalletAddrs @n
+        scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+            [ fixtureRandomWalletAddrs n
+            , fixtureIcarusWalletAddrs n
             ]
 
         -- Icarus → Icarus
-        scenario_TRANS_CREATE_01_02 @n fixtureIcarusWallet
-            [ fixtureIcarusWalletAddrs @n
+        scenario_TRANS_CREATE_01_02 fixtureIcarusWallet
+            [ fixtureIcarusWalletAddrs n
             ]
 
         -- Icarus → [Icarus, Random]
-        scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-            [ fixtureIcarusWalletAddrs @n
-            , fixtureRandomWalletAddrs @n
+        scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+            [ fixtureIcarusWalletAddrs n
+            , fixtureRandomWalletAddrs n
             ]
 
+<<<<<<< HEAD
         -- TRANS_CREATE_03 requires actually being able to compute exact fees, which
         -- is not really possible w/ cardano-node. So, skipping.
 
         scenario_TRANS_CREATE_04b @n
         scenario_TRANS_CREATE_04c @n
         scenario_TRANS_CREATE_04d @n
+=======
+        scenario_TRANS_CREATE_02x
 
-        scenario_TRANS_CREATE_07 @n
+        -- TRANS_CREATE_03 requires actually being able to compute exact fees, which
+        -- is not really possible w/ cardano-node. So, skipping.
 
-        scenario_TRANS_ESTIMATE_01_02 @n fixtureRandomWallet
-            [ randomAddresses @n . entropyToMnemonic <$> genEntropy
+        scenario_TRANS_CREATE_04a
+        scenario_TRANS_CREATE_04b
+        scenario_TRANS_CREATE_04c
+        scenario_TRANS_CREATE_04d
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
+
+        scenario_TRANS_CREATE_07
+
+        scenario_TRANS_ESTIMATE_01_02 fixtureRandomWallet
+            [ randomAddresses n . entropyToMnemonic <$> genEntropy
             ]
 
-        scenario_TRANS_ESTIMATE_01_02 @n fixtureIcarusWallet
-            [ icarusAddresses @n . entropyToMnemonic <$> genEntropy
-            , icarusAddresses @n . entropyToMnemonic <$> genEntropy
+        scenario_TRANS_ESTIMATE_01_02 fixtureIcarusWallet
+            [ icarusAddresses n . entropyToMnemonic <$> genEntropy
+            , icarusAddresses n . entropyToMnemonic <$> genEntropy
             ]
 
+<<<<<<< HEAD
         scenario_TRANS_ESTIMATE_04b @n
         scenario_TRANS_ESTIMATE_04c @n
+=======
+        scenario_TRANS_ESTIMATE_04a
+        scenario_TRANS_ESTIMATE_04b
+        scenario_TRANS_ESTIMATE_04c
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
-        scenario_TRANS_REG_1670 @n (fixtureIcarusWalletWith @n)
+        scenario_TRANS_REG_1670 (fixtureIcarusWalletWith)
 
     describe "BYRON_RESTORATION" $ do
-        scenario_RESTORE_01 @n fixtureRandomWallet
-        scenario_RESTORE_02 @n (fixtureRandomWalletAddrs @n)
-        scenario_RESTORE_03 @n (fixtureRandomWalletAddrs @n)
+        scenario_RESTORE_01 fixtureRandomWallet
+        scenario_RESTORE_02 (fixtureRandomWalletAddrs n)
+        scenario_RESTORE_03 (fixtureRandomWalletAddrs n)
 
     describe "BYRON_UTXO" $ do
-        scenario_TRANS_UTXO_01 @n fixtureIcarusWallet (fixtureIcarusWalletAddrs @n)
-        scenario_TRANS_UTXO_01 @n fixtureRandomWallet (fixtureRandomWalletAddrs @n)
+        scenario_TRANS_UTXO_01 fixtureIcarusWallet (fixtureIcarusWalletAddrs n)
+        scenario_TRANS_UTXO_01 fixtureRandomWallet (fixtureRandomWalletAddrs n)
 
+<<<<<<< HEAD
+=======
+    describe "BYRON_MIGRATE" $ do
+        scenario_MIGRATE_01 fixtureRandomWallet
+        scenario_MIGRATE_02 fixtureRandomWallet 1
+        scenario_MIGRATE_02 fixtureRandomWallet 3
+        scenario_MIGRATE_02 fixtureRandomWallet 10
+        scenario_MIGRATE_02 fixtureIcarusWallet 1
+        scenario_MIGRATE_02 fixtureIcarusWallet 3
+        scenario_MIGRATE_02 fixtureIcarusWallet 10
+
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 --
 -- Scenarios
 --
 
 scenario_TRANS_CREATE_01_02
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -182,6 +221,10 @@ scenario_TRANS_CREATE_01_02
         )
     => (Context t -> IO ApiByronWallet)
     -> [Context t -> IO (ApiByronWallet, [Address])]
+=======
+    :: (Context t -> IO ApiByronWallet)
+    -> [Context t -> IO (ApiByronWallet, [ApiAddress])]
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- SETUP
@@ -189,11 +232,15 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
     (recipients, payments) <- fmap unzip $ forM fixtures $ \fixtureTarget -> do
         (wDest, addrs) <- fixtureTarget ctx
-        pure (wDest, mkPayment @n (head addrs) amnt)
+        pure (wDest, mkPayment (head addrs) amnt)
 
     -- ACTION
+<<<<<<< HEAD
     r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
     let txid = getFromResponse #id r
+=======
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
     -- ASSERTIONS
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
@@ -231,7 +278,7 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
                     (`shouldBe` Quantity (faucetAmt + amnt))
                 ]
         let link = Link.listTransactions @'Byron wDest
-        rTrans <- request @([ApiTransaction n]) ctx link Default Empty
+        rTrans <- request @([ApiTransaction]) ctx link Default Empty
         verify rTrans
             [ expectResponseCode @IO HTTP.status200
             , expectListSize 11
@@ -261,6 +308,7 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     n = fromIntegral $ length fixtures
 
 scenario_TRANS_ESTIMATE_01_02
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -268,6 +316,10 @@ scenario_TRANS_ESTIMATE_01_02
         )
     => (Context t -> IO ApiByronWallet)
     -> [IO [Address]]
+=======
+    :: (Context t -> IO ApiByronWallet)
+    -> [IO [ApiAddress]]
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- SETUP
@@ -275,7 +327,7 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
     payments <- forM fixtures $ \fixtureTarget -> do
         addrs <- fixtureTarget
-        pure $ mkPayment @n (head addrs) amnt
+        pure $ mkPayment (head addrs) amnt
 
     -- ACTION
     r <- estimateByronTransaction ctx wSrc payments
@@ -293,6 +345,7 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
   where
     title = "TRANS_ESTIMATE_01/02 - " ++ show (length fixtures) ++ " recipient(s)"
 
+<<<<<<< HEAD
 scenario_TRANS_CREATE_04b
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -301,12 +354,50 @@ scenario_TRANS_CREATE_04b
         , PaymentAddress n IcarusKey
         )
     => SpecWith (Context t)
-scenario_TRANS_CREATE_04b = it title $ \ctx -> do
+=======
+scenario_TRANS_CREATE_02x
+    :: SpecWith (Context t)
+scenario_TRANS_CREATE_02x = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+    (wSrc, payments) <- fixtureSingleUTxO ctx
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403UTxO
+        ]
+  where
+    title = "TRANS_CREATE_02x - Multi-output failure w/ single UTxO"
+
+scenario_TRANS_CREATE_04a
+    :: SpecWith (Context t)
+scenario_TRANS_CREATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted ctx
+
+    -- ACTION
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403InputsDepleted
+        ]
+  where
+    title = "TRANS_CREATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_CREATE_04b
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
+scenario_TRANS_CREATE_04b = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureCantCoverFee ctx
+
+    -- ACTION
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
 
     -- ASSERTIONS
     verify r
@@ -317,6 +408,7 @@ scenario_TRANS_CREATE_04b = it title $ \ctx -> do
     title = "TRANS_CREATE_04 - Can't cover fee"
 
 scenario_TRANS_CREATE_04c
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -324,12 +416,15 @@ scenario_TRANS_CREATE_04c
         , PaymentAddress n IcarusKey
         )
     => SpecWith (Context t)
+=======
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 scenario_TRANS_CREATE_04c = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+    (wSrc, payments) <- fixtureNotEnoughMoney ctx
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
 
     -- ASSERTIONS
     verify r
@@ -340,6 +435,7 @@ scenario_TRANS_CREATE_04c = it title $ \ctx -> do
     title = "TRANS_CREATE_04 - Not enough money"
 
 scenario_TRANS_CREATE_04d
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -347,12 +443,15 @@ scenario_TRANS_CREATE_04d
         , PaymentAddress n IcarusKey
         )
     => SpecWith (Context t)
+=======
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 scenario_TRANS_CREATE_04d = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureWrongPassphrase @n ctx
+    (wSrc, payments) <- fixtureWrongPassphrase ctx
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc payments "This passphrase is wrong"
+    r <- postByronTransaction ctx wSrc payments "This passphrase is wrong"
 
     -- ASSERTIONS
     verify r
@@ -362,6 +461,7 @@ scenario_TRANS_CREATE_04d = it title $ \ctx -> do
   where
     title = "TRANS_CREATE_04 - Wrong password"
 
+<<<<<<< HEAD
 scenario_TRANS_ESTIMATE_04b
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -370,9 +470,30 @@ scenario_TRANS_ESTIMATE_04b
         , PaymentAddress n IcarusKey
         )
     => SpecWith (Context t)
+=======
+scenario_TRANS_ESTIMATE_04a
+    :: SpecWith (Context t)
+scenario_TRANS_ESTIMATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted ctx
+
+    -- ACTION
+    r <- estimateByronTransaction ctx wSrc payments
+
+    -- ASSERTIONS
+    verify r
+        [ expectResponseCode HTTP.status403
+        , expectErrorMessage errMsg403InputsDepleted
+        ]
+  where
+    title = "TRANS_ESTIMATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_ESTIMATE_04b
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+    (wSrc, payments) <- fixtureCantCoverFee ctx
 
     -- ACTION
     r <- estimateByronTransaction ctx wSrc payments
@@ -391,6 +512,7 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     title = "TRANS_ESTIMATE_04 - Can't cover fee"
 
 scenario_TRANS_ESTIMATE_04c
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -398,9 +520,12 @@ scenario_TRANS_ESTIMATE_04c
         , PaymentAddress n IcarusKey
         )
     => SpecWith (Context t)
+=======
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 scenario_TRANS_ESTIMATE_04c = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+    (wSrc, payments) <- fixtureNotEnoughMoney ctx
 
     -- ACTION
     r <- estimateByronTransaction ctx wSrc payments
@@ -414,6 +539,7 @@ scenario_TRANS_ESTIMATE_04c = it title $ \ctx -> do
     title = "TRANS_ESTIMATE_04 - Not enough money"
 
 scenario_TRANS_CREATE_07
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -421,12 +547,15 @@ scenario_TRANS_CREATE_07
         , PaymentAddress n ByronKey
         )
     => SpecWith (Context t)
+=======
+    :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 scenario_TRANS_CREATE_07 = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureDeletedWallet @n ctx
+    (wSrc, payments) <- fixtureDeletedWallet ctx
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc payments fixturePassphrase
+    r <- postByronTransaction ctx wSrc payments fixturePassphrase
 
     -- ASSERTIONS
     verify r
@@ -437,6 +566,7 @@ scenario_TRANS_CREATE_07 = it title $ \ctx -> do
     title = "TRANS_CREATE_07 - Deleted wallet"
 
 scenario_RESTORE_01
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -444,6 +574,9 @@ scenario_RESTORE_01
         , PaymentAddress n ByronKey
         )
     => (Context t -> IO ApiByronWallet)
+=======
+    :: (Context t -> IO ApiByronWallet)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_RESTORE_01 fixtureSource = it title $ \ctx -> do
     -- SETUP
@@ -451,11 +584,11 @@ scenario_RESTORE_01 fixtureSource = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
     (wDest, payment, mnemonics) <- do
         (wDest, mnemonics) <- fixtureRandomWalletMws ctx
-        let addrs = randomAddresses @n mnemonics
-        pure (wDest, mkPayment @n (head addrs) amnt, mnemonics)
+        let addrs = randomAddresses (_network ctx) mnemonics
+        pure (wDest, mkPayment (head addrs) amnt, mnemonics)
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+    r <- postByronTransaction ctx wSrc [payment] fixturePassphrase
 
     -- ASSERTIONS
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
@@ -515,12 +648,16 @@ scenario_RESTORE_01 fixtureSource = it title $ \ctx -> do
     title = "BYRON_RESTORE_01 - can restore recipient wallet from xprv"
 
 scenario_RESTORE_02
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
         , EncodeAddress n
         )
     => (Context t -> IO (ApiByronWallet, [Address]))
+=======
+    :: (Context t -> IO (ApiByronWallet, [ApiAddress]))
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_RESTORE_02 fixtureTarget = it title $ \ctx -> do
     -- SETUP
@@ -531,10 +668,10 @@ scenario_RESTORE_02 fixtureTarget = it title $ \ctx -> do
             ("Byron Wallet Restored", rootXPrv, fixturePassphraseEncrypted)
     (wDest, payment) <- do
         (wDest, addrs) <- fixtureTarget ctx
-        pure (wDest, mkPayment @n (head addrs) amnt)
+        pure (wDest, mkPayment (head addrs) amnt)
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+    r <- postByronTransaction ctx wSrc [payment] fixturePassphrase
 
     -- ASSERTIONS
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
@@ -573,12 +710,16 @@ scenario_RESTORE_02 fixtureTarget = it title $ \ctx -> do
     title = "BYRON_RESTORE_02 - can send tx from restored wallet from xprv"
 
 scenario_RESTORE_03
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
         , EncodeAddress n
         )
     => (Context t -> IO (ApiByronWallet, [Address]))
+=======
+    :: (Context t -> IO (ApiByronWallet, [ApiAddress]))
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_RESTORE_03 fixtureTarget = it title $ \ctx -> do
     -- SETUP
@@ -588,7 +729,7 @@ scenario_RESTORE_03 fixtureTarget = it title $ \ctx -> do
     let amnt = 100_000 :: Natural
     (_, payment) <- do
         (wDest, addrs) <- fixtureTarget ctx
-        pure (wDest, mkPayment @n (head addrs) amnt)
+        pure (wDest, mkPayment (head addrs) amnt)
 
     -- ACTION
     wSrc <- emptyByronWalletFromXPrvWith ctx "random"
@@ -602,7 +743,7 @@ scenario_RESTORE_03 fixtureTarget = it title $ \ctx -> do
         ]
 
     -- ACTION
-    r <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+    r <- postByronTransaction ctx wSrc [payment] fixturePassphrase
     -- ASSERTIONS
     verify r
         [ expectResponseCode HTTP.status403
@@ -614,6 +755,7 @@ scenario_RESTORE_03 fixtureTarget = it title $ \ctx -> do
             \ proper balance but sending tx fails"
 
 scenario_TRANS_UTXO_01
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -621,6 +763,10 @@ scenario_TRANS_UTXO_01
         )
     => (Context t -> IO ApiByronWallet)
     -> (Context t -> IO (ApiByronWallet, [Address]))
+=======
+    :: (Context t -> IO ApiByronWallet)
+    -> (Context t -> IO (ApiByronWallet, [ApiAddress]))
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_TRANS_UTXO_01 fixtureSource fixtureTarget = it title $ \ctx -> do
     -- SETUP
@@ -630,10 +776,10 @@ scenario_TRANS_UTXO_01 fixtureSource fixtureTarget = it title $ \ctx -> do
     (wDest, addrs) <- fixtureTarget ctx
 
     forM_ matrix $ \(c, alreadyAbsorbed) -> do
-        let payment = mkPayment @n (head addrs) c
+        let payment = mkPayment (head addrs) c
 
         -- ACTION
-        r <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+        r <- postByronTransaction ctx wSrc [payment] fixturePassphrase
         let coinsSent = map fromIntegral $ take alreadyAbsorbed coins
         let coinsSentAll = sum coinsSent
 
@@ -659,6 +805,7 @@ scenario_TRANS_UTXO_01 fixtureSource fixtureTarget = it title $ \ctx -> do
   where
     title = "TRANS_UTXO_01 - one recipient multiple txs received"
 
+<<<<<<< HEAD
 scenario_TRANS_REG_1670
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -667,8 +814,87 @@ scenario_TRANS_REG_1670
         , PaymentAddress n IcarusKey
         )
     => (Context t -> [Natural] -> IO ApiByronWallet)
+=======
+scenario_MIGRATE_01
+    :: (Context t -> IO ApiByronWallet)
+    -> SpecWith (Context t)
+scenario_MIGRATE_01 fixtureSource = it title $ \ctx -> do
+    wSrc <- fixtureSource ctx
+
+    r <- request @[ApiTransaction] ctx
+         (Link.migrateWallet @'Byron wSrc)
+         Default
+         (NonJson "{passphrase:,}")
+    expectResponseCode @IO HTTP.status400 r
+    expectErrorMessage errMsg400ParseError r
+  where
+    title = "BYRON_MIGRATE_01 - invalid payload, parser error"
+
+scenario_MIGRATE_02
+    :: (Context t -> IO ApiByronWallet)
+    -> Int
+    -> SpecWith (Context t)
+scenario_MIGRATE_02 fixtureSource addrCount = it title $ \ctx -> do
+
+    let n = _network ctx
+
+    -- Restore a Byron wallet with funds, to act as a source wallet:
+    wSrc <- fixtureSource ctx
+    let originalBalance =
+            view (#balance . #available . #getQuantity) wSrc
+
+    -- Create an empty target wallet:
+    (wDest, mw) <- emptyRandomWalletMws ctx
+    let addresses :: [Text] =
+            take addrCount $ apiAddress <$> randomAddresses n mw
+
+    -- Calculate the expected migration fee:
+    r0 <- request @ApiWalletMigrationInfo ctx
+          (Link.getMigrationInfo @'Byron wSrc) Default Empty
+    verify r0
+        [ expectResponseCode @IO HTTP.status200
+        , expectField #migrationCost (.> Quantity 0)
+        ]
+    let expectedFee = getFromResponse (#migrationCost . #getQuantity) r0
+
+    -- Perform a migration from the source wallet to the target wallet:
+    r1 <- request @[ApiTransaction] ctx
+          (Link.migrateWallet @'Byron wSrc)
+          Default
+          (Json [json|
+              { passphrase: #{fixturePassphrase}
+              , addresses: #{addresses}
+              }|])
+    verify r1
+        [ expectResponseCode @IO HTTP.status202
+        , expectField id (`shouldSatisfy` (not . null))
+        ]
+
+    -- Check that funds become available in the target wallet:
+    let expectedBalance = originalBalance - expectedFee
+    eventually "Wallet has expectedBalance" $ do
+        r2 <- request @ApiByronWallet ctx
+              (Link.getWallet @'Byron wDest) Default Empty
+        verify r2
+            [ expectField
+                (#balance . #available)
+                (`shouldBe` Quantity expectedBalance)
+            , expectField
+                (#balance . #total)
+                (`shouldBe` Quantity expectedBalance)
+            ]
+  where
+    title = "BYRON_MIGRATE_02 - after a migration operation successfully \
+            \completes, the correct amount eventually becomes available \
+            \in the target wallet for an arbitrary number of specified addresses."
+
+scenario_TRANS_REG_1670
+    :: (Context t -> [Natural] -> IO ApiByronWallet)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> SpecWith (Context t)
 scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
+    let n = _network ctx
+
     -- SETUP
     -- We want to construct two transactions, where the second transaction uses
     -- an output of the first one. We achieve this by having a wallet with a
@@ -685,13 +911,13 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
     let amnt = 1
     let (_, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
     wSrc <- fixture ctx [2*amnt+2*feeMax]
-    [sink] <- take 1 . icarusAddresses @n . entropyToMnemonic <$> genEntropy
-    let payment = mkPayment @n sink amnt
+    [sink] <- take 1 . icarusAddresses n . entropyToMnemonic <$> genEntropy
+    let payment = mkPayment sink amnt
 
     -- 1st TX
-    _ <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+    _ <- postByronTransaction ctx wSrc [payment] fixturePassphrase
     eventually "transaction is inserted" $ do
-        rTxs <- request @[ApiTransaction n] ctx
+        rTxs <- request @[ApiTransaction] ctx
             (Link.listTransactions @'Byron wSrc) Default Empty
         verify rTxs
             [ expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
@@ -699,9 +925,9 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
             ]
 
     -- 2nd TX
-    _ <- postByronTransaction @n ctx wSrc [payment] fixturePassphrase
+    _ <- postByronTransaction ctx wSrc [payment] fixturePassphrase
     start <- eventually "transaction is inserted" $ do
-        rTxs <- request @[ApiTransaction n] ctx
+        rTxs <- request @[ApiTransaction] ctx
             (Link.listTransactions @'Byron wSrc) Default Empty
         verify rTxs
             [ expectListField 0 (#status . #getApiT) (`shouldBe` InLedger)
@@ -712,6 +938,7 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
         pure $ Iso8601Time $ maximum $ getTime <$> getFromResponse id rTxs
 
     -- ACTION
+<<<<<<< HEAD
     rTxsFromDate <- request @[ApiTransaction n] ctx
         (Link.listTransactions' @'Byron wSrc Nothing (Just start) Nothing Nothing)
         Default
@@ -719,12 +946,21 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
 
     rTxsAll <- request @[ApiTransaction n] ctx
         (Link.listTransactions' @'Byron wSrc Nothing Nothing Nothing Nothing)
+=======
+    rTxsFromDate <- request @[ApiTransaction] ctx
+        (Link.listTransactions' @'Byron wSrc (Just start) Nothing Nothing)
+        Default
+        Empty
+
+    rTxsAll <- request @[ApiTransaction] ctx
+        (Link.listTransactions' @'Byron wSrc Nothing Nothing Nothing)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         Default
         Empty
 
     -- ASSERTIONS
     let outgoing t = (view (#direction. #getApiT) t) == Outgoing
-    let txsFromDate, txsAllOutgoing :: [ApiTransaction n]
+    let txsFromDate, txsAllOutgoing :: [ApiTransaction]
         txsFromDate = getFromResponse id rTxsFromDate
         txsAllOutgoing = filter outgoing (getFromResponse id rTxsAll)
 
@@ -738,6 +974,7 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
   where
     title = "TRANS_REG_1670"
     verifyTxInputsAndOutputs
+<<<<<<< HEAD
         :: forall (d :: NetworkDiscriminant).
             ( DecodeAddress d
             , DecodeStakeAddress d
@@ -745,6 +982,9 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
             , PaymentAddress d IcarusKey
             )
         => [ApiTransaction d]
+=======
+        :: [ApiTransaction]
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         -> IO()
     verifyTxInputsAndOutputs transactions = do
         let inputs = view (#inputs)
@@ -762,6 +1002,7 @@ scenario_TRANS_REG_1670 fixture = it title $ \ctx -> do
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
+<<<<<<< HEAD
 fixtureCantCoverFee
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -770,17 +1011,54 @@ fixtureCantCoverFee
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+fixtureSingleUTxO
+    :: Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureSingleUTxO ctx = do
+    let n = _network ctx
+    wSrc  <- fixtureRandomWalletWith ctx [1_000_000]
+    addrs <- randomAddresses n . entropyToMnemonic <$> genEntropy
+    let payments =
+            [ mkPayment (head addrs) 100_000
+            , mkPayment (head addrs) 100_000
+            ]
+    pure (wSrc, payments)
+
+-- | Returns a source wallet and a list of payments. If submitted, the payments
+-- should result in an error 403.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureErrInputsDepleted
+    :: Context t
+    -> IO (ApiByronWallet, [Aeson.Value])
+fixtureErrInputsDepleted ctx = do
+    let n = _network ctx
+    wSrc  <- fixtureRandomWalletWith ctx [12_000_000, 20_000_000, 17_000_000]
+    addrs <- randomAddresses n . entropyToMnemonic <$> genEntropy
+    let amnts = [40_000_000, 22, 22] :: [Natural]
+    let payments = flip map (zip addrs amnts) $ uncurry (mkPayment)
+    pure (wSrc, payments)
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureCantCoverFee
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Aeson.Value])
 fixtureCantCoverFee ctx = do
+    let n = _network ctx
     let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
-    wSrc <- fixtureIcarusWalletWith @n ctx [feeMin `div` 2]
-    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, [mkPayment @n (head addrs) 1])
+    wSrc <- fixtureIcarusWalletWith ctx [feeMin `div` 2]
+    addrs <- icarusAddresses n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment (head addrs) 1])
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureNotEnoughMoney
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -788,16 +1066,21 @@ fixtureNotEnoughMoney
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Aeson.Value])
 fixtureNotEnoughMoney ctx = do
+    let n = _network ctx
     wSrc <- emptyIcarusWallet ctx
-    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, [mkPayment @n (head addrs) 1])
+    addrs <- icarusAddresses n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment (head addrs) 1])
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureWrongPassphrase
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -805,15 +1088,20 @@ fixtureWrongPassphrase
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Aeson.Value])
 fixtureWrongPassphrase ctx = do
-    (wSrc, addrs) <- fixtureIcarusWalletAddrs @n ctx
-    pure (wSrc, [mkPayment @n (head addrs) 100_000])
+    let n = _network ctx
+    (wSrc, addrs) <- fixtureIcarusWalletAddrs n ctx
+    pure (wSrc, [mkPayment (head addrs) 100_000])
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureDeletedWallet
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -821,12 +1109,16 @@ fixtureDeletedWallet
         , PaymentAddress n ByronKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Aeson.Value])
 fixtureDeletedWallet ctx = do
+    let n = _network ctx
     wSrc <- emptyRandomWallet ctx
     _ <- request @() ctx (Link.deleteWallet @'Byron wSrc) Default Empty
-    addrs <- randomAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, [mkPayment @n (head addrs) 100_000])
+    addr:_ <- randomAddresses n . entropyToMnemonic <$> genEntropy
+    pure (wSrc, [mkPayment addr 100_000])
 
 --
 -- Helpers
@@ -834,28 +1126,27 @@ fixtureDeletedWallet ctx = do
 
 -- | Construct a JSON payload for a single payment (address + amount)
 mkPayment
-    :: forall (n :: NetworkDiscriminant).
-        ( EncodeAddress n
-        )
-    => Address
+    :: ApiAddress
     -> Natural
     -> Aeson.Value
-mkPayment addr_ amnt = [json|
+mkPayment (ApiAddress addr) amnt = [json|
     { "address": #{addr}
     , "amount":
         { "quantity": #{amnt}
         , "unit": "lovelace"
         }
     } |]
-  where
-    addr = encodeAddress @n addr_
 
 postByronTransaction
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         -- A surrounding API context
     -> ApiByronWallet
         -- ^ Source wallet
@@ -863,7 +1154,7 @@ postByronTransaction
         -- ^ A list of payment
     -> Text
         -- ^ Passphrase
-    -> IO (HTTP.Status, Either RequestException (ApiTransaction n))
+    -> IO (HTTP.Status, Either RequestException ApiTransaction)
 postByronTransaction ctx wSrc payments passphrase = do
     let body = [json|
             { "payments": #{payments}

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
@@ -17,23 +17,23 @@ import Prelude
 import Cardano.Mnemonic
     ( entropyToMnemonic, genEntropy )
 import Cardano.Wallet.Api.Types
-    ( ApiByronWallet
+    ( ApiAddress (..)
+    , ApiByronWallet
     , ApiFee
     , ApiT (..)
     , ApiTransaction
+<<<<<<< HEAD
     , DecodeAddress (..)
     , DecodeStakeAddress (..)
     , EncodeAddress (..)
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant (..), PaymentAddress (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+    ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address, Direction (..), TxStatus (..) )
+    ( Direction (..), TxStatus (..) )
 import Control.Monad
     ( forM, forM_, join )
 import Data.Generics.Internal.VL.Lens
@@ -62,7 +62,7 @@ import Test.Hspec
     , shouldSatisfy
     )
 import Test.Integration.Framework.DSL
-    ( Context
+    ( Context (..)
     , Headers (..)
     , KnownCommand
     , Payload (..)
@@ -115,6 +115,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
 
 spec
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( PaymentAddress n IcarusKey
         , PaymentAddress n ByronKey
@@ -125,47 +126,71 @@ spec
         )
     => SpecWith (Context t)
 spec = describe "BYRON_TXS_CLI" $ do
+=======
+    :: forall t. KnownCommand t
+    => NetworkDiscriminant
+    -> SpecWith (Context t)
+spec n = describe "BYRON_TXS_CLI" $ do
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -- Random → Random
-    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-        [ fixtureRandomWalletAddrs @n ]
+    scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+        [ fixtureRandomWalletAddrs n ]
 
     -- Random → [Random, Icarus]
-    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-        [ fixtureRandomWalletAddrs @n
-        , fixtureIcarusWalletAddrs @n
+    scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+        [ fixtureRandomWalletAddrs n
+        , fixtureIcarusWalletAddrs n
         ]
 
     -- Icarus → Icarus
-    scenario_TRANS_CREATE_01_02 @n fixtureIcarusWallet
-        [ fixtureIcarusWalletAddrs @n
+    scenario_TRANS_CREATE_01_02 fixtureIcarusWallet
+        [ fixtureIcarusWalletAddrs n
         ]
 
     -- Icarus → [Icarus, Random]
-    scenario_TRANS_CREATE_01_02 @n fixtureRandomWallet
-        [ fixtureIcarusWalletAddrs @n
-        , fixtureRandomWalletAddrs @n
+    scenario_TRANS_CREATE_01_02 fixtureRandomWallet
+        [ fixtureIcarusWalletAddrs n
+        , fixtureRandomWalletAddrs n
         ]
 
+<<<<<<< HEAD
     -- TRANS_CREATE_03 requires actually being able to compute exact fees, which
     -- is not really possible w/ cardano-node. So, skipping.
 
     scenario_TRANS_CREATE_04b @n
     scenario_TRANS_CREATE_04c @n
     scenario_TRANS_CREATE_04d @n
+=======
+    scenario_TRANS_CREATE_02x
 
-    scenario_TRANS_CREATE_07 @n
+    -- TRANS_CREATE_03 requires actually being able to compute exact fees, which
+    -- is not really possible w/ cardano-node. So, skipping.
 
-    scenario_TRANS_ESTIMATE_01_02 @n fixtureRandomWallet
-        [ randomAddresses @n . entropyToMnemonic <$> genEntropy
+    scenario_TRANS_CREATE_04a
+    scenario_TRANS_CREATE_04b
+    scenario_TRANS_CREATE_04c
+    scenario_TRANS_CREATE_04d
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
+
+    scenario_TRANS_CREATE_07
+
+    scenario_TRANS_ESTIMATE_01_02 fixtureRandomWallet
+        [ randomAddresses n . entropyToMnemonic <$> genEntropy
         ]
 
-    scenario_TRANS_ESTIMATE_01_02 @n fixtureIcarusWallet
-        [ icarusAddresses @n . entropyToMnemonic <$> genEntropy
-        , icarusAddresses @n . entropyToMnemonic <$> genEntropy
+    scenario_TRANS_ESTIMATE_01_02 fixtureIcarusWallet
+        [ icarusAddresses n . entropyToMnemonic <$> genEntropy
+        , icarusAddresses n . entropyToMnemonic <$> genEntropy
         ]
 
+<<<<<<< HEAD
     scenario_TRANS_ESTIMATE_04b @n
     scenario_TRANS_ESTIMATE_04c @n
+=======
+    scenario_TRANS_ESTIMATE_04a
+    scenario_TRANS_ESTIMATE_04b
+    scenario_TRANS_ESTIMATE_04c
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
     it "TRANS_LIST_01 - 0 txs on empty Byron wallet"
         $ \ctx -> forM_ [emptyRandomWallet, emptyIcarusWallet] $ \emptyByronWallet -> do
@@ -174,7 +199,7 @@ spec = describe "BYRON_TXS_CLI" $ do
                 listTransactionsViaCLI @t ctx [T.unpack $ w ^. walletId]
             err `shouldBe` cmdOk
             code `shouldBe` ExitSuccess
-            list <- expectValidJSON (Proxy @([ApiTransaction n])) out
+            list <- expectValidJSON (Proxy @([ApiTransaction])) out
             length list `shouldBe` 0
 
     it "TRANS_LIST_01 - Can list transactions on Byron Wallet"
@@ -185,11 +210,11 @@ spec = describe "BYRON_TXS_CLI" $ do
                 listTransactionsViaCLI @t ctx [T.unpack $ w ^. walletId]
             err `shouldBe` cmdOk
             code `shouldBe` ExitSuccess
-            list <- expectValidJSON (Proxy @([ApiTransaction n])) out
+            list <- expectValidJSON (Proxy @([ApiTransaction])) out
             length list `shouldBe` 10
 
     it "TRANS_LIST_03 - Can order results"
-        $ \ctx -> forM_ [fixtureRandomWalletWith @n, fixtureIcarusWalletWith @n]
+        $ \ctx -> forM_ [fixtureRandomWalletWith, fixtureIcarusWalletWith]
         $ \fixtureByronWalletWith -> do
             let a1 = Quantity $ sum $ replicate 10 1
             let a2 = Quantity $ sum $ replicate 10 2
@@ -222,7 +247,7 @@ spec = describe "BYRON_TXS_CLI" $ do
                     listTransactionsViaCLI @t ctx args
                 err `shouldBe` cmdOk
                 code `shouldBe` ExitSuccess
-                outJson <- expectValidJSON (Proxy @([ApiTransaction n])) out
+                outJson <- expectValidJSON (Proxy @([ApiTransaction])) out
                 length outJson `shouldBe` 2
                 verify outJson expects
 
@@ -276,12 +301,12 @@ spec = describe "BYRON_TXS_CLI" $ do
 
     it "TRANS_LIST_RANGE_01 - \
        \Transaction at time t is SELECTED by small ranges that cover it"
-       $ \ctx -> forM_ [fixtureRandomWalletWith @n, fixtureIcarusWalletWith @n]
+       $ \ctx -> forM_ [fixtureRandomWalletWith, fixtureIcarusWalletWith]
        $ \fixtureByronWalletWith -> do
               w <- fixtureByronWalletWith ctx [1]
               let walId = w ^. walletId
               Stdout o  <- listTransactionsViaCLI @t ctx [ T.unpack walId ]
-              oJson <- expectValidJSON (Proxy @([ApiTransaction n])) o
+              oJson <- expectValidJSON (Proxy @([ApiTransaction])) o
               let t = unsafeGetTransactionTime oJson
               let (te, tl) = (utcTimePred t, utcTimeSucc t)
               let query t1 t2 =
@@ -296,50 +321,50 @@ spec = describe "BYRON_TXS_CLI" $ do
                     ( T.unpack <$> walId : (query t tl) )
               Stdout o4 <- listTransactionsViaCLI @t ctx
                     ( T.unpack <$> walId : (query te tl) )
-              oJson1 <- expectValidJSON (Proxy @([ApiTransaction n])) o1
-              oJson2 <- expectValidJSON (Proxy @([ApiTransaction n])) o2
-              oJson3 <- expectValidJSON (Proxy @([ApiTransaction n])) o3
-              oJson4 <- expectValidJSON (Proxy @([ApiTransaction n])) o4
+              oJson1 <- expectValidJSON (Proxy @([ApiTransaction])) o1
+              oJson2 <- expectValidJSON (Proxy @([ApiTransaction])) o2
+              oJson3 <- expectValidJSON (Proxy @([ApiTransaction])) o3
+              oJson4 <- expectValidJSON (Proxy @([ApiTransaction])) o4
               length <$> [oJson1, oJson2, oJson3, oJson4] `shouldSatisfy` all (== 1)
 
     it "TRANS_LIST_RANGE_02 - \
        \Transaction at time t is NOT selected by range [t + 𝛿t, ...)"
-       $ \ctx -> forM_ [fixtureRandomWalletWith @n, fixtureIcarusWalletWith @n]
+       $ \ctx -> forM_ [fixtureRandomWalletWith, fixtureIcarusWalletWith]
        $ \fixtureByronWalletWith -> do
               w <- fixtureByronWalletWith ctx [1]
               let walId = w ^. walletId
               Stdout o  <- listTransactionsViaCLI @t ctx [ T.unpack walId ]
-              oJson <- expectValidJSON (Proxy @([ApiTransaction n])) o
+              oJson <- expectValidJSON (Proxy @([ApiTransaction])) o
               let t = unsafeGetTransactionTime oJson
               let tl = utcIso8601ToText $ utcTimeSucc t
               Stdout o1  <- listTransactionsViaCLI @t ctx
                     ( T.unpack <$> [walId, "--start", tl] )
               Stdout o2 <- listTransactionsViaCLI @t ctx
                     ( T.unpack <$> [walId, "--start", tl, "--end", tl] )
-              oJson1 <- expectValidJSON (Proxy @([ApiTransaction n])) o1
-              oJson2 <- expectValidJSON (Proxy @([ApiTransaction n])) o2
+              oJson1 <- expectValidJSON (Proxy @([ApiTransaction])) o1
+              oJson2 <- expectValidJSON (Proxy @([ApiTransaction])) o2
               length <$> [oJson1, oJson2] `shouldSatisfy` all (== 0)
 
     it "TRANS_LIST_RANGE_03 - \
        \Transaction at time t is NOT selected by range (..., t - 𝛿t]"
-       $ \ctx -> forM_ [fixtureRandomWalletWith @n, fixtureIcarusWalletWith @n]
+       $ \ctx -> forM_ [fixtureRandomWalletWith, fixtureIcarusWalletWith]
        $ \fixtureByronWalletWith -> do
               w <- fixtureByronWalletWith ctx [1]
               let walId = w ^. walletId
               Stdout o  <- listTransactionsViaCLI @t ctx [ T.unpack walId ]
-              oJson <- expectValidJSON (Proxy @([ApiTransaction n])) o
+              oJson <- expectValidJSON (Proxy @([ApiTransaction])) o
               let t = unsafeGetTransactionTime oJson
               let te = utcIso8601ToText $ utcTimePred t
               Stdout o1  <- listTransactionsViaCLI @t ctx
                       ( T.unpack <$> [walId, "--end", te] )
               Stdout o2 <- listTransactionsViaCLI @t ctx
                       ( T.unpack <$> [walId, "--start", te, "--end", te] )
-              oJson1 <- expectValidJSON (Proxy @([ApiTransaction n])) o1
-              oJson2 <- expectValidJSON (Proxy @([ApiTransaction n])) o2
+              oJson1 <- expectValidJSON (Proxy @([ApiTransaction])) o1
+              oJson2 <- expectValidJSON (Proxy @([ApiTransaction])) o2
               length <$> [oJson1, oJson2] `shouldSatisfy` all (== 0)
 
     it "TRANS_DELETE_01a - Can forget pending tx, still it resolves when it is OK"
-        $ \ctx ->forM_ [fixtureRandomWalletAddrs @n, fixtureRandomWalletAddrs @n]
+        $ \ctx ->forM_ [fixtureRandomWalletAddrs n, fixtureRandomWalletAddrs n]
         $ \fixtureByronWallet -> do
         pendingWith
             "This test is built on a race-condition. Should the transaction be \
@@ -349,7 +374,7 @@ spec = describe "BYRON_TXS_CLI" $ do
         --SETUP
         let amnt = 100_000 :: Natural
         (wSrc, addrs) <- fixtureByronWallet ctx
-        let payment = mkPaymentCmd @n (head addrs) amnt
+        let payment = mkPaymentCmd (head addrs) amnt
         let wSrcId = T.unpack (wSrc ^. walletId)
 
         -- post transaction
@@ -357,7 +382,7 @@ spec = describe "BYRON_TXS_CLI" $ do
         (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args
         err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         c `shouldBe` ExitSuccess
-        txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
+        txJson <- expectValidJSON (Proxy @ApiTransaction) out
 
         -- Try Forget transaction once it's no longer pending
         let txId =  getTxId txJson
@@ -369,7 +394,7 @@ spec = describe "BYRON_TXS_CLI" $ do
 
         eventually "Tx is in ledger" $ do
             (fromStdout <$> listTransactionsViaCLI @t ctx [wSrcId])
-                >>= expectValidJSON (Proxy @([ApiTransaction n]))
+                >>= expectValidJSON (Proxy @([ApiTransaction]))
                 >>= flip verify
                     [ expectCliListField 0
                         (#direction . #getApiT) (`shouldBe` Outgoing)
@@ -378,12 +403,12 @@ spec = describe "BYRON_TXS_CLI" $ do
                     ]
 
     it "TRANS_DELETE_01b - Cannot forget pending transaction when not pending anymore via CLI"
-        $ \ctx -> forM_ [fixtureRandomWalletAddrs @n, fixtureRandomWalletAddrs @n]
+        $ \ctx -> forM_ [fixtureRandomWalletAddrs n, fixtureRandomWalletAddrs n]
         $ \fixtureByronWallet -> do
         --SETUP
         let amnt = 100_000 :: Natural
         (wSrc, addrs) <- fixtureByronWallet ctx
-        let payment = mkPaymentCmd @n (head addrs) amnt
+        let payment = mkPaymentCmd (head addrs) amnt
         let wSrcId = T.unpack (wSrc ^. walletId)
 
         -- post transaction
@@ -391,11 +416,11 @@ spec = describe "BYRON_TXS_CLI" $ do
         (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args
         err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         c `shouldBe` ExitSuccess
-        txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
+        txJson <- expectValidJSON (Proxy @ApiTransaction) out
 
         eventually "Tx is in ledger" $ do
             (fromStdout <$> listTransactionsViaCLI @t ctx [wSrcId])
-                >>= expectValidJSON (Proxy @([ApiTransaction n]))
+                >>= expectValidJSON (Proxy @([ApiTransaction]))
                 >>= flip verify
                     [ expectCliListField 0
                         (#direction . #getApiT) (`shouldBe` Outgoing)
@@ -441,19 +466,19 @@ spec = describe "BYRON_TXS_CLI" $ do
 
     it "TRANS_DELETE_06 -\
         \ Cannot forget tx that is performed from different wallet via CLI"
-        $ \ctx -> forM_ [fixtureRandomWalletAddrs @n, fixtureRandomWalletAddrs @n]
+        $ \ctx -> forM_ [fixtureRandomWalletAddrs n, fixtureRandomWalletAddrs n]
         $ \fixtureByronWallet -> do
         --SETUP
         let amnt = 100_000 :: Natural
         (wSrc, addrs) <- fixtureByronWallet ctx
-        let payment = mkPaymentCmd @n (head addrs) amnt
+        let payment = mkPaymentCmd (head addrs) amnt
 
         -- post transaction
         let args = T.unpack <$> ((wSrc ^. walletId) : payment)
         (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args
         err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
         c `shouldBe` ExitSuccess
-        txJson <- expectValidJSON (Proxy @(ApiTransaction n)) out
+        txJson <- expectValidJSON (Proxy @ApiTransaction) out
 
         -- Try Forget transaction using different wallet
         let txId =  getTxId txJson
@@ -486,14 +511,18 @@ spec = describe "BYRON_TXS_CLI" $ do
 --
 
 scenario_TRANS_CREATE_01_02
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
         , EncodeAddress n
         , KnownCommand t
         )
+=======
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => (Context t -> IO ApiByronWallet)
-    -> [(Context t -> IO (ApiByronWallet, [Address]))]
+    -> [(Context t -> IO (ApiByronWallet, [ApiAddress]))]
     -> SpecWith (Context t)
 scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- SETUP
@@ -501,7 +530,7 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
     (recipients, payments) <- fmap unzip $ forM fixtures $ \fixtureDest -> do
         (wDest, addrs) <- fixtureDest ctx
-        pure (wDest, (mkPaymentCmd @n (head addrs) amnt))
+        pure (wDest, (mkPaymentCmd (head addrs) amnt))
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : (join payments))
@@ -510,9 +539,13 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- ASSERTIONS
     err `shouldBe` "Please enter your passphrase: **************\nOk.\n"
     c `shouldBe` ExitSuccess
+<<<<<<< HEAD
     r <- expectValidJSON (Proxy @(ApiTransaction n)) out
     let txId =  getTxId r
 
+=======
+    r <- expectValidJSON (Proxy @ApiTransaction) out
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
             { nInputs  =  fromIntegral n
             , nOutputs =  fromIntegral n
@@ -574,14 +607,18 @@ scenario_TRANS_CREATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     n = fromIntegral $ length fixtures
 
 scenario_TRANS_ESTIMATE_01_02
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
         , EncodeAddress n
         , KnownCommand t
         )
+=======
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => (Context t -> IO ApiByronWallet)
-    -> [IO [Address]]
+    -> [IO [ApiAddress]]
     -> SpecWith (Context t)
 scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     -- SETUP
@@ -589,7 +626,7 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
     payments <- forM fixtures $ \fixtureTarget -> do
         addrs <- fixtureTarget
-        pure $ mkPaymentCmd @n (head addrs) amnt
+        pure $ mkPaymentCmd (head addrs) amnt
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : (join payments))
@@ -611,6 +648,7 @@ scenario_TRANS_ESTIMATE_01_02 fixtureSource fixtures = it title $ \ctx -> do
   where
     title = "CLI_TRANS_ESTIMATE_01/02 - " ++ show (length fixtures) ++ " recipient(s)"
 
+<<<<<<< HEAD
 scenario_TRANS_CREATE_04b
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -619,10 +657,51 @@ scenario_TRANS_CREATE_04b
         , PaymentAddress n IcarusKey
         , KnownCommand t
         )
+=======
+scenario_TRANS_CREATE_02x
+    :: forall t. KnownCommand t
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_02x = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureSingleUTxO ctx
+
+    -- ACTION
+    let args = T.unpack <$> ((wSrc ^. walletId) : payments)
+    (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args
+
+    -- ASSERTIONS
+    T.unpack err `shouldContain` errMsg403UTxO
+    c `shouldBe` ExitFailure 1
+    out `shouldBe` mempty
+
+  where
+    title = "CLI_TRANS_CREATE_02x - Multi-output failure w/ single UTxO"
+
+scenario_TRANS_CREATE_04a
+    :: forall t. KnownCommand t
+    => SpecWith (Context t)
+scenario_TRANS_CREATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted ctx
+
+    -- ACTION
+    let args = T.unpack <$> ((wSrc ^. walletId) : payments)
+    (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args
+
+    -- ASSERTIONS
+    T.unpack err `shouldContain` errMsg403InputsDepleted
+    c `shouldBe` ExitFailure 1
+    out `shouldBe` mempty
+  where
+    title = "CLI_TRANS_CREATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_CREATE_04b
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_CREATE_04b = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+    (wSrc, payments) <- fixtureCantCoverFee ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -636,6 +715,7 @@ scenario_TRANS_CREATE_04b = it title $ \ctx -> do
     title = "CLI_TRANS_CREATE_04 - Can't cover fee"
 
 scenario_TRANS_CREATE_04c
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -643,10 +723,13 @@ scenario_TRANS_CREATE_04c
         , PaymentAddress n IcarusKey
         , KnownCommand t
         )
+=======
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_CREATE_04c = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+    (wSrc, payments) <- fixtureNotEnoughMoney ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -660,6 +743,7 @@ scenario_TRANS_CREATE_04c = it title $ \ctx -> do
     title = "CLI_TRANS_CREATE_04 - Not enough money"
 
 scenario_TRANS_CREATE_04d
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -667,10 +751,13 @@ scenario_TRANS_CREATE_04d
         , PaymentAddress n IcarusKey
         , KnownCommand t
         )
+=======
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_CREATE_04d = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureWrongPassphrase @n ctx
+    (wSrc, payments) <- fixtureWrongPassphrase ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -683,6 +770,7 @@ scenario_TRANS_CREATE_04d = it title $ \ctx -> do
   where
     title = "CLI_TRANS_CREATE_04 - Wrong password"
 
+<<<<<<< HEAD
 scenario_TRANS_ESTIMATE_04b
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -691,10 +779,32 @@ scenario_TRANS_ESTIMATE_04b
         , PaymentAddress n IcarusKey
         , KnownCommand t
         )
+=======
+scenario_TRANS_ESTIMATE_04a
+    :: forall t. KnownCommand t
+    => SpecWith (Context t)
+scenario_TRANS_ESTIMATE_04a = it title $ \ctx -> do
+    -- SETUP
+    (wSrc, payments) <- fixtureErrInputsDepleted ctx
+
+    -- ACTION
+    let args = T.unpack <$> ((wSrc ^. walletId) : payments)
+    (Exit c, Stdout out, Stderr err) <- postTransactionFeeViaCLI @t ctx args
+
+    -- ASSERTIONS
+    err `shouldContain` errMsg403InputsDepleted
+    c `shouldBe` ExitFailure 1
+    out `shouldBe` mempty
+  where
+    title = "CLI_TRANS_ESTIMATE_04 - Error shown when ErrInputsDepleted encountered"
+
+scenario_TRANS_ESTIMATE_04b
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureCantCoverFee @n ctx
+    (wSrc, payments) <- fixtureCantCoverFee ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -717,6 +827,7 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     title = "CLI_TRANS_ESTIMATE_04 - Can't cover fee"
 
 scenario_TRANS_ESTIMATE_04c
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -724,10 +835,13 @@ scenario_TRANS_ESTIMATE_04c
         , PaymentAddress n IcarusKey
         , KnownCommand t
         )
+=======
+    :: forall t.KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_ESTIMATE_04c = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureNotEnoughMoney @n ctx
+    (wSrc, payments) <- fixtureNotEnoughMoney ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -741,6 +855,7 @@ scenario_TRANS_ESTIMATE_04c = it title $ \ctx -> do
     title = "CLI_TRANS_ESTIMATE_04 - Not enough money"
 
 scenario_TRANS_CREATE_07
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -748,10 +863,13 @@ scenario_TRANS_CREATE_07
         , PaymentAddress n ByronKey
         , KnownCommand t
         )
+=======
+    :: forall t. KnownCommand t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     => SpecWith (Context t)
 scenario_TRANS_CREATE_07 = it title $ \ctx -> do
     -- SETUP
-    (wSrc, payments) <- fixtureDeletedWallet @n ctx
+    (wSrc, payments) <- fixtureDeletedWallet ctx
 
     -- ACTION
     let args = T.unpack <$> ((wSrc ^. walletId) : payments)
@@ -772,6 +890,7 @@ scenario_TRANS_CREATE_07 = it title $ \ctx -> do
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
+<<<<<<< HEAD
 fixtureCantCoverFee
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
@@ -780,17 +899,54 @@ fixtureCantCoverFee
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+fixtureSingleUTxO
+    :: Context t
+    -> IO (ApiByronWallet, [Text])
+fixtureSingleUTxO ctx = do
+    let n = _network ctx
+    wSrc  <- fixtureRandomWalletWith ctx [1_000_000]
+    addrs <- randomAddresses n . entropyToMnemonic <$> genEntropy
+    let addrStr = apiAddress $ head addrs
+    let payments =
+            [ "--payment", "100000@" <> addrStr
+            , "--payment", "100000@" <> addrStr
+            ]
+    pure (wSrc, payments)
+
+-- | Returns a source wallet and a list of payments. If submitted, the payments
+-- should result in an error 403.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureErrInputsDepleted
+    :: Context t
+    -> IO (ApiByronWallet, [Text])
+fixtureErrInputsDepleted ctx = do
+    wSrc  <- fixtureRandomWalletWith ctx [12_000_000, 20_000_000, 17_000_000]
+    addrs <- randomAddresses (_network ctx) . entropyToMnemonic <$> genEntropy
+    -- let addrStrs = encodeAddress <$> (addrs)
+    let amnts = [40_000_000, 22, 22] :: [Natural]
+    let payments = flip map (zip addrs amnts) $ uncurry (mkPaymentCmd)
+    pure (wSrc, join payments)
+
+-- | Returns a source wallet and a list of payments.
+--
+-- NOTE: Random or Icarus wallets can be used interchangeably here.
+fixtureCantCoverFee
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Text])
 fixtureCantCoverFee ctx = do
     let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
-    wSrc <- fixtureIcarusWalletWith @n ctx [feeMin `div` 2]
-    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, join [mkPaymentCmd @n (head addrs) 1])
+    wSrc <- fixtureIcarusWalletWith ctx [feeMin `div` 2]
+    addrs <- icarusAddresses (_network ctx) . entropyToMnemonic <$> genEntropy
+    pure (wSrc, join [mkPaymentCmd (head addrs) 1])
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureNotEnoughMoney
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -798,16 +954,20 @@ fixtureNotEnoughMoney
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Text])
 fixtureNotEnoughMoney ctx = do
     wSrc <- emptyIcarusWallet ctx
-    addrs <- icarusAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, mkPaymentCmd @n (head addrs) 1)
+    addrs <- icarusAddresses (_network ctx) . entropyToMnemonic <$> genEntropy
+    pure (wSrc, mkPaymentCmd (head addrs) 1)
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureWrongPassphrase
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -815,15 +975,19 @@ fixtureWrongPassphrase
         , PaymentAddress n IcarusKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Text])
 fixtureWrongPassphrase ctx = do
-    (wSrc, addrs) <- fixtureIcarusWalletAddrs @n ctx
-    pure (wSrc, mkPaymentCmd @n (head addrs) 100_000)
+    (wSrc, addrs) <- fixtureIcarusWalletAddrs (_network ctx) ctx
+    pure (wSrc, mkPaymentCmd (head addrs) 100_000)
 
 -- | Returns a source wallet and a list of payments.
 --
 -- NOTE: Random or Icarus wallets can be used interchangeably here.
 fixtureDeletedWallet
+<<<<<<< HEAD
     :: forall (n :: NetworkDiscriminant) t.
         ( DecodeAddress n
         , DecodeStakeAddress n
@@ -831,24 +995,22 @@ fixtureDeletedWallet
         , PaymentAddress n ByronKey
         )
     => Context t
+=======
+    :: Context t
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> IO (ApiByronWallet, [Text])
 fixtureDeletedWallet ctx = do
     wSrc <- emptyRandomWallet ctx
     _ <- request @() ctx (Link.deleteWallet @'Byron wSrc) Default Empty
-    addrs <- randomAddresses @n . entropyToMnemonic <$> genEntropy
-    pure (wSrc, mkPaymentCmd @n (head addrs) 100_000)
+    addrs <- randomAddresses (_network ctx) . entropyToMnemonic <$> genEntropy
+    pure (wSrc, mkPaymentCmd (head addrs) 100_000)
 
 --
 -- Helpers
 --
 -- | Construct a Cmd param for a single payment (address + amount)
 mkPaymentCmd
-    :: forall (n :: NetworkDiscriminant).
-        ( EncodeAddress n
-        )
-    => Address
+    :: ApiAddress
     -> Natural
     -> [Text]
-mkPaymentCmd addr_ amnt = ["--payment", T.pack (show amnt) <> "@" <> addr]
-  where
-    addr = encodeAddress @n addr_
+mkPaymentCmd (ApiAddress addr) amnt = ["--payment", T.pack (show amnt) <> "@" <> addr]

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -49,10 +50,10 @@ import Cardano.Mnemonic
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..)
+    , AddressScheme (..)
     , DerivationType (..)
     , HardDerivation (..)
     , NetworkDiscriminant (..)
-    , PaymentAddress (..)
     , WalletKey (..)
     , deriveRewardAccount
     , liftIndex
@@ -1426,10 +1427,11 @@ genByronFaucets = genFaucet encodeAddress genAddresses
             addrXPrv =
                 Byron.deriveAddressPrivateKey pwd accXPrv
         in
-            [ paymentAddress @'Mainnet
+            [ addressFromKey
                 $ publicKey $ addrXPrv $ liftIndex @'Hardened ix
             | ix <- [minBound..maxBound]
             ]
+    AddressScheme{addressFromKey} = Byron.byronScheme Mainnet
 
 -- | Generate faucets addresses and mnemonics to a file.
 --
@@ -1453,9 +1455,10 @@ genIcarusFaucets = genFaucet encodeAddress genAddresses
             addrXPrv =
                 deriveAddressPrivateKey pwd accXPrv UTxOExternal
         in
-            [ paymentAddress @'Mainnet $ publicKey $ addrXPrv ix
+            [ addressFromKey $ publicKey $ addrXPrv ix
             | ix <- [minBound..maxBound]
             ]
+    AddressScheme{addressFromKey} = Icarus.icarusScheme Mainnet
 
 -- | Generate faucets addresses and mnemonics to a file.
 --
@@ -1467,6 +1470,7 @@ genShelleyFaucets = genFaucet encodeAddress (genShelleyAddresses . SomeMnemonic)
     encodeAddress (Address bytes) =
         T.decodeUtf8 $ convertToBase Base16 bytes
 
+<<<<<<< HEAD
 genShelleyAddresses :: SomeMnemonic -> [Address]
 genShelleyAddresses mw =
     let
@@ -1494,6 +1498,24 @@ genRewardAccounts mw =
             deriveRewardAccount pwd rootXPrv
     in
         [getRawKey $ publicKey acctXPrv]
+=======
+    genAddresses :: Mnemonic 15 -> [Address]
+    genAddresses mw =
+        let
+            (seed, pwd) =
+                (SomeMnemonic mw, mempty)
+            rootXPrv =
+                Shelley.generateKeyFromSeed (seed, Nothing) pwd
+            accXPrv =
+                deriveAccountPrivateKey pwd rootXPrv minBound
+            addrXPrv =
+                deriveAddressPrivateKey pwd accXPrv UTxOExternal
+        in
+            [ addressFromKey $ publicKey $ addrXPrv ix
+            | ix <- [minBound..maxBound]
+            ]
+    AddressScheme{addressFromKey} = Shelley.shelleyScheme Mainnet Nothing
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
 -- | Abstract function for generating a faucet.
 genFaucet

--- a/lib/core-integration/src/Test/Integration/Framework/Request.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Request.hs
@@ -23,6 +23,8 @@ import Prelude
 
 import Cardano.CLI
     ( Port (..) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters )
 import Cardano.Wallet.Transaction
@@ -95,6 +97,8 @@ data Context t = Context
         -- ^ A fee estimator for the integration tests
     , _networkParameters :: NetworkParameters
         -- ^ Blockchain parameters for the underlying chain
+    , _network
+        :: NetworkDiscriminant
     , _target
         :: Proxy t
     } deriving Generic

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -18,35 +18,31 @@ import Prelude
 import Cardano.Mnemonic
     ( Mnemonic )
 import Cardano.Wallet.Api.Types
-    ( ApiAddress
+    ( ApiAddress (..)
+    , ApiAddressWithState
     , ApiByronWallet
     , ApiPutAddressesData
     , ApiT (..)
+<<<<<<< HEAD
     , DecodeAddress
     , DecodeStakeAddress
     , EncodeAddress (..)
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     , WalletStyle (..)
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
-import Data.Generics.Product.Positions
-    ( position )
 import Test.Hspec
     ( SpecWith, describe, shouldBe )
 import Test.Hspec.Extra
     ( it )
 import Test.Integration.Framework.DSL
-    ( Context
+    ( Context (..)
     , Headers (..)
     , Payload (..)
     , emptyIcarusWallet
@@ -77,6 +73,7 @@ import Web.HttpApiData
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Network.HTTP.Types.Status as HTTP
 
+<<<<<<< HEAD
 spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
@@ -84,40 +81,47 @@ spec :: forall n t.
     , PaymentAddress n ByronKey
     , PaymentAddress n IcarusKey
     ) => SpecWith (Context t)
+=======
+spec :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 spec = do
     describe "BYRON_ADDRESSES" $ do
-        scenario_ADDRESS_LIST_01 @n emptyRandomWallet
-        scenario_ADDRESS_LIST_01 @n emptyIcarusWallet
+        scenario_ADDRESS_LIST_01 emptyRandomWallet
+        scenario_ADDRESS_LIST_01 emptyIcarusWallet
 
-        scenario_ADDRESS_LIST_02 @n fixtureRandomWallet
-        scenario_ADDRESS_LIST_02 @n fixtureIcarusWallet
+        scenario_ADDRESS_LIST_02 fixtureRandomWallet
+        scenario_ADDRESS_LIST_02 fixtureIcarusWallet
 
-        scenario_ADDRESS_LIST_04 @n emptyRandomWallet
-        scenario_ADDRESS_LIST_04 @n emptyIcarusWallet
+        scenario_ADDRESS_LIST_04 emptyRandomWallet
+        scenario_ADDRESS_LIST_04 emptyIcarusWallet
 
-        scenario_ADDRESS_CREATE_01 @n
-        scenario_ADDRESS_CREATE_02 @n
-        scenario_ADDRESS_CREATE_03 @n
-        scenario_ADDRESS_CREATE_04 @n
-        scenario_ADDRESS_CREATE_05 @n
-        scenario_ADDRESS_CREATE_06 @n
+        scenario_ADDRESS_CREATE_01
+        scenario_ADDRESS_CREATE_02
+        scenario_ADDRESS_CREATE_03
+        scenario_ADDRESS_CREATE_04
+        scenario_ADDRESS_CREATE_05
+        scenario_ADDRESS_CREATE_06
 
+<<<<<<< HEAD
         scenario_ADDRESS_IMPORT_01 @n emptyRandomWalletMws
         scenario_ADDRESS_IMPORT_02 @n emptyIcarusWalletMws
         scenario_ADDRESS_IMPORT_03 @n emptyRandomWalletMws
         scenario_ADDRESS_IMPORT_04 @n fixtureRandomWallet
         scenario_ADDRESS_IMPORT_05 @n 15000 emptyRandomWalletMws
+=======
+        scenario_ADDRESS_IMPORT_01 emptyRandomWalletMws
+        scenario_ADDRESS_IMPORT_02 emptyIcarusWalletMws
+        scenario_ADDRESS_IMPORT_03 emptyRandomWalletMws
+        scenario_ADDRESS_IMPORT_04 fixtureRandomWallet
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
 scenario_ADDRESS_LIST_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
 scenario_ADDRESS_LIST_01 fixture = it title $ \ctx -> do
     w <- fixture ctx
-    r <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    r <- request @[ApiAddressWithState] ctx (Link.listAddresses @'Byron w) Default Empty
     verify r [ expectResponseCode @IO HTTP.status200 ]
     let n = length $ getFromResponse id r
     forM_ [0..n-1] $ \addrIx -> do
@@ -126,17 +130,14 @@ scenario_ADDRESS_LIST_01 fixture = it title $ \ctx -> do
     title = "ADDRESS_LIST_01 - Can list known addresses on a default wallet"
 
 scenario_ADDRESS_LIST_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
 scenario_ADDRESS_LIST_02 fixture = it title $ \ctx -> do
     w <- fixture ctx
 
     -- filtering ?state=used
-    rUsed <- request @[ApiAddress n] ctx
+    rUsed <- request @[ApiAddressWithState] ctx
         (Link.listAddresses' @'Byron w (Just Used)) Default Empty
     verify rUsed
         [ expectResponseCode @IO HTTP.status200
@@ -147,7 +148,7 @@ scenario_ADDRESS_LIST_02 fixture = it title $ \ctx -> do
         expectListField addrIx #state (`shouldBe` ApiT Used) rUsed
 
     -- filtering ?state=unused
-    rUnused <- request @[ApiAddress n] ctx
+    rUnused <- request @[ApiAddressWithState] ctx
         (Link.listAddresses' @'Byron w (Just Unused)) Default Empty
     let nUnused = length $ getFromResponse id rUnused
     forM_ [0..nUnused-1] $ \addrIx -> do
@@ -156,16 +157,13 @@ scenario_ADDRESS_LIST_02 fixture = it title $ \ctx -> do
     title = "ADDRESS_LIST_02 - Can filter used and unused addresses"
 
 scenario_ADDRESS_LIST_04
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
 scenario_ADDRESS_LIST_04 fixture = it title $ \ctx -> do
     w <- fixture ctx
     _ <- request @() ctx (Link.deleteWallet @'Byron w) Default Empty
-    r <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    r <- request @[ApiAddressWithState] ctx (Link.listAddresses @'Byron w) Default Empty
     verify r
         [ expectResponseCode @IO HTTP.status404
         , expectErrorMessage $ errMsg404NoWallet $ w ^. walletId
@@ -174,15 +172,17 @@ scenario_ADDRESS_LIST_04 fixture = it title $ \ctx -> do
     title = "ADDRESS_LIST_04 - Delete wallet"
 
 scenario_ADDRESS_CREATE_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_01 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
+<<<<<<< HEAD
     let payload = Json [json| { "passphrase": #{fixturePassphrase} }|]
     r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+=======
+    let payload = Json [json| { "passphrase": "Secure Passphrase" }|]
+    r <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     verify r
         [ expectResponseCode @IO HTTP.status201
         , expectField #state (`shouldBe` ApiT Unused)
@@ -191,15 +191,17 @@ scenario_ADDRESS_CREATE_01 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_01 - Can create a random address without index"
 
 scenario_ADDRESS_CREATE_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_02 = it title $ \ctx -> do
     w <- emptyIcarusWallet ctx
+<<<<<<< HEAD
     let payload = Json [json| { "passphrase": #{fixturePassphrase} }|]
     r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+=======
+    let payload = Json [json| { "passphrase": "Secure Passphrase" }|]
+    r <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     verify r
         [ expectResponseCode @IO HTTP.status403
         , expectErrorMessage errMsg403NotAByronWallet
@@ -208,15 +210,12 @@ scenario_ADDRESS_CREATE_02 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_02 - Creation is forbidden on Icarus wallets"
 
 scenario_ADDRESS_CREATE_03
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_03 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
     let payload = Json [json| { "passphrase": "Give me all your money." }|]
-    r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+    r <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
     verify r
         [ expectResponseCode @IO HTTP.status403
         , expectErrorMessage errMsg403WrongPass
@@ -225,20 +224,22 @@ scenario_ADDRESS_CREATE_03 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_03 - Cannot create a random address with wrong passphrase"
 
 scenario_ADDRESS_CREATE_04
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_04 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
 
+<<<<<<< HEAD
     let payload = Json [json| { "passphrase": #{fixturePassphrase} }|]
     rA <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+=======
+    let payload = Json [json| { "passphrase": "Secure Passphrase" }|]
+    rA <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     verify rA [ expectResponseCode @IO HTTP.status201 ]
     let addr = getFromResponse id rA
 
-    rL <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    rL <- request @[ApiAddressWithState] ctx (Link.listAddresses @'Byron w) Default Empty
     verify rL
         [ expectResponseCode @IO HTTP.status200
         , expectListField 0 id (`shouldBe` addr)
@@ -247,10 +248,7 @@ scenario_ADDRESS_CREATE_04 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_04 - Can list address after creating it"
 
 scenario_ADDRESS_CREATE_05
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -258,7 +256,7 @@ scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
             { "passphrase": #{fixturePassphrase}
             , "address_index": 2147483662
             }|]
-    r <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+    r <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
     verify r
         [ expectResponseCode @IO HTTP.status201
         , expectField #state (`shouldBe` ApiT Unused)
@@ -267,10 +265,7 @@ scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_05 - Can create an address and specify the index"
 
 scenario_ADDRESS_CREATE_06
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        )
+    :: forall t. ()
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -278,9 +273,9 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
             { "passphrase": #{fixturePassphrase}
             , "address_index": 2147483662
             }|]
-    r0 <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+    r0 <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
     verify r0 [ expectResponseCode @IO HTTP.status201 ]
-    r1 <- request @(ApiAddress n) ctx (Link.postRandomAddress w) Default payload
+    r1 <- request @(ApiAddressWithState) ctx (Link.postRandomAddress w) Default payload
     verify r1
         [ expectResponseCode @IO HTTP.status409
         , expectErrorMessage "I already know of such address."
@@ -289,48 +284,38 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_06 - Cannot create an address that already exists"
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n ByronKey
-        )
-    => (Context t -> IO (ApiByronWallet, Mnemonic 12))
+    :: (Context t -> IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith (Context t)
 scenario_ADDRESS_IMPORT_01 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
     -- Get an unused address
-    let addr = randomAddresses @n mw !! 42
+    let addr = randomAddresses (_network ctx) mw !! 42
     let (_, base) = Link.postRandomAddress w
-    let link = base <> "/" <> encodeAddress @n addr
+    let link = base <> "/" <> (apiAddress addr)
     r0 <- request @() ctx ("PUT", link) Default Empty
     verify r0
         [ expectResponseCode @IO HTTP.status204
         ]
 
     -- Import it
-    r1 <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+    r1 <- request @[ApiAddressWithState] ctx (Link.listAddresses @'Byron w) Default Empty
     verify r1
         [ expectListField 0 #state (`shouldBe` ApiT Unused)
-        , expectListField 0 (#id . position @1) (`shouldBe` ApiT addr)
+        , expectListField 0 #id (`shouldBe` addr)
         ]
   where
     title = "ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n IcarusKey
-        )
-    => (Context t -> IO (ApiByronWallet, Mnemonic 15))
+    :: (Context t -> IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith (Context t)
 scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
-    let addr = icarusAddresses @n mw !! 42
+    let addr = icarusAddresses (_network ctx) mw !! 42
     let (_, base) = Link.postRandomAddress w
-    let link = base <> "/" <> encodeAddress @n addr
+    let link = base <> "/" <> (apiAddress addr)
     r0 <- request @() ctx ("PUT", link) Default Empty
     verify r0
         [ expectResponseCode @IO HTTP.status403
@@ -340,20 +325,15 @@ scenario_ADDRESS_IMPORT_02 fixture = it title $ \ctx -> do
     title = "ADDRESS_IMPORT_02 - I can't import an address on an Icarus wallet"
 
 scenario_ADDRESS_IMPORT_03
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n ByronKey
-        )
-    => (Context t -> IO (ApiByronWallet, Mnemonic 12))
+    :: (Context t -> IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith (Context t)
 scenario_ADDRESS_IMPORT_03 fixture = it title $ \ctx -> do
     (w, mw) <- fixture ctx
 
     -- Get an unused address
-    let addr = randomAddresses @n mw !! 42
+    let addr = randomAddresses (_network ctx) mw !! 42
     let (_, base) = Link.postRandomAddress w
-    let link = base <> "/" <> encodeAddress @n addr
+    let link = base <> "/" <> apiAddress addr
 
     -- Insert it twice
     r0 <- request @() ctx ("PUT", link) Default Empty
@@ -364,18 +344,14 @@ scenario_ADDRESS_IMPORT_03 fixture = it title $ \ctx -> do
     title = "ADDRESS_IMPORT_03 - I can import an unused address multiple times"
 
 scenario_ADDRESS_IMPORT_04
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n ByronKey
-        )
+    :: forall t. ()
     => (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
 scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> do
     w <- fixture ctx
 
     -- Get a used address
-    r0 <- request @[ApiAddress n] ctx
+    r0 <- request @[ApiAddressWithState] ctx
         (Link.listAddresses' @'Byron w (Just Used)) Default Empty
     let (addr:_) = getFromResponse id r0
 
@@ -386,7 +362,7 @@ scenario_ADDRESS_IMPORT_04 fixture = it title $ \ctx -> do
     verify r1 [ expectResponseCode @IO HTTP.status204 ]
 
     -- Verify that the address is unchanged
-    r2 <- request @[ApiAddress n] ctx
+    r2 <- request @[ApiAddressWithState] ctx
         (Link.listAddresses' @'Byron w (Just Used)) Default Empty
     verify r2 [ expectListField 0 id (`shouldBe` addr) ]
   where

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -16,12 +16,16 @@ module Test.Integration.Scenario.API.Byron.Transactions
 import Prelude
 
 import Cardano.Wallet.Api.Types
+<<<<<<< HEAD
     ( ApiByronWallet
     , ApiTransaction
     , DecodeAddress
     , DecodeStakeAddress
     , WalletStyle (..)
     )
+=======
+    ( ApiByronWallet, ApiTransaction, WalletStyle (..) )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens
@@ -68,10 +72,14 @@ data TestCase a = TestCase
     , assertions :: [(HTTP.Status, Either RequestException a) -> IO ()]
     }
 
+<<<<<<< HEAD
 spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
     ) => SpecWith (Context t)
+=======
+spec :: forall t. SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 spec = do
 
     it "BYRON_RESTORE_08 - Icarus wallet with high indexes" $ \ctx -> do
@@ -124,7 +132,7 @@ spec = do
         $ \ctx -> forM_ [emptyRandomWallet, emptyIcarusWallet] $ \emptyByronWallet -> do
             w <- emptyByronWallet ctx
             let link = Link.listTransactions @'Byron w
-            r <- request @([ApiTransaction n]) ctx link Default Empty
+            r <- request @([ApiTransaction]) ctx link Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status200
                 , expectListSize 0
@@ -135,7 +143,7 @@ spec = do
         $ \fixtureByronWallet -> do
             w <- fixtureByronWallet ctx
             let link = Link.listTransactions @'Byron w
-            r <- request @([ApiTransaction n]) ctx link Default Empty
+            r <- request @([ApiTransaction]) ctx link Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status200
                 , expectListSize 10
@@ -146,7 +154,7 @@ spec = do
             \ ascending, descending."
         let startEndErr = "Expecting ISO 8601 date-and-time format\
             \ (basic or extended), e.g. 2012-09-25T10:15:00Z."
-        let queries :: [TestCase [ApiTransaction n]] =
+        let queries :: [TestCase [ApiTransaction]] =
                 [
                   TestCase
                     { query = toQueryString [ ("start", "2009") ]
@@ -214,7 +222,7 @@ spec = do
         forM_ queries $ \tc -> it (T.unpack $ query tc) $ \ctx -> do
             w <- emptyRandomWallet ctx
             let link = withQuery (query tc) $ Link.listTransactions @'Byron w
-            r <- request @([ApiTransaction n]) ctx link Default Empty
+            r <- request @([ApiTransaction]) ctx link Default Empty
             verify r (assertions tc)
 
     it "BYRON_TX_LIST_01 - Start time shouldn't be later than end time" $
@@ -227,7 +235,7 @@ spec = do
                     (either (const Nothing) Just $ fromText $ T.pack startTime)
                     (either (const Nothing) Just $ fromText $ T.pack endTime)
                     Nothing
-            r <- request @([ApiTransaction n]) ctx link Default Empty
+            r <- request @([ApiTransaction]) ctx link Default Empty
             expectResponseCode @IO HTTP.status400 r
             expectErrorMessage
                 (errMsg400StartTimeLaterThanEndTime startTime endTime) r
@@ -237,6 +245,6 @@ spec = do
         _ <- request @ApiByronWallet ctx
             (Link.deleteWallet @'Byron w) Default Empty
         let link = Link.listTransactions @'Byron w
-        r <- request @([ApiTransaction n]) ctx link Default Empty
+        r <- request @([ApiTransaction]) ctx link Default Empty
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -29,6 +29,7 @@ import Cardano.Wallet.Api.Types
     ( ApiByronWallet
     , ApiUtxoStatistics
     , ApiWalletDiscovery (..)
+<<<<<<< HEAD
     , DecodeAddress
     , DecodeStakeAddress
     , EncodeAddress (..)
@@ -39,6 +40,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.SyncProgress
+=======
+    , ApiWalletMigrationInfo (..)
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( PassphraseMaxLength (..), PassphraseMinLength (..) )
+import Cardano.Wallet.Primitive.Types
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     ( SyncProgress (..) )
 import Control.Monad
     ( forM_, void )
@@ -101,12 +110,16 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
+<<<<<<< HEAD
 spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
+=======
+spec :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 spec = do
     it "BYRON_GET_04, DELETE_01 - Deleted wallet is not available" $ \ctx -> do
         w <- emptyRandomWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -13,6 +13,7 @@ module Test.Integration.Scenario.API.Shelley.Addresses
 import Prelude
 
 import Cardano.Wallet.Api.Types
+<<<<<<< HEAD
     ( ApiAddress
     , ApiTransaction
     , ApiWallet
@@ -21,6 +22,9 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress
     , WalletStyle (..)
     )
+=======
+    ( ApiAddressWithState, ApiTransaction, ApiWallet, WalletStyle (..) )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
@@ -62,24 +66,28 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
+<<<<<<< HEAD
 spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
+=======
+spec :: SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 spec = do
     it "BYRON_ADDRESS_LIST - Byron wallet on Shelley ep" $ \ctx -> do
         w <- emptyRandomWallet ctx
         let wid = w ^. walletId
         let ep = ("GET", "v2/wallets/" <> wid <> "/addresses")
-        r <- request @[ApiAddress n] ctx ep Default Empty
+        r <- request @[ApiAddressWithState] ctx ep Default Empty
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet wid) r
 
     it "ADDRESS_LIST_01 - Can list known addresses on a default wallet" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
         w <- emptyWallet ctx
-        r <- request @[ApiAddress n] ctx
+        r <- request @[ApiAddressWithState] ctx
             (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status200 r
         expectListSize g r
@@ -89,7 +97,7 @@ spec = do
     it "ADDRESS_LIST_01 - Can list addresses with non-default pool gap" $ \ctx -> do
         let g = 15
         w <- emptyWalletWith ctx ("Wallet", "cardano-wallet", g)
-        r <- request @[ApiAddress n] ctx
+        r <- request @[ApiAddressWithState] ctx
             (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status200 r
         expectListSize g r
@@ -99,14 +107,14 @@ spec = do
     it "ADDRESS_LIST_02 - Can filter used and unused addresses" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap
         w <- fixtureWallet ctx
-        rUsed <- request @[ApiAddress n] ctx
+        rUsed <- request @[ApiAddressWithState] ctx
             (Link.listAddresses' @'Shelley w (Just Used)) Default Empty
         expectResponseCode @IO HTTP.status200 rUsed
         expectListSize 10 rUsed
         forM_ [0..9] $ \addrNum -> do
             expectListField
                 addrNum (#state . #getApiT) (`shouldBe` Used) rUsed
-        rUnused <- request @[ApiAddress n] ctx
+        rUnused <- request @[ApiAddressWithState] ctx
             (Link.listAddresses' @'Shelley w (Just Unused)) Default Empty
         expectResponseCode @IO HTTP.status200 rUnused
         expectListSize g rUnused
@@ -117,9 +125,9 @@ spec = do
     it "ADDRESS_LIST_02 - Shows nothing when there are no used addresses"
         $ \ctx -> do
         w <- emptyWallet ctx
-        rUsed <- request @[ApiAddress n] ctx
+        rUsed <- request @[ApiAddressWithState] ctx
             (Link.listAddresses' @'Shelley w (Just Used)) Default Empty
-        rUnused <- request @[ApiAddress n] ctx
+        rUnused <- request @[ApiAddressWithState] ctx
             (Link.listAddresses' @'Shelley w (Just Unused)) Default Empty
         expectResponseCode @IO HTTP.status200 rUsed
         expectListSize 0 rUsed
@@ -148,7 +156,7 @@ spec = do
         forM_ filters $ \fil -> it fil $ \ctx -> do
             w <- emptyWallet ctx
             let link = withQuery fil $ Link.listAddresses @'Shelley w
-            r <- request @[ApiAddress n] ctx link Default Empty
+            r <- request @[ApiAddressWithState] ctx link Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status400
                 , expectErrorMessage $
@@ -162,7 +170,7 @@ spec = do
         wDest <- emptyWalletWith ctx ("Wallet", "cardano-wallet", 10)
 
         -- make sure all addresses in address_pool_gap are 'Unused'
-        r <- request @[ApiAddress n] ctx
+        r <- request @[ApiAddressWithState] ctx
             (Link.listAddresses @'Shelley wDest) Default Empty
         verify r
             [ expectResponseCode @IO HTTP.status200
@@ -170,11 +178,11 @@ spec = do
             ]
         forM_ [0..9] $ \addrNum -> do
             expectListField addrNum (#state . #getApiT) (`shouldBe` Unused) r
-        addrs <- listAddresses @n ctx wDest
+        addrs <- listAddresses  ctx wDest
 
         -- run 10 transactions to make all addresses `Used`
         forM_ [0..9] $ \addrNum -> do
-            let destination = (addrs !! addrNum) ^. #id
+            let destination = addrs !! addrNum
             let payload = Json [json|{
                     "payments": [{
                         "address": #{destination},
@@ -186,7 +194,7 @@ spec = do
                     "passphrase": "cardano-wallet"
                 }|]
 
-            rTrans <- request @(ApiTransaction n) ctx
+            rTrans <- request @ApiTransaction ctx
                 (Link.createTransaction @'Shelley wSrc) Default payload
             expectResponseCode @IO HTTP.status202 rTrans
 
@@ -198,7 +206,7 @@ spec = do
                 (#balance . #getApiT . #available) (`shouldBe` Quantity 10) rb
 
         -- verify new address_pool_gap has been created
-        rAddr <- request @[ApiAddress n] ctx
+        rAddr <- request @[ApiAddressWithState] ctx
             (Link.listAddresses @'Shelley wDest) Default Empty
         verify rAddr
             [ expectResponseCode @IO HTTP.status200
@@ -215,7 +223,7 @@ spec = do
         w <- emptyWallet ctx
         _ <- request @ApiWallet ctx
             (Link.deleteWallet @'Shelley w) Default Empty
-        r <- request @[ApiAddress n] ctx
+        r <- request @[ApiAddressWithState] ctx
             (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -14,18 +14,9 @@ module Test.Integration.Scenario.CLI.Byron.Addresses
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiAddress
-    , ApiByronWallet
-    , ApiT (..)
-    , DecodeAddress
-    , EncodeAddress (..)
-    )
+    ( ApiAddress (..), ApiAddressWithState, ApiByronWallet, ApiT (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
-import Cardano.Wallet.Primitive.AddressDerivation.Byron
-    ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
+    ( NetworkDiscriminant )
 import Cardano.Wallet.Primitive.Types
     ( AddressState (..) )
 import Control.Monad
@@ -67,34 +58,31 @@ import Test.Integration.Framework.TestData
 
 import qualified Data.Text as T
 
-spec :: forall n t.
-    ( DecodeAddress n
-    , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
-    , KnownCommand t
-    ) => SpecWith (Context t)
-spec = do
+spec
+    :: forall t. KnownCommand t
+    => NetworkDiscriminant
+    -> SpecWith (Context t)
+spec n = do
     describe "BYRON_CLI_ADDRESSES" $ do
-        scenario_ADDRESS_LIST_01 @n "random" emptyRandomWallet
-        scenario_ADDRESS_LIST_01 @n "icarus" emptyIcarusWallet
+        scenario_ADDRESS_LIST_01  "random" emptyRandomWallet
+        scenario_ADDRESS_LIST_01  "icarus" emptyIcarusWallet
 
-        scenario_ADDRESS_LIST_02 @n "random" fixtureRandomWallet
-        scenario_ADDRESS_LIST_02 @n "icarus" fixtureIcarusWallet
+        scenario_ADDRESS_LIST_02  "random" fixtureRandomWallet
+        scenario_ADDRESS_LIST_02  "icarus" fixtureIcarusWallet
 
-        scenario_ADDRESS_LIST_04 @n "random" emptyRandomWallet
-        scenario_ADDRESS_LIST_04 @n "icarus" emptyIcarusWallet
+        scenario_ADDRESS_LIST_04  "random" emptyRandomWallet
+        scenario_ADDRESS_LIST_04  "icarus" emptyIcarusWallet
 
-        scenario_ADDRESS_CREATE_01 @n
-        scenario_ADDRESS_CREATE_02 @n
-        scenario_ADDRESS_CREATE_03 @n
-        scenario_ADDRESS_CREATE_04 @n
-        scenario_ADDRESS_CREATE_05 @n
-        scenario_ADDRESS_CREATE_06 @n
+        scenario_ADDRESS_CREATE_01
+        scenario_ADDRESS_CREATE_02
+        scenario_ADDRESS_CREATE_03
+        scenario_ADDRESS_CREATE_04
+        scenario_ADDRESS_CREATE_05
+        scenario_ADDRESS_CREATE_06
 
-        scenario_ADDRESS_IMPORT_01 @n
-        scenario_ADDRESS_IMPORT_02 @n
-        scenario_ADDRESS_IMPORT_03 @n
+        scenario_ADDRESS_IMPORT_01 n
+        scenario_ADDRESS_IMPORT_02 n
+        scenario_ADDRESS_IMPORT_03
 
         describe "CLI_ADDRESS_CREATE_07 - False indexes" $ do
             let outOfBoundIndexes =
@@ -105,21 +93,17 @@ spec = do
                     \ between Index {getIndex = 2147483648}\
                     \ and Index {getIndex = 4294967295}"
             forM_ outOfBoundIndexes $ \idx ->
-                scenario_ADDRESS_CREATE_07 @n idx expectedMsgOutOfBound
+                scenario_ADDRESS_CREATE_07  idx expectedMsgOutOfBound
 
             let invalidIndexes = [ "patate", "1500sto900", "2147483648e"]
             let expectedMsginvalidIdx =
                     "Int is an integer number between\
                     \ -9223372036854775808 and 9223372036854775807."
             forM_ invalidIndexes $ \idx ->
-                scenario_ADDRESS_CREATE_07 @n idx expectedMsginvalidIdx
+                scenario_ADDRESS_CREATE_07  idx expectedMsginvalidIdx
 
 scenario_ADDRESS_LIST_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall  t.  KnownCommand t
     => String
     -> (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
@@ -129,7 +113,7 @@ scenario_ADDRESS_LIST_01 walType fixture = it title $ \ctx -> do
     (Exit c, Stdout out, Stderr err) <- listAddressesViaCLI @t ctx [wid]
     err `shouldBe` cmdOk
     c `shouldBe` ExitSuccess
-    j <- expectValidJSON (Proxy @[ApiAddress n]) out
+    j <- expectValidJSON (Proxy @[ApiAddressWithState]) out
     let n = length j
     forM_ [0..(n-1)] $ \addrNum -> do
         expectCliListField
@@ -139,11 +123,7 @@ scenario_ADDRESS_LIST_01 walType fixture = it title $ \ctx -> do
         ++ walType ++ " can list known addresses on a default wallet"
 
 scenario_ADDRESS_LIST_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => String
     -> (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
@@ -157,7 +137,7 @@ scenario_ADDRESS_LIST_02 walType fixture = it title $ \ctx -> do
     (Exit c, Stdout out, Stderr err) <- listAddressesViaCLI @t ctx (args "used")
     err `shouldBe` cmdOk
     c `shouldBe` ExitSuccess
-    j <- expectValidJSON (Proxy @[ApiAddress n]) out
+    j <- expectValidJSON (Proxy @[ApiAddressWithState]) out
     let n = length j
     forM_ [0..(n-1)] $ \addrNum -> do
         expectCliListField
@@ -167,7 +147,7 @@ scenario_ADDRESS_LIST_02 walType fixture = it title $ \ctx -> do
     (Exit c2, Stdout out2, Stderr err2) <- listAddressesViaCLI @t ctx (args "unused")
     err2 `shouldBe` cmdOk
     c2 `shouldBe` ExitSuccess
-    j2 <- expectValidJSON (Proxy @[ApiAddress n]) out2
+    j2 <- expectValidJSON (Proxy @[ApiAddressWithState]) out2
     let n2 = length j2
     forM_ [0..(n2-1)] $ \addrNum -> do
         expectCliListField
@@ -177,11 +157,7 @@ scenario_ADDRESS_LIST_02 walType fixture = it title $ \ctx -> do
         ++ walType ++ " can filter used and unused addresses"
 
 scenario_ADDRESS_LIST_04
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => String
     -> (Context t -> IO ApiByronWallet)
     -> SpecWith (Context t)
@@ -198,10 +174,8 @@ scenario_ADDRESS_LIST_04 walType fixture = it title $ \ctx -> do
     title = "CLI_ADDRESS_LIST_04 - " ++ walType ++ " deleted wallet"
 
 scenario_ADDRESS_CREATE_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
+    :: forall t.
+        ( KnownCommand t
         )
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_01 = it title $ \ctx -> do
@@ -210,17 +184,13 @@ scenario_ADDRESS_CREATE_01 = it title $ \ctx -> do
     (c, out, err) <- createAddressViaCLI @t ctx [wid] (T.unpack fixturePassphrase)
     T.unpack err `shouldContain` cmdOk
     c `shouldBe` ExitSuccess
-    j <- expectValidJSON (Proxy @(ApiAddress n)) (T.unpack out)
+    j <- expectValidJSON (Proxy @(ApiAddressWithState)) (T.unpack out)
     verify j [ expectCliField #state (`shouldBe` ApiT Unused) ]
   where
     title = "CLI_ADDRESS_CREATE_01 - Can create a random address without index"
 
 scenario_ADDRESS_CREATE_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_02 = it title $ \ctx -> do
     w <- emptyIcarusWallet ctx
@@ -233,11 +203,7 @@ scenario_ADDRESS_CREATE_02 = it title $ \ctx -> do
     title = "CLI_ADDRESS_CREATE_02 - Creation is forbidden on Icarus wallets"
 
 scenario_ADDRESS_CREATE_03
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_03 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -250,11 +216,7 @@ scenario_ADDRESS_CREATE_03 = it title $ \ctx -> do
     title = "ADDRESS_CREATE_03 - Cannot create a random address with wrong passphrase"
 
 scenario_ADDRESS_CREATE_04
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_04 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -262,22 +224,18 @@ scenario_ADDRESS_CREATE_04 = it title $ \ctx -> do
     (c, out, err) <- createAddressViaCLI @t ctx [wid] (T.unpack fixturePassphrase)
     T.unpack err `shouldContain` cmdOk
     c `shouldBe` ExitSuccess
-    addr <- expectValidJSON (Proxy @(ApiAddress n)) (T.unpack out)
+    addr <- expectValidJSON (Proxy @(ApiAddressWithState)) (T.unpack out)
 
     (Exit cl, Stdout outl, Stderr errl) <- listAddressesViaCLI @t ctx [wid]
     errl `shouldBe` cmdOk
     cl `shouldBe` ExitSuccess
-    j <- expectValidJSON (Proxy @[ApiAddress n]) outl
+    j <- expectValidJSON (Proxy @[ApiAddressWithState]) outl
     expectCliListField 0 id (`shouldBe` addr) j
   where
     title = "CLI_ADDRESS_CREATE_04 - Can list address after creating it"
 
 scenario_ADDRESS_CREATE_05
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -286,17 +244,13 @@ scenario_ADDRESS_CREATE_05 = it title $ \ctx -> do
     (c, out, err) <- createAddressViaCLI @t ctx args (T.unpack fixturePassphrase)
     T.unpack err `shouldContain` cmdOk
     c `shouldBe` ExitSuccess
-    j <- expectValidJSON (Proxy @(ApiAddress n)) (T.unpack out)
+    j <- expectValidJSON (Proxy @(ApiAddressWithState)) (T.unpack out)
     verify j [ expectCliField #state (`shouldBe` ApiT Unused) ]
   where
     title = "CLI_ADDRESS_CREATE_05 - Can create an address and specify the index"
 
 scenario_ADDRESS_CREATE_06
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx
@@ -314,11 +268,7 @@ scenario_ADDRESS_CREATE_06 = it title $ \ctx -> do
     title = "CLI_ADDRESS_CREATE_06 - Cannot create an address that already exists"
 
 scenario_ADDRESS_CREATE_07
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => String
     -> String
     -> SpecWith (Context t)
@@ -332,17 +282,13 @@ scenario_ADDRESS_CREATE_07 index expectedMsg = it index $ \ctx -> do
     out `shouldBe` mempty
 
 scenario_ADDRESS_IMPORT_01
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n ByronKey
-        , KnownCommand t
-        )
-    => SpecWith (Context t)
-scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> do
+    :: forall t. KnownCommand t
+    => NetworkDiscriminant
+    -> SpecWith (Context t)
+scenario_ADDRESS_IMPORT_01 n = it title $ \ctx -> do
     (w, mw) <- emptyRandomWalletMws ctx
     let wid = T.unpack (w ^. walletId)
-    let addr = T.unpack $ encodeAddress @n $ randomAddresses @n mw !! 42
+    let addr = T.unpack $ apiAddress $ randomAddresses n mw !! 42
     (Exit c, Stdout _out, Stderr err) <- importAddressViaCLI @t ctx [wid, addr]
     c `shouldBe` ExitSuccess
     err `shouldContain` cmdOk
@@ -350,17 +296,13 @@ scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> do
     title = "CLI_ADDRESS_IMPORT_01 - I can import an address from my wallet"
 
 scenario_ADDRESS_IMPORT_02
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n IcarusKey
-        , KnownCommand t
-        )
-    => SpecWith (Context t)
-scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> do
+    :: forall t . KnownCommand t
+    => NetworkDiscriminant
+    -> SpecWith (Context t)
+scenario_ADDRESS_IMPORT_02 n = it title $ \ctx -> do
     (w, mw) <- emptyIcarusWalletMws ctx
     let wid = T.unpack (w ^. walletId)
-    let addr = T.unpack $ encodeAddress @n $ icarusAddresses @n mw !! 42
+    let addr = T.unpack $ apiAddress $ icarusAddresses n mw !! 42
     (Exit c, Stdout _out, Stderr err) <- importAddressViaCLI @t ctx [wid, addr]
     c `shouldBe` ExitFailure 1
     err `shouldContain` errMsg403NotAByronWallet
@@ -368,12 +310,7 @@ scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> do
     title = "CLI_ADDRESS_IMPORT_02 - I can't import an address on an Icarus wallets"
 
 scenario_ADDRESS_IMPORT_03
-    :: forall (n :: NetworkDiscriminant) t.
-        ( DecodeAddress n
-        , EncodeAddress n
-        , PaymentAddress n ByronKey
-        , KnownCommand t
-        )
+    :: forall t. KnownCommand t
     => SpecWith (Context t)
 scenario_ADDRESS_IMPORT_03 = it title $ \ctx -> do
     w <- emptyRandomWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -24,7 +24,7 @@ import Cardano.Mnemonic
     , mnemonicToText
     )
 import Cardano.Wallet.Api.Types
-    ( ApiByronWallet, ApiUtxoStatistics, DecodeAddress )
+    ( ApiByronWallet, ApiUtxoStatistics )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.SyncProgress
@@ -89,10 +89,8 @@ import Test.Integration.Framework.TestData
 
 import qualified Data.Text as T
 
-spec :: forall n t.
-    ( DecodeAddress n
-    , KnownCommand t
-    ) => SpecWith (Context t)
+spec :: forall t. KnownCommand t
+     => SpecWith (Context t)
 spec = do
 
     describe "CLI_BYRON_GET_04, CLI_BYRON_DELETE_01, BYRON_RESTORE_02, BYRON_RESTORE_03 -\

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -12,16 +12,19 @@ module Test.Integration.Scenario.CLI.Shelley.HWWallets
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiAddress
+    ( ApiAddressWithState (..)
     , ApiFee
     , ApiTransaction
     , ApiUtxoStatistics
     , ApiWallet
+<<<<<<< HEAD
     , DecodeAddress (..)
     , DecodeStakeAddress (..)
     , EncodeAddress (..)
     , encodeAddress
     , getApiT
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
@@ -63,7 +66,8 @@ import Test.Integration.Framework.DSL
     , generateMnemonicsViaCLI
     , getWalletUtxoStatisticsViaCLI
     , getWalletViaCLI
-    , listAddresses
+    , listAddressesAsText
+    , listAddressesAsText
     , listAddressesViaCLI
     , listTransactionsViaCLI
     , listWalletsViaCLI
@@ -83,14 +87,17 @@ import Test.Integration.Scenario.CLI.Shelley.Wallets
 
 import qualified Data.Text as T
 
+<<<<<<< HEAD
 spec :: forall n t.
     ( KnownCommand t
     , DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
+=======
+spec :: forall t . KnownCommand t => SpecWith (Context t)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 spec = do
-
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
 
@@ -109,8 +116,7 @@ spec = do
 
         --send transaction to the wallet
         let amount = 11
-        addrs:_ <- listAddresses @n ctx wDest
-        let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
+        addr:_ <- listAddressesAsText ctx wDest
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amount) <> "@" <> addr
@@ -118,7 +124,7 @@ spec = do
 
         (cp, op, ep) <- postTransactionViaCLI @t ctx "cardano-wallet" args
         T.unpack ep `shouldContain` cmdOk
-        _ <- expectValidJSON (Proxy @(ApiTransaction n)) op
+        _ <- expectValidJSON (Proxy @ApiTransaction) op
         cp `shouldBe` ExitSuccess
 
         eventually "Wallet balance is as expected" $ do
@@ -170,8 +176,7 @@ spec = do
 
             -- make sure you cannot send tx from wallet
             wDest <- emptyWallet ctx
-            addrs:_ <- listAddresses @n ctx wDest
-            let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
+            addr:_ <- listAddressesAsText ctx wDest
             let args = T.unpack <$>
                     [ wRestored ^. walletId
                     , "--payment", "1@" <> addr
@@ -225,9 +230,14 @@ spec = do
 
             -- get fee
             wDest <- emptyWallet ctx
+<<<<<<< HEAD
             addrs:_ <- listAddresses @n ctx wDest
             let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
             let amt = 1 :: Int
+=======
+            addr:_ <- listAddressesAsText ctx wDest
+            let amt = 1
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
             let args = T.unpack <$>
                     [ wRestored ^. walletId
                     , "--payment", T.pack (show amt) <> "@" <> addr
@@ -266,7 +276,7 @@ spec = do
                 listAddressesViaCLI @t ctx [T.unpack (w ^. walletId)]
             err `shouldBe` "Ok.\n"
             c `shouldBe` ExitSuccess
-            json <- expectValidJSON (Proxy @[ApiAddress n]) out
+            json <- expectValidJSON (Proxy @[ApiAddressWithState]) out
             length json `shouldBe` g
             forM_ [0..(g-1)] $ \addrNum -> do
                 expectCliListField

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -46,6 +46,7 @@ library
     , cryptonite
     , data-default
     , deepseq
+    , base58-bytestring
     , digest
     , directory
     , exceptions

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -104,32 +104,32 @@ import Prelude
 import Cardano.Wallet
     ( WalletLayer (..), WalletLog )
 import Cardano.Wallet.Api.Types
-    ( ApiAddressIdT
-    , ApiAddressT
+    ( ApiAddress
+    , ApiAddressWithState
     , ApiByronWallet
-    , ApiCoinSelectionT
+    , ApiCoinSelection
     , ApiFee
     , ApiNetworkClock
     , ApiNetworkInformation
     , ApiNetworkParameters
     , ApiPoolId
     , ApiPostRandomAddressData
-    , ApiPutAddressesDataT
-    , ApiSelectCoinsDataT
+    , ApiPutAddressesData
+    , ApiSelectCoinsData
     , ApiT
-    , ApiTransactionT
+    , ApiTransaction
     , ApiTxId
     , ApiUtxoStatistics
     , ApiWallet
     , ApiWalletMigrationInfo
-    , ApiWalletMigrationPostDataT
+    , ApiWalletMigrationPostData
     , ApiWalletPassphrase
     , ByronWalletPutPassphraseData
     , Iso8601Time
     , MinWithdrawal
     , PostExternalTransactionData
-    , PostTransactionDataT
-    , PostTransactionFeeDataT
+    , PostTransactionData
+    , PostTransactionFeeData
     , SomeByronWalletPostData
     , WalletOrAccountPostData
     , WalletPutData
@@ -140,7 +140,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.Network
     ( NetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth )
+    ( AddressScheme, Depth )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
@@ -187,23 +187,23 @@ import Servant.API.Verbs
     , PutNoContent
     )
 
-type ApiV2 n apiPool = "v2" :> Api n apiPool
+type ApiV2 apiPool = "v2" :> Api apiPool
 
 -- | The full cardano-wallet API.
 --
 -- The API used in cardano-wallet-jormungandr may differ from this one.
-type Api n apiPool =
+type Api apiPool =
          Wallets
-    :<|> Addresses n
-    :<|> CoinSelections n
-    :<|> Transactions n
-    :<|> ShelleyMigrations n
-    :<|> StakePools n apiPool
+    :<|> Addresses
+    :<|> CoinSelections
+    :<|> Transactions
+    :<|> ShelleyMigrations
+    :<|> StakePools apiPool
     :<|> ByronWallets
-    :<|> ByronAddresses n
-    :<|> ByronCoinSelections n
-    :<|> ByronTransactions n
-    :<|> ByronMigrations n
+    :<|> ByronAddresses
+    :<|> ByronCoinSelections
+    :<|> ByronTransactions
+    :<|> ByronMigrations
     :<|> Network
     :<|> Proxy_
 
@@ -267,15 +267,15 @@ type GetUTxOsStatistics = "wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Addresses
 -------------------------------------------------------------------------------}
 
-type Addresses n =
-    ListAddresses n
+type Addresses =
+    ListAddresses
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listAddresses
-type ListAddresses n = "wallets"
+type ListAddresses = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
-    :> Get '[JSON] [ApiAddressT n]
+    :> Get '[JSON] [ApiAddressWithState]
 
 {-------------------------------------------------------------------------------
                                Coin Selections
@@ -284,16 +284,16 @@ type ListAddresses n = "wallets"
   https://input-output-hk.github.io/cardano-wallet/api/#tag/Coin-Selections
 -------------------------------------------------------------------------------}
 
-type CoinSelections n =
-    SelectCoins n
+type CoinSelections =
+    SelectCoins
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/selectCoins
-type SelectCoins n = "wallets"
+type SelectCoins = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "coin-selections"
     :> "random"
-    :> ReqBody '[JSON] (ApiSelectCoinsDataT n)
-    :> Post '[JSON] (ApiCoinSelectionT n)
+    :> ReqBody '[JSON] ApiSelectCoinsData
+    :> Post '[JSON] ApiCoinSelection
 
 {-------------------------------------------------------------------------------
                                   Transactions
@@ -301,42 +301,42 @@ type SelectCoins n = "wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Transactions
 -------------------------------------------------------------------------------}
 
-type Transactions n =
-    CreateTransaction n
-    :<|> ListTransactions n
-    :<|> PostTransactionFee n
+type Transactions =
+    CreateTransaction
+    :<|> ListTransactions
+    :<|> PostTransactionFee
     :<|> DeleteTransaction
-    :<|> GetTransaction n
+    :<|> GetTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postTransaction
-type CreateTransaction n = "wallets"
+type CreateTransaction = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
-    :> ReqBody '[JSON] (PostTransactionDataT n)
-    :> PostAccepted '[JSON] (ApiTransactionT n)
+    :> ReqBody '[JSON] (PostTransactionData)
+    :> PostAccepted '[JSON] (ApiTransaction)
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listTransactions
-type ListTransactions n = "wallets"
+type ListTransactions = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
     :> QueryParam "minWithdrawal" MinWithdrawal
     :> QueryParam "start" Iso8601Time
     :> QueryParam "end" Iso8601Time
     :> QueryParam "order" (ApiT SortOrder)
-    :> Get '[JSON] [ApiTransactionT n]
+    :> Get '[JSON] [ApiTransaction]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getTransaction
-type GetTransaction n = "wallets"
+type GetTransaction = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
     :> Capture "transactionId" ApiTxId
-    :> Get '[JSON] (ApiTransactionT n)
+    :> Get '[JSON] ApiTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postTransactionFee
-type PostTransactionFee n = "wallets"
+type PostTransactionFee = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "payment-fees"
-    :> ReqBody '[JSON] (PostTransactionFeeDataT n)
+    :> ReqBody '[JSON] (PostTransactionFeeData)
     :> PostAccepted '[JSON] ApiFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteTransaction
@@ -353,16 +353,16 @@ See also:
 https://input-output-hk.github.io/cardano-wallet/api/#tag/Migrations
 -------------------------------------------------------------------------------}
 
-type ShelleyMigrations n =
+type ShelleyMigrations =
          GetShelleyWalletMigrationInfo
-    :<|> MigrateShelleyWallet n
+    :<|> MigrateShelleyWallet
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/migrateShelleyWallet
-type MigrateShelleyWallet n = "wallets"
+type MigrateShelleyWallet = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "migrations"
-    :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "raw")
-    :> PostAccepted '[JSON] [ApiTransactionT n]
+    :> ReqBody '[JSON] (ApiWalletMigrationPostData "raw")
+    :> PostAccepted '[JSON] [ApiTransaction]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getShelleyWalletMigrationInfo
 type GetShelleyWalletMigrationInfo = "wallets"
@@ -376,10 +376,10 @@ type GetShelleyWalletMigrationInfo = "wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/edge/#tag/Stake-Pools
 -------------------------------------------------------------------------------}
 
-type StakePools n apiPool =
+type StakePools apiPool =
     ListStakePools apiPool
-    :<|> JoinStakePool n
-    :<|> QuitStakePool n
+    :<|> JoinStakePool
+    :<|> QuitStakePool
     :<|> DelegationFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listStakePools
@@ -388,20 +388,20 @@ type ListStakePools apiPool = "stake-pools"
     :> Get '[JSON] [apiPool]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/joinStakePool
-type JoinStakePool n = "stake-pools"
+type JoinStakePool = "stake-pools"
     :> Capture "stakePoolId" ApiPoolId
     :> "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiWalletPassphrase
-    :> PutAccepted '[JSON] (ApiTransactionT n)
+    :> PutAccepted '[JSON] ApiTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/quitStakePool
-type QuitStakePool n = "stake-pools"
+type QuitStakePool = "stake-pools"
     :> "*"
     :> "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> ReqBody '[JSON] ApiWalletPassphrase
-    :> DeleteAccepted '[JSON] (ApiTransactionT n)
+    :> DeleteAccepted '[JSON] ApiTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getDelegationFee
 type DelegationFee = "wallets"
@@ -469,39 +469,39 @@ type PutByronWalletPassphrase = "byron-wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Addresses
 -------------------------------------------------------------------------------}
 
-type ByronAddresses n =
-    PostByronAddress n
-    :<|> PutByronAddress n
-    :<|> PutByronAddresses n
-    :<|> ListByronAddresses n
+type ByronAddresses =
+    PostByronAddress
+    :<|> PutByronAddress
+    :<|> PutByronAddresses
+    :<|> ListByronAddresses
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/createAddress
-type PostByronAddress n = "byron-wallets"
+type PostByronAddress = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> ReqBody '[JSON] ApiPostRandomAddressData
-    :> PostCreated '[JSON] (ApiAddressT n)
+    :> PostCreated '[JSON] (ApiAddressWithState)
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/restoreAddress
-type PutByronAddress n = "byron-wallets"
+type PutByronAddress = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
-    :> Capture "addressId" (ApiAddressIdT n)
+    :> Capture "addressId" ApiAddress
     :> PutNoContent
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/importAddresses
-type PutByronAddresses n = "byron-wallets"
+type PutByronAddresses = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
-    :> ReqBody '[JSON] (ApiPutAddressesDataT n)
+    :> ReqBody '[JSON] ApiPutAddressesData
     :> PutNoContent
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronAddresses
-type ListByronAddresses n = "byron-wallets"
+type ListByronAddresses = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
-    :> Get '[JSON] [ApiAddressT n]
+    :> Get '[JSON] [ApiAddressWithState]
 
 {-------------------------------------------------------------------------------
                                Coin Selections
@@ -510,16 +510,16 @@ type ListByronAddresses n = "byron-wallets"
   https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Coin-Selections
 -------------------------------------------------------------------------------}
 
-type ByronCoinSelections n =
-    ByronSelectCoins n
+type ByronCoinSelections =
+    ByronSelectCoins
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/byronSelectCoins
-type ByronSelectCoins n = "byron-wallets"
+type ByronSelectCoins = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "coin-selections"
     :> "random"
-    :> ReqBody '[JSON] (ApiSelectCoinsDataT n)
-    :> Post '[JSON] (ApiCoinSelectionT n)
+    :> ReqBody '[JSON] ApiSelectCoinsData
+    :> Post '[JSON] ApiCoinSelection
 
 {-------------------------------------------------------------------------------
                                  Byron Transactions
@@ -527,41 +527,41 @@ type ByronSelectCoins n = "byron-wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Transactions
 -------------------------------------------------------------------------------}
 
-type ByronTransactions n =
-    CreateByronTransaction n
-    :<|> ListByronTransactions n
-    :<|> PostByronTransactionFee n
+type ByronTransactions =
+    CreateByronTransaction
+    :<|> ListByronTransactions
+    :<|> PostByronTransactionFee
     :<|> DeleteByronTransaction
-    :<|> GetByronTransaction n
+    :<|> GetByronTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronTransaction
-type CreateByronTransaction n = "byron-wallets"
+type CreateByronTransaction = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
-    :> ReqBody '[JSON] (PostTransactionDataT n)
-    :> PostAccepted '[JSON] (ApiTransactionT n)
+    :> ReqBody '[JSON] (PostTransactionData)
+    :> PostAccepted '[JSON] (ApiTransaction)
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listByronTransactions
-type ListByronTransactions n = "byron-wallets"
+type ListByronTransactions = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
     :> QueryParam "start" Iso8601Time
     :> QueryParam "end" Iso8601Time
     :> QueryParam "order" (ApiT SortOrder)
-    :> Get '[JSON] [ApiTransactionT n]
+    :> Get '[JSON] [ApiTransaction]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronTransaction
-type GetByronTransaction n = "byron-wallets"
+type GetByronTransaction = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
     :> Capture "transactionId" ApiTxId
-    :> Get '[JSON] (ApiTransactionT n)
+    :> Get '[JSON] ApiTransaction
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/postByronTransactionFee
-type PostByronTransactionFee n = "byron-wallets"
+type PostByronTransactionFee = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "payment-fees"
-    :> ReqBody '[JSON] (PostTransactionFeeDataT n)
+    :> ReqBody '[JSON] PostTransactionFeeData
     :> PostAccepted '[JSON] ApiFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteByronTransaction
@@ -577,16 +577,16 @@ type DeleteByronTransaction = "byron-wallets"
   See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Byron-Migrations
 -------------------------------------------------------------------------------}
 
-type ByronMigrations n =
+type ByronMigrations =
          GetByronWalletMigrationInfo
-    :<|> MigrateByronWallet n
+    :<|> MigrateByronWallet
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/migrateByronWallet
-type MigrateByronWallet n = "byron-wallets"
+type MigrateByronWallet = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "migrations"
-    :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "lenient")
-    :> PostAccepted '[JSON] [ApiTransactionT n]
+    :> ReqBody '[JSON] (ApiWalletMigrationPostData "lenient")
+    :> PostAccepted '[JSON] [ApiTransaction]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronWalletMigrationInfo
 type GetByronWalletMigrationInfo = "byron-wallets"
@@ -645,14 +645,15 @@ data ApiLayer s t (k :: Depth -> * -> *)
         (TransactionLayer t k)
         (DBFactory IO s k)
         (WorkerRegistry WalletId (DBLayer IO s k))
+        (AddressScheme k)
     deriving (Generic)
 
 instance HasWorkerCtx (DBLayer IO s k) (ApiLayer s t k) where
     type WorkerCtx (ApiLayer s t k) = WalletLayer s t k
     type WorkerMsg (ApiLayer s t k) = WalletLog
     type WorkerKey (ApiLayer s t k) = WalletId
-    hoistResource db transform (ApiLayer tr gp nw tl _ _) =
-        WalletLayer (contramap transform tr) gp nw tl db
+    hoistResource db transform (ApiLayer tr gp nw tl _ _ as) =
+        WalletLayer (contramap transform tr) gp nw tl db as
 
 {-------------------------------------------------------------------------------
                                Capabilities

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels #-}
@@ -41,6 +42,7 @@ module Cardano.Wallet.Api.Types
 
     -- * API Types
     , ApiAddress (..)
+    , ApiAddressWithState (..)
     , ApiEpochInfo (..)
     , ApiSelectCoinsData (..)
     , ApiCoinSelection (..)
@@ -101,26 +103,9 @@ module Cardano.Wallet.Api.Types
     , ApiAccountPublicKey (..)
     , WalletOrAccountPostData (..)
 
-    -- * User-Facing Address Encoding/Decoding
-    , EncodeAddress (..)
-    , DecodeAddress (..)
-    , EncodeStakeAddress (..)
-    , DecodeStakeAddress (..)
-
     -- * Polymorphic Types
     , ApiT (..)
     , ApiMnemonicT (..)
-
-    -- * Type families
-    , ApiAddressT
-    , ApiPutAddressesDataT
-    , ApiAddressIdT
-    , ApiCoinSelectionT
-    , ApiSelectCoinsDataT
-    , ApiTransactionT
-    , PostTransactionDataT
-    , PostTransactionFeeDataT
-    , ApiWalletMigrationPostDataT
     ) where
 
 import Prelude
@@ -138,8 +123,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
     , Index (..)
-    , NetworkDiscriminant (..)
-    , Passphrase (..)
+    , Passphrase
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
     , hex
@@ -154,10 +138,9 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
     , AddressState (..)
+    , AddressState
     , BoundType
-    , ChimericAccount (..)
     , Coin (..)
     , DecentralizationLevel (..)
     , Direction (..)
@@ -338,8 +321,19 @@ fmtAllowedWords =
                                   API Types
 -------------------------------------------------------------------------------}
 
-data ApiAddress (n :: NetworkDiscriminant) = ApiAddress
-    { id :: !(ApiT Address, Proxy n)
+-- | User-presentable address.
+--
+-- Depening on the targeted blockchain, this may for instance encoded as:
+-- - hex
+-- - bech32
+-- - base58
+newtype ApiAddress = ApiAddress
+    { apiAddress :: Text
+    } deriving stock (Eq, Generic, Show)
+      deriving newtype (FromText, ToText)
+
+data ApiAddressWithState = ApiAddressWithState
+    { id :: !(ApiAddress)
     , state :: !(ApiT AddressState)
     } deriving (Eq, Generic, Show)
 
@@ -348,19 +342,19 @@ data ApiEpochInfo = ApiEpochInfo
     , epochStartTime :: !UTCTime
     } deriving (Eq, Generic, Show)
 
-newtype ApiSelectCoinsData (n :: NetworkDiscriminant) = ApiSelectCoinsData
-    { payments :: NonEmpty (AddressAmount (ApiT Address, Proxy n))
+newtype ApiSelectCoinsData = ApiSelectCoinsData
+    { payments :: NonEmpty (AddressAmount ApiAddress)
     } deriving (Eq, Generic, Show)
 
-data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
-    { inputs :: !(NonEmpty (ApiCoinSelectionInput n))
-    , outputs :: !(NonEmpty (AddressAmount (ApiT Address, Proxy n)))
+data ApiCoinSelection = ApiCoinSelection
+    { inputs :: !(NonEmpty ApiCoinSelectionInput)
+    , outputs :: !(NonEmpty (AddressAmount ApiAddress))
     } deriving (Eq, Generic, Show)
 
-data ApiCoinSelectionInput (n :: NetworkDiscriminant) = ApiCoinSelectionInput
+data ApiCoinSelectionInput = ApiCoinSelectionInput
     { id :: !(ApiT (Hash "Tx"))
     , index :: !Word32
-    , address :: !(ApiT Address, Proxy n)
+    , address :: !ApiAddress
     , amount :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
 
@@ -486,14 +480,14 @@ data ByronWalletPutPassphraseData = ByronWalletPutPassphraseData
     , newPassphrase :: !(ApiT (Passphrase "raw"))
     } deriving (Eq, Generic, Show)
 
-data PostTransactionData (n :: NetworkDiscriminant) = PostTransactionData
-    { payments :: !(NonEmpty (AddressAmount (ApiT Address, Proxy n)))
+data PostTransactionData = PostTransactionData
+    { payments :: !(NonEmpty (AddressAmount ApiAddress))
     , passphrase :: !(ApiT (Passphrase "lenient"))
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     } deriving (Eq, Generic, Show)
 
-data PostTransactionFeeData (n :: NetworkDiscriminant) = PostTransactionFeeData
-    { payments :: (NonEmpty (AddressAmount (ApiT Address, Proxy n)))
+data PostTransactionFeeData = PostTransactionFeeData
+    { payments :: (NonEmpty (AddressAmount ApiAddress))
     , withdrawal :: !(Maybe ApiWithdrawalPostData)
     } deriving (Eq, Generic, Show)
 
@@ -541,21 +535,21 @@ newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")
     } deriving (Eq, Generic, Show)
 
-data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
+data ApiTransaction = ApiTransaction
     { id :: !(ApiT (Hash "Tx"))
     , amount :: !(Quantity "lovelace" Natural)
     , insertedAt :: !(Maybe ApiTimeReference)
     , pendingSince :: !(Maybe ApiTimeReference)
     , depth :: !(Maybe (Quantity "block" Natural))
     , direction :: !(ApiT Direction)
-    , inputs :: ![ApiTxInput n]
-    , outputs :: ![AddressAmount (ApiT Address, Proxy n)]
-    , withdrawals :: ![ApiWithdrawal n]
+    , inputs :: ![ApiTxInput]
+    , outputs :: ![AddressAmount ApiAddress]
+    , withdrawals :: ![ApiWithdrawal]
     , status :: !(ApiT TxStatus)
     } deriving (Eq, Generic, Show)
 
-data ApiWithdrawal n = ApiWithdrawal
-    { stakeAddress :: !(ApiT ChimericAccount, Proxy n)
+data ApiWithdrawal = ApiWithdrawal
+    { stakeAddress :: !Text
     , amount :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
 
@@ -564,8 +558,8 @@ data ApiWithdrawalPostData
     | ExternalWithdrawal (ApiMnemonicT '[15,18,21,24])
     deriving (Eq, Generic, Show)
 
-data ApiTxInput (n :: NetworkDiscriminant) = ApiTxInput
-    { source :: !(Maybe (AddressAmount (ApiT Address, Proxy n)))
+data ApiTxInput = ApiTxInput
+    { source :: !(Maybe (AddressAmount ApiAddress))
     , input :: !(ApiT TxIn)
     } deriving (Eq, Generic, Show)
 
@@ -617,14 +611,14 @@ data ApiPostRandomAddressData = ApiPostRandomAddressData
     , addressIndex :: !(Maybe (ApiT (Index 'Hardened 'AddressK)))
     } deriving (Eq, Generic, Show)
 
-data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
+data ApiWalletMigrationPostData (s :: Symbol) =
     ApiWalletMigrationPostData
     { passphrase :: !(ApiT (Passphrase s))
-    , addresses :: ![(ApiT Address, Proxy n)]
+    , addresses :: ![ApiAddress]
     } deriving (Eq, Generic, Show)
 
-newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
-    { addresses :: [(ApiT Address, Proxy n)]
+newtype ApiPutAddressesData = ApiPutAddressesData
+    { addresses :: [ApiAddress]
     } deriving (Eq, Generic, Show)
 
 data ApiWalletMigrationInfo = ApiWalletMigrationInfo
@@ -785,15 +779,6 @@ instance FromText (ApiT (Hash "encryption"))  where
             , "expecting a hex-encoded value."
             ]
 
-instance DecodeAddress n => FromHttpApiData (ApiT Address, Proxy n) where
-    parseUrlPiece txt = do
-        let proxy = Proxy @n
-        addr <- bimap (T.pack . getTextDecodingError) ApiT (decodeAddress @n txt)
-        return (addr, proxy)
-
-instance EncodeAddress n => ToHttpApiData (ApiT Address, Proxy n) where
-    toUrlPiece = encodeAddress @n . getApiT . fst
-
 {-------------------------------------------------------------------------------
                               API Types: Byron
 -------------------------------------------------------------------------------}
@@ -816,10 +801,10 @@ data ApiWalletDiscovery
 class KnownDiscovery s where
     knownDiscovery :: ApiWalletDiscovery
 
-instance KnownDiscovery (RndState network) where
+instance KnownDiscovery RndState where
     knownDiscovery = DiscoveryRandom
 
-instance KnownDiscovery (SeqState network key) where
+instance KnownDiscovery (SeqState key) where
     knownDiscovery = DiscoverySequential
 
 {-------------------------------------------------------------------------------
@@ -863,42 +848,36 @@ newtype ApiMnemonicT (sizes :: [Nat]) =
                                JSON Instances
 -------------------------------------------------------------------------------}
 
-instance DecodeAddress n => FromJSON (ApiAddress n) where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiAddress n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiEpochInfo where
     parseJSON = genericParseJSON defaultRecordTypeOptions
 instance ToJSON ApiEpochInfo where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance DecodeAddress n => FromJSON (ApiSelectCoinsData n) where
+instance FromJSON ApiSelectCoinsData where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiSelectCoinsData n) where
+instance ToJSON ApiSelectCoinsData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance DecodeAddress n => FromJSON (ApiCoinSelection n) where
+instance FromJSON ApiCoinSelection where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiCoinSelection n) where
+instance ToJSON ApiCoinSelection where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance DecodeAddress n => FromJSON (ApiCoinSelectionInput n) where
+instance FromJSON ApiCoinSelectionInput where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiCoinSelectionInput n) where
+instance ToJSON ApiCoinSelectionInput where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance {-# OVERLAPS #-} DecodeAddress n => FromJSON (ApiT Address, Proxy n)
-  where
-    parseJSON x = do
-        let proxy = Proxy @n
-        addr <- parseJSON x >>= eitherToParser
-            . bimap ShowFmt ApiT
-            . decodeAddress @n
-        return (addr, proxy)
-instance {-# OVERLAPS #-} EncodeAddress n => ToJSON (ApiT Address, Proxy n)
-  where
-    toJSON (addr, _) = toJSON . encodeAddress @n . getApiT $ addr
+instance FromJSON ApiAddressWithState where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiAddressWithState where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+instance FromJSON ApiAddress where
+    parseJSON = fmap ApiAddress . parseJSON
+instance ToJSON ApiAddress where
+    toJSON (ApiAddress text) = toJSON text
 
 instance FromJSON (ApiT AddressState) where
     parseJSON = fmap ApiT . genericParseJSON defaultSumTypeOptions
@@ -1147,9 +1126,9 @@ instance ToJSON (ApiT BoundType) where
 instance FromJSON (ApiT BoundType) where
     parseJSON = fmap ApiT . genericParseJSON defaultSumTypeOptions
 
-instance DecodeAddress t => FromJSON (PostTransactionData t) where
+instance FromJSON PostTransactionData where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress t => ToJSON (PostTransactionData t) where
+instance ToJSON PostTransactionData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiWithdrawalPostData where
@@ -1164,9 +1143,9 @@ instance ToJSON ApiWithdrawalPostData where
         SelfWithdrawal -> toJSON ("self" :: String)
         ExternalWithdrawal mw -> toJSON mw
 
-instance DecodeAddress t => FromJSON (PostTransactionFeeData t) where
+instance FromJSON PostTransactionFeeData where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress t => ToJSON (PostTransactionFeeData t) where
+instance ToJSON PostTransactionFeeData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON ApiTimeReference where
@@ -1207,35 +1186,22 @@ instance FromJSON a => FromJSON (AddressAmount a) where
 instance ToJSON a => ToJSON (AddressAmount a) where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance
-    ( DecodeAddress n
-    , DecodeStakeAddress n
-    ) => FromJSON (ApiTransaction n)
-  where
+instance (PassphraseMaxLength s , PassphraseMinLength s)
+    => FromJSON (ApiWalletMigrationPostData s) where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance
-    ( EncodeAddress n
-    , EncodeStakeAddress n
-    ) => ToJSON (ApiTransaction n)
-  where
+
+instance FromJSON ApiTransaction where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiTransaction where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance (DecodeAddress n , PassphraseMaxLength s , PassphraseMinLength s) => FromJSON (ApiWalletMigrationPostData n s)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiWalletMigrationPostData n s) where
+instance ToJSON ApiPutAddressesData where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance (DecodeAddress n) => FromJSON (ApiPutAddressesData n)
-  where
-    parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeAddress n => ToJSON (ApiPutAddressesData n) where
-    toJSON = genericToJSON defaultRecordTypeOptions
-
-instance DecodeAddress n => FromJSON (ApiTxInput n) where
+instance FromJSON ApiTxInput where
     parseJSON v = ApiTxInput <$> optional (parseJSON v) <*> parseJSON v
 
-instance EncodeAddress n => ToJSON (ApiTxInput n) where
+instance ToJSON ApiTxInput where
     toJSON (ApiTxInput s i) =
         Object (maybe mempty (fromValue . toJSON) s <> fromValue (toJSON i))
       where
@@ -1322,25 +1288,26 @@ instance FromJSON ApiNetworkParameters where
 instance ToJSON ApiNetworkParameters where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance DecodeStakeAddress n => FromJSON (ApiWithdrawal n) where
+instance FromJSON ApiWithdrawal where
     parseJSON = genericParseJSON defaultRecordTypeOptions
-instance EncodeStakeAddress n => ToJSON (ApiWithdrawal n) where
+instance ToJSON ApiWithdrawal where
     toJSON = genericToJSON defaultRecordTypeOptions
 
-instance {-# OVERLAPS #-} (DecodeStakeAddress n)
-    => FromJSON (ApiT ChimericAccount, Proxy n)
-  where
-    parseJSON x = do
-        let proxy = Proxy @n
-        acct <- parseJSON x >>= eitherToParser
-            . bimap ShowFmt ApiT
-            . decodeStakeAddress @n
-        return (acct, proxy)
-
-instance {-# OVERLAPS #-} EncodeStakeAddress n
-    => ToJSON (ApiT ChimericAccount, Proxy n)
-  where
-    toJSON (acct, _) = toJSON . encodeStakeAddress @n . getApiT $ acct
+-- TODO?
+--instance {-# OVERLAPS #-} (DecodeStakeAddress n)
+--    => FromJSON (ApiT ChimericAccount, Proxy n)
+--  where
+--    parseJSON x = do
+--        let proxy = Proxy @n
+--        acct <- parseJSON x >>= eitherToParser
+--            . bimap ShowFmt ApiT
+--            . decodeStakeAddress @n
+--        return (acct, proxy)
+--
+--instance {-# OVERLAPS #-} EncodeStakeAddress n
+--    => ToJSON (ApiT ChimericAccount, Proxy n)
+--  where
+--    toJSON (acct, _) = toJSON . encodeStakeAddress @n . getApiT $ acct
 
 instance ToJSON ApiErrorCode where
     toJSON = genericToJSON defaultSumTypeOptions
@@ -1404,14 +1371,14 @@ instance ToJSON ApiWalletDiscovery where
                              FromText/ToText instances
 -------------------------------------------------------------------------------}
 
-instance FromText (AddressAmount Text) where
+instance FromText (AddressAmount ApiAddress) where
     fromText text = do
         let err = Left . TextDecodingError $ "Parse error. Expecting format \
             \\"<amount>@<address>\" but got " <> show text
         case split (=='@') text of
             [] -> err
             [_] -> err
-            [l, r] -> AddressAmount r <$> fromText l
+            [l, r] -> AddressAmount <$> (fromText r) <*> fromText l
             _ -> err
 
 instance FromText PostExternalTransactionData where
@@ -1429,6 +1396,11 @@ instance FromText a => FromHttpApiData (ApiT a) where
     parseUrlPiece = bimap pretty ApiT . fromText
 instance ToText a => ToHttpApiData (ApiT a) where
     toUrlPiece = toText . getApiT
+
+instance ToHttpApiData ApiAddress where
+    toUrlPiece = toText . apiAddress
+instance FromHttpApiData ApiAddress where
+    parseUrlPiece = bimap pretty ApiAddress . fromText
 
 instance MimeUnrender OctetStream PostExternalTransactionData where
     mimeUnrender _ =
@@ -1490,80 +1462,15 @@ taggedSumTypeOptions base opts = base
 eitherToParser :: Show s => Either s a -> Aeson.Parser a
 eitherToParser = either (fail . show) pure
 
-{-------------------------------------------------------------------------------
-                          User-Facing Address Encoding
--------------------------------------------------------------------------------}
-
--- | An abstract class to allow encoding of addresses depending on the target
--- backend used.
-class EncodeAddress (n :: NetworkDiscriminant) where
-    encodeAddress :: Address -> Text
-
-instance EncodeAddress 'Mainnet => EncodeAddress ('Staging pm) where
-    encodeAddress = encodeAddress @'Mainnet
-
--- | An abstract class to allow decoding of addresses depending on the target
--- backend used.
-class DecodeAddress (n :: NetworkDiscriminant) where
-    decodeAddress :: Text -> Either TextDecodingError Address
-
-instance DecodeAddress 'Mainnet => DecodeAddress ('Staging pm) where
-    decodeAddress = decodeAddress @'Mainnet
-
-class EncodeStakeAddress (n :: NetworkDiscriminant) where
-    encodeStakeAddress :: ChimericAccount -> Text
-
-instance EncodeStakeAddress 'Mainnet => EncodeStakeAddress ('Staging pm) where
-    encodeStakeAddress = encodeStakeAddress @'Mainnet
-
-class DecodeStakeAddress (n :: NetworkDiscriminant) where
-    decodeStakeAddress :: Text -> Either TextDecodingError ChimericAccount
-
-instance DecodeStakeAddress 'Mainnet => DecodeStakeAddress ('Staging pm) where
-    decodeStakeAddress = decodeStakeAddress @'Mainnet
-
--- NOTE:
--- The type families below are useful to allow building more flexible API
--- implementation from the definition above. In particular, the API client we
--- use for the command-line doesn't really _care much_ about how addresses are
--- serialized / deserialized. So, we use a poly-kinded type family here to allow
--- defining custom types in the API client with a minimal overhead and, without
--- having to actually rewrite any of the API definition.
+-- TODO: Replace
+-- class EncodeStakeAddress (n :: NetworkDiscriminant) where
+--     encodeStakeAddress :: ChimericAccount -> Text
 --
--- We use an open type family so it can be extended by other module in places.
-type family ApiAddressT (n :: k) :: *
-type family ApiAddressIdT (n :: k) :: *
-type family ApiCoinSelectionT (n :: k) :: *
-type family ApiSelectCoinsDataT (n :: k) :: *
-type family ApiTransactionT (n :: k) :: *
-type family PostTransactionDataT (n :: k) :: *
-type family PostTransactionFeeDataT (n :: k) :: *
-type family ApiWalletMigrationPostDataT (n :: k1) (s :: k2) :: *
-type family ApiPutAddressesDataT (n :: k) :: *
-
-type instance ApiAddressT (n :: NetworkDiscriminant) =
-    ApiAddress n
-
-type instance ApiPutAddressesDataT (n :: NetworkDiscriminant) =
-    ApiPutAddressesData n
-
-type instance ApiAddressIdT (n :: NetworkDiscriminant) =
-    (ApiT Address, Proxy n)
-
-type instance ApiCoinSelectionT (n :: NetworkDiscriminant) =
-    ApiCoinSelection n
-
-type instance ApiSelectCoinsDataT (n :: NetworkDiscriminant) =
-    ApiSelectCoinsData n
-
-type instance ApiTransactionT (n :: NetworkDiscriminant) =
-    ApiTransaction n
-
-type instance PostTransactionDataT (n :: NetworkDiscriminant) =
-    PostTransactionData n
-
-type instance PostTransactionFeeDataT (n :: NetworkDiscriminant) =
-    PostTransactionFeeData n
-
-type instance ApiWalletMigrationPostDataT (n :: NetworkDiscriminant) (s :: Symbol) =
-    ApiWalletMigrationPostData n s
+-- instance EncodeStakeAddress 'Mainnet => EncodeStakeAddress ('Staging pm) where
+--     encodeStakeAddress = encodeStakeAddress @'Mainnet
+--
+-- class DecodeStakeAddress (n :: NetworkDiscriminant) where
+--     decodeStakeAddress :: Text -> Either TextDecodingError ChimericAccount
+--
+-- instance DecodeStakeAddress 'Mainnet => DecodeStakeAddress ('Staging pm) where
+--     decodeStakeAddress = decodeStakeAddress @'Mainnet

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -184,6 +184,10 @@ data AddressScheme (key :: Depth -> * -> *) = AddressScheme
         :: KeyFingerprint -> Address
         -- TODO: Can we remove the need for this somehow?
         -- I think we can, by parameterizing AddressPool over address.
+    , stakeAddressFromText
+        :: Text -> Either TextDecodingError ChimericAccount
+    , stakeAddressToText
+        :: ChimericAccount -> Text
     } deriving Generic
 
 instance Show (AddressScheme k) where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -39,6 +39,7 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , HardDerivation (..)
     , SoftDerivation (..)
     , liftIndex
+    , AddressScheme (..)
 
     -- * Delegation
     , ChimericAccount (..)
@@ -51,16 +52,11 @@ module Cardano.Wallet.Primitive.AddressDerivation
 
     -- * Network Discrimination
     , NetworkDiscriminant (..)
-    , NetworkDiscriminantVal
-    , networkDiscriminantVal
 
     -- * Backends Interoperability
-    , PaymentAddress(..)
-    , DelegationAddress(..)
     , WalletKey(..)
     , PersistPrivateKey(..)
     , PersistPublicKey(..)
-    , MkKeyFingerprint(..)
     , ErrMkKeyFingerprint(..)
     , KeyFingerprint(..)
 
@@ -126,7 +122,7 @@ import Fmt
 import GHC.Generics
     ( Generic )
 import GHC.TypeLits
-    ( KnownNat, Nat, Symbol, natVal )
+    ( Symbol )
 import Safe
     ( toEnumMay )
 
@@ -137,6 +133,63 @@ import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+
+-- @AddressScheme@ correlates @key@s with @Addresses@.
+--
+-- In a @SeqState@ we need tell if an @Address@ was created using a given @key@.
+--
+-- A @key@ may corrspond to multiple @Address@es. We cannot* convert
+-- an address into a public key.
+--
+-- To be able to compare @key@s and addresses, we convert them both to
+-- fingerprints, which are hashes of the public keys.
+--
+-- @@
+--
+--            paymentAddress         delegationAddress
+--
+--    Address ◀────────────── Key ──────────────▶ Address
+--        ╲                                         ╱
+--          ╲                  │                  ╱
+--            ╲                │                ╱
+--              ╲              │              ╱
+--                ╲            │            ╱
+--                  ╲          │          ╱
+--                    ╲        │        ╱
+--                      ╲      │      ╱
+--                        ╲    │    ╱
+--                          ╲  │  ╱
+--                            ╲│╱
+--                            ▼▼▼
+--                        Fingerprint
+-- @@
+--
+-- *) Except in jormungandr
+--
+-- TODO: @addressToText@ and @addressFromText@ could /maybe/ be removed if we made
+-- Address an anbstract type. But something entirely differnt could be desired
+-- as well.
+data AddressScheme (key :: Depth -> * -> *) = AddressScheme
+    { addressFromKey
+        :: key 'AddressK XPub -> Address
+    , keyFingerprint
+        :: key 'AddressK XPub -> Either ErrMkKeyFingerprint KeyFingerprint
+    , addressFingerprint
+        :: Address -> Either ErrMkKeyFingerprint KeyFingerprint
+    , addressToText
+        :: Address -> Text
+    , addressFromText
+        :: Text -> Either TextDecodingError Address
+    , addressFromFingerprint
+        :: KeyFingerprint -> Address
+        -- TODO: Can we remove the need for this somehow?
+        -- I think we can, by parameterizing AddressPool over address.
+    } deriving Generic
+
+instance Show (AddressScheme k) where
+    show _ = "<AddressScheme>"
+
+instance NFData (AddressScheme key)
 
 {-------------------------------------------------------------------------------
                                 HD Hierarchy
@@ -495,23 +548,14 @@ instance MonadRandom ((->) (Passphrase "salt")) where
 --              discrimination. Genesis file needs to be passed explicitly when
 --              starting the application.
 --
-data NetworkDiscriminant = Mainnet | Testnet Nat | Staging Nat
-    deriving Typeable
+-- TODO: Use ProtocolMagic instead of Int?
+data NetworkDiscriminant = Mainnet | Testnet Int | Staging Int
+    deriving (Eq, Show)
 
-class NetworkDiscriminantVal (n :: NetworkDiscriminant) where
-    networkDiscriminantVal :: Text
-
-instance NetworkDiscriminantVal 'Mainnet where
-    networkDiscriminantVal =
-        "mainnet"
-
-instance KnownNat pm => NetworkDiscriminantVal ('Testnet pm) where
-    networkDiscriminantVal =
-        "testnet (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
-
-instance KnownNat pm => NetworkDiscriminantVal ('Staging pm) where
-    networkDiscriminantVal =
-        "staging (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
+instance ToText NetworkDiscriminant where
+    toText Mainnet = "mainnet"
+    toText (Testnet pm) = "testnet (" <> T.pack (show pm) <> ")"
+    toText (Staging pm) = "staging (" <> T.pack (show pm) <> ")"
 
 {-------------------------------------------------------------------------------
                      Interface over keys / address types
@@ -552,56 +596,6 @@ class WalletKey (key :: Depth -> * -> *) where
         :: key depth raw
         -> raw
 
--- | Encoding of addresses for certain key types and backend targets.
-class MkKeyFingerprint key Address
-    => PaymentAddress (network :: NetworkDiscriminant) key where
-    -- | Convert a public key to a payment 'Address' valid for the given
-    -- network discrimination.
-    --
-    -- Note that 'paymentAddress' is ambiguous and requires therefore a type
-    -- application.
-    paymentAddress
-        :: key 'AddressK XPub
-        -> Address
-
-    -- | Lift a payment fingerprint back into a payment address.
-    liftPaymentAddress
-        :: KeyFingerprint "payment" key
-            -- ^ Payment fingerprint
-        -> Address
-
-instance PaymentAddress 'Mainnet k => PaymentAddress ('Staging pm) k where
-    paymentAddress = paymentAddress @'Mainnet
-    liftPaymentAddress = liftPaymentAddress @'Mainnet
-
-class PaymentAddress network key
-    => DelegationAddress (network :: NetworkDiscriminant) key where
-    -- | Convert a public key and a staking key to a delegation 'Address' valid
-    -- for the given network discrimination. Funds sent to this address will be
-    -- delegated according to the delegation settings attached to the delegation
-    -- key.
-    --
-    -- Note that 'delegationAddress' is ambiguous and requires therefore a type
-    -- application.
-    delegationAddress
-        :: key 'AddressK XPub
-            -- ^ Payment key
-        -> key 'AddressK XPub
-            -- ^ Staking key / Reward account
-        -> Address
-
-    -- | Lift a payment fingerprint back into a delegation address.
-    liftDelegationAddress
-        :: KeyFingerprint "payment" key
-            -- ^ Payment fingerprint
-        -> key 'AddressK XPub
-            -- ^ Staking key / Reward account
-        -> Address
-
-instance DelegationAddress 'Mainnet k => DelegationAddress ('Staging pm) k where
-    delegationAddress = delegationAddress @'Mainnet
-    liftDelegationAddress = liftDelegationAddress @'Mainnet
-
 -- | Operations for saving a private key into a database, and restoring it from
 -- a database. The keys should be encoded in hexadecimal strings.
 class PersistPrivateKey (key :: * -> *) where
@@ -634,35 +628,14 @@ class PersistPublicKey (key :: * -> *) where
 
 -- | Something that uniquely identifies a public key. Typically,
 -- a hash of that key or the key itself.
-newtype KeyFingerprint (s :: Symbol) key = KeyFingerprint ByteString
+newtype KeyFingerprint = KeyFingerprint ByteString
     deriving (Generic, Show, Eq, Ord)
 
-instance NFData (KeyFingerprint s key)
+instance NFData KeyFingerprint
 
--- | Produce 'KeyFingerprint' for existing types. A fingerprint here uniquely
--- identifies part of an address. It can refer to either the payment key or, if
--- any, the delegation key of an address.
---
--- The fingerprint obeys the following rules:
---
--- - If two addresses are the same, then they have the same fingerprints
--- - It is possible to lift the fingerprint back into an address
---
--- This second rule pretty much fixes what can be chosen as a fingerprint for
--- various key types:
---
--- 1. For 'ByronKey', it can only be the address itself!
--- 2. For 'ShelleyKey', then the "payment" fingerprint refers to the payment key
---    within a single or grouped address.
-class Show from => MkKeyFingerprint (key :: Depth -> * -> *) from where
-    paymentKeyFingerprint
-        :: from
-        -> Either
-            (ErrMkKeyFingerprint key from)
-            (KeyFingerprint "payment" key)
 
-data ErrMkKeyFingerprint key from
-    = ErrInvalidAddress from (Proxy key) deriving (Show, Eq)
+newtype ErrMkKeyFingerprint
+    = ErrInvalidAddress Address deriving (Show, Eq)
 
 {-------------------------------------------------------------------------------
                                 Helpers

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -169,6 +169,8 @@ byronScheme net = AddressScheme
         Mainnet -> decodeLegacyAddress Nothing
         Testnet pm -> decodeLegacyAddress . Just . ProtocolMagic . fromIntegral $ pm
         Staging _ -> error "TODO: staging"
+    , stakeAddressFromText = error "todo"
+    , stakeAddressToText = error "todo"
     }
   where
     _addressFromKey = \k ->

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -391,6 +391,8 @@ icarusScheme net = AddressScheme
         Mainnet -> decodeLegacyAddress Nothing
         Testnet pm -> decodeLegacyAddress . Just . ProtocolMagic . fromIntegral $ pm
         Staging _ -> error "TODO: staging"
+    , stakeAddressFromText = error "todo"
+    , stakeAddressToText = error "todo"
     }
   where
     _addressFromKey k = Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
@@ -303,6 +303,8 @@ jormungandrScheme net rewardKey = AddressScheme
     , addressFromFingerprint = error "todo: jorm addressFromFingerprint"
     , addressToText = error "todo: jorm addressToText"
     , addressFromText = error "todo: jormungandr addressFromText"
+    , stakeAddressFromText = error "todo"
+    , stakeAddressToText = error "todo"
     }
 
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -287,6 +287,8 @@ shelleyScheme net mstakingKey = AddressScheme
         BS.pack [enterprise + networkId] <> f
     , addressToText = T.decodeUtf8 . hex . unAddress
     , addressFromText = _decodeAddress
+    , stakeAddressFromText = error "todo"
+    , stakeAddressToText = error "todo"
     }
   where
     keyHash = blake2b224 . unXPub . getRawKey

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -22,7 +22,6 @@ module Cardano.Wallet.Primitive.AddressDiscovery
     -- * Abstractions
       IsOurs(..)
     , IsOwned(..)
-    , GenChange(..)
     , CompareDiscovery(..)
     , KnownAddresses(..)
     ) where
@@ -79,20 +78,6 @@ class IsOurs s Address => IsOwned s key where
         -- operation can be costly. Note that the state is discarded from this
         -- function as we do not intend to discover any addresses from this
         -- operation; This is merely a lookup from known addresses.
-
--- | Abstracting over change address generation. In theory, this is only needed
--- for sending transactions on a wallet following a particular scheme. This
--- abstractions allows for defining an heuristic to pick new change address. For
--- instance, in BIP-44, change addresses belong to a particular change chain
--- (also called "Internal Chain").
-class GenChange s where
-    type ArgGenChange s :: *
-    genChange
-        :: ArgGenChange s
-        -> s
-        -> (Address, s)
-        -- ^ Generate a new change address for the given scheme. The rules for
-        -- generating a new change address depends on the underlying scheme.
 
 -- | Ordering addresses by discovery date.
 --

--- a/lib/core/src/Cardano/Wallet/Unsafe.hs
+++ b/lib/core/src/Cardano/Wallet/Unsafe.hs
@@ -10,7 +10,6 @@
 module Cardano.Wallet.Unsafe
     ( unsafeFromHex
     , unsafeFromHexFile
-    , unsafeDecodeAddress
     , unsafeDecodeHex
     , unsafeFromText
     , unsafeRunExceptT
@@ -44,10 +43,6 @@ import Cardano.Mnemonic
     , mkEntropy
     , mkMnemonic
     )
-import Cardano.Wallet.Api.Types
-    ( DecodeAddress (..) )
-import Cardano.Wallet.Primitive.Types
-    ( Address )
 import Control.Monad
     ( (>=>) )
 import Control.Monad.Fail
@@ -94,14 +89,6 @@ unsafeFromHex =
 -- | Load a hex string from file. Any non-hexadecimal characters are ignored.
 unsafeFromHexFile :: HasCallStack => FilePath -> IO ByteString
 unsafeFromHexFile = fmap (unsafeFromHex . B8.filter isHexDigit) . B8.readFile
-
--- | Decode a bech32-encoded 'Text' into an 'Address', or fail.
-unsafeDecodeAddress
-    :: forall n. (HasCallStack, DecodeAddress n)
-    => Text
-    -> Address
-unsafeDecodeAddress =
-    either (error . show ) id . decodeAddress @n
 
 -- | Run a decoder on a hex-encoded 'ByteString', or fail.
 unsafeDecodeHex :: HasCallStack => Get a -> ByteString -> a

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -102,6 +102,7 @@ import Cardano.Binary
 import Cardano.Crypto.Hash.Class
     ( Hash (UnsafeHash), hashToBytes )
 import Cardano.Slotting.Slot
+<<<<<<< HEAD
     ( EpochNo (..), EpochSize (..) )
 import Cardano.Wallet.Api.Types
     ( DecodeAddress (..)
@@ -146,6 +147,11 @@ import Data.ByteString.Base58
     ( bitcoinAlphabet, decodeBase58, encodeBase58 )
 import Data.ByteString.Short
     ( fromShort, toShort )
+=======
+    ( EpochSize (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeDeserialiseCbor )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Data.Coerce
     ( coerce )
 import Data.Foldable
@@ -160,10 +166,13 @@ import Data.Quantity
     ( Percentage, Quantity (..), mkPercentage )
 import Data.Text
     ( Text )
+<<<<<<< HEAD
 import Data.Text.Class
     ( TextDecodingError (..) )
 import Data.Type.Equality
     ( testEquality )
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Data.Word
     ( Word16, Word32, Word64, Word8 )
 import Fmt
@@ -220,8 +229,11 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
+<<<<<<< HEAD
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import qualified Ouroboros.Consensus.Shelley.Ledger as O
 import qualified Ouroboros.Network.Block as O
 import qualified Ouroboros.Network.Point as Point
@@ -894,6 +906,7 @@ toStakePoolDlgCert xpub (W.PoolId pid) =
     pool = SL.KeyHash $ UnsafeHash $ toShort pid
 
 {-------------------------------------------------------------------------------
+<<<<<<< HEAD
                       Address Encoding / Decoding
 -------------------------------------------------------------------------------}
 
@@ -1071,6 +1084,8 @@ instance Buildable LocalAddress where
     build (LocalAddress p) = build p
 
 {-------------------------------------------------------------------------------
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
                                  Utilities
 -------------------------------------------------------------------------------}
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -76,6 +76,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), hex )
 import Cardano.Wallet.Primitive.Types
+<<<<<<< HEAD
     ( Block (..)
     , Coin (..)
     , EpochLength (..)
@@ -89,6 +90,9 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
+=======
+    ( Block (..), NetworkParameters (..), ProtocolMagic (..) )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Cardano.Wallet.Shelley.Compatibility
     ( NodeVersionData )
 import Cardano.Wallet.Unsafe
@@ -118,6 +122,7 @@ import Control.Tracer
 import Crypto.Hash.Utils
     ( blake2b256 )
 import Data.Aeson
+<<<<<<< HEAD
     ( FromJSON (..), toJSON, (.:), (.=) )
 import Data.ByteArray.Encoding
     ( Base (..), convertToBase )
@@ -137,16 +142,23 @@ import Data.Maybe
     ( catMaybes )
 import Data.Proxy
     ( Proxy (..) )
+=======
+    ( eitherDecode, toJSON )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
 import Data.Time.Clock
+<<<<<<< HEAD
     ( NominalDiffTime, UTCTime, addUTCTime, getCurrentTime )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime, utcTimeToPOSIXSeconds )
 import GHC.TypeLits
     ( KnownNat, Nat, SomeNat (..), someNatVal )
+=======
+    ( getCurrentTime )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Options.Applicative
     ( Parser, flag', help, long, metavar, (<|>) )
 import Ouroboros.Consensus.Shelley.Node
@@ -240,6 +252,7 @@ networkConfigurationOption = mainnet <|> testnet <|> staging
         <> metavar "FILE"
         <> help ("Path to the " <> era <> " genesis data in JSON format.")
 
+<<<<<<< HEAD
 someCustomDiscriminant
     :: (forall (pm :: Nat). KnownNat pm => Proxy pm -> SomeNetworkDiscriminant)
     -> ProtocolMagic
@@ -253,11 +266,14 @@ someCustomDiscriminant mkSomeNetwork pm@(ProtocolMagic n) =
         _ -> error "networkDiscriminantFlag: failed to convert \
             \ProtocolMagic to SomeNat."
 
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 parseGenesisData
     :: NetworkConfiguration
     -> ExceptT String IO
-        (SomeNetworkDiscriminant, NetworkParameters, NodeVersionData, Block)
+        (NetworkDiscriminant, NetworkParameters, NodeVersionData, Block)
 parseGenesisData = \case
+<<<<<<< HEAD
     MainnetConfig -> do
         pure
             ( SomeNetworkDiscriminant $ Proxy @'Mainnet
@@ -304,8 +320,18 @@ parseGenesisData = \case
         let (np, outs) = Byron.fromGenesisData (genesisData, genesisHash)
         let block0 = Byron.genesisBlockFromTxOuts (genesisParameters np) outs
 
+=======
+    TestnetConfig genesisFile -> do
+        (genesis :: ShelleyGenesis TPraosStandardCrypto)
+            <- ExceptT $ eitherDecode <$> BL.readFile genesisFile
+        -- TODO: Protocol magic and testnet magic aint the same ting?
+        let nm = unNetworkMagic $ sgNetworkMagic genesis
+        let pm = ProtocolMagic $ fromIntegral nm
+        let vData = testnetVersionData pm
+        let (np, block0) = fromGenesisData genesis
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
         pure
-            ( discriminant
+            ( Testnet (fromIntegral nm)
             , np
             , vData
             , block0

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -93,8 +93,11 @@ import Data.ByteString
     ( ByteString )
 import Data.Maybe
     ( fromMaybe )
+<<<<<<< HEAD
 import Data.Proxy
     ( Proxy (..) )
+=======
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
@@ -211,7 +214,13 @@ newTransactionLayer
         , TxWitnessTagFor k
         , WalletKey k
         )
+<<<<<<< HEAD
     => NetworkId
+=======
+    => NetworkDiscriminant
+    -> ProtocolMagic
+    -> EpochLength
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     -> TransactionLayer t k
 newTransactionLayer networkId = TransactionLayer
     { mkStdTx = \acc ks tip ->

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -41,12 +41,16 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( Coin (..) )
 import Cardano.Wallet.Shelley
+<<<<<<< HEAD
     ( SomeNetworkDiscriminant (..)
     , Tracers
     , serveWallet
     , setupTracers
     , tracerSeverities
     )
+=======
+    ( serveWallet, setupTracers, tracerSeverities )
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley )
 import Cardano.Wallet.Shelley.Faucet
@@ -135,12 +139,18 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 instance KnownCommand Shelley where
     commandName = "cardano-wallet-shelley"
 
+<<<<<<< HEAD
 main :: forall t n . (t ~ Shelley, n ~ 'Mainnet) => IO ()
 main = withUtf8Encoding $ withTracers $ \tracers -> do
+=======
+main :: forall t . (t ~ Shelley) => IO ()
+main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     hSetBuffering stdout LineBuffering
     hspec $ do
         describe "No backend required" $ do
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
+<<<<<<< HEAD
         specWithServer tracers $ do
             describe "API Specifications" $ do
                 Addresses.spec @n
@@ -175,6 +185,22 @@ testPoolConfigs =
       -- This pool should retire, but not within the duration of a test run:
     , PoolConfig {retirementEpoch = Just 1_000_000}
     ]
+=======
+            describe "Key CLI tests" $ parallel (KeyCLI.spec @t)
+        describe "API Specifications" $ specWithServer tr $ do
+            Addresses.spec
+            Transactions.spec
+            Wallets.spec
+            HWWallets.spec
+            Network.spec
+        describe "CLI Specifications" $ specWithServer tr $ do
+            AddressesCLI.spec
+            TransactionsCLI.spec
+            WalletsCLI.spec
+            HWWalletsCLI.spec
+            PortCLI.spec @t
+            NetworkCLI.spec
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
 
 specWithServer
     :: (Tracer IO TestsLog, Tracers IO)
@@ -182,6 +208,7 @@ specWithServer
     -> Spec
 specWithServer (tr, tracers) = aroundAll withContext . after tearDown
   where
+    networkDiscriminant = Mainnet
     withContext :: (Context Shelley -> IO ()) -> IO ()
     withContext action = bracketTracer' tr "withContext" $ do
         ctx <- newEmptyMVar
@@ -201,6 +228,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
                     , _faucet = faucet
                     , _feeEstimator = error "feeEstimator: unused in shelley specs"
                     , _networkParameters = np
+                    , _network = networkDiscriminant
                     , _target = Proxy
                     }
 
@@ -237,8 +265,13 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
         -- having three callbacks like this might not work well for that.
         withTempDir tr' dir "wallets" $ \db -> do
             serveWallet @(IO Shelley)
+<<<<<<< HEAD
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
                 tracers
+=======
+                networkDiscriminant
+                (setupTracers (tracerSeverities (Just Info)) tr)
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
                 (SyncTolerance 10)
                 (Just db)
                 "127.0.0.1"

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -31,8 +31,13 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
+<<<<<<< HEAD
     , PaymentAddress (..)
     , WalletKey
+=======
+    , Passphrase (..)
+    , getRawKey
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -138,8 +143,15 @@ spec = do
             Right x
 
     describe "Shelley Addresses" $ do
+<<<<<<< HEAD
         prop "(Mainnet) can be deserialised by shelley ledger spec" $ \k -> do
             let Address addr = paymentAddress @'Mainnet @ShelleyKey k
+=======
+        it "(Mainnet) can be deserialised by shelley ledger spec" $
+            property $ \(k::ShelleyKey 'AddressK XPrv) -> do
+            let AddressScheme{keyToAddress} = shelleyScheme Mainnet Nothing
+            let Address addr = keyToAddress $ publicKey k
+>>>>>>> 59d9eb545... Refactor type-level NetworkDiscriminant
             case SL.deserialiseAddr @TPraosStandardCrypto addr of
                 Just _ -> property True
                 Nothing -> property False

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -42,6 +42,7 @@
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."data-default" or (errorHandler.buildDepError "data-default"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
           (hsPkgs."digest" or (errorHandler.buildDepError "digest"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
           (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))


### PR DESCRIPTION
# Overview

We use a type-level `NetworkDiscriminant` and type-classes for much logic. I believe the benefits are negligible, with greater-than-realised costs.

This PR makes `NetworkDiscriminant` used at the value-level. I hope this opens up for lots of additional future simplifications.

# Current state

We have code like this:
```haskell
data SomeNetworkDiscriminant where
    SomeNetworkDiscriminant
        :: forall (n :: NetworkDiscriminant).
            ( NetworkDiscriminantVal n
            , PaymentAddress n IcarusKey
            , PaymentAddress n ByronKey
            , DecodeAddress n
            , EncodeAddress n
            , MaxSizeOf Address n IcarusKey
            , MaxSizeOf Address n ByronKey
            )
        => Proxy n
        -> SomeNetworkDiscriminant
```

## Benefits with current approach

- With `EncodeAddress n` and `DecodeAddress n`, Servant can automatically convert between the textual (e.g. hex, bech32) encodings of addresses and the binary.

## Problems with current approach

- It can be complicated to work with type-level `NetworkDiscriminant` (calls for code like above), and compiler error messages can be frustrating.
- Since it is tricky to work with, we may end up not making the abstractions we "should" be making.
- Can be tricky to realise what effect `@n` has, since type-class instances are scattered everywhere.
- High-level functions often need many constraint-annotations.
    - IIRC, sometimes when changing a small detail, we have to update lots of constraints everywhere. This is annoying. 

# Overview

- [x] I removed the `MkKeyFingerprint`, `GenChange`, `PaymentAddress`, `DelegationAddress`, `NetworkDiscriminantVal` classes.
- [x] I added a `AddressScheme k` record.
- [x] I made the outside Servant-API use `Text` as type for Address, and use 
- [ ] **TODO** 🏗️ Handle Address decoding errors, and make all targets and tests compile and pass
    - [ ] Make core compile without TODOs

## Future work
- We could remove `KeyFingerprint` and `Address <-> Text` conversions by parameterising more over `address`.
- We could seek to reduce duplication in integration tests
    -  I think a record-layer-type for transaction capabilities could be great
- We could seek to reduce duplication in `Api.Server`
- We could allow target-specific `NetworkDiscriminants`
    - In shelley we could use it to allow the `networkMagic` from the genesis file to _actually be used_, instead of re-calculating it ourselves.

## Comments

- This PR has a fundamental preference for records over type-classes.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
