### PR TITLE
Add pending test for joining pool with pre-existing stake key

### DIFF
--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -187,6 +187,8 @@ test-suite integration
     , async
     , bytestring
     , cardano-wallet-cli
+    , cardano-addresses
+    , cardano-slotting
     , cardano-wallet-core
     , cardano-wallet-core-integration
     , cardano-wallet-launcher

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -38,6 +38,7 @@ module Cardano.Wallet.Shelley.Compatibility
       -- * Genesis
     , emptyGenesis
     , genesisTip
+    , initialFundsPseudoTxIn
 
       -- * Conversions
     , toShelleyHash
@@ -618,6 +619,14 @@ fromShelleyTxIn (SL.TxIn txid ix) =
     unsafeCast :: Natural -> Word32
     unsafeCast = fromIntegral
 
+-- | Create a TxIn pointing to the initial funds in the genesis file.
+initialFundsPseudoTxIn :: W.Address -> W.TxIn
+initialFundsPseudoTxIn =
+    fromShelleyTxIn
+    . SL.initialFundsPseudoTxIn @TPraosStandardCrypto
+    . fromMaybe (error "initialFundsPseudoTxIn: invalid addr")
+    . toShelleyAddress
+
 fromShelleyTxOut :: SL.TxOut crypto -> W.TxOut
 fromShelleyTxOut (SL.TxOut addr amount) =
   W.TxOut (fromShelleyAddress addr) (fromShelleyCoin amount)
@@ -625,6 +634,9 @@ fromShelleyTxOut (SL.TxOut addr amount) =
 fromShelleyAddress :: SL.Addr crypto -> W.Address
 fromShelleyAddress = W.Address
     . SL.serialiseAddr
+
+toShelleyAddress :: O.Crypto crypto => W.Address -> Maybe (SL.Addr crypto)
+toShelleyAddress = SL.deserialiseAddr . W.unAddress
 
 fromShelleyCoin :: SL.Coin -> W.Coin
 fromShelleyCoin (SL.Coin c) = W.Coin $ unsafeCast c

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -31,6 +31,8 @@ module Cardano.Wallet.Shelley.Transaction
     , mkWitness
     , realFee
     , mkTx
+    , TxPayload (..)
+    , emptyTxPayload
     ) where
 
 import Prelude

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -1427,3 +1427,8 @@ initialFunds:
 - 610cdec48bb2168dbaa18f5a7e67ede598449e3783891f926d99c7ace8: 1
 - 61d1e87828a2ff41f11e575e7827d0c38f48f2bf6778b359042c7a2e3e: 1
 - 610130f3030867e827cb09eb1bf50401b0d9f413b2ca872b57a8d2fae4: 1
+
+# Special wallet ["over", "decorate", "flock", "badge", "beauty", "stamp", "chest", "owner", "excess", "omit", "bid", "raccoon", "spin", "reduce", "rival"]
+# for STAKE_POOLS_JOIN_05.
+- 6199a7c32aaa55a628d936b539f01d5415318dec8bcb5e59ec71af695b: 10000000000
+- 60386c7a86d8844f4085a50241556043c9842d72c315c897a42a8a0510: 10000000000

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -140,6 +140,8 @@
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+            (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
             (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))


### PR DESCRIPTION
# Issue Number

#1835 and ADP-358 


# Overview

- [x] Begun abstracting the notion of creating a tx with an arbitrary payload
- [x] At the start of the integration tests, register the stake key of a special wallet
- [x] Test that this wallet can delegate to a pool (pending the actual fix)

# Comments

Failure from `STAKE_POOLS_JOIN_05 - Can join when stake key already exists`:

```
       from the following response: Left (DecodeFailure "{\"code\":\"created_invalid_transaction\",\"message\":\"That's embarrassing. It looks like I've created an invalid transaction that could not be parsed by the node. Here's an error message that may help with debugging: ApplyTxError [LedgerFailure (DelegsFailure (DelplFailure (DelegFailure (StakeKeyAlreadyRegisteredDELEG (KeyHashObj (KeyHash 342dac9f95ee4f92567f652a736d64bfa0afaa2da795dda8de658580))))))]\"}")

```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
