### PR TITLE
More integration test cluster logging improvements

### DIFF
--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -36,6 +36,7 @@ library
     , code-page
     , contra-tracer
     , extra
+    , filepath
     , fmt
     , iohk-monitoring
     , process
@@ -45,6 +46,7 @@ library
       src
   exposed-modules:
       Cardano.Launcher
+    , Cardano.Launcher.Node
     , Cardano.Startup
   if os(windows)
     build-depends: Win32

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -67,8 +67,8 @@ import System.Exit
 import System.IO
     ( Handle )
 import System.Process
-    ( CreateProcess (..)
-    , CmdSpec (..)
+    ( CmdSpec (..)
+    , CreateProcess (..)
     , ProcessHandle
     , StdStream (..)
     , getPid

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -16,19 +16,19 @@ module Cardano.Launcher.Node
 import Prelude
 
 import Cardano.Launcher
-    ( LauncherLog
-    , ProcessHasExited
-    , withBackendCreateProcess
-    )
+    ( LauncherLog, ProcessHasExited, withBackendCreateProcess )
 import Control.Tracer
     ( Tracer (..) )
+import Data.Maybe
+    ( maybeToList )
+import System.Environment
+    ( getEnvironment )
 import System.FilePath
     ( takeFileName, (</>) )
 import System.Info
     ( os )
-import System.Process (CreateProcess (..), proc)
-import System.Environment (getEnvironment)
-import Data.Maybe (maybeToList)
+import System.Process
+    ( CreateProcess (..), proc )
 
 -- | Parameters for connecting to the node.
 newtype CardanoNodeConn = CardanoNodeConn

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE TupleSections #-}
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Provides a function to launch @cardano-node@.
+
+module Cardano.Launcher.Node
+    ( withCardanoNode
+    , CardanoNodeConfig (..)
+    , defaultCardanoNodeConfig
+    , CardanoNodeConn (..)
+    , NodePort (..)
+    ) where
+
+import Prelude
+
+import Cardano.Launcher
+    ( LauncherLog
+    , ProcessHasExited
+    , withBackendCreateProcess
+    )
+import Control.Tracer
+    ( Tracer (..) )
+import System.FilePath
+    ( takeFileName, (</>) )
+import System.Info
+    ( os )
+import System.Process (CreateProcess (..), proc)
+import System.Environment (getEnvironment)
+import Data.Maybe (maybeToList)
+
+-- | Parameters for connecting to the node.
+newtype CardanoNodeConn = CardanoNodeConn
+    { nodeSocketFile :: FilePath
+    } deriving (Show, Eq)
+
+newtype NodePort = NodePort { unNodePort :: Int }
+    deriving (Show, Eq)
+
+-- | A subset of the @cardano-node@ CLI parameters, used for starting the
+-- backend.
+data CardanoNodeConfig = CardanoNodeConfig
+    { nodeDir             :: FilePath
+    , nodeConfigFile      :: FilePath
+    , nodeTopologyFile    :: FilePath
+    , nodeDatabaseDir     :: FilePath
+    , nodeDlgCertFile     :: Maybe FilePath
+    , nodeSignKeyFile     :: Maybe FilePath
+    , nodeOpCertFile      :: Maybe FilePath
+    , nodeKesKeyFile      :: Maybe FilePath
+    , nodeVrfKeyFile      :: Maybe FilePath
+    , nodePort            :: Maybe NodePort
+    , nodeLoggingHostname :: Maybe String
+    } deriving (Show, Eq)
+
+defaultCardanoNodeConfig :: CardanoNodeConfig
+defaultCardanoNodeConfig = CardanoNodeConfig
+    { nodeDir             = "."
+    , nodeConfigFile      = "configuration.json"
+    , nodeTopologyFile    = "topology.json"
+    , nodeDatabaseDir     = "db"
+    , nodeDlgCertFile     = Nothing
+    , nodeSignKeyFile     = Nothing
+    , nodeOpCertFile      = Nothing
+    , nodeKesKeyFile      = Nothing
+    , nodeVrfKeyFile      = Nothing
+    , nodePort            = Nothing
+    , nodeLoggingHostname = Nothing
+    }
+
+-- | Spawns a @cardano-node@ process.
+--
+-- IMPORTANT: @cardano-node@ must be available on the current path.
+withCardanoNode
+    :: Tracer IO LauncherLog
+    -- ^ Trace for subprocess control logging
+    -> CardanoNodeConfig
+    -> (CardanoNodeConn -> IO a)
+    -- ^ Callback function with a socket filename and genesis params
+    -> IO (Either ProcessHasExited a)
+withCardanoNode tr cfg action = do
+    let socketPath = nodeSocketPath (nodeDir cfg)
+    cp <- cardanoNodeProcess cfg socketPath
+    withBackendCreateProcess tr cp $ \_ _ -> action $ CardanoNodeConn socketPath
+
+{-------------------------------------------------------------------------------
+                                    Helpers
+-------------------------------------------------------------------------------}
+
+-- | Generate command-line arguments for launching @cardano-node@.
+cardanoNodeProcess :: CardanoNodeConfig -> FilePath -> IO CreateProcess
+cardanoNodeProcess cfg socketPath = do
+    myEnv <- getEnvironment
+    let env' = ("CARDANO_NODE_LOGGING_HOSTNAME",) <$> nodeLoggingHostname cfg
+
+    pure $ (proc "cardano-node" args)
+        { env = Just $ maybeToList env' ++ myEnv
+        , cwd = Just $ nodeDir cfg
+        }
+  where
+    args =
+        [ "run"
+        , "--config", nodeConfigFile cfg
+        , "--topology", nodeTopologyFile cfg
+        , "--database-path", nodeDatabaseDir cfg
+        , "--socket-path", socketPath
+        ]
+        ++ opt "--port" (show . unNodePort <$> nodePort cfg)
+        ++ opt "--signing-key" (nodeSignKeyFile cfg)
+        ++ opt "--delegation-certificate" (nodeDlgCertFile cfg)
+        ++ opt "--shelley-operational-certificate" (nodeOpCertFile cfg)
+        ++ opt "--shelley-kes-key" (nodeKesKeyFile cfg)
+        ++ opt "--shelley-vrf-key" (nodeVrfKeyFile cfg)
+
+    opt _ Nothing = []
+    opt arg (Just val) = [arg, val]
+
+-- | Generate a 'FilePath' for the @cardano-node@ domain socket/named pipe.
+nodeSocketPath
+    :: FilePath -- ^ @cardano-node@ state directory
+    -> FilePath -- ^ UNIX socket file path or Windows named pipe name
+nodeSocketPath dir
+    | os == "mingw32" = "\\\\.\\pipe\\" ++ takeFileName dir
+    | otherwise = dir </> "node.socket"

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -196,7 +196,6 @@ test-suite integration
     , http-client
     , iohk-monitoring
     , random
-    , temporary
     , text
     , text-class
   build-tools:

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -45,6 +45,8 @@ defaultBackends:
 
 # if not indicated otherwise, then log output is directed to this:
 defaultScribes:
+  - - FileSK
+    - "cardano-node.log"
   - - StdoutSK
     - stdout
 
@@ -69,6 +71,11 @@ setupBackends:
 
 # here we set up outputs of logging in 'katip':
 setupScribes:
+  - scKind: FileSK
+    scName: "cardano-node.log"
+    scFormat: ScText
+    scMinSev: Debug
   - scName: stdout
     scKind: StdoutSK
     scFormat: ScText
+    scMinSev: Error

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Shelley.Compatibility
     ( NodeVersionData )
 import Cardano.Wallet.Shelley.Launch
-    ( singleNodeConfig, withBFTNode )
+    ( singleNodeParams, withBFTNode, withSystemTempDir )
 import Cardano.Wallet.Shelley.Network
     ( NetworkLayerLog (..), withNetworkLayer )
 import Control.Retry
@@ -69,9 +69,10 @@ withTestNode
     :: (NetworkParameters -> FilePath -> NodeVersionData -> IO a)
     -> IO a
 withTestNode action = do
-    cfg <- singleNodeConfig Error
-    withBFTNode nullTracer cfg $ \sock _block0 (np, vData) ->
-        action np sock vData
+    cfg <- singleNodeParams Error
+    withSystemTempDir nullTracer "network-spec" $ \dir ->
+        withBFTNode nullTracer dir cfg $ \sock _block0 (np, vData) ->
+            action np sock vData
 
 isMsgProtocolParams :: NetworkLayerLog -> Maybe ProtocolParameters
 isMsgProtocolParams (MsgProtocolParameters pp) = Just pp

--- a/nix/.stack.nix/cardano-api.nix
+++ b/nix/.stack.nix/cardano-api.nix
@@ -107,8 +107,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "478230484677e1940291eff6004e93d71692a242";
-      sha256 = "0v9f2bn3zq181wdzlkf3klibbmf3jkq5q6sd2y564ramq9yh4k45";
+      rev = "a1dd8ebb7b0a959619abceb34ef1044b9ea696b0";
+      sha256 = "1vyl8v784af0wg8vzsgwbky99w40nyhw5pw7mmlp2s50zy2qh9z0";
       });
     postUnpack = "sourceRoot+=/cardano-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-cli.nix
