### PR TITLE
Faster hydra eval

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -112,8 +112,6 @@ let
     checks = pkgs.recurseIntoAttrs (getPackageChecks (filterCardanoPackages haskellPackages));
     # `benchmarks` are only built, not run.
     benchmarks = collectComponents "benchmarks" isCardanoWallet haskellPackages;
-    # `migration-tests` build previous releases then check if the database successfully upgrades.
-    migration-tests = import ./nix/migration-tests.nix { inherit system crossSystem config pkgs; };
 
     dockerImage = let
       mkDockerImage = backend: exe: pkgs.callPackage ./nix/docker.nix { inherit backend exe; };

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -26,36 +26,28 @@ let
 
   # Chop out a subdirectory of the source, so that the package is only
   # rebuilt when something in the subdirectory changes.
-  filterSubDir = dir: with pkgs.lib; let
-      isFiltered = src ? _isLibCleanSourceWith;
-      origSrc = if isFiltered then src.origSrc else src;
-      hasPathPrefix = prefix: hasPrefix (toString origSrc + toString prefix);
-    in cleanSourceWith {
-      inherit src;
-      filter = path: type:
-        (type == "directory" && hasPathPrefix (dirOf dir) path) ||
-        hasPathPrefix dir path;
-    } + dir;
+  filterSubDir = subDir:
+    haskell.haskellLib.cleanSourceWith { inherit src subDir; };
 
   pkgSet = haskell.mkStackPkgSet {
     inherit stack-pkgs;
     modules = [
       # Add source filtering to local packages
       {
-        packages.cardano-wallet-core.src = filterSubDir /lib/core;
+        packages.cardano-wallet-core.src = filterSubDir "lib/core";
         packages.cardano-wallet-core.components.tests.unit.keepSource = true;
-        packages.cardano-wallet-core-integration.src = filterSubDir /lib/core-integration;
-        packages.cardano-wallet-cli.src = filterSubDir /lib/cli;
-        packages.cardano-wallet-launcher.src = filterSubDir /lib/launcher;
-        packages.cardano-wallet-byron.src = filterSubDir /lib/byron;
+        packages.cardano-wallet-core-integration.src = filterSubDir "lib/core-integration";
+        packages.cardano-wallet-cli.src = filterSubDir "lib/cli";
+        packages.cardano-wallet-launcher.src = filterSubDir "lib/launcher";
+        packages.cardano-wallet-byron.src = filterSubDir "lib/byron";
         packages.cardano-wallet-byron.components.tests.integration.keepSource = true;
-        packages.cardano-wallet-shelley.src = filterSubDir /lib/shelley;
+        packages.cardano-wallet-shelley.src = filterSubDir "lib/shelley";
         packages.cardano-wallet-shelley.components.tests.integration.keepSource = true;
-        packages.cardano-wallet-jormungandr.src = filterSubDir /lib/jormungandr;
+        packages.cardano-wallet-jormungandr.src = filterSubDir "lib/jormungandr";
         packages.cardano-wallet-jormungandr.components.tests.unit.keepSource = true;
         packages.cardano-wallet-jormungandr.components.tests.jormungandr-integration.keepSource = true;
-        packages.cardano-wallet-test-utils.src = filterSubDir /lib/test-utils;
-        packages.text-class.src = filterSubDir /lib/text-class;
+        packages.cardano-wallet-test-utils.src = filterSubDir "lib/test-utils";
+        packages.text-class.src = filterSubDir "lib/text-class";
         packages.text-class.components.tests.unit.keepSource = true;
       }
 
@@ -227,7 +219,7 @@ let
         # systemd can't be statically linked - disable lobemo-scribe-journal
         packages.cardano-config.flags.systemd = false;
 
-        # Haddock not working and not needed for cross builds
+        # Haddock not working for cross builds and is not needed anyway
         doHaddock = false;
       }))
 

--- a/nix/windows-migration-tests-bundle.nix
+++ b/nix/windows-migration-tests-bundle.nix
@@ -4,18 +4,27 @@
 # This zips up the windows build of the migration tests and adds
 # metadata for the Hydra build artifact.
 #
