### PR TITLE
Fix incorrect env var in make_changelog

### DIFF
--- a/scripts/make_changelog
+++ b/scripts/make_changelog
@@ -18,7 +18,7 @@ REPO="input-output-hk/cardano-wallet"
 : ${GITHUB_API_TOKEN?"Please provide a Github Api Token for fetching pull requests"}
 
 PULL_REQUESTS=$(curl -X GET \
-  -H "Authorization: token $API_TOKEN" \
+  -H "Authorization: token $GITHUB_API_TOKEN" \
   -H "Accept: application/vnd.github.v3+json" \
   https://api.github.com/search/issues?per_page=500\&q=repo:$REPO+is:pr+is:merged+merged:%3E$1)
 


### PR DESCRIPTION
# Issue Number

None.

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] The script was making sure `GITHUB_API_TOKEN` was set, but actually using `API_TOKEN` :/ 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
