### PR TITLE
Add latency benchmark for shelley

### DIFF
--- a/.buildkite/bench-latency.sh
+++ b/.buildkite/bench-latency.sh
@@ -3,12 +3,10 @@
 
 set -euo pipefail
 
-bench_name_jormungandr=bench-latency-jormungandr
-bench_name_byron=bench-latency-byron
-
 echo "--- Build"
-nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o $bench_name_jormungandr
-nix-build -A benchmarks.cardano-wallet-byron.latency -o $bench_name_byron
+nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o bench-latency-jormungandr
+nix-build -A benchmarks.cardano-wallet-byron.latency -o bench-latency-byron
+nix-build -A benchmarks.cardano-wallet-shelley.latency -o bench-latency-byron
 
 # Note: the tracing will not work if program output is piped
 # to another process (e.g. "tee").
@@ -16,8 +14,12 @@ nix-build -A benchmarks.cardano-wallet-byron.latency -o $bench_name_byron
 
 echo "+++ Run benchmark - byron"
 
-./$bench_name_byron/bin/latency
+./bench-latency-byron/bin/latency
+
+echo "+++ Run benchmark - shelley"
+
+./bench-latency-shelley/bin/latency
 
 echo "+++ Run benchmark - jormungandr"
 
-./$bench_name_jormungandr/bin/latency
+./bench-latency-jormungandr/bin/latency

--- a/.buildkite/bench-latency.sh
+++ b/.buildkite/bench-latency.sh
@@ -3,10 +3,12 @@
 
 set -euo pipefail
 
+cd `dirname $0`/..
+
 echo "--- Build"
 nix-build -A benchmarks.cardano-wallet-jormungandr.latency -o bench-latency-jormungandr
 nix-build -A benchmarks.cardano-wallet-byron.latency -o bench-latency-byron
-nix-build -A benchmarks.cardano-wallet-shelley.latency -o bench-latency-byron
+nix-build -A benchmarks.cardano-wallet-shelley.latency -o bench-latency-shelley
 
 # Note: the tracing will not work if program output is piped
 # to another process (e.g. "tee").
@@ -14,12 +16,12 @@ nix-build -A benchmarks.cardano-wallet-shelley.latency -o bench-latency-byron
 
 echo "+++ Run benchmark - byron"
 
-./bench-latency-byron/bin/latency
+( cd lib/byron && ../../bench-latency-byron/bin/latency )
 
 echo "+++ Run benchmark - shelley"
 
-./bench-latency-shelley/bin/latency
+( cd lib/shelley && ../../bench-latency-shelley/bin/latency )
 
 echo "+++ Run benchmark - jormungandr"
 
-./bench-latency-jormungandr/bin/latency
+( cd lib/jormungandr && ../../bench-latency-jormungandr/bin/latency )

--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -16,6 +16,13 @@
       - name: Module reused between components
       - module: Cardano.Wallet.Byron.Faucet
 - package:
+  - name: cardano-wallet-shelley
+  - section:
+    - name: test:integration bench:latency
+    - message:
+      - name: Module reused between components
+      - module: Cardano.Wallet.Shelley.Faucet
+- package:
   - name: cardano-wallet-core
   - section:
     - name: test:unit

--- a/lib/byron/cardano-wallet-byron.cabal
+++ b/lib/byron/cardano-wallet-byron.cabal
@@ -277,8 +277,6 @@ benchmark latency
    , stm
    , temporary
    , text
-  build-tools:
-      cardano-wallet-byron
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -312,8 +312,6 @@ benchmark latency
     , stm
     , temporary
     , text
