### PR TITLE
Move sync progress logic to new module

### DIFF
--- a/lib/byron/bench/Latency.hs
+++ b/lib/byron/bench/Latency.hs
@@ -60,7 +60,7 @@ import Cardano.Wallet.Network.Ports
     ( unsafePortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Control.Concurrent.Async
     ( race )

--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -97,6 +97,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState, mkRndState )
 import Cardano.Wallet.Primitive.Model
     ( currentTip, totalUTxO )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..), mkSyncTolerance, syncProgressRelativeToTime )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , Block (..)
@@ -105,15 +107,12 @@ import Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , NetworkParameters (..)
     , SlotId (..)
-    , SyncProgress (..)
     , WalletId (..)
     , WalletName (..)
     , computeUtxoStatistics
     , log10
-    , mkSyncTolerance
     , slotAt
     , slotParams
-    , syncProgressRelativeToTime
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkMnemonic, unsafeRunExceptT )

--- a/lib/byron/exe/cardano-wallet-byron.hs
+++ b/lib/byron/exe/cardano-wallet-byron.hs
@@ -86,7 +86,7 @@ import Cardano.Wallet.Byron.Launch
     )
 import Cardano.Wallet.Logging
     ( trMessage, transformTextTrace )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Version
     ( GitRevision, Version, gitRevision, showFullVersion, version )

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -96,6 +96,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , Block
@@ -103,7 +105,6 @@ import Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
-    , SyncTolerance
     , WalletId
     )
 import Cardano.Wallet.Registry

--- a/lib/byron/test/integration/Main.hs
+++ b/lib/byron/test/integration/Main.hs
@@ -50,13 +50,14 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , FeePolicy (..)
     , Hash (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
-    , SyncTolerance (..)
     , TxIn (..)
     , TxOut (..)
     , TxParameters (..)

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -152,15 +152,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, defaultAddressPoolGap )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState
-    , Coin (..)
-    , Hash
-    , SortOrder
-    , SyncTolerance (..)
-    , WalletId
-    , WalletName
-    )
+    ( AddressState, Coin (..), Hash, SortOrder, WalletId, WalletName )
 import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Control.Applicative

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -189,6 +189,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -201,7 +203,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , SlotParameters (..)
     , SortOrder (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxOut (..)
     , TxStatus (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( PassphraseMaxLength (..), PassphraseMinLength (..), PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Monad
     ( forM_, void )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -17,7 +17,7 @@ import Cardano.Wallet.Api.Types
     , NtpSyncingStatus (..)
     , WalletStyle (..)
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Monad
     ( when )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -49,8 +49,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncProgress (..), walletNameMaxLength, walletNameMinLength )
+    ( walletNameMaxLength, walletNameMinLength )
 import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.Api.Types
     ( ApiByronWallet, ApiUtxoStatistics, DecodeAddress )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( PassphraseMaxLength (..), PassphraseMinLength (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -27,8 +27,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( SyncProgress (..), walletNameMaxLength, walletNameMinLength )
+    ( walletNameMaxLength, walletNameMinLength )
 import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -287,6 +287,7 @@ test-suite unit
       Cardano.Wallet.Primitive.CoinSelectionSpec
       Cardano.Wallet.Primitive.FeeSpec
       Cardano.Wallet.Primitive.ModelSpec
+      Cardano.Wallet.Primitive.SyncProgressSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.RegistrySpec
       Cardano.Wallet.TransactionSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -143,6 +143,7 @@ library
       Cardano.Wallet.Primitive.AddressDiscovery.Random
       Cardano.Wallet.Primitive.AddressDiscovery.Sequential
       Cardano.Wallet.Primitive.CoinSelection
+      Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.CoinSelection.LargestFirst
       Cardano.Wallet.Primitive.CoinSelection.Migration
       Cardano.Wallet.Primitive.CoinSelection.Random

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -253,6 +253,8 @@ import Cardano.Wallet.Primitive.Model
     , initWallet
     , updateState
     )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress, SyncTolerance (..), syncProgressRelativeToTime )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
@@ -275,8 +277,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotParameters (..)
     , SortOrder (..)
-    , SyncProgress (..)
-    , SyncTolerance
     , TransactionInfo (..)
     , Tx
     , TxMeta (..)
@@ -298,7 +298,6 @@ import Cardano.Wallet.Primitive.Types
     , slotParams
     , slotRangeFromTimeRange
     , slotStartTime
-    , syncProgressRelativeToTime
     , wholeRange
     )
 import Cardano.Wallet.Transaction

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -138,13 +138,14 @@ import Cardano.Wallet.Network
     ( NetworkLayer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( AddressState
     , Block
     , Coin (..)
     , NetworkParameters
     , SortOrder (..)
-    , SyncTolerance
     , WalletId (..)
     )
 import Cardano.Wallet.Registry

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -241,6 +241,8 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..), changeBalance, inputBalance )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, availableBalance, currentTip, getState, totalBalance )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..), SyncTolerance, syncProgressRelativeToTime )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , AddressState (..)
@@ -252,8 +254,6 @@ import Cardano.Wallet.Primitive.Types
     , PassphraseScheme (..)
     , PoolId
     , SortOrder (..)
