### PR TITLE
Move slotting to separate module

### DIFF
--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -96,6 +96,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState, mkRndState )
 import Cardano.Wallet.Primitive.Model
     ( currentTip, totalUTxO )
+import Cardano.Wallet.Primitive.Slotting
+    ( slotAt, slotParams )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), mkSyncTolerance, syncProgressRelativeToTime )
 import Cardano.Wallet.Primitive.Types
@@ -111,8 +113,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , computeUtxoStatistics
     , log10
-    , slotAt
-    , slotParams
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkMnemonic, unsafeRunExceptT )

--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -96,6 +96,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( decodeLegacyAddress )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, fromFlatSlot )
 import Cardano.Wallet.Unsafe
     ( unsafeDeserialiseCbor, unsafeFromHex )
 import Data.ByteString
@@ -306,7 +308,7 @@ toPoint genesisH epLength (W.BlockHeader sid _ h _)
 
 toSlotInEpoch :: W.EpochLength -> W.SlotId -> SlotNo
 toSlotInEpoch epLength =
-    SlotNo . W.flatSlot epLength
+    SlotNo . flatSlot epLength
 
 -- | SealedTx are the result of rightfully constructed byron transactions so, it
 -- is relatively safe to unserialize them from CBOR.
@@ -388,7 +390,7 @@ fromChainHash genesisHash = \case
 
 fromSlotNo :: W.EpochLength -> SlotNo -> W.SlotId
 fromSlotNo epLength (SlotNo sl) =
-    W.fromFlatSlot epLength sl
+    fromFlatSlot epLength sl
 
 -- FIXME unsafe conversion (Word64 -> Word32)
 fromBlockNo :: BlockNo -> Quantity "block" Word32

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/CompatibilitySpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/CompatibilitySpec.hs
@@ -50,8 +50,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( generateKeyFromHardwareLedger )
+import Cardano.Wallet.Primitive.Slotting
+    ( fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
-    ( EpochLength (..), Hash (..), SealedTx (..), SlotId (..), fromFlatSlot )
+    ( EpochLength (..), Hash (..), SealedTx (..), SlotId (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkSomeMnemonicFromEntropy )
 import Control.Monad

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -151,7 +151,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddress
     , ApiByronWallet
     , ApiCoinSelection
-    , ApiEpochInfo (..)
+    , ApiEpochInfo (ApiEpochInfo)
     , ApiFee
     , ApiNetworkInformation
     , ApiNetworkParameters (..)
@@ -190,6 +190,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), epochStartTime )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
@@ -202,7 +204,6 @@ import Cardano.Wallet.Primitive.Types
     , HistogramBar (..)
     , PoolId (..)
     , SlotLength (..)
-    , SlotParameters (..)
     , SortOrder (..)
     , TxIn (..)
     , TxOut (..)
@@ -1715,10 +1716,10 @@ mkEpochInfo
     -> SlotParameters
     -- ^ Blockchain slot parameters
     -> ApiEpochInfo
-mkEpochInfo epochNo sp = ApiEpochInfo
-    { epochNumber = ApiT epochNo
-    , epochStartTime = W.epochStartTime sp epochNo
-    }
+mkEpochInfo epochNo sp =
+    ApiEpochInfo
+        (ApiT epochNo)
+        (epochStartTime sp epochNo)
 
 -- | Wallet not delegating and not about to join any stake pool.
 notDelegating

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -140,6 +140,7 @@ library
       Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
       Cardano.Wallet.Primitive.AddressDerivation.Shelley
       Cardano.Wallet.Primitive.AddressDiscovery
+      Cardano.Wallet.Primitive.Slotting
       Cardano.Wallet.Primitive.AddressDiscovery.Random
       Cardano.Wallet.Primitive.AddressDiscovery.Sequential
       Cardano.Wallet.Primitive.CoinSelection
@@ -191,6 +192,7 @@ test-suite unit
     , cardano-wallet-core
     , cardano-wallet-launcher
     , cardano-wallet-test-utils
+    , cardano-slotting
     , cborg
     , connection
     , containers

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -289,6 +289,7 @@ test-suite unit
       Cardano.Wallet.Primitive.CoinSelectionSpec
       Cardano.Wallet.Primitive.FeeSpec
       Cardano.Wallet.Primitive.ModelSpec
+      Cardano.Wallet.Primitive.SlottingSpec
       Cardano.Wallet.Primitive.SyncProgressSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.RegistrySpec

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -253,6 +253,8 @@ import Cardano.Wallet.Primitive.Model
     , initWallet
     , updateState
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), slotParams, slotRangeFromTimeRange, slotStartTime )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress, SyncTolerance (..), syncProgressRelativeToTime )
 import Cardano.Wallet.Primitive.Types
