### PR TITLE
Remove redundant integration test jobs on hydra

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -121,7 +121,7 @@ let
           unit.build-tools = [ jmPkgs.jormungandr ];
         };
         packages.cardano-wallet-jormungandr.components.benchmarks.latency =
-          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+          lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/latency \
@@ -132,7 +132,7 @@ let
 
         # Add cardano-node to the PATH of the byron latency benchmark
         packages.cardano-wallet-byron.components.benchmarks.latency =
-          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+          lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/latency \
@@ -144,7 +144,7 @@ let
         # cardano-node will want to write logs to a subdirectory of the working directory.
         # We don't `cd $src` because of that.
         packages.cardano-wallet-byron.components.benchmarks.restore =
-          pkgs.lib.optionalAttrs (!pkgs.stdenv.hostPlatform.isWindows) {
+          lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
             build-tools = [ pkgs.makeWrapper ];
             postInstall = ''
               wrapProgram $out/bin/restore \
@@ -163,17 +163,17 @@ let
         '';
 
         # Workaround for Haskell.nix issue
-        packages.cardano-wallet-jormungandr.components.all.preBuild = pkgs.lib.mkForce "";
-        packages.cardano-wallet-jormungandr.components.all.postInstall = pkgs.lib.mkForce "";
-        packages.cardano-wallet-core.components.all.preBuild = pkgs.lib.mkForce "";
-        packages.cardano-wallet-byron.components.all.postInstall = pkgs.lib.mkForce "";
+        packages.cardano-wallet-byron.components.all.postInstall = lib.mkForce "";
+        packages.cardano-wallet-core.components.all.preBuild = lib.mkForce "";
+        packages.cardano-wallet-jormungandr.components.all.postInstall = lib.mkForce "";
+        packages.cardano-wallet-jormungandr.components.all.preBuild = lib.mkForce "";
       }
 
       # Build fixes for library dependencies
       {
         # Make the /usr/bin/security tool available because it's
         # needed at runtime by the x509-system Haskell package.
-        packages.x509-system.components.library.preBuild = pkgs.lib.optionalString (pkgs.stdenv.isDarwin) ''
+        packages.x509-system.components.library.preBuild = lib.optionalString (stdenv.isDarwin) ''
           substituteInPlace System/X509/MacOS.hs --replace security /usr/bin/security
         '';
 

--- a/release.nix
+++ b/release.nix
@@ -67,6 +67,7 @@ let
   buildNative  = builtins.elem builtins.currentSystem supportedSystems;
   buildLinux   = builtins.elem "x86_64-linux" supportedSystems;
   buildMacOS   = builtins.elem "x86_64-darwin" supportedSystems;
+  buildMusl    = builtins.elem "x86_64-linux" supportedCrossSystems && buildLinux;
   buildWindows = builtins.elem builtins.currentSystem supportedCrossSystems;
 in
 
@@ -107,7 +108,7 @@ let
     # Cross compilation, excluding the dockerImage and shells that we cannnot cross compile
     "${mingwW64.config}" = mapTestOnCross mingwW64
       (packagePlatformsCross (filterJobsCross project));
-  } // optionalAttrs buildLinux {
+  } // optionalAttrs buildMusl {
     musl64 = mapTestOnCross musl64
       (packagePlatformsCross (filterJobsCross project));
   }
@@ -136,7 +137,7 @@ let
           jobs.cardano-wallet-byron-macos64
           jobs.cardano-wallet-shelley-macos64
         ]) ++
-      optionals buildLinux [
+      optionals buildMusl [
           # Release packages for Linux
           jobs.cardano-wallet-jormungandr-linux64
           jobs.cardano-wallet-byron-linux64
@@ -185,7 +186,7 @@ let
       tests = collectTests jobs.x86_64-w64-mingw32.tests;
       benchmarks = collectTests jobs.x86_64-w64-mingw32.benchmarks;
     };
-  } // optionalAttrs buildLinux {
+  } // optionalAttrs buildMusl {
     # Fully-static linux binaries
     cardano-wallet-jormungandr-linux64 = import ./nix/linux-release.nix {
       inherit pkgs;


### PR DESCRIPTION
### Overview

Remove redundant integration test jobs on hydra
    
We don't need to run integration tests for both linux glibc and musl. Choose musl, because that's what our release binaries are.

And remove the windows cardano-node integration test jobs, because ouroboros-network doesn't fully work under Wine.

- [PR Jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-1748#tabs-jobs)

~And while we're here, update Haskell.nix and iohk-nix, and fix resulting errors.~ ⇒  #1791

### Comments

- First attempt editing `nix/haskell.nix` did not work because the jobset evaluator is always a linux system. The job filtering needs to be done in `release.nix`.