+++ b/nix/.stack.nix/cardano-cli.nix
@@ -121,8 +121,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "478230484677e1940291eff6004e93d71692a242";
-      sha256 = "0v9f2bn3zq181wdzlkf3klibbmf3jkq5q6sd2y564ramq9yh4k45";
+      rev = "a1dd8ebb7b0a959619abceb34ef1044b9ea696b0";
+      sha256 = "1vyl8v784af0wg8vzsgwbky99w40nyhw5pw7mmlp2s50zy2qh9z0";
       });
     postUnpack = "sourceRoot+=/cardano-cli; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -113,8 +113,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "478230484677e1940291eff6004e93d71692a242";
-      sha256 = "0v9f2bn3zq181wdzlkf3klibbmf3jkq5q6sd2y564ramq9yh4k45";
+      rev = "a1dd8ebb7b0a959619abceb34ef1044b9ea696b0";
+      sha256 = "1vyl8v784af0wg8vzsgwbky99w40nyhw5pw7mmlp2s50zy2qh9z0";
       });
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -114,8 +114,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "478230484677e1940291eff6004e93d71692a242";
-      sha256 = "0v9f2bn3zq181wdzlkf3klibbmf3jkq5q6sd2y564ramq9yh4k45";
+      rev = "a1dd8ebb7b0a959619abceb34ef1044b9ea696b0";
+      sha256 = "1vyl8v784af0wg8vzsgwbky99w40nyhw5pw7mmlp2s50zy2qh9z0";
       });
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -33,6 +33,7 @@
           (hsPkgs."code-page" or (errorHandler.buildDepError "code-page"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -149,7 +149,6 @@
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             ];

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -34,8 +34,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -108,8 +108,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-aggregation.nix
+++ b/nix/.stack.nix/lobemo-backend-aggregation.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/plugins/backend-aggregation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-ekg.nix
+++ b/nix/.stack.nix/lobemo-backend-ekg.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/plugins/backend-ekg; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-monitoring.nix
+++ b/nix/.stack.nix/lobemo-backend-monitoring.nix
@@ -83,8 +83,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/plugins/backend-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-backend-trace-forwarder.nix
+++ b/nix/.stack.nix/lobemo-backend-trace-forwarder.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/plugins/backend-trace-forwarder; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/lobemo-scribe-systemd.nix
+++ b/nix/.stack.nix/lobemo-scribe-systemd.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/plugins/scribe-systemd; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/tracer-transformers.nix
+++ b/nix/.stack.nix/tracer-transformers.nix
@@ -57,8 +57,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "2a1afe23d88b91027f972dd7c70cd4aadfb19768";
-      sha256 = "0azd8m9qqvpmlqaddyi41iyksx08zn4ffyngmg83psp74l6dwzyf";
+      rev = "efa4b5ecd7f0a13124616b12679cd42517cd905a";
+      sha256 = "0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf";
       });
     postUnpack = "sourceRoot+=/tracer-transformers; echo source root reset to \$sourceRoot";
     }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "93ca68b8004031df297063a3715178b664c61bac",
