### PR TITLE
Introduce k parameter

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -189,6 +189,7 @@ mainnetNetworkParameters = W.NetworkParameters
             , getTxMaxSize =
                 Quantity 4096
             }
+        , desiredNumberOfStakePools = Nothing
         }
     }
 
@@ -429,6 +430,7 @@ protocolParametersFromPP pp = W.ProtocolParameters
         { getFeePolicy = fromTxFeePolicy $ Update.ppTxFeePolicy pp
         , getTxMaxSize = fromMaxTxSize $ Update.ppMaxTxSize pp
         }
+    , desiredNumberOfStakePools = Nothing
     }
 
 -- | Extract the protocol parameters relevant to the wallet out of the

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -189,7 +189,7 @@ mainnetNetworkParameters = W.NetworkParameters
             , getTxMaxSize =
                 Quantity 4096
             }
-        , desiredNumberOfStakePools = Nothing
+        , desiredNumberOfStakePools = 0
         }
     }
 
@@ -430,7 +430,7 @@ protocolParametersFromPP pp = W.ProtocolParameters
         { getFeePolicy = fromTxFeePolicy $ Update.ppTxFeePolicy pp
         , getTxMaxSize = fromMaxTxSize $ Update.ppMaxTxSize pp
         }
-    , desiredNumberOfStakePools = Nothing
+    , desiredNumberOfStakePools = 0
     }
 
 -- | Extract the protocol parameters relevant to the wallet out of the

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -36,5 +36,7 @@ spec = do
         r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty
         expectResponseCode @IO HTTP.status200 r
         let Right d = Quantity <$> mkPercentage (3 % 4)
+        let nOpt = Just 100
         verify r