+# To build:
+#
+#   nix-build \
+#        --arg crossSystem '{ config = "x86_64-w64-mingw32"; libc = "msvcrt"; platform = { }; }' \
+#        nix/windows-migration-tests-bundle.nix
+#
 ############################################################################
 
-{ pkgs
-, project
-, migration-tests
+{ system ? builtins.currentSystem
+, crossSystem ? null
+, config ? {}
+, project ? import ../default.nix { inherit system crossSystem config; }
+, pkgs ? project.pkgs
 }:
 
 let
   name = "cardano-wallet-jormungandr-${project.version}-migration-tests-win64";
+  migration-tests = import ./migration-tests.nix { inherit system crossSystem config pkgs; };
 
-in pkgs.runCommand name {
-  nativeBuildInputs = [ pkgs.zip ];
+in pkgs.buildPackages.runCommand name {
+  nativeBuildInputs = [ pkgs.buildPackages.zip ];
 } ''
   mkdir -p $out/nix-support
   cd ${migration-tests}

--- a/release.nix
+++ b/release.nix
@@ -132,13 +132,6 @@ let
         jobs.cardano-wallet-tests-win64
       ]))
   // {
-    # These derivations are used for the Daedalus installer.
-    daedalus-jormungandr = with jobs; {
-      linux = native.cardano-wallet-jormungandr.x86_64-linux;
-      macos = native.cardano-wallet-jormungandr.x86_64-darwin;
-      windows = x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux;
-    };
-
     # Windows release ZIP archive - jormungandr
     cardano-wallet-jormungandr-win64 = import ./nix/windows-release.nix {
       inherit pkgs;
@@ -167,8 +160,6 @@ let
       tests = collectTests jobs.x86_64-w64-mingw32.tests;
       benchmarks = collectTests jobs.x86_64-w64-mingw32.benchmarks;
     };
-    # alias to old name so download links don't break
-    cardano-wallet-jormungandr-tests-win64 = jobs.cardano-wallet-tests-win64;
 
     # Fully-static linux binaries
     cardano-wallet-jormungandr-linux64 = import ./nix/linux-release.nix {
@@ -206,11 +197,6 @@ let
     buildkiteScript = import ./.buildkite/default.nix {
       walletPackages = project;
     };
-  }
-  # Build the shell derivation in Hydra so that all its dependencies
-  # are cached.
-  // mapTestOn (packagePlatforms {
-    inherit (project) shell stackShell;
-  });
+  };
 
 in jobs

--- a/release.nix
+++ b/release.nix
@@ -170,12 +170,6 @@ let
     # alias to old name so download links don't break
     cardano-wallet-jormungandr-tests-win64 = jobs.cardano-wallet-tests-win64;
 
-    # For testing migration tests on windows
-    migration-tests-win64 = import ./nix/windows-migration-tests-bundle.nix {
-      inherit pkgs project;
-      migration-tests = jobs.x86_64-w64-mingw32.migration-tests.x86_64-linux;
-    };
-
     # Fully-static linux binaries
     cardano-wallet-jormungandr-linux64 = import ./nix/linux-release.nix {
       inherit pkgs;

--- a/release.nix
+++ b/release.nix
@@ -25,6 +25,13 @@
 # ... or by looking at the jobset evaluated by Hydra:
 #   https://hydra.iohk.io/jobset/Cardano/cardano-wallet#tabs-jobs
 #
+# To build locally when you do not have access to remote builders for
+# either macOS or Linux, change the `supportedSystems` argument.
+# - To build on Linux (without macOS):
+#     nix-build --arg supportedSystems '["x86_64-linux"]' release.nix
+# - To build on macOS (without Linux):
+#     nix-build --arg supportedSystems '["x86_64-darwin"]' supportedCrossSystems '["x86_64-darwin"]' release.nix
+#
 ############################################################################
 
 # The project sources
@@ -56,9 +63,19 @@
 , pr ? null
 }:
 