-    , SyncProgress
-    , SyncTolerance
     , TransactionInfo (TransactionInfo)
     , Tx (..)
     , TxIn (..)
@@ -265,7 +265,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , slotAt
     , slotMinBound
-    , syncProgressRelativeToTime
     )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
@@ -937,7 +936,7 @@ getWallet ctx mkApiWallet (ApiT wid) = do
     whenNotResponding _ = Handler $ ExceptT $ withDatabase df wid $ \db -> runHandler $ do
         let wrk = hoistResource db (MsgFromWorker wid) ctx
         (cp, meta, pending) <- liftHandler $ W.readWallet @_ @s @k wrk wid
-        (, meta ^. #creationTime) <$> mkApiWallet ctx wid cp meta pending W.NotResponding
+        (, meta ^. #creationTime) <$> mkApiWallet ctx wid cp meta pending NotResponding
 
 listWallets
     :: forall ctx s t k apiWallet.

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -143,6 +143,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, SeqState, getAddressPoolGap )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -162,7 +164,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , StakePoolMetadata
     , StartTime (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxStatus (..)
     , WalletBalance (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Cardano.Wallet.Primitive.SyncProgress
+    ( -- * Types
+      SyncProgress (..)
+    , SyncTolerance (..)
+    , mkSyncTolerance
+
+      -- * Implementations
+    , syncProgress
+    , syncProgressRelativeToTime
+    , )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient (..)
+    , BlockHeader (..)
+    , SlotId (..)
+    , SlotLength (..)
+    , SlotParameters (..)
+    , distance
+    , flatSlot
+    , slotAt
+    )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Quantity
+    ( Percentage (..), Quantity (..), mkPercentage )
+import Data.Ratio
+    ( (%) )
+import Data.Text.Class
+    ( FromText (..), TextDecodingError (..), ToText (..) )
+import Data.Time.Clock
+    ( NominalDiffTime, UTCTime )
+import Fmt
+    ( Buildable, build )
+import GHC.Generics
+    ( Generic )
+import Safe
+    ( readMay )
+
+import qualified Data.Text as T
+
+data SyncProgress
+    = Ready
+    | Syncing !(Quantity "percent" Percentage)
+    | NotResponding
+    deriving (Generic, Eq, Show)
+
+instance NFData SyncProgress
+
+instance Ord SyncProgress where
+    NotResponding <= _ = True
+    _ <= NotResponding = False
+    Ready <= Ready = True
+    Ready <= Syncing _ = False
+    Syncing _ <= Ready = True
+    Syncing a <= Syncing b = a <= b
+
+instance Buildable SyncProgress where
+    build = \case
+        Ready ->
+            "restored"
+        Syncing (Quantity p) ->
+            "still restoring (" <> build (toText p) <> ")"
+        NotResponding ->
+            "not responding"
+
+
+newtype SyncTolerance = SyncTolerance NominalDiffTime
+    deriving stock (Generic, Eq, Show)
+
+-- | Construct a 'SyncTolerance' from a number of __seconds__
+mkSyncTolerance :: Int -> SyncTolerance
+mkSyncTolerance =
+    SyncTolerance . toEnum . (* pico)
+  where
+    pico = 1_000_000_000_000
+
+instance ToText SyncTolerance where
+    toText (SyncTolerance t) = T.pack (show t)
+
+instance FromText SyncTolerance where
+    fromText t = case T.splitOn "s" t of
+        [v,""] ->
+            maybe
+                (Left errSyncTolerance)
+                (Right . mkSyncTolerance)
+                (readMay $ T.unpack v)
+        _ ->
+            Left errSyncTolerance
+      where
+        errSyncTolerance = TextDecodingError $ unwords
+            [ "Cannot parse given time duration. Here are a few examples of"
+            , "valid text representing a sync tolerance: '3s', '3600s', '42s'."
+            ]
+
+-- | Estimate restoration progress based on:
+--
+-- - The current local tip
+-- - The last slot
+--
+-- For the sake of this calculation, we are somewhat conflating the definitions
+-- of slots and block height. Because we can't reliably _trust_ that the current
+-- node is actually itself synced with the network. So, we compute the progress
+-- as:
+--
+-- @
+-- p = h / (h + X)
+-- @
+--
+-- Where:
+--
+-- - @h@: the number of blocks we have ingested so far.
+-- - @X@: the estimatd remaining slots to reach the network tip.
+--
+-- Initially, `X` gives a relatively poor estimation of the network height, as
+-- it assumes that every next slot will be a block. But, as we ingest blocks,
+-- `h` becomes bigger and `X` becomes smaller making the progress estimation
+-- better and better. At some point, `X` is null, and we have `p = h / h`
+syncProgress
+    :: SyncTolerance
+        -- ^ A time tolerance inside which we consider ourselves synced
+    -> SlotParameters
+        -- ^ Parameters relative to slot arithmetics
+    -> BlockHeader
+        -- ^ Local tip
+    -> SlotId
+        -- ^ Last slot that could have been produced
+    -> SyncProgress
+syncProgress (SyncTolerance timeTolerance) sp tip slotNow =
+    let
+        bhTip = fromIntegral . getQuantity $ blockHeight tip
+
+        epochLength = getEpochLength sp
+        (SlotLength slotLength)  = getSlotLength sp
+
+        n0 = flatSlot epochLength (slotId tip)
+        n1 = flatSlot epochLength slotNow
+
+        tolerance = floor (timeTolerance / slotLength)
+
+        remainingSlots = fromIntegral $ n1 - n0
+
+        ActiveSlotCoefficient f = getActiveSlotCoefficient sp
+        remainingBlocks = round (remainingSlots * f)
+
+        -- Using (max 1) to avoid division by 0.
+        progress = bhTip % (max 1 (bhTip + remainingBlocks))
+    in if distance n1 n0 < tolerance || n0 >= n1 || progress >= 1 then
+        Ready
+    else
+        Syncing
+        . Quantity
+        . either (const . error $ errMsg progress) id
+        . mkPercentage
+        $ progress
+  where
+    errMsg x = "syncProgress: " ++ show x ++ " is out of bounds"
+
+-- | Helper to compare the /local tip/ with the slot corresponding to a
+-- @UTCTime@, and calculate progress based on that.
+syncProgressRelativeToTime
+    :: SyncTolerance
+        -- ^ A time tolerance inside which we consider ourselves synced
+    -> SlotParameters
+        -- ^ Parameters relative to slot arithmetics
+    -> BlockHeader
+    -- ^ Local tip
+    -> UTCTime
+    -- ^ Where we believe the network tip is (e.g. @getCurrentTime@).
+    -> SyncProgress
+syncProgressRelativeToTime tolerance sp tip time =
+    maybe
+        (Syncing minBound)
+        (syncProgress tolerance sp tip)
+        (slotAt sp time)

--- a/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 
+-- | Functionality for calculating @SyncProgress@ of wallets.
 module Cardano.Wallet.Primitive.SyncProgress
     ( -- * Types
       SyncProgress (..)
@@ -128,7 +129,10 @@ syncProgress
     :: SyncTolerance
         -- ^ A time tolerance inside which we consider ourselves synced
     -> SlotParameters
-        -- ^ Parameters relative to slot arithmetics
+        -- ^ Parameters for slot arithmetic which are assumed to be static.
+        --
+        -- NOTE: This is no longer the case with the Hard Fork Combinator and
+        -- Byron-to-Shelley era transition.
     -> BlockHeader
         -- ^ Local tip
     -> SlotId
@@ -170,7 +174,10 @@ syncProgressRelativeToTime
     :: SyncTolerance
         -- ^ A time tolerance inside which we consider ourselves synced
     -> SlotParameters
-        -- ^ Parameters relative to slot arithmetics
+        -- ^ Parameters for slot arithmetic which are assumed to be static.
+        --
+        -- NOTE: This is no longer the case with the Hard Fork Combinator and
+        -- Byron-to-Shelley era transition.
     -> BlockHeader
     -- ^ Local tip
     -> UTCTime

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -102,16 +102,11 @@ module Cardano.Wallet.Primitive.Types
     , slotParams
 
     -- * Slotting
-    , SyncProgress(..)
-    , SyncTolerance(..)
-    , mkSyncTolerance
     , unsafeEpochNo
     , epochStartTime
     , epochPred
     , epochSucc
     , SlotParameters (..)
-    , syncProgress
-    , syncProgressRelativeToTime
     , flatSlot
     , fromFlatSlot
     , slotStartTime
@@ -225,9 +220,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Percentage (..), Quantity (..), mkPercentage )
-import Data.Ratio
-    ( (%) )
+    ( Percentage (..), Quantity (..) )
 import Data.Set
     ( Set )
 import Data.String
@@ -273,8 +266,6 @@ import GHC.TypeLits
     ( KnownNat, KnownSymbol, Symbol, natVal, symbolVal )
 import Numeric.Natural
     ( Natural )
-import Safe
-    ( readMay )
 
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
@@ -1543,140 +1534,6 @@ data SlotParameters = SlotParameters
     , getActiveSlotCoefficient
         :: ActiveSlotCoefficient
     } deriving (Eq, Generic, Show)
-
-data SyncProgress
-    = Ready
-    | Syncing !(Quantity "percent" Percentage)
-    | NotResponding
-    deriving (Generic, Eq, Show)
-
-instance NFData SyncProgress
-
-instance Ord SyncProgress where
-    NotResponding <= _ = True
-    _ <= NotResponding = False
-    Ready <= Ready = True
-    Ready <= Syncing _ = False
-    Syncing _ <= Ready = True
-    Syncing a <= Syncing b = a <= b
-
-instance Buildable SyncProgress where
-    build = \case
-        Ready ->
-            "restored"
-        Syncing (Quantity p) ->
-            "still restoring (" <> build (toText p) <> ")"
-        NotResponding ->
-            "not responding"
-
-newtype SyncTolerance = SyncTolerance NominalDiffTime
-    deriving stock (Generic, Eq, Show)
-
--- | Construct a 'SyncTolerance' from a number of __seconds__
-mkSyncTolerance :: Int -> SyncTolerance
-mkSyncTolerance =
-    SyncTolerance . toEnum . (* pico)
-  where
-    pico = 1_000_000_000_000
-
-instance ToText SyncTolerance where
-    toText (SyncTolerance t) = T.pack (show t)
-
-instance FromText SyncTolerance where
-    fromText t = case T.splitOn "s" t of
-        [v,""] ->
-            maybe
-                (Left errSyncTolerance)
-                (Right . mkSyncTolerance)
-                (readMay $ T.unpack v)
-        _ ->
-            Left errSyncTolerance
-      where
-        errSyncTolerance = TextDecodingError $ unwords
-            [ "Cannot parse given time duration. Here are a few examples of"
-            , "valid text representing a sync tolerance: '3s', '3600s', '42s'."
-            ]
-
--- | Estimate restoration progress based on:
---
--- - The current local tip
--- - The last slot
---
--- For the sake of this calculation, we are somewhat conflating the definitions
--- of slots and block height. Because we can't reliably _trust_ that the current
--- node is actually itself synced with the network. So, we compute the progress
--- as:
---
--- @
--- p = h / (h + X)
--- @
---
--- Where:
---
--- - @h@: the number of blocks we have ingested so far.
--- - @X@: the estimatd remaining slots to reach the network tip.
---
--- Initially, `X` gives a relatively poor estimation of the network height, as
--- it assumes that every next slot will be a block. But, as we ingest blocks,
--- `h` becomes bigger and `X` becomes smaller making the progress estimation
--- better and better. At some point, `X` is null, and we have `p = h / h`
-syncProgress
-    :: SyncTolerance
-        -- ^ A time tolerance inside which we consider ourselves synced
-    -> SlotParameters
-        -- ^ Parameters relative to slot arithmetics
-    -> BlockHeader
-        -- ^ Local tip
-    -> SlotId
-        -- ^ Last slot that could have been produced
-    -> SyncProgress
-syncProgress (SyncTolerance timeTolerance) sp tip slotNow =
-    let
-        bhTip = fromIntegral . getQuantity $ tip ^. #blockHeight
-
-        epochLength = sp ^. #getEpochLength
-        (SlotLength slotLength)  = (sp ^. #getSlotLength)
-
-        n0 = flatSlot epochLength (tip ^. #slotId)
-        n1 = flatSlot epochLength slotNow
-
-        tolerance = floor (timeTolerance / slotLength)
-
-        remainingSlots = fromIntegral $ n1 - n0
-
-        ActiveSlotCoefficient f = sp ^. #getActiveSlotCoefficient
-        remainingBlocks = round (remainingSlots * f)
-
-        -- Using (max 1) to avoid division by 0.
-        progress = bhTip % (max 1 (bhTip + remainingBlocks))
-    in if distance n1 n0 < tolerance || n0 >= n1 || progress >= 1 then
-        Ready
-    else
-        Syncing
-        . Quantity
-        . either (const . error $ errMsg progress) id
-        . mkPercentage
-        $ progress
-  where
-    errMsg x = "syncProgress: " ++ show x ++ " is out of bounds"
-
--- | Helper to compare the /local tip/ with the slot corresponding to a
--- @UTCTime@, and calculate progress based on that.
-syncProgressRelativeToTime
-    :: SyncTolerance
-        -- ^ A time tolerance inside which we consider ourselves synced
-    -> SlotParameters
-        -- ^ Parameters relative to slot arithmetics
-    -> BlockHeader
-    -- ^ Local tip
-    -> UTCTime
-    -- ^ Where we believe the network tip is (e.g. @getCurrentTime@).
-    -> SyncProgress
-syncProgressRelativeToTime tolerance sp tip time =
-    maybe
-        (Syncing minBound)
-        (syncProgress tolerance sp tip)
-        (slotAt sp time)
 
 -- | Convert a 'SlotId' to the number of slots since genesis.
 flatSlot :: EpochLength -> SlotId -> Word64

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -110,6 +110,8 @@ import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, getAddressPoolGap )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
@@ -126,7 +128,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolMetadata (..)
     , StakePoolTicker
     , StartTime (..)
-    , SyncProgress (..)
     , TxIn (..)
     , TxIn (..)
     , TxOut (..)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Cardano.Wallet.Primitive.SyncProgressSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Gen
+    ( genActiveSlotCoefficient
+    , genBlockHeader
+    , genSlotId
+    , shrinkActiveSlotCoefficient
+    )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..), SyncTolerance (..), syncProgress )
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient (..)
+    , BlockHeader (..)
+    , EpochLength (..)
+    , Hash (..)
+    , SlotId (..)
+    , SlotLength (..)
+    , SlotNo (..)
+    , SlotParameters (..)
+    , StartTime (..)
+    , unsafeEpochNo
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeMkPercentage )
+import Control.DeepSeq
+    ( deepseq )
+import Control.Exception
+    ( SomeException (..), evaluate, try )
+import Control.Monad
+    ( forM_, when )
+import Data.Either
+    ( isRight )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Ratio
+    ( (%) )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , choose
+    , counterexample
+    , forAll
+    , property
+    , withMaxSuccess
+    )
+import Test.QuickCheck.Monadic
+    ( assert, monadicIO, monitor, run )
+
+spec :: Spec
+spec = do
+    let sp = SlotParameters
+            { getEpochLength = EpochLength 21600
+            , getSlotLength  = SlotLength 10
+            , getGenesisBlockDate = StartTime (read "2019-11-09 16:43:02 UTC")
+            , getActiveSlotCoefficient = 1
+            }
+    let st = SyncTolerance 10
+    describe "syncProgress" $ do
+        it "works for any two slots" $ property $ \sl0 sl1 ->
+            syncProgress st sp sl0 sl1 `deepseq` ()
+
+        let mockBlockHeader sl h = BlockHeader
+                { slotId = sl
+                , blockHeight = Quantity h
+                , headerHash = Hash "-"
+                , parentHeaderHash = Hash "-"
+                }
+
+        let mockSlotParams f = SlotParameters
+                { getEpochLength = EpochLength 10
+                , getSlotLength = SlotLength 10
+                , getGenesisBlockDate = StartTime $
+                    read "2019-01-01 00:00:00 UTC"
+                , getActiveSlotCoefficient = f
+                }
+
+        let syncTolerance = SyncTolerance 0
+
+        it "unit test #1 - 0/10   0%" $ do
+            let slotParams = mockSlotParams 1
+            let nodeTip = mockBlockHeader (SlotId 0 0) 0
+            let ntwkTip = SlotId 1 0
+            syncProgress syncTolerance slotParams nodeTip ntwkTip
+                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0)
+
+        it "unit test #2 - 10/20 50%" $ do
+            let slotParams = mockSlotParams 1
+            let nodeTip = mockBlockHeader (SlotId 1 0) 10
+            let ntwkTip = SlotId 2 0
+            syncProgress syncTolerance slotParams nodeTip ntwkTip
+                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.5)
+
+        it "unit test #3 - 12/15 80% " $ do
+            let slotParams = mockSlotParams 0.5
+            let nodeTip = mockBlockHeader (SlotId 2 2) 12
+            let ntwkTip = SlotId 2 8
+            syncProgress syncTolerance slotParams nodeTip ntwkTip
+                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.8)
+
+        it "unit test #4 - 10/10 100%" $ do
+            let slotParams = mockSlotParams 1
+            let nodeTip = mockBlockHeader (SlotId 1 0) 10
+            let ntwkTip = SlotId 1 0
+            syncProgress syncTolerance slotParams nodeTip ntwkTip
+                `shouldBe` Ready
+
+        it "unit test #5 - 11/10 100%" $ do
+            let slotParams = mockSlotParams 1
+            let nodeTip = mockBlockHeader (SlotId 1 1) 11
+            let ntwkTip = SlotId 1 0
+            syncProgress syncTolerance slotParams nodeTip ntwkTip
+                `shouldBe` Ready
+
+        --   100 |                          +  +
+        --       |
+        --       |                       +
+        --       |                    +
+        --       |              +  +
+        --       |
+        --       |           +
+        --       |     +  +
+        --       |  +
+        --       |
+        --       |--|--|--|--|--|--|--|--|--|--|
+        --       0  1  2  3  4  5  6  7  8  9  10
+        --
+        it "unit test #5 - distribution over several slots" $ do
+            let slotParams = mockSlotParams 0.5
+            let ntwkTip = SlotId 1 0
+            let plots =
+                    [ (mockBlockHeader (SlotId 0 0) 0, 0.0)
+                    , (mockBlockHeader (SlotId 0 1) 1, 0.2)
+                    , (mockBlockHeader (SlotId 0 2) 2, 1 % 3)
+                    , (mockBlockHeader (SlotId 0 3) 2, 1 % 3)
+                    , (mockBlockHeader (SlotId 0 4) 2, 0.40)
+                    , (mockBlockHeader (SlotId 0 5) 3, 0.60)
+                    , (mockBlockHeader (SlotId 0 6) 3, 0.60)
+                    , (mockBlockHeader (SlotId 0 7) 4, 2 % 3)
+                    , (mockBlockHeader (SlotId 0 8) 5, 5 % 6)
+                    , (mockBlockHeader (SlotId 0 9) 5, 1.00)
+                    , (mockBlockHeader (SlotId 1 0) 5, 1.00)
+                    ]
+            forM_ plots $ \(nodeTip, p) -> do
+                let progress = if p == 1
+                        then Ready
+                        else Syncing (Quantity $ unsafeMkPercentage p)
+                syncProgress syncTolerance slotParams nodeTip ntwkTip
+                    `shouldBe` progress
+
+        it "unit test #6 - block height 0" $ do
+            let slotParams = mockSlotParams 0.5
+            let ntwkTip = SlotId 1 0
+            let plots =
+                    [ (mockBlockHeader (SlotId 0 8) 0, 0)
+                    , (mockBlockHeader (SlotId 0 9) 0, 0)
+                    , (mockBlockHeader (SlotId 1 0) 0, 1)
+                    ]
+            forM_ plots $ \(nodeTip, p) -> do
+                let progress = if p == 1
+                        then Ready
+                        else Syncing (Quantity $ unsafeMkPercentage p)
+                syncProgress syncTolerance slotParams nodeTip ntwkTip
+                    `shouldBe` progress
+
+        it "syncProgress should never crash" $ withMaxSuccess 10000
+            $ property $ \f bh -> do
+                let slotParams = mockSlotParams f
+                let el = getEpochLength slotParams
+                let genSlotIdPair = (,) <$> (genSlotId el) <*> (genSlotId el)
+                forAll genSlotIdPair $ \(walSlot, netSlot) -> monadicIO $ do
+                    let nodeTip = mockBlockHeader walSlot bh
+                    let x = syncProgress syncTolerance slotParams nodeTip netSlot
+                    when (netSlot > walSlot) $ do
+                        res <- run (try @SomeException $ evaluate x)
+                        monitor (counterexample $ "Result: " ++ show res)
+                        assert (isRight res)
+
+
+instance Arbitrary BlockHeader where
+    shrink _ = []
+    arbitrary = arbitrary >>= genBlockHeader
+
+instance Arbitrary SlotId where
+    shrink _ = []
+    arbitrary = do
+        ep <- choose (0, 10)
+        sl <- choose (0, 100)
+        return (SlotId (unsafeEpochNo ep) (SlotNo sl))
+
+instance Arbitrary ActiveSlotCoefficient where
+    shrink = shrinkActiveSlotCoefficient
+    arbitrary = genActiveSlotCoefficient

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -17,12 +17,14 @@ import Prelude
 
 import Cardano.Address.Derivation
     ( XPrv )