-            [ expectField (#decentralizationLevel) (`shouldBe` d) ]
+            [ expectField (#decentralizationLevel) (`shouldBe` d)
+            , expectField (#desiredPoolNumber) (`shouldBe` nOpt)]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -36,7 +36,7 @@ spec = do
         r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty
         expectResponseCode @IO HTTP.status200 r
         let Right d = Quantity <$> mkPercentage (3 % 4)
-        let nOpt = Just 100
+        let nOpt = 100
         verify r
             [ expectField (#decentralizationLevel) (`shouldBe` d)
             , expectField (#desiredPoolNumber) (`shouldBe` nOpt)]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -36,7 +36,7 @@ spec = do
         r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty
         expectResponseCode @IO HTTP.status200 r
         let Right d = Quantity <$> mkPercentage (3 % 4)
-        let nOpt = 100
+        let nOpt = 3
         verify r
             [ expectField (#decentralizationLevel) (`shouldBe` d)
             , expectField (#desiredPoolNumber) (`shouldBe` nOpt)]

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -502,7 +502,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , epochStability :: !(Quantity "block" Word32)
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
-    , desiredPoolNumber :: !Word16
+    , desiredPoolNumber :: !(Maybe Word16)
     } deriving (Eq, Generic, Show)
 
 toApiNetworkParameters :: NetworkParameters -> ApiNetworkParameters

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -232,7 +232,7 @@ import Data.Time.Clock
 import Data.Time.Text
     ( iso8601, iso8601ExtendedUtc, utcTimeFromText, utcTimeToText )
 import Data.Word
-    ( Word32, Word64 )
+    ( Word16, Word32, Word64 )
 import Data.Word.Odd
     ( Word31 )
 import Fmt
@@ -502,6 +502,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , epochStability :: !(Quantity "block" Word32)
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
+    , desiredPoolNumber :: !Word16
     } deriving (Eq, Generic, Show)
 
 toApiNetworkParameters :: NetworkParameters -> ApiNetworkParameters
@@ -516,6 +517,7 @@ toApiNetworkParameters (NetworkParameters gp pp) = ApiNetworkParameters
         $ unActiveSlotCoefficient
         $ getActiveSlotCoefficient gp)
     (Quantity $ unDecentralizationLevel $ view #decentralizationLevel pp)
+    (view #desiredNumberOfStakePools pp)
 
 newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -502,7 +502,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , epochStability :: !(Quantity "block" Word32)
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
-    , desiredPoolNumber :: !(Maybe Word16)
+    , desiredPoolNumber :: !Word16
     } deriving (Eq, Generic, Show)
 
 toApiNetworkParameters :: NetworkParameters -> ApiNetworkParameters

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1003,18 +1003,22 @@ mkProtocolParametersEntity
     -> W.ProtocolParameters
     -> ProtocolParameters
 mkProtocolParametersEntity wid pp =
-    ProtocolParameters wid fp (getQuantity mx) dl
+    ProtocolParameters wid fp (getQuantity mx) dl desiredPoolNum
   where
-    (W.ProtocolParameters (W.DecentralizationLevel dl) (W.TxParameters fp mx)) =
-        pp
+    (W.ProtocolParameters
+        (W.DecentralizationLevel dl)
+        (W.TxParameters fp mx)
+        desiredPoolNum
+        ) = pp
 
 protocolParametersFromEntity
     :: ProtocolParameters
     -> W.ProtocolParameters
-protocolParametersFromEntity (ProtocolParameters _ fp mx dl) =
+protocolParametersFromEntity (ProtocolParameters _ fp mx dl poolNum) =
     W.ProtocolParameters
         (W.DecentralizationLevel dl)
         (W.TxParameters fp (Quantity mx))
+        poolNum
 
 {-------------------------------------------------------------------------------
                                    DB Queries

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -151,7 +151,7 @@ ProtocolParameters
     protocolParametersFeePolicy             W.FeePolicy     sql=fee_policy
     protocolParametersTxMaxSize             Word16          sql=tx_max_size
     protocolParametersDecentralizationLevel Percentage      sql=decentralization_level
-    protocolParametersDesiredNumberOfPools  Word16 Maybe    sql=desired_pool_number
+    protocolParametersDesiredNumberOfPools  Word16          sql=desired_pool_number
     Primary protocolParametersWalletId
     Foreign Wallet fk_wallet_protocol_parameters protocolParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -147,11 +147,11 @@ Checkpoint
     deriving Show Generic
 
 ProtocolParameters
-    protocolParametersWalletId              W.WalletId  sql=wallet_id
-    protocolParametersFeePolicy             W.FeePolicy sql=fee_policy
-    protocolParametersTxMaxSize             Word16      sql=tx_max_size
-    protocolParametersDecentralizationLevel Percentage  sql=decentralization_level
-    protocolParametersDesiredNumberOfPools  Word16      sql=desired_pool_number
+    protocolParametersWalletId              W.WalletId      sql=wallet_id
+    protocolParametersFeePolicy             W.FeePolicy     sql=fee_policy
+    protocolParametersTxMaxSize             Word16          sql=tx_max_size
+    protocolParametersDecentralizationLevel Percentage      sql=decentralization_level
+    protocolParametersDesiredNumberOfPools  Word16 Maybe    sql=desired_pool_number
     Primary protocolParametersWalletId
     Foreign Wallet fk_wallet_protocol_parameters protocolParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -151,6 +151,7 @@ ProtocolParameters
     protocolParametersFeePolicy             W.FeePolicy sql=fee_policy
     protocolParametersTxMaxSize             Word16      sql=tx_max_size
     protocolParametersDecentralizationLevel Percentage  sql=decentralization_level
+    protocolParametersDesiredNumberOfPools  Word16      sql=desired_pool_number
     Primary protocolParametersWalletId
     Foreign Wallet fk_wallet_protocol_parameters protocolParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1401,6 +1401,10 @@ data ProtocolParameters = ProtocolParameters
     , txParameters
         :: TxParameters
         -- ^ Parameters that affect transaction construction.
+    , desiredNumberOfStakePools
+        :: Word16
+        -- ^ The current desired number of stakepools in the network.
+        -- Also known as k parameter.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters
@@ -1409,6 +1413,7 @@ instance Buildable ProtocolParameters where
     build pp = blockListF' "" id
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
+        , "K parameter: " <> build (pp ^. #desiredNumberOfStakePools)
         ]
 
 -- | Indicates the current level of decentralization in the network.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1413,7 +1413,7 @@ instance Buildable ProtocolParameters where
     build pp = blockListF' "" id
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
-        , "K parameter: " <> build (pp ^. #desiredNumberOfStakePools)
+        , "Desired number of pools: " <> build (pp ^. #desiredNumberOfStakePools)
         ]
 
 -- | Indicates the current level of decentralization in the network.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1413,7 +1413,9 @@ instance Buildable ProtocolParameters where
     build pp = blockListF' "" id
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
-        , "K parameter: " <> build (pp ^. #desiredNumberOfStakePools)
+        , case pp ^. #desiredNumberOfStakePools of
+              Just kparameter -> "K parameter: " <> build kparameter
+              Nothing -> mempty
         ]
 
 -- | Indicates the current level of decentralization in the network.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1402,9 +1402,9 @@ data ProtocolParameters = ProtocolParameters
         :: TxParameters
         -- ^ Parameters that affect transaction construction.
     , desiredNumberOfStakePools
-        :: Maybe Word16
+        :: Word16
         -- ^ The current desired number of stakepools in the network.
-        -- Also known as k parameter. If specified has to be bigger than 0.
+        -- Also known as k parameter.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters
@@ -1413,9 +1413,7 @@ instance Buildable ProtocolParameters where
     build pp = blockListF' "" id
         [ "Decentralization level: " <> build (pp ^. #decentralizationLevel)
         , "Transaction parameters: " <> build (pp ^. #txParameters)
-        , case pp ^. #desiredNumberOfStakePools of
-              Just kparameter -> "K parameter: " <> build kparameter
-              Nothing -> mempty
+        , "K parameter: " <> build (pp ^. #desiredNumberOfStakePools)
         ]
 
 -- | Indicates the current level of decentralization in the network.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1402,9 +1402,9 @@ data ProtocolParameters = ProtocolParameters
         :: TxParameters
         -- ^ Parameters that affect transaction construction.
     , desiredNumberOfStakePools
-        :: Word16
+        :: Maybe Word16
         -- ^ The current desired number of stakepools in the network.
-        -- Also known as k parameter.
+        -- Also known as k parameter. If specified has to be bigger than 0.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
@@ -1,243 +1,253 @@
 {
-    "seed": -1331206292408369414,
+    "seed": 1783641201901976871,
     "samples": [
         {
             "slot_length": {
-                "quantity": 4481,
+                "quantity": 4898,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 67,
+                "quantity": 5.85,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 26318,
+                "quantity": 528,
                 "unit": "block"
             },
-            "genesis_block_hash": "7f1535376d0c60752d213266651b90b1095573f1326d110169f0396e016e1b63",
-            "blockchain_start_time": "1908-08-05T09:00:00Z",
+            "genesis_block_hash": "374ca035306ae5516835045e4b233b5971c9840127700f6d20752d4439024740",
+            "blockchain_start_time": "1869-05-07T07:10:00Z",
+            "desired_pool_number": 246,
             "epoch_length": {
-                "quantity": 13609,
+                "quantity": 20945,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 78.62708373240245,
+                "quantity": 94.55547664569349,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 3359,
+                "quantity": 5803,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 59.77,
+                "quantity": 91.83,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 6460,
+                "quantity": 15302,
                 "unit": "block"
             },
-            "genesis_block_hash": "673b352d3c2f6c57176825e532f86c19b5a0356237b78c3e960d5c28616d7066",
-            "blockchain_start_time": "1883-09-17T08:37:33.480496398755Z",
+            "genesis_block_hash": "7d3cf56b896e087ddc6f2e793d77224f7c742ff065463a16bb4a6b437443327b",
+            "blockchain_start_time": "1880-03-03T09:00:00Z",
+            "desired_pool_number": 1332,
             "epoch_length": {
-                "quantity": 22307,
+                "quantity": 14005,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 58.146715325079654,
+                "quantity": 29.678701480196924,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 7255,
+                "quantity": 1210,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 28.94,
+                "quantity": 84.39,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 5369,
+                "quantity": 24490,
                 "unit": "block"
             },
-            "genesis_block_hash": "7c4f4b2e0703a155761c6a5d693b5868244a415f11c47d63627f151571062a23",
-            "blockchain_start_time": "1867-09-15T04:44:07.18685544607Z",
+            "genesis_block_hash": "b2d75f565952443844295b853eb3045c0a1817366e5c2e293596093f4dd02854",
+            "blockchain_start_time": "1864-05-18T18:07:13.640068095679Z",
+            "desired_pool_number": 907,
             "epoch_length": {
-                "quantity": 32596,
+                "quantity": 8497,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 31.533960051384536,
+                "quantity": 41.0009989127716,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 3285,
+                "quantity": 4155,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 63.69,
+                "quantity": 25.84,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 2008,
+                "quantity": 10252,
                 "unit": "block"
             },
-            "genesis_block_hash": "0d212e27f76e13ca63bd2d63102c667b321203a84077396c786753100943c15c",
-            "blockchain_start_time": "1860-03-07T22:01:48Z",
+            "genesis_block_hash": "5a59c67da96f38177509e8023306205a62ab3b504d0963532e1333380d113961",
+            "blockchain_start_time": "1901-10-16T12:05:49Z",
+            "desired_pool_number": 670,
             "epoch_length": {
-                "quantity": 25091,
+                "quantity": 261,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 36.72480953416392,
+                "quantity": 58.28661284335994,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 6702,
+                "quantity": 566,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 72.49,
+                "quantity": 30.33,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 17350,
+                "quantity": 472,
                 "unit": "block"
             },
-            "genesis_block_hash": "77706a697cdc1a976e2c09125a7f4d368f7f5d0437b2560a650462504a7368df",
-            "blockchain_start_time": "1898-07-20T16:00:00Z",
+            "genesis_block_hash": "24721c606c6919353377db135c08603f68ec495d0935502731ff8e4e1b5a0c4f",
+            "blockchain_start_time": "1866-03-22T03:01:21.729708338291Z",
+            "desired_pool_number": 24,
             "epoch_length": {
-                "quantity": 30963,
+                "quantity": 29237,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 50.93074806849109,
+                "quantity": 67.80354754258157,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 772,
+                "quantity": 5956,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 35.59,
+                "quantity": 21.87,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 22445,
+                "quantity": 1687,
                 "unit": "block"
             },
-            "genesis_block_hash": "4e524827324137b84f48336e741b56073f362d393941215b6b0416a7027d0535",
-            "blockchain_start_time": "1896-11-17T16:15:36.595743770768Z",
+            "genesis_block_hash": "ad31d660575c2504372e950862042a764b074b31da225d63fc4e4f7f43183e6a",
+            "blockchain_start_time": "1903-10-15T12:17:45.5065572951Z",
+            "desired_pool_number": 29,
             "epoch_length": {
-                "quantity": 18281,
+                "quantity": 14271,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 23.914063381142526,
+                "quantity": 83.43727081721306,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 665,
+                "quantity": 3908,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 78.14,
+                "quantity": 48.46,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 25293,
+                "quantity": 22186,
                 "unit": "block"
             },
-            "genesis_block_hash": "4b072032a102699632952d600f49a00efb1d58647a354a556d9f602d41226c21",
-            "blockchain_start_time": "1904-02-07T22:39:44Z",
+            "genesis_block_hash": "b8be756e7f4d75045f02ed031170165a1376506432a0271a5d73583223091f36",
+            "blockchain_start_time": "1859-06-20T02:53:30.051677675312Z",
+            "desired_pool_number": 131,
             "epoch_length": {
-                "quantity": 26670,
+                "quantity": 26820,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 44.94722400324369,
+                "quantity": 99.86983178290603,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 2354,
+                "quantity": 6162,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 55.69,
+                "quantity": 77.42,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 27989,
+                "quantity": 3633,
                 "unit": "block"
             },
-            "genesis_block_hash": "f1af112711150a07f09d796e4731062a5f3e60666f325a071dcb3a95453f0272",
-            "blockchain_start_time": "1906-08-22T21:33:20.123872129442Z",
+            "genesis_block_hash": "8dfb5e5d261e25785877564e1560c06b4f55207c5b160a4f054d51af1f00306d",
+            "blockchain_start_time": "1882-01-28T01:08:48Z",
+            "desired_pool_number": 1742,
             "epoch_length": {
-                "quantity": 24789,
+                "quantity": 17463,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 38.097207764414755,
+                "quantity": 41.24160362212043,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 2971,
+                "quantity": 7121,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 80.73,
+                "quantity": 64.87,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 14987,
+                "quantity": 26035,
                 "unit": "block"
             },
-            "genesis_block_hash": "4e365b357a766d0b02760f362df3e73b21b5d2365f52007e75f360534754044d",
-            "blockchain_start_time": "1906-12-13T04:46:01.284275225298Z",
+            "genesis_block_hash": "645b5c3820a62a72190b397340498f2c15793c4d19234a692637d257d55f207f",
+            "blockchain_start_time": "1868-07-20T19:00:00Z",
+            "desired_pool_number": 1253,
             "epoch_length": {
-                "quantity": 17350,
+                "quantity": 22546,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 5.981136244796314,
+                "quantity": 75.4233809757601,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 8555,
+                "quantity": 5096,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 26.8,
+                "quantity": 16.74,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 16129,
+                "quantity": 29252,
                 "unit": "block"
             },
-            "genesis_block_hash": "13aa2072246c4b33103f32734f393d660e40120b6534d22366247f3d41605bde",
-            "blockchain_start_time": "1878-01-18T02:46:53Z",
+            "genesis_block_hash": "42612d053e2a9b1e6d122e74223c65015f7342432f7960137e75271a2a537d1d",
+            "blockchain_start_time": "1907-03-24T21:54:55.587984051255Z",
+            "desired_pool_number": 1873,
             "epoch_length": {
-                "quantity": 23138,
+                "quantity": 28293,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 49.91311704166292,
+                "quantity": 91.91285590796747,
                 "unit": "percent"
             }
         }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
@@ -1,253 +1,249 @@
 {
-    "seed": 1783641201901976871,
+    "seed": 6501795791117850161,
     "samples": [
         {
             "slot_length": {
-                "quantity": 4898,
+                "quantity": 2082,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 5.85,
+                "quantity": 95.5,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 528,
+                "quantity": 28376,
                 "unit": "block"
             },
-            "genesis_block_hash": "374ca035306ae5516835045e4b233b5971c9840127700f6d20752d4439024740",
-            "blockchain_start_time": "1869-05-07T07:10:00Z",
-            "desired_pool_number": 246,
+            "genesis_block_hash": "66c2793479f0671742231a03035f4f6e5355594a34546f57f050015714227c0b",
+            "blockchain_start_time": "1876-10-06T05:38:40.833248904705Z",
             "epoch_length": {
-                "quantity": 20945,
+                "quantity": 5336,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 94.55547664569349,
+                "quantity": 33.963623549260305,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 5803,
+                "quantity": 1187,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 91.83,
+                "quantity": 88.02,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 15302,
+                "quantity": 11857,
                 "unit": "block"
             },
-            "genesis_block_hash": "7d3cf56b896e087ddc6f2e793d77224f7c742ff065463a16bb4a6b437443327b",
-            "blockchain_start_time": "1880-03-03T09:00:00Z",
-            "desired_pool_number": 1332,
+            "genesis_block_hash": "39152a094036b807a21976b56030204d206d4348600c516d365c23581d1e1450",
+            "blockchain_start_time": "1880-09-11T07:00:00Z",
             "epoch_length": {
-                "quantity": 14005,
+                "quantity": 22920,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 29.678701480196924,
+                "quantity": 97.68438021439569,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 1210,
+                "quantity": 3950,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 84.39,
+                "quantity": 85.42,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 24490,
+                "quantity": 30424,
                 "unit": "block"
             },
-            "genesis_block_hash": "b2d75f565952443844295b853eb3045c0a1817366e5c2e293596093f4dd02854",
-            "blockchain_start_time": "1864-05-18T18:07:13.640068095679Z",
-            "desired_pool_number": 907,
+            "genesis_block_hash": "34286e96f677354d57147c5a0925b96e716f333f1b06440db95e7d846a083c7f",
+            "blockchain_start_time": "1891-11-26T02:07:13.105316497171Z",
             "epoch_length": {
-                "quantity": 8497,
+                "quantity": 8507,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 41.0009989127716,
+                "quantity": 50.100302778181586,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 4155,
+                "quantity": 7012,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 25.84,
+                "quantity": 29.99,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 10252,
+                "quantity": 18641,
                 "unit": "block"
             },
-            "genesis_block_hash": "5a59c67da96f38177509e8023306205a62ab3b504d0963532e1333380d113961",
-            "blockchain_start_time": "1901-10-16T12:05:49Z",
-            "desired_pool_number": 670,
+            "genesis_block_hash": "42242af27a39265835471e5826446a6e1bab1718e87d1c03440a322c29244e25",
+            "blockchain_start_time": "1875-10-26T09:59:54.477906634455Z",
+            "desired_pool_number": 1119,
             "epoch_length": {
-                "quantity": 261,
+                "quantity": 11030,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 58.28661284335994,
+                "quantity": 88.81357965738106,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 566,
+                "quantity": 912,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 30.33,
+                "quantity": 12.03,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 472,
+                "quantity": 21744,
                 "unit": "block"
             },
-            "genesis_block_hash": "24721c606c6919353377db135c08603f68ec495d0935502731ff8e4e1b5a0c4f",
-            "blockchain_start_time": "1866-03-22T03:01:21.729708338291Z",
-            "desired_pool_number": 24,
+            "genesis_block_hash": "503f460c43542c085b2e0c5e1760035b646b006821e82f5e1f4552d153675d58",
+            "blockchain_start_time": "1866-05-12T17:00:12Z",
+            "desired_pool_number": 1518,
             "epoch_length": {
-                "quantity": 29237,
+                "quantity": 2915,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 67.80354754258157,
+                "quantity": 93.33027763903885,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 5956,
+                "quantity": 5083,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 21.87,
+                "quantity": 62.71,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 1687,
+                "quantity": 21660,
                 "unit": "block"
             },
-            "genesis_block_hash": "ad31d660575c2504372e950862042a764b074b31da225d63fc4e4f7f43183e6a",
-            "blockchain_start_time": "1903-10-15T12:17:45.5065572951Z",
-            "desired_pool_number": 29,
+            "genesis_block_hash": "292e2d6bddbc1b657b673f4c2b017d690a061c4c5f383a3e3c551133cfc22058",
+            "blockchain_start_time": "1864-06-03T00:00:00Z",
+            "desired_pool_number": 1357,
             "epoch_length": {
-                "quantity": 14271,
+                "quantity": 18333,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 83.43727081721306,
+                "quantity": 23.341837917629405,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 3908,
+                "quantity": 3331,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 48.46,
+                "quantity": 2.73,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 22186,
+                "quantity": 25628,
                 "unit": "block"
             },
-            "genesis_block_hash": "b8be756e7f4d75045f02ed031170165a1376506432a0271a5d73583223091f36",
-            "blockchain_start_time": "1859-06-20T02:53:30.051677675312Z",
-            "desired_pool_number": 131,
+            "genesis_block_hash": "006b956740be6b25933cc6010d6661e46814705e760c7c0e07152b6280283d68",
+            "blockchain_start_time": "1898-02-06T10:05:05Z",
+            "desired_pool_number": 1148,
             "epoch_length": {
-                "quantity": 26820,
+                "quantity": 21211,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 99.86983178290603,
+                "quantity": 14.569490138736608,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 6162,
+                "quantity": 7132,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 77.42,
+                "quantity": 73.55,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 3633,
+                "quantity": 19746,
                 "unit": "block"
             },
-            "genesis_block_hash": "8dfb5e5d261e25785877564e1560c06b4f55207c5b160a4f054d51af1f00306d",
-            "blockchain_start_time": "1882-01-28T01:08:48Z",
-            "desired_pool_number": 1742,
+            "genesis_block_hash": "8d45f8067f50477137813f1a5107948c3f9e672e0fcf0775370f15053f7b6649",
+            "blockchain_start_time": "1860-12-09T05:00:00Z",
+            "desired_pool_number": 396,
             "epoch_length": {
-                "quantity": 17463,
+                "quantity": 5265,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 41.24160362212043,
+                "quantity": 56.77289414783849,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 7121,
+                "quantity": 1705,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 64.87,
+                "quantity": 7.33,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 26035,
+                "quantity": 4135,
                 "unit": "block"
             },
-            "genesis_block_hash": "645b5c3820a62a72190b397340498f2c15793c4d19234a692637d257d55f207f",
-            "blockchain_start_time": "1868-07-20T19:00:00Z",
-            "desired_pool_number": 1253,
+            "genesis_block_hash": "190b7a59614f0349383f3973156f0e6644eb0a791b495dea8b3527905d9d6a4a",
+            "blockchain_start_time": "1899-05-09T10:40:44.56590500803Z",
             "epoch_length": {
-                "quantity": 22546,
+                "quantity": 8066,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 75.4233809757601,
+                "quantity": 88.4364008357964,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 5096,
+                "quantity": 6749,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 16.74,
+                "quantity": 77.28,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 29252,
+                "quantity": 23699,
                 "unit": "block"
             },
-            "genesis_block_hash": "42612d053e2a9b1e6d122e74223c65015f7342432f7960137e75271a2a537d1d",
-            "blockchain_start_time": "1907-03-24T21:54:55.587984051255Z",
-            "desired_pool_number": 1873,
+            "genesis_block_hash": "de10370b086e7d3e4733205561457b57006a2a0e632c9c78b44b32435d6e4951",
+            "blockchain_start_time": "1900-07-06T08:14:59.595751126258Z",
+            "desired_pool_number": 1604,
             "epoch_length": {
-                "quantity": 28293,
+                "quantity": 7038,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 91.91285590796747,
+                "quantity": 48.378902424719584,
                 "unit": "percent"
             }
         }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
@@ -1,249 +1,253 @@
 {
-    "seed": 6501795791117850161,
+    "seed": -1984240878940569186,
     "samples": [
         {
             "slot_length": {
-                "quantity": 2082,
+                "quantity": 8804,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 95.5,
+                "quantity": 27.44,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 28376,
+                "quantity": 14698,
                 "unit": "block"
             },
-            "genesis_block_hash": "66c2793479f0671742231a03035f4f6e5355594a34546f57f050015714227c0b",
-            "blockchain_start_time": "1876-10-06T05:38:40.833248904705Z",
+            "genesis_block_hash": "2d0c106c427d16063756bb255d31250cc923325c6b5f19645266814c794e3e09",
+            "blockchain_start_time": "1881-08-19T09:40:33.993547684331Z",
+            "desired_pool_number": 32038,
             "epoch_length": {
-                "quantity": 5336,
+                "quantity": 21008,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 33.963623549260305,
+                "quantity": 24.109475832319728,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 1187,
+                "quantity": 8092,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 88.02,
+                "quantity": 10.18,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 11857,
+                "quantity": 1843,
                 "unit": "block"
             },
-            "genesis_block_hash": "39152a094036b807a21976b56030204d206d4348600c516d365c23581d1e1450",
-            "blockchain_start_time": "1880-09-11T07:00:00Z",
+            "genesis_block_hash": "0353fdf93759307c230d19ba4a7d3b1a315d813161770866ff6f023a2f494b32",
+            "blockchain_start_time": "1877-07-19T22:03:55.536832695831Z",
+            "desired_pool_number": 27299,
             "epoch_length": {
-                "quantity": 22920,
+                "quantity": 32442,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 97.68438021439569,
+                "quantity": 35.782018645281,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 3950,
+                "quantity": 9154,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 85.42,
+                "quantity": 14.08,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 30424,
+                "quantity": 23685,
                 "unit": "block"
             },
-            "genesis_block_hash": "34286e96f677354d57147c5a0925b96e716f333f1b06440db95e7d846a083c7f",
-            "blockchain_start_time": "1891-11-26T02:07:13.105316497171Z",
+            "genesis_block_hash": "050f4e400e13552f2535e51557662c0306335024723e42625958b34578716a5b",
+            "blockchain_start_time": "1906-01-23T04:00:00Z",
+            "desired_pool_number": 30831,
             "epoch_length": {
-                "quantity": 8507,
+                "quantity": 722,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 50.100302778181586,
+                "quantity": 45.505485658621616,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 7012,
+                "quantity": 6902,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 29.99,
+                "quantity": 36.38,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 18641,
+                "quantity": 13954,
                 "unit": "block"
             },
-            "genesis_block_hash": "42242af27a39265835471e5826446a6e1bab1718e87d1c03440a322c29244e25",
-            "blockchain_start_time": "1875-10-26T09:59:54.477906634455Z",
-            "desired_pool_number": 1119,
+            "genesis_block_hash": "7a3b7c3d6b0a2215222f511ba967037a17556823633c495542cf207632005714",
+            "blockchain_start_time": "1889-05-02T20:01:52.165487876522Z",
+            "desired_pool_number": 18465,
             "epoch_length": {
-                "quantity": 11030,
+                "quantity": 2100,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 88.81357965738106,
+                "quantity": 36.52505119563008,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 912,
+                "quantity": 6939,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 12.03,
+                "quantity": 50.83,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 21744,
+                "quantity": 14689,
                 "unit": "block"
             },
-            "genesis_block_hash": "503f460c43542c085b2e0c5e1760035b646b006821e82f5e1f4552d153675d58",
-            "blockchain_start_time": "1866-05-12T17:00:12Z",
-            "desired_pool_number": 1518,
+            "genesis_block_hash": "461826053f5339281c3e7e799c71080a1aea304c1c3f682f10b457563c545714",
+            "blockchain_start_time": "1876-12-05T11:38:02.49568317573Z",
+            "desired_pool_number": 6799,
             "epoch_length": {
-                "quantity": 2915,
+                "quantity": 6181,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 93.33027763903885,
+                "quantity": 95.30023564427918,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 5083,
+                "quantity": 4158,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 62.71,
+                "quantity": 86.74,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 21660,
+                "quantity": 11252,
                 "unit": "block"
             },
-            "genesis_block_hash": "292e2d6bddbc1b657b673f4c2b017d690a061c4c5f383a3e3c551133cfc22058",
-            "blockchain_start_time": "1864-06-03T00:00:00Z",
-            "desired_pool_number": 1357,
+            "genesis_block_hash": "0c4816ac577b75a94a6010457544043859286c74424b4792724a55535233ce0f",
+            "blockchain_start_time": "1895-06-12T18:38:51.613463116487Z",
+            "desired_pool_number": 6332,
             "epoch_length": {
-                "quantity": 18333,
+                "quantity": 6203,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 23.341837917629405,
+                "quantity": 59.013819454586034,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 3331,
+                "quantity": 4545,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 2.73,
+                "quantity": 35.19,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 25628,
+                "quantity": 10310,
                 "unit": "block"
             },
-            "genesis_block_hash": "006b956740be6b25933cc6010d6661e46814705e760c7c0e07152b6280283d68",
-            "blockchain_start_time": "1898-02-06T10:05:05Z",
-            "desired_pool_number": 1148,
+            "genesis_block_hash": "8ecbf461186f4638d4097425387c357d392976a2705c62791d361667692293cf",
+            "blockchain_start_time": "1906-01-18T09:34:53.923334751052Z",
+            "desired_pool_number": 2936,
             "epoch_length": {
-                "quantity": 21211,
+                "quantity": 19601,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 14.569490138736608,
+                "quantity": 41.975201347713764,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 7132,
+                "quantity": 3194,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 73.55,
+                "quantity": 65.66,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 19746,
+                "quantity": 21442,
                 "unit": "block"
             },
-            "genesis_block_hash": "8d45f8067f50477137813f1a5107948c3f9e672e0fcf0775370f15053f7b6649",
-            "blockchain_start_time": "1860-12-09T05:00:00Z",
-            "desired_pool_number": 396,
+            "genesis_block_hash": "4f7f286d773a3b5176653631117b251a1d1b776609011e1c17666959b4046427",
+            "blockchain_start_time": "1876-02-24T02:04:56Z",
+            "desired_pool_number": 10647,
             "epoch_length": {
-                "quantity": 5265,
+                "quantity": 2455,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 56.77289414783849,
+                "quantity": 95.08852182419434,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 1705,
+                "quantity": 4415,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 7.33,
+                "quantity": 19.99,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 4135,
+                "quantity": 20840,
                 "unit": "block"
             },
-            "genesis_block_hash": "190b7a59614f0349383f3973156f0e6644eb0a791b495dea8b3527905d9d6a4a",
-            "blockchain_start_time": "1899-05-09T10:40:44.56590500803Z",
+            "genesis_block_hash": "6b245905223c1b36063a61e815556e1f73033a9b3021213737680f797057444a",
+            "blockchain_start_time": "1879-08-09T17:36:30.572650906619Z",
+            "desired_pool_number": 19374,
             "epoch_length": {
-                "quantity": 8066,
+                "quantity": 24669,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 88.4364008357964,
+                "quantity": 8.427169510319887,
                 "unit": "percent"
             }
         },
         {
             "slot_length": {
-                "quantity": 6749,
+                "quantity": 9912,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 77.28,
+                "quantity": 39.97,
                 "unit": "percent"
             },
             "epoch_stability": {
-                "quantity": 23699,
+                "quantity": 26046,
                 "unit": "block"
             },
-            "genesis_block_hash": "de10370b086e7d3e4733205561457b57006a2a0e632c9c78b44b32435d6e4951",
-            "blockchain_start_time": "1900-07-06T08:14:59.595751126258Z",
-            "desired_pool_number": 1604,
+            "genesis_block_hash": "c51d5d2506519e71265b672f622aa51b2d6e434d7e7a4a1103715f25de426e50",
+            "blockchain_start_time": "1879-07-02T14:07:16.914969860618Z",
+            "desired_pool_number": 16799,
             "epoch_length": {
-                "quantity": 7038,
+                "quantity": 77,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 48.378902424719584,
+                "quantity": 22.710583012744756,
                 "unit": "percent"
             }
         }

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -98,7 +98,7 @@ dummyProtocolParameters :: ProtocolParameters
 dummyProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = dummyTxParameters
-    , desiredNumberOfStakePools = 100
+    , desiredNumberOfStakePools = Just 100
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -98,6 +98,7 @@ dummyProtocolParameters :: ProtocolParameters
 dummyProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = dummyTxParameters
+    , desiredNumberOfStakePools = 100
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -98,7 +98,7 @@ dummyProtocolParameters :: ProtocolParameters
 dummyProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = dummyTxParameters
-    , desiredNumberOfStakePools = Just 100
+    , desiredNumberOfStakePools = 100
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1183,7 +1183,7 @@ instance Arbitrary ApiNetworkParameters where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> choose (1, 2000)
+        <*> oneof [pure Nothing, Just <$> choose (1, 2000)]
     shrink = genericShrink
 
 instance Arbitrary SlotId where

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -778,6 +778,8 @@ spec = do
                         activeSlotCoefficient (x :: ApiNetworkParameters)
                     , decentralizationLevel =
                         decentralizationLevel (x :: ApiNetworkParameters)
+                    , desiredPoolNumber =
+                        desiredPoolNumber (x :: ApiNetworkParameters)
                     }
             in
             x' === x .&&. show x' === show x
@@ -1173,7 +1175,15 @@ instance Arbitrary (Quantity "percent" Double) where
     arbitrary = Quantity <$> choose (0,100)
 
 instance Arbitrary ApiNetworkParameters where
-    arbitrary = genericArbitrary
+    arbitrary = ApiNetworkParameters
+        <$> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> arbitrary
+        <*> choose (1, 2000)
     shrink = genericShrink
 
 instance Arbitrary SlotId where

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1175,15 +1175,7 @@ instance Arbitrary (Quantity "percent" Double) where
     arbitrary = Quantity <$> choose (0,100)
 
 instance Arbitrary ApiNetworkParameters where
-    arbitrary = ApiNetworkParameters
-        <$> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> oneof [pure Nothing, Just <$> choose (1, 2000)]
+    arbitrary = genericArbitrary
     shrink = genericShrink
 
 instance Arbitrary SlotId where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -571,8 +571,10 @@ rootKeysRnd = unsafePerformIO $ generate (vectorOf 10 genRootKeysRnd)
 -------------------------------------------------------------------------------}
 
 instance Arbitrary ProtocolParameters where
-    arbitrary =
-        ProtocolParameters <$> arbitrary <*> arbitrary <*> choose (1, 2000)
+    arbitrary = ProtocolParameters
+        <$> arbitrary
+        <*> arbitrary
+        <*> oneof [pure Nothing, Just <$> choose (1, 2000)]
     shrink = genericShrink
 
 instance Arbitrary TxParameters where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -341,7 +341,6 @@ instance Arbitrary WalletMetadata where
 instance Arbitrary PassphraseScheme where
     arbitrary = genericArbitrary
 
-
 {-------------------------------------------------------------------------------
                                    Blocks
 -------------------------------------------------------------------------------}
@@ -574,7 +573,7 @@ instance Arbitrary ProtocolParameters where
     arbitrary = ProtocolParameters
         <$> arbitrary
         <*> arbitrary
-        <*> oneof [pure Nothing, Just <$> choose (1, 2000)]
+        <*> arbitrary
     shrink = genericShrink
 
 instance Arbitrary TxParameters where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -571,7 +571,8 @@ rootKeysRnd = unsafePerformIO $ generate (vectorOf 10 genRootKeysRnd)
 -------------------------------------------------------------------------------}
 
 instance Arbitrary ProtocolParameters where
-    arbitrary = ProtocolParameters <$> arbitrary <*> arbitrary
+    arbitrary =
+        ProtocolParameters <$> arbitrary <*> arbitrary <*> choose (1, 2000)
     shrink = genericShrink
 
 instance Arbitrary TxParameters where

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -320,6 +320,7 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
                                         policy
                                 , getTxMaxSize = softTxMaxSize
                                 }
+                            , desiredNumberOfStakePools = Nothing
                             }
                         }
                     )

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -507,6 +507,7 @@ genesisProtocolParameters :: ProtocolParameters
 genesisProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = genesisTxParameters
+    , desiredNumberOfStakePools = Nothing
     }
 
 genesisTxParameters :: TxParameters

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -507,7 +507,7 @@ genesisProtocolParameters :: ProtocolParameters
 genesisProtocolParameters = ProtocolParameters
     { decentralizationLevel = minBound
     , txParameters = genesisTxParameters
-    , desiredNumberOfStakePools = Nothing
+    , desiredNumberOfStakePools = 10
     }
 
 genesisTxParameters :: TxParameters

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -423,6 +423,7 @@ mockJormungandrClient logLine = JormungandrClient
                     { getFeePolicy = error "mock gp"
                     , getTxMaxSize = error "mock gp"
                     }
+                , desiredNumberOfStakePools = Nothing
                 }
             })
 

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -423,7 +423,7 @@ mockJormungandrClient logLine = JormungandrClient
                     { getFeePolicy = error "mock gp"
                     , getTxMaxSize = error "mock gp"
                     }
-                , desiredNumberOfStakePools = Nothing
+                , desiredNumberOfStakePools = 10
                 }
             })
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -454,6 +454,8 @@ fromPParams pp = W.ProtocolParameters
         decentralizationLevelFromPParams pp
     , txParameters =
         txParametersFromPParams pp
+    , desiredNumberOfStakePools =
+        desiredNumberOfStakePoolsFromPParams pp
     }
 
 -- | Extract the current network decentralization level from the given set of
@@ -498,6 +500,11 @@ txParametersFromPParams pp = W.TxParameters
   where
     naturalToDouble :: Natural -> Double
     naturalToDouble = fromIntegral
+
+desiredNumberOfStakePoolsFromPParams
+    :: SL.PParams
+    -> Maybe Word16
+desiredNumberOfStakePoolsFromPParams pp = Just $ fromIntegral (SL._nOpt pp)
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -503,8 +503,8 @@ txParametersFromPParams pp = W.TxParameters
 
 desiredNumberOfStakePoolsFromPParams
     :: SL.PParams
-    -> Maybe Word16
-desiredNumberOfStakePoolsFromPParams pp = Just $ fromIntegral (SL._nOpt pp)
+    -> Word16
+desiredNumberOfStakePoolsFromPParams pp = fromIntegral (SL._nOpt pp)
 
 -- | Convert genesis data into blockchain params and an initial set of UTxO
 fromGenesisData

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -30,6 +30,11 @@ x-slotNumber: &slotNumber
   minimum: 0
   example: 1337
 
+x-stakePoolsNumber: &stakePoolsNumber
+  type: integer
+  minimum: 1
+  example: 150
+
 x-numberOfSeconds: &numberOfSeconds
   type: object
   required:
@@ -812,6 +817,7 @@ components:
         - epoch_stability
         - active_slot_coefficient
         - decentralization_level
+        - desired_number_of_pools
       properties:
         genesis_block_hash: *blockId
         blockchain_start_time: *date
@@ -820,6 +826,7 @@ components:
         epoch_stability: *numberOfBlocks
         active_slot_coefficient: *percentage
         decentralization_level: *percentage
+        desired_number_of_pools: *stakePoolsNumber
 
     ApiSelectCoinsData: &ApiSelectCoinsData
       type: object

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -32,8 +32,8 @@ x-slotNumber: &slotNumber
 
 x-stakePoolsNumber: &stakePoolsNumber
   type: integer
-  minimum: 1
-  example: 150
+  minimum: 0
+  example: 100
 
 x-numberOfSeconds: &numberOfSeconds
   type: object
@@ -817,6 +817,7 @@ components:
         - epoch_stability
         - active_slot_coefficient
         - decentralization_level
+        - desired_pool_number
       properties:
         genesis_block_hash: *blockId
         blockchain_start_time: *date

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -817,7 +817,7 @@ components:
         - epoch_stability
         - active_slot_coefficient
         - decentralization_level
-        - desired_number_of_pools
+        - desired_pool_number
       properties:
         genesis_block_hash: *blockId
         blockchain_start_time: *date
@@ -826,7 +826,7 @@ components:
         epoch_stability: *numberOfBlocks
         active_slot_coefficient: *percentage
         decentralization_level: *percentage
-        desired_number_of_pools: *stakePoolsNumber
+        desired_pool_number: *stakePoolsNumber
 
     ApiSelectCoinsData: &ApiSelectCoinsData
       type: object

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -817,7 +817,6 @@ components:
         - epoch_stability
         - active_slot_coefficient
         - decentralization_level
-        - desired_pool_number
       properties:
         genesis_block_hash: *blockId
         blockchain_start_time: *date


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
#1822 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have extended ApiNetworkParameters for desired number of pools. This is optional as it does not make sense for byron, it is unknown in jormungandr 
- [x] I have made the changes in swagger
- [x] I have updated unit tests in core, especially made a change to Arbitrary for ApiNetworkParameters to allow Word16. 
- [x] I have added 0 to byron and used max value of participation capping in jormungandr
- [x] I have added impl in shelley using ledger accessors
- [x] I have updated all other places in the code to account for this change 
- [x] I have extended integration network test for shelley and see that desired number of pools is 3.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
