### PR TITLE
Use and combine chain data with LSQ data for stake pools

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -55,7 +55,6 @@ library
     , http-types
     , memory
     , process
-    , QuickCheck
     , retry
     , scrypt
     , template-haskell

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -426,7 +426,6 @@ spec = do
             , expectErrorMessage $ errMsg403DelegationFee fee
             ]
 
-    let fixTypeInference = True `shouldBe` True
     let listPools ctx = request @[ApiStakePool] @IO ctx (Link.listStakePools arbitraryStake) Default Empty
     describe "STAKE_POOLS_LIST_01 - List stake pools" $ do
         it "immediately has non-zero saturation & stake" $ \ctx -> do
@@ -520,15 +519,13 @@ spec = do
                     ]
 
     it "STAKE_POOLS_LIST_05 - Fails without query parameter" $ \ctx -> do
-        fixTypeInference
-        r <- request @[ApiStakePool] ctx
+        r <- request @[ApiStakePool] @IO ctx
             (Link.listStakePools Nothing) Default Empty
         expectResponseCode HTTP.status400 r
 
     it "STAKE_POOLS_LIST_06 - NonMyopicMemberRewards are 0 when stake is 0" $ \ctx -> do
-        fixTypeInference
         let stake = Just $ Coin 0
-        r <- request @[ApiStakePool] ctx (Link.listStakePools stake) Default Empty
+        r <- request @[ApiStakePool] @IO ctx (Link.listStakePools stake) Default Empty
         expectResponseCode HTTP.status200 r
         verify r
             [ expectListSize 3

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -364,6 +364,7 @@ data DBLog
     | MsgRun Bool
     | MsgConnStr Text
     | MsgClosing (Maybe FilePath)
+    | MsgWillOpenDB (Maybe FilePath)
     | MsgDatabaseReset
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
@@ -439,6 +440,7 @@ instance HasSeverityAnnotation DBLog where
         MsgRun _ -> Debug
         MsgConnStr _ -> Debug
         MsgClosing _ -> Debug
+        MsgWillOpenDB _ -> Info
         MsgDatabaseReset -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
@@ -463,6 +465,7 @@ instance ToText DBLog where
         MsgQuery stmt _ -> stmt
         MsgRun False -> "Running database action - Start"
         MsgRun True -> "Running database action - Finish"
+        MsgWillOpenDB fp -> "Will open db at " <> (maybe "in-memory" T.pack fp)
         MsgConnStr connStr -> "Using connection string: " <> connStr
         MsgClosing fp -> "Closing database ("+|fromMaybe "in-memory" fp|+")"
         MsgDatabaseReset ->

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -135,6 +135,9 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -> stm ()
         -- ^ Store metadata fetched from a remote server.
 
+    , readPoolMetadata
+        :: stm (Map StakePoolMetadataHash StakePoolMetadata)
+
     , readSystemSeed
         :: stm StdGen
         -- ^ Read the seed assigned to this particular database. The seed is

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -30,6 +30,7 @@ import Cardano.Pool.DB.Model
     , mPutPoolRegistration
     , mPutStakeDistribution
     , mReadCursor
+    , mReadPoolMetadata
     , mReadPoolProduction
     , mReadPoolRegistration
     , mReadStakeDistribution
@@ -100,6 +101,8 @@ newDBLayer = do
 
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction
+
+        , readPoolMetadata = readPoolDB db mReadPoolMetadata
 
         , atomically = id
         }

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -37,6 +37,7 @@ module Cardano.Pool.DB.Model
     , mReadTotalProduction
     , mPutStakeDistribution
     , mReadStakeDistribution
+    , mReadPoolMetadata
     , mPutPoolRegistration
     , mReadPoolRegistration
     , mUnfetchedPoolMetadataRefs
@@ -227,6 +228,10 @@ mPutPoolMetadata _ hash meta db@PoolDatabase{metadata} =
     ( Right ()
     , db { metadata = Map.insert hash meta metadata }
     )
+
+mReadPoolMetadata
+    :: ModelPoolOp (Map StakePoolMetadataHash StakePoolMetadata)
+mReadPoolMetadata db@PoolDatabase{metadata} = (Right metadata, db)
 
 mReadSystemSeed
     :: PoolDatabase

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -129,7 +129,8 @@ withDBLayer
     -> (DBLayer IO -> IO a)
        -- ^ Action to run.
     -> IO a
-withDBLayer trace fp action =
+withDBLayer trace fp action = do
+    traceWith trace (MsgWillOpenDB fp)
     bracket before after (action . snd)
   where
     before = newDBLayer trace fp

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,6 +51,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolRegistrationCertificate (..)
     , SlotId (..)
     , StakePoolMetadata (..)
+    , StakePoolMetadataHash
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
@@ -274,6 +276,10 @@ newDBLayer trace fp = do
             let StakePoolMetadata{ticker,name,description,homepage} = metadata
             putMany [PoolMetadata hash poolId name ticker description homepage]
 
+        , readPoolMetadata = do
+            Map.fromList . map (fromPoolMeta . entityVal)
+                <$> selectList [] []
+
         , listRegisteredPools = do
             fmap (poolRegistrationPoolId . entityVal) <$> selectList [ ]
                 [ Desc PoolRegistrationSlot ]