+import Cardano.Wallet.Gen
+    ( genActiveSlotCoefficient, genBlockHeader, shrinkActiveSlotCoefficient )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), WalletKey (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncProgress (..), SyncTolerance (..), mkSyncTolerance, syncProgress )
+    ( SyncTolerance (..), mkSyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -97,13 +99,11 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Cardano.Wallet.Unsafe
-    ( someDummyMnemonic, unsafeFromHex, unsafeMkPercentage )
-import Control.DeepSeq
-    ( deepseq )
+    ( someDummyMnemonic, unsafeFromHex )
 import Control.Exception
-    ( SomeException, evaluate, try )
+    ( evaluate )
 import Control.Monad
-    ( forM_, replicateM, when )
+    ( forM_, replicateM )
 import Crypto.Hash
     ( hash )
 import Data.Either
@@ -118,8 +118,6 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( (%) )
 import Data.Set
     ( Set, (\\) )
 import Data.Text
@@ -148,7 +146,6 @@ import Test.Hspec
     )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Gen
     , NonNegative (..)
     , NonZero (..)
     , Property
@@ -164,7 +161,6 @@ import Test.QuickCheck
     , counterexample
     , cover
     , elements
-    , forAll
     , infiniteList
     , oneof
     , property
@@ -180,7 +176,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Monadic
-    ( assert, monadicIO, monitor, run )
+    ( monadicIO, run )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 import Test.Utils.Time
@@ -280,135 +276,14 @@ spec = do
                 , " ... 45000000000000000 0\n"
                 ]
 
