### PR TITLE
Better nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -141,8 +141,9 @@ let
         ]) ++ (with pkgs; [
           niv
           pkgconfig
-          sqlite-interactive
           python3Packages.openapi-spec-validator
+          ruby
+          sqlite-interactive
           yq
         ]);
       tools = {

--- a/default.nix
+++ b/default.nix
@@ -156,6 +156,17 @@ let
       };
       CARDANO_NODE_CONFIGS = cardano-node.deployments;
       meta.platforms = lib.platforms.unix;
+      shellHook = ''
+        setup_completion() {
+          local p
+          for p in $buildInputs; do
+            if [ -d "$p/share/bash-completion" ]; then
+              addToSearchPath XDG_DATA_DIRS "$p/share"
+            fi
+          done
+        }
+        setup_completion
+      '';
     };
     stackShell = import ./nix/stack-shell.nix {
       walletPackages = self;

--- a/default.nix
+++ b/default.nix
@@ -77,12 +77,17 @@ let
 
   self = {
     inherit pkgs commonLib src haskellPackages stackNixRegenerate;
+    # Jormungandr
     inherit (jmPkgs) jormungandr jormungandr-cli;
     # expose cardano-node, so daedalus can ship it without needing to pin cardano-node
     inherit (pkgs) cardano-node cardano-cli;
     inherit (haskellPackages.cardano-wallet-core.identifier) version;
     # expose db-converter, so daedalus can ship it without needing to pin a ouroborus-network rev
     inherit (haskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
+    # adrestia tool belt
+    inherit (haskellPackages.bech32.components.exes) bech32;
+    inherit (haskellPackages.cardano-addresses.components.exes) cardano-address;
+    inherit (haskellPackages.cardano-transactions.components.exes) cardano-tx;
 
     cardano-wallet-jormungandr = import ./nix/package-jormungandr.nix {
       inherit (haskellPackages.cardano-wallet-jormungandr.components.exes)
@@ -128,7 +133,9 @@ let
           jormungandr-cli
           cardano-node
           cardano-cli
-          haskellPackages.cardano-addresses.components.exes.cardano-address
+          cardano-address
+          cardano-tx
+          bech32
         ]) ++ (with pkgs; [
           niv
           pkgconfig

--- a/default.nix
+++ b/default.nix
@@ -157,6 +157,9 @@ let
     stackShell = import ./nix/stack-shell.nix {
       walletPackages = self;
     };
+    # This attribute ensures that every single derivation required for
+    # evaluation of the haskell package set is built and cached on CI.
+    inherit (pkgs.haskell-nix) haskellNixRoots;
   };
 
 in

--- a/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Wallet.LatencyBenchShared
   ( -- * Measuring traces

--- a/nix/.stack.nix/bech32-th.nix
+++ b/nix/.stack.nix/bech32-th.nix
@@ -1,0 +1,59 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { werror = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "bech32-th"; version = "1.0.2"; };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/bech32";
+      url = "";
+      synopsis = "Template Haskell extensions to the Bech32 library.";
+      description = "Template Haskell extensions to the Bech32 library, including\nquasi-quoters for compile-time checking of Bech32 string\nliterals.";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+          (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      tests = {
+        "bech32-th-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "dd3fc9488595af23ce80740e2df133bee4c1c1a5";
+      sha256 = "0dd6x7pcszn2hcfx16gjfv5v6qsx9afadws2frav0f2fasnhbrfa";
+      });
+    postUnpack = "sourceRoot+=/bech32-th; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/bech32.nix
+++ b/nix/.stack.nix/bech32.nix
@@ -1,0 +1,84 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { werror = false; release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "bech32"; version = "1.0.2"; };
+      license = "Apache-2.0";
+      copyright = "2017 Marko Bencun, 2019-2020 IOHK";
+      maintainer = "operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/bech32";
+      url = "";
+      synopsis = "Implementation of the Bech32 cryptocurrency address format (BIP 0173).";
+      description = "Implementation of the Bech32 cryptocurrency address format documented in the\nBIP (Bitcoin Improvement Proposal) 0173.";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."array" or (errorHandler.buildDepError "array"))
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "bech32" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        };
+      tests = {
+        "bech32-test" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+            (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
+            (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
+            (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/bech32";
+      rev = "dd3fc9488595af23ce80740e2df133bee4c1c1a5";
+      sha256 = "0dd6x7pcszn2hcfx16gjfv5v6qsx9afadws2frav0f2fasnhbrfa";
+      });
+    postUnpack = "sourceRoot+=/bech32; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/cardano-transactions.nix
+++ b/nix/.stack.nix/cardano-transactions.nix
@@ -1,0 +1,88 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  ({
+    flags = { release = false; };
+    package = {
+      specVersion = "1.12";
+      identifier = { name = "cardano-transactions"; version = "1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "https://github.com/input-output-hk/cardano-transactions#readme";
+      url = "";
+      synopsis = "Library utilities for constructing and signing Cardano transactions.";
+      description = "Please see the README on GitHub at <https://github.com/input-output-hk/cardano-transactions>";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
+          (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-binary" or (errorHandler.buildDepError "cardano-binary"))
+          (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-crypto-wrapper" or (errorHandler.buildDepError "cardano-crypto-wrapper"))
+          (hsPkgs."cardano-ledger" or (errorHandler.buildDepError "cardano-ledger"))
+          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
+          (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
+          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          ];
+        buildable = true;
+        };
+      exes = {
+        "cardano-tx" = {
+          depends = [
+            (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-transactions" or (errorHandler.buildDepError "cardano-transactions"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+            (hsPkgs."cardano-crypto-wrapper" or (errorHandler.buildDepError "cardano-crypto-wrapper"))
+            (hsPkgs."cardano-ledger" or (errorHandler.buildDepError "cardano-ledger"))
+            (hsPkgs."cardano-ledger-test" or (errorHandler.buildDepError "cardano-ledger-test"))
+            (hsPkgs."cardano-transactions" or (errorHandler.buildDepError "cardano-transactions"))
+            (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+            (hsPkgs."hedgehog-quickcheck" or (errorHandler.buildDepError "hedgehog-quickcheck"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.cardano-tx or (pkgs.buildPackages.cardano-tx or (errorHandler.buildToolDepError "cardano-tx")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/cardano-transactions";
+      rev = "a68107c1682c3fd119c7e83f5adcbba2c37e1744";
+      sha256 = "17xlwawlm5in1ivqq5dm6pw31mcafh8kfllxy7rfr1gdbck5qdry";
+      });
+    }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -2,8 +2,6 @@
   extras = hackage:
     {
       packages = {
-        "bech32" = (((hackage.bech32)."1.0.2").revisions).default;
-        "bech32-th" = (((hackage.bech32-th)."1.0.2").revisions).default;
         "OddWord" = (((hackage.OddWord)."1.0.2.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
         "wai-extra" = (((hackage.wai-extra)."3.0.29.1").revisions).default;
@@ -73,6 +71,9 @@
         persistent-sqlite = ./persistent-sqlite.nix;
         persistent-template = ./persistent-template.nix;
         cardano-addresses = ./cardano-addresses.nix;
+        bech32 = ./bech32.nix;
+        bech32-th = ./bech32-th.nix;
+        cardano-transactions = ./cardano-transactions.nix;
         cardano-binary = ./cardano-binary.nix;
         cardano-binary-test = ./cardano-binary-test.nix;
         cardano-crypto-class = ./cardano-crypto-class.nix;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,24 +12,24 @@
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohkNix = import sources.iohk-nix {};
+  iohKNix = import sources.iohk-nix {};
   haskellNix = (import sources."haskell.nix" { inherit system sourcesOverride; }).nixpkgsArgs;
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
   nixpkgs = if (sources ? nixpkgs)
     then (builtins.trace "Not using IOHK default nixpkgs (use 'niv drop nixpkgs' to use default for better sharing)"
       sources.nixpkgs)
-    else iohkNix.nixpkgs;
+    else iohKNix.nixpkgs;
 
   # for inclusion in pkgs:
   overlays =
     # Haskell.nix (https://github.com/input-output-hk/haskell.nix)
     haskellNix.overlays
     # haskell-nix.haskellLib.extra: some useful extra utility functions for haskell.nix
-    ++ iohkNix.overlays.haskell-nix-extra
-    ++ iohkNix.overlays.crypto
+    ++ iohKNix.overlays.haskell-nix-extra
+    ++ iohKNix.overlays.crypto
     # iohkNix: nix utilities and niv:
-    ++ iohkNix.overlays.iohkNix
+    ++ iohKNix.overlays.iohkNix
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -200,8 +200,17 @@ let
 
         # split data output for ekg to reduce closure size
         packages.ekg.components.library.enableSeparateDataOutput = true;
-        enableLibraryProfiling = profiling;
       }
+
+      # Enable profiling on executables if the profiling argument is set.
+      (lib.optionalAttrs profiling {
+        enableLibraryProfiling = true;
+        packages.cardano-wallet-shelley.components.exes.cardano-wallet-shelley.enableExecutableProfiling = true;
+        packages.cardano-wallet-byron.components.exes.cardano-wallet-byron.enableExecutableProfiling = true;
+        packages.cardano-wallet-byron.components.benchmarks.restore.enableExecutableProfiling = true;
+        packages.cardano-wallet-byron.components.benchmarks.latency.enableExecutableProfiling = true;
+        packages.cardano-wallet-jormungandr.components.exes.cardano-wallet-jormungandr.enableExecutableProfiling = true;
+      })
 
       # Musl libc fully static build
       (lib.optionalAttrs stdenv.hostPlatform.isMusl (let

--- a/nix/linux-release.nix
+++ b/nix/linux-release.nix
@@ -15,18 +15,35 @@ with pkgs.lib;
 assert (assertMsg (builtins.length exes > 0) "empty list of exes");
 
 let
-  name = (head exes).meta.name;
-  tarname = "${name}-linux64.tar.gz";
+  exe = head exes;
+  name = exe.meta.name;
 
-in pkgs.runCommand name {
+in pkgs.stdenv.mkDerivation {
+  inherit name;
   buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
-} ''
-  mkdir ${name}
-  cp -R ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
-  chmod -R 755 ${name}
-  strip ${name}/*
+  checkInputs = [ pkgs.buildPackages.ruby ];
+  doCheck = true;
+  phases = [ "buildPhase" "checkPhase" ];
+  tarname = "${name}-linux64.tar.gz";
+  buildPhase = ''
+    mkdir $name
+    cp -nR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} $name
+    chmod -R 755 $name
+    strip $name/*
 
-  mkdir -p $out/nix-support
-  tar -czf $out/${tarname} ${name}
-  echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
-''
+    mkdir -p $out/nix-support
+    tar -czf $out/$tarname $name
+    echo "file binary-dist $out/$tarname" > $out/nix-support/hydra-build-products
+  '';
+
+  # test that executables work
+  checkPhase = ''
+    cd `mktemp -d`
+    echo " - extracting $tarname"
+    tar -xzvf $out/$tarname
+    export PATH=`pwd`/$name:$PATH
+
+    echo " - running checks"
+    ruby ${../scripts/check-bundle.rb} ${getName exe.name}
+  '';
+}

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -22,7 +22,7 @@ in pkgs.runCommand name {
   buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
 } ''
   mkdir ${name}
-  cp -R ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
+  cp -fR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
   chmod -R 755 ${name}
 
   mkdir -p $out/nix-support

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -24,7 +24,7 @@ in pkgs.stdenv.mkDerivation {
   checkInputs = [ pkgs.buildPackages.ruby ];
   doCheck = true;
   phases = [ "buildPhase" "checkPhase" ];
-  tarname = "${name}-linux64.tar.gz";
+  tarname = "${name}-macos64.tar.gz";
   buildPhase = ''
     mkdir $name
     cp -nR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} $name

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -15,17 +15,34 @@ with pkgs.lib;
 assert (assertMsg (builtins.length exes > 0) "empty list of exes");
 
 let
-  name = (head exes).meta.name;
-  tarname = "${name}-macos64.tar.gz";
+  exe = head exes;
+  name = exe.meta.name;
 
-in pkgs.runCommand name {
+in pkgs.stdenv.mkDerivation {
+  inherit name;
   buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
-} ''
-  mkdir ${name}
-  cp -fR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} ${name}
-  chmod -R 755 ${name}
+  checkInputs = [ pkgs.buildPackages.ruby ];
+  doCheck = true;
+  phases = [ "buildPhase" "checkPhase" ];
+  tarname = "${name}-linux64.tar.gz";
+  buildPhase = ''
+    mkdir $name
+    cp -nR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} $name
+    chmod -R 755 $name
 
-  mkdir -p $out/nix-support
-  tar -czf $out/${tarname} ${name}
-  echo "file binary-dist $out/${tarname}" > $out/nix-support/hydra-build-products
-''
+    mkdir -p $out/nix-support
+    tar -czf $out/$tarname $name
+    echo "file binary-dist $out/$tarname" > $out/nix-support/hydra-build-products
+  '';
+
+  # test that executables work
+  checkPhase = ''
+    cd `mktemp -d`
+    echo " - extracting $tarname"
+    tar -xzvf $out/$tarname
+    export PATH=`pwd`/$name:$PATH
+
+    echo " - running checks"
+    ruby ${../scripts/check-bundle.rb} ${getName exe.name}
+  '';
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "285b4ae6ef222c299c100ae0d89e5060f6b0c879",
-        "sha256": "0dppnh7iigyxm5904g6a8m919zixsad3hbr8y6bphqia28glm0fa",
+        "rev": "94d758d1f1306ff1a89e3acedf0553f6173c2505",
+        "sha256": "0garvddpxfw1d435s5h51bnqpq9yv60kp95hx1ksidlaj49w21y0",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/285b4ae6ef222c299c100ae0d89e5060f6b0c879.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/94d758d1f1306ff1a89e3acedf0553f6173c2505.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -11,11 +11,6 @@ with lib; with haskell-nix.haskellLib;
     recRecurseIntoAttrs
     collectChecks;
 
-  isCardanoWallet = package:
-    (package.isHaskell or false) &&
-      ((hasPrefix "cardano-wallet" package.identifier.name) ||
-       (elem package.identifier.name [ "text-class" ]));
-
   # lib.cleanSourceWith filter function which removes socket files
   # from a source tree. This files can be created by cardano-node and
   # cause errors when nix attempts to copy them into the store.

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -7,17 +7,19 @@
 ############################################################################
 
 { pkgs
-, exe
+, exes ? []
 }:
 
 let
+  # Take the filename from the first exe passed in
+  exe = pkgs.lib.head exes;
   name = "${exe.meta.name}-win64";
 
 in pkgs.runCommand name { buildInputs = [ pkgs.buildPackages.zip ]; } ''
   mkdir -p $out/nix-support release
   cd release
 
-  cp ${exe}/bin/* .
+  cp -fR ${pkgs.lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} .
   chmod -R +w .
 
   zip -r $out/${name}.zip .

--- a/nix/windows-release.nix
+++ b/nix/windows-release.nix
@@ -10,38 +10,68 @@
 , exes ? []
 }:
 
+with pkgs.lib;
+
+assert (assertMsg (builtins.length exes > 0) "empty list of exes");
+
 let
   # Take the filename from the first exe passed in
-  exe = pkgs.lib.head exes;
+  exe = head exes;
   name = "${exe.meta.name}-win64";
 
-in pkgs.runCommand name { buildInputs = [ pkgs.buildPackages.zip ]; } ''
-  mkdir -p $out/nix-support release
-  cd release
+in pkgs.stdenv.mkDerivation {
+  inherit name;
+  buildInputs = [ pkgs.buildPackages.zip ];
+  checkInputs = with pkgs.buildPackages; [ unzip ruby wineMinimal ];
+  doCheck = true;
+  phases = [ "buildPhase" "checkPhase" ];
+  zipname = "${name}.zip";
+  buildPhase = ''
+    mkdir -p $out/nix-support release
+    cd release
 
-  cp -fR ${pkgs.lib.concatMapStringsSep " " (exe: "${exe}/bin/*") exes} .
-  chmod -R +w .
-
-  zip -r $out/${name}.zip .
-  echo "file binary-dist $out/${name}.zip" > $out/nix-support/hydra-build-products
-
-  # make a separate configuration package if needed
-  if [ -d ${exe}/configuration ]; then
-    cp -R ${exe}/configuration ..
-    cd ../configuration
+    cp -nR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} .
     chmod -R +w .
 
-    zip -r $out/${exe.name}-configuration.zip .
-    echo "file binary-dist $out/${exe.name}-configuration.zip" >> $out/nix-support/hydra-build-products
-  fi
+    zip -r $out/$zipname .
+    echo "file binary-dist $out/$zipname" > $out/nix-support/hydra-build-products
 
-  # make a separate deployments configuration package if needed
-  if [ -d ${exe}/deployments ]; then
-    cp -R ${exe}/deployments ..
-    cd ../deployments
-    chmod -R +w .
+    # make a separate configuration package if needed
+    if [ -d ${exe}/configuration ]; then
+      cp -R ${exe}/configuration ..
+      cd ../configuration
+      chmod -R +w .
 
-    zip -r $out/${exe.name}-deployments.zip .
-    echo "file binary-dist $out/${exe.name}-deployments.zip" >> $out/nix-support/hydra-build-products
-  fi
-''
+      zip -r $out/${exe.name}-configuration.zip .
+      echo "file binary-dist $out/${exe.name}-configuration.zip" >> $out/nix-support/hydra-build-products
+    fi
+
+    # make a separate deployments configuration package if needed
+    if [ -d ${exe}/deployments ]; then
+      cp -R ${exe}/deployments ..
+      cd ../deployments
+      chmod -R +w .
+
+      zip -r $out/${exe.name}-deployments.zip .
+      echo "file binary-dist $out/${exe.name}-deployments.zip" >> $out/nix-support/hydra-build-products
+    fi
+  '';
+
+  # test that executables work under wine
+  checkPhase = ''
+    cd `mktemp -d`
+    echo " - extracting $zipname"
+    unzip $out/$zipname
+    export PATH=`pwd`/$name:$PATH
+
+    # setup wine
+    export WINEPREFIX=$TMP
+    export HOME=$TMP
+    export WINEDLLOVERRIDES="winemac.drv=d"
+    export WINEDEBUG=warn-all,fixme-all,-menubuilder,-mscoree,-ole,-secur32,-winediag
+    export LC_ALL=en_US.UTF-8
+
+    echo " - running checks"
+    ruby ${../scripts/check-bundle.rb} ${getName exe.name} wine64
+  '';
+}

--- a/release.nix
+++ b/release.nix
@@ -256,18 +256,18 @@ let
     };
   } // optionalAttrs buildMacOS {
     # macOS binary and dependencies in tarball
-    cardano-wallet-jormungandr-macos64 = import ./nix/macos-release.nix {
-      inherit pkgs;
+    cardano-wallet-jormungandr-macos64 = hydraJob' (import ./nix/macos-release.nix {
+      inherit (pkgsFor "x86_64-darwin") pkgs;
       exes = selectExes jobs.native "x86_64-darwin" releaseContents.jormungandr;
-    };
-    cardano-wallet-byron-macos64 = import ./nix/macos-release.nix {
-      inherit pkgs;
+    });
+    cardano-wallet-byron-macos64 = hydraJob' (import ./nix/macos-release.nix {
+      inherit (pkgsFor "x86_64-darwin") pkgs;
       exes = selectExes jobs.native "x86_64-darwin" releaseContents.byron;
-    };
-    cardano-wallet-shelley-macos64 = import ./nix/macos-release.nix {
-      inherit pkgs;
+    });
+    cardano-wallet-shelley-macos64 = hydraJob' (import ./nix/macos-release.nix {
+      inherit (pkgsFor "x86_64-darwin") pkgs;
       exes = selectExes jobs.native "x86_64-darwin" releaseContents.shelley;
-    };
+    });
   };
 
   ############################################################################

--- a/scripts/check-bundle.rb
+++ b/scripts/check-bundle.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+
+############################################################################
+# Checks that every executable required in the release package is
+# present and works.
+############################################################################
+
+require 'open3'
+
+tests = {
+  "cardano-wallet-jormungandr" => [ "jormungandr", "jcli" ],
+  "cardano-wallet-byron" => [ "cardano-node", "cardano-cli", "bech32", "cardano-tx", "cardano-address" ],
+  "cardano-wallet-shelley" => [ "cardano-node", "cardano-cli", "bech32", "cardano-tx", "cardano-address" ]
+}
+
+if ARGV.length < 1 || ARGV.length > 2 || tests[ARGV[0]] == nil
+  STDERR.puts "Usage: check-bundle cardano-wallet-(jormungandr|byron|shelley) [RUNNER]"
+  exit 1
+end
+
+wallet = ARGV[0]
+
+# Runner is used to run windows exes under wine.
+runner = ARGV.fetch(1, "")
+
+$failed = 0
+
+def report(cmd, status)
+  res = status == 0 ? "pass" : "FAIL"
+  puts "#{cmd.ljust(40)}[#{res}]"
+  if status then
+    $failed = status
+  end
+end
+
+cmd = "#{wallet} version"
+ver, status = Open3.capture2("#{runner} #{cmd}")
+report(cmd, status)
+
+tests[wallet].each do |cmd|
+  begin
+    stdout_str, status = Open3.capture2("#{runner} #{cmd} --help")
+    report(cmd, 0)
+  rescue Errno::ENOENT
+    report(cmd, 1)
+  end
+end
+
+exit($failed)

--- a/scripts/check-bundle.rb
+++ b/scripts/check-bundle.rb
@@ -28,19 +28,19 @@ $failed = 0
 def report(cmd, status)
   res = status == 0 ? "pass" : "FAIL"
   puts "#{cmd.ljust(40)}[#{res}]"
-  if status then
-    $failed = status
+  if status != 0 then
+    $failed = 1
   end
 end
 
 cmd = "#{wallet} version"
 ver, status = Open3.capture2("#{runner} #{cmd}")
-report(cmd, status)
+report(cmd, status.to_i)
 
 tests[wallet].each do |cmd|
   begin
     stdout_str, status = Open3.capture2("#{runner} #{cmd} --help")
-    report(cmd, 0)
+    report(cmd, status.to_i)
   rescue Errno::ENOENT
     report(cmd, 1)
   end

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,13 +13,9 @@ packages:
 
 extra-deps:
 # Miscellaneous
-- bech32-1.0.2
-- bech32-th-1.0.2
 - OddWord-1.0.2.0
 - command-0.1.1
 - wai-extra-3.0.29.1
-
-
 
 # Needed because network > 3.1 is needed for cardano-wallet-byron
 - servant-0.17
@@ -43,6 +39,18 @@ extra-deps:
 
 - git: https://github.com/input-output-hk/cardano-addresses
   commit: 197015670a0c6df4eaae63d66ae7b3e48007abc0
+
+# Unreleased version - provides bech32 cli util
+- git: https://github.com/input-output-hk/bech32
+  commit: dd3fc9488595af23ce80740e2df133bee4c1c1a5
+  subdirs:
+    - bech32
+    - bech32-th
+
+# Not strictly a dependency at present, but building it here to get
+# access to the cardano-tx cli.
+- git: https://github.com/input-output-hk/cardano-transactions
+  commit: a68107c1682c3fd119c7e83f5adcbba2c37e1744
 
 flags:
   # Avoid a system library which causes difficulty with cross-compilation


### PR DESCRIPTION
### User story

ADP-369

### Overview

- Uses new Haskell.nix features to put haskell tools in the nix-shell.
- Adds bech32, cardano-address, cardano-tx to the nix-shell.
- Adds these tools to the release archives ("Adrestia tool belt").
- Adds automated tests to the release archives.
- Add nix option for building libraries and exes with profiling enabled.
- Add bash completion for select tools in nix-shell.

### Comments

- Merge #1877 first.
