### PR TITLE
Report live value of decentralization parameter d.

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -603,8 +603,8 @@ instance ToText NetworkLayerLog where
             [ "Network node tip is"
             , pretty bh
             ]
-        MsgProtocolParameters params -> T.unwords
-            [ "ProtocolParams for tip are:"
+        MsgProtocolParameters params -> T.unlines
+            [ "Protocol parameters for tip are:"
             , pretty params
             ]
         MsgLocalStateQueryError e -> T.unwords

--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -42,10 +42,10 @@ import Cardano.Wallet.Byron.Compatibility
     , fromChainHash
     , fromSlotNo
     , fromTip
+    , protocolParametersFromUpdateState
     , toEpochSlots
     , toGenTx
     , toPoint
-    , txParametersFromUpdateState
     )
 import Cardano.Wallet.Network
     ( Cursor, ErrPostTx (..), NetworkLayer (..), mapCursor )
@@ -214,12 +214,11 @@ withNetworkLayer tr np addrInfo versionData action = do
     -- doesn't really do anything but sending dummy messages to get the node's
     -- tip. It doesn't rely on the intersection to be up-to-date.
     nodeTipVar <- atomically $ newTVar TipGenesis
-    txParamsVar <- atomically $ newTVar $
-        W.txParameters $ W.protocolParameters np
+    protocolParamsVar <- atomically $ newTVar $ W.protocolParameters np
     nodeTipClient <- mkTipSyncClient tr np
         localTxSubmissionQ
         (atomically . writeTVar nodeTipVar)
-        (atomically . writeTVar txParamsVar)
+        (atomically . writeTVar protocolParamsVar)
     let handlers = retryOnConnectionLost tr
     link =<< async
         (connectClient tr handlers nodeTipClient versionData addrInfo)
@@ -230,7 +229,7 @@ withNetworkLayer tr np addrInfo versionData action = do
             , nextBlocks = _nextBlocks
             , initCursor = _initCursor
             , cursorSlotId = _cursorSlotId
-            , getTxParameters = atomically $ readTVar txParamsVar
+            , getProtocolParameters = atomically $ readTVar protocolParamsVar
             , postTx = _postTx localTxSubmissionQ
             , stakeDistribution = _stakeDistribution
             , getAccountBalance = _getAccountBalance
@@ -363,15 +362,15 @@ mkTipSyncClient
         -- ^ Communication channel with the LocalTxSubmission client
     -> (Tip ByronBlock -> m ())
         -- ^ Notifier callback for when tip changes
-    -> (W.TxParameters -> m ())
+    -> (W.ProtocolParameters -> m ())
         -- ^ Notifier callback for when parameters for tip change.
     -> m (NetworkClient m)
-mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onTxParamsUpdate = do
+mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onProtocolParamsUpdate = do
     localStateQueryQ <- atomically newTQueue
 
-    onTxParamsUpdate' <- debounce $ \txParams -> do
-        traceWith tr $ MsgTxParameters txParams
-        onTxParamsUpdate txParams
+    onProtocolParamsUpdate' <- debounce $ \pp -> do
+        traceWith tr $ MsgProtocolParameters pp
+        onProtocolParamsUpdate pp
 
     let
         queryLocalState pt = do
@@ -383,7 +382,7 @@ mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onTxParamsUpdate = do
             Left (e :: AcquireFailure) ->
                 traceWith tr $ MsgLocalStateQueryError $ show e
             Right ls ->
-                onTxParamsUpdate' $ txParametersFromUpdateState ls
+                onProtocolParamsUpdate' $ protocolParametersFromUpdateState ls
 
     onTipUpdate' <- debounce $ \tip -> do
         traceWith tr $
@@ -565,7 +564,7 @@ data NetworkLayerLog
     | MsgFindIntersectionTimeout
     | MsgPostSealedTx W.SealedTx
     | MsgNodeTip W.BlockHeader
-    | MsgTxParameters W.TxParameters
+    | MsgProtocolParameters W.ProtocolParameters
     | MsgLocalStateQueryError String
 
 type HandshakeTrace = TraceSendRecv (Handshake NodeToClientVersion CBOR.Term)
@@ -604,8 +603,8 @@ instance ToText NetworkLayerLog where
             [ "Network node tip is"
             , pretty bh
             ]
