### PR TITLE
install a query flag for driving withdrawals creation on Shelley tx

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
@@ -152,9 +152,9 @@ server byron icarus ntp =
 
     transactions :: Server (Transactions n)
     transactions =
-             (\_ _ -> throwError err501)
+             (\_ _ _ -> throwError err501)
         :<|> (\_ _ _ _ -> throwError err501)
-        :<|> (\_ _ -> throwError err501)
+        :<|> (\_ _ _ -> throwError err501)
         :<|> (\_ _ -> throwError err501)
         :<|> (\_ _ -> throwError err501)
 
@@ -237,11 +237,11 @@ server byron icarus ntp =
                  (byron , do
                     let pwd = coerce (getApiT $ tx ^. #passphrase)
                     genChange <- rndStateChange byron wid pwd
-                    postTransaction byron genChange wid tx
+                    postTransaction byron genChange wid False tx
                  )
                  (icarus, do
                     let genChange k _ = paymentAddress @n k
-                    postTransaction icarus genChange wid tx
+                    postTransaction icarus genChange wid False tx
                  )
              )
         :<|>
@@ -251,8 +251,8 @@ server byron icarus ntp =
              )
         :<|>
             (\wid tx -> withLegacyLayer wid
-                (byron , postTransactionFee byron wid tx)
-                (icarus, postTransactionFee icarus wid tx)
+                (byron , postTransactionFee byron wid False tx)
+                (icarus, postTransactionFee icarus wid False tx)
             )
         :<|> (\wid txid -> withLegacyLayer wid
                 (byron , deleteTransaction byron wid txid)

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -251,7 +251,7 @@ spec = do
 
         ["transaction", "create", "--help"] `shouldShowUsage`
             [ "Usage:  transaction create [--port INT] WALLET_ID"
-            , "                           --payment PAYMENT"
+            , "                           --payment PAYMENT [--withdraw-rewards]"
             , "  Create and submit a new transaction."
             , ""
             , "Available options:"
@@ -261,10 +261,14 @@ spec = do
             , "  --payment PAYMENT        address to send to and amount to send"
             , "                           separated by @, e.g."
             , "                           '<amount>@<address>'"
+            ,"  --withdraw-rewards       Withdraw rewards as change in this"
+            ,"                           transaction, provided they contribute"
+            ,"                           positively to the balance."
             ]
 
         ["transaction", "fees", "--help"] `shouldShowUsage`
             [ "Usage:  transaction fees [--port INT] WALLET_ID --payment PAYMENT"
+            , "                         [--withdraw-rewards]"
             , "  Estimate fees for a transaction."
             , ""
             , "Available options:"
@@ -274,6 +278,9 @@ spec = do
             , "  --payment PAYMENT        address to send to and amount to send"
             , "                           separated by @, e.g."
             , "                           '<amount>@<address>'"
+            ,"  --withdraw-rewards       Withdraw rewards as change in this"
+            ,"                           transaction, provided they contribute"
+            ,"                           positively to the balance."
             ]
 
         ["transaction", "list", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -19,6 +19,7 @@ import Cardano.Wallet.Api.Types
     , ApiT (..)
     , ApiTransaction
     , ApiWallet
+    , ApiWithdrawRewards (..)
     , DecodeAddress
     , EncodeAddress
     , WalletStyle (..)
@@ -184,10 +185,12 @@ spec = do
                     ]
                 , "passphrase": #{fixturePassphrase}
                 }|]