@@ -275,7 +277,6 @@ import Cardano.Wallet.Primitive.Types
     , Range (..)
     , SealedTx
     , SlotId (..)
-    , SlotParameters (..)
     , SortOrder (..)
     , TransactionInfo (..)
     , Tx
@@ -295,9 +296,6 @@ import Cardano.Wallet.Primitive.Types
     , dlgCertPoolId
     , fromTransactionInfo
     , log10
-    , slotParams
-    , slotRangeFromTimeRange
-    , slotStartTime
     , wholeRange
     )
 import Cardano.Wallet.Transaction

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -265,8 +265,6 @@ import Cardano.Wallet.Primitive.Types
     , UnsignedTx (..)
     , WalletId (..)
     , WalletMetadata (..)
-    , slotAt
-    , slotMinBound
     )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
@@ -385,6 +383,7 @@ import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Network as NW
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
+import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Data.Aeson as Aeson
@@ -1418,7 +1417,7 @@ getNetworkInformation
 getNetworkInformation (_block0, np, st) nl = do
     now <- liftIO getCurrentTime
     nodeTip <- liftHandler (NW.currentNodeTip nl)
-    let ntrkTip = fromMaybe slotMinBound (slotAt sp now)
+    let ntrkTip = fromMaybe W.slotMinBound (W.slotAt sp now)
     let nextEpochNo = unsafeEpochSucc (ntrkTip ^. #epochNumber)
     pure $ ApiNetworkInformation
         { syncProgress =

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -67,6 +67,8 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Model
     ( Wallet, blockchainParameters, currentTip, utxo )
+import Cardano.Wallet.Primitive.Slotting
+    ( slotParams, slotStartTime )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (blockHeight, slotId)
     , Coin (..)
@@ -91,8 +93,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , dlgCertPoolId
     , isWithinRange
-    , slotParams
-    , slotStartTime
     )
 import Control.Monad
     ( when )

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -101,6 +101,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , SoftDerivation (..)
     , WalletKey (..)
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters, slotParams, slotStartTime )
 import Control.Concurrent.MVar
     ( modifyMVar, modifyMVar_, newMVar, readMVar )
 import Control.Exception
@@ -1038,7 +1040,7 @@ mkTxMetaEntity wid txid meta = TxMeta
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already be sorted by index
 txHistoryFromEntity
-    :: W.SlotParameters
+    :: SlotParameters
     -> W.BlockHeader
     -> [TxMeta]
     -> [(TxIn, Maybe TxOut)]
@@ -1063,7 +1065,7 @@ txHistoryFromEntity sp tip metas ins outs ws =
         , W.txInfoDepth =
             Quantity $ fromIntegral $ if tipH > txH then tipH - txH else 0
         , W.txInfoTime =
-            W.slotStartTime sp (meta ^. #slotId)
+            slotStartTime sp (meta ^. #slotId)
         }
       where
         txH  = getQuantity (meta ^. #blockHeight)
@@ -1330,7 +1332,7 @@ selectTxHistory wid minWithdrawal order conditions = do
 
             let wal = checkpointFromEntity cp [] ()
             let tip = W.currentTip wal
-            let slp = W.slotParams $ W.blockchainParameters wal
+            let slp = slotParams $ W.blockchainParameters wal
 
             return $ txHistoryFromEntity slp tip metas ins outs ws
   where

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -24,6 +24,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..), Passphrase (..), PassphraseScheme (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), getAddressPoolGap, mkAddressPoolGap )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , ChimericAccount (..)
@@ -43,8 +45,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolTicker
     , TxStatus (..)
     , WalletId (..)
