### PR TITLE
Release notes template: remove Troubleshooting section

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -3,7 +3,7 @@
 Compatible with [`jormungandr@{{JORM_TAG}}`](https://github.com/input-output-hk/jormungandr/releases/tag/{{JORM_TAG}}) and [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-output-hk/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
 
 <!-- A CHANGELOG, organized in three sections:
- 
+
  - New Features
  - Improvements
  - Resolved Issues
@@ -91,26 +91,6 @@ $ docker run --rm inputoutput/cardano-wallet:{{CABAL_VERSION}}-byron version
 ### Additional notes
 
 - On macOS: Make sure all `*.dylib` files are in the same directory as `cardano-wallet` binary.
-
-
-#### TroubleShooting
-
-<details>
-<summary>cardano-wallet: error while loading shared libraries: <code>libcrypto.so.1.0.0</code>: cannot open shared object file: No such file or directory</summary>
-
-`libcrypto 1.0.0` is no longer shipped with RHEL for a while (since ver. 6) and
-SuSE. On these distributions, it is impossible to install it using native
-package manager (e.g. `yum`).
-
-One possible work-around is to create an artificial symbolic link from a newer version of `libcrypto`:
-
-```bash
-sudo ln -s /usr/lib64/libcrypto.so.1.1.1 /usr/lib64/libcrypto.so.1.0.0
-```
-
-Alternatively, one may also try using the docker image instead.
-
-</details>
 
 ## Signatures
 


### PR DESCRIPTION
The Linux shared libraries issue no longer applies. The binary is now fully statically linked.

    /tmp/cardano-wallet: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
