### PR TITLE
Simplify Shelley `listPools` operation.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -130,7 +130,7 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- Note that a pool may also have other certificates associated with it
         -- that affect its current lifecycle status.
         --
-        -- See 'readPoolLifeCycleStatus'.
+        -- See 'readPoolLifeCycleStatus' for a complete picture.
 
     , putPoolRetirement
         :: CertificatePublicationTime
@@ -147,7 +147,7 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- Note that a pool may also have other certificates associated with it
         -- that affect its current lifecycle status.
         --
-        -- See 'readPoolLifeCycleStatus'.
+        -- See 'readPoolLifeCycleStatus' for a complete picture.
 
     , unfetchedPoolMetadataRefs
         :: Int

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -66,6 +66,8 @@ module Cardano.Wallet.Primitive.Types
     , PoolRegistrationCertificate (..)
     , PoolRetirementCertificate (..)
     , PoolCertificate (..)
+    , getPoolRegistrationCertificate
+    , getPoolRetirementCertificate
 
     -- * Coin
     , Coin (..)
@@ -1822,6 +1824,20 @@ data PoolLifeCycleStatus
         -- ^ Indicates that a pool is registered AND ALSO marked for retirement.
         -- Records the latest registration and retirement certificates.
     deriving (Eq, Show)
+
+getPoolRegistrationCertificate
+    :: PoolLifeCycleStatus -> Maybe PoolRegistrationCertificate
+getPoolRegistrationCertificate = \case
+    PoolNotRegistered            -> Nothing
+    PoolRegistered           c   -> Just c
+    PoolRegisteredAndRetired c _ -> Just c
+
+getPoolRetirementCertificate
+    :: PoolLifeCycleStatus -> Maybe PoolRetirementCertificate
+getPoolRetirementCertificate = \case
+    PoolNotRegistered            -> Nothing
+    PoolRegistered           _   -> Nothing
+    PoolRegisteredAndRetired _ c -> Just c
 
 {-------------------------------------------------------------------------------
                                Polymorphic Types

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -157,23 +157,23 @@ newStakePoolLayer gp nl db = StakePoolLayer
         :: Coin
         -> ExceptT ErrNetworkUnavailable IO [Api.ApiStakePool]
     _listPools userStake = do
-            tip <- liftIO getTip
-            lsqData <- combineLsqData <$> stakeDistribution nl tip userStake
-            chainData <- liftIO $ readDBPoolData db
-            return
-              . sortOn (Down . (view (#metrics . #nonMyopicMemberRewards)))
-              . map snd
-              . Map.toList
-              $ combineDbAndLsqData (slotParams gp) lsqData chainData
+        tip <- liftIO getTip
+        lsqData <- combineLsqData <$> stakeDistribution nl tip userStake
+        chainData <- liftIO $ readDBPoolData db
+        return
+            . sortOn (Down . (view (#metrics . #nonMyopicMemberRewards)))
+            . map snd
+            . Map.toList
+            $ combineDbAndLsqData (slotParams gp) lsqData chainData
 
     -- Note: We shouldn't have to do this conversion.
     el = getEpochLength gp
     gh = getGenesisBlockHash gp
-    getTip = fmap (toPoint gh el) . liftIO $ unsafeRunExceptT $ currentNodeTip nl
+    getTip = fmap (toPoint gh el) . liftIO $
+        unsafeRunExceptT $ currentNodeTip nl
 
 --
 -- Data Combination functions
---
 --
 
 -- | Stake pool-related data that has been read from the node using a local
@@ -293,7 +293,7 @@ combineChainData
 combineChainData =
     Map.merge registeredNoProductions notRegisteredButProducing bothPresent
   where
-    registeredNoProductions  = traverseMissing $ \_k cert ->
+    registeredNoProductions = traverseMissing $ \_k cert ->
         pure (cert, Quantity 0)
 
     -- Ignore blocks produced by BFT nodes.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -313,16 +313,16 @@ readPoolDbData DBLayer {..} = atomically $ do
     let certMap = Map.fromList
             [ (poolId, certs)
             | (poolId, Just certs) <- zip pools
-                (certificatesFromRegistrationStatus <$> registrationStatuses)
+                (certificatesFromLifeCycleStatus <$> registrationStatuses)
             ]
     prodMap <- readTotalProduction
     metaMap <- readPoolMetadata
     return $ Map.map (lookupMetaIn metaMap) (combineChainData certMap prodMap)
   where
-    certificatesFromRegistrationStatus
+    certificatesFromLifeCycleStatus
         :: PoolLifeCycleStatus
         -> Maybe (PoolRegistrationCertificate, Maybe PoolRetirementCertificate)
-    certificatesFromRegistrationStatus = \case
+    certificatesFromLifeCycleStatus = \case
         PoolNotRegistered ->
             Nothing
         PoolRegistered regCert ->

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -292,7 +292,7 @@ combineChainData
     -> Map PoolId (Quantity "block" Word64)
     -> Map PoolId PoolDbData
 combineChainData metaMap registrationMap retirementMap prodMap =
-    Map.map lookupMetaIn $
+    Map.map mkPoolDbData $
         Map.merge
             registeredNoProductions
             notRegisteredButProducing
@@ -308,10 +308,10 @@ combineChainData metaMap registrationMap retirementMap prodMap =
 
     bothPresent = zipWithMatched $ const (,)
 
-    lookupMetaIn
+    mkPoolDbData
         :: (PoolRegistrationCertificate, Quantity "block" Word64)
         -> PoolDbData
-    lookupMetaIn (registrationCert, n) =
+    mkPoolDbData (registrationCert, n) =
         PoolDbData registrationCert mRetirementCert n meta
       where
         metaHash = snd <$> poolMetadata registrationCert

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -320,8 +320,8 @@ combineChainData registrationMap retirementMap prodMap metaMap =
             Map.lookup (view #poolId registrationCert) retirementMap
 
 -- NOTE: If performance becomes a problem, we could try replacing all
--- the individual DB queries, and combbination functions with a single
--- hand-written Sqlite query.
+-- the individual database queries and combining functions with a single
+-- hand-written database query.
 readPoolDbData
     :: DBLayer IO
     -> IO (Map PoolId PoolDbData)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -159,12 +159,12 @@ newStakePoolLayer gp nl db = StakePoolLayer
     _listPools userStake = do
         tip <- liftIO getTip
         lsqData <- combineLsqData <$> stakeDistribution nl tip userStake
-        chainData <- liftIO $ readPoolDbData db
+        dbData <- liftIO $ readPoolDbData db
         return
             . sortOn (Down . (view (#metrics . #nonMyopicMemberRewards)))
             . map snd
             . Map.toList
-            $ combineDbAndLsqData (slotParams gp) lsqData chainData
+            $ combineDbAndLsqData (slotParams gp) lsqData dbData
 
     -- Note: We shouldn't have to do this conversion.
     el = getEpochLength gp

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -159,7 +159,7 @@ newStakePoolLayer gp nl db = StakePoolLayer
     _listPools userStake = do
         tip <- liftIO getTip
         lsqData <- combineLsqData <$> stakeDistribution nl tip userStake
-        chainData <- liftIO $ readDBPoolData db
+        chainData <- liftIO $ readPoolDbData db
         return
             . sortOn (Down . (view (#metrics . #nonMyopicMemberRewards)))
             . map snd
@@ -304,10 +304,10 @@ combineChainData =
 -- NOTE: If performance becomes a problem, we could try replacing all
 -- the individual DB queries, and combbination functions with a single
 -- hand-written Sqlite query.
-readDBPoolData
+readPoolDbData
     :: DBLayer IO
     -> IO (Map PoolId PoolDbData)
-readDBPoolData DBLayer {..} = atomically $ do
+readPoolDbData DBLayer {..} = atomically $ do
     pools <- listRegisteredPools
     registrationStatuses <- mapM readPoolLifeCycleStatus pools
     let certMap = Map.fromList

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -322,9 +322,7 @@ combineChainData registrationMap retirementMap prodMap metaMap =
 -- NOTE: If performance becomes a problem, we could try replacing all
 -- the individual database queries and combining functions with a single
 -- hand-written database query.
-readPoolDbData
-    :: DBLayer IO
-    -> IO (Map PoolId PoolDbData)
+readPoolDbData :: DBLayer IO -> IO (Map PoolId PoolDbData)
 readPoolDbData DBLayer {..} = atomically $ do
     pools <- listRegisteredPools
     registrationStatuses <- mapM readPoolLifeCycleStatus pools

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -337,11 +337,10 @@ readPoolDbData DBLayer {..} = atomically $ do
             )
         -> PoolDbData
     lookupMetaIn m ((registrationCert, mRetirementCert), n) =
-        let
-            metaHash = snd <$> poolMetadata registrationCert
-            meta = flip Map.lookup m =<< metaHash
-        in
-            PoolDbData registrationCert mRetirementCert n meta
+        PoolDbData registrationCert mRetirementCert n meta
+      where
+        metaHash = snd <$> poolMetadata registrationCert
+        meta = flip Map.lookup m =<< metaHash
 
 --
 -- Monitoring stake pool

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -292,7 +292,7 @@ combineChainData
     -> Map PoolId (Quantity "block" Word64)
     -> Map PoolId PoolDbData
 combineChainData metaMap registrationMap retirementMap prodMap =
-    Map.map (lookupMetaIn metaMap) $
+    Map.map lookupMetaIn $
         Map.merge
             registeredNoProductions
             notRegisteredButProducing
@@ -309,14 +309,13 @@ combineChainData metaMap registrationMap retirementMap prodMap =
     bothPresent = zipWithMatched $ const (,)
 
     lookupMetaIn
-        :: Map StakePoolMetadataHash StakePoolMetadata
-        -> (PoolRegistrationCertificate, Quantity "block" Word64)
+        :: (PoolRegistrationCertificate, Quantity "block" Word64)
         -> PoolDbData
-    lookupMetaIn m (registrationCert, n) =
+    lookupMetaIn (registrationCert, n) =
         PoolDbData registrationCert mRetirementCert n meta
       where
         metaHash = snd <$> poolMetadata registrationCert
-        meta = flip Map.lookup m =<< metaHash
+        meta = flip Map.lookup metaMap =<< metaHash
         mRetirementCert =
             Map.lookup (view #poolId registrationCert) retirementMap
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -325,11 +325,11 @@ combineChainData registrationMap retirementMap prodMap metaMap =
 readPoolDbData :: DBLayer IO -> IO (Map PoolId PoolDbData)
 readPoolDbData DBLayer {..} = atomically $ do
     pools <- listRegisteredPools
-    registrationStatuses <- mapM readPoolLifeCycleStatus pools
+    lifeCycleStatuses <- mapM readPoolLifeCycleStatus pools
     let mkCertificateMap
             :: forall a . (PoolLifeCycleStatus -> Maybe a) -> Map PoolId a
         mkCertificateMap f = Map.fromList
-            [(p, c) | (p, Just c) <- zip pools (f <$> registrationStatuses)]
+            [(p, c) | (p, Just c) <- zip pools (f <$> lifeCycleStatuses)]
     combineChainData
         (mkCertificateMap getPoolRegistrationCertificate)
         (mkCertificateMap getPoolRetirementCertificate)


### PR DESCRIPTION
# Issue Number

#1847 

# Overview

This PR tidies up some loose ends from PR #1847:

- [x] Coalesces the various pool DB data merging functions into a single function with a more straightforward type.
- [x] Simplifies the definition of `readPoolDbData`.
- [x] Revises comments for `readPool{Registration, Retirement}` functions.