### PR TITLE
Revise documentation for `NetworkParameters` and related types.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1299,6 +1299,12 @@ instance NFData NetworkParameters
 instance Buildable NetworkParameters where
     build (NetworkParameters gp pp) = build gp <> build pp
 
+-- | Parameters defined by the __genesis block__.
+--
+-- At present, these values cannot be changed through the update system.
+--
+-- They can only be changed through a soft or hard fork.
+--
 data GenesisParameters = GenesisParameters
     { getGenesisBlockHash :: Hash "Genesis"
         -- ^ Hash of the very first block

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1360,8 +1360,9 @@ data ProtocolParameters = ProtocolParameters
     { decentralizationLevel
         :: Quantity "percent" Percentage
         -- ^ The current level of decentralization in the network.
-        --   * '  0%' indicates that the network is /completely federalized/.
-        --   * '100%' indicates that the network is /completely decentralized/.
+        --   (also known as the 'd' parameter).
+        -- * '  0%' indicates that the network is /completely federalized/.
+        -- * '100%' indicates that the network is /completely decentralized/.
     , txParameters
         :: TxParameters
         -- ^ Parameters relating to transactions.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1357,11 +1357,17 @@ slotParams gp =
         (gp ^. #getGenesisBlockDate)
         (gp ^. #getActiveSlotCoefficient)
 
+-- | Protocol parameters that can be changed through the update system.
+--
 data ProtocolParameters = ProtocolParameters
     { decentralizationLevel
         :: Quantity "percent" Percentage
+        -- ^ The current level of decentralization in the network.
+        --   * '  0%' indicates that the network is /completely federalized/.
+        --   * '100%' indicates that the network is /completely decentralized/.
     , txParameters
         :: TxParameters
+        -- ^ Parameters relating to transactions.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1365,7 +1365,7 @@ data ProtocolParameters = ProtocolParameters
         -- * '100%' indicates that the network is /completely decentralized/.
     , txParameters
         :: TxParameters
-        -- ^ Parameters relating to transactions.
+        -- ^ Parameters that affect transaction construction.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1279,7 +1279,7 @@ computeUtxoStatistics btype utxos =
     (^!) = (^)
 
 {-------------------------------------------------------------------------------
-                             Blockchain Parameters
+                              Network Parameters
 -------------------------------------------------------------------------------}
 
 -- | Initial blockchain parameters loaded from the application configuration and

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1378,7 +1378,8 @@ instance Buildable ProtocolParameters where
         , "Transaction parameters: " <> build (pp ^. #txParameters)
         ]
 
--- | Blockchain parameters relating to constructing transactions.
+-- | Parameters that relate to the construction of __transactions__.
+--
 data TxParameters = TxParameters
     { getFeePolicy :: FeePolicy
         -- ^ Formula for calculating the transaction fee.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1282,7 +1282,8 @@ computeUtxoStatistics btype utxos =
                               Network Parameters
 -------------------------------------------------------------------------------}
 
--- | Records the complete set of parameters currently in use by the network.
+-- | Records the complete set of parameters currently in use by the network
+--   that are relevant to the wallet.
 --
 data NetworkParameters = NetworkParameters
     { genesisParameters :: GenesisParameters

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1282,16 +1282,13 @@ computeUtxoStatistics btype utxos =
                               Network Parameters
 -------------------------------------------------------------------------------}
 
--- | Initial blockchain parameters loaded from the application configuration and
--- genesis block.
+-- | Records the complete set of parameters currently in use by the network.
+--
 data NetworkParameters = NetworkParameters
     { genesisParameters :: GenesisParameters
-       -- ^ These parameters are defined by the configuration and genesis
-       -- block. At present, none of these are covered by the update system.
+       -- ^ See 'GenesisParameters'.
     , protocolParameters :: ProtocolParameters
-       -- ^ These parameters may be changed through update proposals. Currently
-       -- the only dynamic blockchain parameters that the wallet needs are
-       -- related to creating transactions.
+       -- ^ See 'ProtocolParameters'.
     } deriving (Generic, Show, Eq)
 
 instance NFData NetworkParameters


### PR DESCRIPTION
# Related Issues

#1693 

# Overview

PR #1700 changed the way that network parameters are defined.

This PR revises and adds documentation for the following types:

- [x] `NetworkParameters`
- [x] `GenesisParameters`
- [x] `ProtocolParameters`
- [x] `TxParameters`