### PR TITLE
Resurrected WIP: Automatically generate CLI docs

### DIFF
--- a/doc-doc
+++ b/doc-doc
@@ -1,0 +1,1 @@
+/nix/store/mp1ywc41ckmzrm3521dq5sv40lm4shpr-cardano-wallet-shelley-lib-cardano-wallet-shelley-2020.6.5-doc

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -112,6 +112,8 @@ module Cardano.CLI
     , setupDirectory
     , waitForService
     , WaitForServiceLog (..)
+
+    , cliDocs
     ) where
 
 import Prelude hiding
@@ -402,9 +404,13 @@ cli cmds = info (helper <*> subparser cmds) $ mempty
 -- | Name and description for every CLI command recusively
 data DCommand = DCommand String String [DCommand]
 
+
 dev :: IO ()
-dev = do
-    putStrLn $ fmt $ commandF $ toDCommand "" "" (cli (cmdKey <> cmdMnemonic <> cmdNetwork undefined <> cmdWallet cmdByronWalletCreate undefined))
+dev = putStrLn cliDocs
+
+cliDocs :: String
+cliDocs = do
+    fmt $ commandF $ toDCommand "" "" (cli (cmdWallet cmdByronWalletCreate undefined <> cmdKey <> cmdMnemonic <> cmdNetwork undefined))
   where
     toDCommand :: String -> String -> ParserInfo a -> DCommand
     toDCommand n docs c = DCommand n docs $ join $ mapParser desc (infoParser c)

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -414,7 +414,7 @@ dev = putStrLn cliDocs
 cliDocs :: String
 cliDocs =
     let
-        render = renderSmart 1.0 80
+        render = renderSmart 1.0 300
         c = cli (cmdWallet cmdByronWalletCreate undefined <> cmdKey <> cmdMnemonic <> cmdNetwork undefined)
 
         summary = commandF $ toDCommand "" "" mempty c
@@ -477,7 +477,11 @@ cliDocs =
             mdHeader y = text $ (replicate (depth + 2) '#') <> " " <> y
 
     commandF :: Tree (String, Doc, Doc) -> Doc
