### PR TITLE
List stake pools

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -27,13 +27,13 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..), PoolId (..), TxStatus (..) )
+    ( Direction (..), PoolId (..), TxStatus (..), WalletId )
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text.Class
-    ( toText )
+    ( fromText, toText )
 import Test.Hspec
     ( SpecWith, describe, it, shouldBe, xit )
 import Test.Integration.Framework.DSL
@@ -79,6 +79,7 @@ import Test.Integration.Framework.TestData
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.ByteString as BS
+import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
 
@@ -469,5 +470,13 @@ spec = do
                     (#metrics . #saturation) (.>= 0)
                 ]
 
+    it "STAKE_POOLS_LIST_05 - Fails for unknown wallets" $ \ctx -> do
+        -- FIXME: Type inference breaks without this line:
+        _w <- fixtureWallet ctx
+
+        r <- request @[ApiStakePool] ctx (Link.listStakePools (ApiT invalidWalletId, ())) Default Empty
+        expectResponseCode HTTP.status404 r
   where
+    invalidWalletId :: WalletId
+    invalidWalletId = either (error . show) id $ fromText $ T.pack $ replicate 40 '0'
     passwd = "Secure Passphrase"

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -476,6 +476,21 @@ spec = do
 
         r <- request @[ApiStakePool] ctx (Link.listStakePools (ApiT invalidWalletId, ())) Default Empty
         expectResponseCode HTTP.status404 r
