### PR TITLE
withdrawals as part of the coin selection

### DIFF
--- a/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/TransactionSpec.hs
@@ -390,7 +390,7 @@ genSelection = do
     genSelectionFor :: NonEmpty TxOut -> Gen CoinSelection
     genSelectionFor outs = do
         utxo <- vectorOf (NE.length outs * 3) genCoin >>= genUTxO @n @k
-        case runIdentity $ runExceptT $ largestFirst opts outs utxo of
+        case runIdentity $ runExceptT $ largestFirst opts outs (Quantity 0) utxo of
             Left _ -> genSelectionFor outs
             Right (s,_) -> return s
 

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -49,7 +49,6 @@ module Test.Integration.Framework.TestData
     , errMsg403NotAByronWallet
     , errMsg403NotEnoughMoney
     , errMsg403NotEnoughMoney_
-    , errMsg403UTxO
     , errMsg403WrongPass
     , errMsg403NoPendingAnymore
     , errMsg404NoSuchPool
@@ -62,7 +61,6 @@ module Test.Integration.Framework.TestData
     , errMsg403NoRootKey
     , errMsg404NoWallet
     , errMsg409WalletExists
-    , errMsg403InputsDepleted
     , errMsg403TxTooBig
     , errMsg400MalformedTxPayload
     , errMsg400WronglyEncodedTxPayload
@@ -285,19 +283,15 @@ errMsg403NotAByronWallet =
 
 errMsg403NotEnoughMoney_ :: String
 errMsg403NotEnoughMoney_ =
-    "I can't process this payment because there's \
-    \not enough UTxO available in the wallet."
+    "I cannot select enough UTxO from your wallet to construct an adequate \
+    \transaction. Try sending a smaller amount or increasing the number of \
+    \available UTxO."
 
 errMsg403NotEnoughMoney :: Int -> Int -> String
 errMsg403NotEnoughMoney has needs = "I can't process this payment because there's\
     \ not enough UTxO available in the wallet. The total UTxO sums up to\
     \ " ++ show has ++ " Lovelace, but I need " ++ show needs ++ " Lovelace\
     \ (excluding fee amount) in order to proceed  with the payment."
-
-errMsg403InputsDepleted :: String
-errMsg403InputsDepleted = "I had to select inputs to construct the requested\
-    \ transaction. Unfortunately, one output of the transaction depleted all\
-    \ available inputs. Try sending a smaller amount."
 
 errMsg403TxTooBig :: Int -> String
 errMsg403TxTooBig n = "I had to select " ++ show n ++ " inputs to construct the\
@@ -331,11 +325,6 @@ _errMsg403InpsOrOutsExceeded (maxNumInps, maxNumOuts) =
     "I can't validate coin selection because either the number of inputs is\
     \   more than " ++ show maxNumInps ++ " or the number of outputs\
     \ exceeds " ++ show maxNumOuts ++ "."
-
-errMsg403UTxO :: String
-errMsg403UTxO = "When creating new transactions, I'm not able to re-use the\
-    \ same UTxO for different outputs. Here, I only have 1\
-    \ available, but there are 2 outputs."
 
 errMsg403WrongPass :: String
 errMsg403WrongPass = "The given encryption passphrase doesn't match the one\

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1178,15 +1178,15 @@ selectCoinsForPaymentFromUTxO
     -> NonEmpty TxOut
     -> Quantity "lovelace" Word64
     -> ExceptT (ErrSelectForPayment e) IO CoinSelection
