### PR TITLE
Server: Use the network layer to get protocol parameters

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
@@ -270,8 +270,8 @@ server byron icarus ntp =
     network :: Server Network
     network =
         getNetworkInformation genesis nl
-        :<|> (getNetworkParameters genesis)
-        :<|> (getNetworkClock ntp)
+        :<|> getNetworkParameters genesis nl
+        :<|> getNetworkClock ntp
       where
         nl = icarus ^. networkLayer @t
         genesis = icarus ^. genesisData

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1398,9 +1398,11 @@ getNetworkInformation (_block0, np, st) nl = do
 
 getNetworkParameters
     :: (Block, NetworkParameters, SyncTolerance)
+    -> NetworkLayer IO t Block
     -> Handler ApiNetworkParameters
-getNetworkParameters (_block0, np, _st) =
-    pure $ toApiNetworkParameters np
+getNetworkParameters (_block0, np, _st) nl = do
+    pp <- liftIO $ NW.getProtocolParameters nl
+    pure $ toApiNetworkParameters np { protocolParameters = pp }
 
 getNetworkClock :: NtpClient -> Bool -> Handler ApiNetworkClock
 getNetworkClock client = liftIO . getNtpStatus client

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -262,8 +262,8 @@ server byron icarus jormungandr spl ntp =
     network :: Server Network
     network =
         getNetworkInformation genesis nl
-        :<|> (getNetworkParameters genesis)
-        :<|> (getNetworkClock ntp)
+        :<|> getNetworkParameters genesis nl
+        :<|> getNetworkClock ntp
       where
         nl = jormungandr ^. networkLayer @t
         genesis = jormungandr ^. genesisData

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -283,8 +283,8 @@ server byron icarus shelley knownPools ntp =
     network :: Server Network
     network =
         getNetworkInformation genesis nl
-        :<|> (getNetworkParameters genesis)
-        :<|> (getNetworkClock ntp)
+        :<|> getNetworkParameters genesis nl
+        :<|> getNetworkClock ntp
       where
         nl = icarus ^. networkLayer @t
         genesis = icarus ^. genesisData


### PR DESCRIPTION
### Issue Number

ADP-244 / #1693

### Overview

The API server was previously getting all network parameters from the genesis block. This change makes it use the network layer to get the latest protocol parameters.

### Comments

An integration test for this is going to be hairy.
