### PR TITLE
Support for staging network

### DIFF
--- a/lib/byron/bench/Restore.hs
+++ b/lib/byron/bench/Restore.hs
@@ -218,6 +218,7 @@ exec c = do
     let networkDir = case c of
             MainnetConfig _ -> "mainnet"
             TestnetConfig _ -> "testnet"
+            StagingConfig _ -> "staging"
         topology = configs </> networkDir </> "topology.json"
         config = configs </> networkDir </> "configuration.json"
 

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction/Size.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2020 IOHK
@@ -126,8 +128,14 @@ sizeOf = fromIntegral . BL.length . CBOR.toLazyByteString
 class MaxSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
     maxSizeOf :: Int
 
+instance forall t k pm. (MaxSizeOf t 'Mainnet k) => MaxSizeOf t ('Staging pm) k where
+    maxSizeOf = maxSizeOf @t @'Mainnet @k
+
 class MinSizeOf (t :: *) (n :: NetworkDiscriminant) (k :: Depth -> * -> *) where
     minSizeOf :: Int
+
+instance forall t k pm. (MinSizeOf t 'Mainnet k) => MinSizeOf t ('Staging pm) k where
+    minSizeOf = minSizeOf @t @'Mainnet @k
 
 -- ADDRESS (MainNet, Icarus)
 --     = CBOR-LIST-LEN (2)    --     1 byte

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1405,10 +1405,16 @@ eitherToParser = either (fail . show) pure
 class EncodeAddress (n :: NetworkDiscriminant) where
     encodeAddress :: Address -> Text
 
+instance EncodeAddress 'Mainnet => EncodeAddress ('Staging pm) where
+    encodeAddress = encodeAddress @'Mainnet
+
 -- | An abstract class to allow decoding of addresses depending on the target
 -- backend used.
 class DecodeAddress (n :: NetworkDiscriminant) where
     decodeAddress :: Text -> Either TextDecodingError Address
+
+instance DecodeAddress 'Mainnet => DecodeAddress ('Staging pm) where
+    decodeAddress = decodeAddress @'Mainnet
 
 -- NOTE:
 -- The type families below are useful to allow building more flexible API

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -472,7 +472,22 @@ instance MonadRandom ((->) (Passphrase "salt")) where
 -------------------------------------------------------------------------------}
 
 -- | Available network options.
-data NetworkDiscriminant = Mainnet | Testnet Nat deriving Typeable
+--
+-- - @Mainnet@: is a shortcut for quickly pointing to mainnet. On Byron and
+--              Shelley, it assumes no discrimination. It has a known magic and
+--              known genesis parameters.
+--
+-- - @Testnet@: can be used to identify any network that has a custom genesis
+--              and, that requires _explicit_ network discrimination in
+--              addresses. Genesis file needs to be passed explicitly when
+--              starting the application.
+--
+-- - @Staging@: very much like testnet, but like mainnet, assumes to no address
+--              discrimination. Genesis file needs to be passed explicitly when
+--              starting the application.
+--
+data NetworkDiscriminant = Mainnet | Testnet Nat | Staging Nat
+    deriving Typeable
 
 class NetworkDiscriminantVal (n :: NetworkDiscriminant) where
     networkDiscriminantVal :: Text
@@ -484,6 +499,10 @@ instance NetworkDiscriminantVal 'Mainnet where
 instance KnownNat pm => NetworkDiscriminantVal ('Testnet pm) where
     networkDiscriminantVal =
         "testnet (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
+
+instance KnownNat pm => NetworkDiscriminantVal ('Staging pm) where
+    networkDiscriminantVal =
+        "staging (" <> T.pack (show $ natVal $ Proxy @pm) <> ")"
 
 {-------------------------------------------------------------------------------
                      Interface over keys / address types

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -561,6 +561,10 @@ class MkKeyFingerprint key Address
             -- ^ Payment fingerprint
         -> Address
 
+instance PaymentAddress 'Mainnet k => PaymentAddress ('Staging pm) k where
+    paymentAddress = paymentAddress @'Mainnet
+    liftPaymentAddress = liftPaymentAddress @'Mainnet
+
 class PaymentAddress network key
     => DelegationAddress (network :: NetworkDiscriminant) key where
     -- | Convert a public key and a staking key to a delegation 'Address' valid
@@ -584,6 +588,10 @@ class PaymentAddress network key
         -> key 'AddressK XPub
             -- ^ Staking key / Reward account
         -> Address
+
+instance DelegationAddress 'Mainnet k => DelegationAddress ('Staging pm) k where
+    delegationAddress = delegationAddress @'Mainnet
+    liftDelegationAddress = liftDelegationAddress @'Mainnet
 
 -- | Operations for saving a private key into a database, and restoring it from
 -- a database. The keys should be encoded in hexadecimal strings.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1885

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 6f0ab28cdb71af7f67592dd2a242ce6c3fd138f2
  :round_pushpin: **add a 'Staging' network discriminant**
  
- b9f56f7ae1683ffc2e381adcdd3b1fdfb3b3f422
  :round_pushpin: **add necessary class instances for 'Staging' discrimination**
  This is quite straighforward in the end since we can make all these instances default to the mainnet instance.

- cbadcac0103831f6332dd37ec2c6fc02d3e50511
  :round_pushpin: **allow starting the server in a 'staging' mode, using a custom genesis, but no explicit address discrimination**
  

# Comments

<!-- Additional comments or screenshots to attach if any -->

One can now start a wallet and connect to a staging network via:

```
cardano-wallet-{shelley,byron} serve \
    --node-socket node.socket \
    --staging genesis.json 
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