+
     let sp = SlotParameters
             { getEpochLength = EpochLength 21600
             , getSlotLength  = SlotLength 10
             , getGenesisBlockDate = StartTime (read "2019-11-09 16:43:02 UTC")
             , getActiveSlotCoefficient = 1
             }
-    let st = SyncTolerance 10
     let slotsPerEpoch = getEpochLength sp
-
-    describe "syncProgress" $ do
-        it "works for any two slots" $ property $ \sl0 sl1 ->
-            syncProgress st sp sl0 sl1 `deepseq` ()
-
-        let mockBlockHeader sl h = BlockHeader
-                { slotId = sl
-                , blockHeight = Quantity h
-                , headerHash = Hash "-"
-                , parentHeaderHash = Hash "-"
-                }
-
-        let mockSlotParams f = SlotParameters
-                { getEpochLength = EpochLength 10
-                , getSlotLength = SlotLength 10
-                , getGenesisBlockDate = StartTime $
-                    read "2019-01-01 00:00:00 UTC"
-                , getActiveSlotCoefficient = f
-                }
-
-        let syncTolerance = SyncTolerance 0
-
-        it "unit test #1 - 0/10   0%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 0 0) 0
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0)
-
-        it "unit test #2 - 10/20 50%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 0) 10
-            let ntwkTip = SlotId 2 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.5)
-
-        it "unit test #3 - 12/15 80% " $ do
-            let slotParams = mockSlotParams 0.5
-            let nodeTip = mockBlockHeader (SlotId 2 2) 12
-            let ntwkTip = SlotId 2 8
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.8)
-
-        it "unit test #4 - 10/10 100%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 0) 10
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Ready
-
-        it "unit test #5 - 11/10 100%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 1) 11
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Ready
-
-        --   100 |                          +  +
-        --       |
-        --       |                       +
-        --       |                    +
-        --       |              +  +
-        --       |
-        --       |           +
-        --       |     +  +
-        --       |  +
-        --       |
-        --       |--|--|--|--|--|--|--|--|--|--|
-        --       0  1  2  3  4  5  6  7  8  9  10
-        --
-        it "unit test #5 - distribution over several slots" $ do
-            let slotParams = mockSlotParams 0.5
-            let ntwkTip = SlotId 1 0
-            let plots =
-                    [ (mockBlockHeader (SlotId 0 0) 0, 0.0)
-                    , (mockBlockHeader (SlotId 0 1) 1, 0.2)
-                    , (mockBlockHeader (SlotId 0 2) 2, 1 % 3)
-                    , (mockBlockHeader (SlotId 0 3) 2, 1 % 3)
-                    , (mockBlockHeader (SlotId 0 4) 2, 0.40)
-                    , (mockBlockHeader (SlotId 0 5) 3, 0.60)
-                    , (mockBlockHeader (SlotId 0 6) 3, 0.60)
-                    , (mockBlockHeader (SlotId 0 7) 4, 2 % 3)
-                    , (mockBlockHeader (SlotId 0 8) 5, 5 % 6)
-                    , (mockBlockHeader (SlotId 0 9) 5, 1.00)
-                    , (mockBlockHeader (SlotId 1 0) 5, 1.00)
-                    ]
-            forM_ plots $ \(nodeTip, p) -> do
-                let progress = if p == 1
-                        then Ready
-                        else Syncing (Quantity $ unsafeMkPercentage p)
-                syncProgress syncTolerance slotParams nodeTip ntwkTip
-                    `shouldBe` progress
-
-        it "unit test #6 - block height 0" $ do
-            let slotParams = mockSlotParams 0.5
-            let ntwkTip = SlotId 1 0
-            let plots =
-                    [ (mockBlockHeader (SlotId 0 8) 0, 0)
-                    , (mockBlockHeader (SlotId 0 9) 0, 0)
-                    , (mockBlockHeader (SlotId 1 0) 0, 1)
-                    ]
-            forM_ plots $ \(nodeTip, p) -> do
-                let progress = if p == 1
-                        then Ready
-                        else Syncing (Quantity $ unsafeMkPercentage p)
-                syncProgress syncTolerance slotParams nodeTip ntwkTip
-                    `shouldBe` progress
-
-        it "syncProgress should never crash" $ withMaxSuccess 10000
-            $ property $ \f bh -> do
-                let slotParams = mockSlotParams f
-                let el = getEpochLength slotParams
-                let genSlotIdPair = (,) <$> (genSlotId el) <*> (genSlotId el)
-                forAll genSlotIdPair $ \(walSlot, netSlot) -> monadicIO $ do
-                    let nodeTip = mockBlockHeader walSlot bh
-                    let x = syncProgress syncTolerance slotParams nodeTip netSlot
-                    when (netSlot > walSlot) $ do
-                        res <- run (try @SomeException $ evaluate x)
-                        monitor (counterexample $ "Result: " ++ show res)
-                        assert (isRight res)
-
     describe "flatSlot" $ do
 
         it "fromFlatSlot . flatSlot == id" $ property $ \sl ->
