### PR TITLE
Fix mistakes in .travis.yml deployment preventing shelley binaries from being deployed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,21 +114,21 @@ jobs:
     # Fetch the linux archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-linux64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-shelley-*" -exec mv \{} cardano-wallet-shelley-linux64 \;
-    - mv cardano-wallet-shelley-linux64/cardano-wallet-shelley cardano-wallet-shelley-linux64/cardano-wallet-shelley
+    - mv cardano-wallet-shelley-linux64/cardano-wallet-shelley cardano-wallet-shelley-linux64/cardano-wallet
     - tar czf cardano-wallet-shelley-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-shelley-linux64
     - rm -r cardano-wallet-shelley-linux64
 
     # Fetch the MacOS archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-macos64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-shelley-*" -exec mv \{} cardano-wallet-shelley-macos64 \;
-    - mv cardano-wallet-shelley-macos64/cardano-wallet-shelley cardano-wallet-shelley-macos64/cardano-wallet-shelley
+    - mv cardano-wallet-shelley-macos64/cardano-wallet-shelley cardano-wallet-shelley-macos64/cardano-wallet
     - tar czf cardano-wallet-shelley-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-shelley-macos64
     - rm -r cardano-wallet-shelley-macos64
 
     # Fetch the Windows archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-win64/latest/download/1 --output cardano-wallet-shelley-win64.zip
     - unzip -d cardano-wallet-shelley-win64 cardano-wallet-shelley-win64.zip
-    - mv cardano-wallet-shelley-win64/cardano-wallet-shelley.exe cardano-wallet-shelley-win64/cardano-wallet-shelley.exe
+    - mv cardano-wallet-shelley-win64/cardano-wallet-shelley.exe cardano-wallet-shelley-win64/cardano-wallet.exe
     - zip -r cardano-wallet-shelley-$TRAVIS_TAG-win64.zip cardano-wallet-shelley-win64
     - rm -r cardano-wallet-shelley-win64
     - rm cardano-wallet-shelley-win64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,21 +140,21 @@ jobs:
     # Fetch the linux archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-linux64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-byron-*" -exec mv \{} cardano-wallet-byron-linux64 \;
-    - mv cardano-wallet-byron-linux64/cardano-wallet-byron cardano-wallet-byron-linux64/cardano-wallet-byron
+    - mv cardano-wallet-byron-linux64/cardano-wallet-byron cardano-wallet-byron-linux64/cardano-wallet
     - tar czf cardano-wallet-byron-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-byron-linux64
     - rm -r cardano-wallet-byron-linux64
 
     # Fetch the MacOS archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-macos64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-byron-*" -exec mv \{} cardano-wallet-byron-macos64 \;
-    - mv cardano-wallet-byron-macos64/cardano-wallet-byron cardano-wallet-byron-macos64/cardano-wallet-byron
+    - mv cardano-wallet-byron-macos64/cardano-wallet-byron cardano-wallet-byron-macos64/cardano-wallet
     - tar czf cardano-wallet-byron-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-byron-macos64
     - rm -r cardano-wallet-byron-macos64
 
     # Fetch the Windows archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-win64/latest/download/1 --output cardano-wallet-byron-win64.zip
     - unzip -d cardano-wallet-byron-win64 cardano-wallet-byron-win64.zip
-    - mv cardano-wallet-byron-win64/cardano-wallet-byron.exe cardano-wallet-byron-win64/cardano-wallet-byron.exe
+    - mv cardano-wallet-byron-win64/cardano-wallet-byron.exe cardano-wallet-byron-win64/cardano-wallet.exe
     - zip -r cardano-wallet-byron-$TRAVIS_TAG-win64.zip cardano-wallet-byron-win64
     - rm -r cardano-wallet-byron-win64
     - rm cardano-wallet-byron-win64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
     name: "Pre-cache Dependencies"
     script:
     - stack --no-terminal build --only-snapshot --stack-yaml .travis/stack.yaml
+    - tar czf $STACK_WORK_CACHE .stack-work
 
   - stage: cache 💾
     if: type != pull_request AND (branch = master OR tag =~ ^v)

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,22 +114,22 @@ jobs:
     # Fetch the linux archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-linux64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-shelley-*" -exec mv \{} cardano-wallet-shelley-linux64 \;
-    - mv cardano-wallet-shelley-linux64/cardano-wallet-shelley cardano-wallet-shelley-linux64/cardano-wallet
-    - tar czf cardano-wallet-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-shelley-linux64
+    - mv cardano-wallet-shelley-linux64/cardano-wallet-shelley cardano-wallet-shelley-linux64/cardano-wallet-shelley
+    - tar czf cardano-wallet-shelley-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-shelley-linux64
     - rm -r cardano-wallet-shelley-linux64
 
     # Fetch the MacOS archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-macos64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-shelley-*" -exec mv \{} cardano-wallet-shelley-macos64 \;
-    - mv cardano-wallet-shelley-macos64/cardano-wallet-shelley cardano-wallet-shelley-macos64/cardano-wallet
-    - tar czf cardano-wallet-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-shelley-macos64
+    - mv cardano-wallet-shelley-macos64/cardano-wallet-shelley cardano-wallet-shelley-macos64/cardano-wallet-shelley
+    - tar czf cardano-wallet-shelley-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-shelley-macos64
     - rm -r cardano-wallet-shelley-macos64
 
     # Fetch the Windows archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-shelley-win64/latest/download/1 --output cardano-wallet-shelley-win64.zip
     - unzip -d cardano-wallet-shelley-win64 cardano-wallet-shelley-win64.zip
