### PR TITLE
Piotr/testing shelley transactions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -1064,13 +1064,15 @@ spec = do
           , (Just validTime1, Just validTime2)
           ]
 
-      longAddr = replicate 10000 '1'
       encodeErr = "Unable to decode Address:"
       parseErr = "Parse error. Expecting format \"<amount>@<address>\""
       matrixInvalidAddrs =
-          [ ( "long hex", longAddr, encodeErr )
-          , ( "short hex", "1", encodeErr )
-          , ( "-1000", "-1000", encodeErr )
+-- TODO: For the haskell node, hex is valid. For jormungandr it is not.
+--  longAddr = replicate 10000 '1'
+--  We should optimally find a way to test this.
+--          [ ( "long hex", longAddr, encodeErr )
+--          , ( "short hex", "1", encodeErr )
+          [ ( "-1000", "-1000", encodeErr )
           , ( "q", "q", encodeErr )
           , ( "empty", "", encodeErr )
           , ( "wildcards", T.unpack wildcardsWalletName, parseErr )

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -8,10 +8,10 @@ protocolParams:
     major: 0
   decentralisationParam: 1
   maxTxSize: 4096
-  minFeeA: 1000000
+  minFeeA: 100
   maxBlockBodySize: 239857
   keyMinRefund: 0
-  minFeeB: 1000
+  minFeeB: 100000
   eMax: 0
   extraEntropy:
     tag: NeutralNonce

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -109,8 +109,13 @@ import qualified Data.ByteString as BS
 import qualified Data.Text as T
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.API.Shelley.Addresses as Addresses
+import qualified Test.Integration.Scenario.API.Shelley.HWWallets as HWWallets
 import qualified Test.Integration.Scenario.API.Shelley.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Shelley.Wallets as Wallets
+import qualified Test.Integration.Scenario.CLI.Shelley.Addresses as AddressesCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 import qualified Test.Integration.Scenario.CLI.Keys as KeyCLI
 import qualified Test.Integration.Scenario.CLI.Miscellaneous as MiscellaneousCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
@@ -133,8 +138,13 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             Addresses.spec @n
             Transactions.spec @n
             Wallets.spec @n
+            HWWallets.spec @n
             Network.spec
         describe "CLI Specifications" $ specWithServer tr $ do
+            AddressesCLI.spec @n
+            TransactionsCLI.spec @n
+            WalletsCLI.spec @n
+            HWWalletsCLI.spec @n
             PortCLI.spec @t
             NetworkCLI.spec @t
 

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -112,15 +112,15 @@ import qualified Test.Integration.Scenario.API.Shelley.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.Shelley.HWWallets as HWWallets
 import qualified Test.Integration.Scenario.API.Shelley.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Shelley.Wallets as Wallets
-import qualified Test.Integration.Scenario.CLI.Shelley.Addresses as AddressesCLI
-import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
-import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
-import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 import qualified Test.Integration.Scenario.CLI.Keys as KeyCLI
 import qualified Test.Integration.Scenario.CLI.Miscellaneous as MiscellaneousCLI
 import qualified Test.Integration.Scenario.CLI.Mnemonics as MnemonicsCLI
 import qualified Test.Integration.Scenario.CLI.Network as NetworkCLI
 import qualified Test.Integration.Scenario.CLI.Port as PortCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.Addresses as AddressesCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
+import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Shelley where


### PR DESCRIPTION
# Issue Number

#1672


# Overview

- 2472454a33b9057db75ebb59903f6cc1b24f40e4
  Move HW_WALLETS tests related to delegagation into StakePools scenarios
  
- 2d12434b0a32824c81cef1c18002ec526015dcab
  Add HW_WALLETS API tests and CLI tests for Addresses, HW_Wallets, Transactions and Wallets for cardano-wallet-shelley


# Comments

I have added few more tests which I thought should be working (HW_Wallets and some CLI tests for Addresses, Transactions, Addresses) for Shelley.

Getting few errors locally:
```
Failures:

  src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs:362:9: 
  1) CLI Specifications TRANS_CREATE_04 - Not enough money
       "Please enter your passphrase: *****************\nOk.\n" does not contain "I can't process this payment because there's not enough UTxO available in the wallet. The total UTxO sums up to 290001000 Lovelace, but I need 1000000 Lovelace (excluding fee amount) in order to proceed  with the payment."

  To rerun use: --match "/CLI Specifications/TRANS_CREATE_04 - Not enough money/"

  src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs:391:13: 
  2) CLI Specifications, TRANS_CREATE_05 - Invalid addresses, long hex
       "Please enter your passphrase: *****************\nI can't process this payment because there's not enough UTxO available in the wallet. The total UTxO sums up to 0 Lovelace, but I need 12 Lovelace (excluding fee amount) in order to proceed  with the payment.\n" does not contain "Unable to decode Address:"

  To rerun use: --match "/CLI Specifications/TRANS_CREATE_05 - Invalid addresses/long hex/"

  src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs:613:9: 
  3) CLI Specifications TRANS_ESTIMATE_07 - Not enough money
       "Ok.\n" does not contain "I can't process this payment because there's not enough UTxO available in the wallet. The total UTxO sums up to 290001000 Lovelace, but I need 1000000 Lovelace (excluding fee amount) in order to proceed  with the payment."

  To rerun use: --match "/CLI Specifications/TRANS_ESTIMATE_07 - Not enough money/"

  src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs:627:13: 
  4) CLI Specifications, TRANS_ESTIMATE_08 - Invalid addresses, long hex
       "I can't process this payment because there's not enough UTxO available in the wallet. The total UTxO sums up to 0 Lovelace, but I need 12 Lovelace (excluding fee amount) in order to proceed  with the payment.\n" does not contain "Unable to decode Address:"

  To rerun use: --match "/CLI Specifications/TRANS_ESTIMATE_08 - Invalid addresses/long hex/"
```
