### PR TITLE
Make quitting on a non-empty reward account forbidden

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -55,6 +55,7 @@ module Test.Integration.Framework.TestData
     , errMsg404NoSuchPool
     , errMsg403PoolAlreadyJoined
     , errMsg403NotDelegating
+    , errMsg403NonNullReward
     , errMsg403NothingToMigrate
     , errMsg404NoEndpoint
     , errMsg404CannotFindTx
@@ -368,6 +369,10 @@ errMsg403NotDelegating :: String
 errMsg403NotDelegating = "It seems that you're trying to retire from \
     \delegation although you're not even delegating, nor won't be in an \
     \immediate future."
+
+errMsg403NonNullReward :: String
+errMsg403NonNullReward = "It seems that you're trying to retire from delegation \
+    \although you've unspoiled rewards in your rewards account!"
 
 errMsg404CannotFindTx :: Text -> String
 errMsg404CannotFindTx tid = "I couldn't find a transaction with the given id: "

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2123,6 +2123,13 @@ instance LiftHandler ErrQuitStakePool where
                     , "although you're not even delegating, nor won't be in an "
                     , "immediate future."
                     ]
+            ErrNonNullRewards (Quantity rewards) ->
+                apiError err403 NonNullRewards $ mconcat
+                    [ "It seems that you're trying to retire from delegation "
+                    , "although you've unspoiled rewards in your rewards "
+                    , "account! Make sure to withdraw your ", pretty rewards
+                    , " lovelace first."
+                    ]
 
 instance LiftHandler ErrCreateRandomAddress where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -639,6 +639,7 @@ data ApiErrorCode
     | AddressAlreadyExists
     | InvalidWalletType
     | QueryParamMissing
+    | NonNullRewards
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

The Cardano ledger forbids to de-register a stake key, if there are
still rewards associated with it. We could have implemented some more
convoluted logic where the wallet would automatically collect rewards as
part of a de-registration, but we are a bit lacking time here so we'll
simply make this a manual operation that users have to undergo. Yet, the
backend will still return a meaningful error message explaining the
situation.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