@@ -391,3 +397,14 @@ fromStakeDistribution distribution =
     ( stakeDistributionPoolId distribution
     , Quantity (stakeDistributionStake distribution)
     )
+
+fromPoolMeta
+    :: PoolMetadata
+    -> (StakePoolMetadataHash, StakePoolMetadata)
+fromPoolMeta meta = (poolMetadataHash meta,) $
+    StakePoolMetadata
+        { ticker = poolMetadataTicker meta
+        , name = poolMetadataName meta
+        , description = poolMetadataDescription meta
+        , homepage = poolMetadataHomepage meta
+        }

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -393,8 +393,8 @@ data ApiStakePool = ApiStakePool
     { id :: !(ApiT PoolId)
     , metrics :: !ApiStakePoolMetrics
     , metadata :: !(Maybe (ApiT StakePoolMetadata))
-    , cost :: !(Quantity "lovelace" Natural)
-    , margin :: !(Quantity "percent" Percentage)
+    , cost :: !(Maybe (Quantity "lovelace" Natural))
+    , margin :: !(Maybe (Quantity "percent" Percentage))
     } deriving (Eq, Generic, Show)
 
 data ApiStakePoolMetrics = ApiStakePoolMetrics

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -71,7 +71,6 @@ library
     , retry
     , servant-server
     , shelley-spec-ledger
-    , sort
     , temporary
     , text
     , text-class

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -82,6 +82,8 @@ import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Generics.Internal.VL.Lens
     ( view )
+import Data.List
+    ( sortOn )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map
@@ -94,8 +96,6 @@ import Data.Ord
     ( Down (..) )
 import Data.Quantity
     ( Percentage (..), Quantity (..) )
-import Data.Sort
-    ( sortOn )
 import Data.Text.Class
     ( ToText (..) )
 import Data.Word

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -6,7 +6,7 @@ protocolParams:
   protocolVersion:
     minor: 0
     major: 0
-  decentralisationParam: 0.1 # means 90% decentralised
+  decentralisationParam: 0.97 # means 3% decentralised
   maxTxSize: 4096
   minFeeA: 100
   maxBlockBodySize: 239857

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -6,7 +6,7 @@ protocolParams:
   protocolVersion:
     minor: 0
     major: 0
-  decentralisationParam: 0.97 # means 3% decentralised
+  decentralisationParam: 0.1 # means 90% decentralised
   maxTxSize: 4096
   minFeeA: 100
   maxBlockBodySize: 239857

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -55,7 +55,6 @@
           (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
-          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -68,7 +68,6 @@
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
-          (hsPkgs."sort" or (errorHandler.buildDepError "sort"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -579,16 +579,31 @@ x-jormungandrStakePoolMetadata: &jormungandrStakePoolMetadata
       format: bech32
       example: addr1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2xfvz82xgwh7wal6g2xt8n996s3xvu5g
 
-x-stakePoolCost: &stakePoolCost
+x-jormungandrStakePoolCost: &jormungandrStakePoolCost
   <<: *amount
   description: |
       Estimated cost set by the pool operator when registering his pool.
       This fixed cost is taken from each reward earned by the pool before splitting rewards between stakeholders.
 
-x-stakePoolMargin: &stakePoolMargin
+x-jormungandrStakePoolMargin: &jormungandrStakePoolMargin
   <<: *percentage
   description: |
       Variable margin on the total reward given to an operator before splitting rewards between stakeholders.
+
+x-stakePoolCost: &stakePoolCost
+  <<: *jormungandrStakePoolCost
+  description: |
+      Estimated cost set by the pool operator when registering his pool.
+      This fixed cost is taken from each reward earned by the pool before splitting rewards between stakeholders.
+
+      May be ommitted if the wallet hasn't found the pool's registration cerificate yet.
+
+x-stakePoolMargin: &stakePoolMargin
+  <<: *jormungandrStakePoolMargin
+  description: |
+      Variable margin on the total reward given to an operator before splitting rewards between stakeholders.
+
+      May be ommitted if the wallet hasn't found the pool's registration cerificate yet.
 
 x-stakePoolSaturation: &stakePoolSaturation
   type: number
@@ -811,8 +826,7 @@ components:
       type: object
       required:
         - id
-        - cost
-        - margin
+        - metrics
       properties:
         id: *stakePoolId
         metrics: *stakePoolMetrics
@@ -834,8 +848,8 @@ components:
         id: *stakePoolId
         metrics: *jormungandrStakePoolMetrics
         apparent_performance: *stakePoolApparentPerformance
-        cost: *stakePoolCost
-        margin: *stakePoolMargin
+        cost: *jormungandrStakePoolCost
+        margin: *jormungandrStakePoolMargin
         metadata: *jormungandrStakePoolMetadata
         saturation: *stakePoolSaturation
         desirability: *stakePoolDesirability


### PR DESCRIPTION
# Issue Number

ADP-311, #1719 

# Overview

- [x] Add Shelley `MsgFetchedNodePoolLsqData` trace
- [x] Use and combine chain data with LSQ when listing pools
- [x] Update swagger to make pool cost and margin nullable
- [x] Make API types nullable
- [x] Add model implementation for `readPoolMetadata`


# Comments

- [ ] We should test that we order by non-myopic rewards, but that would require the pools producing blocks. 
- [ ] Maybe we should have a DB test checking that `readMetadata` returns what we previously put in the DB.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