+let
+  buildNative  = builtins.elem builtins.currentSystem supportedSystems;
+  buildLinux   = builtins.elem "x86_64-linux" supportedSystems;
+  buildMacOS   = builtins.elem "x86_64-darwin" supportedSystems;
+  buildWindows = builtins.elem builtins.currentSystem supportedCrossSystems;
+in
+
 with (import pkgs.iohkNix.release-lib) {
   inherit pkgs;
-  inherit supportedSystems supportedCrossSystems scrubJobs projectArgs;
+  inherit supportedCrossSystems scrubJobs projectArgs;
+  supportedSystems =
+    pkgs.lib.optional buildLinux "x86_64-linux" ++
+    pkgs.lib.optional buildMacOS "x86_64-darwin";
   packageSet = import cardano-wallet;
   gitrev = cardano-wallet.rev;
 };
@@ -66,7 +83,10 @@ with (import pkgs.iohkNix.release-lib) {
 with pkgs.lib;
 
 let
-  testsSupportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+  testsSupportedSystems =
+    optional buildLinux "x86_64-linux" ++
+    optional buildMacOS "x86_64-darwin";
+
   # Recurse through an attrset, returning all test derivations in a list.
   collectTests' = ds: filter (d: elem d.system testsSupportedSystems) (collect isDerivation ds);
   # Adds the package name to the test derivations for windows-testing-bundle.nix
@@ -81,57 +101,62 @@ let
 
   inherit (systems.examples) mingwW64 musl64;
 
-  jobs = {
+  jobs = optionalAttrs buildNative {
     native = mapTestOn (packagePlatformsOrig project);
+  } // optionalAttrs buildWindows {
     # Cross compilation, excluding the dockerImage and shells that we cannnot cross compile
     "${mingwW64.config}" = mapTestOnCross mingwW64
       (packagePlatformsCross (filterJobsCross project));
+  } // optionalAttrs buildLinux {
     musl64 = mapTestOnCross musl64
       (packagePlatformsCross (filterJobsCross project));
   }
     # This aggregate job is what IOHK Hydra uses to update
     # the CI status in GitHub.
-  // (mkRequiredJob (
-      collectTests jobs.native.checks ++
-      collectTests jobs.x86_64-w64-mingw32.checks ++
-      collectTests jobs.native.benchmarks ++
-      [ jobs.native.shell.x86_64-linux
-        jobs.native.shell.x86_64-darwin
+  // mkRequiredJob (
+      optionals buildNative (
+        collectTests jobs.native.checks ++
+        collectTests jobs.native.benchmarks ++
+        optionals buildLinux [
+          jobs.native.shell.x86_64-linux
+          # executables for linux
+          jobs.native.cardano-wallet-jormungandr.x86_64-linux
+          jobs.native.cardano-wallet-byron.x86_64-linux
+          jobs.native.cardano-wallet-shelley.x86_64-linux
+        ] ++
+        optionals buildMacOS [
+          jobs.native.shell.x86_64-darwin
+          # executables for macOS
+          jobs.native.cardano-wallet-jormungandr.x86_64-darwin
+          jobs.native.cardano-wallet-byron.x86_64-darwin
+          jobs.native.cardano-wallet-shelley.x86_64-darwin
 
-        # jormungandr
-        jobs.native.cardano-wallet-jormungandr.x86_64-linux
-        jobs.native.cardano-wallet-jormungandr.x86_64-darwin
-        jobs.x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux
+          # Release packages for macOS
+          jobs.cardano-wallet-jormungandr-macos64
+          jobs.cardano-wallet-byron-macos64
+          jobs.cardano-wallet-shelley-macos64
+        ]) ++
+      optionals buildLinux [
+          # Release packages for Linux
+          jobs.cardano-wallet-jormungandr-linux64
+          jobs.cardano-wallet-byron-linux64
+          jobs.cardano-wallet-shelley-linux64
+      ] ++
+      optionals buildWindows (
+        collectTests jobs.x86_64-w64-mingw32.checks ++
+        [ jobs.x86_64-w64-mingw32.cardano-wallet-jormungandr.x86_64-linux
+          jobs.x86_64-w64-mingw32.cardano-wallet-byron.x86_64-linux
+          jobs.x86_64-w64-mingw32.cardano-wallet-shelley.x86_64-linux
 
-        # cardano-node (Byron)
-        jobs.native.cardano-wallet-byron.x86_64-linux
-        jobs.native.cardano-wallet-byron.x86_64-darwin
-        jobs.x86_64-w64-mingw32.cardano-wallet-byron.x86_64-linux
+          # Release packages for Windows
+          jobs.cardano-wallet-jormungandr-win64
+          jobs.cardano-wallet-byron-win64
+          jobs.cardano-wallet-shelley-win64
 
-        # cardano-node (Shelley)
-        jobs.native.cardano-wallet-shelley.x86_64-linux
-        jobs.native.cardano-wallet-shelley.x86_64-darwin
-        jobs.x86_64-w64-mingw32.cardano-wallet-shelley.x86_64-linux
-
-        # release packages - jormungandr
-        jobs.cardano-wallet-jormungandr-linux64
-        jobs.cardano-wallet-jormungandr-macos64
-        jobs.cardano-wallet-jormungandr-win64
-
-        # release packages - cardano-node (Byron)
-        jobs.cardano-wallet-byron-linux64
-        jobs.cardano-wallet-byron-macos64
-        jobs.cardano-wallet-byron-win64
-
-        # release packages - cardano-node (Shelley)
-        jobs.cardano-wallet-shelley-linux64
-        jobs.cardano-wallet-shelley-macos64
-        jobs.cardano-wallet-shelley-win64
-
-        # Windows testing package - is run nightly in CI.
-        jobs.cardano-wallet-tests-win64
-      ]))
-  // {
+          # Windows testing package - is run nightly in CI.
+          jobs.cardano-wallet-tests-win64
+        ]))
+  // optionalAttrs buildWindows {
     # Windows release ZIP archive - jormungandr
     cardano-wallet-jormungandr-win64 = import ./nix/windows-release.nix {
       inherit pkgs;
@@ -160,7 +185,7 @@ let
       tests = collectTests jobs.x86_64-w64-mingw32.tests;
       benchmarks = collectTests jobs.x86_64-w64-mingw32.benchmarks;
     };
