### PR TITLE
Cluster of stake pools in integration tests

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -75,6 +75,7 @@ library
       Test.Integration.Scenario.API.Byron.Transactions
       Test.Integration.Scenario.API.Shelley.Addresses
       Test.Integration.Scenario.API.Shelley.HWWallets
+      Test.Integration.Scenario.API.Shelley.Network
       Test.Integration.Scenario.API.Shelley.Transactions
       Test.Integration.Scenario.API.Shelley.Wallets
       Test.Integration.Scenario.API.Network

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -104,15 +104,9 @@ spec = do
         let networkParams = getFromResponse id r
         networkParams `shouldBe`
             toApiNetworkParameters (ctx ^. #_networkParameters)
-        let Right zeroPercent = Quantity <$> mkPercentage 0
+        let Right d = Quantity <$> mkPercentage .75 -- d is set to 0.25 in genesis
         verify r
-            -- NOTE: Currently, the decentralization level is hard-wired to 0%.
-            -- TODO: Adjust this test to expect the live value.
-            --
-            -- Related issue:
-            -- https://github.com/input-output-hk/cardano-wallet/issues/1693
-            --
-            [ expectField (#decentralizationLevel) (`shouldBe` zeroPercent) ]
+            [ expectField (#decentralizationLevel) (`shouldBe` d) ]
 
     it "NETWORK_CLOCK - Can query network clock" $ \ctx -> do
         sandboxed <- inNixBuild

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -14,10 +14,8 @@ import Cardano.Wallet.Api.Types
     , ApiEpochInfo (..)
     , ApiNetworkClock
     , ApiNetworkInformation
-    , ApiNetworkParameters (..)
     , NtpSyncingStatus (..)
     , WalletStyle (..)
-    , toApiNetworkParameters
     )
 import Cardano.Wallet.Primitive.Types
     ( SyncProgress (..) )
@@ -25,10 +23,6 @@ import Control.Monad
     ( when )
 import Control.Monad.IO.Class
     ( liftIO )
-import Data.Generics.Internal.VL.Lens
-    ( (^.) )
-import Data.Quantity
-    ( Quantity (..), mkPercentage )
 import Data.Time.Clock
     ( getCurrentTime )
 import Test.Hspec
@@ -96,17 +90,6 @@ spec = do
                     , expectField (#tip . #slotNumber  . #getApiT) (`shouldBe` slotNum)
                     , expectField (#tip . #height) (`shouldBe` blockHeight)
                     ]
-
-    it "NETWORK_PARAMS - Able to fetch network parameters" $ \ctx -> do
-        let endpoint = ( "GET", "v2/network/parameters" )
-        r <- request @ApiNetworkParameters ctx endpoint Default Empty
-        expectResponseCode @IO HTTP.status200 r
-        let networkParams = getFromResponse id r
-        networkParams `shouldBe`
-            toApiNetworkParameters (ctx ^. #_networkParameters)
-        let Right d = Quantity <$> mkPercentage .75 -- d is set to 0.25 in genesis
-        verify r
-            [ expectField (#decentralizationLevel) (`shouldBe` d) ]
 
     it "NETWORK_CLOCK - Can query network clock" $ \ctx -> do
         sandboxed <- inNixBuild

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Integration.Scenario.API.Shelley.Network
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiNetworkParameters (..), toApiNetworkParameters )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Quantity
+    ( Quantity (..), mkPercentage )
+import Test.Hspec
+    ( SpecWith, it, shouldBe )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , expectField
+    , expectResponseCode
+    , getFromResponse
+    , request
+    , verify
+    )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall t. SpecWith (Context t)
+spec = do
+    it "NETWORK_PARAMS - Able to fetch network parameters" $ \ctx -> do
+        r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty
+        expectResponseCode @IO HTTP.status200 r
+        let networkParams = getFromResponse id r
+        networkParams `shouldBe`
+            toApiNetworkParameters (ctx ^. #_networkParameters)
+        let Right d = Quantity <$> mkPercentage 0.75 -- d is set to 0.25 in genesis
+        verify r
+            [ expectField (#decentralizationLevel) (`shouldBe` d) ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -601,7 +601,7 @@ submitTx signedTx = do
 waitForSocket :: FilePath -> IO ()
 waitForSocket socketPath = do
     setEnv "CARDANO_NODE_SOCKET_PATH" socketPath
-    (st, _, err) <- retrying pol (const isSuccess) (const queryTip)
+    (st, _, err) <- retrying pol (const isFail) (const queryTip)
     unless (st == ExitSuccess) $
        throwIO $ ProcessHasExited
            ("cluster bft node didn't start correctly: " <> err) st
@@ -609,7 +609,7 @@ waitForSocket socketPath = do
     queryTip = readProcessWithExitCode
         "cardano-cli" ["shelley", "query", "tip", "--mainnet"]
         mempty
-    isSuccess (st, _, _) = pure (st == ExitSuccess)
+    isFail (st, _, _) = pure (st /= ExitSuccess)
     pol = limitRetriesByCumulativeDelay 30_000_000 $ constantDelay 1_000_000
 
 -- | Wait until a stake pool shows as registered on-chain.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -97,7 +97,7 @@ import Ouroboros.Network.NodeToClient
 import System.Directory
     ( copyFile, doesPathExist )
 import System.Environment
-    ( setEnv )
+    ( getEnv, setEnv )
 import System.Exit
     ( ExitCode (..) )
 import System.FilePath
@@ -114,6 +114,7 @@ import Test.Utils.Paths
     ( getTestData )
 
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
@@ -332,6 +333,25 @@ withStakePool tr severity (port, peers) action =
         ((either throwIO pure) =<<)
             $ withBackendProcess (trMessageText tr) cmd
             $ do
+                path <- getEnv "CARDANO_NODE_SOCKET_PATH"
+                doesExist <- doesPathExist path
+                B8.putStrLn $ B8.pack $ unlines
+                    [ "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , path
+                    , "does exist? " <> if doesExist then "yes" else "no"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    , "@@@@@@@@@@@@@@@@@@@@"
+                    ]
+
                 -- In order to get a working stake pool we need to.
                 --
                 -- 1. Register a stake key for our pool.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -97,9 +97,9 @@ import Ouroboros.Network.Magic
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..), nodeToClientCodecCBORTerm )
 import System.Directory
-    ( copyFile, doesPathExist )
+    ( copyFile )
 import System.Environment
-    ( getEnv, lookupEnv, setEnv )
+    ( lookupEnv, setEnv )
 import System.Exit
     ( ExitCode (..) )
 import System.FilePath
@@ -339,25 +339,6 @@ withStakePool tr severity idx (port, peers) action =
         ((either throwIO pure) =<<)
             $ withBackendProcess (trMessageText tr) cmd
             $ do
-                path <- getEnv "CARDANO_NODE_SOCKET_PATH"
-                doesExist <- doesPathExist path
-                B8.putStrLn $ B8.pack $ unlines
-                    [ "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , path
-                    , "does exist? " <> if doesExist then "yes" else "no"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    , "@@@@@@@@@@@@@@@@@@@@"
-                    ]
-
                 -- In order to get a working stake pool we need to.
                 --
                 -- 1. Register a stake key for our pool.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -117,6 +117,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import qualified Data.Yaml as Yaml
 
 data NetworkConfiguration where
@@ -232,6 +233,7 @@ withCluster tr severity n action = do
                     writeChan waitGroup $ Right port
                     readChan doneGroup)
 
+        TIO.putStrLn cartouche
         group <- waitAll
         if length (filter isRight group) /= n then do
             cancelAll
@@ -693,3 +695,21 @@ timeout t (title, action) = do
     race (threadDelay $ t * 1000000) action >>= \case
         Left _  -> fail ("Waited too long for: " <> title)
         Right a -> pure a
+
+-- | A little disclaimer shown in the logs when setting up the cluster.
+cartouche :: Text
+cartouche = T.unlines
+    [ ""
+    , "################################################################################"
+    , "#                                                                              #"
+    , "#  ⚠                           DISCLAIMER                                   ⚠  #"
+    , "#                                                                              #"
+    , "#        Cluster is booting. Stake pools are being registered on chain.        #"
+    , "#                                                                              #"
+    , "#        This may take roughly 30s, after what pools will become active        #"
+    , "#        and will start producing blocks. Please be patient...                 #"
+    , "#                                                                              #"
+    , "#  ⚠                           DISCLAIMER                                   ⚠  #"
+    , "#                                                                              #"
+    , "################################################################################"
+    ]

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -23,7 +23,6 @@ protocolParams:
   poolMinRefund: 0
   tau: 0
   a0: 0
-protocolMagicId: 0
 genDelegs:
   109adb1947f63d34cac80d3eed7bfe6bca605782580edfdc7bbc7af7c5089d47:
     delegate: caad228782456a194fbcbf42be829b09d58f0ef21e604711c19158b1f68b0805
@@ -32,7 +31,8 @@ updateQuorum: 5
 maxMajorPV: 25446
 initialFunds: {}
 maxLovelaceSupply: 45000000000000000
-networkMagic: 1
+protocolMagicId: 1
+networkMagic: 764824073
 networkId: Mainnet
 epochLength: 100
 staking:
@@ -41,6 +41,54 @@ slotLength: 0.2
 maxKESEvolutions: 90
 securityParam: 2160
 initialFunds:
+  # Cluster Faucets, used for setting up stake pools
+  #
+  # Generated with cardano-cli
+  # ==========================
+  # $ cardano-cli shelley genesis key-gen-utxo --verification-key-file utxo.pub --signing-key-file utxo.prv
+  # $ cardano-cli shelley genesis initial-addr --mainnet --verification-key-file utxo.pub
+  # $ cardano-cli shelley genesis initial-txin --mainnet --verification-key-file utxo.pub
+
+  # txin: ca2cada0a7c518cecddcdad2ea9b320d7a2d197565c64c37b3638a3428c9988a#0
+  # xprv:
+  #   type: Genesis UTxO signing key
+  #   title: Genesis initial UTxO key
+  #   cbor-hex:
+  #    582089574dc85f0359010458a6160836776fe2c8073ad460d3fba6d08ace684a90a3
+  61ca2cada0a7c518cecddcdad2ea9b320d7a2d197565c64c37b3638a3428c9988a: 10000000000000
+
+  # txin: cf28494def86c9917c8bef9faa9b3891e9e0a9f30a76f4576921a39b049d9398#0
+  # xprv:
+  #  type: Genesis UTxO signing key
+  #  title: Genesis initial UTxO key
+  #  cbor-hex:
+  #    5820cd42926a6a0d1651dbb08aa393322b0f9a0037f3579b5f8062a57c2ff6c025e4
+  61cf28494def86c9917c8bef9faa9b3891e9e0a9f30a76f4576921a39b049d9398: 10000000000000
+
+  # txin: 9b659bf3d026cf49e0387eb19473dad4b96db8480b7e26a3e20f5c63551303a7#0
+  # xprv:
+  #  type: Genesis UTxO signing key
+  #  title: Genesis initial UTxO key
+  #  cbor-hex:
+  #    5820863d7c0d65d34bebea180435b13e1c9bb885f2a18d3ff2b47435b91fad0293c0
+  619b659bf3d026cf49e0387eb19473dad4b96db8480b7e26a3e20f5c63551303a7: 10000000000000
+
+  # txin: 3c015335bd3a676a62e3d3c61828fa1ff0eb3dd950331aba93eec68e9e024411#0
+  # xprv:
+  #  type: Genesis UTxO signing key
+  #  title: Genesis initial UTxO key
+  #  cbor-hex:
+  #    5820c92896ab4c0af89459acf786315a6b13b23f037e4d9747c8414a0d48f7418075
+  613c015335bd3a676a62e3d3c61828fa1ff0eb3dd950331aba93eec68e9e024411: 10000000000000
+
+  # txin: 82a8981af11569eef547e012232f5306b85016d27aff4c1bbd5801800f83baab#0
+  # xprv:
+  #  type: Genesis UTxO signing key
+  #  title: Genesis initial UTxO key
+  #  cbor-hex:
+  #    58207b9de02388f78146cb53e4fb4a4d8917ac367cdfe0ff1d4008cc9da52af6ac74
+  6182a8981af11569eef547e012232f5306b85016d27aff4c1bbd5801800f83baab: 10000000000000
+
   # Byron wallets
   #
   # TODO: when supported by the cardano-node

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -1,12 +1,12 @@
 ---
-activeSlotsCoeff: 1
+activeSlotsCoeff: 0.1
 protocolParams:
   poolDecayRate: 0
   poolDeposit: 0
   protocolVersion:
     minor: 0
     major: 0
-  decentralisationParam: 1
+  decentralisationParam: 0.25
   maxTxSize: 4096
   minFeeA: 100
   maxBlockBodySize: 239857

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -57,7 +57,8 @@ options:
     cardano.node.ChainDB.metrics: []
     cardano.node.metrics.ChainDB: []
     cardano.node.metrics: []
-    cardano.node.metrics: []
+    cardano.node.ForgeTime: []
+    cardano.node.Forge: []
   mapSubtrace:
     cardano.node.Forge.metrics:
       subtrace: NoTrace

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -132,19 +132,20 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             describe "Mnemonics CLI tests" $ parallel (MnemonicsCLI.spec @t)
             describe "Miscellaneous CLI tests" $ parallel (MiscellaneousCLI.spec @t)
             describe "Key CLI tests" $ parallel (KeyCLI.spec @t)
-        describe "API Specifications" $ specWithServer tr $ do
-            Addresses.spec @n
-            Transactions.spec @n
-            Wallets.spec @n
-            HWWallets.spec @n
-            Network.spec
-        describe "CLI Specifications" $ specWithServer tr $ do
-            AddressesCLI.spec @n
-            TransactionsCLI.spec @n
-            WalletsCLI.spec @n
-            HWWalletsCLI.spec @n
-            PortCLI.spec @t
-            NetworkCLI.spec @t
+        specWithServer tr $ do
+            describe "API Specifications" $ do
+                Addresses.spec @n
+                Transactions.spec @n
+                Wallets.spec @n
+                HWWallets.spec @n
+                Network.spec
+            describe "CLI Specifications" $ do
+                AddressesCLI.spec @n
+                TransactionsCLI.spec @n
+                WalletsCLI.spec @n
+                HWWalletsCLI.spec @n
+                PortCLI.spec @t
+                NetworkCLI.spec @t
 
 specWithServer
     :: Trace IO Text

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -120,6 +120,9 @@ import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 
+import Test.Hspec
+    ( it )
+
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Shelley where
     commandName = "cardano-wallet-shelley"
@@ -145,6 +148,10 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             HWWalletsCLI.spec @n
             PortCLI.spec @t
             NetworkCLI.spec @t
+        describe "TEMPORARY" $ specWithServer tr $ do
+            it "PATATE" $ \_ -> do
+                pure () :: IO ()
+                -- threadDelay 10000000
 
 specWithServer
     :: Trace IO Text
@@ -180,7 +187,7 @@ specWithServer tr = aroundAll withContext . after tearDown
             either pure (throwIO . ProcessHasExited "integration")
 
     withServer action =
-        withCluster tr Info 1 $ \socketPath block0 (gp,vData) ->
+        withCluster tr Error 1 $ \socketPath block0 (gp,vData) ->
             withSystemTempDirectory "cardano-wallet-databases" $ \db ->
                 serveWallet @(IO Shelley)
                     (SomeNetworkDiscriminant $ Proxy @'Mainnet)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -108,6 +108,7 @@ import qualified Data.Text as T
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.API.Shelley.Addresses as Addresses
 import qualified Test.Integration.Scenario.API.Shelley.HWWallets as HWWallets
+import qualified Test.Integration.Scenario.API.Shelley.Network as Network_
 import qualified Test.Integration.Scenario.API.Shelley.Transactions as Transactions
 import qualified Test.Integration.Scenario.API.Shelley.Wallets as Wallets
 import qualified Test.Integration.Scenario.CLI.Keys as KeyCLI
@@ -139,6 +140,7 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
                 Wallets.spec @n
                 HWWallets.spec @n
                 Network.spec
+                Network_.spec
             describe "CLI Specifications" $ do
                 AddressesCLI.spec @n
                 TransactionsCLI.spec @n

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -120,9 +120,6 @@ import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 
-import Test.Hspec
-    ( it )
-
 -- | Define the actual executable name for the bridge CLI
 instance KnownCommand Shelley where
     commandName = "cardano-wallet-shelley"
@@ -148,10 +145,6 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             HWWalletsCLI.spec @n
             PortCLI.spec @t
             NetworkCLI.spec @t
-        describe "TEMPORARY" $ specWithServer tr $ do
-            it "PATATE" $ \_ -> do
-                pure () :: IO ()
-                -- threadDelay 10000000
 
 specWithServer
     :: Trace IO Text
@@ -187,7 +180,7 @@ specWithServer tr = aroundAll withContext . after tearDown
             either pure (throwIO . ProcessHasExited "integration")
 
     withServer action =
-        withCluster tr Error 1 $ \socketPath block0 (gp,vData) ->
+        withCluster tr Info 3 $ \socketPath block0 (gp,vData) ->
             withSystemTempDirectory "cardano-wallet-databases" $ \db ->
                 serveWallet @(IO Shelley)
                     (SomeNetworkDiscriminant $ Proxy @'Mainnet)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -180,21 +180,20 @@ specWithServer tr = aroundAll withContext . after tearDown
             either pure (throwIO . ProcessHasExited "integration")
 
     withServer action =
-        ((either throwIO pure) =<<) $
-        withCluster tr Info 0 $ \socketPath block0 (gp,vData) ->
-        withSystemTempDirectory "cardano-wallet-databases" $ \db -> do
-            serveWallet @(IO Shelley)
-                (SomeNetworkDiscriminant $ Proxy @'Mainnet)
-                (setupTracers (tracerSeverities (Just Info)) tr)
-                (SyncTolerance 10)
-                (Just db)
-                "127.0.0.1"
-                ListenOnRandomPort
-                Nothing
-                socketPath
-                block0
-                (gp, vData)
-                (action gp)
+        withCluster tr Info 1 $ \socketPath block0 (gp,vData) ->
+            withSystemTempDirectory "cardano-wallet-databases" $ \db ->
+                serveWallet @(IO Shelley)
+                    (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                    (setupTracers (tracerSeverities (Just Info)) tr)
+                    (SyncTolerance 10)
+                    (Just db)
+                    "127.0.0.1"
+                    ListenOnRandomPort
+                    Nothing
+                    socketPath
+                    block0
+                    (gp, vData)
+                    (action gp)
 
     -- | teardown after each test (currently only deleting all wallets)
     tearDown :: Context t -> IO ()

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -88,7 +88,7 @@ let
           # Only run integration tests on non-PR jobsets. Note that
           # the master branch jobset will just re-use the cached Bors
           # staging build and test results.
-          integration.doCheck = !isHydraPRJobset;
+          integration.doCheck = !isHydraPRJobset || stdenv.isDarwin; # fixme: rvl temp
 
           # Running Windows integration tests under Wine is disabled
           # because ouroboros-network doesn't fully work under Wine.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -88,7 +88,7 @@ let
           # Only run integration tests on non-PR jobsets. Note that
           # the master branch jobset will just re-use the cached Bors
           # staging build and test results.
-          integration.doCheck = !isHydraPRJobset || stdenv.isDarwin; # fixme: rvl temp
+          integration.doCheck = !isHydraPRJobset;
 
           # Running Windows integration tests under Wine is disabled
           # because ouroboros-network doesn't fully work under Wine.

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -98,8 +98,8 @@ let
           unit.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
           integration.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
 
-          # provide cardano-node command to integration tests
-          integration.build-tools = [ pkgs.cardano-node ];
+          # provide cardano-node & cardano-cli to integration tests
+          integration.build-tools = [ pkgs.cardano-node pkgs.cardano-cli ];
         };
         packages.cardano-wallet-jormungandr.components.tests = {
           # Next releases are going to be about cardano-node and we

--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -10,7 +10,7 @@ haskell.lib.buildStackProject rec {
   ghc = walletPackages.haskellPackages._config.ghc.package;
 
   buildInputs =
-    (with walletPackages; [ jormungandr jormungandr-cli cardano-node ]) ++
+    (with walletPackages; [ jormungandr jormungandr-cli cardano-node cardano-cli ]) ++
     [ zlib gmp ncurses lzma openssl ] ++
     (lib.optionals (!stdenv.isDarwin) [ git systemd.dev ]) ++
     (lib.optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [ Cocoa CoreServices libcxx libiconv ]));


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- de6fec030e2ec6ba0ea232df79f4ff133fe82f5a
  :round_pushpin: **add command-line helpers for generating stake key and certificates**
  
- 50ae86187a8dae89d67840c9d801df193f4d59fb
  :round_pushpin: **improve error handling and reporting when member of the cluster fail to start**
  It's actually nice to be able to tell what's going on. The command-line will likely undergo changes so it's really likely
that a command that used to work will fail. The previous message was sort of opaque / cryptic. Now we get a better error.

- 772c813dcfa9cc7831119756d92d432590eb9417
  :round_pushpin: **fixup add new gen methods**
  
- bb2b82e906f1df0c8fcaea6fa5e903578c997ef8
  :round_pushpin: **register stake pool and delegate funds to it using genesis faucets.**
  This makes sure that a stake pool joins the cluster only after it has been registered and is ready to process block.

- e08d5cd6f973f6be70fbabb3019d15c2d92a6a7c
  :round_pushpin: **Drop use of 'withAsync' so pools boot in parallel**
  The issue with 'withAsync' is that it's actually synchronous.
While the underlying action is executed in a thread, 'withAsync' will
only resolve when the async action is done. Yet, in our case, we want
all async actions to run in parallel and to be stopped when the test
suite is completed.

- de7559f772f3d173fbddcd5afb27afbf35bac69b
  :round_pushpin: **make the node a little less verbose regarding forging**
  With a slot length of 0.2, blocks are produced at a much faster pace.

- b2b3c0b97d5a9283380285a640765c9306d086a4
  :round_pushpin: **tweak genesis parameters with sensible values**
  A value of '1' for the active slot coefficient makes actually no sense. Only small values of it are
considered sensible. Tweaking also the decentralization level so that some blocks are deferred to
registered stake pools

- adf9dda8b854d148df22486a162f32de8ddb0af1
  :round_pushpin: **start a cluster of 3 pools when running integration tests**
  
- aaf7d6d1d04fb299126e40f121121db52320a7f2
  :round_pushpin: **show little disclaimer when starting integration tests**
  
- 2d7ece596e0c99d7b4846875399d069b2707cf75
  :round_pushpin: **do not restart the cluster between CLI and API spec**
  We have a limited number of faucets, and it takes quite some time now

# Comments

<!-- Additional comments or screenshots to attach if any -->

With this, we should be able to test all sort of things regarding pools o/ 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