-    - mv cardano-wallet-shelley-win64/cardano-wallet-shelley.exe cardano-wallet-shelley-win64/cardano-wallet.exe
-    - zip -r cardano-wallet-$TRAVIS_TAG-win64.zip cardano-wallet-shelley-win64
+    - mv cardano-wallet-shelley-win64/cardano-wallet-shelley.exe cardano-wallet-shelley-win64/cardano-wallet-shelley.exe
+    - zip -r cardano-wallet-shelley-$TRAVIS_TAG-win64.zip cardano-wallet-shelley-win64
     - rm -r cardano-wallet-shelley-win64
     - rm cardano-wallet-shelley-win64.zip
 
@@ -140,22 +140,22 @@ jobs:
     # Fetch the linux archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-linux64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-byron-*" -exec mv \{} cardano-wallet-byron-linux64 \;
-    - mv cardano-wallet-byron-linux64/cardano-wallet-byron cardano-wallet-byron-linux64/cardano-wallet
-    - tar czf cardano-wallet-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-byron-linux64
+    - mv cardano-wallet-byron-linux64/cardano-wallet-byron cardano-wallet-byron-linux64/cardano-wallet-byron
+    - tar czf cardano-wallet-byron-$TRAVIS_TAG-linux64.tar.gz cardano-wallet-byron-linux64
     - rm -r cardano-wallet-byron-linux64
 
     # Fetch the MacOS archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-macos64/latest/download/1 | tar xz
     - find . -maxdepth 1 -type d -name "cardano-wallet-byron-*" -exec mv \{} cardano-wallet-byron-macos64 \;
-    - mv cardano-wallet-byron-macos64/cardano-wallet-byron cardano-wallet-byron-macos64/cardano-wallet
-    - tar czf cardano-wallet-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-byron-macos64
+    - mv cardano-wallet-byron-macos64/cardano-wallet-byron cardano-wallet-byron-macos64/cardano-wallet-byron
+    - tar czf cardano-wallet-byron-$TRAVIS_TAG-macos64.tar.gz cardano-wallet-byron-macos64
     - rm -r cardano-wallet-byron-macos64
 
     # Fetch the Windows archive
     - travis_retry curl -L https://hydra.iohk.io/job/Cardano/cardano-wallet/cardano-wallet-byron-win64/latest/download/1 --output cardano-wallet-byron-win64.zip
     - unzip -d cardano-wallet-byron-win64 cardano-wallet-byron-win64.zip
-    - mv cardano-wallet-byron-win64/cardano-wallet-byron.exe cardano-wallet-byron-win64/cardano-wallet.exe
-    - zip -r cardano-wallet-$TRAVIS_TAG-win64.zip cardano-wallet-byron-win64
+    - mv cardano-wallet-byron-win64/cardano-wallet-byron.exe cardano-wallet-byron-win64/cardano-wallet-byron.exe
+    - zip -r cardano-wallet-byron-$TRAVIS_TAG-win64.zip cardano-wallet-byron-win64
     - rm -r cardano-wallet-byron-win64
     - rm cardano-wallet-byron-win64.zip
 
@@ -201,9 +201,14 @@ jobs:
       skip_cleanup: true # Make sure that files from the previous stages aren't cleaned up
       file:
         # cardano-node / Byron
-        - cardano-wallet-$TRAVIS_TAG-linux64.tar.gz
-        - cardano-wallet-$TRAVIS_TAG-macos64.tar.gz
-        - cardano-wallet-$TRAVIS_TAG-win64.zip
+        - cardano-wallet-byron-$TRAVIS_TAG-linux64.tar.gz
+        - cardano-wallet-byron-$TRAVIS_TAG-macos64.tar.gz
+        - cardano-wallet-byron-$TRAVIS_TAG-win64.zip
+
+        # cardano-node / Shelley
+        - cardano-wallet-shelley-$TRAVIS_TAG-linux64.tar.gz
+        - cardano-wallet-shelley-$TRAVIS_TAG-macos64.tar.gz
+        - cardano-wallet-shelley-$TRAVIS_TAG-win64.zip
 
         # Jörmungandr / ITN
         - cardano-wallet-itn-$TRAVIS_TAG-linux64.tar.gz

--- a/.travis/stack.yaml
+++ b/.travis/stack.yaml
@@ -1,3 +1,3 @@
 resolver: lts-14.25
 packages:
-- lib/text-class
+- ../lib/text-class


### PR DESCRIPTION
# Issue Number

For v2020-06-05 release.


# Overview

- Rename `cardano-wallet` to `cardano-wallet-byron`
- Make sure shelley binaries are called `cardano-wallet-shelley`, and remember to add the output to the `files` list


# Comments

Should work now:

<img width="597" alt="Skärmavbild 2020-06-08 kl  15 50 21" src="https://user-images.githubusercontent.com/304423/84038168-dcf29100-a99f-11ea-9928-aed39200f761.png">


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