-    commandF = extractChunk . tabulate . foldMap (return . go) . markDepth
+    commandF = extractChunk
+        . tabulate
+        . foldMap (return . go)
+        . recordFullPath
+        . markDepth
       where
         -- Example output from go:
         -- [ ("wallet", "Manage wallets.")
@@ -489,9 +493,18 @@ cliDocs =
         --   list                  List all known wallets.
         --
         -- I.e. the first column contains indentation, but not the second one.
-        go :: (Int, (String, Doc, Doc)) -> (Doc, Doc)
-        go (depth, (n', d, _)) =
-              (text (replicate depth ' ' ++ n'), d)
+        go :: (Int, [String], (String, Doc, Doc)) -> (Doc, Doc)
+        go (depth, fp, (n', d, _)) =
+              (text (replicate depth ' ' ++ link), d)
+          where
+            anchor = intercalate "-" fp
+            link = mconcat
+                [ "<a href=\"#"
+                , drop 1 anchor
+                , "\">"
+                , n'
+                , "</a>"
+                ]
 
 
         -- TODO: Add links

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -428,14 +428,19 @@ cliDocs =
       where
         desc _ opt =
           case optMain opt of
-            CmdReader gn cmds p ->
-                    -- TODO: Replace newlines with spaces?
-                  [ toDCommand cmd (extractChunk d)
-                      (extractChunk $ fullDesc defaultPrefs (infoParser $ fromJust (p cmd)))
-                      (fromJust $ p cmd)
-                    | cmd <- reverse cmds,
-                      d <- maybeToList . fmap infoProgDesc $ p cmd
-                  ]
+            -- TODO: Make sure to print flags
+            -- Maybe be inspired by:
+            -- https://github.com/pcapriotti/optparse-applicative/blob/260c0ef45671bd660cee7890ff880ba5db8cfe68/src/Options/Applicative/Help/Core.hs
+            CmdReader gn cmds p -> do
+                cmd <- reverse cmds
+                d <- maybeToList . fmap infoProgDesc $ p cmd
+                let p' = fromJust (p cmd)
+                let h = extractChunk $ infoHeader p'
+                let args = extractChunk $ briefDesc defaultPrefs $ infoParser p'
+                let fd = extractChunk $ fullDesc defaultPrefs $ infoParser p'
+                return $ toDCommand cmd (extractChunk d)
+                    (args <> fd)
+                    p'
             _ -> []
 
 
@@ -465,7 +470,7 @@ cliDocs =
             [ mdHeader (intercalate " " fullN)
             , d
             , text "```"
-            , h
+            , text ("Usage: " <> intercalate " " fullN) <> " " <> h
             , text "```"
             ]
           where

--- a/lib/cli/test/cli-docs.md
+++ b/lib/cli/test/cli-docs.md
@@ -1,0 +1,43 @@
+Usage: cardano-wallet COMMAND
+  Cardano Wallet Command-Line Interface (CLI)
+
+Available OPTIONS:
+  -h | --help
+
+Available COMMANDS:
+  <a href="#launch">launch</a>                Launch and monitor a wallet server and its chain producers.
+  <a href="#serve">serve</a>                 Serve an HTTP API that listens for commands/actions.
+  mnemonic
+    <a href="#mnemonic-generate">generate</a>            Generate BIP-39 mnemonic words
+    <a href="#mnemonic-reward-credentials">reward-credentials</a>  Derive reward account private key from mnemonic.
+  wallet
+    <a href="#wallet-list">list</a>                List all known wallets
+    create
+      <a href="#wallet-create-from-mnemonic">from-mnemonic</a>     Create a new wallet using a mnemonic
+      <a href="#wallet-create-from-public-key">from-public-key</a>   Create a wallet using a public account key
+    <a href="#wallet-get">get</a>                 Fetch a particular wallet
+    <a href="#wallet-utxo">utxo</a>                Get a wallet's UTxO distribution
+    update
+      <a href="#wallet-update-passphrase">passphrase</a>        Update a wallet's master passphrase
+      <a href="#wallet-update-name">name</a>              Update a wallet's name
+    <a href="#wallet-delete">delete</a>              Forget a wallet and its metadata
+  transaction
+    <a href="#transaction-create">create</a>              Create a transaction from a known wallet
+    <a href="#transaction-fees">fees</a>                Estimate fees for a transaction
+    <a href="#transaction-list">list</a>                List the transactions associated with a wallet
+    <a href="#transaction-submit">submit</a>              Submit an externally-signed transaction
+    <a href="#transaction-forget">forget</a>              Forget a pending transaction with specified id
+  address
+    <a href="#address-list">list</a>                List all known addresses of a wallet
+  stake-pool
+      <a href="#stake-pool-list">list</a>              List all known stake pools
+  network
+    <a href="#network-information">information</a>         View network information
+    <a href="#network-parameters">parameters</a>          View network parameters
+    <a href="#network-clock">clock</a>               View NTP offset
+  key
+    <a href="#key-root">root</a>                Extract root extended private key from a mnemonic sentence.
+    <a href="#key-child">child</a>               Derive child keys.
+    <a href="#key-public">public</a>              Extract public key from a private key.
+    <a href="#key-inspect">inspect</a>             Show information about a key.
+  <a href="#version">version</a>               Show the program's current version

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -23,3 +23,144 @@
     information            View network information.
     parameters             View network parameters for the current epoch.
     clock                  View NTP offset.
+## 
+
+```
+
+```
+### wallet
+Manage wallets.
+```
+  -h,--help                Show this help text
+```
+#### list
+List all known wallets.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### create
+Create a new Byron wallet.
+```
+  -h,--help                Show this help text
+```
+##### from-mnemonic
+Create a new wallet using a mnemonic.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+  --wallet-style WALLET_STYLE
+                           Any of the following (default: icarus)
+                             random (12 mnemonic words)
+                             icarus (15 mnemonic words)
+                             trezor (12, 15, 18, 21 or 24 mnemonic words)
+                             ledger (12, 15, 18, 21 or 24 mnemonic words)
+```
+#### get
+Fetch the wallet with specified id.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### update
+Update a wallet.
+```
+  -h,--help                Show this help text
+```
+##### name
+Update a wallet's name.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+##### passphrase
+Update a wallet's passphrase.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### delete
+Deletes wallet with specified wallet id.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### utxo
+Get UTxO statistics for the wallet with specified id.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+### key
+Derive and manipulate keys.
+```
+  -h,--help                Show this help text
+```
+#### root
+Extract root extended private key from a mnemonic sentence.
+```
+  -h,--help                Show this help text
+  --wallet-style WALLET_STYLE
+                           Any of the following (default: icarus)
+                             icarus (15 mnemonic words)
+                             trezor (12, 15, 18, 21 or 24 mnemonic words)
+                             ledger (12, 15, 18, 21 or 24 mnemonic words)
+  --encoding KEY-ENCODING  Either 'hex' or 'bech32' (default: hex)
+```
+#### child
+Derive child keys.
+```
+  -h,--help                Show this help text
+  --path DER-PATH          Derivation path e.g. 44H/1815H/0H/0
+```
+#### public
+Extract the public key from a private key.
+```
+  -h,--help                Show this help text
+```
+#### inspect
+Show information about a key.
+```
+  -h,--help                Show this help text
+```
+### mnemonic
+Manage mnemonic phrases.
+```
+  -h,--help                Show this help text
+```
+#### generate
+Generate English BIP-0039 compatible mnemonic words.
+```
+  -h,--help                Show this help text
+  --size INT               number of mnemonic words to generate. (default: 15)
+```
+#### reward-credentials
+Derive reward account private key from a given mnemonic.
+```
+  -h,--help                Show this help text
+```
+### network
+Manage network.
+```
+  -h,--help                Show this help text
+```
+#### information
+View network information.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### parameters
+View network parameters for the current epoch.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+```
+#### clock
+View NTP offset.
+```
+  -h,--help                Show this help text
+  --port INT               port used for serving the wallet API. (default: 8090)
+  --force-ntp-check        When set, will block and force an NTP check with the
+                           server. Otherwise, uses an available cached result.
+```

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -1,0 +1,30 @@
+ -           
+
+    wallet -           
+    Manage wallets.
+        list -           List all known wallets.
+        create -           
+        Create a new Byron wallet.
+            from-mnemonic -           Create a new wallet using amnemonic.
+        get -           Fetch the wallet with specifiedid.
+        update -           
+        Update a wallet.
+            name -           Update a wallet's name.
+            passphrase -           Update a wallet's passphrase.
+        delete -           Deletes wallet with specifiedwallet id.
+        utxo -           Get UTxO statistics for thewallet with specified id.
+    key -           
+    Derive and manipulate keys.
+        root -           Extract root extended privatekey from a mnemonic sentence.
+        child -           Derive child keys.
+        public -           Extract the public key from aprivate key.
+        inspect -           Show information about a key.
+    mnemonic -           
+    Manage mnemonic phrases.
+        generate -           Generate English BIP-0039compatible mnemonic words.
+        reward-credentials -           Derive reward account privatekey from a given mnemonic.
+    network -           
+    Manage network.
+        information -           View network information.
+        parameters -           View network parameters for thecurrent epoch.
+        clock -           View NTP offset.

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -26,28 +26,29 @@
 ## 
 
 ```
-
+Usage:  
 ```
 ###  wallet
 Manage wallets.
 ```
-  -h,--help                Show this help text
+Usage:  wallet COMMAND  -h,--help                Show this help text
 ```
 ####  wallet list
 List all known wallets.
 ```
-  -h,--help                Show this help text
+Usage:  wallet list [--port INT]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet create
 Create a new Byron wallet.
 ```
-  -h,--help                Show this help text
+Usage:  wallet create COMMAND  -h,--help                Show this help text
 ```
 #####  wallet create from-mnemonic
 Create a new wallet using a mnemonic.
 ```
-  -h,--help                Show this help text
+Usage:  wallet create from-mnemonic [--port INT] STRING
+[--wallet-style WALLET_STYLE]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
   --wallet-style WALLET_STYLE
                            Any of the following (default: icarus)
@@ -59,47 +60,53 @@ Create a new wallet using a mnemonic.
 ####  wallet get
 Fetch the wallet with specified id.
 ```
-  -h,--help                Show this help text
+Usage:  wallet get [--port INT] WALLET_ID  -h,--help                Show this
+                                                                    help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet update
 Update a wallet.
 ```
-  -h,--help                Show this help text
+Usage:  wallet update COMMAND  -h,--help                Show this help text
 ```
 #####  wallet update name
 Update a wallet's name.
 ```
-  -h,--help                Show this help text
+Usage:  wallet update name [--port INT] WALLET_ID
+STRING  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 #####  wallet update passphrase
 Update a wallet's passphrase.
 ```
-  -h,--help                Show this help text
+Usage:  wallet update passphrase [--port INT]
+WALLET_ID  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet delete
 Deletes wallet with specified wallet id.
 ```
-  -h,--help                Show this help text
+Usage:  wallet delete [--port INT] WALLET_ID  -h,--help                Show this
+                                                                       help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet utxo
 Get UTxO statistics for the wallet with specified id.
 ```
-  -h,--help                Show this help text
+Usage:  wallet utxo [--port INT] WALLET_ID  -h,--help                Show this
+                                                                     help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ###  key
 Derive and manipulate keys.
 ```
-  -h,--help                Show this help text
+Usage:  key COMMAND  -h,--help                Show this help text
 ```
 ####  key root
 Extract root extended private key from a mnemonic sentence.
 ```
-  -h,--help                Show this help text
+Usage:  key root [--wallet-style WALLET_STYLE] [--encoding KEY-ENCODING]
+MNEMONIC_WORD...  -h,--help                Show this help text
   --wallet-style WALLET_STYLE
                            Any of the following (default: icarus)
                              icarus (15 mnemonic words)
@@ -110,56 +117,61 @@ Extract root extended private key from a mnemonic sentence.
 ####  key child
 Derive child keys.
 ```
-  -h,--help                Show this help text
+Usage:  key child --path DER-PATH  -h,--help                Show this help text
   --path DER-PATH          Derivation path e.g. 44H/1815H/0H/0
 ```
 ####  key public
 Extract the public key from a private key.
 ```
-  -h,--help                Show this help text
+Usage:  key public   -h,--help                Show this help text
 ```
 ####  key inspect
 Show information about a key.
 ```
-  -h,--help                Show this help text
+Usage:  key inspect   -h,--help                Show this help text
 ```
 ###  mnemonic
 Manage mnemonic phrases.
 ```
-  -h,--help                Show this help text
+Usage:  mnemonic COMMAND  -h,--help                Show this help text
 ```
 ####  mnemonic generate
 Generate English BIP-0039 compatible mnemonic words.
 ```
-  -h,--help                Show this help text
+Usage:  mnemonic generate [--size INT]  -h,--help                Show this help
+                                                                 text
   --size INT               number of mnemonic words to generate. (default: 15)
 ```
 ####  mnemonic reward-credentials
 Derive reward account private key from a given mnemonic.
 ```
-  -h,--help                Show this help text
+Usage:  mnemonic reward-credentials   -h,--help                Show this help
+                                                               text
 ```
 ###  network
 Manage network.
 ```
-  -h,--help                Show this help text
+Usage:  network COMMAND  -h,--help                Show this help text
 ```
 ####  network information
 View network information.
 ```
-  -h,--help                Show this help text
+Usage:  network information [--port INT]  -h,--help                Show this
+                                                                   help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  network parameters
 View network parameters for the current epoch.
 ```
-  -h,--help                Show this help text
+Usage:  network parameters [--port INT]  -h,--help                Show this help
+                                                                  text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  network clock
 View NTP offset.
 ```
-  -h,--help                Show this help text
+Usage:  network clock [--port INT]
+[--force-ntp-check]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
   --force-ntp-check        When set, will block and force an NTP check with the
                            server. Otherwise, uses an available cached result.

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -1,30 +1,25 @@
- -           
-
-    wallet -           
-    Manage wallets.
-        list -           List all known wallets.
-        create -           
-        Create a new Byron wallet.
-            from-mnemonic -           Create a new wallet using amnemonic.
-        get -           Fetch the wallet with specifiedid.
-        update -           
-        Update a wallet.
-            name -           Update a wallet's name.
-            passphrase -           Update a wallet's passphrase.
-        delete -           Deletes wallet with specifiedwallet id.
-        utxo -           Get UTxO statistics for thewallet with specified id.
-    key -           
-    Derive and manipulate keys.
-        root -           Extract root extended privatekey from a mnemonic sentence.
-        child -           Derive child keys.
-        public -           Extract the public key from aprivate key.
-        inspect -           Show information about a key.
-    mnemonic -           
-    Manage mnemonic phrases.
-        generate -           Generate English BIP-0039compatible mnemonic words.
-        reward-credentials -           Derive reward account privatekey from a given mnemonic.
-    network -           
-    Manage network.
-        information -           View network information.
-        parameters -           View network parameters for thecurrent epoch.
-        clock -           View NTP offset.
+                           
+   wallet                  Manage wallets.
+    list                   List all known wallets.
+    create                 Create a new Byron wallet.
+     from-mnemonic         Create a new wallet using a mnemonic.
+    get                    Fetch the wallet with specified id.
+    update                 Update a wallet.
+     name                  Update a wallet's name.
+     passphrase            Update a wallet's passphrase.
+    delete                 Deletes wallet with specified wallet id.
+    utxo                   Get UTxO statistics for the wallet with specified id.
+   key                     Derive and manipulate keys.
+    root                   Extract root extended private key from a mnemonic
+  sentence.
+    child                  Derive child keys.
+    public                 Extract the public key from a private key.
+    inspect                Show information about a key.
+   mnemonic                Manage mnemonic phrases.
+    generate               Generate English BIP-0039 compatible mnemonic words.
+    reward-credentials     Derive reward account private key from a given
+  mnemonic.
+   network                 Manage network.
+    information            View network information.
+    parameters             View network parameters for the current epoch.
+    clock                  View NTP offset.

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -1,28 +1,47 @@
-                           
-   wallet                  Manage wallets.
-    list                   List all known wallets.
-    create                 Create a new Byron wallet.
-     from-mnemonic         Create a new wallet using a mnemonic.
-    get                    Fetch the wallet with specified id.
-    update                 Update a wallet.
-     name                  Update a wallet's name.
-     passphrase            Update a wallet's passphrase.
-    delete                 Deletes wallet with specified wallet id.
-    utxo                   Get UTxO statistics for the wallet with specified id.
-   key                     Derive and manipulate keys.
-    root                   Extract root extended private key from a mnemonic
-  sentence.
-    child                  Derive child keys.
-    public                 Extract the public key from a private key.
-    inspect                Show information about a key.
-   mnemonic                Manage mnemonic phrases.
-    generate               Generate English BIP-0039 compatible mnemonic words.
-    reward-credentials     Derive reward account private key from a given
-  mnemonic.
-   network                 Manage network.
-    information            View network information.
-    parameters             View network parameters for the current epoch.
-    clock                  View NTP offset.
+  <a href="#"></a>         
+   <a href="#wallet">wallet</a>
+                           Manage wallets.
+    <a href="#wallet-list">list</a>
+                           List all known wallets.
+    <a href="#wallet-create">create</a>
+                           Create a new Byron wallet.
+     <a href="#wallet-create-from-mnemonic">from-mnemonic</a>
+                           Create a new wallet using a mnemonic.
+    <a href="#wallet-get">get</a>
+                           Fetch the wallet with specified id.
+    <a href="#wallet-update">update</a>
+                           Update a wallet.
+     <a href="#wallet-update-name">name</a>
+                           Update a wallet's name.
+     <a href="#wallet-update-passphrase">passphrase</a>
+                           Update a wallet's passphrase.
+    <a href="#wallet-delete">delete</a>
+                           Deletes wallet with specified wallet id.
+    <a href="#wallet-utxo">utxo</a>
+                           Get UTxO statistics for the wallet with specified id.
+   <a href="#key">key</a>  Derive and manipulate keys.
+    <a href="#key-root">root</a>
+                           Extract root extended private key from a mnemonic sentence.
+    <a href="#key-child">child</a>
+                           Derive child keys.
+    <a href="#key-public">public</a>
+                           Extract the public key from a private key.
+    <a href="#key-inspect">inspect</a>
+                           Show information about a key.
+   <a href="#mnemonic">mnemonic</a>
+                           Manage mnemonic phrases.
+    <a href="#mnemonic-generate">generate</a>
+                           Generate English BIP-0039 compatible mnemonic words.
+    <a href="#mnemonic-reward-credentials">reward-credentials</a>
+                           Derive reward account private key from a given mnemonic.
+   <a href="#network">network</a>
+                           Manage network.
+    <a href="#network-information">information</a>
+                           View network information.
+    <a href="#network-parameters">parameters</a>
+                           View network parameters for the current epoch.
+    <a href="#network-clock">clock</a>
+                           View NTP offset.
 ## 
 
 ```
@@ -47,8 +66,7 @@ Usage:  wallet create COMMAND  -h,--help                Show this help text
 #####  wallet create from-mnemonic
 Create a new wallet using a mnemonic.
 ```
-Usage:  wallet create from-mnemonic [--port INT] STRING
-[--wallet-style WALLET_STYLE]  -h,--help                Show this help text
+Usage:  wallet create from-mnemonic [--port INT] STRING [--wallet-style WALLET_STYLE]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
   --wallet-style WALLET_STYLE
                            Any of the following (default: icarus)
@@ -60,8 +78,7 @@ Usage:  wallet create from-mnemonic [--port INT] STRING
 ####  wallet get
 Fetch the wallet with specified id.
 ```
-Usage:  wallet get [--port INT] WALLET_ID  -h,--help                Show this
-                                                                    help text
+Usage:  wallet get [--port INT] WALLET_ID  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet update
@@ -72,29 +89,25 @@ Usage:  wallet update COMMAND  -h,--help                Show this help text
 #####  wallet update name
 Update a wallet's name.
 ```
-Usage:  wallet update name [--port INT] WALLET_ID
-STRING  -h,--help                Show this help text
+Usage:  wallet update name [--port INT] WALLET_ID STRING  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 #####  wallet update passphrase
 Update a wallet's passphrase.
 ```
-Usage:  wallet update passphrase [--port INT]
-WALLET_ID  -h,--help                Show this help text
+Usage:  wallet update passphrase [--port INT] WALLET_ID  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet delete
 Deletes wallet with specified wallet id.
 ```
-Usage:  wallet delete [--port INT] WALLET_ID  -h,--help                Show this
-                                                                       help text
+Usage:  wallet delete [--port INT] WALLET_ID  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  wallet utxo
 Get UTxO statistics for the wallet with specified id.
 ```
-Usage:  wallet utxo [--port INT] WALLET_ID  -h,--help                Show this
-                                                                     help text
+Usage:  wallet utxo [--port INT] WALLET_ID  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ###  key
@@ -105,8 +118,7 @@ Usage:  key COMMAND  -h,--help                Show this help text
 ####  key root
 Extract root extended private key from a mnemonic sentence.
 ```
-Usage:  key root [--wallet-style WALLET_STYLE] [--encoding KEY-ENCODING]
-MNEMONIC_WORD...  -h,--help                Show this help text
+Usage:  key root [--wallet-style WALLET_STYLE] [--encoding KEY-ENCODING] MNEMONIC_WORD...  -h,--help                Show this help text
   --wallet-style WALLET_STYLE
                            Any of the following (default: icarus)
                              icarus (15 mnemonic words)
@@ -138,15 +150,13 @@ Usage:  mnemonic COMMAND  -h,--help                Show this help text
 ####  mnemonic generate
 Generate English BIP-0039 compatible mnemonic words.
 ```
-Usage:  mnemonic generate [--size INT]  -h,--help                Show this help
-                                                                 text
+Usage:  mnemonic generate [--size INT]  -h,--help                Show this help text
   --size INT               number of mnemonic words to generate. (default: 15)
 ```
 ####  mnemonic reward-credentials
 Derive reward account private key from a given mnemonic.
 ```
-Usage:  mnemonic reward-credentials   -h,--help                Show this help
-                                                               text
+Usage:  mnemonic reward-credentials   -h,--help                Show this help text
 ```
 ###  network
 Manage network.
@@ -156,23 +166,19 @@ Usage:  network COMMAND  -h,--help                Show this help text
 ####  network information
 View network information.
 ```
-Usage:  network information [--port INT]  -h,--help                Show this
-                                                                   help text
+Usage:  network information [--port INT]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  network parameters
 View network parameters for the current epoch.
 ```
-Usage:  network parameters [--port INT]  -h,--help                Show this help
-                                                                  text
+Usage:  network parameters [--port INT]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
 ####  network clock
 View NTP offset.
 ```
-Usage:  network clock [--port INT]
-[--force-ntp-check]  -h,--help                Show this help text
+Usage:  network clock [--port INT] [--force-ntp-check]  -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
-  --force-ntp-check        When set, will block and force an NTP check with the
-                           server. Otherwise, uses an available cached result.
+  --force-ntp-check        When set, will block and force an NTP check with the server. Otherwise, uses an available cached result.
 ```

--- a/lib/cli/test/generated.md
+++ b/lib/cli/test/generated.md
@@ -28,23 +28,23 @@
 ```
 
 ```
-### wallet
+###  wallet
 Manage wallets.
 ```
   -h,--help                Show this help text
 ```
-#### list
+####  wallet list
 List all known wallets.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### create
+####  wallet create
 Create a new Byron wallet.
 ```
   -h,--help                Show this help text
 ```
-##### from-mnemonic
+#####  wallet create from-mnemonic
 Create a new wallet using a mnemonic.
 ```
   -h,--help                Show this help text
@@ -56,47 +56,47 @@ Create a new wallet using a mnemonic.
                              trezor (12, 15, 18, 21 or 24 mnemonic words)
                              ledger (12, 15, 18, 21 or 24 mnemonic words)
 ```
-#### get
+####  wallet get
 Fetch the wallet with specified id.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### update
+####  wallet update
 Update a wallet.
 ```
   -h,--help                Show this help text
 ```
-##### name
+#####  wallet update name
 Update a wallet's name.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-##### passphrase
+#####  wallet update passphrase
 Update a wallet's passphrase.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### delete
+####  wallet delete
 Deletes wallet with specified wallet id.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### utxo
+####  wallet utxo
 Get UTxO statistics for the wallet with specified id.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-### key
+###  key
 Derive and manipulate keys.
 ```
   -h,--help                Show this help text
 ```
-#### root
+####  key root
 Extract root extended private key from a mnemonic sentence.
 ```
   -h,--help                Show this help text
@@ -107,56 +107,56 @@ Extract root extended private key from a mnemonic sentence.
                              ledger (12, 15, 18, 21 or 24 mnemonic words)
   --encoding KEY-ENCODING  Either 'hex' or 'bech32' (default: hex)
 ```
-#### child
+####  key child
 Derive child keys.
 ```
   -h,--help                Show this help text
   --path DER-PATH          Derivation path e.g. 44H/1815H/0H/0
 ```
-#### public
+####  key public
 Extract the public key from a private key.
 ```
   -h,--help                Show this help text
 ```
-#### inspect
+####  key inspect
 Show information about a key.
 ```
   -h,--help                Show this help text
 ```
-### mnemonic
+###  mnemonic
 Manage mnemonic phrases.
 ```
   -h,--help                Show this help text
 ```
-#### generate
+####  mnemonic generate
 Generate English BIP-0039 compatible mnemonic words.
 ```
   -h,--help                Show this help text
   --size INT               number of mnemonic words to generate. (default: 15)
 ```
-#### reward-credentials
+####  mnemonic reward-credentials
 Derive reward account private key from a given mnemonic.
 ```
   -h,--help                Show this help text
 ```
-### network
+###  network
 Manage network.
 ```
   -h,--help                Show this help text
 ```
-#### information
+####  network information
 View network information.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### parameters
+####  network parameters
 View network parameters for the current epoch.
 ```
   -h,--help                Show this help text
   --port INT               port used for serving the wallet API. (default: 8090)
 ```
-#### clock
+####  network clock
 View NTP offset.
 ```
   -h,--help                Show this help text

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -27,6 +27,7 @@ import Cardano.CLI
     , TxId
     , XPrvOrXPub (..)
     , cli
+    , cliDocs
     , cmdAddress
     , cmdKey
     , cmdMnemonic
@@ -156,6 +157,12 @@ import qualified Data.Text.IO as TIO
 
 spec :: Spec
 spec = do
+    describe "Automatic CLI docs" $ do
+        it "maches golden" $ do
+
+            g <- T.unpack <$> TIO.readFile "lib/cli/test/cli-docs.md"
+            TIO.writeFile "lib/cli/test/generated.md" (T.pack cliDocs)
+            cliDocs `shouldBe` g
     describe "Specification / Usage Overview" $ do
 
         ["--help"] `shouldShowUsage`


### PR DESCRIPTION
# Issue Number

ADP-238

# Overview

- [x] Traverse CLI definition output a nicely formatted recursive summary
- [x] Add the "full details" in a new section
- [x] Add links from the summary to the details
- [ ] The `Doc` table doesn't work with HTML. Needs some workaround.
- [ ] Polish
- [ ] We should start moving information from the existing wiki docs to the actually CLI help text.
- [ ] Add a hidden cli command to output the html docs


# Comments

- Though, tbh, not sure if we even want to look at this before the shelley release.
- Was less obvious at the time how to get this far than I expected; opening this PR merely to avoid someone else also wasting that time.



Example output:

https://gist.github.com/Anviking/92d526e7db2421160acf4d845c1c45b1

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
