### PR TITLE
run integration tests twice if the first time failed

### DIFF
--- a/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
+++ b/lib/byron/test/integration/Test/Integration/Byron/Scenario/API/Transactions.hs
@@ -50,7 +50,9 @@ import Data.Text
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldNotBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldNotBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Faucet
     ( nextWallet )
 import Test.Integration.Framework.DSL

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -40,7 +40,9 @@ import Data.Generics.Internal.VL.Lens
 import Data.Generics.Product.Positions
     ( position )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe )
+    ( SpecWith, describe, shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -58,7 +58,9 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -49,7 +49,9 @@ import Data.Text
 import Data.Word
     ( Word64 )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -26,7 +26,9 @@ import Data.Quantity
 import Data.Text.Class
     ( fromText )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe )
+    ( SpecWith, describe, shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -52,9 +52,11 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Test.Hspec
-    ( SpecWith, describe, it, runIO, shouldNotBe, shouldSatisfy )
+    ( SpecWith, describe, runIO, shouldNotBe, shouldSatisfy )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -26,7 +26,9 @@ import Control.Monad.IO.Class
 import Data.Time.Clock
     ( getCurrentTime )
 import Test.Hspec
-    ( SpecWith, it, pendingWith, shouldBe )
+    ( SpecWith, pendingWith, shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -31,7 +31,9 @@ import Data.Generics.Internal.VL.Lens
 import Data.Quantity
     ( Quantity (..) )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe )
+    ( SpecWith, describe, shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -42,7 +42,9 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -48,7 +48,9 @@ import Data.Text
 import Data.Word
     ( Word64 )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -16,7 +16,9 @@ import Data.Quantity
 import Data.Ratio
     ( (%) )
 import Test.Hspec
-    ( SpecWith, it, shouldBe )
+    ( SpecWith, shouldBe )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -62,7 +62,9 @@ import Data.Text.Class
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe, it, pendingWith, shouldBe, shouldSatisfy )
+    ( SpecWith, describe, pendingWith, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -53,9 +53,11 @@ import Network.HTTP.Types.Method
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe, it, pendingWith )
+    ( SpecWith, describe, pendingWith )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context
     , Headers (..)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -70,7 +70,9 @@ import Data.Text.Class
 import Data.Word
     ( Word64 )
 import Test.Hspec
-    ( SpecWith, describe, it, shouldBe, shouldNotBe, shouldSatisfy )
+    ( SpecWith, describe, shouldBe, shouldNotBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
@@ -124,7 +126,6 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
-
 
 spec :: forall n t.
     ( DecodeAddress n

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
@@ -33,9 +33,11 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, it, pendingWith )
+    ( SpecWith, pendingWith )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
@@ -27,9 +27,11 @@ import System.IO
 import System.Process
     ( waitForProcess, withCreateProcess )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( KnownCommand (..)
     , cardanoWalletCLI

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -32,9 +32,11 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -39,9 +39,11 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -47,9 +47,11 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain, shouldSatisfy )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -50,9 +50,11 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, describe, it )
+    ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain, shouldNotBe, shouldNotContain )
+import Test.Hspec.Extra
+    ( it )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 9aa974bd3adec2ce3b330639c6c2f4273c9d48ae
  :round_pushpin: **run integration tests twice if the first time failed**
    This is to cope with their inherent flakyness due to the very 'volatile' nature of the chain. Indeed, in Praos, rollbacks happens quite often and, while this is not a problem under normal circumstances, it can be pretty annoying when fixtures are being rolled back or when the wallet hasn't got time to catch up between a rollback and a test assertion.

  So, instead of retrying every single assertion, we simply retry every scenario once if they fail.

  Hspec 'aroundAll', 'before', 'beforeAll' etc.. are built with monad composition and exception primitivies ('finally'), so re-running the IO action should also re-run automatically the necessary tear up and down code



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