-  build-tools:
-      cardano-wallet-jormungandr
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Main where
+
+import Prelude
+
+import Cardano.BM.Data.LogItem
+    ( LogObject )
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.BM.Data.Tracer
+    ( contramap, nullTracer )
+import Cardano.BM.Trace
+    ( traceInTVarIO )
+import Cardano.CLI
+    ( Port (..) )
+import Cardano.Startup
+    ( withUtf8Encoding )
+import Cardano.Wallet.Api.Server
+    ( Listen (..) )
+import Cardano.Wallet.Api.Types
+    ( ApiAddress
+    , ApiFee
+    , ApiNetworkInformation
+    , ApiTransaction
+    , ApiUtxoStatistics
+    , ApiWallet
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.LatencyBenchShared
+    ( LogCaptureFunc, fmtResult, fmtTitle, measureApiLogs, withLatencyLogging )
+import Cardano.Wallet.Logging
+    ( trMessage )
+import Cardano.Wallet.Network.Ports
+    ( unsafePortNumber )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.Types
+    ( SyncTolerance (..) )
+import Cardano.Wallet.Shelley
+    ( SomeNetworkDiscriminant (..)
+    , Tracers
+    , Tracers' (..)
+    , nullTracers
+    , serveWallet
+    )
+import Cardano.Wallet.Shelley.Compatibility
+    ( Shelley )
+import Cardano.Wallet.Shelley.Faucet
+    ( initFaucet )
+import Cardano.Wallet.Shelley.Launch
+    ( singleNodeParams, withBFTNode, withSystemTempDir )
+import Control.Concurrent.Async
+    ( race_ )
+import Control.Concurrent.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
+import Control.Concurrent.STM.TVar
+    ( TVar )
+import Control.Monad
+    ( mapM_, replicateM, replicateM_, void )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Proxy
+    ( Proxy (..) )
+import Network.HTTP.Client
+    ( defaultManagerSettings
+    , managerResponseTimeout
+    , newManager
+    , responseTimeoutMicro
+    )
+import Network.Wai.Middleware.Logging
+    ( ApiLog (..) )
+import Numeric.Natural
+    ( Natural )
+import System.Directory
+    ( createDirectory )
+import System.FilePath
+    ( (</>) )
+import Test.Hspec
+    ( shouldBe )
+import Test.Integration.Framework.DSL
+    ( Context (..)
+    , Headers (..)
+    , Payload (..)
+    , eventually
+    , expectField
+    , expectResponseCode
+    , expectSuccess
+    , expectWalletUTxO
+    , faucetAmt
+    , fixturePassphrase
+    , fixtureWallet
+    , fixtureWalletWith
+    , json
+    , request
+    , unsafeRequest
+    , verify
+    )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Text as T
+import qualified Network.HTTP.Types.Status as HTTP
+
+main :: forall t n. (t ~ Shelley, n ~ 'Mainnet) => IO ()
+main = withUtf8Encoding $
+    withLatencyLogging setupTracers $ \tracers capture ->
+        walletApiBench @t @n capture (benchWithShelleyServer tracers)
+
+  where
+    setupTracers :: TVar [LogObject ApiLog] -> Tracers IO
+    setupTracers tvar = nullTracers
+        { apiServerTracer = trMessage $ contramap snd (traceInTVarIO tvar) }
+
+walletApiBench
+    :: forall t (n :: NetworkDiscriminant). (t ~ Shelley, n ~ 'Mainnet)
+    => LogCaptureFunc ApiLog ()
+    -> ((Context t -> IO ()) -> IO ())
+    -> IO ()
+walletApiBench capture benchWithServer = do
+    fmtTitle "Non-cached run"
+    runWarmUpScenario
+
+    fmtTitle "Latencies for 2 fixture wallets scenario"
+    runScenario (nFixtureWallet 2)
+
+    fmtTitle "Latencies for 10 fixture wallets scenario"
+    runScenario (nFixtureWallet 10)
+
+    fmtTitle "Latencies for 100 fixture wallets scenario"
+    runScenario (nFixtureWallet 100)
+
+    fmtTitle "Latencies for 2 fixture wallets with 10 txs scenario"
+    runScenario (nFixtureWalletWithTxs 2 10)
+
+    fmtTitle "Latencies for 2 fixture wallets with 20 txs scenario"
+    runScenario (nFixtureWalletWithTxs 2 20)
+
+    fmtTitle "Latencies for 2 fixture wallets with 100 txs scenario"
+    runScenario (nFixtureWalletWithTxs 2 100)
+
+    fmtTitle "Latencies for 10 fixture wallets with 10 txs scenario"
+    runScenario (nFixtureWalletWithTxs 10 10)
+
+    fmtTitle "Latencies for 10 fixture wallets with 20 txs scenario"
+    runScenario (nFixtureWalletWithTxs 10 20)
+
+    fmtTitle "Latencies for 10 fixture wallets with 100 txs scenario"
+    runScenario (nFixtureWalletWithTxs 10 100)
+
+    fmtTitle "Latencies for 2 fixture wallets with 100 utxos scenario"
+    runScenario (nFixtureWalletWithUTxOs 2 100)
+
+    fmtTitle "Latencies for 2 fixture wallets with 200 utxos scenario"
+    runScenario (nFixtureWalletWithUTxOs 2 200)
+
+    fmtTitle "Latencies for 2 fixture wallets with 500 utxos scenario"
+    runScenario (nFixtureWalletWithUTxOs 2 500)
+
+    fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenario"
+    runScenario (nFixtureWalletWithUTxOs 2 1000)
+  where
+
+    -- Creates n fixture wallets and return two of them
+    nFixtureWallet n ctx = do
+        wal1 : wal2 : _ <- replicateM n (fixtureWallet ctx)
+        pure (wal1, wal2)
+
+    -- Creates n fixture wallets and send 1-lovelace transactions to one of them
+    -- (m times). The money is sent in batches (see batchSize below) from
+    -- additionally created source fixture wallet. Then we wait for the money
+    -- to be accommodated in recipient wallet. After that the source fixture
+    -- wallet is removed.
+    nFixtureWalletWithTxs n m ctx = do
+        (wal1, wal2) <- nFixtureWallet n ctx
+
+        let amt = (1 :: Natural)
+        let batchSize = 10
+        let whole10Rounds = div m batchSize
+        let lastBit = mod m batchSize
+        let amtExp val = fromIntegral ((fromIntegral val) + faucetAmt) :: Natural
+        let expInflows =
+                if whole10Rounds > 0 then
+                    [x*batchSize | x<-[1..whole10Rounds]] ++ [lastBit]
+                else
+                    [lastBit]
+        let expInflows' = filter (/=0) expInflows
+
+        mapM_ (repeatPostTx ctx wal1 amt batchSize . amtExp) expInflows'
+        pure (wal1, wal2)
+
+    nFixtureWalletWithUTxOs n utxoNumber ctx = do
+        let utxoExp = replicate utxoNumber 1
+        wal1 <- fixtureWalletWith @n ctx utxoExp
+        (_, wal2) <- nFixtureWallet n ctx
+
+        eventually "Wallet balance is as expected" $ do
+            rWal1 <- request @ApiWallet ctx
+                (Link.getWallet @'Shelley wal1) Default Empty
+            verify rWal1
+                [ expectSuccess
+                , expectField
+                        (#balance . #getApiT . #available . #getQuantity)
+                        (`shouldBe` fromIntegral utxoNumber)
+                ]
+
+        rStat <- request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics @'Shelley wal1) Default Empty
+        expectResponseCode @IO HTTP.status200 rStat
+        expectWalletUTxO (fromIntegral <$> utxoExp) (snd rStat)
+        pure (wal1, wal2)
+
+    repeatPostTx ctx wDest amtToSend batchSize amtExp = do
+        wSrc <- fixtureWallet ctx
+        replicateM_ batchSize
+            (postTx ctx (wSrc, Link.createTransaction @'Shelley, fixturePassphrase) wDest amtToSend)
+        eventually "repeatPostTx: wallet balance is as expected" $ do
+            rWal1 <- request @ApiWallet  ctx (Link.getWallet @'Shelley wDest) Default Empty
+            verify rWal1
+                [ expectSuccess
+                , expectField
+                    (#balance . #getApiT . #available . #getQuantity)
+                    (`shouldBe` amtExp)
+                ]
+        rDel <- request @ApiWallet  ctx (Link.deleteWallet @'Shelley wSrc) Default Empty
+        expectResponseCode @IO HTTP.status204 rDel
+        pure ()
+
+    postTx ctx (wSrc, postTxEndp, pass) wDest amt = do
+        (_, addrs) <- unsafeRequest @[ApiAddress n] ctx
+                      (Link.listAddresses @'Shelley wDest) Empty
+        let destination = (addrs !! 1) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": #{pass}
+            }|]
+        r <- request @(ApiTransaction n) ctx (postTxEndp wSrc) Default payload
+        expectResponseCode HTTP.status202 r
+        return r
+
+    runScenario scenario = benchWithServer $ \ctx -> do
+        (wal1, wal2) <- scenario ctx
+
+        t1 <- measureApiLogs capture
+            (request @[ApiWallet] ctx (Link.listWallets @'Shelley) Default Empty)
+        fmtResult "listWallets        " t1
+
+        t2 <- measureApiLogs capture
+            (request @ApiWallet  ctx (Link.getWallet @'Shelley wal1) Default Empty)
+        fmtResult "getWallet          " t2
+
+        t3 <- measureApiLogs capture
+            (request @ApiUtxoStatistics ctx (Link.getUTxOsStatistics @'Shelley wal1) Default Empty)
+        fmtResult "getUTxOsStatistics " t3
+
+        t4 <- measureApiLogs capture
+            (request @[ApiAddress n] ctx (Link.listAddresses @'Shelley wal1) Default Empty)
+        fmtResult "listAddresses      " t4
+
+        t5 <- measureApiLogs capture
+            (request @[ApiTransaction n] ctx (Link.listTransactions @'Shelley wal1) Default Empty)
+        fmtResult "listTransactions   " t5
+
+        (_, addrs) <- unsafeRequest @[ApiAddress n] ctx (Link.listAddresses @'Shelley wal2) Empty
+        let amt = 1 :: Natural
+        let destination = (addrs !! 1) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }]
+            }|]
+        t6 <- measureApiLogs capture $ request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wal1) Default payload
+        fmtResult "postTransactionFee " t6
+
+        t7 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
+            Link.getNetworkInfo Default Empty
+        fmtResult "getNetworkInfo     " t7
+
+        pure ()
+
+    runWarmUpScenario = benchWithServer $ \ctx -> do
+        -- this one is to have comparable results from first to last measurement
+        -- in runScenario
+        t <- measureApiLogs capture $ request @ApiNetworkInformation ctx
+            Link.getNetworkInfo Default Empty
+        fmtResult "getNetworkInfo     " t
+        pure ()
+
+benchWithShelleyServer
+    :: Tracers IO
+    -> (Context Shelley -> IO ())
+    -> IO ()
+benchWithShelleyServer tracers action = do
+    ctx <- newEmptyMVar
+    let setupContext np wAddr = do
+            let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
+            let sixtySeconds = 60*1000*1000 -- 60s in microseconds
+            manager <- (baseUrl,) <$> newManager (defaultManagerSettings
+                { managerResponseTimeout =
+                    responseTimeoutMicro sixtySeconds
+                })
+            faucet <- initFaucet
+            putMVar ctx $ Context
+                { _cleanup = pure ()
+                , _manager = manager
+                , _walletPort = Port . fromIntegral $ unsafePortNumber wAddr
+                , _faucet = faucet
+                , _feeEstimator = \_ -> error "feeEstimator not available"
+                , _networkParameters = np
+                , _target = Proxy
+                }
+    race_ (takeMVar ctx >>= action) (withServer setupContext)
+
+  where
+    withServer act = withSystemTempDir nullTracer "latency" $ \dir -> do
+        params <- singleNodeParams Error
+        let db = dir </> "wallets"
+        createDirectory db
+        withBFTNode nullTracer dir params $ \socketPath block0 (gp, vData) ->
+            void $ serveWallet
+                (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                tracers
+                (SyncTolerance 10)
+                (Just db)
+                "127.0.0.1"
+                ListenOnRandomPort
+                Nothing
+                socketPath
+                block0
+                (gp, vData)
+                (act gp)

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -32,6 +32,7 @@ import Cardano.Wallet.Api.Types
     ( ApiAddress
     , ApiFee
     , ApiNetworkInformation
+    , ApiStakePool
     , ApiTransaction
     , ApiUtxoStatistics
     , ApiWallet
@@ -46,7 +47,7 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncTolerance (..) )
+    ( Coin (..), SyncTolerance (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..)
     , Tracers
@@ -292,11 +293,20 @@ walletApiBench capture benchWithServer = do
             (Link.getTransactionFee @'Shelley wal1) Default payload
         fmtResult "postTransactionFee " t6
 
-        t7 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
+        t7 <- measureApiLogs capture $ request @[ApiStakePool] ctx
+            (Link.listStakePools arbitraryStake) Default Empty
+
+        fmtResult "listStakePools     " t7
+
+        t8 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
-        fmtResult "getNetworkInfo     " t7
+        fmtResult "getNetworkInfo     " t8
 
         pure ()
+     where
+       arbitraryStake :: Maybe Coin
+       arbitraryStake = Just $ ada 10000
+         where ada = Coin . (1000*1000*)
 
     runWarmUpScenario = benchWithServer $ \ctx -> do
         -- this one is to have comparable results from first to last measurement

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -46,8 +46,10 @@ import Cardano.Wallet.Network.Ports
     ( unsafePortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), SyncTolerance (..) )
+    ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..)
     , Tracers

--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -205,3 +205,42 @@ test-suite integration
       Main.hs
   other-modules:
       Cardano.Wallet.Shelley.Faucet
+
+benchmark latency
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+     base
+   , aeson
+   , async
+   , cardano-wallet-cli
+   , cardano-wallet-core
+   , cardano-wallet-core-integration
+   , cardano-wallet-shelley
+   , cardano-wallet-launcher
+   , directory
+   , filepath
+   , generic-lens
+   , http-client
+   , http-types
+   , hspec
+   , iohk-monitoring
+   , stm
+   , text
+  type:
+     exitcode-stdio-1.0
+  hs-source-dirs:
+      bench
+      test/integration
+  main-is:
+      Latency.hs
+  other-modules:
+      Cardano.Wallet.Shelley.Faucet

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -384,7 +384,7 @@ withCluster tr severity n dir action = bracketTracer' tr "withCluster" $ do
                 (ExitFailure 1)
         else do
             let cfg = NodeParams severity systemStart (port0, ports)
-            withPassiveNode tr dir cfg $ \socket -> do
+            withRelayNode tr dir cfg $ \socket -> do
                 action socket block0 params `finally` cancelAll
   where
     -- | Get permutations of the size (n-1) for a list of n elements, alongside with
@@ -455,7 +455,7 @@ withBFTNode tr baseDir (NodeParams severity systemStart (port, peers)) action =
 -- | Launches a @cardano-node@ with the given configuration which will not forge
 -- blocks, but has every other cluster node as its peer. Any transactions
 -- submitted to this node will be broadcast to every node in the cluster.
-withPassiveNode
+withRelayNode
     :: Tracer IO ClusterLog
     -- ^ Trace for subprocess control logging
     -> FilePath
@@ -466,8 +466,8 @@ withPassiveNode
     -> (FilePath -> IO a)
     -- ^ Callback function with socket path
     -> IO a
-withPassiveNode tr baseDir (NodeParams severity systemStart (port, peers)) act =
-    bracketTracer' tr "withPassiveNode" $ do
+withRelayNode tr baseDir (NodeParams severity systemStart (port, peers)) act =
+    bracketTracer' tr "withRelayNode" $ do
         createDirectory dir
 
         (config, _, _, _) <- genConfig dir severity systemStart

--- a/nix/.stack.nix/cardano-wallet-byron.nix
+++ b/nix/.stack.nix/cardano-wallet-byron.nix
@@ -199,9 +199,6 @@
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
-          build-tools = [
-            (hsPkgs.buildPackages.cardano-wallet-byron or (pkgs.buildPackages.cardano-wallet-byron or (errorHandler.buildToolDepError "cardano-wallet-byron")))
-            ];
           buildable = true;
           };
         };

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -246,9 +246,6 @@
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
-          build-tools = [
-            (hsPkgs.buildPackages.cardano-wallet-jormungandr or (pkgs.buildPackages.cardano-wallet-jormungandr or (errorHandler.buildToolDepError "cardano-wallet-jormungandr")))
-            ];
           buildable = true;
           };
         };

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -156,5 +156,29 @@
           buildable = true;
           };
         };
+      benchmarks = {
+        "latency" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+            (hsPkgs."async" or (errorHandler.buildDepError "async"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-shelley" or (errorHandler.buildDepError "cardano-wallet-shelley"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
+            (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+            (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
+            (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        };
       };
     } // rec { src = (pkgs.lib).mkDefault ../.././lib/shelley; }

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -132,26 +132,9 @@ let
         };
 
         # Add jormungandr to the PATH of the latency benchmark
-        packages.cardano-wallet-jormungandr.components.benchmarks.latency =
-          lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-            build-tools = [ pkgs.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/latency \
-                --run "cd $src" \
-                --prefix PATH : ${jmPkgs.jormungandr}/bin
-            '';
-          };
-
+        packages.cardano-wallet-jormungandr.components.benchmarks.latency = wrapBench jmPkgs.jormungandr;
         # Add cardano-node to the PATH of the byron latency benchmark
-        packages.cardano-wallet-byron.components.benchmarks.latency =
-          lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
-            build-tools = [ pkgs.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/latency \
-                --run "cd $src" \
-                --prefix PATH : ${pkgs.cardano-node}/bin
-            '';
-          };
+        packages.cardano-wallet-byron.components.benchmarks.latency = wrapBench pkgs.cardano-node;
 
         # Add cardano-node to the PATH of the byroon restore benchmark.
         # cardano-node will want to write logs to a subdirectory of the working directory.
@@ -322,6 +305,19 @@ let
     "$out/bin/$exeName" --zsh-completion-script "$out/bin/$exeName" >"$zshCompDir/_$exeName"
     "$out/bin/$exeName" --fish-completion-script "$out/bin/$exeName" >"$fishCompDir/$exeName.fish"
   '';
+
+  # Add component options to wrap a benchmark exe, so that it has the
+  # backend executable on its path, and the source tree as its working
+  # directory.
+  wrapBench = backend:
+    lib.optionalAttrs (!stdenv.hostPlatform.isWindows) {
+      build-tools = [ pkgs.makeWrapper ];
+      postInstall = ''
+        wrapProgram $out/bin/* \
+          --run "cd $src" \
+          --prefix PATH : ${backend}/bin
+      '';
+    };
 
 in
   pkgSet.config.hsPkgs // { _config = pkgSet.config; }


### PR DESCRIPTION
Relates to #1825.

### Overview

- Ports latency benchmarks to shelley backend.
- Refactors duplicate code into a shared module.
- Adds listStakePools to benchmarks