-    , flatSlot
-    , fromFlatSlot
     , isValidCoin
     , unsafeEpochNo
     )

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Contains tools for converting between @SlotNo@, @EpochNo@, @SlotInEpoch@,
+-- @UTCTime@.
+
+module Cardano.Wallet.Primitive.Slotting
+    ( -- * Legacy functions
+      unsafeEpochNo
+    , epochStartTime
+    , epochPred
+    , epochSucc
+    , SlotParameters (..)
+    , slotParams
+    , flatSlot
+    , fromFlatSlot
+    , slotStartTime
+    , slotCeiling
+    , slotFloor
+    , slotAt
+    , slotDifference
+    , slotPred
+    , slotSucc
+    , slotMinBound
+    , slotRangeFromTimeRange
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient (..)
+    , EpochLength (..)
+    , EpochNo (..)
+    , GenesisParameters (..)
+    , Range (..)
+    , SlotId (..)
+    , SlotInEpoch (..)
+    , SlotLength (..)
+    , StartTime (..)
+    , unsafeEpochNo
+    )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Time.Clock
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+import Data.Word
+    ( Word64 )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+import Ouroboros.Consensus.HardFork.History.EraParams
+    ( EraParams (..), noLowerBoundSafeZone )
+import Ouroboros.Consensus.HardFork.History.Qry
+import Ouroboros.Consensus.HardFork.History.Summary
+    ( Summary (..), neverForksSummary )
+
+import qualified Cardano.Slotting.Slot as Cardano
+import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as Cardano
+
+-- -----------------------------------------------------------------------------
+-- Legacy functions
+-- These only work for a single era. We need to stop using them.
+
+-- | The essential parameters necessary for performing slot arithmetic.
+data SlotParameters = SlotParameters
+    { getEpochLength
+        :: EpochLength
+    , getSlotLength
+        :: SlotLength
+    , getGenesisBlockDate
+        :: StartTime
+    , getActiveSlotCoefficient
+        :: ActiveSlotCoefficient
+    } deriving (Eq, Generic, Show)
+
+slotParams :: GenesisParameters -> SlotParameters
+slotParams gp = SlotParameters
+    (gp ^. #getEpochLength)
+    (gp ^. #getSlotLength)
+    (gp ^. #getGenesisBlockDate)
+    (gp ^. #getActiveSlotCoefficient)
+
+-- | Calculate the time at which an epoch begins.
+epochStartTime :: SlotParameters -> EpochNo -> UTCTime
+epochStartTime sps e = slotStartTime sps $ SlotId e 0
+
+-- | Return the epoch immediately before the given epoch, or 'Nothing' if there
+--   is no representable epoch before the given epoch.
+epochPred :: EpochNo -> Maybe EpochNo
+epochPred (EpochNo e)
+    | e == minBound = Nothing
+    | otherwise = Just $ EpochNo $ pred e
+
+-- | Return the epoch immediately after the given epoch, or 'Nothing' if there
+--   is no representable epoch after the given epoch.
+epochSucc :: EpochNo -> Maybe EpochNo
+epochSucc (EpochNo e)
+    | e == maxBound = Nothing
+    | otherwise = Just $ EpochNo $ succ e
+
+-- | Convert a 'SlotId' to the number of slots since genesis.
+flatSlot :: EpochLength -> SlotId -> Word64
+flatSlot (EpochLength epochLength) (SlotId (EpochNo e) (SlotInEpoch s)) =
+    fromIntegral epochLength * fromIntegral e + fromIntegral s
+
+-- | Convert a 'flatSlot' index to 'SlotId'.
+--
+-- This function will fail if applied to a value that is higher than the maximum
+-- value of 'flatSlot' for the specified 'EpochLength'.
+--
+fromFlatSlot :: EpochLength -> Word64 -> SlotId
+fromFlatSlot el@(EpochLength epochLength) n
+    | n <= maxFlatSlot =
+        SlotId (EpochNo $ fromIntegral e) (fromIntegral s)
+    | otherwise =
+        error $ mconcat
+            [ "fromFlatSlot: The specified flat slot number ("
+            , show n
+            , ") is higher than the maximum flat slot number ("
+            , show maxFlatSlot
+            , ") for the specified epoch length ("
+            , show epochLength
+            , ")."
+            ]
+  where
+    e = n `div` fromIntegral epochLength
+    s = n `mod` fromIntegral epochLength
+    maxFlatSlot =
+        flatSlot el (SlotId (EpochNo maxBound) (SlotInEpoch $ epochLength - 1))
+
+-- | @slotDifference a b@ is how many slots @a@ is after @b@. The result is
+-- non-negative, and if @b > a@ then this function returns zero.
+slotDifference :: SlotParameters -> SlotId -> SlotId -> Quantity "slot" Natural
+slotDifference (SlotParameters el _ _ _) a b
+    | a' > b' = Quantity $ fromIntegral $ a' - b'
+    | otherwise = Quantity 0
+  where
+    a' = flatSlot el a
+    b' = flatSlot el b
+
+-- | Return the slot immediately before the given slot.
+slotPred :: SlotParameters -> SlotId -> Maybe SlotId
+slotPred (SlotParameters (EpochLength el) _ _ _) (SlotId en sn)
+    | en == 0 && sn == 0 = Nothing
+    | sn > 0 = Just $ SlotId en (sn - 1)
+    | otherwise = Just $ SlotId (en - 1) (SlotInEpoch $ el - 1)
+
+-- | Return the slot immediately after the given slot.
+slotSucc :: SlotParameters -> SlotId -> SlotId
+slotSucc (SlotParameters (EpochLength el) _ _ _) (SlotId en (SlotInEpoch sn))
+    | sn < el - 1 = SlotId en (SlotInEpoch $ sn + 1)
+    | otherwise = SlotId (en + 1) 0
+
+-- | The time when a slot begins.
+slotStartTime :: SlotParameters -> SlotId -> UTCTime
+slotStartTime (SlotParameters el (SlotLength sl) (StartTime st) _) slot =
+    addUTCTime offset st
+  where
+    offset = sl * fromIntegral (flatSlot el slot)
+
+-- | For the given time 't', determine the ID of the earliest slot with start
+--   time 's' such that 't ≤ s'.
+slotCeiling :: SlotParameters -> UTCTime -> SlotId
+slotCeiling sp@(SlotParameters _ (SlotLength sl) _ _) t =
+    fromMaybe slotMinBound $ slotAt sp (addUTCTime (pred sl) t)
+
+-- | For the given time 't', determine the ID of the latest slot with start
+--   time 's' such that 's ≤ t'.
+slotFloor :: SlotParameters -> UTCTime -> Maybe SlotId
+slotFloor = slotAt
+
+-- | Returns the earliest slot.
+slotMinBound :: SlotId
+slotMinBound = SlotId 0 0
+
+-- | For the given time 't', determine the ID of the unique slot with start
+--   time 's' and end time 'e' such that 's ≤ t ≤ e'.
+slotAt :: SlotParameters -> UTCTime -> Maybe SlotId
+slotAt (SlotParameters (EpochLength el) (SlotLength sl) (StartTime st) _) t
+    | t < st = Nothing
+    | otherwise = Just $ SlotId {epochNumber, slotNumber}
+  where
+    diff :: NominalDiffTime
+    diff = t `diffUTCTime` st
+
+    epochLength :: NominalDiffTime
+    epochLength = fromIntegral el * sl
+
+    epochNumber = EpochNo $
+        floor (diff / epochLength)
+
+    slotNumber = SlotInEpoch $
+        floor ((diff - fromIntegral (unEpochNo epochNumber) * epochLength) / sl)
+
+-- | Transforms the given inclusive time range into an inclusive slot range.
+--
+-- This function returns a slot range if (and only if) the specified time range
+-- intersects with the life of the blockchain.
+--
+-- If, on the other hand, the specified time range terminates before the start
+-- of the blockchain, this function returns 'Nothing'.
+--
+slotRangeFromTimeRange
+    :: SlotParameters -> Range UTCTime -> Maybe (Range SlotId)
+slotRangeFromTimeRange sps (Range mStart mEnd) =
+    Range slotStart <$> slotEnd
+  where
+    slotStart =
+        slotCeiling sps <$> mStart
+    slotEnd =
+        maybe (Just Nothing) (fmap Just . slotFloor sps) mEnd

--- a/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
@@ -19,15 +19,14 @@ module Cardano.Wallet.Primitive.SyncProgress
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), flatSlot, slotAt )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , SlotId (..)
     , SlotLength (..)
-    , SlotParameters (..)
     , distance
-    , flatSlot
-    , slotAt
     )
 import Control.DeepSeq
     ( NFData (..) )

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -98,30 +98,12 @@ module Cardano.Wallet.Primitive.Types
     , DecentralizationLevel (..)
     , EpochLength (..)
     , EpochNo (..)
+    , unsafeEpochNo
     , FeePolicy (..)
     , SlotId (..)
     , SlotLength (..)
     , SlotInEpoch (..)
     , StartTime (..)
-    , slotParams
-
-    -- * Slotting
-    , unsafeEpochNo
-    , epochStartTime
-    , epochPred
-    , epochSucc
-    , SlotParameters (..)
-    , flatSlot
-    , fromFlatSlot
-    , slotStartTime
-    , slotCeiling
-    , slotFloor
-    , slotAt
-    , slotDifference
-    , slotMinBound
-    , slotPred
-    , slotSucc
-    , slotRangeFromTimeRange
 
     -- * Wallet Metadata
     , WalletMetadata(..)
@@ -220,7 +202,7 @@ import Data.List.NonEmpty
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust )
+    ( isJust )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -240,7 +222,7 @@ import Data.Text.Class
     , toTextFromBoundedEnum
     )
 import Data.Time.Clock