-selectCoinsForPaymentFromUTxO ctx utxo txp recipients (Quantity withdrawal) = do
+selectCoinsForPaymentFromUTxO ctx utxo txp recipients withdrawal = do
     lift . traceWith tr $ MsgPaymentCoinSelectionStart utxo txp recipients
     (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
         let opts = coinSelOpts tl (txp ^. #getTxMaxSize)
-        CoinSelection.random opts recipients utxo
+        CoinSelection.random opts recipients withdrawal utxo
     lift . traceWith tr $ MsgPaymentCoinSelection sel
     let feePolicy = feeOpts tl Nothing (txp ^. #getFeePolicy)
     withExceptT ErrSelectForPaymentFee $ do
-        balancedSel <- adjustForFee feePolicy utxo' (sel { withdrawal })
+        balancedSel <- adjustForFee feePolicy utxo' sel
         lift . traceWith tr $ MsgPaymentCoinSelectionAdjusted balancedSel
         pure balancedSel
   where

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1862,13 +1862,6 @@ instance Buildable e => LiftHandler (ErrCoinSelection e) where
                 , " Lovelace (excluding fee amount) in order to proceed "
                 , " with the payment."
                 ]
-        ErrUtxoNotEnoughFragmented nUtxo nOuts ->
-            apiError err403 UtxoNotEnoughFragmented $ mconcat
-                [ "When creating new transactions, I'm not able to re-use "
-                , "the same UTxO for different outputs. Here, I only have "
-                , showT nUtxo, " available, but there are ", showT nOuts
-                , " outputs."
-                ]
         ErrMaximumInputsReached n ->
             apiError err403 TransactionIsTooBig $ mconcat
                 [ "I had to select ", showT n, " inputs to construct the "

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1878,10 +1878,9 @@ instance Buildable e => LiftHandler (ErrCoinSelection e) where
                 ]
         ErrInputsDepleted ->
             apiError err403 InputsDepleted $ mconcat
-                [ "I had to select inputs to construct the "
-                , "requested transaction. Unfortunately, one output of the "
-                , "transaction depleted all available inputs. "
-                , "Try sending a smaller amount."
+                [ "I cannot select enough UTxO from your wallet to construct "
+                , "an adequate transaction. Try sending a smaller amount or "
+                , "increasing the number of available UTxO."
                 ]
         ErrInvalidSelection e ->
             apiError err403 InvalidCoinSelection $ pretty e

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Primitive.CoinSelection
     , outputBalance
     , changeBalance
     , feeBalance
+    , totalBalance
     , proportionallyTo
     , ErrCoinSelection (..)
     , CoinSelectionOptions (..)
@@ -28,9 +29,11 @@ module Cardano.Wallet.Primitive.CoinSelection
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxIn, TxOut (..) )
+    ( Coin (..), TxIn, TxOut (..), balance' )
 import Data.List
     ( foldl' )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Ratio
     ( Ratio, denominator, numerator )
 import Data.Word
@@ -119,6 +122,10 @@ changeBalance = foldl' addCoin 0 . change
 
 feeBalance :: CoinSelection -> Word64
 feeBalance sel = inputBalance sel - outputBalance sel - changeBalance sel
+
+-- | Total UTxO balance + withdrawal.
+totalBalance :: Quantity "lovelace" Word64 -> [(TxIn, TxOut)] -> Word64
+totalBalance (Quantity withdraw) inps = balance' inps + withdraw
 
 addTxOut :: Integral a => a -> TxOut -> a
 addTxOut total = addCoin total . coin

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -21,7 +21,6 @@ module Cardano.Wallet.Primitive.CoinSelection
     , changeBalance
     , feeBalance
     , totalBalance
-    , proportionallyTo
     , ErrCoinSelection (..)
     , CoinSelectionOptions (..)
     ) where
@@ -34,8 +33,6 @@ import Data.List
     ( foldl' )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( Ratio, denominator, numerator )
 import Data.Word
     ( Word64, Word8 )
 import Fmt
@@ -132,25 +129,6 @@ addTxOut total = addCoin total . coin
 
 addCoin :: Integral a => a -> Coin -> a
 addCoin total c = total + (fromIntegral (getCoin c))
-
--- | Compute the fraction of the first input to match the given ratio, rounded
--- down.
---
--- /invariant:/ The ratio mustn't be greater than 1 without risk to overflow.
---
--- >>> 10 `proportionallyTo` 1%1
--- 10
---
--- >>> 10 `proportionallyTo` 1%2
--- 5
---
--- >>> 10 `proportionallyTo` 1%3
--- 3
-proportionallyTo :: Integral a => a -> Ratio a -> a
-proportionallyTo n r
-    | r > 1 = error "proportionallyTo: ratio is greater than 1!"
-    | otherwise = fromIntegral $
-        toInteger n * toInteger (numerator r) `div` toInteger (denominator r)
 
 data ErrCoinSelection e
     = ErrNotEnoughMoney Word64 Word64

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -135,10 +135,6 @@ data ErrCoinSelection e
     -- ^ UTxO exhausted during input selection
     -- We record the balance of the UTxO as well as the size of the payment
     -- we tried to make.
-    | ErrUtxoNotEnoughFragmented Word64 Word64
-    -- ^ UTxO is not enough fragmented for the number of transaction outputs
-    -- We record the number of UTxO entries as well as the number of the
-    -- outputs of the transaction.
     | ErrMaximumInputsReached Word64
     -- ^ When trying to construct a transaction, the max number of allowed
     -- inputs was reached.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 
 
@@ -31,6 +32,10 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Ord
     ( Down (..) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Word
+    ( Word64 )
 
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -42,9 +47,10 @@ largestFirst
     :: forall m e. Monad m
     => CoinSelectionOptions e
     -> NonEmpty TxOut
+    -> Quantity "lovelace" Word64
     -> UTxO
     -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
-largestFirst opt outs utxo = do
+largestFirst opt outs _withdrawals utxo = do
     let descending = L.sortOn (Down . coin) . NE.toList
     let nOuts = fromIntegral $ NE.length outs
     let maxN = fromIntegral $ maximumNumberOfInputs opt (fromIntegral nOuts)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 
@@ -27,7 +28,7 @@ import Cardano.Wallet.Primitive.Types
 import Control.Arrow
     ( left )
 import Control.Monad
-    ( foldM, when )
+    ( when )
 import Control.Monad.Trans.Except
     ( ExceptT (..), except, throwE )
 import Data.Functor
@@ -45,7 +46,6 @@ import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 
-
 -- | Largest-first input selection policy
 largestFirst
     :: forall m e. Monad m
@@ -54,23 +54,22 @@ largestFirst
     -> Quantity "lovelace" Word64
     -> UTxO
     -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
-largestFirst opt outs withdraw utxo = do
-    let descending = L.sortOn (Down . coin) . NE.toList
+largestFirst opt outs withdrawal utxo = do
     let nOuts = fromIntegral $ NE.length outs
-    let maxN = fromIntegral $ maximumNumberOfInputs opt (fromIntegral nOuts)
+    let maxN = fromIntegral $ maximumNumberOfInputs opt nOuts
     let nLargest = take maxN
             . L.sortOn (Down . coin . snd)
             . Map.toList
             . getUTxO
     let guard = except . left ErrInvalidSelection . validate opt
 
-    case foldM atLeast (nLargest utxo, mempty) (descending outs) of
+    case atLeast (nLargest utxo) withdrawal (NE.toList outs) of
         Just (utxo', s) ->
             guard s $> (s, UTxO $ Map.fromList utxo')
         Nothing -> do
-            let moneyRequested = sum $ (getCoin . coin) <$> (descending outs)
+            let moneyRequested = sum $ (getCoin . coin) <$> outs
             let utxoList = Map.toList $ getUTxO utxo
-            let total = totalBalance withdraw utxoList
+            let total = totalBalance withdrawal utxoList
             let nUtxo = fromIntegral $ Map.size $ getUTxO utxo
 
             when (null utxoList)
@@ -79,37 +78,34 @@ largestFirst opt outs withdraw utxo = do
             when (total < moneyRequested)
                 $ throwE $ ErrNotEnoughMoney total moneyRequested
 
-            when (nUtxo < nOuts)
-                $ throwE $ ErrUtxoNotEnoughFragmented nUtxo nOuts
-
-            when (fromIntegral maxN > nUtxo)
+            when (maxN > nUtxo)
                 $ throwE ErrInputsDepleted
 
             throwE $ ErrMaximumInputsReached (fromIntegral maxN)
 
 -- Selecting coins to cover at least the specified value
 -- The details of the algorithm are following:
--- (a) transaction outputs are processed starting from the largest one
+--
+-- (a) transaction outputs are considered as a whole (sum of all outputs).
+--
 -- (b) `maximumNumberOfInputs` biggest available UTxO inputs are taken
 --      into consideration. They constitute a candidate UTxO inputs from
---      which coin selection will be tried. Each output is treated independently
---      with the heuristic described in (c).
--- (c) the biggest candidate UTxO input is tried first to cover the transaction
---     output. If the input is not enough, then the next biggest one is added
---     to check if they can cover the transaction output. This process is continued
---     until the output is covered or the candidates UTxO inputs are depleted.
---     In the latter case `MaximumInputsReached` error is triggered. If the transaction
---     output is covered the next biggest one is processed. Here, the biggest
---     UTxO input, not participating in the coverage, is taken. We are back at (b)
---     step as a result
+--      which coin selection will be tried.
 --
--- The steps are continued until all transaction are covered.
+-- (c) the biggest candidate UTxO input is tried first to cover the transaction
+--     total output. If the input is not enough, then the next biggest one is added
+--     to check if they can cover the total.
+--
+--     This process is continued until the total is covered or the candidates UTxO
+--     inputs are depleted. In the latter case `MaximumInputsReached` error is
+--     triggered.
 atLeast
-    :: ([(TxIn, TxOut)], CoinSelection)
-    -> TxOut
+    :: [(TxIn, TxOut)]
+    -> Quantity "lovelace" Word64
+    -> [TxOut]
     -> Maybe ([(TxIn, TxOut)], CoinSelection)
-atLeast (utxo0, selection) txout =
-    coverOutput (fromIntegral $ getCoin $ coin txout, mempty) utxo0
+atLeast utxo0 (Quantity withdrawal) outs =
+    coverOutput (toInteger $ sum $ getCoin . coin <$> outs, mempty) utxo0
   where
     coverOutput
         :: (Integer, [(TxIn, TxOut)])
@@ -118,17 +114,25 @@ atLeast (utxo0, selection) txout =
     coverOutput (target, ins) utxo
         | target <= 0 = Just
             ( utxo
-            , selection <> mempty
+            , mempty
                 { inputs  = ins
-                , outputs = [txout]
+                , outputs = outs
                 , change  = filter (/= (Coin 0)) [Coin (fromIntegral $ abs target)]
+                , withdrawal
                 }
             )
+
         | null utxo =
             Nothing
+
         | otherwise =
             let
                 (inp, out):utxo' = utxo
-                target' = target - (fromIntegral (getCoin (coin out)))
+                outAmount = getCoin (coin out)
+                -- NOTE: For the /first/ selected input, we also use the entire
+                -- withdrawal. If it's not enough, new inputs will be selected.
+                target'
+                    | null ins  = target - fromIntegral (outAmount + withdrawal)
+                    | otherwise = target - fromIntegral outAmount
             in
                 coverOutput (target', (inp, out):ins) utxo'

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
 
@@ -21,7 +22,6 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..)
     , CoinSelectionOptions (..)
     , ErrCoinSelection (..)
-    , proportionallyTo
     , totalBalance
     )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
@@ -48,8 +48,6 @@ import Data.Ord
     ( comparing )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( (%) )
 import Data.Word
     ( Word64 )
 
@@ -117,98 +115,104 @@ random
     -> Quantity "lovelace" Word64
     -> UTxO
     -> ExceptT (ErrCoinSelection e) m (CoinSelection, UTxO)
-random opt outs (Quantity totalWithdraw) utxo = do
+random opt outs (Quantity withdrawal) utxo = do
     let descending = NE.toList . NE.sortBy (flip $ comparing coin)
     let nOuts = fromIntegral $ NE.length outs
     let maxN = fromIntegral $ maximumNumberOfInputs opt nOuts
-    let totalOut = sum (getCoin . coin <$> outs)
-    randomMaybe <- lift $ runMaybeT $
-        foldM
-            (\acc out ->
-                let
-                    withdraw = totalWithdraw
-                        `proportionallyTo` (getCoin (coin out) % totalOut)
-                in
-                    makeSelection (Quantity withdraw) acc out
-            )
-            (maxN, utxo, [])
-            (descending outs)
+    randomMaybe <- lift $ runMaybeT $ do
+        let initialState = SelectionState maxN utxo (Quantity withdrawal) []
+        foldM makeSelection initialState (descending outs)
     case randomMaybe of
-        Just (maxN', utxo', res) -> do
+        Just (SelectionState maxN' utxo' _ res) -> do
             (_, sel, remUtxo) <- lift $
                 foldM improveTxOut (maxN', mempty, utxo') (reverse res)
-            -- NOTE re-assigning total withdrawal to cope with potential
-            -- rounding issues.
-            guard sel $> (sel { withdrawal = totalWithdraw }, remUtxo)
+            let result = sel { withdrawal }
+            guard result $> (result, remUtxo)
         Nothing ->
-            largestFirst opt outs (Quantity totalWithdraw) utxo
+            largestFirst opt outs (Quantity withdrawal) utxo
   where
     guard = except . left ErrInvalidSelection . validate opt
+
+-- A little type-alias to ease signature below
+data SelectionState = SelectionState
+    { _maxN :: Word64
+    , _utxo :: UTxO
+    , _withdrawal :: Quantity "lovelace" Word64
+    , _selection :: [CoinSelection]
+    } deriving Show
 
 -- | Perform a random selection on a given output, without improvement.
 makeSelection
     :: forall m. MonadRandom m
-    => Quantity "lovelace" Word64
-    -> (Word64, UTxO, [(Quantity "lovelace" Word64, [(TxIn, TxOut)], TxOut)])
+    => SelectionState
     -> TxOut
-    -> MaybeT m
-        ( Word64 -- Number of remaining inputs that can be selected
-        , UTxO -- New UTxO
-        , [(Quantity "lovelace" Word64, [(TxIn, TxOut)], TxOut)] -- Ongoing selection
-        )
-makeSelection withdraw (maxNumInputs, utxo0, selection) txout = do
-    (inps, utxo1) <- coverRandomly ([], utxo0)
-    return
-        ( maxNumInputs - fromIntegral (L.length inps)
-        , utxo1
-        , (withdraw, inps, txout) : selection
-        )
+    -> MaybeT m SelectionState
+makeSelection (SelectionState maxN utxo0 withdrawal0 selection0) txout = do
+    (selection', utxo') <- coverRandomly ([], utxo0)
+    return $ SelectionState
+        { _maxN = maxN - fromIntegral (L.length $ inputs selection')
+        , _utxo = utxo'
+        , _withdrawal = (\w -> w - withdrawal selection') <$> withdrawal0
+        , _selection = selection' : selection0
+        }
   where
+    TargetRange{targetMin} = mkTargetRange $ getCoin $ coin txout
+
     coverRandomly
         :: forall m. MonadRandom m
         => ([(TxIn, TxOut)], UTxO)
-        -> MaybeT m ([(TxIn, TxOut)], UTxO)
+        -> MaybeT m (CoinSelection, UTxO)
     coverRandomly (inps, utxo)
-        | L.length inps > fromIntegral maxNumInputs =
+        | L.length inps > fromIntegral maxN =
             MaybeT $ return Nothing
-        | currentBalance >= targetMin (mkTargetRange txout) =
-            MaybeT $ return $ Just (inps, utxo)
+        | currentBalance >= targetMin =
+            MaybeT $ return $ Just
+                ( mempty
+                    { inputs = inps
+                    , outputs = [txout]
+                    , withdrawal = currentBalance - inputBalance
+                    }
+                , utxo
+                )
         | otherwise = do
             pickRandomT utxo >>= \(io, utxo') -> coverRandomly (io:inps, utxo')
       where
         -- Withdrawal can only count towards the input balance if there's been
         -- at least one selected input.
         currentBalance
-            | null inps && null selection = totalBalance (Quantity 0) inps
-            | otherwise = totalBalance withdraw inps
+            | null inps && null selection0 = inputBalance
+            | otherwise = totalBalance withdrawal0 inps
+
+        inputBalance =
+            totalBalance (Quantity 0) inps
 
 -- | Perform an improvement to random selection on a given output.
 improveTxOut
     :: forall m. MonadRandom m
     => (Word64, CoinSelection, UTxO)
-    -> (Quantity "lovelace" Word64, [(TxIn, TxOut)], TxOut)
+    -> CoinSelection
     -> m (Word64, CoinSelection, UTxO)
-improveTxOut (maxN0, selection, utxo0) (withdraw, inps0, txout) = do
+improveTxOut (maxN0, selection, utxo0) (CoinSelection inps0 withdraw _ outs _ _) = do
     (maxN, inps, utxo) <- improve (maxN0, inps0, utxo0)
     return
         ( maxN
         , selection <> mempty
             { inputs = inps
-            , outputs = [txout]
-            , change = mkChange withdraw txout inps
-            , withdrawal = getQuantity withdraw
+            , outputs = outs
+            , change = mkChange (Quantity withdraw) outs inps
+            , withdrawal = withdraw
             }
         , utxo
         )
   where
-    target = mkTargetRange txout
+    target = mkTargetRange $ sum $ getCoin . coin <$> outs
 
     improve
         :: forall m. MonadRandom m
         => (Word64, [(TxIn, TxOut)], UTxO)
         -> m (Word64, [(TxIn, TxOut)], UTxO)
     improve (maxN, inps, utxo)
-        | maxN >= 1 && totalBalance withdraw inps < targetAim target = do
+        | maxN >= 1 && totalBalance (Quantity withdraw) inps < targetAim target = do
             runMaybeT (pickRandomT utxo) >>= \case
                 Nothing ->
                     return (maxN, inps, utxo)
@@ -224,13 +228,21 @@ improveTxOut (maxN0, selection, utxo0) (withdraw, inps0, txout) = do
     isImprovement :: (TxIn, TxOut) -> [(TxIn, TxOut)] -> Bool
     isImprovement io selected =
         let
+            balanceWithExtraInput =
+                totalBalance (Quantity withdraw) (io : selected)
+
+            balanceWithoutExtraInput =
+                totalBalance (Quantity withdraw) selected
+
             condA = -- (a) It doesn’t exceed a specified upper limit.
-                totalBalance withdraw (io : selected) < targetMax target
+                balanceWithExtraInput
+                <
+                targetMax target
 
             condB = -- (b) Addition gets us closer to the ideal change
-                distance (targetAim target) (totalBalance withdraw (io : selected))
+                distance (targetAim target) balanceWithExtraInput
                 <
-                distance (targetAim target) (totalBalance withdraw selected)
+                distance (targetAim target) balanceWithoutExtraInput
 
             -- (c) Doesn't exceed maximum number of inputs
             -- Guaranteed by the precondition on 'improve'.
@@ -247,20 +259,21 @@ pickRandomT =
     MaybeT . fmap (\(m,u) -> (,u) <$> m) . pickRandom
 
 -- | Compute the target range for a given output
-mkTargetRange :: TxOut -> TargetRange
-mkTargetRange (TxOut _ (Coin c)) = TargetRange
-    { targetMin = c
-    , targetAim = 2 * c
-    , targetMax = 3 * c
+mkTargetRange :: Word64 -> TargetRange
+mkTargetRange base = TargetRange
+    { targetMin = base
+    , targetAim = 2 * base
+    , targetMax = 3 * base
     }
 
 -- | Compute corresponding change outputs from a target output and a selection
 -- of inputs.
 --
 -- > pre-condition: the output must be smaller (or eq) than the sum of inputs
-mkChange :: Quantity "lovelace" Word64 -> TxOut -> [(TxIn, TxOut)] -> [Coin]
-mkChange withdraw (TxOut _ (Coin out)) inps =
+mkChange :: Quantity "lovelace" Word64 -> [TxOut] -> [(TxIn, TxOut)] -> [Coin]
+mkChange withdraw outs inps =
     let
+        out = sum $ getCoin . coin <$> outs
         selected = invariant
             "mkChange: output is smaller than selected inputs!"
             (totalBalance withdraw inps)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -18,7 +18,11 @@ module Cardano.Wallet.Primitive.CoinSelection.Random
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
+    ( CoinSelection (..)
+    , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
+    , proportionallyTo
+    )
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.Types
@@ -51,10 +55,10 @@ import Data.Ord
     ( comparing )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( Ratio, denominator, numerator, (%) )
 import Data.Word
     ( Word64 )
+import Data.Ratio
+    ( (%) )
 
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -278,18 +282,3 @@ mkChange (TxOut _ (Coin out)) inps =
                 []
             c ->
                 [ Coin c ]
-
--- | Compute the fraction of the first input to match the given ratio, rounded
--- down.
---
--- >>> 10 `proportionallyTo` 1%1
--- 10
---
--- >>> 10 `proportionallyTo` 1%2
--- 5
---
--- >>> 10 `proportionallyTo` 1%3
--- 3
-proportionallyTo :: Integral a => a -> Ratio a -> a
-proportionallyTo n r = fromIntegral $
-    toInteger n * toInteger (numerator r) `div` toInteger (denominator r)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -165,12 +165,15 @@ makeSelection (SelectionState maxN utxo0 withdrawal0 selection0) txout = do
     coverRandomly (inps, utxo)
         | L.length inps > fromIntegral maxN =
             MaybeT $ return Nothing
-        | currentBalance >= targetMin =
+        | currentBalance >= targetMin = do
+            let remainder
+                    | inputBalance >= targetMin = 0
+                    | otherwise = targetMin - inputBalance
             MaybeT $ return $ Just
                 ( mempty
                     { inputs = inps
                     , outputs = [txout]
-                    , withdrawal = currentBalance - inputBalance
+                    , withdrawal = min remainder (getQuantity withdrawal0)
                     }
                 , utxo
                 )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -118,6 +118,44 @@ spec = do
                 , totalWithdrawal = 0
                 })
 
+        coinSelectionUnitTest largestFirst "with withdrawal"
+            (Right $ CoinSelectionResult
+                { rsInputs = [1]
+                , rsChange = []
+                , rsOutputs = [100]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , validateSelection = noValidation
+                , utxoInputs = [1]
+                , txOutputs = 100 :| []
+                , totalWithdrawal = 99
+                })
+
+        coinSelectionUnitTest largestFirst "with withdrawal & change"
+            (Right $ CoinSelectionResult
+                { rsInputs = [30]
+                , rsChange = [40]
+                , rsOutputs = [40]
+                })
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , validateSelection = noValidation
+                , utxoInputs = [10,30]
+                , txOutputs = 40 :| []
+                , totalWithdrawal = 50
+                })
+
+        coinSelectionUnitTest largestFirst "withdrawal requires at least one input"
+            (Left ErrInputsDepleted)
+            (CoinSelectionFixture
+                { maxNumOfInputs = 100
+                , validateSelection = noValidation
+                , utxoInputs = []
+                , txOutputs = 1 :| []
+                , totalWithdrawal = 10
+                })
+
         coinSelectionUnitTest largestFirst "not enough coins"
             (Left $ ErrNotEnoughMoney 39 40)
             (CoinSelectionFixture

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -270,17 +270,6 @@ spec = do
                 , totalWithdrawal = 10
                 })
 
-
-        coinSelectionUnitTest random "enough funds, proper fragmentation, inputs depleted"
-            (Left ErrInputsDepleted)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , validateSelection = noValidation
-                , utxoInputs = [10,10,10,10]
-                , txOutputs = 38 :| [1]
-                , totalWithdrawal = 0
-                })
-
         coinSelectionUnitTest random ""
             (Left $ ErrMaximumInputsReached 2)
             (CoinSelectionFixture
@@ -327,16 +316,6 @@ spec = do
                 { maxNumOfInputs = 100
                 , validateSelection = noValidation
                 , utxoInputs = [12,10,17]
-                , txOutputs = 40 :| [1,1,1]
-                , totalWithdrawal = 0
-                })
-
-        coinSelectionUnitTest random ""
-            (Left $ ErrUtxoNotEnoughFragmented 3 4)
-            (CoinSelectionFixture
-                { maxNumOfInputs = 100
-                , validateSelection = noValidation
-                , utxoInputs = [12,20,17]
                 , txOutputs = 40 :| [1,1,1]
                 , totalWithdrawal = 0
                 })

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -28,11 +28,7 @@ import Prelude
 import Cardano.Wallet.Api.Server
     ( assignMigrationAddresses )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..)
-    , CoinSelectionOptions (..)
-    , ErrCoinSelection (..)
-    , proportionallyTo
-    )
+    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -51,8 +47,6 @@ import Data.Maybe
     ( catMaybes )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( Ratio, (%) )
 import Data.Vector.Shuffle
     ( shuffle )
 import Data.Word
