### PR TITLE
Add logging and tracing to shelley integration tests

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -62,6 +62,7 @@ module Cardano.CLI
     , helperTracing
     , loggingOptions
     , loggingSeverities
+    , parseLoggingSeverity
     , loggingSeverityOrOffReader
     , loggingSeverityReader
 
@@ -1783,24 +1784,18 @@ forceNtpCheckOption = flag False True $ mempty
     <> help "When set, will block and force an NTP check with the server. \
             \Otherwise, uses an available cached result."
 
+-- | The lower-case names of all 'Severity' values.
 loggingSeverities :: [(String, Severity)]
-loggingSeverities =
-    [ ("debug", Debug)
-    , ("info", Info)
-    , ("notice", Notice)
-    , ("warning", Warning)
-    , ("error", Error)
-    , ("critical", Critical)
-    , ("alert", Alert)
-    , ("emergency", Emergency)
-    ]
+loggingSeverities = [(toLower <$> show s, s) | s <- [minBound .. maxBound]]
 
-loggingSeverityReader :: ReadM Severity
-loggingSeverityReader = do
-    arg <- readerAsk
+parseLoggingSeverity :: String -> Either String Severity
+parseLoggingSeverity arg =
     case lookup (map toLower arg) loggingSeverities of
         Just sev -> pure sev
         Nothing -> fail $ "unknown logging severity: " ++ arg
+
+loggingSeverityReader :: ReadM Severity
+loggingSeverityReader = eitherReader parseLoggingSeverity
 
 loggingSeverityOrOffReader :: ReadM (Maybe Severity)
 loggingSeverityOrOffReader = do

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -586,8 +586,11 @@ mkShelleyWallet
         )
     => MkApiWallet ctx s ApiWallet
 mkShelleyWallet ctx wid cp meta pending progress = do
+    -- TODO: issue #1750 re-enable querying reward balance when it's faster
     reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk -> liftHandler $
-        W.fetchRewardBalance @_ @s @t @k wrk wid
+        if False
+            then W.fetchRewardBalance @_ @s @t @k wrk wid
+            else pure $ Quantity 0
     pure ApiWallet
         { addressPoolGap = ApiT $ getState cp ^. #externalPool . #gap
         , balance = ApiT $ WalletBalance

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -191,12 +191,14 @@ test-suite integration
     , cardano-wallet-launcher
     , cardano-wallet-shelley
     , cardano-wallet-test-utils
+    , contra-tracer
     , hspec
     , http-client
     , iohk-monitoring
     , random
     , temporary
     , text
+    , text-class
   build-tools:
       cardano-wallet-shelley
   type:

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Shelley.Compatibility
     ( NodeVersionData )
 import Cardano.Wallet.Shelley.Launch
-    ( withBFTNode )
+    ( singleNodeConfig, withBFTNode )
 import Cardano.Wallet.Shelley.Network
     ( NetworkLayerLog (..), withNetworkLayer )
 import Control.Retry
@@ -68,8 +68,10 @@ spec = describe "getTxParameters" $ do
 withTestNode
     :: (NetworkParameters -> FilePath -> NodeVersionData -> IO a)
     -> IO a
-withTestNode action = withBFTNode nullTracer Error (0, []) $
-    \sock _block0 (np, vData) -> action np sock vData
+withTestNode action = do
+    cfg <- singleNodeConfig Error
+    withBFTNode nullTracer cfg $ \sock _block0 (np, vData) ->
+        action np sock vData
 
 isMsgProtocolParams :: NetworkLayerLog -> Maybe ProtocolParameters
 isMsgProtocolParams (MsgProtocolParameters pp) = Just pp

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -144,12 +144,14 @@
             (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-shelley" or (errorHandler.buildDepError "cardano-wallet-shelley"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.cardano-wallet-shelley or (pkgs.buildPackages.cardano-wallet-shelley or (errorHandler.buildToolDepError "cardano-wallet-shelley")))

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -96,7 +96,10 @@ let
 
           # cardano-node socket path becomes too long otherwise
           unit.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
-          integration.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
+          integration.preCheck = lib.optionalString stdenv.isDarwin ''export TMPDIR=/tmp'' + ''
+              export CARDANO_WALLET_TRACING_MIN_SEVERITY=debug
+              export CARDANO_NODE_TRACING_MIN_SEVERITY=info
+            '';
 
           # provide cardano-node & cardano-cli to tests
           unit.build-tools = [ pkgs.cardano-node pkgs.cardano-cli ];

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -96,7 +96,9 @@ let
 
           # cardano-node socket path becomes too long otherwise
           unit.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
-          integration.preCheck = lib.optionalString stdenv.isDarwin ''export TMPDIR=/tmp'' + ''
+          integration.preCheck = lib.optionalString stdenv.isDarwin ''
+              export TMPDIR=/tmp
+            '' + ''
               export CARDANO_WALLET_TRACING_MIN_SEVERITY=debug
               export CARDANO_NODE_TRACING_MIN_SEVERITY=info
             '';


### PR DESCRIPTION
### Overview

To help debug integration tests cluster issues.

- [x] Add debug tracing around cluster startup and shutdown.
- [x] Allow increasing the minimum log severity for integration tests with an environment variable.
- [x] Make sure all cluster nodes have exactly the same start time. This prevents these errors:
   ```
   [blue:cardano.node.IpSubscription:Error:46] [2020-06-15 15:34:20.86 UTC] [String "Failed to start all required subscriptions",String "[127.0.0.1:3263,127.0.0.1:32865]",String "WithIPList SubscriptionTrace",String "LocalAddresses {laIpv4 = Just 0.0.0.0:0, laIpv6 = Just [::]:0, laUnix = Nothing}"]
   ```
- [x] Re-enable stake pools in test cluster.

# Comments

To do later:
- Output debug log files for each cardano-node process to the temporary directory — requires [CAD-1247](https://jira.iohk.io/browse/CAD-1247)
- Different hostnames in cardano-node logs — requires input-output-hk/cardano-node#1278