-        request @(ApiTransaction n) ctx (Link.createTransaction @'Shelley w) Default (Json payload) >>= flip verify
-            [ expectField #amount (.> (Quantity coin))
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            ]
+        request @(ApiTransaction n) ctx
+            (Link.createTransaction' @'Shelley w (ApiWithdrawRewards True))
+            Default (Json payload) >>= flip verify
+                [ expectField #amount (.> (Quantity coin))
+                , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+                ]
 
         -- Rewards are have been consumed.
         eventually "Wallet has consumed rewards" $ do

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -308,6 +308,7 @@ type Transactions n =
 type CreateTransaction n = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "transactions"
+    :> QueryFlag "withdrawRewards"
     :> ReqBody '[JSON] (PostTransactionDataT n)
     :> PostAccepted '[JSON] (ApiTransactionT n)
 
@@ -331,6 +332,7 @@ type GetTransaction n = "wallets"
 type PostTransactionFee n = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "payment-fees"
+    :> QueryFlag "withdrawRewards"
     :> ReqBody '[JSON] (PostTransactionFeeDataT n)
     :> PostAccepted '[JSON] ApiFee
 

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -74,6 +74,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiWallet (..)
     , ApiWalletPassphrase
+    , ApiWithdrawRewards (..)
     , ByronWalletPutPassphraseData (..)
     , Iso8601Time (..)
     , PostExternalTransactionData (..)
@@ -143,10 +144,12 @@ data TransactionClient = TransactionClient
         -> ClientM [ApiTransactionT Aeson.Value]
     , postTransaction
         :: ApiT WalletId
+        -> ApiWithdrawRewards
         -> PostTransactionDataT Aeson.Value
         -> ClientM (ApiTransactionT Aeson.Value)
     , postTransactionFee
         :: ApiT WalletId
+        -> ApiWithdrawRewards
         -> PostTransactionFeeDataT Aeson.Value
         -> ClientM ApiFee
     , postExternalTransaction
@@ -269,8 +272,8 @@ transactionClient =
     in
         TransactionClient
             { listTransactions = _listTransactions
-            , postTransaction = _postTransaction
-            , postTransactionFee = _postTransactionFee
+            , postTransaction = \wid -> _postTransaction wid . coerce
+            , postTransactionFee = \wid -> _postTransactionFee wid . coerce
             , postExternalTransaction = _postExternalTransaction
             , deleteTransaction = _deleteTransaction
             , getTransaction = _getTransaction
@@ -293,8 +296,8 @@ byronTransactionClient =
 
     in TransactionClient
         { listTransactions = _listTransactions
-        , postTransaction = _postTransaction
-        , postTransactionFee = _postTransactionFee
+        , postTransaction = \wid _ -> _postTransaction wid
+        , postTransactionFee = \wid _ -> _postTransactionFee wid
         , postExternalTransaction = _postExternalTransaction
         , deleteTransaction = _deleteTransaction
         , getTransaction = _getTransaction

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -58,9 +58,11 @@ module Cardano.Wallet.Api.Link
 
       -- * Transactions
     , createTransaction
+    , createTransaction'
     , listTransactions
     , listTransactions'
     , getTransactionFee
+    , getTransactionFee'
     , deleteTransaction
     , getTransaction
 
@@ -90,6 +92,7 @@ import Cardano.Wallet.Api.Types
     ( ApiPoolId (..)
     , ApiT (..)
     , ApiTxId (ApiTxId)
+    , ApiWithdrawRewards (..)
     , Iso8601Time
     , WalletStyle (..)
     )
@@ -313,10 +316,25 @@ createTransaction
     => w
     -> (Method, Text)
 createTransaction w = discriminate @style
-    (endpoint @(Api.CreateTransaction Net) (wid &))
+    (endpoint @(Api.CreateTransaction Net) (($ False) . ($ wid)))
     (endpoint @(Api.CreateByronTransaction Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
+
+createTransaction'
+    :: forall style w.
+        ( HasType (ApiT WalletId) w
+        , Discriminate style
+        )
+    => w
+    -> ApiWithdrawRewards
+    -> (Method, Text)
+createTransaction' w (ApiWithdrawRewards withdraw) = discriminate @style
+    (endpoint @(Api.CreateTransaction Net) (($ withdraw) . ($ wid)))
+    (endpoint @(Api.CreateByronTransaction Net) (wid &))
+  where
+    wid = w ^. typed @(ApiT WalletId)
+
 
 listTransactions
     :: forall (style :: WalletStyle) w.
@@ -353,10 +371,25 @@ getTransactionFee
     => w
     -> (Method, Text)
 getTransactionFee w = discriminate @style
-    (endpoint @(Api.PostTransactionFee Net) (wid &))
+    (endpoint @(Api.PostTransactionFee Net) (($ False) . ($ wid)))
     (endpoint @(Api.PostByronTransactionFee Net) (wid &))
   where
     wid = w ^. typed @(ApiT WalletId)
+
+getTransactionFee'
+    :: forall style w.
+        ( HasType (ApiT WalletId) w
+        , Discriminate style
+        )
+    => w
+    -> ApiWithdrawRewards
+    -> (Method, Text)
+getTransactionFee' w (ApiWithdrawRewards withdraw) = discriminate @style
+    (endpoint @(Api.PostTransactionFee Net) (($ withdraw) . ($ wid)))
+    (endpoint @(Api.PostByronTransactionFee Net) (wid &))
+  where
+    wid = w ^. typed @(ApiT WalletId)
+
 
 deleteTransaction
     :: forall (style :: WalletStyle) w t.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -79,6 +79,7 @@ module Cardano.Wallet.Api.Types
     , ApiPoolId (..)
     , ApiWalletMigrationPostData (..)
     , ApiWalletMigrationInfo (..)
+    , ApiWithdrawRewards (..)
 
     -- * API Types (Byron)
     , ApiByronWallet (..)
@@ -597,6 +598,9 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
 newtype ApiWalletMigrationInfo = ApiWalletMigrationInfo
     { migrationCost :: Quantity "lovelace" Natural
     } deriving (Eq, Generic, Show)
+
+newtype ApiWithdrawRewards = ApiWithdrawRewards Bool
+    deriving (Eq, Generic, Show)
 
 -- | Error codes returned by the API, in the form of snake_cased strings
 data ApiErrorCode

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -262,11 +262,11 @@ server byron icarus shelley spl ntp =
                  (byron , do
                     let pwd = coerce (getApiT $ tx ^. #passphrase)
                     genChange <- rndStateChange byron wid pwd
-                    postTransaction byron genChange wid tx
+                    postTransaction byron genChange wid False tx
                  )
                  (icarus, do
                     let genChange k _ = paymentAddress @n k
-                    postTransaction icarus genChange wid tx
+                    postTransaction icarus genChange wid False tx
                  )
              )
         :<|>
@@ -276,8 +276,8 @@ server byron icarus shelley spl ntp =
              )
         :<|>
             (\wid tx -> withLegacyLayer wid
-                (byron , postTransactionFee byron wid tx)
-                (icarus, postTransactionFee icarus wid tx)
+                (byron , postTransactionFee byron wid False tx)
+                (icarus, postTransactionFee icarus wid False tx)
             )
         :<|> (\wid txid -> withLegacyLayer wid
                 (byron , deleteTransaction byron wid txid)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1365,6 +1365,16 @@ x-parametersForceNtpCheck: &parametersForceNtpCheck
   schema:
     type: boolean
 
+x-parametersWithdrawal: &parametersWithdrawal
+  in: query
+  name: withdrawRewards
+  allowEmptyValue: true
+  description: |
+    Withdraw rewards as change in this transaction, provided they contribute positively towards the balance (i.e. adding them results in at least as much value as their value after fee calculation).
+
+    This is a flag, off by default.
+  schema:
+    type: boolean
 
 #############################################################################
 #                                                                           #
@@ -1927,6 +1937,7 @@ paths:
 
       parameters:
         - *parametersWalletId
+        - *parametersWithdrawal
       requestBody:
         required: true
         content:
@@ -1945,6 +1956,7 @@ paths:
         Create and send transaction from the wallet.
       parameters:
         - *parametersWalletId
+        - *parametersWithdrawal
       requestBody:
         required: true
         content:


### PR DESCRIPTION


# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- b448b07816a7efd42e65393fb92257693a16e9b4
  :round_pushpin: **install a query flag for driving withdrawals creation on Shelley transactions**
  Withdrawals currently occur by default, implicitely which turns out to
be very confusing for end-users (seeing their rewards balance disappear
freak them out, as well as transaction which seems much bigger than what
they requested).

# Comments

<!-- Additional comments or screenshots to attach if any -->

![Screenshot from 2020-07-06 07-53-08](https://user-images.githubusercontent.com/5680256/86563306-6c21a300-bf64-11ea-81b4-6ad2d53fee65.png)
<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
