### PR TITLE
Fix fee estimation error handler (cannot cover fee) 

### DIFF
--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -61,7 +61,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..) )
+    ( CoinSelection (..), feeBalance )
+import Cardano.Wallet.Primitive.Fee
+    ( Fee (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (BlockHeader)
@@ -529,8 +531,8 @@ prop_estimateFee (NonEmpty results) = case actual of
 
     -- Pops a pre-canned result off the state and returns it
     mockCoinSelection
-        :: ExceptT String (State [Either String CoinSelection]) CoinSelection
-    mockCoinSelection = ExceptT $ state (\(r:rs) -> (r,rs))
+        :: ExceptT String (State [Either String CoinSelection]) Fee
+    mockCoinSelection = fmap (Fee . feeBalance) $ ExceptT $ state (\(r:rs) -> (r,rs))
 
     runTest vals action = evalState (runExceptT action) vals
 

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -145,6 +145,7 @@ test-suite unit
     , cardano-wallet-shelley
     , cardano-wallet-test-utils
     , containers
+    , fmt
     , generic-lens
     , hspec
     , iohk-monitoring
@@ -155,6 +156,7 @@ test-suite unit
     , shelley-spec-ledger
     , text
     , text-class
+    , transformers
     , QuickCheck
   build-tools:
       hspec-discover

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -145,7 +145,6 @@ test-suite unit
     , cardano-wallet-shelley
     , cardano-wallet-test-utils
     , containers
-    , fmt
     , generic-lens
     , hspec
     , iohk-monitoring

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -97,8 +97,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Word
     ( Word16, Word8 )
-import Fmt
-    ( Buildable (..) )
 import Ouroboros.Network.Block
     ( SlotNo )
 
@@ -403,10 +401,4 @@ unsafeMkEd25519 =
 -- Extra validations on coin selection
 --
 
--- | Transaction with 0 output amount is tried
-data ErrInvalidTxOutAmount -- FIXME: = ErrInvalidTxOutAmount
-
-instance Buildable ErrInvalidTxOutAmount where
-    build _ = "Invalid coin selection: at least one output is null."
-
-type instance ErrValidateSelection (IO Shelley) = ErrInvalidTxOutAmount
+type instance ErrValidateSelection (IO Shelley) = ()

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -68,7 +68,7 @@ import Data.Word
 import Ouroboros.Network.Block
     ( SlotNo (..) )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe, shouldNotBe )
+    ( Spec, describe, it, shouldBe )
 import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
@@ -134,15 +134,14 @@ data DecodeSetup = DecodeSetup
                 [ TxOut dummyAddress (Coin 4834720)
                 ]
 
-        let selectCoins = flip catchE (handleCannotCover utxo) $ do
+        let selectCoins = flip catchE (handleCannotCover utxo recipients) $ do
                 (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
                     CS.random testCoinSelOpts recipients utxo
                 withExceptT ErrSelectForPaymentFee $
                     (Fee . CS.feeBalance) <$> adjustForFee testFeeOpts utxo' sel
-
         res <- runExceptT $ estimateFeeForCoinSelection selectCoins
 
-        res `shouldNotBe` Right (FeeEstimation 5000001 5000001)
+        res `shouldBe` Right (FeeEstimation 165281 165281)
 
 prop_decodeSignedTxRoundtrip
     :: DecodeSetup

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -50,7 +50,12 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Shelley.Compatibility
     ( toSealed )
 import Cardano.Wallet.Shelley.Transaction
-    ( mkUnsignedTx, mkWitness, _decodeSignedTx, _estimateMaxNumberOfInputs, newTransactionLayer, _decodeSignedTx )
+    ( mkUnsignedTx
+    , mkWitness
+    , newTransactionLayer
+    , _decodeSignedTx
+    , _estimateMaxNumberOfInputs
+    )
 import Cardano.Wallet.Transaction
     ( WithDelegation (..) )
 import Control.Monad
@@ -116,13 +121,6 @@ spec = do
         prop "more outputs ==> less inputs" prop_moreOutputsMeansLessInputs
         prop "less outputs ==> more inputs" prop_lessOutputsMeansMoreInputs
         prop "bigger size  ==> more inputs" prop_biggerMaxSizeMeansMoreInputs
-
-data DecodeSetup = DecodeSetup
-    { inputs :: UTxO
-    , outputs :: [TxOut]
-    , ttl :: SlotNo
-    , keyPasswd :: [(XPrv, Passphrase "encryption")]
-    } deriving Show
 
     it "regression #1740 - fee estimation at the boundaries" $ do
         let utxo = UTxO $ Map.fromList
@@ -205,6 +203,13 @@ testFeeOpts = feeOpts tl (WithDelegation False) feePolicy
     epLength  = EpochLength 42 -- irrelevant here
     tl        = newTransactionLayer @_ @ShelleyKey (Proxy @'Mainnet) pm epLength
     feePolicy = LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)
+
+data DecodeSetup = DecodeSetup
+    { inputs :: UTxO
+    , outputs :: [TxOut]
+    , ttl :: SlotNo
+    , keyPasswd :: [(XPrv, Passphrase "encryption")]
+    } deriving Show
 
 instance Arbitrary DecodeSetup where
     arbitrary = do

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -125,6 +125,7 @@
             (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             ];
           build-tools = [


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1740 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 5f6a28f54f3e089bf8b279a423d2944c4edc2628
  :round_pushpin: **remove unused 'ErrInvalidTxOutSubmit' data-type from Shelley transaction layer**
  
- 41530d62058ac87c37468c21dcb8bf198fe93b02
  :round_pushpin: **move error handler one layer down, out of the API layer**
  So that it can be more tested more easily at the unit level.

- d9d2cd022e9ed8606c2a1f37089d9a037c985e59
  :round_pushpin: **write unit test to illustrate #1740 at the unit-level.**
  The test currently fails, so the regression is indeed identified.

- 0bd806a7acea3c736e8706c5c3822f6e437de403
  :round_pushpin: **slightly change type signature of 'estimateFeeForCS' to allow mounting the error handler on each selection.**
  
- ed03123f42c45107d070a7fec4abf45686235561
  :round_pushpin: **fix error handler in estimated fee, take recipients into account.**



# Comments

<!-- Additional comments or screenshots to attach if any -->

The issue wasn't actually in the coin selection or fee estimation procedures, but in an extra error handler that was set only in the API layer. 
This PR supersedes #1756 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
