### PR TITLE
Handle key deposit for Shelley transactions

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
@@ -42,21 +42,19 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , GenesisParameters (..)
     , Hash (..)
-    , PoolId
     , ProtocolMagic (..)
     , SealedTx (..)
     , SlotId (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)
-    , WalletDelegation
     )
 import Cardano.Wallet.Transaction
-    ( ErrDecodeSignedTx (..)
+    ( Certificate (..)
+    , ErrDecodeSignedTx (..)
     , ErrMkTx (..)
     , ErrValidateSelection
     , TransactionLayer (..)
-    , WithDelegation (..)
     )
 import Control.Arrow
     ( second )
@@ -135,7 +133,7 @@ newTransactionLayer _proxy protocolMagic = TransactionLayer
 
     _minimumFee
         :: FeePolicy
-        -> WithDelegation
+        -> [Certificate]
         -> CoinSelection
         -> Fee
     _minimumFee policy _ (CoinSelection inps outs chngs) =
@@ -187,25 +185,9 @@ newTransactionLayer _proxy protocolMagic = TransactionLayer
                 , SealedTx bytes
                 )
 
-    _mkDelegationJoinTx
-        :: WalletDelegation
-        -> PoolId
-        -> (k 'AddressK XPrv, Passphrase "encryption") -- reward account
-        -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
-        -> SlotId
-        -> [(TxIn, TxOut)]
-        -> [TxOut]
-        -> Either ErrMkTx (Tx, SealedTx)
     _mkDelegationJoinTx =
         notImplemented "mkDelegationJoinTx"
 
-    _mkDelegationQuitTx
-        :: (k 'AddressK XPrv, Passphrase "encryption") -- reward account
-        -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
-        -> SlotId
-        -> [(TxIn, TxOut)]
-        -> [TxOut]
-        -> Either ErrMkTx (Tx, SealedTx)
     _mkDelegationQuitTx =
         notImplemented "mkDelegationQuitTx"
 

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/NetworkSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/NetworkSpec.hs
@@ -58,7 +58,7 @@ spec = describe "getTxParameters" $ do
                 -- After a short while, the network layer should have gotten
                 -- protocol parameters from the node, and they should reflect
                 -- the genesis block configuration.
-                let retryPolicy = constantDelay 1_000_000 <> limitRetries 60
+                let retryPolicy = constantDelay 1_000_000 <> limitRetries 100
                 recoverAll retryPolicy $ const $
                     getProtocolParameters nl `shouldReturn`
                         protocolParameters np

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
@@ -77,7 +77,7 @@ import Cardano.Wallet.Primitive.Types
     , testnetMagic
     )
 import Cardano.Wallet.Transaction
-    ( TransactionLayer (..), WithDelegation (..) )
+    ( TransactionLayer (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Arrow
@@ -134,7 +134,7 @@ spec = do
     describe "Coin Selection w/ Byron" $ do
         it "REG #1561 - Correct balancing of amounts close to the limit" $ do
             let opts = FeeOptions
-                    { estimateFee = minimumFee tlayer feePolicy (WithDelegation False)
+                    { estimateFee = minimumFee tlayer feePolicy []
                     , dustThreshold = minBound
                     , onDanglingChange = SaveMoney
                     }
@@ -305,7 +305,7 @@ prop_rebalanceChangeOutputs sel onDangling = do
   where
     delta s = inputBalance s - (outputBalance s + changeBalance s)
     opts = FeeOptions
-        { estimateFee = minimumFee tlayer feePolicy (WithDelegation False)
+        { estimateFee = minimumFee tlayer feePolicy []
         , dustThreshold = minBound
         , onDanglingChange = onDangling
         }
@@ -358,7 +358,7 @@ propSizeEstimation pm genSel genChngAddrs =
     estimateSize :: TransactionLayer t k -> CoinSelection -> Quantity "bytes" Int
     estimateSize tl sel =
         let
-            Fee fee = minimumFee tl idPolicy (WithDelegation False) sel
+            Fee fee = minimumFee tl idPolicy [] sel
         in
             Quantity $ fromIntegral fee
       where

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -303,11 +303,11 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Cardano.Wallet.Transaction
-    ( ErrDecodeSignedTx (..)
+    ( Certificate (..)
+    , ErrDecodeSignedTx (..)
     , ErrMkTx (..)
     , ErrValidateSelection
     , TransactionLayer (..)
-    , WithDelegation (..)
     )
 import Control.Exception
     ( Exception )
@@ -1045,11 +1045,11 @@ coinSelOpts tl txMaxSize = CoinSelectionOptions
 
 feeOpts
     :: TransactionLayer t k
-    -> WithDelegation
+    -> [Certificate]
     -> FeePolicy
     -> FeeOptions
-feeOpts tl withDelegation feePolicy = FeeOptions
-    { estimateFee = minimumFee tl feePolicy withDelegation
+feeOpts tl certs feePolicy = FeeOptions
+    { estimateFee = minimumFee tl feePolicy certs
     , dustThreshold = minBound
     , onDanglingChange = if allowUnbalancedTx tl then SaveMoney else PayAndBalance
     }
@@ -1104,7 +1104,7 @@ selectCoinsForPaymentFromUTxO ctx utxo txp recipients = do
         let opts = coinSelOpts tl (txp ^. #getTxMaxSize)
         CoinSelection.random opts recipients utxo
     lift . traceWith tr $ MsgPaymentCoinSelection sel
-    let feePolicy = feeOpts tl (WithDelegation False) (txp ^. #getFeePolicy)
+    let feePolicy = feeOpts tl [] (txp ^. #getFeePolicy)
     withExceptT ErrSelectForPaymentFee $ do
         balancedSel <- adjustForFee feePolicy utxo' sel
         lift . traceWith tr $ MsgPaymentCoinSelectionAdjusted balancedSel
@@ -1123,11 +1123,12 @@ selectCoinsForDelegation
         )
     => ctx
     -> WalletId
+    -> [Certificate]
     -> ExceptT ErrSelectForDelegation IO CoinSelection
-selectCoinsForDelegation ctx wid = do
+selectCoinsForDelegation ctx wid certs = do
     (utxo, txp) <- withExceptT ErrSelectForDelegationNoSuchWallet $
         selectCoinsSetup @ctx @s @k ctx wid
-    selectCoinsForDelegationFromUTxO @_ @t @k ctx utxo txp
+    selectCoinsForDelegationFromUTxO @_ @t @k ctx utxo txp certs
 
 selectCoinsForDelegationFromUTxO
     :: forall ctx t k.
@@ -1137,10 +1138,11 @@ selectCoinsForDelegationFromUTxO
     => ctx
     -> W.UTxO
     -> W.TxParameters
+    -> [Certificate]
     -> ExceptT ErrSelectForDelegation IO CoinSelection
-selectCoinsForDelegationFromUTxO ctx utxo txp = do
+selectCoinsForDelegationFromUTxO ctx utxo txp certs = do
     let sel = CoinSelection [] [] []
-    let feePolicy = feeOpts tl (WithDelegation True) (txp ^. #getFeePolicy)
+    let feePolicy = feeOpts tl certs (txp ^. #getFeePolicy)
     withExceptT ErrSelectForDelegationFee $ do
         balancedSel <- adjustForFee feePolicy utxo sel
         lift $ traceWith tr $ MsgDelegationCoinSelection balancedSel
@@ -1162,7 +1164,9 @@ estimateFeeForDelegation
 estimateFeeForDelegation ctx wid = do
     (utxo, txp) <- withExceptT ErrSelectForDelegationNoSuchWallet $
         selectCoinsSetup @ctx @s @k ctx wid
-    let selectCoins = selectCoinsForDelegationFromUTxO @_ @t @k ctx utxo txp
+    -- NOTE: consider the worst case scenario for the estimation.
+    let certs = [KeyRegistrationCertificate,PoolDelegationCertificate]
+    let selectCoins = selectCoinsForDelegationFromUTxO @_ @t @k ctx utxo txp certs
     estimateFeeForCoinSelection $ Fee . feeBalance <$> selectCoins
 
 -- | Constructs a set of coin selections that select all funds from the given
@@ -1198,7 +1202,7 @@ selectCoinsForMigrationFromUTxO
     -> ExceptT ErrSelectForMigration IO [CoinSelection]
 selectCoinsForMigrationFromUTxO ctx utxo txp wid = do
     let feePolicy@(LinearFee (Quantity a) _ _) = txp ^. #getFeePolicy
-    let feeOptions = (feeOpts tl (WithDelegation False) feePolicy)
+    let feeOptions = (feeOpts tl [] feePolicy)
             { dustThreshold = Coin $ ceiling a }
     let selOptions = coinSelOpts tl (txp ^. #getTxMaxSize)
     case depleteUTxO feeOptions (idealBatchSize selOptions) utxo of
@@ -1406,6 +1410,9 @@ signDelegation ctx wid argGenChange pwd coinSel action = db & \DBLayer{..} -> do
     nodeTip <- withExceptT ErrSignDelegationNetwork $ currentNodeTip nl
     withRootKey @_ @s ctx wid pwd ErrSignDelegationWithRootKey $ \xprv scheme -> do
         let pwdP = preparePassphrase scheme pwd
+        txp <- txParameters <$> withExceptT ErrSignDelegationNoSuchWallet
+            (readWalletProtocolParameters @ctx @s @k ctx wid)
+        let feePolicy = txp ^. #getFeePolicy
         mapExceptT atomically $ do
             cp <- withExceptT ErrSignDelegationNoSuchWallet $ withNoSuchWallet wid $
                 readCheckpoint (PrimaryKey wid)
@@ -1417,12 +1424,21 @@ signDelegation ctx wid argGenChange pwd coinSel action = db & \DBLayer{..} -> do
                 readWalletMeta (PrimaryKey wid)
             let rewardAcc = deriveRewardAccount @k pwdP xprv
             let keyFrom = isOwned (getState cp) (xprv, pwdP)
+
             (tx, sealedTx) <- withExceptT ErrSignDelegationMkTx $ ExceptT $ pure $
                 case action of
                     Join poolId ->
-                        mkDelegationJoinTx tl wDeleg poolId (rewardAcc, pwdP) keyFrom (nodeTip ^. #slotId) ins allOuts
+                        mkDelegationJoinTx tl feePolicy wDeleg poolId
+                            (rewardAcc, pwdP)
+                            keyFrom
+                            (nodeTip ^. #slotId)
+                            ins allOuts
                     Quit ->
-                        mkDelegationQuitTx tl (rewardAcc, pwdP) keyFrom (nodeTip ^. #slotId) ins allOuts
+                        mkDelegationQuitTx tl feePolicy
+                            (rewardAcc, pwdP)
+                            keyFrom
+                            (nodeTip ^. #slotId)
+                            ins allOuts
 
             let gp = blockchainParameters cp
             let (time, meta) = mkTxMeta gp (currentTip cp) s' ins allOuts
@@ -1606,8 +1622,9 @@ joinStakePool ctx wid (pid, pools) argGenChange pwd = db & \DBLayer{..} -> do
     withExceptT ErrJoinStakePoolCannotJoin $ except $
         guardJoin pools (walMeta ^. #delegation) pid
 
+    let certs = getRequiredCertificates walMeta
     selection <- withExceptT ErrJoinStakePoolSelectCoin $
-        selectCoinsForDelegation @ctx @s @t @k ctx wid
+        selectCoinsForDelegation @ctx @s @t @k ctx wid certs
 
     (tx, txMeta, txTime, sealedTx) <- withExceptT ErrJoinStakePoolSignDelegation $
         signDelegation @ctx @s @t @k ctx wid argGenChange pwd selection (Join pid)
@@ -1618,6 +1635,15 @@ joinStakePool ctx wid (pid, pools) argGenChange pwd = db & \DBLayer{..} -> do
     pure (tx, txMeta, txTime)
   where
     db = ctx ^. dbLayer @s @k
+
+    getRequiredCertificates (WalletMetadata _ _ _ wDeleg) =
+        case wDeleg of
+            (WalletDelegation NotDelegating []) ->
+                [ PoolDelegationCertificate
+                , KeyRegistrationCertificate
+                ]
+            _ ->
+                [PoolDelegationCertificate]
 
 -- | Helper function to factor necessary logic for quitting a stake pool.
 quitStakePool
@@ -1643,8 +1669,9 @@ quitStakePool ctx wid argGenChange pwd = db & \DBLayer{..} -> do
     withExceptT ErrQuitStakePoolCannotQuit $ except $
         guardQuit (walMeta ^. #delegation)
 
+    let certs = [KeyDeRegistrationCertificate]
     selection <- withExceptT ErrQuitStakePoolSelectCoin $
-        selectCoinsForDelegation @ctx @s @t @k ctx wid
+        selectCoinsForDelegation @ctx @s @t @k ctx wid certs
 
     (tx, txMeta, txTime, sealedTx) <- withExceptT ErrQuitStakePoolSignDelegation $
         signDelegation @ctx @s @t @k ctx wid argGenChange pwd selection Quit

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1873,6 +1873,13 @@ instance LiftHandler ErrMkTx where
                 , "input address I should keep track of: ", showT addr, ". "
                 , "Retrying may work, but something really went wrong..."
                 ]
+        ErrChangeIsEmptyForRetirement ->
+            apiError err500 UnexpectedError $ mconcat
+                [ "That's embarassing. I need to one change output to give you "
+                , "back you key registration deposit but it seems that I've "
+                , "generated a coin selection that has none! Since the coin "
+                , "selection algorithm has randomness, retrying may work."
+                ]
 
 instance LiftHandler ErrSignPayment where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -106,11 +106,11 @@ data TransactionLayer t k = TransactionLayer
         -> SlotId
             -- Tip of the chain, for TTL
         -> [(TxIn, TxOut)]
-            -- ^ Resolved inputs
+            -- Resolved inputs
         -> [TxOut]
-            -- ^ Outputs
+            -- Outputs
         -> [TxOut]
-            -- ^ Change, with assigned address
+            -- Change, with assigned address
         -> Either ErrMkTx (Tx, SealedTx)
         -- ^ Construct a transaction containing a certificate for quiting from
         -- a stake pool.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -71,13 +71,23 @@ data TransactionLayer t k = TransactionLayer
 
     , mkDelegationJoinTx
         :: FeePolicy
+            -- Latest fee policy
         -> WalletDelegation
+            -- Wallet current delegation status
         -> PoolId
-        -> (k 'AddressK XPrv, Passphrase "encryption") -- reward account
+            -- Pool Id to which we're planning to delegate
+        -> (k 'AddressK XPrv, Passphrase "encryption")
+            -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+            -- Key store
         -> SlotId
+            -- Tip of the chain, for TTL
         -> [(TxIn, TxOut)]
+            --  Resolved inputs
         -> [TxOut]
+            -- Outputs
+        -> [TxOut]
+            -- Change, with assigned address
         -> Either ErrMkTx (Tx, SealedTx)
         -- ^ Construct a transaction containing a certificate for delegating to
         -- a stake pool.
@@ -88,11 +98,19 @@ data TransactionLayer t k = TransactionLayer
 
     , mkDelegationQuitTx
         :: FeePolicy
-        -> (k 'AddressK XPrv, Passphrase "encryption") -- reward account
+            -- Latest fee policy
+        -> (k 'AddressK XPrv, Passphrase "encryption")
+            -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
+            -- Key store
         -> SlotId
+            -- Tip of the chain, for TTL
         -> [(TxIn, TxOut)]
+            -- ^ Resolved inputs
         -> [TxOut]
+            -- ^ Outputs
+        -> [TxOut]
+            -- ^ Change, with assigned address
         -> Either ErrMkTx (Tx, SealedTx)
         -- ^ Construct a transaction containing a certificate for quiting from
         -- a stake pool.
@@ -145,9 +163,14 @@ data ErrDecodeSignedTx
     deriving (Show, Eq)
 
 -- | Possible signing error
-newtype ErrMkTx
+data ErrMkTx
     = ErrKeyNotFoundForAddress Address
     -- ^ We tried to sign a transaction with inputs that are unknown to us?
+    | ErrChangeIsEmptyForRetirement
+    -- ^ When retiring on Shelley, we need to add a deposit amount made when
+    -- creating a stake key. This requires at least one change output, which
+    -- ought to be present anyway by construction of the coin selection when
+    -- quitting delegation.
     deriving (Eq, Show)
 
 data Certificate

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -521,7 +521,16 @@ goldenTestDelegationCertTx
     -> SpecWith ()
 goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inps outs bytes' = it title $ do
     let walDelegs = WalletDelegation NotDelegating []
-    let res = mkDelegationJoinTx tl walDelegs pool (accountXPrv, pass) keystore (SlotId 0 0) inps outs
+    let res = mkDelegationJoinTx tl
+            policy
+            walDelegs
+            pool
+            (accountXPrv, pass)
+            keystore
+            (SlotId 0 0)
+            inps
+            outs
+            []
     let sealed = getSealedTx . snd <$> res
     sealed `shouldBe` Right (unsafeFromHex bytes')
     & counterexample ("poolId = " <> showHex (getPoolId pool))
@@ -529,6 +538,7 @@ goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inps outs bytes'
     title = "golden test mkCertificateTx: " <> show pool
         <> show inps <> show outs
     showHex = B8.unpack . hex
+    policy = error "fee policy unused by Jörmungandr"
 
 xprvSeqFromSeed
     :: ByteString

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -492,7 +492,7 @@ txParametersFromPParams pp = W.TxParameters
     { getFeePolicy = W.LinearFee
         (Quantity (naturalToDouble (SL._minfeeB pp)))
         (Quantity (fromIntegral (SL._minfeeA pp)))
-        (Quantity 0) -- TODO: it's not as simple as this?
+        (Quantity (fromIntegral (SL._keyDeposit pp)))
     , getTxMaxSize = fromMaxTxSize $ SL._maxTxSize pp
     }
   where

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -768,7 +768,7 @@ prepareTx tr dir stakePub certs = do
         , "--tx-in", faucetInput
         , "--tx-out", init addr <> "+" <> show pledgeAmt
         , "--ttl", "100"
-        , "--fee", show (faucetAmt - pledgeAmt)
+        , "--fee", show (faucetAmt - pledgeAmt - depositAmt)
         , "--out-file", file
         ] ++ mconcat ((\cert -> ["--certificate-file",cert]) <$> certs)
 
@@ -978,6 +978,9 @@ operators = unsafePerformIO $ newMVar
     ]
 {-# NOINLINE operators #-}
 
+-- | Deposit amount required for registering certificates.
+depositAmt :: Integer
+depositAmt = 100
 
 -- | Pledge amount used for each pool.
 pledgeAmt :: Integer

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -31,7 +31,7 @@ protocolParams:
   extraEntropy:
     tag: NeutralNonce
   maxBlockHeaderSize: 217569
-  keyDeposit: 0
+  keyDeposit: 100
   keyDecayRate: 0
   nOpt: 100
   rho: 0

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Shelley.Launch
 import Cardano.Wallet.Shelley.Transaction
     ( _minimumFee )
 import Cardano.Wallet.Transaction
-    ( WithDelegation (..) )
+    ( Certificate (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar
@@ -239,13 +239,16 @@ mkFeeEstimator :: FeePolicy -> TxDescription -> (Natural, Natural)
 mkFeeEstimator policy = \case
     PaymentDescription i o c ->
         let
-            fee = computeFee (dummySelection i o c) (WithDelegation False)
+            fee = computeFee (dummySelection i o c) []
         in
             ( fee, fee )
 
     DelegDescription i o _ ->
         let
-            fee = computeFee (dummySelection i o 0) (WithDelegation True)
+            fee = computeFee (dummySelection i o 0)
+                    [ PoolDelegationCertificate
+                    , KeyRegistrationCertificate
+                    ]
         in
             ( fee, fee )
   where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -53,11 +53,10 @@ import Cardano.Wallet.Shelley.Transaction
     ( mkUnsignedTx
     , mkWitness
     , newTransactionLayer
+    , realFee
     , _decodeSignedTx
     , _estimateMaxNumberOfInputs
     )
-import Cardano.Wallet.Transaction
-    ( WithDelegation (..) )
 import Control.Monad
     ( replicateM )
 import Control.Monad.Trans.Except
@@ -146,7 +145,7 @@ prop_decodeSignedTxRoundtrip
     -> Property
 prop_decodeSignedTxRoundtrip (DecodeSetup utxo outs slotNo pairs) = do
     let ownedIns = Map.toList $ getUTxO utxo
-    let unsigned = mkUnsignedTx slotNo ownedIns outs []
+    let unsigned = mkUnsignedTx slotNo ownedIns outs [] (realFee ownedIns outs)
     let addrWits = Set.fromList $ map (mkWitness unsigned) pairs
     let metadata = SL.SNothing
     let wits = SL.WitnessSet addrWits mempty mempty
@@ -197,7 +196,7 @@ testCoinSelOpts = coinSelOpts tl (Quantity 4096)
     tl        = newTransactionLayer @_ @ShelleyKey (Proxy @'Mainnet) pm epLength
 
 testFeeOpts :: FeeOptions
-testFeeOpts = feeOpts tl (WithDelegation False) feePolicy
+testFeeOpts = feeOpts tl [] feePolicy
   where
     pm        = ProtocolMagic 1
     epLength  = EpochLength 42 -- irrelevant here


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1799 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 8085f82b7352cf2912f41812af422e543ef0a9c9
  :round_pushpin: **add a non-null key deposit to genesis, and account for it for launching pools**
  
- 8240a15c825fab379b5fe3baaee259b3803bddc6
  :round_pushpin: **account for key deposit when registering a stake key**
  This is.. tricky, because the deposit is sort of implicit but, because of the dual support with Jörmungandr, we have to treat it as a fee. So, there's a bit of weird logic / work-around when creating the actual transaction.

- 285d0275c0459bb3012bdc213f700ddc7484a7b5
  :round_pushpin: **fix fee calculation for Shelley**
  - using 28-byte hash length for key hashes
- adding certificate witnesses to the estimation

- 0495b965b48150b4ebaf9941063cda742e71be5a
  :round_pushpin: **give deposit back when de-registing a stake key**
  
- a19bc0e3592ddd4b5bd9b69f154d0c03e9ce7c8d
  :round_pushpin: **adjust test scenarios according to recent API changes**

# Comments

<!-- Additional comments or screenshots to attach if any -->

Not 100% ideal, but works without _too much_ added complexity. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