-
+  } // optionalAttrs buildLinux {
     # Fully-static linux binaries
     cardano-wallet-jormungandr-linux64 = import ./nix/linux-release.nix {
       inherit pkgs;
@@ -178,7 +203,7 @@ let
       inherit pkgs;
       exes = [ jobs.musl64.cardano-wallet-shelley.x86_64-linux ];
     };
-
+  } // optionalAttrs buildMacOS {
     # macOS binary and dependencies in tarball
     cardano-wallet-jormungandr-macos64 = import ./nix/macos-release.nix {
       inherit pkgs;
@@ -192,7 +217,7 @@ let
       inherit pkgs;
       exes = [ jobs.native.cardano-wallet-shelley.x86_64-darwin ];
     };
-
+  } // optionalAttrs buildLinux {
     # Build and cache the build script used on Buildkite
     buildkiteScript = import ./.buildkite/default.nix {
       walletPackages = project;


### PR DESCRIPTION
### Overview

Another attempt at fixing out of memory errors on Hydra during evaluation. I think this attempt should because I tested `hydra-eval-jobs` locally (for Linux at least).

- Removes migration tests from release jobset

  Since migration tests include several old revisions of cardano-wallet, they are costly to include in the release jobset, in terms of eval time and memory usage. Furthermore, if there are improvements to nix evaluation speed in new revisions, they still do not apply to old revisions.

   So this moves the full sequence of migration tests out of the release jobset. The migration test driver for the current revision is still built (and cross-built). Therefore, builds of old revisions will be available in the IOHK Hydra cache, where they can be downloaded by the Buildkite nightly pipeline.

- Makes it possible to instantiate `release.nix` locally without access to a macOS remote builder.

### Comments

To test locally:

    nix-shell '<nixpkgs>' -p hydra-unstable --run 'hydra-eval-jobs -I . --option allowed-uris "https://github.com/NixOS https://github.com/input-output-hk" --arg supportedSystems "[\"x86_64-linux\"]"  release.nix'
