### PR TITLE
Allow listing pools based on stake instead of wallet id

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -190,7 +190,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, defaultAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Hash, SortOrder, SyncTolerance (..), WalletId, WalletName )
+    ( AddressState
+    , Coin (..)
+    , Hash
+    , SortOrder
+    , SyncTolerance (..)
+    , WalletId
+    , WalletName
+    )
 import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Codec.Binary.Bech32
@@ -1508,7 +1515,7 @@ cmdStakePool mkClient =
 -- | Arguments for 'stake-pool list' command
 data StakePoolListArgs = StakePoolListArgs
     { _port :: Port "Wallet"
-    , _walletId :: WalletId
+    , _stake :: Maybe Coin
     }
 
 cmdStakePoolList
@@ -1520,9 +1527,9 @@ cmdStakePoolList mkClient =
         <> progDesc "List all known stake pools."
   where
     cmd = fmap exec $ StakePoolListArgs
-        <$> portOption <*> walletIdArgument
-    exec (StakePoolListArgs wPort wid) = do
-        runClient wPort Aeson.encodePretty $ listPools mkClient (ApiT wid)
+        <$> portOption <*> stakeOption
+    exec (StakePoolListArgs wPort stake) = do
+        runClient wPort Aeson.encodePretty $ listPools mkClient (ApiT <$> stake)
 
 {-------------------------------------------------------------------------------
                             Commands - 'network'
@@ -1882,6 +1889,14 @@ tlsOption = TlsConfiguration
 walletIdArgument :: Parser WalletId
 walletIdArgument = argumentT $ mempty
     <> metavar "WALLET_ID"
+
+-- | <stake=STAKE>
+stakeOption :: Parser (Maybe Coin)
+stakeOption = optional $ optionT $ mempty
+    <> long "stake"
+    <> metavar "STAKE"
+    <> help ("The stake you intend to delegate, which affects the rewards and "
+            <> "the ranking of pools.")
 
 -- | <transaction-id=TX_ID>
 transactionIdArgument :: Parser TxId

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -485,13 +485,16 @@ spec = do
             ]
 
         ["stake-pool", "list", "--help"] `shouldShowUsage`
