### PR TITLE
discard metadata URL based on their hash, not URLs

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -273,9 +273,9 @@ newDBLayer trace fp = do
                         , "FROM", metadata
                         , ")"
                     , "AND"
-                    , metadataUrl, "NOT", "IN" -- Recently failed urls
+                    , metadataHash, "NOT", "IN" -- Recently failed urls
                         , "("
-                        , "SELECT", metadataUrl
+                        , "SELECT", metadataHash
                         , "FROM", fetchAttempts
                         , "WHERE", retryAfter, ">=", "datetime('now')"
                         , ")"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1805 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have changed the SQLite filtering to discard metadata URL based on their hash, not URLs


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