+
+    it "STAKE_POOLS_LIST_06 - NonMyopicMemberRewards are 0 for empty wallets" $ \ctx -> do
+        w <- emptyWallet ctx
+        eventually "Listing stake pools shows expected information" $ do
+            r <- request @[ApiStakePool] ctx (Link.listStakePools w) Default Empty
+            expectResponseCode HTTP.status200 r
+            verify r
+                [ expectListSize 3
+                , expectListField 0
+                    (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
+                , expectListField 1
+                    (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
+                , expectListField 2
+                    (#metrics . #nonMyopicMemberRewards) (`shouldBe` Quantity 0)
+                ]
   where
     invalidWalletId :: WalletId
     invalidWalletId = either (error . show) id $ fromText $ T.pack $ replicate 40 '0'

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -48,6 +48,7 @@ import Test.Integration.Framework.DSL
     , expectErrorMessage
     , expectField
     , expectListField
+    , expectListSize
     , expectResponseCode
     , fixturePassphrase
     , fixtureWallet
@@ -65,6 +66,7 @@ import Test.Integration.Framework.DSL
     , walletId
     , (.<=)
     , (.>)
+    , (.>=)
     )
 import Test.Integration.Framework.TestData
     ( errMsg403DelegationFee
@@ -412,6 +414,60 @@ spec = do
             [ expectResponseCode HTTP.status403
             , expectErrorMessage $ errMsg403DelegationFee fee
             ]
+
+    it "STAKE_POOLS_LIST_01 - List stake pools" $ \ctx -> do
+        w <- fixtureWallet ctx
+        eventually "Listing stake pools shows expected information" $ do
+            r <- request @[ApiStakePool] ctx (Link.listStakePools w) Default Empty
+            expectResponseCode HTTP.status200 r
+            verify r
+                [ expectListSize 3
+
+-- Pending a mock metadata registry
+--                , expectListField 0
+--                    #metadata ((`shouldBe` Just "Genesis Pool") . fmap (view #name . getApiT))
+--                , expectListField 1
+--                    #metadata ((`shouldBe` Just "Genesis Pool") . fmap (view #name . getApiT))
+--                , expectListField 2
+--                    #metadata ((`shouldBe` Just "Genesis Pool") . fmap (view #name . getApiT))
+
+                , expectListField 0
+                    #cost (`shouldBe` (Quantity 0))
+                , expectListField 1
+                    #cost (`shouldBe` (Quantity 0))
+                , expectListField 2
+                    #cost (`shouldBe` (Quantity 0))
+
+                , expectListField 0
+                    #margin (`shouldBe` (Quantity minBound))
+                , expectListField 1
+                    #margin (`shouldBe` (Quantity minBound))
+                , expectListField 2
+                    #margin (`shouldBe` (Quantity minBound))
+
+-- Pending stake pools producing blocks in our setup,
+-- AND pending keeping track of block producions
+--                , expectListField 0
+--                    (#metrics . #producedBlocks) (.>= Quantity 0)
+--                , expectListField 1
+--                    (#metrics . #producedBlocks) (.>= Quantity 0)
+--                , expectListField 2
+--                    (#metrics . #producedBlocks) (.>= Quantity 0)
+--
+--                , expectListField 0
+--                    (#metrics . #nonMyopicMemberRewards) (.>= Quantity 0)
+--                , expectListField 1
+--                    (#metrics . #nonMyopicMemberRewards) (.>= Quantity 0)
+--                , expectListField 2
+--                    (#metrics . #nonMyopicMemberRewards) (.>= Quantity 0)
+
+                , expectListField 0
+                    (#metrics . #saturation) (.>= 0)
+                , expectListField 1
+                    (#metrics . #saturation) (.>= 0)
+                , expectListField 2
+                    (#metrics . #saturation) (.>= 0)
+                ]
 
   where
     passwd = "Secure Passphrase"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -81,6 +81,7 @@ module Cardano.Wallet.Api.Server
     , withLegacyLayer'
     , rndStateChange
     , assignMigrationAddresses
+    , withWorkerCtx
     ) where
 
 import Prelude

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -17,6 +17,7 @@ module Cardano.Wallet.Network
     , follow
     , FollowAction (..)
     , FollowExit (..)
+    , GetStakeDistribution
 
     -- * Errors
     , ErrNetworkUnavailable (..)
@@ -43,9 +44,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , ChimericAccount (..)
-    , EpochNo
     , Hash (..)
-    , PoolId (..)
     , ProtocolParameters
     , SealedTx
     , SlotId
@@ -71,8 +70,6 @@ import Control.Tracer
     ( Tracer, traceWith )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Map
-    ( Map )
 import Data.Quantity
     ( Quantity (..) )
 import Data.Text
@@ -128,9 +125,7 @@ data NetworkLayer m target block = NetworkLayer
         -- ^ Broadcast a transaction to the chain producer
 
     , stakeDistribution
-        :: EpochNo
-        -> ExceptT ErrNetworkUnavailable m
-            (Map PoolId (Quantity "lovelace" Word64))
+        :: GetStakeDistribution target m
 
     , getAccountBalance
         :: ChimericAccount
@@ -224,6 +219,12 @@ defaultRetryPolicy =
     limitRetriesByCumulativeDelay (3600 * second) (constantDelay second)
   where
     second = 1000*1000
+
+{-------------------------------------------------------------------------------
+                                 Queries
+-------------------------------------------------------------------------------}
+
+type family GetStakeDistribution target (m :: * -> *) :: *
 
 {-------------------------------------------------------------------------------
                                 Chain Sync

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -107,6 +107,7 @@ import Cardano.Wallet.Jormungandr.Compatibility
 import Cardano.Wallet.Network
     ( Cursor
     , ErrGetAccountBalance (..)
+    , GetStakeDistribution
     , NetworkLayer (..)
     , NextBlocksResult (..)
     , defaultRetryPolicy
@@ -454,6 +455,16 @@ mkRawNetworkLayer np batchSize st j = NetworkLayer
                 RollBackward (cursorBackward baseH cursor)
             _ ->
                 RollBackward $ Cursor emptyBlockHeaders
+
+
+{-------------------------------------------------------------------------------
+                                 Queries
+-------------------------------------------------------------------------------}
+
+type instance GetStakeDistribution Jormungandr m =
+    EpochNo
+    -> ExceptT ErrNetworkUnavailable m
+        (Map PoolId (Quantity "lovelace" Word64))
 
 {-------------------------------------------------------------------------------
                              Jormungandr Cursor

--- a/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -11,13 +11,17 @@ import Cardano.BM.Trace
 import Cardano.Pool.DB
     ( DBLayer (..) )
 import Cardano.Pool.Jormungandr.Metrics
-    ( monitorStakePools )
+    ( Block, monitorStakePools )
 import Cardano.Wallet.Jormungandr
     ( toSPBlock )
+import Cardano.Wallet.Jormungandr.Compatibility
+    ( Jormungandr )
 import Cardano.Wallet.Jormungandr.Launch
     ( withConfig )
 import Cardano.Wallet.Jormungandr.Network
     ( JormungandrBackend (..), withJormungandr, withNetworkLayer )
+import Cardano.Wallet.Network
+    ( NetworkLayer )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , GenesisParameters (..)
@@ -109,7 +113,8 @@ spec = around setup $ do
 
     withMonitorStakePoolsThread (block0, k) nl db action = do
         bracket
-            (forkIO $ void $ monitorStakePools nullTracer (block0, k) nl db)
+            (forkIO $ void $ monitorStakePools nullTracer (block0, k)
+                (nl :: NetworkLayer IO Jormungandr Block) db)
             killThread
             action
 

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -39,10 +39,13 @@ import Cardano.Pool.Jormungandr.Metrics
     )
 import Cardano.Pool.Jormungandr.Ranking
     ( EpochConstants (..), unsafeMkNonNegative, unsafeMkPositive )
+import Cardano.Wallet.Jormungandr.Network
+    ()
 import Cardano.Wallet.Network
     ( Cursor
     , ErrGetBlock (..)
     , ErrNetworkUnavailable (..)
+    , GetStakeDistribution
     , NetworkLayer (..)
     , NextBlocksResult (..)
     )
@@ -271,6 +274,11 @@ prop_trackRegistrations test = monadicIO $ do
             }
 
 data instance Cursor RegistrationsTest = Cursor BlockHeader
+
+type instance GetStakeDistribution RegistrationsTest m =
+    EpochNo
+    -> ExceptT ErrNetworkUnavailable m
+        (Map PoolId (Quantity "lovelace" Word64))
 
 test_emptyDatabaseNotSynced :: IO ()
 test_emptyDatabaseNotSynced = do

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -67,6 +67,7 @@ library
     , retry
     , servant-server
     , shelley-spec-ledger
+    , sort
     , temporary
     , text
     , text-class
@@ -85,6 +86,7 @@ library
       Cardano.Wallet.Shelley.Network
       Cardano.Wallet.Shelley.Transaction
       Cardano.Wallet.Shelley.Launch
+      Cardano.Wallet.Shelley.Pools
 
 executable cardano-wallet-shelley
   default-language:

--- a/lib/shelley/exe/cardano-wallet-shelley.hs
+++ b/lib/shelley/exe/cardano-wallet-shelley.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -36,6 +37,7 @@ import Cardano.CLI
     , cmdKey
     , cmdMnemonic
     , cmdNetwork
+    , cmdStakePool
     , cmdTransaction
     , cmdVersion
     , cmdWallet
@@ -63,9 +65,16 @@ import Cardano.Startup
     , withUtf8Encoding
     )
 import Cardano.Wallet.Api.Client
-    ( addressClient, networkClient, transactionClient, walletClient )
+    ( addressClient
+    , networkClient
+    , stakePoolClient
+    , transactionClient
+    , walletClient
+    )
 import Cardano.Wallet.Api.Server
     ( HostPreference, Listen (..), TlsConfiguration )
+import Cardano.Wallet.Api.Types
+    ( ApiStakePool )
 import Cardano.Wallet.Logging
     ( trMessage, transformTextTrace )
 import Cardano.Wallet.Primitive.Types
@@ -137,6 +146,7 @@ main = withUtf8Encoding $ do
         <> cmdAddress addressClient
         <> cmdTransaction transactionClient walletClient
         <> cmdNetwork networkClient
+        <> cmdStakePool @ApiStakePool stakePoolClient
         <> cmdVersion
 
 beforeMainLoop

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -550,10 +550,11 @@ fromNonMyopicMemberRewards =
     . O.unNonMyopicMemberRewards
 
 optimumNumberOfPools :: SL.PParams -> Int
-optimumNumberOfPools = safeConvert . SL._nOpt
+optimumNumberOfPools = unsafeConvert . SL._nOpt
   where
-    safeConvert :: Natural -> Int
-    safeConvert = fromIntegral
+    -- A value of ~100 can be expected, so should be fine.
+    unsafeConvert :: Natural -> Int
+    unsafeConvert = fromIntegral
 
 --
 -- Txs

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -58,7 +58,7 @@ module Cardano.Wallet.Shelley.Compatibility
       -- ** Stake pools
     , fromPoolId
     , fromPoolDistr
-    , fromRewards
+    , fromNonMyopicMemberRewards
     , optimumNumberOfPools
 
 
@@ -103,6 +103,8 @@ import Control.Arrow
     ( left )
 import Crypto.Hash.Algorithms
     ( Blake2b_256 (..) )
+import Data.Bifunctor
+    ( bimap )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase )
 import Data.ByteString
@@ -538,16 +540,13 @@ fromPoolDistr =
     . Map.mapKeys fromPoolId
     . SL.unPoolDistr
 
--- TODO: Change to return a map of maps, instead of using head
-fromRewards
+-- NOTE: This function disregards results that are using staking keys
+fromNonMyopicMemberRewards
     :: O.NonMyopicMemberRewards TPraosStandardCrypto
-    -> Map W.PoolId (Quantity "lovelace" Word64)
-fromRewards =
-    Map.map (Quantity . fromIntegral)
-    . Map.mapKeys fromPoolId
-    . snd
-    . head
-    . Map.toList
+    -> Map (Either W.Coin W.ChimericAccount) (Map W.PoolId (Quantity "lovelace" Word64))
+fromNonMyopicMemberRewards =
+    Map.map (Map.map (Quantity . fromIntegral) . Map.mapKeys fromPoolId)
+    . Map.mapKeys (bimap fromShelleyCoin fromStakeCredential)
     . O.unNonMyopicMemberRewards
 
 optimumNumberOfPools :: SL.PParams -> Int

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -122,8 +122,9 @@ fetchLsqPoolMetrics queue pt coin = do
         -- calculate the saturation from the relative stake
         sat s = fromRational $ (getPercentage s) / (1 / fromIntegral nOpt)
 
-        -- Haven't figured out how to fetch non-myopic member rewards properly yet.
-        -- Let's provide a default value of 0, at least for now.
+        -- If we fetch non-myopic member rewards of pools using the wallet
+        -- balance of 0, the resulting map will be empty. So we set the rewards
+        -- to 0 here:
         stakeButNoRewards = traverseMissing $ \_k s -> pure $ PoolLsqMetrics
             { nonMyopicMemberRewards = Quantity 0
             , relativeStake = s

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -1,0 +1,202 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+-- |
+-- Copyright: © 2020 IOHK
+-- License: Apache-2.0
+--
+-- Haskell-node "shelley" implementation of the @StakePoolLayer@ abstraction,
+-- i.e. some boring glue.
+module Cardano.Wallet.Shelley.Pools where
+
+import Prelude
+
+import Cardano.Wallet.Api.Server
+    ( LiftHandler (..), apiError )
+import Cardano.Wallet.Api.Types
+    ( ApiErrorCode (..), ApiT (..) )
+import Cardano.Wallet.Network
+    ( NetworkLayer (..) )
+import Cardano.Wallet.Primitive.Types
+    ( Coin (..), GenesisParameters (..), PoolId )
+import Cardano.Wallet.Shelley.Compatibility
+    ( Shelley
+    , ShelleyBlock
+    , fromPoolDistr
+    , fromRewards
+    , optimumNumberOfPools
+    , toPoint
+    , toShelleyCoin
+    )
+import Cardano.Wallet.Shelley.Network
+    ( pattern Cursor )
+import Cardano.Wallet.Unsafe
+    ( unsafeMkPercentage, unsafeRunExceptT )
+import Control.Monad.Class.MonadSTM
+    ( MonadSTM, TQueue )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), runExceptT, withExceptT )
+import Data.Map
+    ( Map )
+import Data.Map.Merge.Strict
+    ( dropMissing, traverseMissing, zipWithMatched )
+import Data.Ord
+    ( Down (..) )
+import Data.Quantity
+    ( Percentage (..), Quantity (..) )
+import Data.Sort
+    ( sortOn )
+import Data.Word
+    ( Word64 )
+import GHC.Generics
+    ( Generic )
+import Ouroboros.Network.Block
+    ( Point )
+import Ouroboros.Network.Client.Wallet
+    ( LocalStateQueryCmd (..), send )
+import Servant
+    ( Handler, err500 )
+
+import qualified Cardano.Wallet.Api.Types as Api
+import qualified Data.Map.Merge.Strict as Map
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Ouroboros.Consensus.Shelley.Ledger as OC
+
+-- | Stake Pool Data fields fetched from the node via LSQ
+data PoolLsqMetrics = PoolLsqMetrics
+    { nonMyopicMemberRewards :: Quantity "lovelace" Word64
+    , stake :: Percentage
+    , saturation :: Double
+    } deriving (Eq, Show, Generic)
+
+
+data ErrFetchMetrics = ErrFetchMetrics
+  deriving Show
+
+askNode
+    :: MonadSTM m
+    => TQueue m (LocalStateQueryCmd ShelleyBlock m)
+    -> Point ShelleyBlock
+    -> Coin
+    -> ExceptT ErrFetchMetrics m (Map PoolId PoolLsqMetrics)
+askNode queue pt coin = do
+    stakeMap <- fromPoolDistr <$> handleQueryFailure
+        (queue `send` CmdQueryLocalState pt OC.GetStakeDistribution)
+    let toStake = Set.singleton $ Left $ toShelleyCoin coin
+    rewardMap <- fromRewards <$> handleQueryFailure
+        (queue `send` CmdQueryLocalState pt (OC.GetNonMyopicMemberRewards toStake))
+    pparams <- handleQueryFailure
+        (queue `send` CmdQueryLocalState pt OC.GetCurrentPParams)
+
+    return $ combine
+        (optimumNumberOfPools pparams)
+        stakeMap
+        rewardMap
+  where
+    handleQueryFailure = withExceptT (const ErrFetchMetrics) . ExceptT
+
+    combine
+        :: Int -- ^ Desired number of pools
+        -> Map PoolId Percentage
+        -> Map PoolId (Quantity "lovelace" Word64)
+        -> Map PoolId PoolLsqMetrics
+    combine nOpt =
+        Map.merge stakeButNoRew rewardsButNoStake bothPresent
+      where
+        -- calculate the saturation from the relative stake
+        sat s = fromRational $ (getPercentage s) / (1 / fromIntegral nOpt)
+
+        -- Haven't figured out how to fetch non-myopic member rewards properly yet.
+        -- Let's provide a default value of 0, at least for now.
+        stakeButNoRew     = traverseMissing $ \_k s -> pure $ PoolLsqMetrics
+            { nonMyopicMemberRewards = Quantity 0
+            , stake = s
+            , saturation = (sat s)
+            }
+
+        rewardsButNoStake = dropMissing
+
+        bothPresent       = zipWithMatched  $ \_k s r -> PoolLsqMetrics r s (sat s)
+
+readBlockProductions :: IO (Map PoolId Int)
+readBlockProductions = return Map.empty
+
+--
+-- Api Server Handler
+--
+
+instance LiftHandler ErrFetchMetrics where
+    handler = \case
+        ErrFetchMetrics ->
+            apiError err500 NotSynced $ mconcat
+                [ "There was a problem fetching metrics from the node."
+                ]
+
+data StakePoolLayer = StakePoolLayer
+    { knownPools :: IO [PoolId]
+    , listStakePools :: Coin -> Handler [Api.ApiStakePool]
+      -- TODO: Maybe weird type, but let's do it for now.
+    }
+
+
+newStakePoolLayer
+    :: GenesisParameters
+    -> NetworkLayer IO (IO Shelley) b
+    -> StakePoolLayer
+newStakePoolLayer gp nl = StakePoolLayer
+    { knownPools = _knownPools
+    , listStakePools = _listPools
+    }
+  where
+    dummyCoin = Coin 0
+
+    -- Note: We shouldn't have to do this conversion.
+    el = getEpochLength gp
+    gh = getGenesisBlockHash gp
+    getTip = fmap (toPoint gh el) . liftIO $ unsafeRunExceptT $ currentNodeTip nl
+
+    _knownPools
+        :: IO [PoolId]
+    _knownPools = do
+        Cursor _workerTip _ lsqQ <- initCursor nl []
+        pt <- getTip
+        res <- runExceptT $ map fst . Map.toList <$> askNode lsqQ pt dummyCoin
+        case res of
+            Right x -> return x
+            Left _e -> return []
+
+
+    _listPools
+        :: Coin
+        -- ^ The amount of stake the user intends to delegate, which may affect the
+        -- ranking of the pools.
+        -> Handler [Api.ApiStakePool]
+    _listPools s = liftHandler $ do
+            Cursor _workerTip _ lsqQ <- liftIO $ initCursor nl []
+            pt <- liftIO getTip
+            map mkApiPool
+                . sortOn (Down . nonMyopicMemberRewards . snd)
+                . Map.toList <$> askNode lsqQ pt s
+      where
+        mkApiPool (pid, PoolLsqMetrics prew pstk psat) = Api.ApiStakePool
+            { Api.id = (ApiT pid)
+            , Api.metrics = Api.ApiStakePoolMetrics
+                { Api.nonMyopicMemberRewards = (mapQ fromIntegral prew)
+                , Api.relativeStake = Quantity pstk
+                , Api.saturation = psat
+                , Api.producedBlocks = Quantity 0 -- TODO: Implement
+                }
+            , Api.metadata = Nothing -- TODO: Implement
+            , Api.cost = Quantity 0 -- TODO: Implement
+            , Api.margin = Quantity $ unsafeMkPercentage 0 -- TODO: Implement
+            }
+
+        mapQ f (Quantity x) = Quantity $ f x

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -75,7 +75,7 @@ import qualified Ouroboros.Consensus.Shelley.Ledger as OC
 -- | Stake Pool Data fields fetched from the node via LSQ
 data PoolLsqMetrics = PoolLsqMetrics
     { nonMyopicMemberRewards :: Quantity "lovelace" Word64
-    , stake :: Percentage
+    , relativeStake :: Percentage
     , saturation :: Double
     } deriving (Eq, Show, Generic)
 
@@ -124,7 +124,7 @@ askNode queue pt coin = do
         -- Let's provide a default value of 0, at least for now.
         stakeButNoRew     = traverseMissing $ \_k s -> pure $ PoolLsqMetrics
             { nonMyopicMemberRewards = Quantity 0
-            , stake = s
+            , relativeStake = s
             , saturation = (sat s)
             }
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -115,14 +115,14 @@ askNode queue pt coin = do
         -> Map PoolId (Quantity "lovelace" Word64)
         -> Map PoolId PoolLsqMetrics
     combine nOpt =
-        Map.merge stakeButNoRew rewardsButNoStake bothPresent
+        Map.merge stakeButNoRewards rewardsButNoStake bothPresent
       where
         -- calculate the saturation from the relative stake
         sat s = fromRational $ (getPercentage s) / (1 / fromIntegral nOpt)
 
         -- Haven't figured out how to fetch non-myopic member rewards properly yet.
         -- Let's provide a default value of 0, at least for now.
-        stakeButNoRew     = traverseMissing $ \_k s -> pure $ PoolLsqMetrics
+        stakeButNoRewards = traverseMissing $ \_k s -> pure $ PoolLsqMetrics
             { nonMyopicMemberRewards = Quantity 0
             , relativeStake = s
             , saturation = (sat s)

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -64,6 +64,7 @@
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
+          (hsPkgs."sort" or (errorHandler.buildDepError "sort"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1610,6 +1610,7 @@ x-responsesListAddresses: &responsesListAddresses
 
 x-responsesListStakePools: &responsesListStakePools
   <<: *responsesErr405
+  <<: *responsesErr404
   200:
     description: Ok
     content:
@@ -1927,9 +1928,7 @@ paths:
         Some pools _may_ also have metadata attached to them.
       parameters:
         - *parametersWalletId
-      responses:
-        - *responsesListStakePools
-        - *responsesErr404
+      responses: *responsesListStakePools
 
   /stake-pools/{stakePoolId}/wallets/{walletId}:
     put:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1927,7 +1927,9 @@ paths:
         Some pools _may_ also have metadata attached to them.
       parameters:
         - *parametersWalletId
-      responses: *responsesListStakePools
+      responses:
+        - *responsesListStakePools
+        - *responsesErr404
 
   /stake-pools/{stakePoolId}/wallets/{walletId}:
     put:


### PR DESCRIPTION
# Issue Number

#1718, #1720

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Allow heterogeneous queues of LSQ queries such that we can query for stake, rewards, and pparams using the same queue.
- [x] Retrieve pool id, stake and saturation and make the API return it
- [x] Stubbed values for non-myopic member rewards, margin, cost, produced blocks

# Comments

- Actually fetching non-myopic member rewards depends on a consensus change reaching cardano-node.

- Working chain following may be a non-goal for this PR, but trying to make room for it.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