-        "sha256": "0wncqd4nig0mmw3yr5c6sm6sa9gb9fjzpl6awhl2875jbnv0w2d1",
+        "rev": "a1dd8ebb7b0a959619abceb34ef1044b9ea696b0",
+        "sha256": "1vyl8v784af0wg8vzsgwbky99w40nyhw5pw7mmlp2s50zy2qh9z0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/93ca68b8004031df297063a3715178b664c61bac.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/a1dd8ebb7b0a959619abceb34ef1044b9ea696b0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -77,7 +77,7 @@ packages:
   - shelley/chain-and-ledger/executable-spec/test
 
 - git: https://github.com/input-output-hk/cardano-node
-  commit: 478230484677e1940291eff6004e93d71692a242
+  commit: a1dd8ebb7b0a959619abceb34ef1044b9ea696b0
   subdirs:
   - cardano-api
   - cardano-cli
@@ -102,7 +102,7 @@ packages:
   commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
 - git: https://github.com/input-output-hk/iohk-monitoring-framework
-  commit: 2a1afe23d88b91027f972dd7c70cd4aadfb19768
+  commit: efa4b5ecd7f0a13124616b12679cd42517cd905a
   subdirs:
   - contra-tracer
   - iohk-monitoring
@@ -143,4 +143,3 @@ packages:
   commit: 1a75bdfca014723dd5d40760fad854b3f0f37156
   subdirs:
   - http-client
-


### PR DESCRIPTION
### Issue Number

ADP-302 / #1750

### Overview

- Output Debug-severity log files for each cardano-node process to the temporary directory, while only showing Error-severity logs on stdout.
- Show different hostnames in cardano-node logs so that it's possible to see which node produced the log message.
- Add a new helper function for starting the cardano-node process.
- Use a single temp directory for all nodes in the cluster - makes inspecting configs and logs easier.
- The environment variable `NO_CLEANUP` causes the integration tests to not delete the temp directory after they have finished.
- The environment variable `CARDANO_NODE_TRACING_MIN_SEVERITY` sets the log level the the cluster nodes for stdout.
- The environment variable `CARDANO_WALLET_TRACING_MIN_SEVERITY` sets the log level for the wallet server.
- Also bumps cardano-node and libraries to latest master (to get latest logging features).
