### PR TITLE
Bump cardano-node to 1.14.2

### DIFF
--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -14,7 +14,7 @@
 # See also: lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs for details.
 
 ---
-activeSlotsCoeff: 0.8
+activeSlotsCoeff: 0.5
 protocolParams:
   poolDeposit: 0
   protocolVersion:
@@ -47,12 +47,12 @@ maxLovelaceSupply: 45000000000000000
 protocolMagicId: 764824073
 networkMagic: 764824073
 networkId: Mainnet
-epochLength: 100
+epochLength: 200
 staking:
 slotsPerKESPeriod: 86400
 slotLength: 0.2
 maxKESEvolutions: 90
-securityParam: 8
+securityParam: 10
 systemStart: "2020-06-19T16:07:37.740128433Z"
 initialFunds:
   # Cluster Faucets, used for setting up stake pools

--- a/nix/.stack.nix/cardano-addresses.nix
+++ b/nix/.stack.nix/cardano-addresses.nix
@@ -86,7 +86,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "2303830a5e92189925d6425c5eea15d19f62eda3";
-      sha256 = "0dar45132lnz76zx777nv9pbd7hrax6ilyvlrl1izwa9a9liwyaq";
+      rev = "197015670a0c6df4eaae63d66ae7b3e48007abc0";
+      sha256 = "1fn85576ynbdpqf5qqz0gzs4kh9fcfg769h1rxxgz2ifsphmj9n2";
       });
     }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/cardano-api.nix
+++ b/nix/.stack.nix/cardano-api.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-api"; version = "1.14.0"; };
+      identifier = { name = "cardano-api"; version = "1.14.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -107,8 +107,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "46f296f8a9f3f497d9bd41e20c8398d2b5730c86";
-      sha256 = "05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl";
+      rev = "924a6f7d8c2bdb1bf525be8b0d5626e440697b01";
+      sha256 = "0bi1vwmb1w6wc2szpr8v1nbsci9y36lnjr4v5pli1wvll1hhpw3c";
       });
     postUnpack = "sourceRoot+=/cardano-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-cli.nix
+++ b/nix/.stack.nix/cardano-cli.nix
@@ -11,7 +11,7 @@
     flags = { unexpected_thunks = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-cli"; version = "1.14.0"; };
+      identifier = { name = "cardano-cli"; version = "1.14.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -121,8 +121,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "46f296f8a9f3f497d9bd41e20c8398d2b5730c86";
-      sha256 = "05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl";
+      rev = "924a6f7d8c2bdb1bf525be8b0d5626e440697b01";
+      sha256 = "0bi1vwmb1w6wc2szpr8v1nbsci9y36lnjr4v5pli1wvll1hhpw3c";
       });
     postUnpack = "sourceRoot+=/cardano-cli; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -113,8 +113,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "46f296f8a9f3f497d9bd41e20c8398d2b5730c86";
-      sha256 = "05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl";
+      rev = "924a6f7d8c2bdb1bf525be8b0d5626e440697b01";
+      sha256 = "0bi1vwmb1w6wc2szpr8v1nbsci9y36lnjr4v5pli1wvll1hhpw3c";
       });
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -11,7 +11,7 @@
     flags = { unexpected_thunks = false; systemd = true; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-node"; version = "1.14.0"; };
+      identifier = { name = "cardano-node"; version = "1.14.2"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -114,8 +114,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "46f296f8a9f3f497d9bd41e20c8398d2b5730c86";
-      sha256 = "05wv990vcg41sl68ii991fkgxp9fgcyig1asp94ig30xb1cg2zbl";
+      rev = "924a6f7d8c2bdb1bf525be8b0d5626e440697b01";
+      sha256 = "0bi1vwmb1w6wc2szpr8v1nbsci9y36lnjr4v5pli1wvll1hhpw3c";
       });
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "master",
+        "branch": "1.14.2",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "e9358cac165ca9d6497834097b2bf15a869af2e0",
-        "sha256": "1yn0wi0jmsm530vyvrgz98iabgnlsnb6g0jj67mwdfkpvs40hv8r",
+        "rev": "924a6f7d8c2bdb1bf525be8b0d5626e440697b01",
+        "sha256": "0bi1vwmb1w6wc2szpr8v1nbsci9y36lnjr4v5pli1wvll1hhpw3c",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/e9358cac165ca9d6497834097b2bf15a869af2e0.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/924a6f7d8c2bdb1bf525be8b0d5626e440697b01.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskell.nix": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,7 +41,7 @@ extra-deps:
     - persistent-template
 
 - git: https://github.com/input-output-hk/cardano-addresses
-  commit: 2303830a5e92189925d6425c5eea15d19f62eda3
+  commit: 197015670a0c6df4eaae63d66ae7b3e48007abc0
 
 flags:
   # Avoid a system library which causes difficulty with cross-compilation

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/0f7d49e6ce0d0d5aaedb05b25993b8aac3e0979c/snapshots/cardano-1.14.0.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/633f6141c3e7211dbb0c6ae6ad50d4976313e190/snapshots/cardano-1.14.2.yaml
 packages:
 - lib/core
 - lib/core-integration


### PR DESCRIPTION
Only very minor updates since 1.14.0, but we may as well use the tag.

https://github.com/input-output-hk/cardano-node/releases/tag/1.14.2
https://github.com/input-output-hk/cardano-node/releases/tag/1.14.1

Depends on input-output-hk/cardano-haskell#23.
