### PR TITLE
adjust LargestFirst error handling to return 'not enough money' when there's no UTxO

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -283,9 +283,8 @@ errMsg403NotAByronWallet =
 
 errMsg403NotEnoughMoney_ :: String
 errMsg403NotEnoughMoney_ =
-    "I cannot select enough UTxO from your wallet to construct an adequate \
-    \transaction. Try sending a smaller amount or increasing the number of \
-    \available UTxO."
+    "I can't process this payment because there's not enough UTxO available in \
+    \the wallet."
 
 errMsg403NotEnoughMoney :: Int -> Int -> String
 errMsg403NotEnoughMoney has needs = "I can't process this payment because there's\

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -72,9 +72,6 @@ largestFirst opt outs withdrawal utxo = do
             let total = totalBalance withdrawal utxoList
             let nUtxo = fromIntegral $ Map.size $ getUTxO utxo
 
-            when (null utxoList)
-                $ throwE ErrInputsDepleted
-
             when (total < moneyRequested)
                 $ throwE $ ErrNotEnoughMoney total moneyRequested
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1889 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 912cf3ade3e523b6413d56f0397fcceb3fc6b7a2
  :round_pushpin: **adjust LargestFirst error handling to return 'not enough money' when there's no UTxO**
  

# Comments

<!-- Additional comments or screenshots to attach if any -->

I imagine there's at least an integration test that would fail and for which the message will need to be changed. I was too lazy to look for it so I'll wait for the CI to fail and report it. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
