### PR TITLE
Allow coin-selection to carry an extra "reserve input"

### DIFF
--- a/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
@@ -496,8 +496,10 @@ goldenTestSignedTx proxy pm nOuts xprvs expected = it title $ do
     let keyFrom a = (,mempty) <$> Map.lookup a s
     let inps = mkInput <$> zip addrs [0..]
     let outs = take nOuts $ mkOutput <$> cycle addrs
+    let cs = mempty { inputs = inps, outputs = outs }
     let curSlot = error "current slot not needed in byron mkStdTx"
-    let res = mkStdTx (newTransactionLayer proxy pm) keyFrom curSlot inps outs
+    let rewardAcnt = error "reward account not needed in byron mkStdTx"
+    let res = mkStdTx (newTransactionLayer proxy pm) rewardAcnt keyFrom curSlot cs
     case res of
         Left e -> fail (show e)
         Right (_tx, SealedTx bytes) ->

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
@@ -62,7 +62,7 @@ import Cardano.Wallet.Primitive.Fee
     , FeePolicy (..)
     , OnDanglingChange (..)
     , adjustForFee
-    , rebalanceChangeOutputs
+    , rebalanceSelection
     )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
@@ -168,7 +168,7 @@ spec = do
     it "1561 - The fee balancing algorithm converges for any coin selection."
         $ property
         $ withMaxSuccess 10000
-        $ forAllBlind (genSelection @'Mainnet @ByronKey) prop_rebalanceChangeOutputs
+        $ forAllBlind (genSelection @'Mainnet @ByronKey) prop_rebalanceSelection
 
     describe "Fee estimation calculation" $ do
         it "Byron / Mainnet" $ property $
@@ -285,12 +285,12 @@ spec = do
                                 Properties
 -------------------------------------------------------------------------------}
 
-prop_rebalanceChangeOutputs
+prop_rebalanceSelection
     :: CoinSelection
     -> OnDanglingChange
     -> Property
-prop_rebalanceChangeOutputs sel onDangling = do
-    let (sel', fee') = rebalanceChangeOutputs opts sel
+prop_rebalanceSelection sel onDangling = do
+    let (sel', fee') = rebalanceSelection opts sel
     let prop = case onDangling of
             PayAndBalance ->
                 fee' /= Fee 0 || Fee (delta sel') == estimateFee opts sel'

--- a/lib/core-integration/src/Test/Integration/Framework/Request.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Request.hs
@@ -25,6 +25,8 @@ import Cardano.CLI
     ( Port (..) )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters )
+import Cardano.Wallet.Transaction
+    ( DelegationAction )
 import Control.Monad.Catch
     ( Exception (..), MonadCatch (..), throwM )
 import Control.Monad.IO.Class
@@ -99,11 +101,7 @@ data Context t = Context
 
 -- | Describe a transaction in terms of its inputs and outputs
 data TxDescription
-    = DelegDescription
-        { nInputs :: Int
-        , nOutputs :: Int
-        , nCertificates :: Int
-        }
+    = DelegDescription DelegationAction
     | PaymentDescription
         { nInputs :: Int
         , nOutputs :: Int

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1903,13 +1903,6 @@ instance LiftHandler ErrMkTx where
                 , "input address I should keep track of: ", showT addr, ". "
                 , "Retrying may work, but something really went wrong..."
                 ]
-        ErrChangeIsEmptyForRetirement ->
-            apiError err500 UnexpectedError $ mconcat
-                [ "That's embarassing. I need to one change output to give you "
-                , "back you key registration deposit but it seems that I've "
-                , "generated a coin selection that has none! Since the coin "
-                , "selection algorithm has randomness, retrying may work."
-                ]
 
 instance LiftHandler ErrSignPayment where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -607,15 +607,15 @@ mkShelleyWallet
         )
     => MkApiWallet ctx s ApiWallet
 mkShelleyWallet ctx wid cp meta pending progress = do
-    reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
+    Quantity reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
         -- never fails - returns zero if balance not found
