### PR TITLE
Rewrite BYRON_MIGRATE_05 to try to migrate to different addresses (sh…

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -721,7 +721,7 @@ scenario_MIGRATE_01 fixtureSource = it title $ \ctx -> do
     wSrc <- fixtureSource ctx
 
     r <- request @[ApiTransaction n] ctx
-         (Link.migrateWallet wSrc)
+         (Link.migrateWallet @'Byron wSrc)
          Default
          (NonJson "{passphrase:,}")
     expectResponseCode @IO HTTP.status400 r
@@ -751,7 +751,7 @@ scenario_MIGRATE_02 fixtureSource addrCount = it title $ \ctx -> do
 
     -- Calculate the expected migration fee:
     r0 <- request @ApiWalletMigrationInfo ctx
-          (Link.getMigrationInfo wSrc) Default Empty
+          (Link.getMigrationInfo @'Byron wSrc) Default Empty
     verify r0
         [ expectResponseCode @IO HTTP.status200
         , expectField #migrationCost (.> Quantity 0)
@@ -760,7 +760,7 @@ scenario_MIGRATE_02 fixtureSource addrCount = it title $ \ctx -> do
 
     -- Perform a migration from the source wallet to the target wallet:
     r1 <- request @[ApiTransaction n] ctx
-          (Link.migrateWallet wSrc)
+          (Link.migrateWallet @'Byron wSrc)
           Default
           (Json [json|
               { passphrase: #{fixturePassphrase}

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -116,7 +116,7 @@ spec = do
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
         $ \fixtureByronWallet -> do
             w <- fixtureByronWallet ctx
-            let ep = Link.getMigrationInfo w
+            let ep = Link.getMigrationInfo @'Byron w
             r <- request @ApiWalletMigrationInfo ctx ep Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status200
@@ -128,7 +128,7 @@ spec = do
         \Cannot calculate fee for empty wallet."
         $ \ctx -> forM_ [emptyRandomWallet, emptyIcarusWallet] $ \emptyByronWallet -> do
             w <- emptyByronWallet ctx
-            let ep = Link.getMigrationInfo w
+            let ep = Link.getMigrationInfo @'Byron w
             r <- request @ApiWalletMigrationInfo ctx ep Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status403
@@ -154,7 +154,7 @@ spec = do
                     } |]
             (_, w) <- unsafeRequest @ApiByronWallet ctx
                 (Link.postWallet @'Byron) payloadRestore
-            let ep = Link.getMigrationInfo w
+            let ep = Link.getMigrationInfo @'Byron w
             r <- request @ApiWalletMigrationInfo ctx ep Default Empty
             verify r
                 [ expectResponseCode @IO HTTP.status403

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1287,7 +1287,7 @@ spec = do
                 { passphrase: #{fixturePassphrase}
                 , addresses: [#{addr1}]
                 }|]
-        let migrEp = Link.migrateWallet sourceWallet
+        let migrEp = Link.migrateWallet @'Byron sourceWallet
         (_, t:_) <- unsafeRequest @[ApiTransaction n] ctx migrEp payload
         t ^. (#status . #getApiT) `shouldBe` Pending
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -42,6 +42,10 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( PassphraseMaxLength (..), PassphraseMinLength (..), PaymentAddress )
+import Cardano.Wallet.Primitive.AddressDerivation.Byron
+    ( ByronKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Icarus
+    ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -99,9 +103,11 @@ import Test.Integration.Framework.DSL
     , fixtureRandomWallet
     , fixtureWallet
     , getFromResponse
+    , icarusAddresses
     , json
     , listAddresses
     , notDelegating
+    , randomAddresses
     , request
     , selectCoins
     , shelleyAddresses
@@ -147,6 +153,8 @@ spec :: forall n t.
     ( DecodeAddress n
     , EncodeAddress n
     , PaymentAddress n ShelleyKey
+    , PaymentAddress n IcarusKey
+    , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
 spec = do
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> do
@@ -1174,68 +1182,56 @@ spec = do
         expectResponseCode @IO HTTP.status404 ru
         expectErrorMessage (errMsg404NoWallet wid) ru
 
-    describe "BYRON_MIGRATE_05 -\
-        \ migrating from inappropriate wallet types" $ do
-        addr <- runIO
+    describe "BYRON_MIGRATE_05 - I could migrate to any valid address" $ do
+        addrShelley <- runIO
             $ encodeAddress @n . head . shelleyAddresses @n
             . entropyToMnemonic @15 <$> genEntropy
+        addrIcarus <- runIO
+            $ encodeAddress @n . head . icarusAddresses @n
+            . entropyToMnemonic @15 <$> genEntropy
+        addrByron <- runIO
+            $ encodeAddress @n . head . randomAddresses @n
+            . entropyToMnemonic @12 <$> genEntropy
 
-        it "Byron" $ \ctx -> do
-            sWallet <- emptyRandomWallet ctx
-            rDel <- request @ApiWallet ctx
-                (Link.deleteWallet @'Byron sWallet) Default Empty
-            expectResponseCode @IO HTTP.status204 rDel
-            r <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sWallet)
-                Default
-                (Json [json|
-                    { passphrase: #{fixturePassphrase}
-                    , addresses: [#{addr}]
-                    }|])
-            verify r
-                [ expectResponseCode @IO HTTP.status404
-                , expectErrorMessage (errMsg404NoWallet $ sWallet ^. walletId)
-                ]
+        forM_ [ ("byron", addrByron)
+              , ("shelley", addrShelley)
+              , ("icarus", addrIcarus)
+              ] $ \(addrType, addr) -> do
+            it ("Wallet: Byron - Address: " ++ addrType) $ \ctx -> do
+                sWallet <- emptyRandomWallet ctx
+                r <- request @[ApiTransaction n] ctx
+                    (Link.migrateWallet @'Byron sWallet)
+                    Default
+                    (Json [json|
+                        { passphrase: #{fixturePassphrase}
+                        , addresses: [#{addr}]
+                        }|])
+                verify r
+                    [ expectResponseCode @IO HTTP.status403
+                    , expectErrorMessage
+                        (errMsg403NothingToMigrate (sWallet ^. walletId))
+                    ]
 
-        it "Icarus" $ \ctx -> do
-            sWallet <- emptyIcarusWallet ctx
-            rDel <- request @ApiWallet ctx
-                (Link.deleteWallet @'Byron sWallet) Default Empty
-            expectResponseCode @IO HTTP.status204 rDel
-            r <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sWallet)
-                Default
-                (Json [json|
-                    { passphrase: #{fixturePassphrase}
-                    , addresses: [#{addr}]
-                    }|])
-            verify r
-                [ expectResponseCode @IO HTTP.status404
-                , expectErrorMessage (errMsg404NoWallet $ sWallet ^. walletId)
-                ]
-
-        it "Shelley" $ \ctx -> do
-            sWallet <- fixtureWallet ctx
-            rDel <- request @ApiWallet ctx
-                (Link.deleteWallet @'Shelley sWallet) Default Empty
-            expectResponseCode @IO HTTP.status204 rDel
-            r <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sWallet)
-                Default
-                (Json [json|
-                    { passphrase: #{fixturePassphrase}
-                    , addresses: [#{addr}]
-                    }|])
-            verify r
-                [ expectResponseCode @IO HTTP.status404
-                , expectErrorMessage (errMsg404NoWallet $ sWallet ^. walletId)
-                ]
+            it ("Wallet: Icarus - Address: " ++ addrType) $ \ctx -> do
+                sWallet <- emptyIcarusWallet ctx
+                r <- request @[ApiTransaction n] ctx
+                    (Link.migrateWallet @'Byron sWallet)
+                    Default
+                    (Json [json|
+                        { passphrase: #{fixturePassphrase}
+                        , addresses: [#{addr}]
+                        }|])
+                verify r
+                    [ expectResponseCode @IO HTTP.status403
+                    , expectErrorMessage
+                        (errMsg403NothingToMigrate (sWallet ^. walletId))
+                    ]
 
     it "BYRON_MIGRATE_07 - invalid payload, parser error" $ \ctx -> do
         sourceWallet <- emptyRandomWallet ctx
 
         r <- request @[ApiTransaction n] ctx
-            (Link.migrateWallet sourceWallet )
+            (Link.migrateWallet @'Byron sourceWallet)
             Default
             (NonJson "{passphrase:,}")
         expectResponseCode @IO HTTP.status400 r
@@ -1345,10 +1341,10 @@ spec = do
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
     it "BYRON_CALCULATE_03 - \
-        \Cannot estimate migration for Shelley wallet"
+        \Cannot estimate migration for Shelley wallet using Byron endpoint"
         $ \ctx -> do
             w <- emptyWallet ctx
-            let ep = Link.getMigrationInfo w
+            let ep = Link.getMigrationInfo @'Byron w
             r <- request @ApiWalletMigrationInfo ctx ep Default Empty
             expectResponseCode @IO HTTP.status404 r
             expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
@@ -1396,7 +1392,7 @@ spec = do
 
         -- Calculate the expected migration fee:
         rFee <- request @ApiWalletMigrationInfo ctx
-            (Link.getMigrationInfo wOld)
+            (Link.getMigrationInfo @'Byron wOld)
             Default
             Empty
         verify rFee
@@ -1416,7 +1412,7 @@ spec = do
                     , addresses: [#{addr1}]
                     }|]
         request @[ApiTransaction n] ctx
-            (Link.migrateWallet wOld)
+            (Link.migrateWallet @'Byron wOld)
             Default
             payloadMigrate >>= flip verify
             [ expectResponseCode @IO HTTP.status202
@@ -1461,7 +1457,7 @@ spec = do
             let addr1 = (addrs !! 1) ^. #id
 
             r0 <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sourceWallet)
+                (Link.migrateWallet @'Byron sourceWallet)
                 Default
                 (Json [json|
                     { passphrase: #{fixturePassphrase}
@@ -1492,7 +1488,7 @@ spec = do
                         { passphrase: #{fixturePassphrase}
                         , addresses: [#{addr1}]
                         }|]
-            let ep = Link.migrateWallet sourceWallet
+            let ep = Link.migrateWallet @'Byron sourceWallet
             r <- request @[ApiTransaction n] ctx ep Default payload
             let srcId = sourceWallet ^. walletId
             verify r
@@ -1536,7 +1532,7 @@ spec = do
                         { passphrase: #{fixturePassphrase}
                         , addresses: [#{addr1}]
                         }|]
-            let ep = Link.migrateWallet sourceWallet
+            let ep = Link.migrateWallet @'Byron sourceWallet
             r <- request @[ApiTransaction n] ctx ep Default payload
             let srcId = sourceWallet ^. walletId
             verify r
@@ -1553,7 +1549,7 @@ spec = do
             sourceWallet <- fixtureByronWallet ctx
 
             -- Request a migration fee prediction.
-            let ep0 = (Link.getMigrationInfo sourceWallet)
+            let ep0 = (Link.getMigrationInfo @'Byron sourceWallet)
             r0 <- request @ApiWalletMigrationInfo ctx ep0 Default Empty
             verify r0
                 [ expectResponseCode @IO HTTP.status200
@@ -1569,7 +1565,7 @@ spec = do
                         { passphrase: #{fixturePassphrase}
                         , addresses: [#{addr1}]
                         }|]
-            let ep1 = Link.migrateWallet sourceWallet
+            let ep1 = Link.migrateWallet @'Byron sourceWallet
             r1 <- request @[ApiTransaction n] ctx ep1 Default payload
             verify r1
                 [ expectResponseCode @IO HTTP.status202
@@ -1595,7 +1591,7 @@ spec = do
         addrs <- listAddresses @n ctx targetWallet
         let addr1 = (addrs !! 1) ^. #id
         r0 <- request @[ApiTransaction n] ctx
-            (Link.migrateWallet sourceWallet )
+            (Link.migrateWallet @'Byron sourceWallet)
             Default
             (Json [json|
                 { passphrase: "not-the-right-passphrase"
@@ -1676,7 +1672,7 @@ spec = do
 
             -- Calculate the expected migration fee:
             r0 <- request @ApiWalletMigrationInfo ctx
-                (Link.getMigrationInfo sourceWallet) Default Empty
+                (Link.getMigrationInfo @'Byron sourceWallet) Default Empty
             verify r0
                 [ expectResponseCode @IO HTTP.status200
                 , expectField #migrationCost (.> Quantity 0)
@@ -1685,7 +1681,7 @@ spec = do
 
             -- Perform a migration from the source wallet to the target wallet:
             r1 <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sourceWallet)
+                (Link.migrateWallet @'Byron sourceWallet)
                 Default
                 (Json [json|
                     { passphrase: #{fixturePassphrase}

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -221,24 +221,28 @@ putWalletPassphrase w = discriminate @style
     wid = w ^. typed @(ApiT WalletId)
 
 migrateWallet
-    :: forall w.
-        ( HasType (ApiT WalletId) w
+    :: forall (style :: WalletStyle) w.
+        ( Discriminate style
+        , HasType (ApiT WalletId) w
         )
     => w
     -> (Method, Text)
-migrateWallet w =
-    endpoint @(Api.MigrateByronWallet Net) (wid &)
+migrateWallet w = discriminate @style
+    (endpoint @(Api.MigrateShelleyWallet Net) (wid &))
+    (endpoint @(Api.MigrateByronWallet Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 
 getMigrationInfo
-    :: forall w.
-        ( HasType (ApiT WalletId) w
+    :: forall (style :: WalletStyle) w.
+        ( Discriminate style
+        , HasType (ApiT WalletId) w
         )
     => w
     -> (Method, Text)
-getMigrationInfo w =
-    endpoint @Api.GetByronWalletMigrationInfo (wid &)
+getMigrationInfo w = discriminate @style
+    (endpoint @Api.GetShelleyWalletMigrationInfo (wid &))
+    (endpoint @Api.GetByronWalletMigrationInfo (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
 

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -367,7 +367,7 @@ spec = do
         forM_ addrsInvalid $ \addr -> do
             sWallet <- fixtureRandomWallet ctx
             r <- request @[ApiTransaction n] ctx
-                (Link.migrateWallet sWallet)
+                (Link.migrateWallet @'Shelley sWallet)
                 Default
                 (Json [json|
                     { passphrase: #{fixturePassphrase}


### PR DESCRIPTION
…elley, byron, icarus) instead of trying to migrate from deleted wallet

# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/1707

# Overview

- b1ba795a998c9cd8899aff3b983e3de5410cbe9d
  Rewrite BYRON_MIGRATE_05 to try to migrate to different addresses (shelley, byron, icarus) instead of trying to migrate from deleted wallet
  
- 1a6fb36dd53dbc7a27a26c6c6bba7e9db6510960
  Use shelley addresses from the wallet in the test
 



# Comments

In attempt of fixing BYRON_MIGRATE_05 (https://github.com/input-output-hk/cardano-wallet/issues/1707) failing on Jormungandr, I have rewritten it a bit, so it is trying to migrate to different address types. This works fine on `cardano-node` but fails for `jormungandr`.

It seems that the address that's causing the issue is `addr1vxyuj54gmnzxxhtrgeqd84df9zeudgvnaxy8lwh8ne29xp5mnl2v55m8r2n` which triggers following response:

```
Code = 400,
Message = {"code":"bad_request","message":"Error in $.addresses[0]:This type of address is not supported: [97]."}
```

The address is produced by the code:

```haskell
        addrShelley <- runIO
            $ encodeAddress @n . head . shelleyAddresses @n
            . entropyToMnemonic @15 <$> genEntropy
```

Cannot reproduce it manually (i.e. taking address from a shelley wallet)

---
**UPDATE:**
In 1a6fb36dd53dbc7a27a26c6c6bba7e9db6510960 I have "fixed" it so the shelley address in test is generated like this:
```
                --shelley address
                wShelley <- emptyWallet ctx
                addrs <- listAddresses @n ctx wShelley
                let addrShelley = (addrs !! 1) ^. #id
```

This works for haskell node and jormungandr...