@@ -110,15 +104,6 @@ spec = do
         prop "All inputs are used per transaction" prop_allInputsAreUsedPerTx
         prop "Addresses are recycled fairly" prop_fairAddressesRecycled
 
-    describe "proportionallyTo" $ do
-        prop "proportionallyTo behaves as expected" prop_proportionallyTo
-        it "10 `proportionallyTo` 1%1 == 10" $
-            (10 `proportionallyTo` (1%1)) `shouldBe` (10 :: Integer)
-        it "10 `proportionallyTo` 1%2 == 5" $
-            (10 `proportionallyTo` (1%2)) `shouldBe` (5 :: Integer)
-        it "10 `proportionallyTo` 1%3 == 3" $
-            (10 `proportionallyTo` (1%3)) `shouldBe` (3 :: Integer)
-
   where
     lowerConfidence :: Confidence
     lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
@@ -126,15 +111,6 @@ spec = do
 {-------------------------------------------------------------------------------
                                  Properties
 -------------------------------------------------------------------------------}
-
-prop_proportionallyTo
-    :: Word8
-    -> Ratio Word8
-    -> Property
-prop_proportionallyTo n r = conjoin
-    [ r <= 1 ==> n `proportionallyTo` r <= n
-    , n `proportionallyTo` 1 === n
-    ]
 
 prop_utxoToListOrderDeterministic
     :: UTxO

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -28,7 +28,11 @@ import Prelude
 import Cardano.Wallet.Api.Server
     ( assignMigrationAddresses )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