-        liftIO $ W.fetchRewardBalance @_ @s @k wrk wid
+        liftIO $ fmap fromIntegral <$> W.fetchRewardBalance @_ @s @k wrk wid
     pure ApiWallet
         { addressPoolGap = ApiT $ getState cp ^. #externalPool . #gap
         , balance = ApiT $ WalletBalance
-            { available = Quantity $ availableBalance pending cp
-            , total = Quantity $ totalBalance pending cp
-            , reward = Quantity $ fromIntegral $ getQuantity reward
+            { available = Quantity $ reward + availableBalance pending cp
+            , total = Quantity $ reward + totalBalance pending cp
+            , reward = Quantity reward
             }
         , delegation = toApiWalletDelegation (meta ^. #delegation)
         , id = ApiT wid

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1117,6 +1117,8 @@ postTransaction
         , GenChange s
         , IsOwned s k
         , ctx ~ ApiLayer s t k
+        , HardDerivation k
+        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
         )
     => ctx
     -> ArgGenChange s
@@ -1325,7 +1327,11 @@ getMigrationInfo ctx (ApiT wid) = do
         W.selectCoinsForMigration @_ @s @t @k wrk wid
 
 migrateWallet
-    :: forall s t k n p. IsOwned s k
+    :: forall s t k n p.
+        ( IsOwned s k
+        , HardDerivation k
+        , Bounded (Index (AddressIndexDerivationType k) 'AddressK)
+        )
     => ApiLayer s t k
         -- ^ Source wallet context
     -> ApiT WalletId

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -98,7 +98,9 @@ import GHC.Generics
 import GHC.TypeLits
     ( KnownNat )
 
+
 import qualified Cardano.Byron.Codec.Cbor as CBOR
+import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Crypto.KDF.PBKDF2 as PBKDF2
@@ -311,6 +313,23 @@ changePassphraseRnd (Passphrase oldPwd) (Passphrase newPwd) key = ByronKey
 {-------------------------------------------------------------------------------
                                  HD derivation
 -------------------------------------------------------------------------------}
+
+-- TODO
+-- This instance is unsound. It only exists because we need to derive the
+-- reward account in the wallet engine when making transaction (in case there
+-- are any withdrawals).
+--
+-- With 'ByronKey', withdrawals will always be `0`, and the result of this
+-- function shouldn't be evaluated (relying on lazyness here). If they do, then
+-- we're doing something wrong.
+instance W.HardDerivation ByronKey where
+    type AddressIndexDerivationType ByronKey = 'WholeDomain
+
+    deriveAccountPrivateKey _ _ _ = error
+        "unsound evaluation of 'deriveAccountPrivateKey' in the context of Byron key"
+
+    deriveAddressPrivateKey _ _ _ _ = error
+        "unsound evaluation of 'deriveAddressPrivateKey' in the context of Byron key"
 
 -- | Derives account private key from the given root private key, using
 -- derivation scheme 1.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -29,6 +29,9 @@ module Cardano.Wallet.Primitive.AddressDerivation.Shelley
     , generateKeyFromSeed
     , unsafeGenerateKeyFromSeed
 
+    -- * Reward Account
+    , toChimericAccountRaw
+
     -- * Address
     , decodeShelleyAddress
     ) where
@@ -346,7 +349,10 @@ instance MkKeyFingerprint ShelleyKey (Proxy (n :: NetworkDiscriminant), ShelleyK
 
 instance forall n. HasRewardAccount (SeqState n ShelleyKey) ShelleyKey where
     rewardAccountKey  = Seq.rewardAccountKey
-    toChimericAccount = ChimericAccount . blake2b224 . xpubPublicKey . getKey
+    toChimericAccount = toChimericAccountRaw . getKey
+
+toChimericAccountRaw :: XPub -> ChimericAccount
+toChimericAccountRaw = ChimericAccount . blake2b224 . xpubPublicKey
 
 {-------------------------------------------------------------------------------
                           Storing and retrieving keys

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -96,9 +96,12 @@ data CoinSelectionOptions e = CoinSelectionOptions
 -- | Calculate the sum of all input values
 inputBalance :: CoinSelection -> Word64
 inputBalance cs =
-    withdrawal cs + reclaim cs
-    +
     foldl' (\total -> addTxOut total . snd) 0 (inputs cs)
+    +
+    -- NOTE
+    -- reclaim and withdrawal can only count towards the input balance if and
+    -- only if there's already a transaction input.
+    if null (inputs cs) then 0 else withdrawal cs + reclaim cs
 
 -- | Calculate the sum of all output values
 outputBalance :: CoinSelection -> Word64

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -106,9 +106,9 @@ inputBalance cs =
 -- | Calculate the sum of all output values
 outputBalance :: CoinSelection -> Word64
 outputBalance cs =
-    deposit cs
-    +
     foldl' addTxOut 0 (outputs cs)
+    +
+    deposit cs
 
 -- | Calculate the sum of all output values
 changeBalance :: CoinSelection -> Word64

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -104,11 +104,10 @@ atLeast (utxo0, selection) txout =
     coverOutput (target, ins) utxo
         | target <= 0 = Just
             ( utxo
-            , selection <> CoinSelection
+            , selection <> mempty
                 { inputs  = ins
                 , outputs = [txout]
                 , change  = filter (/= (Coin 0)) [Coin (fromIntegral $ abs target)]
-                , reserve = Nothing
                 }
             )
         | null utxo =

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -105,9 +105,10 @@ atLeast (utxo0, selection) txout =
         | target <= 0 = Just
             ( utxo
             , selection <> CoinSelection
-                { inputs = ins
+                { inputs  = ins
                 , outputs = [txout]
-                , change = filter (/= (Coin 0)) [Coin (fromIntegral $ abs target)]
+                , change  = filter (/= (Coin 0)) [Coin (fromIntegral $ abs target)]
+                , reserve = Nothing
                 }
             )
         | null utxo =

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -97,13 +97,11 @@ depleteUTxO feeOpts batchSize utxo =
     -- Note that the selection may look a bit weird at first sight as it has
     -- no outputs (we are paying everything to ourselves!).
     mkCoinSelection :: [(TxIn, TxOut)] -> CoinSelection
-    mkCoinSelection inps = CoinSelection
+    mkCoinSelection inps = mempty
         { inputs = inps
-        , outputs = []
         , change =
             let chgs = mapMaybe (noDust . snd) inps
             in if null chgs then [dustThreshold feeOpts] else chgs
-        , reserve = Nothing
         }
       where
         noDust :: TxOut -> Maybe Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -103,6 +103,7 @@ depleteUTxO feeOpts batchSize utxo =
         , change =
             let chgs = mapMaybe (noDust . snd) inps
             in if null chgs then [dustThreshold feeOpts] else chgs
+        , reserve = Nothing
         }
       where
         noDust :: TxOut -> Maybe Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -166,11 +166,10 @@ improveTxOut (maxN0, selection, utxo0) (inps0, txout) = do
     (maxN, inps, utxo) <- improve (maxN0, inps0, utxo0)
     return
         ( maxN
-        , selection <> CoinSelection
+        , selection <> mempty
             { inputs = inps
             , outputs = [txout]
             , change = mkChange txout inps
-            , reserve = Nothing
             }
         , utxo
         )

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -170,6 +170,7 @@ improveTxOut (maxN0, selection, utxo0) (inps0, txout) = do
             { inputs = inps
             , outputs = [txout]
             , change = mkChange txout inps
+            , reserve = Nothing
             }
         , utxo
         )

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -164,7 +164,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         :: MonadRandom m
         => CoinSelection
         -> StateT UTxO (ExceptT ErrAdjustForFee m) CoinSelection
-    go coinSel@(CoinSelection inps outs chgs) = do
+    go coinSel@(CoinSelection inps outs chgs rsv) = do
         -- Substract fee from change outputs, proportionally to their value.
         let (coinSel', remFee) = rebalanceChangeOutputs opt coinSel
 
@@ -189,7 +189,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
             -- we can now correctly cover fee.
             inps' <- coverRemainingFee remFee
             let extraChange = splitChange (Coin $ balance' inps') chgs
-            go $ CoinSelection (inps <> inps') outs extraChange
+            go $ CoinSelection (inps <> inps') outs extraChange rsv
 
 -- | A short / simple version of the 'random' fee policy to cover for fee in
 -- case where existing change were not enough.

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -229,6 +229,15 @@ rebalanceSelection
     -> CoinSelection
     -> (CoinSelection, Fee)
 rebalanceSelection opts s
+    -- When inputs of a coin selection are less than outputs, we can't do
+    -- anything, another input needs to be selected first. A case where this
+    -- could occur is when selections are balanced in the context of delegation
+    -- / de-registration.
+    --
+    -- A transaction would have initially no inputs, but have a deposit amount.
+    | inputBalance s < outputBalance s + changeBalance s =
+        (s, Fee φ_original)
+
     -- selection is now balanced, nothing to do.
     | φ_original == δ_original =
         (s, Fee 0)

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -164,7 +164,7 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
         :: MonadRandom m
         => CoinSelection
         -> StateT UTxO (ExceptT ErrAdjustForFee m) CoinSelection
-    go coinSel@(CoinSelection inps outs chgs rsv) = do
+    go coinSel@(CoinSelection inps _ _ outs chgs _) = do
         -- Substract fee from change outputs, proportionally to their value.
         let (coinSel', remFee) = rebalanceSelection opt coinSel
 
@@ -189,7 +189,11 @@ senderPaysFee opt utxo sel = evalStateT (go sel) utxo where
             -- we can now correctly cover fee.
             inps' <- coverRemainingFee remFee
             let chgs' = splitChange (Coin $ balance' inps') chgs
-            go $ CoinSelection (inps <> inps') outs chgs' rsv
+            go $ coinSel
+                { inputs  = inps <> inps'
+                , outputs = outs
+                , change  = chgs'
+                }
 
 -- | A short / simple version of the 'random' fee policy to cover for fee in
 -- case where existing change were not enough.

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -229,17 +229,6 @@ rebalanceSelection opts s
     | φ_original == δ_original =
         (s, Fee 0)
 
-    -- some fee left to pay, and the reserve is non-empty, use it first.
-    | φ_original > δ_original && reserve s > Just (Coin 0) =
-        let
-            -- Safe because of the above guard.
-            Just (Coin r) = reserve s
-            r' = if r > φ_original
-                then Coin (r - φ_original)
-                else Coin 0
-        in
-            rebalanceSelection opts (s { reserve = Just r' })
-
     -- some fee left to pay, but we've depleted all change outputs
     | φ_original > δ_original && null (change s) =
         (s, Fee (φ_original - δ_original))
@@ -283,10 +272,7 @@ rebalanceSelection opts s
     δ_dangling = φ_original -- by construction of the change output
 
     extraChng = Coin (δ_original - φ_original)
-    sDangling = s
-        { change = splitChange extraChng (change s)
-        , reserve = Coin 0 <$ reserve s
-        }
+    sDangling = s { change = splitChange extraChng (change s) }
 
 -- | Reduce single change output by a given fee amount. If fees are too big for
 -- a single coin, returns a `Coin 0`.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -162,12 +162,7 @@ data ErrDecodeSignedTx
     deriving (Show, Eq)
 
 -- | Possible signing error
-data ErrMkTx
+newtype ErrMkTx
     = ErrKeyNotFoundForAddress Address
     -- ^ We tried to sign a transaction with inputs that are unknown to us?
-    | ErrChangeIsEmptyForRetirement
-    -- ^ When retiring on Shelley, we need to add a deposit amount made when
-    -- creating a stake key. This requires at least one change output, which
-    -- ought to be present anyway by construction of the coin selection when
-    -- quitting delegation.
     deriving (Eq, Show)

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -70,9 +70,7 @@ data TransactionLayer t k = TransactionLayer
         -- key corresponding to a particular address.
 
     , mkDelegationJoinTx
-        :: FeePolicy
-            -- Latest fee policy
-        -> WalletDelegation
+        :: WalletDelegation
             -- Wallet current delegation status
         -> PoolId
             -- Pool Id to which we're planning to delegate
@@ -82,12 +80,9 @@ data TransactionLayer t k = TransactionLayer
             -- Key store
         -> SlotId
             -- Tip of the chain, for TTL
-        -> [(TxIn, TxOut)]
-            --  Resolved inputs
-        -> [TxOut]
-            -- Outputs
-        -> [TxOut]
-            -- Change, with assigned address
+        -> CoinSelection
+            -- A balanced coin selection where all change addresses have been
+            -- assigned.
         -> Either ErrMkTx (Tx, SealedTx)
         -- ^ Construct a transaction containing a certificate for delegating to
         -- a stake pool.
@@ -97,20 +92,15 @@ data TransactionLayer t k = TransactionLayer
         -- HD account keys are something different)
 
     , mkDelegationQuitTx
-        :: FeePolicy
-            -- Latest fee policy
-        -> (k 'AddressK XPrv, Passphrase "encryption")
+        :: (k 'AddressK XPrv, Passphrase "encryption")
             -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
             -- Key store
         -> SlotId
             -- Tip of the chain, for TTL
-        -> [(TxIn, TxOut)]
-            -- Resolved inputs
-        -> [TxOut]
-            -- Outputs
-        -> [TxOut]
-            -- Change, with assigned address
+        -> CoinSelection
+            -- A balanced coin selection where all change addresses have been
+            -- assigned.
         -> Either ErrMkTx (Tx, SealedTx)
         -- ^ Construct a transaction containing a certificate for quiting from
         -- a stake pool.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -146,6 +146,7 @@ data TransactionLayer t k = TransactionLayer
 
 -- | Whether the user is attempting any particular delegation action.
 data DelegationAction = RegisterKeyAndJoin PoolId | Join PoolId | Quit
+    deriving (Show)
 
 -- | A type family for validations that are specific to a particular backend
 -- type. This demands an instantiation of the family for a particular backend:

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -51,7 +51,6 @@ spec = do
                 { rsInputs = [17]
                 , rsChange = []
                 , rsOutputs = [17]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -65,7 +64,6 @@ spec = do
                 { rsInputs = [17]
                 , rsChange = [16]
                 , rsOutputs = [1]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -79,7 +77,6 @@ spec = do
                 { rsInputs = [12, 17]
                 , rsChange = [11]
                 , rsOutputs = [18]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -93,7 +90,6 @@ spec = do
                 { rsInputs = [10, 12, 17]
                 , rsChange = [9]
                 , rsOutputs = [30]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -107,7 +103,6 @@ spec = do
                 { rsInputs = [6,10,5]
                 , rsChange = [5,4]
                 , rsOutputs = [11,1]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 3
@@ -231,8 +226,8 @@ propAtLeast
 propAtLeast (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
-    prop (CoinSelection inps _ _ _) =
-        L.length inps `shouldSatisfy` (>= NE.length txOuts)
+    prop cs =
+        L.length (inputs cs) `shouldSatisfy` (>= NE.length txOuts)
     selection = runIdentity $ runExceptT $
         largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo
 
@@ -242,12 +237,12 @@ propInputDecreasingOrder
 propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
-    prop (CoinSelection inps _ _ _) =
+    prop cs =
         let
             utxo' = (Map.toList . getUTxO) $
-                utxo `excluding` (Set.fromList . map fst $ inps)
+                utxo `excluding` (Set.fromList . map fst $ inputs cs)
         in unless (L.null utxo') $
-            (getExtremumValue L.minimum inps)
+            getExtremumValue L.minimum (inputs cs)
             `shouldSatisfy`
             (>= (getExtremumValue L.maximum utxo'))
     getExtremumValue f = f . map (getCoin . coin . snd)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -51,6 +51,7 @@ spec = do
                 { rsInputs = [17]
                 , rsChange = []
                 , rsOutputs = [17]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -64,6 +65,7 @@ spec = do
                 { rsInputs = [17]
                 , rsChange = [16]
                 , rsOutputs = [1]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -77,6 +79,7 @@ spec = do
                 { rsInputs = [12, 17]
                 , rsChange = [11]
                 , rsOutputs = [18]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -90,6 +93,7 @@ spec = do
                 { rsInputs = [10, 12, 17]
                 , rsChange = [9]
                 , rsOutputs = [30]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -103,6 +107,7 @@ spec = do
                 { rsInputs = [6,10,5]
                 , rsChange = [5,4]
                 , rsOutputs = [11,1]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 3
@@ -226,7 +231,7 @@ propAtLeast
 propAtLeast (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
-    prop (CoinSelection inps _ _) =
+    prop (CoinSelection inps _ _ _) =
         L.length inps `shouldSatisfy` (>= NE.length txOuts)
     selection = runIdentity $ runExceptT $
         largestFirst (CoinSelectionOptions (const 100) noValidation) txOuts utxo
@@ -237,7 +242,7 @@ propInputDecreasingOrder
 propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
-    prop (CoinSelection inps _ _) =
+    prop (CoinSelection inps _ _ _) =
         let
             utxo' = (Map.toList . getUTxO) $
                 utxo `excluding` (Set.fromList . map fst $ inps)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -53,7 +53,6 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -67,7 +66,6 @@ spec = do
                 { rsInputs = [1,1,1,1,1,1]
                 , rsChange = [2,1]
                 , rsOutputs = [2,1]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -81,7 +79,6 @@ spec = do
                 { rsInputs = [1,1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2,1]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -95,7 +92,6 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [2,1]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -109,7 +105,6 @@ spec = do
                 { rsInputs = [5]
                 , rsChange = [3]
                 , rsOutputs = [2]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -123,7 +118,6 @@ spec = do
                 { rsInputs = [10,10]
                 , rsChange = [8,8]
                 , rsOutputs = [2,2]
-                , rsReserve = Nothing
                 }
             )
             (CoinSelectionFixture
@@ -138,7 +132,6 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [3]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
@@ -152,7 +145,6 @@ spec = do
                 { rsInputs = [oneAda, oneAda, oneAda, oneAda]
                 , rsChange = [oneAda, oneAda `div` 2]
                 , rsOutputs = [2*oneAda,oneAda `div` 2]
-                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
@@ -255,8 +247,8 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
                 (selection1, selection2)
         in prop (s1, s2)
   where
-    prop (CoinSelection inps1 _ _ _, CoinSelection inps2 _ _ _) =
-        L.length inps1 `shouldSatisfy` (>= L.length inps2)
+    prop (cs1, cs2) =
+        L.length (inputs cs1) `shouldSatisfy` (>= L.length (inputs cs2))
     (selection1,_) = withDRG drg
         (runExceptT $ random opt txOuts utxo)
     selection2 = runIdentity $ runExceptT $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -53,6 +53,7 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -66,6 +67,7 @@ spec = do
                 { rsInputs = [1,1,1,1,1,1]
                 , rsChange = [2,1]
                 , rsOutputs = [2,1]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -79,6 +81,7 @@ spec = do
                 { rsInputs = [1,1,1,1,1]
                 , rsChange = [2]
                 , rsOutputs = [2,1]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -92,6 +95,7 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [2,1]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -105,6 +109,7 @@ spec = do
                 { rsInputs = [5]
                 , rsChange = [3]
                 , rsOutputs = [2]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 100
@@ -118,6 +123,7 @@ spec = do
                 { rsInputs = [10,10]
                 , rsChange = [8,8]
                 , rsOutputs = [2,2]
+                , rsReserve = Nothing
                 }
             )
             (CoinSelectionFixture
@@ -132,6 +138,7 @@ spec = do
                 { rsInputs = [1,1,1,1]
                 , rsChange = [1]
                 , rsOutputs = [3]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
@@ -145,6 +152,7 @@ spec = do
                 { rsInputs = [oneAda, oneAda, oneAda, oneAda]
                 , rsChange = [oneAda, oneAda `div` 2]
                 , rsOutputs = [2*oneAda,oneAda `div` 2]
+                , rsReserve = Nothing
                 })
             (CoinSelectionFixture
                 { maxNumOfInputs = 4
@@ -247,7 +255,7 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
                 (selection1, selection2)
         in prop (s1, s2)
   where
-    prop (CoinSelection inps1 _ _, CoinSelection inps2 _ _) =
+    prop (CoinSelection inps1 _ _ _, CoinSelection inps2 _ _ _) =
         L.length inps1 `shouldSatisfy` (>= L.length inps2)
     (selection1,_) = withDRG drg
         (runExceptT $ random opt txOuts utxo)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -52,8 +52,6 @@ import Data.Functor.Identity
     ( Identity (runIdentity) )
 import Data.List.NonEmpty
     ( NonEmpty )
-import Data.Maybe
-    ( isNothing )
 import Data.Word
     ( Word64 )
 import Fmt
@@ -506,13 +504,11 @@ prop_rebalanceSelection sel onDangling = do
                 fee' /= Fee 0 || Fee (delta sel') == estimateFee opts sel'
             SaveMoney ->
                 fee' /= Fee 0 || Fee (delta sel') >= estimateFee opts sel'
-    let reserveIsEmpty =
-            case reserve sel of
-                Nothing -> isNothing (reserve sel')
-                Just{}  -> reserve sel' == Just (Coin 0)
+    let reserveIsUnchanged =
+            reserve sel == reserve sel'
     conjoin
         [ property selectionIsBalanced
-        , property reserveIsEmpty
+        , property reserveIsUnchanged
         ]
         & counterexample (unlines
             [ "selection (before):", pretty sel

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), feeBalance )
+    ( CoinSelection, feeBalance )
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..) )
 import Cardano.Wallet.Primitive.Types
@@ -178,6 +178,7 @@ import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
+import qualified Cardano.Wallet.Primitive.CoinSelection as CS
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -473,14 +474,15 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
             unsafeRunExceptT $ W.signPayment @_ @_ @DummyTarget wl wid () newPwd selection
         txOld `shouldBe` txNew
   where
-    selection = CoinSelection
-        [ ( TxIn (Hash "eb4ab6028bd0ac971809d514c92db1") 1
-          , TxOut (Address "source") (Coin 42)
-          )
-        ]
-        [ TxOut (Address "destination") (Coin 14) ]
-        []
-        Nothing
+    selection = mempty
+        { CS.inputs =
+            [ ( TxIn (Hash "eb4ab6028bd0ac971809d514c92db1") 1
+              , TxOut (Address "source") (Coin 42)
+              )
+            ]
+        , CS.outputs =
+            [ TxOut (Address "destination") (Coin 14) ]
+        }
 
 walletListTransactionsSorted
     :: (WalletId, WalletName, DummyState)
@@ -560,11 +562,9 @@ instance Arbitrary FeeGen where
 
 -- | Manufacture a coin selection that would result in the given fee.
 coinSelectionForFee :: FeeGen -> CoinSelection
-coinSelectionForFee (FeeGen (Coin fee)) = CoinSelection
-    { inputs = [(TxIn (Hash "") 0, TxOut (Address "") (Coin (1 + fee)))]
-    , outputs = [TxOut (Address "") (Coin 1)]
-    , change = []
-    , reserve = Nothing
+coinSelectionForFee (FeeGen (Coin fee)) = mempty
+    { CS.inputs  = [(TxIn (Hash "") 0, TxOut (Address "") (Coin (1 + fee)))]
+    , CS.outputs = [TxOut (Address "") (Coin 1)]
     }
 {-------------------------------------------------------------------------------
                       Tests machinery, Arbitrary instances

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -480,6 +480,7 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
         ]
         [ TxOut (Address "destination") (Coin 14) ]
         []
+        Nothing
 
 walletListTransactionsSorted
     :: (WalletId, WalletName, DummyState)
@@ -563,6 +564,7 @@ coinSelectionForFee (FeeGen (Coin fee)) = CoinSelection
     { inputs = [(TxIn (Hash "") 0, TxOut (Address "") (Coin (1 + fee)))]
     , outputs = [TxOut (Address "") (Coin 1)]
     , change = []
+    , reserve = Nothing
     }
 {-------------------------------------------------------------------------------
                       Tests machinery, Arbitrary instances

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -631,6 +631,8 @@ dummyTransactionLayer = TransactionLayer
         -- (tx1, wit1) == (tx2, wit2) <==> fakebinary1 == fakebinary2
         let fakeBinary = SealedTx . B8.pack $ show (tx, wit)
         return (tx, fakeBinary)
+    , initDelegationSelection =
+        error "dummyTransactionLayer: initDelegationSelection not implemented"
     , mkDelegationJoinTx =
         error "dummyTransactionLayer: mkDelegationJoinTx not implemented"
     , mkDelegationQuitTx =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -617,11 +617,11 @@ setupFixture (wid, wname, wstate) = do
 -- implements a fake signer that still produces sort of witnesses
 dummyTransactionLayer :: TransactionLayer DummyTarget JormungandrKey
 dummyTransactionLayer = TransactionLayer
-    { mkStdTx = \keyFrom _slot inps outs -> do
-        let inps' = map (second coin) inps
-        let tid = mkTxId inps' outs
-        let tx = Tx tid inps' outs
-        wit <- forM inps $ \(_, TxOut addr _) -> do
+    { mkStdTx = \_ keyFrom _slot cs -> do
+        let inps' = map (second coin) (CS.inputs cs)
+        let tid = mkTxId inps' (CS.outputs cs)
+        let tx = Tx tid inps' (CS.outputs cs)
+        wit <- forM (CS.inputs cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither
                 (ErrKeyNotFoundForAddress addr) $ keyFrom addr
             let (Hash sigData) = txId tx

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -83,10 +83,10 @@ newTransactionLayer
     => Hash "Genesis"
     -> TransactionLayer t k
 newTransactionLayer block0H = TransactionLayer
-    { mkStdTx = \keyFrom _ inps outs ->
+    { mkStdTx = \_rewardAcnt keyFrom _ cs ->
         mkFragment
             ( MkFragmentSimpleTransaction (txWitnessTagFor @k)
-            ) keyFrom inps outs
+            ) keyFrom (CS.inputs cs) (CS.outputs cs)
 
     , mkDelegationJoinTx = \pool accXPrv keyFrom _ cs ->
         let acc = ChimericAccount . xpubPublicKey . getRawKey . publicKey . fst $ accXPrv

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -244,9 +244,12 @@ mkFeeEstimator policy = \case
     PaymentDescription nInps nOuts nChgs ->
         let fee = linear (nInps + nOuts + nChgs) 0
         in (fee, fee)
-    DelegDescription nInps nOuts nCerts ->
-        let fee = linear (nInps + nOuts) nCerts
-        in (fee, fee)
+    DelegDescription _action ->
+        let
+            feeMin = linear 0 1
+            feeMax = linear 2 1
+        in
+            (feeMin, feeMax)
   where
     LinearFee (Quantity a) (Quantity b) (Quantity c) = policy
     -- NOTE¹

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -108,6 +108,7 @@ import Test.QuickCheck
     ( generate, vector )
 
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Cardano.Wallet.Primitive.CoinSelection as CS
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Data.ByteArray as BA
@@ -515,15 +516,18 @@ fixtureExternalTx ctx toSend = do
             , nOutputs = 1
             , nChanges = 1
             }
-    let theInps =
-            [ (TxIn theTxId 0, TxOut addrSrc (Coin (fromIntegral amt))) ]
-    let theOuts =
-            [ TxOut addrDest' (Coin (fromIntegral toSend))
-            , TxOut addrChng (Coin (fromIntegral $ amt - toSend - fee))
-            ]
+    let cs = mempty
+            { CS.inputs =
+                [ (TxIn theTxId 0, TxOut addrSrc (Coin (fromIntegral amt))) ]
+            , CS.outputs =
+                [ TxOut addrDest' (Coin (fromIntegral toSend))
+                , TxOut addrChng (Coin (fromIntegral $ amt - toSend - fee))
+                ]
+            }
     tl <- newTransactionLayer <$> getBlock0H
+    let rewardAcnt = error "rewardAcnt unused"
     let curSlot = error "current slot not needed in jormungandr mkStdTx"
-    let (Right (tx, bin)) = mkStdTx tl keystore curSlot theInps theOuts
+    let (Right (tx, bin)) = mkStdTx tl rewardAcnt keystore curSlot cs
 
     return ExternalTxFixture
         { srcWallet = wSrc

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -42,8 +43,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , TxIn (..)
     , TxOut (..)
-    , WalletDelegation (..)
-    , WalletDelegationStatus (..)
     )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )
@@ -519,26 +518,20 @@ goldenTestDelegationCertTx
     -> [TxOut]
     -> ByteString
     -> SpecWith ()
-goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inps outs bytes' = it title $ do
-    let walDelegs = WalletDelegation NotDelegating []
+goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inputs outputs bytes' = it title $ do
     let res = mkDelegationJoinTx tl
-            policy
-            walDelegs
             pool
             (accountXPrv, pass)
             keystore
             (SlotId 0 0)
-            inps
-            outs
-            []
+            (mempty { inputs, outputs })
     let sealed = getSealedTx . snd <$> res
     sealed `shouldBe` Right (unsafeFromHex bytes')
     & counterexample ("poolId = " <> showHex (getPoolId pool))
   where
     title = "golden test mkCertificateTx: " <> show pool
-        <> show inps <> show outs
+        <> show inputs <> show outputs
     showHex = B8.unpack . hex
-    policy = error "fee policy unused by Jörmungandr"
 
 xprvSeqFromSeed
     :: ByteString
@@ -602,15 +595,15 @@ tooNumerousInpsTest
 tooNumerousInpsTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = validateSelection tl (CoinSelection inps outs chngs Nothing)
+    let res = validateSelection tl $ mempty { inputs, outputs, change }
           where
             tl = newTransactionLayer @JormungandrKey block0
-            inps = replicate 256
+            inputs = replicate 256
                 ( TxIn (Hash "arbitrary") 0
                 , TxOut addr (Coin 1)
                 )
-            outs = []
-            chngs = []
+            outputs = []
+            change  = []
     res `shouldBe` Left ErrExceededInpsOrOuts
   where
     title = "Too numerous inputs yields an error ("
@@ -625,15 +618,15 @@ tooNumerousOutsTest
 tooNumerousOutsTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = validateSelection tl (CoinSelection inps outs chngs Nothing)
+    let res = validateSelection tl $ mempty { inputs, outputs, change }
           where
             tl = newTransactionLayer @JormungandrKey block0
-            inps = replicate 255
+            inputs = replicate 255
                 ( TxIn (Hash "arbitrary") 0
                 , TxOut addr (Coin 10)
                 )
-            outs = replicate 256 (TxOut addr (Coin 9))
-            chngs = replicate 256 (Coin 9)
+            outputs = replicate 256 (TxOut addr (Coin 9))
+            change  = replicate 256 (Coin 9)
     res `shouldBe` Left ErrExceededInpsOrOuts
   where
     title = "Too numerous outputs yields an error ("

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -502,7 +502,9 @@ goldenTestStdTx
     -> ByteString
     -> SpecWith ()
 goldenTestStdTx tl keystore inps outs bytes' = it title $ do
-    let tx = mkStdTx tl keystore (SlotId 0 0) inps outs
+    let cs = mempty { inputs = inps, outputs = outs }
+    let rewardAcnt = error "unused"
+    let tx = mkStdTx tl rewardAcnt keystore (SlotId 0 0) cs
     let bytes = hex . getSealedTx . snd <$> tx
     bytes `shouldBe` Right bytes'
   where
@@ -571,16 +573,20 @@ unknownInputTest
 unknownInputTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = mkStdTx tl keyFrom (SlotId 0 0) inps outs
+    let res = mkStdTx tl rewardAcnt keyFrom (SlotId 0 0) cs
           where
             tl = newTransactionLayer @JormungandrKey block0
+            rewardAcnt = error "unused"
             keyFrom = const Nothing
-            inps =
-                [ ( TxIn (Hash "arbitrary") 0
-                  , TxOut addr (Coin 0)
-                  )
-                ]
-            outs = []
+            cs = mempty
+                { inputs =
+                    [ ( TxIn (Hash "arbitrary") 0
+                      , TxOut addr (Coin 0)
+                      )
+                    ]
+                , outputs =
+                    []
+                }
     res `shouldBe` Left (ErrKeyNotFoundForAddress addr)
   where
     title = "Unknown input address yields an error ("

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -16,7 +16,7 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv )
 import Cardano.Wallet.Jormungandr.Transaction
-    ( ErrExceededInpsOrOuts (..), newTransactionLayer )
+    ( ErrValidateSelection (..), newTransactionLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
@@ -602,7 +602,7 @@ tooNumerousInpsTest
 tooNumerousInpsTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = validateSelection tl (CoinSelection inps outs chngs)
+    let res = validateSelection tl (CoinSelection inps outs chngs Nothing)
           where
             tl = newTransactionLayer @JormungandrKey block0
             inps = replicate 256
@@ -625,7 +625,7 @@ tooNumerousOutsTest
 tooNumerousOutsTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = validateSelection tl (CoinSelection inps outs chngs)
+    let res = validateSelection tl (CoinSelection inps outs chngs Nothing)
           where
             tl = newTransactionLayer @JormungandrKey block0
             inps = replicate 255

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -992,7 +992,7 @@ operators = unsafePerformIO $ newMVar
 
 -- | Deposit amount required for registering certificates.
 depositAmt :: Integer
-depositAmt = 100
+depositAmt = 100000
 
 -- | Initial amount in each of these special cluster faucet
 faucetAmt :: Integer

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -29,7 +29,7 @@ protocolParams:
   extraEntropy:
     tag: NeutralNonce
   maxBlockHeaderSize: 217569
-  keyDeposit: 100
+  keyDeposit: 100000
   keyDecayRate: 0
   nOpt: 3
   rho: 0.178650067

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -266,7 +266,7 @@ mkFeeEstimator policy = \case
             outs =
                 replicate (nOuts + nChgs) (Coin minBound)
         in
-            CoinSelection inps [] outs
+            CoinSelection inps [] outs Nothing
 
     computeFee selection dlg =
         fromIntegral $ getFee $ _minimumFee policy dlg selection

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -53,7 +53,6 @@ import Cardano.Wallet.Shelley.Transaction
     ( mkUnsignedTx
     , mkWitness
     , newTransactionLayer
-    , realFee
     , _decodeSignedTx
     , _estimateMaxNumberOfInputs
     )
@@ -144,8 +143,9 @@ prop_decodeSignedTxRoundtrip
     :: DecodeSetup
     -> Property
 prop_decodeSignedTxRoundtrip (DecodeSetup utxo outs slotNo pairs) = do
-    let ownedIns = Map.toList $ getUTxO utxo
-    let unsigned = mkUnsignedTx slotNo ownedIns outs [] (realFee Nothing ownedIns outs)
+    let inps = Map.toList $ getUTxO utxo
+    let cs = mempty { CS.inputs = inps, CS.outputs = outs }
+    let unsigned = mkUnsignedTx slotNo cs []
     let addrWits = Set.fromList $ map (mkWitness unsigned) pairs
     let metadata = SL.SNothing
     let wits = SL.WitnessSet addrWits mempty mempty
@@ -196,7 +196,7 @@ testCoinSelOpts = coinSelOpts tl (Quantity 4096)
     tl        = newTransactionLayer @_ @ShelleyKey (Proxy @'Mainnet) pm epLength
 
 testFeeOpts :: FeeOptions
-testFeeOpts = feeOpts tl [] feePolicy
+testFeeOpts = feeOpts tl Nothing feePolicy
   where
     pm        = ProtocolMagic 1
     epLength  = EpochLength 42 -- irrelevant here

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -145,7 +145,7 @@ prop_decodeSignedTxRoundtrip
     -> Property
 prop_decodeSignedTxRoundtrip (DecodeSetup utxo outs slotNo pairs) = do
     let ownedIns = Map.toList $ getUTxO utxo
-    let unsigned = mkUnsignedTx slotNo ownedIns outs [] (realFee ownedIns outs)
+    let unsigned = mkUnsignedTx slotNo ownedIns outs [] (realFee Nothing ownedIns outs)
     let addrWits = Set.fromList $ map (mkWitness unsigned) pairs
     let metadata = SL.SNothing
     let wits = SL.WitnessSet addrWits mempty mempty


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1821 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 859f53bdeed9fc641f83a98201e184254eb14591
  :round_pushpin: **extend 'CoinSelection' type to carry an extra reserve amount that can be used as input**
  For now, the reserve is always 'Nothing', which should not alter any of the existing behavior. Then, it can be
set to a specific value (e.g. the reward balance) to be used on the left side of the balance (i.e. the input side).

- eebc981a6e80d9403f0df5c9dc5a9917cf5289e0
  :round_pushpin: **rename 'rebalanceChangeOutput' in 'rebalanceSelection' and allow picking from the reserve**
  The approach is still very 'simple', before trying to deplete any change output, we first try to remove fees
from the reserve. Once the reserve is empty, we'll start depleting change outputs.

- 08a6cbe852793398b642d70faeae834d64620406
  :round_pushpin: **move prop_rebalanceSelection from byron package to core package**
  It was originally in `-byron` because it was using the fee policy and
fee estimation from Byron, so, while moving it, I also changed the way
the transaction size is estimated to make it mimics the way it's done on
shelley and byron, with rather realistic fee values.

- 338dde73e990924e3004d4e3a11825deb0382a2e
  :round_pushpin: **generate arbitrary selection with reserve, add more classification and assertions to properties**
  
- 20c161bd8cb528d1c6a16cfada568dcebc5dd137
  :round_pushpin: **do not mutate the reserve as part of the fee balancing process**
  Everything in the past coin selection (without reserve) was easy to reason about. One could always look at the sum
of inputs and compare it with the sum of outputs and changes, and there were some nice properties about this. Having
mutable reserve makes it somewhat very confusing because, there's no trace of where the money comes from (turning
reserve into changes shouldn't make it disappear).

- 22e17144e678bd0292acc3891c186af2fa0d4cc4
  :round_pushpin: **expand 'reserve' to also cover deposit and reclaim**
  So that types are clear from the coin selection and a bit less confusing.

- 43cace27cff105b6d3a8428bbec2998ada0398a0
  :round_pushpin: **extend transaction layer with an 'initDelegationSelection'**
    This in order to defer to the relevant backend the necessary bits of logic regarding withdrawal, deposits and reclaims.
  I've also removed the 'WalletDelegation' from 'mkDelegationJoinTx' as this can now be inferred from the presence of a deposit in the coin selection.

  We have the following situation:

  object     | cardano-node | jormungandr
   ----      | ----         | ----
  inputs     | explicit     | explicit
  reclaim    | implicit     | N/A
  withdrawal | explicit     | N/A
  ---        | ---          | ---
  outputs    | explicit     | explicit
  deposit    | implicit     | N/A

  Regardless of the situation, we must always have at least one input (replay protection) and output (although outputs may be entirely change outputs).
  Then, depending on the situation, we may have 'withdrawal', 'reclaim' and or 'deposit' present.

  `reclaim` and `deposit` are "opposed" and can't be present together. `withdrawal` can in theory be present with both, but in practice, will only be present alone: we'll only
  allow users to withdraw their reward as part of standard transaction. `deposit` are only present when registering a stake-key for the first time. In summary, this gives us:

  type of transaction  | objects
  -------------------  | --------
  standard transaction | inputs, outputs, withdrawal? (if users said so)
  initial delegation   | inputs, outputs, deposit
  re-delegation        | inputs, outputs
  de-registration      | inputs, outputs, reclaim

- 227dcd9d9287d4ef3d76f602fc4cdd5b5e15d347
  :round_pushpin: **only count reclaim and withdrawal as part of the input balance if there's already a UTxO input**
  
- dd003064e32d82cdb53bfeb164ad3614c8b0fb93
  :round_pushpin: **tweak arbitrary coin selection generator to produce more realistic cases**
  The generator was good for 'payment' kind of selection. Yet, we also sort of abuse the fee balancing when creating selection for delegation with special delegation
with no inputs and no outputs. This was therefore completely untested by the current generator! Now it does, sometimes, create typical selections we would create when
delegating or undelegating. It nicely caught an error in the fee balancing algorithm which this commit also fixes

- 523ca66a8c5c7cc8417836830c4d467c29381ffa
  :round_pushpin: **re-implement shelley's transaction layer accordingly**
  In the end, it is much simpler and cleaner, no more hacky-hack to get things working. The newly introduced 'initDelegationSelection' makes it easier to construct a correct coin selection from the start and simply go with it.

- 7fa1162927b32e4510d93ae2c52753c2eae5ca55
  :round_pushpin: **review integration 'feeEstimator' to use 'DelegationAction'**
  We have two different ways of computing fees, and this is because in Byron, it used to be complicated to evaluate fees for a transaction. Now, this fee estimator feels sort of redundant and we should solely rely on the result from the fee estimation endpoint. In the meantime, I've adjusted it to make a bit more consistent with how fees are calculated elsewhere.

I've also adjusted the genesis file to have a much bigger deposit key.  The previous code was actually handling things in a very wrong way, but it went unnoticed because two errors were cancelling each others: fee were slightly over-evaluated, and the deposit for key was small enough to compensate.

- f8faf55502f57a203be4470954820df5b31fd8b3
  :round_pushpin: **re-implement byron & jormungandr transaction layers accordingly**
  
- ff7ee223cb549538025b75f6cd4cddccd3f3d7a7
  :round_pushpin: **add withdrawal on each payment transaction**
  We could make it slightly smarter here and requires that the withdrawal is only requested when the balance is somewhat sufficient.
Sufficient would mean, bigger than the cost of adding it. Indeed, adding a withdrawal would only make sense if the cost of adding it
isn't greater to its value.

- 98ace73a0f2e8d43faa0fa0859ea9ca2d2316def
  :round_pushpin: **only set withdrawal when they are sufficiently big**
  Otherwise, we end-up paying for more than the value they offer.

- d6b1db1038f2c455433dae5dc0b4dc079bc1b7fd
  :round_pushpin: **remove now obsolete 'ErrChangeIsEmptyForRetirement'**
  
- ba174deb629f70a9f19f6c406384f733543c05ca
  :round_pushpin: **prepare foundation to support withdrawals witnesses in standard transaction**
  I've once again changed a bit the transaction layer to be more aligned with the recent changes (now takes a full coin selection).
Also, it now requires a reward account to be given; this is relatively 'unsound' for Byron and Icarus wallet since they have no
reward account, yet, the account is only used when a non-null withdrawal is provided which should never happen for these wallet types
since they aren't receiving rewards at all.

- e7ab562ade96ec58d7d47aefd61da5c814164121
  :round_pushpin: **add property showing that withdrawals are correctly estimated by Shelley tx layer**
  
- 3035ec7dffe0ca0b63cb1185b73b5af0d1a19464
  :round_pushpin: **add integration test showing that rewards are spent with a transaction**
  
- 10e04f46d1d6efab8d6d5a74757c26aa31fd6c27
  :round_pushpin: **count rewards as part of the total and available balance**

# Comments

<!-- Additional comments or screenshots to attach if any -->

- ~~TODO: need to create the a corresponding withdrawal witness inside payment transactions~~
- ~~TODO: need to NOT add a withdrawal when it's below certain threshold~~
- ~~TODO: need to add an integration test showing that reward are withdrawn successfully.~~

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