-    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+    ( NominalDiffTime, UTCTime )
 import Data.Time.Format
     ( defaultTimeLocale, formatTime )
 import Data.Word
@@ -1388,13 +1370,6 @@ newtype ActiveSlotCoefficient
 
 instance NFData ActiveSlotCoefficient
 
-slotParams :: GenesisParameters -> SlotParameters
-slotParams gp =
-    SlotParameters
-        (gp ^. #getEpochLength)
-        (gp ^. #getSlotLength)
-        (gp ^. #getGenesisBlockDate)
-        (gp ^. #getActiveSlotCoefficient)
 
 -- | Protocol parameters that can be changed through the update system.
 --
@@ -1515,23 +1490,6 @@ unsafeEpochNo epochNo
     maxEpochNo :: Word32
     maxEpochNo = fromIntegral @Word31 $ unEpochNo maxBound
 
--- | Calculate the time at which an epoch begins.
-epochStartTime :: SlotParameters -> EpochNo -> UTCTime
-epochStartTime sps e = slotStartTime sps $ SlotId e 0
-
--- | Return the epoch immediately before the given epoch, or 'Nothing' if there
---   is no representable epoch before the given epoch.
-epochPred :: EpochNo -> Maybe EpochNo
-epochPred (EpochNo e)
-    | e == minBound = Nothing
-    | otherwise = Just $ EpochNo $ pred e
-
--- | Return the epoch immediately after the given epoch, or 'Nothing' if there
---   is no representable epoch after the given epoch.
-epochSucc :: EpochNo -> Maybe EpochNo
-epochSucc (EpochNo e)
-    | e == maxBound = Nothing
-    | otherwise = Just $ EpochNo $ succ e
 
 instance NFData SlotId
 
@@ -1539,129 +1497,6 @@ instance Buildable SlotId where
     build (SlotId (EpochNo e) (SlotInEpoch s)) =
         fromString (show e) <> "." <> fromString (show s)
 
--- | The essential parameters necessary for performing slot arithmetic.
-data SlotParameters = SlotParameters
-    { getEpochLength
-        :: EpochLength
-    , getSlotLength
-        :: SlotLength
-    , getGenesisBlockDate
-        :: StartTime
-    , getActiveSlotCoefficient
-        :: ActiveSlotCoefficient
-    } deriving (Eq, Generic, Show)
-
--- | Convert a 'SlotId' to the number of slots since genesis.
-flatSlot :: EpochLength -> SlotId -> Word64
-flatSlot (EpochLength epochLength) (SlotId (EpochNo e) (SlotInEpoch s)) =
-    fromIntegral epochLength * fromIntegral e + fromIntegral s
-
--- | Convert a 'flatSlot' index to 'SlotId'.
---
--- This function will fail if applied to a value that is higher than the maximum
--- value of 'flatSlot' for the specified 'EpochLength'.
---
-fromFlatSlot :: EpochLength -> Word64 -> SlotId
-fromFlatSlot el@(EpochLength epochLength) n
-    | n <= maxFlatSlot =
-        SlotId (EpochNo $ fromIntegral e) (fromIntegral s)
-    | otherwise =
-        error $ mconcat
-            [ "fromFlatSlot: The specified flat slot number ("
-            , show n
-            , ") is higher than the maximum flat slot number ("
-            , show maxFlatSlot
-            , ") for the specified epoch length ("
-            , show epochLength
-            , ")."
-            ]
-  where
-    e = n `div` fromIntegral epochLength
-    s = n `mod` fromIntegral epochLength
-    maxFlatSlot =
-        flatSlot el (SlotId (EpochNo maxBound) (SlotInEpoch $ epochLength - 1))
-
--- | @slotDifference a b@ is how many slots @a@ is after @b@. The result is
--- non-negative, and if @b > a@ then this function returns zero.
-slotDifference :: SlotParameters -> SlotId -> SlotId -> Quantity "slot" Natural
-slotDifference (SlotParameters el _ _ _) a b
-    | a' > b' = Quantity $ fromIntegral $ a' - b'
-    | otherwise = Quantity 0
-  where
-    a' = flatSlot el a
-    b' = flatSlot el b
-
--- | Return the slot immediately before the given slot.
-slotPred :: SlotParameters -> SlotId -> Maybe SlotId
-slotPred (SlotParameters (EpochLength el) _ _ _) (SlotId en sn)
-    | en == 0 && sn == 0 = Nothing
-    | sn > 0 = Just $ SlotId en (sn - 1)
-    | otherwise = Just $ SlotId (en - 1) (SlotInEpoch $ el - 1)
-
--- | Return the slot immediately after the given slot.
-slotSucc :: SlotParameters -> SlotId -> SlotId
-slotSucc (SlotParameters (EpochLength el) _ _ _) (SlotId en (SlotInEpoch sn))
-    | sn < el - 1 = SlotId en (SlotInEpoch $ sn + 1)
-    | otherwise = SlotId (en + 1) 0
-
--- | The time when a slot begins.
-slotStartTime :: SlotParameters -> SlotId -> UTCTime
-slotStartTime (SlotParameters el (SlotLength sl) (StartTime st) _) slot =
-    addUTCTime offset st
-  where
-    offset = sl * fromIntegral (flatSlot el slot)
-
--- | For the given time 't', determine the ID of the earliest slot with start
---   time 's' such that 't ≤ s'.
-slotCeiling :: SlotParameters -> UTCTime -> SlotId
-slotCeiling sp@(SlotParameters _ (SlotLength sl) _ _) t =
-    fromMaybe slotMinBound $ slotAt sp (addUTCTime (pred sl) t)
-
--- | For the given time 't', determine the ID of the latest slot with start
---   time 's' such that 's ≤ t'.
-slotFloor :: SlotParameters -> UTCTime -> Maybe SlotId
-slotFloor = slotAt
-
--- | Returns the earliest slot.
-slotMinBound :: SlotId
-slotMinBound = SlotId 0 0
-
--- | For the given time 't', determine the ID of the unique slot with start
---   time 's' and end time 'e' such that 's ≤ t ≤ e'.
-slotAt :: SlotParameters -> UTCTime -> Maybe SlotId
-slotAt (SlotParameters (EpochLength el) (SlotLength sl) (StartTime st) _) t
-    | t < st = Nothing
-    | otherwise = Just $ SlotId {epochNumber, slotNumber}
-  where
-    diff :: NominalDiffTime
-    diff = t `diffUTCTime` st
-
-    epochLength :: NominalDiffTime
-    epochLength = fromIntegral el * sl
-
-    epochNumber = EpochNo $
-        floor (diff / epochLength)
-
-    slotNumber = SlotInEpoch $
-        floor ((diff - fromIntegral (unEpochNo epochNumber) * epochLength) / sl)
-
--- | Transforms the given inclusive time range into an inclusive slot range.
---
--- This function returns a slot range if (and only if) the specified time range
--- intersects with the life of the blockchain.
---
--- If, on the other hand, the specified time range terminates before the start
--- of the blockchain, this function returns 'Nothing'.
---
-slotRangeFromTimeRange
-    :: SlotParameters -> Range UTCTime -> Maybe (Range SlotId)
-slotRangeFromTimeRange sps (Range mStart mEnd) =
-    Range slotStart <$> slotEnd
-  where
-    slotStart =
-        slotCeiling sps <$> mStart
-    slotEnd =
-        maybe (Just Nothing) (fmap Just . slotFloor sps) mEnd
 
 -- | Duration of a single slot.
 newtype SlotLength = SlotLength { unSlotLength :: NominalDiffTime }

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -73,6 +73,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet, unsafeInitWallet )
+import Cardano.Wallet.Primitive.Slotting
+    ( fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -97,7 +99,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
-    , fromFlatSlot
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeRunExceptT )

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -17,6 +17,8 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Slotting
+    ( slotMinBound )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
@@ -35,7 +37,6 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxOut (..)
     , TxParameters (..)
-    , slotMinBound
     )
 import Crypto.Hash
     ( Blake2b_256, hash )

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -17,6 +17,8 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyGenesisParameters )
 import Cardano.Wallet.Gen
     ( genPercentage )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), slotSucc, unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , CertificatePublicationTime (..)
