### PR TITLE
integration tests: Shorten cardano-node socket path

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Launch.hs
@@ -289,7 +289,7 @@ withConfig tdir minSeverity action =
         let nodeSocketFile =
                 if os == "mingw32"
                 then "\\\\.\\pipe\\" ++ takeFileName dir
-                else dir </> "node.socket"
+                else dir </> "socket"
 
         -- we need to specify genesis file location every run in tmp
         Yaml.decodeFileThrow (source </> "node.config")

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -374,7 +374,7 @@ withBFTNode tr baseDir (NodeParams severity systemStart (port, peers)) action =
     source :: FilePath
     source = $(getTestData) </> "cardano-node-shelley"
 
-    name = "bft-node"
+    name = "bft"
     dir = baseDir </> name
 
 singleNodeParams :: Severity -> IO NodeParams
@@ -470,7 +470,7 @@ withStakePool tr baseDir idx params action =
                 action
   where
     dir = baseDir </> name
-    name = "stake-pool-" ++ show idx
+    name = "pool-" ++ show idx
 
 withCardanoNodeProcess
     :: Tracer IO ClusterLog

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -207,7 +207,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
     withServer onStart = bracketTracer' tr "withServer" $ do
         minSev <- nodeMinSeverityFromEnv
         let tr' = contramap MsgCluster tr
-        withSystemTempDir tr' "integration" $ \dir ->
+        withSystemTempDir tr' "test" $ \dir ->
             withCluster tr' minSev 3 dir $ \socketPath block0 (gp, vData) ->
                 withTempDir tr' dir "wallets" $ \db ->
                     serveWallet @(IO Shelley)


### PR DESCRIPTION
### Issue Number

ADP-302 / #1750

### Overview

The socket path needs to be short enough to work in the default temp directory on macOS.