-            [ "Usage:  stake-pool list [--port INT] WALLET_ID"
+            [ "Usage:  stake-pool list [--port INT] [--stake STAKE]"
             , "  List all known stake pools."
             , ""
             , "Available options:"
             , "  -h,--help                Show this help text"
             , "  --port INT               port used for serving the wallet"
             , "                           API. (default: 8090)"
+            , "  --stake STAKE            The stake you intend to delegate,"
+            , "                           which affects the rewards and the"
+            , "                           ranking of pools."
             ]
 
         ["network", "--help"] `shouldShowUsage`

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -139,6 +139,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( AddressState
     , Block
+    , Coin (..)
     , NetworkParameters
     , SortOrder (..)
     , SyncTolerance
@@ -367,9 +368,8 @@ type StakePools n apiPool =
     :<|> DelegationFee
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/listStakePools
-type ListStakePools apiPool = "wallets"
-    :> Capture "walletId" (ApiT WalletId)
-    :> "stake-pools"
+type ListStakePools apiPool = "stake-pools"
+    :> QueryParam "stake" (ApiT Coin)
     :> Get '[JSON] [apiPool]
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/joinStakePool

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -83,7 +83,7 @@ import Cardano.Wallet.Api.Types
     , WalletPutPassphraseData (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, SortOrder, WalletId )
+    ( AddressState, Coin (..), SortOrder, WalletId )
 import Control.Monad
     ( void )
 import Data.Coerce
@@ -175,7 +175,7 @@ data AddressClient = AddressClient
 
 data StakePoolClient apiPool = StakePoolClient
     { listPools
-        :: ApiT WalletId -> ClientM [apiPool]
+        :: Maybe (ApiT Coin) -> ClientM [apiPool]
     , joinStakePool
         :: ApiPoolId
         -> ApiT WalletId

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -96,7 +96,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Hash, PoolId, SortOrder, WalletId (..) )
+    ( AddressState, Coin (..), Hash, PoolId, SortOrder, WalletId (..) )
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens
@@ -107,8 +107,6 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Text
     ( Text )
-import Data.Text.Class
-    ( fromText )
 import GHC.TypeLits
     ( Symbol )
 import Network.HTTP.Types.Method
@@ -131,7 +129,6 @@ import Web.HttpApiData
     ( ToHttpApiData (..) )
 
 import qualified Cardano.Wallet.Api as Api
-import qualified Data.Text as T
 
 --
 -- Wallets
@@ -383,22 +380,16 @@ deleteTransaction w t = discriminate @style
 --
 
 listStakePools
-    :: forall  w.
-        ( HasType (ApiT WalletId) w
-        )
-    => w
+    :: Maybe Coin
     -> (Method, Text)
-listStakePools w =
-    endpoint @(Api.ListStakePools ()) (\mk -> mk wid)
-  where
-    wid = w ^. typed @(ApiT WalletId)
+listStakePools stake =
+    endpoint @(Api.ListStakePools ()) (\mk -> mk (ApiT <$> stake))
 
--- | Like @listStakePools@, but with a dummy wallet id.
+-- | Like @listStakePools@ but with out the query parameter for the stake that
+-- the user intends to delegate.
 listJormungandrStakePools :: (Method, Text)
 listJormungandrStakePools =
-    endpoint @(Api.ListStakePools ()) (\mk -> mk wid)
-  where
-    wid = ApiT $ either (error . show) id $ fromText $ T.pack $replicate 40 '0'
+    endpoint @(Api.ListStakePools ()) (\mk -> mk Nothing)
 
 joinStakePool
     :: forall s w.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -654,6 +654,7 @@ data ApiErrorCode
     | WalletNotResponding
     | AddressAlreadyExists
     | InvalidWalletType
+    | QueryParamMissing
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -188,7 +188,7 @@ import Control.Arrow
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
-    ( (>=>) )
+    ( (<=<), (>=>) )
 import Crypto.Hash
     ( Blake2b_160, Digest, digestFromByteString )
 import Crypto.Number.Generate
@@ -1091,6 +1091,18 @@ instance ToText AddressState where
 newtype Coin = Coin
     { getCoin :: Word64
     } deriving stock (Show, Ord, Eq, Generic)
+
+instance ToText Coin where
+    toText (Coin c) = T.pack $ show c
+
+instance FromText Coin where
+    fromText = validate <=< (fmap (Coin . fromIntegral) . fromText @Natural)
+      where
+        validate x
+            | isValidCoin x =
+                return x
+            | otherwise =
+                Left $ TextDecodingError "Coin value is out of bounds"
 
 instance NFData Coin
 

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -338,6 +338,7 @@ spec = do
         describe "Can perform roundtrip textual encoding & decoding" $ do
             textRoundtrip $ Proxy @Iso8601Time
             textRoundtrip $ Proxy @SortOrder
+            textRoundtrip $ Proxy @Coin
 
     describe "AddressAmount" $ do
         it "fromText \"22323\"" $

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -103,7 +103,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
 import Cardano.Wallet.Primitive.Types
-    ( StakePool (..), StakePoolMetadata, WalletId )
+    ( Coin, StakePool (..), StakePoolMetadata )
 import Control.Applicative
     ( liftA2 )
 import Data.Generics.Internal.VL.Lens
@@ -279,7 +279,7 @@ server byron icarus jormungandr spl ntp =
 listPools
     :: LiftHandler e
     => StakePoolLayer e IO
-    -> ApiT WalletId
+    -> Maybe (ApiT Coin)
     -- ^ Not needed, but there for consistency with haskell node.
     -> Handler [ApiJormungandrStakePool]
 listPools spl _walletId =

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1193,6 +1193,19 @@ x-parametersWalletId: &parametersWalletId
     maxLength: 40
     minLength: 40
 
+  x-parametersIntendedStakeAmount: &parametersIntendedStakeAmount
+    in: query
+    name: stake
+    required: false
+    schema:
+      type: integer
+      minimum: 0
+      maximum: 45_000_000_000_000_000 # 45 B ada (in Lovelace)
+    description: |
+      The stake the user intends to delegate in Lovelace. Required.
+
+      > ⚠️  On the incentivized testnet, this parameter is not requred, but rather completely ignored.
+
 x-parametersTransactionId: &parametersTransactionId
   in: path
   name: transactionId
@@ -1910,7 +1923,7 @@ paths:
         - *parametersAddressState
       responses: *responsesListAddresses
 
-  /wallets/{walletId}/stake-pools:
+  /stake-pools:
     get:
       operationId: listStakePools
       tags: ["Stake Pools"]
@@ -1919,15 +1932,15 @@ paths:
         <p align="right">status: <strong>stable</strong></p>
 
         List all known stake pools ordered by descending `non_myopic_member_rewards`.
-        The `non_myopic_member_rewards` — and thus the ordering — depends on
-        the balance of the given wallet.
+        The `non_myopic_member_rewards` — and thus the ordering — depends on the `?stake` query
+        parameter.
 
-        > /!\ On the incentivized testnet, pools are instead ordered by
+        > ⚠️  On the incentivized testnet, pools are instead ordered by
         descending `desirability`.
 
         Some pools _may_ also have metadata attached to them.
       parameters:
-        - *parametersWalletId
+        - *parametersIntendedStakeAmount
       responses: *responsesListStakePools
 
   /stake-pools/{stakePoolId}/wallets/{walletId}:


### PR DESCRIPTION
# Issue Number

#1720 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Make list stake pool endpoint take `Coin` instead of `WalletId`.
- [x] Adjust corresponding types and tests (A few more I think)
- [x] Fail with `err400` when query param is not present on Shelley.
- [x] Adjust swagger



# Comments

```
Originally:
GET /stake-pools

What was recently introduced:
GET /wallets/:wid/stake-pools

Now:
GET /stake-pools?stake=1000

For jormungandr the query parameter is not required, and unused. This
minimises breaking changes.
```

 - [Slack thread](https://input-output-rnd.slack.com/archives/C819S481Y/p1592322972378700)
- This PR gives greater flexibility to Daedalus and other API users

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