@@ -30,13 +32,10 @@ import Cardano.Wallet.Primitive.Types
     , PoolRetirementCertificate (..)
     , SlotId (..)
     , SlotInEpoch (..)
-    , SlotParameters (..)
     , StakePoolMetadata (..)
     , StakePoolMetadataHash (..)
     , StakePoolMetadataUrl (..)
     , StakePoolTicker (..)
-    , slotSucc
-    , unsafeEpochNo
     )
 import Control.Arrow
     ( second )

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -30,6 +30,8 @@ import Cardano.Pool.DB.Arbitrary
     ( StakePoolsFixture (..), genStakePoolMetadata )
 import Cardano.Pool.DB.Sqlite
     ( newDBLayer )
+import Cardano.Wallet.Primitive.Slotting
+    ( slotMinBound )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , CertificatePublicationTime (..)
@@ -40,7 +42,6 @@ import Cardano.Wallet.Primitive.Types
     , PoolRegistrationCertificate (..)
     , PoolRetirementCertificate (..)
     , SlotId (..)
-    , slotMinBound
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -70,6 +70,8 @@ import Cardano.Wallet.Primitive.Model
     , unsafeInitWallet
     , utxo
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), flatSlot, slotSucc, unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
@@ -90,7 +92,6 @@ import Cardano.Wallet.Primitive.Types
     , ShowFmt (..)
     , SlotId (..)
     , SlotInEpoch (..)