@@ -1322,19 +1197,8 @@ instance Arbitrary Tx where
           ]
 
 instance Arbitrary BlockHeader where
-    -- No Shrinking
-    arbitrary = do
-        sl <- arbitrary
-        BlockHeader sl (mockBlockHeight sl) <$> genHash <*> genHash
-      where
-        mockBlockHeight :: SlotId -> Quantity "block" Word32
-        mockBlockHeight = Quantity . fromIntegral . flatSlot (EpochLength 200)
-
-        genHash = elements
-            [ Hash "BLOCK01"
-            , Hash "BLOCK02"
-            , Hash "BLOCK03"
-            ]
+    shrink _ = []
+    arbitrary = arbitrary >>= genBlockHeader
 
 instance Arbitrary EpochNo where
     arbitrary = EpochNo <$> oneof
@@ -1350,14 +1214,6 @@ instance Arbitrary EpochNo where
         closeToMinBound =                getSmall <$> arbitrary
         closeToMaxBound = (maxBound -) . getSmall <$> arbitrary
     shrink = genericShrink
-
-
-genSlotId :: EpochLength -> Gen SlotId
-genSlotId (EpochLength el) | el > 0 = do
-    ep <- choose (0, 10)
-    sl <- choose (0, el - 1)
-    return (SlotId (unsafeEpochNo ep) (SlotNo sl))
-genSlotId _ = error "genSlotId: epochLength must > 0"
 
 instance Arbitrary SlotId where
     shrink _ = []