+    ( CoinSelection (..)
+    , CoinSelectionOptions (..)
+    , ErrCoinSelection (..)
+    , proportionallyTo
+    )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -47,6 +51,8 @@ import Data.Maybe
     ( catMaybes )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Ratio
+    ( Ratio, (%) )
 import Data.Vector.Shuffle
     ( shuffle )
 import Data.Word
@@ -65,6 +71,7 @@ import Test.QuickCheck
     , applyArbitrary2
     , checkCoverageWith
     , choose
+    , conjoin
     , counterexample
     , cover
     , elements
@@ -72,6 +79,7 @@ import Test.QuickCheck
     , scale
     , vector
     , (===)
+    , (==>)
     )
 import Test.QuickCheck.Monadic
     ( monadicIO )
@@ -101,6 +109,16 @@ spec = do
         prop "All inputs are used" prop_allInputsAreUsed
         prop "All inputs are used per transaction" prop_allInputsAreUsedPerTx
         prop "Addresses are recycled fairly" prop_fairAddressesRecycled
+
+    describe "proportionallyTo" $ do
+        prop "proportionallyTo behaves as expected" prop_proportionallyTo
+        it "10 `proportionallyTo` 1%1 == 10" $
+            (10 `proportionallyTo` (1%1)) `shouldBe` (10 :: Integer)
+        it "10 `proportionallyTo` 1%2 == 5" $
+            (10 `proportionallyTo` (1%2)) `shouldBe` (5 :: Integer)
+        it "10 `proportionallyTo` 1%3 == 3" $
+            (10 `proportionallyTo` (1%3)) `shouldBe` (3 :: Integer)
+
   where
     lowerConfidence :: Confidence
     lowerConfidence = Confidence (10^(6 :: Integer)) 0.75