-    , SlotParameters (..)
     , SortOrder (..)
     , Tx (..)
     , TxIn (..)
@@ -105,11 +106,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
-    , flatSlot
     , isPending
     , rangeIsValid
-    , slotSucc
-    , unsafeEpochNo
     , wholeRange
     )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -24,6 +24,8 @@ import Cardano.Address.Derivation
     ( xpubFromBytes )
 import Cardano.Mnemonic
     ( ConsistentEntropy, EntropySize, Mnemonic, entropyToMnemonic )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
@@ -33,8 +35,6 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolMagic (..)
     , SlotId (..)
     , SlotInEpoch (..)
-    , flatSlot
-    , unsafeEpochNo
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy, unsafeMkPercentage )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Cardano.Wallet.Primitive.SlottingSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Slotting.Slot
+    ( SlotNo (..) )
+import Cardano.Wallet.Gen
+    ( genActiveSlotCoefficient, shrinkActiveSlotCoefficient )
+import Cardano.Wallet.Primitive.Slotting
+    ( epochOf, fromFlatSlot, runQuery, singleEraInterpreter )
+import Cardano.Wallet.Primitive.Types
+    ( ActiveSlotCoefficient
+    , EpochLength (..)
+    , GenesisParameters (..)
+    , Hash (..)
+    , SlotId (epochNumber)
+    , SlotLength (..)
+    , StartTime (..)
+    )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Word
+    ( Word32 )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..), choose, property, (===) )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
+import Test.Utils.Time
+    ( genUniformTime )
+
+spec :: Spec
+spec = do
+    describe "slotting" $ do
+        it "runQuery epochNo singleEraInterpreter == epochNumber . fromFlatSlot"
+            $ property $ \gp slotNo -> do
+                let run q = runQuery q (singleEraInterpreter gp)
+                let Right res = run (epochOf slotNo)
+                let legacy = epochNumber $ fromFlatSlot
+                        (getEpochLength gp)
+                        (unSlotNo slotNo)
+                res === legacy
+
+instance Arbitrary SlotNo where
+    -- Don't generate /too/ large slots
+    arbitrary = SlotNo . fromIntegral <$> (arbitrary @Word32)
+    shrink (SlotNo x) = map SlotNo $ shrink x
+
+instance Arbitrary GenesisParameters where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary SlotLength where
+    arbitrary = SlotLength . fromRational . toRational <$> choose (0.1,10::Double)
+    shrink _ = []
+
+instance Arbitrary (Hash "Genesis") where
+    arbitrary = return $ Hash "Genesis Hash"
+    shrink _ = []
+
+instance Arbitrary StartTime where
+    arbitrary = StartTime <$> genUniformTime
+    shrink _ = []
+
+instance Arbitrary EpochLength where
+    arbitrary = EpochLength <$> choose (2,100000)
+    shrink _ = []
+
+instance Arbitrary ActiveSlotCoefficient where
+    arbitrary = genActiveSlotCoefficient
+    shrink = shrinkActiveSlotCoefficient
+
+instance Arbitrary (Quantity "block" Word32) where
+    arbitrary = Quantity <$> choose (1,100000)
+    shrink (Quantity x) = map Quantity $ shrink x

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -12,6 +12,8 @@ import Cardano.Wallet.Gen
     , genSlotId
     , shrinkActiveSlotCoefficient
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..), unsafeEpochNo )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), SyncTolerance (..), syncProgress )
 import Cardano.Wallet.Primitive.Types