@@ -1405,11 +1261,8 @@ instance Arbitrary EpochLength where
     arbitrary = EpochLength . getNonZero <$> arbitrary
 
 instance Arbitrary ActiveSlotCoefficient where
-    shrink (ActiveSlotCoefficient f)
-        | f < 1 = [1]
-        | otherwise = []
-    arbitrary =
-        ActiveSlotCoefficient <$> choose (0.001, 1.0)
+    shrink = shrinkActiveSlotCoefficient
+    arbitrary = genActiveSlotCoefficient
 
 instance Arbitrary SlotParameters where
     arbitrary = applyArbitrary4 SlotParameters

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -21,6 +21,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), WalletKey (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey (..), generateKeyFromSeed )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..), SyncTolerance (..), mkSyncTolerance, syncProgress )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -45,8 +47,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , SlotParameters (..)
     , StartTime (..)
-    , SyncProgress (..)
-    , SyncTolerance (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
@@ -73,7 +73,6 @@ import Cardano.Wallet.Primitive.Types
     , log10
     , mapRangeLowerBound
     , mapRangeUpperBound
-    , mkSyncTolerance
     , rangeHasLowerBound
     , rangeHasUpperBound
     , rangeIsFinite
@@ -92,7 +91,6 @@ import Cardano.Wallet.Primitive.Types
     , slotRangeFromTimeRange
     , slotStartTime
     , slotSucc
-    , syncProgress
     , unsafeEpochNo
     , walletNameMaxLength
     , walletNameMinLength

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -64,6 +64,8 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection, feeBalance )
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (BlockHeader)
@@ -79,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
-    , SyncTolerance (..)
     , TransactionInfo (txInfoMeta)
     , TransactionInfo (..)
     , Tx (..)

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -98,8 +98,10 @@ import Cardano.Wallet.Logging
     ( trMessage, transformTextTrace )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), NetworkParameters, SyncTolerance )