@@ -108,6 +126,15 @@ spec = do
 {-------------------------------------------------------------------------------
                                  Properties
 -------------------------------------------------------------------------------}
+
+prop_proportionallyTo
+    :: Word8
+    -> Ratio Word8
+    -> Property
+prop_proportionallyTo n r = conjoin
+    [ r <= 1 ==> n `proportionallyTo` r <= n
+    , n `proportionallyTo` 1 === n
+    ]
 
 prop_utxoToListOrderDeterministic
     :: UTxO

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -65,7 +65,6 @@ import Test.QuickCheck
     , applyArbitrary2
     , checkCoverageWith
     , choose
-    , conjoin
     , counterexample
     , cover
     , elements
@@ -73,7 +72,6 @@ import Test.QuickCheck
     , scale
     , vector
     , (===)
-    , (==>)
     )
 import Test.QuickCheck.Monadic
     ( monadicIO )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -45,6 +45,8 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Vector.Shuffle
     ( shuffle )
 import Data.Word
@@ -243,6 +245,9 @@ data CoinSelectionFixture = CoinSelectionFixture
         -- ^ Value (in Lovelace) & number of available coins in the UTxO
     , txOutputs :: NonEmpty Word64
         -- ^ Value (in Lovelace) & number of requested outputs
+    , totalWithdrawal :: Word64
+        -- ^ Total withdrawal available for the selection. May be split across
+        -- outputs.
     }
 
 -- | A dummy error for testing extra validation