@@ -22,9 +24,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotInEpoch (..)
     , SlotLength (..)
-    , SlotParameters (..)
     , StartTime (..)
-    , unsafeEpochNo
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -23,6 +23,25 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), WalletKey (..), digest, publicKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey (..), generateKeyFromSeed )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters (..)
+    , epochPred
+    , epochStartTime
+    , epochStartTime
+    , epochSucc
+    , epochSucc
+    , flatSlot
+    , fromFlatSlot
+    , slotAt
+    , slotCeiling
+    , slotDifference
+    , slotFloor
+    , slotMinBound
+    , slotPred
+    , slotRangeFromTimeRange
+    , slotStartTime
+    , slotSucc
+    )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..), mkSyncTolerance )
 import Cardano.Wallet.Primitive.Types
@@ -48,7 +67,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotInEpoch (..)
     , SlotLength (..)
-    , SlotParameters (..)
     , StartTime (..)
     , Tx (..)
     , TxIn (..)
@@ -61,12 +79,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , balance
     , computeUtxoStatistics
-    , epochPred
-    , epochStartTime
-    , epochSucc
     , excluding
-    , flatSlot
-    , fromFlatSlot
     , isAfterRange
     , isBeforeRange
     , isSubrangeOf
@@ -85,15 +98,6 @@ import Cardano.Wallet.Primitive.Types
     , rangeUpperBound
     , restrictedBy
     , restrictedTo