+    ( Hash (..), NetworkParameters )
 import Cardano.Wallet.Version
     ( GitRevision, Version, gitRevision, showFullVersion, version )
 import Control.Applicative

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -119,6 +119,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , Block
@@ -127,7 +129,6 @@ import Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
-    , SyncTolerance
     , WalletId
     )
 import Cardano.Wallet.Registry

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -59,12 +59,10 @@ import Cardano.Wallet.Network.Ports
     ( unsafePortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( NetworkParameters (..)
-    , ProtocolParameters (..)
-    , SyncTolerance (..)
-    , TxParameters (..)
-    )
+    ( NetworkParameters (..), ProtocolParameters (..), TxParameters (..) )
 import Control.Concurrent.Async
     ( race_ )
 import Control.Concurrent.MVar

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -52,12 +52,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey )
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( NetworkParameters (..)
-    , ProtocolParameters (..)
-    , SyncTolerance (..)
-    , TxParameters (..)
-    )
+    ( NetworkParameters (..), ProtocolParameters (..), TxParameters (..) )
 import Control.Concurrent.Async
     ( race )
 import Control.Concurrent.MVar

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -41,11 +41,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( GenChange (..), IsOwned (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, mkSeqStateFromRootXPrv )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( Coin (..)
     , Direction (..)
     , SealedTx (..)
-    , SyncProgress (..)
     , Tx (..)
     , TxIn (..)
     , TxOut (..)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Launcher.hs
@@ -22,7 +22,7 @@ import Cardano.Wallet.Api.Types
     ( ApiWallet )
 import Cardano.Wallet.Network.Ports
     ( findPort )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Exception
     ( finally )

--- a/lib/shelley/exe/cardano-wallet-shelley.hs
+++ b/lib/shelley/exe/cardano-wallet-shelley.hs
@@ -76,7 +76,7 @@ import Cardano.Wallet.Api.Types
     ( ApiStakePool )
 import Cardano.Wallet.Logging
     ( trMessage, transformTextTrace )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Shelley
     ( TracerSeverities

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -91,6 +91,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , Block
@@ -98,7 +100,6 @@ import Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
-    , SyncTolerance
     , WalletId
     )
 import Cardano.Wallet.Registry

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -39,6 +39,8 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..) )
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
@@ -46,7 +48,6 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
-    , SyncTolerance (..)
     , TxIn (..)
     , TxOut (..)
     , TxParameters (..)


### PR DESCRIPTION
# Issue Number

#1869 

# Overview

- [x] Make the sync progress logic easier to grasp by moving it to its own module
- [x] Add a note about the calculation going to break in era-transitions


# Comments

- I believe we may have to have to provide _several_ methods of calculating the sync-progress. Maybe we need a different one for jormungandr. I think a new module is neat regardless.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
