### PR TITLE
Testing byron txs and migrations in Shelley

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -148,7 +148,7 @@ buildStep dryRun bk nightly = do
       titled "Build"
         (build Fast (["--test", "--no-run-tests"] ++ cabalFlags)) .&&.
       titled "Test"
-        (timeout 45 (test Fast Serial cabalFlags .&&. test Fast Parallel cabalFlags)) .&&.
+        (timeout 60 (test Fast Serial cabalFlags .&&. test Fast Parallel cabalFlags)) .&&.
       titled "Checking golden test files"
         (checkUnclean dryRun "lib/core/test/data")
   where

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -76,6 +76,7 @@ library
       Test.Integration.Scenario.API.Byron.Addresses
       Test.Integration.Scenario.API.Byron.Transactions
       Test.Integration.Scenario.API.Byron.Migrations
+      Test.Integration.Scenario.API.Byron.TransactionsShelley
       Test.Integration.Scenario.API.Byron.Network
       Test.Integration.Scenario.API.Shelley.Addresses
       Test.Integration.Scenario.API.Shelley.HWWallets

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -100,7 +100,7 @@ spec :: forall n t.
     , EncodeAddress n
     , PaymentAddress n IcarusKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_HWWALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureIcarusWallet ctx
         -- create wallet

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -89,7 +89,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types as ApiTypes
 import qualified Data.Map.Strict as Map
 import qualified Network.HTTP.Types.Status as HTTP
-
+import qualified Test.Hspec as Hspec
 
 spec :: forall n t.
     ( DecodeAddress n
@@ -99,7 +99,7 @@ spec :: forall n t.
     , PaymentAddress n IcarusKey
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_MIGRATIONS" $ do
     it "BYRON_CALCULATE_01 - \
         \for non-empty wallet calculated fee is > zero."
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
@@ -124,7 +124,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate $ w ^. walletId)
                 ]
 
-    it "BYRON_CALCULATE_02 - \
+    Hspec.it "BYRON_CALCULATE_02 - \
         \Cannot calculate fee for wallet with dust, that cannot be migrated."
         $ \ctx -> do
             -- NOTE
@@ -207,7 +207,7 @@ spec = do
               testAddressCycling ctx 3
               testAddressCycling ctx 10
 
