### PR TITLE
Tx fee estimation edge cases bug

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -424,7 +424,7 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
             { nInputs  = 1
             , nOutputs = 1
-            , nChanges = 0
+            , nChanges = 1
             }
     verify r
         [ expectResponseCode HTTP.status202

--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/CLI/Transactions.hs
@@ -750,7 +750,7 @@ scenario_TRANS_ESTIMATE_04b = it title $ \ctx -> do
     let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription
             { nInputs  = 1
             , nOutputs = 1
-            , nChanges = 0
+            , nChanges = 1
             }
     verify r
         [ expectCliField #estimatedMin $

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -743,7 +743,7 @@ spec = do
             ]
 
     it "TRANS_ESTIMATE_03 - we see result when we can't cover fee" $ \ctx -> do
-        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 0
+        let (feeMin, feeMax) = ctx ^. #_feeEstimator $ PaymentDescription 1 1 1
         wSrc <- fixtureWalletWith @n ctx [feeMin `div` 2]
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -869,7 +869,12 @@ spec = do
                 (`shouldBe` feeMin)
             ]
 
-        let amt1 = walletBalance - 122500 :: Natural
+        let (feeMin', _) = ctx ^. #_feeEstimator $ PaymentDescription
+                { nInputs = 1
+                , nOutputs = 1
+                , nChanges = 0
+                }
+        let amt1 = walletBalance - feeMin' :: Natural
 
         let payload3 = Json [json|{
                 "payments": [{

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -819,7 +819,7 @@ spec = do
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
-    it "TRANS_ESTIMATE_08 - Fee estimation edge case" $ \ctx -> do
+    it "TRANS_ESTIMATE_08 - Fee estimation of edge cases" $ \ctx -> do
         let walletBalance = 5000000
         wSrc <- fixtureWalletWith @n ctx [walletBalance]
         wDest <- emptyWallet ctx
@@ -870,6 +870,7 @@ spec = do
             ]
 
         let amt1 = walletBalance - 122500 :: Natural
+
         let payload3 = Json [json|{
                 "payments": [{
                     "address": #{destination},
@@ -897,6 +898,7 @@ spec = do
                     }
                 }]
             }|]
+
         r4 <- request @ApiFee ctx
             (Link.getTransactionFee @'Shelley wSrc) Default payload4
         verify r4

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1655,7 +1655,7 @@ estimateFeeForCoinSelection
             (_, samples') ->
                 Right samples'
 
-    repeats = 1 -- TODO: modify repeats based on data
+    repeats = 100 -- TODO: modify repeats based on data
 
 {-------------------------------------------------------------------------------
                                   Key Store

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -225,14 +225,6 @@ spec = do
     describe "Tx fee estimation" $ do
         it "Fee estimates are sound"
             (property prop_estimateFee)
-        it "Fee estimation for some edge cases" $ do
-            let cs1 = Right $ CoinSelection
-                    { inputs = [(TxIn (Hash "") 0, TxOut (Address "") (Coin 5000000))]
-                    , outputs = [TxOut (Address "") (Coin 4877501)]
-                    , change = [Coin 122499]
-                    }
-            runTest [cs1] (W.estimateFeeForCoinSelection mkCoinSelections)
-                `shouldBe` Right (W.FeeEstimation 10 10)
 
     describe "Join/Quit Stake pool properties" $ do
         it "You can quit if you cannot join"
@@ -290,10 +282,6 @@ spec = do
          knownPools = [pidA, pidB]
          next epoch dlgStatus =
              WalletDelegationNext {changesAt = epoch, status = dlgStatus}
-         runTest vals action = evalState (runExceptT action) vals
-         mkCoinSelections
-             :: ExceptT String (State [Either String CoinSelection]) CoinSelection
-         mkCoinSelections = ExceptT $ state (\(r:rs) -> (r,rs))
 
 {-------------------------------------------------------------------------------
                                     Properties


### PR DESCRIPTION
finish integration test

# Issue Number

#1740

# Overview

- [x] I have pin down the edge value characteristic in integration test (by bisection). This is different from Shelley testnet value reported by @johnalotoski  and @piotr-iohk , ie., `165281`
- [x] I have added integration test that reproduces issue
- [x] I have fixed the issue


# Comments
Running : 
```
stack test cardano-wallet-shelley:integration --ta '-m "TRANS_ESTIMATE_08 - Fee estimation edge case"'
```

My observations:
1. feeMin = 129 000
2. When estimating with payload amount, we have:
(a) payload < walletBalance - 129 000 => fee est = 129 000
(b) payload is (walletBalance - 129 000, walletBalance - 122 500) => fee est = 129 000 - (payload - 129 000)
(c) payload > walletBalance - 122 500 => fee est = walletBalance + (payload - 122 500 )

So when (a) fee estimation is correct, then when (b) it is decreasing linearly until we want to send `walletBalance - 122500`. Then it is increasing linearly in (c). I encoded those thresholds in integration test 

Investigation details: 
we have 3 cases (the last two give wrong fee):
1 the last proper one when 
```
CoinSel {inputs=[5_000_000], outputs=[4_871_000], change=[129_000]} this goes to rebalanceChangeOutputs twice 
-> branch : φ_original > δ_original && not (null (change s))
φ_original=129_000 δ_original=0 (change s)=[129_000]
-> branch : φ_dangling >= δ_original && φ_dangling > δ_dangling
φ_original=122_500 δ_original=129_000 φ_dangling=129_000 δ_dangling=122_500 (splitChange extraChng (change s))=[6_500]
So in senderPaysFee we have in output CoinSel {inputs=[5_000_000], outputs=[4_871_000], change=[]} as remFee=0
As a result, feeBalance is 5_000_000 - 4_871_000= 129_000 (OK)
```
2. First not proper (type 1):
```
CoinSel {inputs=[5_000_000], outputs=[4_871_001], change=[128_999]} this goes to rebalanceChangeOutputs twice 
-> branch : φ_original > δ_original && not (null (change s))
φ_original=129_000 δ_original=0 (change s)=[128_999]
-> branch : φ_dangling >= δ_original && φ_dangling > δ_dangling
φ_original=122_500 δ_original=128_999 φ_dangling=129_000 δ_dangling=122_500 (splitChange extraChng (change s))=[6_499]
So in senderPaysFee we have in output CoinSel {inputs=[5_000_000], outputs=[4_871_001], change=[]} as remFee=0
As a result, feeBalance is 5_000_000 - 4_871_000= 128_999 (NOT OK as minFee is 129_000)
```
3. then it linearly give underevaluated values (the are 6_500 cases) until we reach first case of type 2:
```
CoinSel {inputs=[5_000_000], outputs=[4_877_501], change=[122_499]} this goes to rebalanceChangeOutputs twice 
-> branch : φ_original > δ_original && not (null (change s))
φ_original=129_000 δ_original=0 (change s)=[122_499]
-> branch : φ_original > δ_original && null (change s)
φ_original=122_500 δ_original=122_499 (change s)=[]
So in senderPaysFee we have in CoinSel {inputs=[5_000_000], outputs=[4_877_501], change=[]} as remFee=1
We are trying to coverRemainingFee ! And here we do : 
-> of course no additional UTXO to be picked and we end up with exception ErrCannotCoverFee 1
As a result, we say estimating fee is 5_000_001 which is strange
```

**better picture:** 
These are value thresholds (for 1 input and 1 output) important:
```
         let (feeMin, _) = ctx ^. #_feeEstimator $ PaymentDescription                                                                                                                                          
                 { nInputs = 1                                                                                                                                                                                  
                 , nOutputs = 1                                                                                                                                                                                 
                 , nChanges = 1                                                                                                                                                                                 
                 }
``` 
```
         let (feeMin', _) = ctx ^. #_feeEstimator $ PaymentDescription                                                                                                                                          
                 { nInputs = 1                                                                                                                                                                                  
                 , nOutputs = 1                                                                                                                                                                                 
                 , nChanges = 0                                                                                                                                                                                 
                 } 
```
From so if `walletBalance - totalOuts < feeMin && walletBalance - totalOuts >= feeMin'` then linear (case 2) regime.
When, `walletBalance - totalOuts < feeMin'`   ErrCoveringFee situation (case 3)