-        MsgTxParameters params -> T.unwords
-            [ "TxParams for tip are:"
+        MsgProtocolParameters params -> T.unwords
+            [ "ProtocolParams for tip are:"
             , pretty params
             ]
         MsgLocalStateQueryError e -> T.unwords
@@ -628,5 +627,5 @@ instance HasSeverityAnnotation NetworkLayerLog where
         MsgPostSealedTx{}          -> Debug
         MsgLocalStateQuery{}       -> Debug
         MsgNodeTip{}               -> Debug
-        MsgTxParameters{}          -> Info
+        MsgProtocolParameters{}    -> Info
         MsgLocalStateQueryError{}  -> Error

--- a/lib/byron/src/Cardano/Wallet/Byron/Network.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Network.hs
@@ -358,7 +358,8 @@ mkTipSyncClient
         -- ^ Base trace for underlying protocols
     -> W.NetworkParameters
         -- ^ Initial blockchain parameters
-    -> TQueue m (LocalTxSubmissionCmd (GenTx ByronBlock) ApplyMempoolPayloadErr m)
+    -> TQueue m
+        (LocalTxSubmissionCmd (GenTx ByronBlock) ApplyMempoolPayloadErr m)
         -- ^ Communication channel with the LocalTxSubmission client
     -> (Tip ByronBlock -> m ())
         -- ^ Notifier callback for when tip changes
@@ -374,7 +375,8 @@ mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onTxParamsUpdate = do
 
     let
         queryLocalState pt = do
-            st <- localStateQueryQ `send` CmdQueryLocalState pt GetUpdateInterfaceState
+            st <- localStateQueryQ `send`
+                CmdQueryLocalState pt GetUpdateInterfaceState
             handleLocalState st
 
         handleLocalState = \case
@@ -384,7 +386,8 @@ mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onTxParamsUpdate = do
                 onTxParamsUpdate' $ txParametersFromUpdateState ls
 
     onTipUpdate' <- debounce $ \tip -> do
-        traceWith tr $ MsgNodeTip $ fromTip getGenesisBlockHash getEpochLength tip
+        traceWith tr $
+            MsgNodeTip $ fromTip getGenesisBlockHash getEpochLength tip
         onTipUpdate tip
         queryLocalState (getTipPoint tip)
 
@@ -550,9 +553,13 @@ notImplemented what = error ("Not implemented: " <> what)
 data NetworkLayerLog
     = MsgCouldntConnect Int
     | MsgConnectionLost (Maybe IOException)
-    | MsgTxSubmission (TraceSendRecv (LocalTxSubmission (GenTx ByronBlock) ApplyMempoolPayloadErr))
-    | MsgLocalStateQuery (TraceSendRecv (LocalStateQuery ByronBlock (Query ByronBlock)))
-    | MsgHandshakeTracer (WithMuxBearer (ConnectionId LocalAddress) HandshakeTrace)
+    | MsgTxSubmission
+        (TraceSendRecv
+            (LocalTxSubmission (GenTx ByronBlock) ApplyMempoolPayloadErr))
+    | MsgLocalStateQuery
+        (TraceSendRecv (LocalStateQuery ByronBlock (Query ByronBlock)))
+    | MsgHandshakeTracer
+        (WithMuxBearer (ConnectionId LocalAddress) HandshakeTrace)
     | MsgFindIntersection [W.BlockHeader]
     | MsgIntersectionFound (W.Hash "BlockHeader")
     | MsgFindIntersectionTimeout

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/NetworkSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/NetworkSpec.hs
@@ -60,11 +60,11 @@ spec = describe "getTxParameters" $ do
                 -- the genesis block configuration.
                 let retryPolicy = constantDelay 1_000_000 <> limitRetries 10
                 recoverAll retryPolicy $ const $
-                    getTxParameters nl `shouldReturn`
-                        txParameters (protocolParameters np)
+                    getProtocolParameters nl `shouldReturn`
+                        protocolParameters np
             -- Parameters update should be logged exactly once.
-            msg <- mapMaybe isMsgTxParams <$> getLogs
-            msg `shouldBe` [txParameters (protocolParameters np)]
+            msg <- mapMaybe isMsgProtocolParams <$> getLogs
+            msg `shouldBe` [protocolParameters np]
 
 withTestNode
     :: (NetworkParameters -> FilePath -> NodeVersionData -> IO a)
@@ -72,9 +72,9 @@ withTestNode
 withTestNode action = withCardanoNode nullTracer $(getTestData) Error $
     \sock _block0 (np, vData) -> action np sock vData
 
-isMsgTxParams :: NetworkLayerLog -> Maybe TxParameters
-isMsgTxParams (MsgTxParameters txp) = Just txp
-isMsgTxParams _ = Nothing
+isMsgProtocolParams :: NetworkLayerLog -> Maybe ProtocolParameters
+isMsgProtocolParams (MsgProtocolParameters pp) = Just pp
+isMsgProtocolParams _ = Nothing
 
 zeroTxParameters :: TxParameters
 zeroTxParameters = TxParameters

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -550,7 +550,8 @@ createIcarusWallet
     -> (k 'RootK XPrv, Passphrase "encryption")
     -> ExceptT ErrWalletAlreadyExists IO WalletId
 createIcarusWallet ctx wid wname credentials = db & \DBLayer{..} -> do
-    let s = mkSeqStateFromRootXPrv @n credentials (mkUnboundedAddressPoolGap 10000)
+    let s = mkSeqStateFromRootXPrv @n credentials $
+            mkUnboundedAddressPoolGap 10000
     let (hist, cp) = initWallet block0 gp s
     let addrs = map address . concatMap (view #outputs . fst) $ hist
     let g  = defaultAddressPoolGap

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -149,6 +149,7 @@ import Cardano.Wallet.Primitive.Types
     , AddressState (..)
     , BoundType
     , Coin (..)
+    , DecentralizationLevel (..)
     , Direction (..)
     , EpochLength (..)
     , EpochNo (..)
@@ -515,7 +516,7 @@ toApiNetworkParameters (NetworkParameters gp pp) = ApiNetworkParameters
         $ (*100)
         $ unActiveSlotCoefficient
         $ getActiveSlotCoefficient gp)
-    (view #decentralizationLevel pp)
+    (Quantity $ unDecentralizationLevel $ view #decentralizationLevel pp)
 
 newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -39,13 +39,13 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader
     , DelegationCertificate
     , Hash
+    , ProtocolParameters
     , Range (..)
     , SlotId (..)
     , SortOrder (..)
     , TransactionInfo
     , Tx (..)
     , TxMeta
-    , TxParameters
     , TxStatus
     , WalletId
     , WalletMetadata
@@ -115,11 +115,11 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -> Wallet s
         -> WalletMetadata
         -> [(Tx, TxMeta)]
-        -> TxParameters
+        -> ProtocolParameters
         -> ExceptT ErrWalletAlreadyExists stm ()
         -- ^ Initialize a database entry for a given wallet. 'putCheckpoint',
-        -- 'putWalletMeta', 'putTxHistory' or 'putTxParameters' will actually
-        -- all fail if they are called _first_ on a wallet.
+        -- 'putWalletMeta', 'putTxHistory' or 'putProtocolParameters' will
+        -- actually all fail if they are called _first_ on a wallet.
 
     , removeWallet
         :: PrimaryKey WalletId
@@ -227,16 +227,16 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
 
-    , putTxParameters
+    , putProtocolParameters
         :: PrimaryKey WalletId
-        -> TxParameters
+        -> ProtocolParameters
         -> ExceptT ErrNoSuchWallet stm ()
-        -- ^ Store blockchain parameters for the node tip.
+        -- ^ Store protocol parameters for the node tip.
 
-    , readTxParameters
+    , readProtocolParameters
         :: PrimaryKey WalletId
-        -> stm (Maybe TxParameters)
-        -- ^ Read the previously stored node tip blockchain parameters.
+        -> stm (Maybe ProtocolParameters)
+        -- ^ Read the previously stored node tip protocol parameters.
 
     , rollbackTo
         :: PrimaryKey WalletId

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -37,13 +37,13 @@ import Cardano.Wallet.DB.Model
     , mPutCheckpoint
     , mPutDelegationCertificate
     , mPutPrivateKey
+    , mPutProtocolParameters
     , mPutTxHistory
-    , mPutTxParameters
     , mPutWalletMeta
     , mReadCheckpoint
     , mReadPrivateKey
+    , mReadProtocolParameters
     , mReadTxHistory
-    , mReadTxParameters
     , mReadWalletMeta
     , mRemovePendingTx
     , mRemoveWallet
@@ -140,13 +140,14 @@ newDBLayer = do
             alterDB errCannotRemovePendingTx db (mRemovePendingTx pk tid)
 
         {-----------------------------------------------------------------------
-                                 Blockchain Parameters
+                                 Protocol Parameters
         -----------------------------------------------------------------------}
 
-        , putTxParameters = \pk txp -> ExceptT $ do
-            txp `deepseq` alterDB errNoSuchWallet db (mPutTxParameters pk txp)
+        , putProtocolParameters = \pk txp -> ExceptT $ do
+            txp `deepseq`
+                alterDB errNoSuchWallet db (mPutProtocolParameters pk txp)
 
-        , readTxParameters = readDB db . mReadTxParameters
+        , readProtocolParameters = readDB db . mReadProtocolParameters
 
         {-----------------------------------------------------------------------
                                       Execution

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -968,13 +968,16 @@ mkProtocolParametersEntity
 mkProtocolParametersEntity wid pp =
     ProtocolParameters wid fp (getQuantity mx) dl
   where
-    (W.ProtocolParameters (Quantity dl) (W.TxParameters fp mx)) = pp
+    (W.ProtocolParameters (W.DecentralizationLevel dl) (W.TxParameters fp mx)) =
+        pp
 
 protocolParametersFromEntity
     :: ProtocolParameters
     -> W.ProtocolParameters
 protocolParametersFromEntity (ProtocolParameters _ fp mx dl) =
-    W.ProtocolParameters (Quantity dl) (W.TxParameters fp (Quantity mx))
+    W.ProtocolParameters
+        (W.DecentralizationLevel dl)
+        (W.TxParameters fp (Quantity mx))
 
 {-------------------------------------------------------------------------------
                                    DB Queries

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -26,6 +26,8 @@ import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Types
     ( BlockId, HDPassphrase, TxId, sqlSettings' )
+import Data.Quantity
+    ( Percentage (..) )
 import Data.Text
     ( Text )
 import Data.Time.Clock
@@ -144,12 +146,13 @@ Checkpoint
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
-TxParameters
-    txParametersWalletId          W.WalletId  sql=wallet_id
-    txParametersFeePolicy         W.FeePolicy sql=fee_policy
-    txParametersTxMaxSize         Word16      sql=tx_max_size
-    Primary txParametersWalletId
-    Foreign Wallet fk_wallet_tx_parameters txParametersWalletId ! ON DELETE CASCADE
+ProtocolParameters
+    protocolParametersWalletId              W.WalletId  sql=wallet_id
+    protocolParametersFeePolicy             W.FeePolicy sql=fee_policy
+    protocolParametersTxMaxSize             Word16      sql=tx_max_size
+    protocolParametersDecentralizationLevel Percentage  sql=decentralization_level
+    Primary protocolParametersWalletId
+    Foreign Wallet fk_wallet_protocol_parameters protocolParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
 -- Store known delegation certificates for a particular wallet

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -66,6 +66,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Quantity
+    ( Percentage )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -155,6 +157,17 @@ instance PersistField FeePolicy where
 
 instance PersistFieldSql FeePolicy where
     sqlType _ = sqlType (Proxy @Text)
+
+----------------------------------------------------------------------------
+-- Percentage
+
+instance PersistField Percentage where
+    toPersistValue = toPersistValue . toText
+    fromPersistValue pv = fromPersistValue pv >>= left (const err) . fromText
+        where err = "not a valid percentage: " <> T.pack (show pv)
+
+instance PersistFieldSql Percentage where
+    sqlType _ = sqlType (Proxy @Rational)
 
 ----------------------------------------------------------------------------
 -- WalletId

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -310,7 +310,8 @@ follow
     -> Tracer IO FollowLog
     -- ^ Logger trace
     -> [BlockHeader]
-    -- ^ A list of known tips to start from. Blocks /after/ the tip will be yielded.
+    -- ^ A list of known tips to start from.
+    -- Blocks /after/ the tip will be yielded.
     -> (NE.NonEmpty block -> (BlockHeader, TxParameters) -> IO (FollowAction e))
     -- ^ Callback with blocks and the current tip of the /node/.
     -- @follow@ stops polling and terminates if the callback errors.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1370,7 +1370,7 @@ data ProtocolParameters = ProtocolParameters
 instance NFData ProtocolParameters
 
 instance Buildable ProtocolParameters where
-    build pp = listF' id
+    build pp = blockListF' "" id
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
         ]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -89,6 +89,7 @@ module Cardano.Wallet.Primitive.Types
     , ProtocolParameters (..)
     , TxParameters (..)
     , ActiveSlotCoefficient (..)
+    , DecentralizationLevel (..)
     , EpochLength (..)
     , EpochNo (..)
     , FeePolicy (..)
@@ -1359,11 +1360,8 @@ slotParams gp =
 --
 data ProtocolParameters = ProtocolParameters
     { decentralizationLevel
-        :: Quantity "percent" Percentage
+        :: DecentralizationLevel
         -- ^ The current level of decentralization in the network.
-        --   (also known as the 'd' parameter).
-        -- * '  0%' indicates that the network is /completely federalized/.
-        -- * '100%' indicates that the network is /completely decentralized/.
     , txParameters
         :: TxParameters
         -- ^ Parameters that affect transaction construction.
@@ -1376,6 +1374,33 @@ instance Buildable ProtocolParameters where
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
         ]
+
+-- | Indicates the current level of decentralization in the network.
+--
+-- According to the Design Specification for Delegation and Incentives in
+-- Cardano, the decentralization parameter __/d/__ is a value in the range
+-- '[0, 1]', where:
+--
+--   * __/d/__ = '1' indicates that the network is /completely federalized/.
+--   * __/d/__ = '0' indicates that the network is /completely decentralized/.
+--
+-- However, in Cardano Wallet, we represent the decentralization level as a
+-- percentage, where:
+--
+--   * '  0 %' indicates that the network is /completely federalized/.
+--   * '100 %' indicates that the network is /completely decentralized/.
+--
+-- * '  0%' indicates that the network is /completely federalized/.
+-- * '100%' indicates that the network is /completely decentralized/.
+--
+newtype DecentralizationLevel = DecentralizationLevel
+    { unDecentralizationLevel :: Percentage }
+    deriving (Bounded, Eq, Generic, Show)
+
+instance NFData DecentralizationLevel
+
+instance Buildable DecentralizationLevel where
+    build = build . unDecentralizationLevel
 
 -- | Parameters that relate to the construction of __transactions__.
 --

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -54,7 +54,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Sqlite
     ( DefaultFieldValues (..), newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( block0, dummyGenesisParameters, dummyTxParameters, mkTxId )
+    ( block0, dummyGenesisParameters, dummyProtocolParameters, mkTxId )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (..)
     , Depth (..)
@@ -366,8 +366,12 @@ withCleanDB db = perRunEnv (walletFixture db $> db)
 walletFixture :: DBLayerBench -> IO ()
 walletFixture db@DBLayer{..} = do
     cleanDB db
-    atomically $ unsafeRunExceptT $
-        initializeWallet testPk testCp testMetadata mempty dummyTxParameters
+    atomically $ unsafeRunExceptT $ initializeWallet
+        testPk
+        testCp
+        testMetadata
+        mempty
+        dummyProtocolParameters
 
 ----------------------------------------------------------------------------
 -- TxHistory benchmarks

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -8,7 +8,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     , block0
     , dummyNetworkParameters
     , dummyGenesisParameters
-    , dummyTxParameters
+    , dummyProtocolParameters
     , genesisHash
     , mockHash
     , mkTxId

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -76,6 +76,7 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , ChimericAccount (..)
     , Coin (..)
+    , DecentralizationLevel (..)
     , DelegationCertificate (..)
     , Direction (..)
     , EpochLength (..)
@@ -604,6 +605,9 @@ instance Arbitrary Percentage where
     arbitrary = unsafeMkPercentage . (% upperLimit) <$> choose (0, upperLimit)
       where
         upperLimit = 10_000
+
+instance Arbitrary DecentralizationLevel where
+    arbitrary = DecentralizationLevel <$> arbitrary
 
 instance Arbitrary (Hash purpose) where
     arbitrary = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -76,13 +76,13 @@ import Cardano.Wallet.DB.Model
     , mPutCheckpoint
     , mPutDelegationCertificate
     , mPutPrivateKey
+    , mPutProtocolParameters
     , mPutTxHistory
-    , mPutTxParameters
     , mPutWalletMeta
     , mReadCheckpoint
     , mReadPrivateKey
+    , mReadProtocolParameters
     , mReadTxHistory
-    , mReadTxParameters
     , mReadWalletMeta
     , mRemovePendingTx
     , mRemoveWallet
@@ -116,6 +116,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , Hash (..)
     , PoolId (..)
+    , ProtocolParameters (..)
     , Range (..)
     , SlotId (..)
     , SlotNo (..)
@@ -125,7 +126,7 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
-    , TxParameters
+    , TxParameters (..)
     , TxStatus
     , UTxO (..)
     , WalletId (..)
@@ -155,7 +156,7 @@ import Data.Map
 import Data.Maybe
     ( catMaybes, fromJust, isJust, isNothing )
 import Data.Quantity
-    ( Quantity (..) )
+    ( Percentage (..), Quantity (..) )
 import Data.Set
     ( Set )
 import Data.TreeDiff
@@ -275,7 +276,7 @@ instance MockPrivKey (ByronKey 'RootK) where
 
 data Cmd s wid
     = CleanDB
-    | CreateWallet MWid (Wallet s) WalletMetadata TxHistory TxParameters
+    | CreateWallet MWid (Wallet s) WalletMetadata TxHistory ProtocolParameters
     | RemoveWallet wid
     | ListWallets
     | PutCheckpoint wid (Wallet s)
@@ -287,8 +288,8 @@ data Cmd s wid
     | ReadTxHistory wid SortOrder (Range SlotId) (Maybe TxStatus)
     | PutPrivateKey wid MPrivKey
     | ReadPrivateKey wid
-    | PutTxParameters wid TxParameters
-    | ReadTxParameters wid
+    | PutProtocolParameters wid ProtocolParameters
+    | ReadProtocolParameters wid
     | RollbackTo wid SlotId
     | RemovePendingTx wid (Hash "Tx")
     | PutDelegationCertificate wid DelegationCertificate SlotId
@@ -302,7 +303,7 @@ data Success s wid
     | Metadata (Maybe WalletMetadata)
     | TxHistory [TransactionInfo]
     | PrivateKey (Maybe MPrivKey)
-    | TxParams (Maybe TxParameters)
+    | ProtocolParams (Maybe ProtocolParameters)
     | BlockHeaders [BlockHeader]
     | Point SlotId
     deriving (Show, Eq, Functor, Foldable, Traversable)
@@ -329,8 +330,9 @@ runMock :: Cmd s MWid -> Mock s -> (Resp s MWid, Mock s)
 runMock = \case
     CleanDB ->
         first (Resp . fmap Unit) . mCleanDB
-    CreateWallet wid wal meta txs txp ->
-        first (Resp . fmap (const (NewWallet wid))) . mInitializeWallet wid wal meta txs txp
+    CreateWallet wid wal meta txs pp ->
+        first (Resp . fmap (const (NewWallet wid)))
+            . mInitializeWallet wid wal meta txs pp
     RemoveWallet wid ->
         first (Resp . fmap Unit) . mRemoveWallet wid
     ListWallets ->
@@ -355,10 +357,10 @@ runMock = \case
         first (Resp . fmap Unit) . mPutPrivateKey wid pk
     ReadPrivateKey wid ->
         first (Resp . fmap PrivateKey) . mReadPrivateKey wid
-    PutTxParameters wid txp ->
-        first (Resp . fmap Unit) . mPutTxParameters wid txp
-    ReadTxParameters wid ->
-        first (Resp . fmap TxParams) . mReadTxParameters wid
+    PutProtocolParameters wid pp ->
+        first (Resp . fmap Unit) . mPutProtocolParameters wid pp
+    ReadProtocolParameters wid ->
+        first (Resp . fmap ProtocolParams) . mReadProtocolParameters wid
     RollbackTo wid sl ->
         first (Resp . fmap Point) . mRollbackTo wid sl
     RemovePendingTx wid tid ->
@@ -385,10 +387,10 @@ runIO db@DBLayer{..} = fmap Resp . go
     go = \case
         CleanDB -> do
             Right . Unit <$> cleanDB db
-        CreateWallet wid wal meta txs txp ->
+        CreateWallet wid wal meta txs pp ->
             catchWalletAlreadyExists (const (NewWallet (unMockWid wid))) $
             mapExceptT atomically $
-            initializeWallet (widPK wid) wal meta txs txp
+            initializeWallet (widPK wid) wal meta txs pp
         RemoveWallet wid -> catchNoSuchWallet Unit $
             mapExceptT atomically $ removeWallet (PrimaryKey wid)
         ListWallets -> Right . WalletIds . fmap unPrimaryKey <$>
@@ -415,10 +417,10 @@ runIO db@DBLayer{..} = fmap Resp . go
             mapExceptT atomically $ putPrivateKey (PrimaryKey wid) (fromMockPrivKey pk)
         ReadPrivateKey wid -> Right . PrivateKey . fmap toMockPrivKey <$>
             atomically (readPrivateKey $ PrimaryKey wid)
-        PutTxParameters wid txp -> catchNoSuchWallet Unit $
-            mapExceptT atomically $ putTxParameters (PrimaryKey wid) txp
-        ReadTxParameters wid -> Right . TxParams <$>
-            atomically (readTxParameters $ PrimaryKey wid)
+        PutProtocolParameters wid pp -> catchNoSuchWallet Unit $
+            mapExceptT atomically $ putProtocolParameters (PrimaryKey wid) pp
+        ReadProtocolParameters wid -> Right . ProtocolParams <$>
+            atomically (readProtocolParameters $ PrimaryKey wid)
         RollbackTo wid sl -> catchNoSuchWallet Point $
             mapExceptT atomically $ rollbackTo (PrimaryKey wid) sl
 
@@ -592,9 +594,9 @@ shrinker (Model _ _) (At cmd) = case cmd of
         [ At $ PutTxHistory wid h'
         | h' <- map unGenTxHistory . shrink . GenTxHistory $ h
         ]
-    CreateWallet wid wal met txs txp ->
-        [ At $ CreateWallet wid wal' met' txs' txp'
-        | (txs', wal', met', txp') <- shrink (txs, wal, met, txp)
+    CreateWallet wid wal met txs pp ->
+        [ At $ CreateWallet wid wal' met' txs' pp'
+        | (txs', wal', met', pp') <- shrink (txs, wal, met, pp)
         ]
     PutWalletMeta wid met ->
         [ At $ PutWalletMeta wid met'
@@ -687,8 +689,8 @@ instance CommandNames (At (Cmd s)) where
     cmdName (At ReadTxHistory{}) = "ReadTxHistory"
     cmdName (At PutPrivateKey{}) = "PutPrivateKey"
     cmdName (At ReadPrivateKey{}) = "ReadPrivateKey"
-    cmdName (At PutTxParameters{}) = "PutTxParameters"
-    cmdName (At ReadTxParameters{}) = "ReadTxParameters"
+    cmdName (At PutProtocolParameters{}) = "PutProtocolParameters"
+    cmdName (At ReadProtocolParameters{}) = "ReadProtocolParameters"
     cmdName (At RollbackTo{}) = "RollbackTo"
     cmdName (At RemovePendingTx{}) = "RemovePendingTx"
     cmdNames _ =
@@ -698,7 +700,7 @@ instance CommandNames (At (Cmd s)) where
         , "PutWalletMeta", "ReadWalletMeta", "PutDelegationCertificate"
         , "PutTxHistory", "ReadTxHistory", "RemovePendingTx"
         , "PutPrivateKey", "ReadPrivateKey"
-        , "PutTxParameters", "ReadTxParameters"
+        , "PutProtocolParameters", "ReadProtocolParameters"
         ]
 
 instance Functor f => Rank2.Functor (At f) where
@@ -799,6 +801,12 @@ instance ToExpr Address where
     toExpr = genericToExpr
 
 instance ToExpr TxMeta where
+    toExpr = genericToExpr
+
+instance ToExpr Percentage where
+    toExpr = genericToExpr
+
+instance ToExpr ProtocolParameters where
     toExpr = genericToExpr
 
 instance ToExpr TxParameters where

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -108,6 +108,7 @@ import Cardano.Wallet.Primitive.Types
     ( Address
     , BlockHeader
     , Coin (..)
+    , DecentralizationLevel
     , DelegationCertificate
     , Direction (..)
     , EpochNo (..)
@@ -807,6 +808,9 @@ instance ToExpr Percentage where
     toExpr = genericToExpr
 
 instance ToExpr ProtocolParameters where
+    toExpr = genericToExpr
+
+instance ToExpr DecentralizationLevel where
     toExpr = genericToExpr
 
 instance ToExpr TxParameters where

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -656,8 +656,8 @@ dummyNetworkLayer = NetworkLayer
         error "dummyNetworkLayer: cursorSlotId not implemented"
     , currentNodeTip =
         pure $ BlockHeader (SlotId 0 0) (Quantity 0) dummyHash dummyHash
-    , getTxParameters =
-        error "dummyNetworkLayer: getTxParameters not implemented"
+    , getProtocolParameters =
+        error "dummyNetworkLayer: getProtocolParameters not implemented"
     , postTx =
         error "dummyNetworkLayer: postTx not implemented"
     , stakeDistribution =

--- a/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
+++ b/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
@@ -70,10 +70,10 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
+    , ProtocolParameters
     , SlotId
     , StakePool (..)
     , StakePoolMetadata (..)
-    , TxParameters
     , sameStakePoolMetadata
     )
 import Cardano.Wallet.Unsafe
@@ -181,7 +181,7 @@ monitorStakePools tr (block0, Quantity k) nl db@DBLayer{..} = do
 
     forward
         :: NonEmpty Block
-        -> (BlockHeader, TxParameters)
+        -> (BlockHeader, ProtocolParameters)
         -> IO (FollowAction ErrMonitorStakePools)
     forward blocks (nodeTip, _params) = handler $ do
         let epochs = NE.nub $ view (#header . #slotId . #epochNumber) <$> blocks

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -135,7 +135,6 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , ProtocolParameters (..)
     , SlotId (..)
-    , TxParameters
     )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar, readMVar )
@@ -300,8 +299,8 @@ mkRawNetworkLayer np batchSize st j = NetworkLayer
     { currentNodeTip =
         _currentNodeTip
 
-    , getTxParameters =
-        _getTxParameters
+    , getProtocolParameters =
+        _getProtocolParameters
 
     , nextBlocks =
         _nextBlocks
@@ -344,8 +343,8 @@ mkRawNetworkLayer np batchSize st j = NetworkLayer
             Just t -> Right (bs', t)
             Nothing -> Left ErrCurrentNodeTipNotFound
 
-    _getTxParameters :: m TxParameters
-    _getTxParameters = pure $ txParameters $ protocolParameters np
+    _getProtocolParameters :: m ProtocolParameters
+    _getProtocolParameters = pure $ protocolParameters np
 
     _initCursor :: [BlockHeader] -> m (Cursor t)
     _initCursor bhs =

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -59,6 +59,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
+    , ProtocolParameters (..)
     , SlotId (..)
     , SlotLength (..)
     , StakePoolMetadata (..)
@@ -266,7 +267,8 @@ prop_trackRegistrations test = monadicIO $ do
                 pure mempty
             , currentNodeTip =
                 pure header0
-            , getTxParameters = pure genesisTxParameters
+            , getProtocolParameters =
+                pure genesisProtocolParameters
             }
 
 data instance Cursor RegistrationsTest = Cursor BlockHeader
@@ -325,8 +327,8 @@ mockNetworkLayer = NetworkLayer
         \_ -> error "mockNetworkLayer: cursorSlotId"
     , currentNodeTip =
         error "mockNetworkLayer: currentNodeTip"
-    , getTxParameters =
-        error "mockNetworkLayer: getTxParameters"
+    , getProtocolParameters =
+        error "mockNetworkLayer: getProtocolParameters"
     , postTx =
         \_ -> error "mockNetworkLayer: postTx"
     , stakeDistribution =
@@ -490,6 +492,12 @@ genesisParameters = GenesisParameters
     , getEpochLength = EpochLength 21600
     , getEpochStability = Quantity 2160
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
+    }
+
+genesisProtocolParameters :: ProtocolParameters
+genesisProtocolParameters = ProtocolParameters
+    { decentralizationLevel = minBound
+    , txParameters = genesisTxParameters
     }
 
 genesisTxParameters :: TxParameters

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -137,6 +137,8 @@ test-suite unit
     , ouroboros-consensus-shelley
     , ouroboros-network
     , shelley-spec-ledger
+    , text
+    , text-class
     , QuickCheck
   build-tools:
       hspec-discover

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -374,6 +374,9 @@ fromPParams pp = W.ProtocolParameters
 --   * '  0 %' indicates that the network is /completely federalized/.
 --   * '100 %' indicates that the network is /completely decentralized/.
 --
+-- Therefore, we must invert the value provided by cardano-node before we
+-- convert it into a percentage.
+--
 decentralizationLevelFromPParams
     :: HasCallStack
     => SL.PParams
@@ -382,6 +385,7 @@ decentralizationLevelFromPParams pp =
     either reportInvalidValue W.DecentralizationLevel
         $ mkPercentage
         $ SL.intervalValue
+        -- We must invert the value provided: (see function comment)
         $ invertUnitInterval d
   where
     d = SL._d pp

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -348,18 +348,11 @@ fromMaxTxSize =
 
 fromPParams :: SL.PParams -> W.ProtocolParameters
 fromPParams pp = W.ProtocolParameters
-    { decentralizationLevel = decentralizationLevelFromPParams pp
-    , txParameters = W.TxParameters
-        { getFeePolicy = W.LinearFee
-            (Quantity (naturalToDouble (SL._minfeeB pp)))
-            (Quantity (fromIntegral (SL._minfeeA pp)))
-            (Quantity 0) -- TODO: it's not as simple as this?
-        , getTxMaxSize = fromMaxTxSize $ SL._maxTxSize pp
-        }
+    { decentralizationLevel =
+        decentralizationLevelFromPParams pp
+    , txParameters =
+        txParametersFromPParams pp
     }
-  where
-    naturalToDouble :: Natural -> Double
-    naturalToDouble = fromIntegral
 
 -- | Extract the current network decentralization level from the given set of
 --   protocol parameters.
@@ -392,6 +385,20 @@ decentralizationLevelFromPParams pp =
         , "encountered invalid decentralization parameter value: "
         , show d
         ]
+
+txParametersFromPParams
+    :: SL.PParams
+    -> W.TxParameters
+txParametersFromPParams pp = W.TxParameters
+    { getFeePolicy = W.LinearFee
+        (Quantity (naturalToDouble (SL._minfeeB pp)))
+        (Quantity (fromIntegral (SL._minfeeA pp)))
+        (Quantity 0) -- TODO: it's not as simple as this?
+    , getTxMaxSize = fromMaxTxSize $ SL._maxTxSize pp
+    }
+  where
+    naturalToDouble :: Natural -> Double
+    naturalToDouble = fromIntegral
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -399,9 +399,11 @@ fromGenesisData g =
 
     -- | Construct a ("fake") genesis block from genesis transaction outputs.
     --
-    -- The genesis data on haskell nodes is not a block at all, unlike the block0 on
-    -- jormungandr. This function is a method to deal with the discrepancy.
-    genesisBlockFromTxOuts :: [(SL.Addr TPraosStandardCrypto, SL.Coin)] -> W.Block
+    -- The genesis data on haskell nodes is not a block at all, unlike the
+    -- block0 on jormungandr. This function is a method to deal with the
+    -- discrepancy.
+    genesisBlockFromTxOuts
+        :: [(SL.Addr TPraosStandardCrypto, SL.Coin)] -> W.Block
     genesisBlockFromTxOuts outs = W.Block
         { delegations  = []
         , header = W.BlockHeader
@@ -417,11 +419,13 @@ fromGenesisData g =
         , transactions = mkTx <$> outs
         }
       where
-        mkTx (addr, c) =
-            W.Tx pseudoHash [] [W.TxOut (fromShelleyAddress addr) (fromShelleyCoin c)]
+        mkTx (addr, c) = W.Tx
+            pseudoHash
+            []
+            [W.TxOut (fromShelleyAddress addr) (fromShelleyCoin c)]
           where
-            W.TxIn pseudoHash _ = fromShelleyTxIn $ initialFundsPseudoTxIn @TPraosStandardCrypto addr
-
+            W.TxIn pseudoHash _ = fromShelleyTxIn $
+                initialFundsPseudoTxIn @TPraosStandardCrypto addr
 
 fromNetworkMagic :: NetworkMagic -> W.ProtocolMagic
 fromNetworkMagic (NetworkMagic magic) =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -346,7 +346,7 @@ fromMaxTxSize :: Natural -> Quantity "byte" Word16
 fromMaxTxSize =
     Quantity . fromIntegral
 
-fromPParams :: SL.PParams -> W.ProtocolParameters
+fromPParams :: HasCallStack => SL.PParams -> W.ProtocolParameters
 fromPParams pp = W.ProtocolParameters
     { decentralizationLevel =
         decentralizationLevelFromPParams pp
@@ -371,7 +371,8 @@ fromPParams pp = W.ProtocolParameters
 --   * '100 %' indicates that the network is /completely decentralized/.
 --
 decentralizationLevelFromPParams
-    :: SL.PParams
+    :: HasCallStack
+    => SL.PParams
     -> W.DecentralizationLevel
 decentralizationLevelFromPParams pp =
     either reportInvalidValue W.DecentralizationLevel
@@ -402,7 +403,8 @@ txParametersFromPParams pp = W.TxParameters
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData
-    :: ShelleyGenesis TPraosStandardCrypto
+    :: HasCallStack
+    => ShelleyGenesis TPraosStandardCrypto
     -> (W.NetworkParameters, W.Block)
 fromGenesisData g =
     ( W.NetworkParameters

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -345,13 +345,16 @@ fromMaxTxSize :: Natural -> Quantity "byte" Word16
 fromMaxTxSize =
     Quantity . fromIntegral
 
-fromPParams :: SL.PParams -> W.TxParameters
-fromPParams pp = W.TxParameters
-    { getFeePolicy = W.LinearFee
-        (Quantity (naturalToDouble (SL._minfeeB pp)))
-        (Quantity (fromIntegral (SL._minfeeA pp)))
-        (Quantity 0) -- TODO: it's not as simple as this?
-    , getTxMaxSize = fromMaxTxSize $ SL._maxTxSize pp
+fromPParams :: SL.PParams -> W.ProtocolParameters
+fromPParams pp = W.ProtocolParameters
+    { decentralizationLevel = minBound
+    , txParameters = W.TxParameters
+        { getFeePolicy = W.LinearFee
+            (Quantity (naturalToDouble (SL._minfeeB pp)))
+            (Quantity (fromIntegral (SL._minfeeA pp)))
+            (Quantity 0) -- TODO: it's not as simple as this?
+        , getTxMaxSize = fromMaxTxSize $ SL._maxTxSize pp
+        }
     }
   where
     naturalToDouble :: Natural -> Double
@@ -376,15 +379,7 @@ fromGenesisData g =
             , getActiveSlotCoefficient =
                 W.ActiveSlotCoefficient 1.0
             }
-        , protocolParameters = W.ProtocolParameters
-            -- TODO: Report live value of decentralization level.
-            -- Related issue:
-            -- https://github.com/input-output-hk/cardano-wallet/issues/1693
-            { decentralizationLevel =
-                minBound
-            , txParameters =
-                fromPParams . sgProtocolParams $ g
-            }
+        , protocolParameters = fromPParams . sgProtocolParams $ g
         }
     , genesisBlockFromTxOuts $ Map.toList $ sgInitialFunds g
     )

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -57,6 +57,10 @@ module Cardano.Wallet.Shelley.Compatibility
     , toCardanoTxOut
     , toCardanoLovelace
     , toSealed
+
+      -- * Utilities
+    , invertUnitInterval
+
     ) where
 
 import Prelude
@@ -377,8 +381,8 @@ decentralizationLevelFromPParams
 decentralizationLevelFromPParams pp =
     either reportInvalidValue W.DecentralizationLevel
         $ mkPercentage
-        $ (1 -)
-        $ SL.intervalValue d
+        $ SL.intervalValue
+        $ invertUnitInterval d
   where
     d = SL._d pp
     reportInvalidValue = error $ mconcat
@@ -574,3 +578,22 @@ instance DecodeAddress 'Mainnet where
 
 instance DecodeAddress ('Testnet pm) where
     decodeAddress = _decodeAddress
+
+{-------------------------------------------------------------------------------
+                                 Utilities
+-------------------------------------------------------------------------------}
+
+-- Inverts a value in the unit interval [0, 1].
+--
+-- Examples:
+--
+-- >>> invertUnitInterval interval0 == interval1
+-- >>> invertUnitInterval interval1 == interval0
+--
+-- Satisfies the following properties:
+--
+-- >>> invertUnitInterval . invertUnitInterval == id
+-- >>> intervalValue (invertUnitInterval i) + intervalValue i == 1
+--
+invertUnitInterval :: SL.UnitInterval -> SL.UnitInterval
+invertUnitInterval = SL.truncateUnitInterval . (1 - ) . SL.intervalValue

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -58,6 +58,9 @@ module Cardano.Wallet.Shelley.Compatibility
     , toCardanoLovelace
     , toSealed
 
+      -- * Internal Conversions
+    , decentralizationLevelFromPParams
+
       -- * Utilities
     , invertUnitInterval
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -624,7 +624,7 @@ instance ToText NetworkLayerLog where
             [ "Network node tip is"
             , pretty bh
             ]
-        MsgProtocolParameters params -> T.unwords
+        MsgProtocolParameters params -> T.unlines
             [ "Protocol parameters for tip are:"
             , pretty params
             ]

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -36,11 +36,19 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Types
     ( Address (..), EpochLength (..), Hash (..), SlotId (..), fromFlatSlot )
 import Cardano.Wallet.Shelley.Compatibility
-    ( ShelleyBlock, TPraosStandardCrypto, fromTip, toPoint, toShelleyHash )
+    ( ShelleyBlock
+    , TPraosStandardCrypto
+    , fromTip
+    , invertUnitInterval
+    , toPoint
+    , toShelleyHash
+    )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkEntropy )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Ratio
+    ( (%) )
 import GHC.TypeLits
     ( natVal )
 import Ouroboros.Consensus.Shelley.Protocol.Crypto
@@ -53,8 +61,12 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , InfiniteList (..)
+    , checkCoverage
     , choose
+    , cover
     , frequency
+    , genericShrink
+    , oneof
     , property
     , vector
     , (===)
@@ -63,6 +75,7 @@ import Test.QuickCheck
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Shelley.Spec.Ledger.Address as SL
+import qualified Shelley.Spec.Ledger.BaseTypes as SL
 
 spec :: Spec
 spec = do
@@ -102,6 +115,39 @@ spec = do
                     \fadc57711600cb1430799c95b52b2a3b7"
             fst (isOurs addr s) `shouldBe` True
 
+    describe "Utilities" $ do
+
+        describe "UnitInterval" $ do
+
+            it "coverage adequate" $
+                checkCoverage $ property $ \i ->
+                    let half = SL.truncateUnitInterval (1 % 2) in
+                    cover 10 (i == half) "i = 0.5" $
+                    cover 10 (i == SL.interval0) "i = 0" $
+                    cover 10 (i == SL.interval1) "i = 1" $
+                    cover 10 (i > SL.interval0 && i < half) "0 < i < 0.5" $
+                    cover 10 (half < i && i < SL.interval1) "0.5 < i < 1"
+                    True
+
+            it "invertUnitInterval . invertUnitInterval == id" $
+                property $ \i ->
+                    invertUnitInterval (invertUnitInterval i) `shouldBe` i
+
+            it "intervalValue i + intervalValue (invertUnitInterval i) == 1" $
+                property $ \i ->
+                    SL.intervalValue i + SL.intervalValue (invertUnitInterval i)
+                        `shouldBe` 1
+
+            it "invertUnitInterval interval0 == interval1" $
+                invertUnitInterval SL.interval0 `shouldBe` SL.interval1
+
+            it "invertUnitInterval interval1 == interval0" $
+                invertUnitInterval SL.interval1 `shouldBe` SL.interval0
+
+            it "invertUnitInterval half == half" $
+                let half = SL.truncateUnitInterval (1 % 2) in
+                invertUnitInterval half `shouldBe` half
+
 instance Arbitrary (Hash "Genesis") where
     arbitrary = Hash . BS.pack <$> vector 32
 
@@ -124,6 +170,15 @@ instance Arbitrary (Tip ShelleyBlock) where
 
 epochLength :: EpochLength
 epochLength = EpochLength 10
+
+instance Arbitrary SL.UnitInterval where
+    arbitrary = oneof
+        [ pure SL.interval0
+        , pure SL.interval1
+        , pure $ SL.truncateUnitInterval (1 % 2)
+        , SL.truncateUnitInterval . (% 1000) <$> choose (0, 1000)
+        ]
+    shrink = genericShrink
 
 instance Arbitrary SlotId where
     arbitrary = fromFlatSlot epochLength <$> choose (0, 100)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -128,8 +128,6 @@ epochLength = EpochLength 10
 instance Arbitrary SlotId where
     arbitrary = fromFlatSlot epochLength <$> choose (0, 100)
 
---
-
 instance Arbitrary (ShelleyKey 'AddressK XPrv) where
     shrink _ = []
     arbitrary = ShelleyKey . getRawKey <$> genRootKeys

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -108,6 +108,8 @@
             (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
             (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
             (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             ];
           build-tools = [


### PR DESCRIPTION
# Issue Number

#1693 

# Overview

This PR:

- [x] Introduces the `DecentralizationLevel` type (based on the `Percentage` type).

    _Greater_ values indicate _greater_ levels of decentralization, as follows:

    | Value | Meaning |
    | --: | :-- |
    | 0% | Network is completely _federalized_ |
    | 100% | Network is completely _decentralized_ |

- [x] Adjusts the **wallet API server** to convert from values of type `DecentralizationLevel` to values of type `Quantity "percent" Percentage`.

- [x] Adjusts the **wallet layer** to store a value of type `ProtocolParameters` instead of `TxParameters`. (Note that `ProtocolParameters` _includes_ `TxParameters`.)

- [x] Adjusts the **network layer** to provide a `getProtocolParameters` function instead of `getTxParameters`.

- [x] Adjusts the **database layer** to use a `protocol_parameters` table instead of a `tx_parameters` table. (Note that `protocol_parameters` is a superset of `tx_parameters`.)

- [x] Adjusts the **chain-following code** to extract the live value of `d`, in the same way as we already do for transaction-related protocol parameters.

- [x] Adds a **conversion function** to convert from `d` parameter values to values of type `DecentralizationLevel`.

    This function performs the following mapping:
    ```
    {1 → 0%, 0.9 → 10%, 0.8 → 20%, ..., 0 → 100%}
    ```

# Comments

Starting a wallet with this PR applied will result in the creation of a new `protocol_parameters` table, if one does not already exist. (We rely on the automatic migration mechanism to create the table, and the network layer to add rows to the table.)

The redundant `tx_parameters` table, if it exists, will be ignored, but _not_ deleted.

In a future PR, we can add a manual migration step that removes the `tx_parameters` table.

See Issue https://github.com/input-output-hk/cardano-wallet/issues/1727.