-    , slotAt
-    , slotCeiling
-    , slotDifference
-    , slotFloor
-    , slotMinBound
-    , slotPred
-    , slotRangeFromTimeRange
-    , slotStartTime
-    , slotSucc
     , unsafeEpochNo
     , walletNameMaxLength
     , walletNameMinLength

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -64,6 +64,8 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection, feeBalance )
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, unsafeEpochNo )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
@@ -94,9 +96,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
-    , flatSlot
     , txId
-    , unsafeEpochNo
     )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -60,6 +60,8 @@ import Cardano.Wallet.Network.Ports
     ( randomUnusedTCPPorts )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), Passphrase (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( slotMinBound )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , Coin (..)
@@ -69,7 +71,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , TxIn (..)
     , TxOut (..)
-    , slotMinBound
     )
 import Cardano.Wallet.Unsafe
     ( unsafeDecodeAddress

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -46,6 +46,8 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     , NextBlocksResult (..)
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, fromFlatSlot, slotParams, slotSucc )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
@@ -63,11 +65,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , StartTime (..)
     , TxParameters (..)
-    , flatSlot
-    , flatSlot
-    , fromFlatSlot
-    , slotParams
-    , slotSucc
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText, unsafeMkPercentage, unsafeRunExceptT )

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -108,6 +108,8 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot, fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
     ( PoolCertificate (..)
     , PoolRegistrationCertificate (..)
@@ -343,7 +345,7 @@ toPoint genesisH epLength (W.BlockHeader sid _ h _)
 
 toSlotNo :: W.EpochLength -> W.SlotId -> SlotNo
 toSlotNo epLength =
-    SlotNo . W.flatSlot epLength
+    SlotNo . flatSlot epLength
 
 toBlockHeader
     :: W.Hash "Genesis"
@@ -423,7 +425,7 @@ fromChainHash genesisHash = \case
 
 fromSlotNo :: W.EpochLength -> SlotNo -> W.SlotId
 fromSlotNo epLength (SlotNo sl) =
-    W.fromFlatSlot epLength sl
+    fromFlatSlot epLength sl
 
 -- FIXME unsafe conversion (Word64 -> Word32)
 fromBlockNo :: BlockNo -> Quantity "block" Word32

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -44,6 +44,8 @@ import Cardano.Wallet.Network
     , NetworkLayer (..)
     , follow
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( SlotParameters, epochStartTime, slotParams )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader
@@ -58,14 +60,11 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters
     , SlotId
     , SlotLength (..)
-    , SlotParameters
     , StakePoolMetadata
     , StakePoolMetadataHash
     , StakePoolMetadataUrl
-    , epochStartTime
     , getPoolRegistrationCertificate
     , getPoolRetirementCertificate
-    , slotParams
     )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -39,6 +39,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
+import Cardano.Wallet.Primitive.Slotting
+    ( fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , ChimericAccount (..)
@@ -46,7 +48,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , Hash (..)
     , SlotId (..)
-    , fromFlatSlot
     )
 import Cardano.Wallet.Shelley.Compatibility
     ( ShelleyBlock

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -117,6 +117,7 @@
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
             (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
             (hsPkgs."connection" or (errorHandler.buildDepError "connection"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))


### PR DESCRIPTION
# Issue Number

ADP-356 #1868, #1869 

# Overview


- [x] I have moved the existing slotting logic (`flatSlot`, `slotAt`, etc.) to a new module `Cardano.Wallet.Primitive.Slotting`
    - It is easier to keep track of remaining uses of static slotting this way
- [x] I started adding a ouroboros-consensus wrapper on top (currently unused)
    - [x] Added property `runQuery epochOf singleEraInterpreter == epochNumber . fromFlatSlot`


# Comments

- I left tests for slotting arithmetic in TypesSpec because the boundary between `Range` tests and slotting tests seemed unclear.
- Next step: Wrap all existing slotting logic using `Qry`/`Interpreter`.
- Could split into two PRs if you want

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