-    it "BYRON_MIGRATE_01 - \
+    Hspec.it "BYRON_MIGRATE_01xxx - \
         \ migrate a big wallet requiring more than one tx" $ \ctx -> do
         -- NOTE
         -- Special mnemonic for which 200 legacy funds are attached to in the

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -62,6 +62,7 @@ import Test.Integration.Framework.TestData
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
+import qualified Test.Hspec as Hspec
 
 data TestCase a = TestCase
     { query :: T.Text
@@ -72,9 +73,9 @@ spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_TX_COMMON" $ do
 
-    it "BYRON_RESTORE_08 - Icarus wallet with high indexes" $ \ctx -> do
+    Hspec.it "BYRON_RESTORE_08 - Icarus wallet with high indexes" $ \ctx -> do
         -- NOTE
         -- Special Icarus mnemonic where address indexes are all after the index
         -- 500. Because we don't have the whole history, restoring sequential
@@ -98,27 +99,27 @@ spec = do
             , expectField (#balance . #available) (`shouldBe` Quantity faucetAmt)
             ]
 
-    it "BYRON_RESTORE_09 - Ledger wallet" $ \ctx -> do
-        -- NOTE
-        -- Special legacy wallets where addresses have been generated from a
-        -- seed derived using the auxiliary method used by Ledger.
-        let mnemonics =
-                [ "vague" , "wrist" , "poet" , "crazy" , "danger" , "dinner"
-                , "grace" , "home" , "naive" , "unfold" , "april" , "exile"
-                , "relief" , "rifle" , "ranch" , "tone" , "betray" , "wrong"
-                ] :: [T.Text]
-        let payload = Json [json| {
-                    "name": "Ledger Wallet",
-                    "mnemonic_sentence": #{mnemonics},
-                    "passphrase": #{fixturePassphrase},
-                    "style": "ledger"
-                    } |]
-
-        r <- request @ApiByronWallet ctx (Link.postWallet @'Byron) Default payload
-        verify r
-            [ expectResponseCode @IO HTTP.status201
-            , expectField (#balance . #available) (`shouldBe` Quantity faucetAmt)
-            ]
+    -- it "BYRON_RESTORE_09 - Ledger wallet" $ \ctx -> do
+    --     -- NOTE
+    --     -- Special legacy wallets where addresses have been generated from a
+    --     -- seed derived using the auxiliary method used by Ledger.
+    --     let mnemonics =
+    --             [ "vague" , "wrist" , "poet" , "crazy" , "danger" , "dinner"
+    --             , "grace" , "home" , "naive" , "unfold" , "april" , "exile"
+    --             , "relief" , "rifle" , "ranch" , "tone" , "betray" , "wrong"
+    --             ] :: [T.Text]
+    --     let payload = Json [json| {
+    --                 "name": "Ledger Wallet",
+    --                 "mnemonic_sentence": #{mnemonics},
+    --                 "passphrase": #{fixturePassphrase},
+    --                 "style": "ledger"
+    --                 } |]
+    --
+    --     r <- request @ApiByronWallet ctx (Link.postWallet @'Byron) Default payload
+    --     verify r
+    --         [ expectResponseCode @IO HTTP.status201
+    --         , expectField (#balance . #available) (`shouldBe` Quantity faucetAmt)
+    --         ]
 
     it "BYRON_TX_LIST_01 - 0 txs on empty Byron wallet"
         $ \ctx -> forM_ [emptyRandomWallet, emptyIcarusWallet] $ \emptyByronWallet -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsShelley.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/TransactionsShelley.hs
@@ -1,0 +1,171 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Integration.Scenario.API.Byron.TransactionsShelley
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Api.Types
+    ( ApiByronWallet
+    , ApiFee
+    , ApiTransaction
+    , ApiWallet
+    , DecodeAddress
+    , DecodeStakeAddress
+    , EncodeAddress
+    , WalletStyle (..)
+    )
+import Cardano.Wallet.Primitive.Types
+    ( Direction (..), TxStatus (..) )
+import Control.Monad
+    ( forM_ )
+import Data.Generics.Internal.VL.Lens
+    ( (^.) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Text
+    ( Text )
+import Network.HTTP.Types.Method
+    ( Method )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( SpecWith, describe )
+import Test.Hspec.Expectations.Lifted
+    ( shouldBe )
+import Test.Hspec.Extra
+    ( it )
+import Test.Integration.Framework.DSL
+    ( Context
+    , Headers (..)
+    , Payload (..)
+    , between
+    , eventually
+    , expectField
+    , expectResponseCode
+    , expectSuccess
+    , faucetAmt
+    , faucetUtxoAmt
+    , fixtureIcarusWallet
+    , fixturePassphrase
+    , fixtureRandomWallet
+    , fixtureWallet
+    , getFromResponse
+    , json
+    , listAddresses
+    , request
+    , verify
+    , (.>=)
+    )
+import Test.Integration.Framework.Request
+    ( RequestException )
+
+import qualified Cardano.Wallet.Api.Link as Link
+import qualified Network.HTTP.Types.Status as HTTP
+
+spec :: forall n t.
+    ( DecodeAddress n
+    , DecodeStakeAddress n
+    , EncodeAddress n
+    ) => SpecWith (Context t)
+spec = do
+  describe "BYRON_TRANS_SHELLEY_01 - Single Output Transaction with non-Shelley witnesses" $
+      forM_ [(fixtureRandomWallet, "Byron wallet"), (fixtureIcarusWallet, "Icarus wallet")] $
+      \(srcFixture,name) -> it name $ \ctx -> do
+
+      (wByron, wShelley) <- (,) <$> srcFixture ctx <*> fixtureWallet ctx
+      addrs <- listAddresses @n ctx wShelley
+
+      let amt = 1
+      let destination = (addrs !! 1) ^. #id
+      let payload = Json [json|{
+              "payments": [{
+                  "address": #{destination},
+                  "amount": {
+                      "quantity": #{amt},
+                      "unit": "lovelace"
+                  }
+              }]
+          }|]
+
+      rFeeEst <- request @ApiFee ctx
+          (Link.getTransactionFee @'Byron wByron) Default payload
+      verify rFeeEst
+          [ expectSuccess
+          , expectResponseCode HTTP.status202
+          ]
+      let (Quantity feeEstMin) = getFromResponse #estimatedMin rFeeEst
+      let (Quantity feeEstMax) = getFromResponse #estimatedMax rFeeEst
+
+      r <- postTx ctx
+          (wByron, Link.createTransaction @'Byron, fixturePassphrase)
+          wShelley
+          amt
+      verify r
+          [ expectSuccess
+          , expectResponseCode HTTP.status202
+          , expectField (#amount . #getQuantity) $
+              between (feeEstMin + amt, feeEstMax + amt)
+          , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
+          , expectField (#status . #getApiT) (`shouldBe` Pending)
+          ]
+
+      ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wByron) Default Empty
+      verify ra
+          [ expectSuccess
+          , expectField (#balance . #total) $
+              between
+                  ( Quantity (faucetAmt - feeEstMax - amt)
+                  , Quantity (faucetAmt - feeEstMin - amt)
+                  )
+          , expectField
+                  (#balance . #available)
+                  (.>= Quantity (faucetAmt - faucetUtxoAmt))
+          ]
+
+      eventually "wByron and wShelley balances are as expected" $ do
+          rb <- request @ApiWallet ctx
+              (Link.getWallet @'Shelley wShelley) Default Empty
+          expectField
+              (#balance . #getApiT . #available)
+              (`shouldBe` Quantity (faucetAmt + amt)) rb
+
+          ra2 <- request @ApiByronWallet ctx
+              (Link.getWallet @'Byron wByron) Default Empty
+          expectField
+              (#balance . #available)
+              (`shouldBe` Quantity (faucetAmt - feeEstMax - amt)) ra2
+  where
+
+    postTx
+        :: Context t
+        -> (wal, wal -> (Method, Text), Text)
+        -> ApiWallet
+        -> Natural
+        -> IO (HTTP.Status, Either RequestException (ApiTransaction n))
+    postTx ctx (wSrc, postTxEndp, pass) wDest amt = do
+        addrs <- listAddresses @n ctx wDest
+        let destination = (addrs !! 1) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": #{pass}
+            }|]
+        r <- request @(ApiTransaction n) ctx (postTxEndp wSrc) Default payload
+        expectResponseCode HTTP.status202 r
+        return r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -87,6 +87,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types as ApiTypes
 import qualified Data.Map.Strict as Map
 import qualified Network.HTTP.Types.Status as HTTP
+import qualified Test.Hspec as Hspec
 
 spec :: forall n t.
     ( DecodeAddress n
@@ -120,7 +121,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate $ w ^. walletId)
                 ]
 
-    it "SHELLEY_CALCULATE_02 - \
+    Hspec.it "SHELLEY_CALCULATE_02 - \
         \Cannot calculate fee for wallet with dust, that cannot be migrated."
         $ \ctx -> do
             -- NOTE
@@ -167,7 +168,7 @@ spec = do
               testAddressCycling 3
               testAddressCycling 10
 
-    it "SHELLEY_MIGRATE_01_big_wallet - \
+    Hspec.it "SHELLEY_MIGRATE_01_big_wallet - \
         \ migrate a big wallet requiring more than one tx" $ \ctx -> do
 
         -- NOTE
@@ -273,7 +274,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate srcId)
                 ]
 
-    it "SHELLEY_MIGRATE_02 - \
+    Hspec.it "SHELLEY_MIGRATE_02 - \
         \migrating wallet with dust should fail."
         $ \ctx -> do
             -- NOTE

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -76,7 +76,6 @@ import Test.Integration.Framework.DSL
     , expectSuccess
     , faucetAmt
     , faucetUtxoAmt
-    , fixtureIcarusWallet
     , fixturePassphrase
     , fixtureRandomWallet
     , fixtureWallet
@@ -449,73 +448,6 @@ spec = do
             r <- request @(ApiTransaction n) ctx
                 (Link.createTransaction @'Shelley w) Default payload
             expectResponseCode @IO HTTP.status400 r
-
-    describe "TRANS_CREATE_09 - Single Output Transaction with non-Shelley witnesses" $
-        forM_ [(fixtureRandomWallet, "Byron wallet"), (fixtureIcarusWallet, "Icarus wallet")] $
-        \(srcFixture,name) -> it name $ \ctx -> do
-
-        (wByron, wShelley) <- (,) <$> srcFixture ctx <*> fixtureWallet ctx
-        addrs <- listAddresses @n ctx wShelley
-
-        let amt = 1
-        let destination = (addrs !! 1) ^. #id
-        let payload = Json [json|{
-                "payments": [{
-                    "address": #{destination},
-                    "amount": {
-                        "quantity": #{amt},
-                        "unit": "lovelace"
-                    }
-                }]
-            }|]
-
-        rFeeEst <- request @ApiFee ctx
-            (Link.getTransactionFee @'Byron wByron) Default payload
-        verify rFeeEst
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            ]
-        let (Quantity feeEstMin) = getFromResponse #estimatedMin rFeeEst
-        let (Quantity feeEstMax) = getFromResponse #estimatedMax rFeeEst
-
-        r <- postTx ctx
-            (wByron, Link.createTransaction @'Byron, fixturePassphrase)
-            wShelley
-            amt
-        verify r
-            [ expectSuccess
-            , expectResponseCode HTTP.status202
-            , expectField (#amount . #getQuantity) $
-                between (feeEstMin + amt, feeEstMax + amt)
-            , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
-            , expectField (#status . #getApiT) (`shouldBe` Pending)
-            ]
-
-        ra <- request @ApiByronWallet ctx (Link.getWallet @'Byron wByron) Default Empty
-        verify ra
-            [ expectSuccess
-            , expectField (#balance . #total) $
-                between
-                    ( Quantity (faucetAmt - feeEstMax - amt)
-                    , Quantity (faucetAmt - feeEstMin - amt)
-                    )
-            , expectField
-                    (#balance . #available)
-                    (.>= Quantity (faucetAmt - faucetUtxoAmt))
-            ]
-
-        eventually "wa and wb balances are as expected" $ do
-            rb <- request @ApiWallet ctx
-                (Link.getWallet @'Shelley wShelley) Default Empty
-            expectField
-                (#balance . #getApiT . #available)
-                (`shouldBe` Quantity (faucetAmt + amt)) rb
-
-            ra2 <- request @ApiByronWallet ctx
-                (Link.getWallet @'Byron wByron) Default Empty
-            expectField
-                (#balance . #available)
-                (`shouldBe` Quantity (faucetAmt - feeEstMax - amt)) ra2
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do
         let matrix =

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -106,10 +106,12 @@ import Test.Integration.Framework.DSL
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
+
 import qualified Test.Integration.Scenario.API.Byron.Addresses as ByronAddresses
 import qualified Test.Integration.Scenario.API.Byron.HWWallets as ByronHWWallets
 import qualified Test.Integration.Scenario.API.Byron.Migrations as ByronMigrations
-import qualified Test.Integration.Scenario.API.Byron.Transactions as ByronTransactions
+import qualified Test.Integration.Scenario.API.Byron.Transactions as ByronTransactionsCommon
+import qualified Test.Integration.Scenario.API.Byron.TransactionsShelley as ByronTransactionsShelley
 import qualified Test.Integration.Scenario.API.Byron.Wallets as ByronWallets
 import qualified Test.Integration.Scenario.API.Network as Network
 import qualified Test.Integration.Scenario.API.Shelley.Addresses as Addresses
@@ -150,8 +152,9 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
                 Network.spec
                 Network_.spec
                 StakePools.spec @n
-                ByronTransactions.spec @n
                 ByronHWWallets.spec @n
+                ByronTransactionsShelley.spec @n
+                ByronTransactionsCommon.spec @n
             describe "CLI Specifications" $ do
                 AddressesCLI.spec @n
                 TransactionsCLI.spec @n


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/1844, https://github.com/input-output-hk/cardano-wallet/issues/1675

# Overview

- 66e5151f26172f957f50eab75e400b4e4c57384c
  Enable more integration tests for byron transactions, migrations, addresses and HW wallets in shelley
  
- d773d955a9990e33c3a51ba6613b87a365d7c7d3
  Add some special Byron and Icarus wallets to genesis for testing migration scenarios
  
- 834923ede8987b78eaf0cc9a32aa0f5b3582347d
  Use regular HSpec.it for tests that use explicit/special mnemonics, otherwise in case they fail, on repeat there will be a 409 as such wallet would exist
  
- 18d1c3487915013512312e413ec2f8ce17f81609
  Don't run Byron tx test on Jormungandr

  



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