@@ -263,11 +268,13 @@ data CoinSelectionResult = CoinSelectionResult
     , rsOutputs :: [Word64]
     } deriving (Eq, Show)
 
+
 -- | Generate a 'UTxO' and 'TxOut' matching the given 'Fixture', and perform
 -- given coin selection on it.
 coinSelectionUnitTest
     :: ( CoinSelectionOptions ErrValidation
          -> NonEmpty TxOut
+         -> Quantity "lovelace" Word64
          -> UTxO
          -> ExceptT (ErrCoinSelection ErrValidation) IO (CoinSelection, UTxO)
        )
@@ -275,11 +282,12 @@ coinSelectionUnitTest
     -> Either (ErrCoinSelection ErrValidation) CoinSelectionResult
     -> CoinSelectionFixture
     -> SpecWith ()
-coinSelectionUnitTest run lbl expected (CoinSelectionFixture n fn utxoF outsF) =
+coinSelectionUnitTest run lbl expected (CoinSelectionFixture n fn utxoF outsF w) =
     it title $ do
         (utxo,txOuts) <- setup
         result <- runExceptT $ do
-            cs <- fst <$> run (CoinSelectionOptions (const n) fn) txOuts utxo
+            cs <- fst <$> run
+                (CoinSelectionOptions (const n) fn) txOuts (Quantity w) utxo
             return $ CoinSelectionResult
                 { rsInputs  = map (getCoin . coin . snd) (inputs cs)
                 , rsChange  = map getCoin (change cs)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -159,7 +159,7 @@ spec = do
 
         let selectCoins = flip catchE (handleCannotCover utxo recipients) $ do
                 (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
-                    CS.random testCoinSelOpts recipients utxo
+                    CS.random testCoinSelOpts recipients (Quantity 0) utxo
                 withExceptT ErrSelectForPaymentFee $
                     (Fee . CS.feeBalance) <$> adjustForFee testFeeOpts utxo' sel
         res <- runExceptT $ estimateFeeForCoinSelection selectCoins


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1861 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 12b28f75b69c4bef47e1d1b7f2b765e9d544f800
  :round_pushpin: **take withdrawals into account, one level earlier, during the coin selection**
  Still to be done:

    - Make sure it's correctly done in the largest-first algorithm
    - Add some test scenario that show the influence of the withdrawal

- 547b1301fe7010cc0285a651aa8448cf88b6abc7
  :round_pushpin: **unit-test the newly introduced 'proportionallyTo'**
  Getting this one wrong would be quite bad :s

- 975f72648879a4f9ee513592e322dd10565f5739
  :round_pushpin: **add unit tests showing how withdrawal impacts the random coin selection**


> :bulb: NOTE
>
> I've chosen not to treat the withdrawal as a single _input_, but more as a "money pot" that is proportionally distributed amongst change output, so that it contributes to every output, based on their size. This is to avoid having a small output consuming the entire withdrawal for itself. Note sure if I'll keep the approach in the end, I'll have the night to think about it.

# Comments

<!-- Additional comments or screenshots to attach if any -->

- [ ] TODO: take into account the withdrawal when doing largest-first (and testing it)
- [ ] TODO: echo the error message change on "ErrInputsDepleted" to integration tests relying on that message.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
