### PR TITLE
Tweak stack.yaml snapshot to include katip-0.8.4.0

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -35,7 +35,7 @@
         "hspec-discover" = (((hackage.hspec-discover)."2.7.0").revisions).default;
         "io-streams" = (((hackage.io-streams)."1.5.1.0").revisions).default;
         "io-streams-haproxy" = (((hackage.io-streams-haproxy)."1.0.1.0").revisions).default;
-        "katip" = (((hackage.katip)."0.8.3.0").revisions).default;
+        "katip" = (((hackage.katip)."0.8.4.0").revisions).default;
         "libsystemd-journal" = (((hackage.libsystemd-journal)."1.4.4").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "moo" = (((hackage.moo)."1.2").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/6043ec618cea169366728a35401f39208fd0d97a/snapshots/cardano-1.13.0.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/0055f4dee47f966f1cb45e03610dac727c87e0a8/snapshots/cardano-1.13.0.yaml
 
 packages:
 - lib/core


### PR DESCRIPTION
See input-output-hk/cardano-haskell#20

Apologies for the rebuild.
