### PR TITLE
Less verbose LSQ pool response trace

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -821,5 +821,5 @@ instance HasSeverityAnnotation NetworkLayerLog where
         MsgAccountDelegationAndRewards{} -> Info
         MsgDestroyCursor{}               -> Notice
         MsgWillQueryRewardsForStake{}    -> Info
-        MsgFetchedNodePoolLsqData{}      -> Info
+        MsgFetchedNodePoolLsqData{}      -> Debug
         MsgWatcherUpdate{}               -> Debug


### PR DESCRIPTION
# Overview

- [x] Log the full response as DEBUG, not INFO
- [x] Log the _size_ of the stake distribution and reward map as INFO 

# Comments

We now see:
```
[cardano-wallet.network:Info:65] [2020-07-06 15:07:56.63 UTC] Will query non-myopic rewards using the stake 100000000000
[cardano-wallet.network:Info:65] [2020-07-06 15:07:56.82 UTC] Fetched pool data from node tip using LSQ. Got 360 pools in the stake distribution, and 360 pools in the non-myopic member reward map.
```

With:
```
--trace-network=DEBUG
```
we still see the full response.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
