### PR TITLE
Use SlotNo and TimeInterpreter

### DIFF
--- a/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -37,6 +37,6 @@ share
     [persistLowerCase|
 AnyAddressState
     anyAddressStateWalletId        W.WalletId  sql=wallet_id
-    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot
+    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot_no
     anyAddressStateProportion      Double      sql=proportion
 |]

--- a/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -37,6 +37,6 @@ share
     [persistLowerCase|
 AnyAddressState
     anyAddressStateWalletId        W.WalletId  sql=wallet_id
-    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot_no
+    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot
     anyAddressStateProportion      Double      sql=proportion
 |]

--- a/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
+++ b/lib/byron/bench/Cardano/Wallet/Primitive/AddressDiscovery/Any/TH.hs
@@ -37,6 +37,6 @@ share
     [persistLowerCase|
 AnyAddressState
     anyAddressStateWalletId        W.WalletId  sql=wallet_id
-    anyAddressStateCheckpointSlot  W.SlotId    sql=slot
+    anyAddressStateCheckpointSlot  W.SlotNo    sql=slot
     anyAddressStateProportion      Double      sql=proportion
 |]

--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -283,6 +283,7 @@ serveWallet
                     minimumUTxOvalue (protocolParameters np)
                 }
             )
+            (timeInterpreter nl)
             databaseDir
         Server.newApiLayer walletEngineTracer params nl' tl db
             Server.idleWorker

--- a/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Api/Server.hs
@@ -179,7 +179,8 @@ server byron icarus ntp =
             SomeTrezorWallet x -> postTrezorWallet icarus x
             SomeLedgerWallet x -> postLedgerWallet icarus x
             SomeAccount x ->
-                postAccountWallet icarus mkLegacyWallet IcarusKey idleWorker x
+                postAccountWallet icarus
+                    (mkLegacyWallet @_ @_ @_ @t) IcarusKey idleWorker x
         )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , deleteWallet byron wid)
@@ -187,20 +188,20 @@ server byron icarus ntp =
              )
         :<|> (\wid -> withLegacyLayer' wid
                 ( byron
-                , fst <$> getWallet byron  mkLegacyWallet wid
-                , const (fst <$> getWallet byron  mkLegacyWallet wid)
+                , fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
                 ( icarus
-                , fst <$> getWallet icarus mkLegacyWallet wid
-                , const (fst <$> getWallet icarus mkLegacyWallet wid)
+                , fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
              )
         :<|> liftA2 (\xs ys -> fmap fst $ sortOn snd $ xs ++ ys)
-            (listWallets byron  mkLegacyWallet)
-            (listWallets icarus mkLegacyWallet)
+            (listWallets byron (mkLegacyWallet @_ @_ @_ @t))
+            (listWallets icarus (mkLegacyWallet @_ @_ @_ @t))
         :<|> (\wid name -> withLegacyLayer wid
-                (byron , putWallet byron mkLegacyWallet wid name)
-                (icarus, putWallet icarus mkLegacyWallet wid name)
+                (byron , putWallet byron (mkLegacyWallet @_ @_ @_ @t) wid name)
+                (icarus, putWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid name)
              )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , getUTxOsStatistics byron wid)

--- a/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Transaction.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , ProtocolMagic (..)
     , SealedTx (..)
-    , SlotId (..)
+    , SlotNo (..)
     , Tx (..)
     , TxOut (..)
     )
@@ -116,7 +116,7 @@ newTransactionLayer _proxy protocolMagic = TransactionLayer
             -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
             -- Key store
-        -> SlotId
+        -> SlotNo
             -- Tip of the chain, for TTL
         -> CoinSelection
             -- A balanced coin selection where all change addresses have been
@@ -231,8 +231,8 @@ genesisBlockFromTxOuts :: GenesisParameters -> [TxOut] -> Block
 genesisBlockFromTxOuts gp outs = Block
     { delegations  = []
     , header = BlockHeader
-        { slotId =
-            SlotId 0 0
+        { slotNo =
+            SlotNo 0
         , blockHeight =
             Quantity 0
         , headerHash =

--- a/lib/byron/test/unit/Cardano/Wallet/Byron/CompatibilitySpec.hs
+++ b/lib/byron/test/unit/Cardano/Wallet/Byron/CompatibilitySpec.hs
@@ -92,8 +92,8 @@ spec = do
 
     describe "Conversions" $
         it "toPoint' . fromTip' == getTipPoint" $ property $ \gh tip -> do
-            let fromTip' = fromTip gh epochLength
-            let toPoint' = toPoint gh epochLength
+            let fromTip' = fromTip gh
+            let toPoint' = toPoint gh
             toPoint' (fromTip' tip) === (getTipPoint tip)
 
     describe "Hardware Ledger" $ do

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -134,6 +134,7 @@ library
       Cardano.Wallet.Network
       Cardano.Wallet.Network.BlockHeaders
       Cardano.Wallet.Network.Ports
+      Cardano.Wallet.Orphans
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Byron
       Cardano.Wallet.Primitive.AddressDerivation.Icarus

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolLifeCycleStatus (..)
     , PoolRegistrationCertificate
     , PoolRetirementCertificate
-    , SlotId (..)
+    , SlotNo (..)
     , StakePoolMetadata
     , StakePoolMetadataHash
     , StakePoolMetadataUrl
@@ -188,7 +188,7 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- results across requests.
 
     , rollbackTo
-        :: SlotId
+        :: SlotNo
         -> stm ()
         -- ^ Remove all entries of slot ids newer than the argument
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -333,7 +333,9 @@ newDBLayer trace fp timeInterpreter = do
                 ]
 
         , rollbackTo = \point -> do
-            -- TODO#1901: What if the time conversion blocks or fails?
+            -- TODO(ADP-356): What if the conversion blocks or fails?
+            --
+            -- Missing a rollback would be bad.
             EpochNo epoch <- liftIO $ timeInterpreter (epochOf point)
             deleteWhere [ StakeDistributionEpoch >. fromIntegral epoch ]
 
@@ -484,7 +486,6 @@ selectPoolProduction
     -> EpochNo
     -> SqlPersistT IO [PoolProduction]
 selectPoolProduction timeInterpreter epoch = do
-    -- TODO#1901: Perhaps we should split the IO and pure parts of @TimeInterpreter@?
     e <- liftIO $ timeInterpreter $ firstSlotInEpoch epoch
     eplus1 <- liftIO $ timeInterpreter $ firstSlotInEpoch (epoch + 1)
     fmap entityVal <$> selectList

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -58,7 +58,7 @@ ArbitrarySeed sql=arbitrary_seed
 -- The set of stake pools that produced a given block
 PoolProduction sql=pool_production
     poolProductionPoolId         W.PoolId     sql=pool_id
-    poolProductionSlot           SlotNo       sql=slot
+    poolProductionSlot           SlotNo       sql=slot_no
     poolProductionHeaderHash     W.BlockId    sql=header_hash
     poolProductionParentHash     W.BlockId    sql=parent_header_hash
     poolProductionBlockHeight    Word32       sql=block_height
@@ -78,8 +78,8 @@ StakeDistribution sql=stake_distribution
 -- Mapping from pool id to owner.
 PoolOwner sql=pool_owner
     poolOwnerPoolId             W.PoolId            sql=pool_id
-    poolOwnerSlot               W.SlotNo            sql=slot
-    poolOwnerSlotInternalIndex  Word64              sql=slot_internal_index
+    poolOwnerSlot               W.SlotNo            sql=slot_no
+    poolOwnerSlotInternalIndex  Word64              sql=slot_no_internal_index
     poolOwnerOwner              W.PoolOwner         sql=pool_owner
     poolOwnerIndex              Word8               sql=pool_owner_index
 
@@ -90,8 +90,8 @@ PoolOwner sql=pool_owner
 -- Mapping of registration certificate to pool
 PoolRegistration sql=pool_registration
     poolRegistrationPoolId            W.PoolId                      sql=pool_id
-    poolRegistrationSlot              W.SlotNo                      sql=slot
-    poolRegistrationSlotInternalIndex Word64                        sql=slot_internal_index
+    poolRegistrationSlot              W.SlotNo                      sql=slot_no
+    poolRegistrationSlotInternalIndex Word64                        sql=slot_no_internal_index
     poolRegistrationMarginNumerator   Word64                        sql=margin_numerator
     poolRegistrationMarginDenominator Word64                        sql=margin_denominator
     poolRegistrationCost              Word64                        sql=cost
@@ -105,8 +105,8 @@ PoolRegistration sql=pool_registration
 -- Mapping of retirement certificates to pools
 PoolRetirement sql=pool_retirement
     poolRetirementPoolId              W.PoolId            sql=pool_id
-    poolRetirementSlot                W.SlotNo            sql=slot
-    poolRetirementSlotInternalIndex   Word64              sql=slot_internal_index
+    poolRetirementSlot                W.SlotNo            sql=slot_no
+    poolRetirementSlotInternalIndex   Word64              sql=slot_no_internal_index
     poolRetirementEpoch               Word64              sql=epoch
 
     Primary poolRetirementPoolId poolRetirementSlot poolRetirementSlotInternalIndex

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -20,6 +20,8 @@ module Cardano.Pool.DB.Sqlite.TH where
 
 import Prelude
 
+import Cardano.Slotting.Slot
+    ( SlotNo )
 import Cardano.Wallet.DB.Sqlite.Types
     ( sqlSettings' )
 import Data.Text
@@ -56,7 +58,7 @@ ArbitrarySeed sql=arbitrary_seed
 -- The set of stake pools that produced a given block
 PoolProduction sql=pool_production
     poolProductionPoolId         W.PoolId     sql=pool_id
-    poolProductionSlot           W.SlotId     sql=slot
+    poolProductionSlot           SlotNo       sql=slot
     poolProductionHeaderHash     W.BlockId    sql=header_hash
     poolProductionParentHash     W.BlockId    sql=parent_header_hash
     poolProductionBlockHeight    Word32       sql=block_height
@@ -76,7 +78,7 @@ StakeDistribution sql=stake_distribution
 -- Mapping from pool id to owner.
 PoolOwner sql=pool_owner
     poolOwnerPoolId             W.PoolId            sql=pool_id
-    poolOwnerSlot               W.SlotId            sql=slot
+    poolOwnerSlot               W.SlotNo            sql=slot
     poolOwnerSlotInternalIndex  Word64              sql=slot_internal_index
     poolOwnerOwner              W.PoolOwner         sql=pool_owner
     poolOwnerIndex              Word8               sql=pool_owner_index
@@ -88,7 +90,7 @@ PoolOwner sql=pool_owner
 -- Mapping of registration certificate to pool
 PoolRegistration sql=pool_registration
     poolRegistrationPoolId            W.PoolId                      sql=pool_id
-    poolRegistrationSlot              W.SlotId                      sql=slot
+    poolRegistrationSlot              W.SlotNo                      sql=slot
     poolRegistrationSlotInternalIndex Word64                        sql=slot_internal_index
     poolRegistrationMarginNumerator   Word64                        sql=margin_numerator
     poolRegistrationMarginDenominator Word64                        sql=margin_denominator
@@ -103,7 +105,7 @@ PoolRegistration sql=pool_registration
 -- Mapping of retirement certificates to pools
 PoolRetirement sql=pool_retirement
     poolRetirementPoolId              W.PoolId            sql=pool_id
-    poolRetirementSlot                W.SlotId            sql=slot
+    poolRetirementSlot                W.SlotNo            sql=slot
     poolRetirementSlotInternalIndex   Word64              sql=slot_internal_index
     poolRetirementEpoch               Word64              sql=epoch
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -58,7 +58,7 @@ ArbitrarySeed sql=arbitrary_seed
 -- The set of stake pools that produced a given block
 PoolProduction sql=pool_production
     poolProductionPoolId         W.PoolId     sql=pool_id
-    poolProductionSlot           SlotNo       sql=slot_no
+    poolProductionSlot           SlotNo       sql=slot
     poolProductionHeaderHash     W.BlockId    sql=header_hash
     poolProductionParentHash     W.BlockId    sql=parent_header_hash
     poolProductionBlockHeight    Word32       sql=block_height
@@ -78,8 +78,8 @@ StakeDistribution sql=stake_distribution
 -- Mapping from pool id to owner.
 PoolOwner sql=pool_owner
     poolOwnerPoolId             W.PoolId            sql=pool_id
-    poolOwnerSlot               W.SlotNo            sql=slot_no
-    poolOwnerSlotInternalIndex  Word64              sql=slot_no_internal_index
+    poolOwnerSlot               W.SlotNo            sql=slot
+    poolOwnerSlotInternalIndex  Word64              sql=slot_internal_index
     poolOwnerOwner              W.PoolOwner         sql=pool_owner
     poolOwnerIndex              Word8               sql=pool_owner_index
 
@@ -90,8 +90,8 @@ PoolOwner sql=pool_owner
 -- Mapping of registration certificate to pool
 PoolRegistration sql=pool_registration
     poolRegistrationPoolId            W.PoolId                      sql=pool_id
-    poolRegistrationSlot              W.SlotNo                      sql=slot_no
-    poolRegistrationSlotInternalIndex Word64                        sql=slot_no_internal_index
+    poolRegistrationSlot              W.SlotNo                      sql=slot
+    poolRegistrationSlotInternalIndex Word64                        sql=slot_internal_index
     poolRegistrationMarginNumerator   Word64                        sql=margin_numerator
     poolRegistrationMarginDenominator Word64                        sql=margin_denominator
     poolRegistrationCost              Word64                        sql=cost
@@ -105,8 +105,8 @@ PoolRegistration sql=pool_registration
 -- Mapping of retirement certificates to pools
 PoolRetirement sql=pool_retirement
     poolRetirementPoolId              W.PoolId            sql=pool_id
-    poolRetirementSlot                W.SlotNo            sql=slot_no
-    poolRetirementSlotInternalIndex   Word64              sql=slot_no_internal_index
+    poolRetirementSlot                W.SlotNo            sql=slot
+    poolRetirementSlotInternalIndex   Word64              sql=slot_internal_index
     poolRetirementEpoch               Word64              sql=epoch
 
     Primary poolRetirementPoolId poolRetirementSlot poolRetirementSlotInternalIndex

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -676,6 +676,9 @@ mkShelleyWallet ctx wid cp meta pending progress = do
             , changesAt = mepochInfo
             }
 
+    -- TODO(ADP-356): This may fail when we are running Byron-Shelley.
+    -- According to Edsko we can know the start time of the next epoch,
+    -- but nothing beyond that.
     toApiEpochInfo ep = do
         time <- ti (firstSlotInEpoch ep >>= startTime)
         return $ ApiEpochInfo (ApiT ep) time
@@ -1479,8 +1482,10 @@ getNetworkInformation (_block0, np, st) nl = do
     nodeTip <-  liftHandler (NW.currentNodeTip nl)
     apiNodeTip <- liftIO $ mkApiBlockReference ti nodeTip
     let ntrkTip = fromMaybe slotMinBound (slotAt' sp now)
-    -- TODO: ADP-356: We need to retrieve the network tip using a different API,
+    -- TODO(ADP-356): We need to retrieve the network tip using a different API,
     -- AND it may not be availible.
+    --
+    -- We should mark it optional.
     let nextEpochNo = unsafeEpochSucc (ntrkTip ^. #epochNumber)
     progress <- liftIO $ syncProgress st ti nodeTip now
     pure $ Api.ApiNetworkInformation

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -132,9 +132,11 @@ import Cardano.Wallet
     , ErrWrongPassphrase (..)
     , FeeEstimation (..)
     , HasLogger
+    , HasNetworkLayer
     , WalletLog
     , genesisData
     , manageRewardBalance
+    , networkLayer
     )
 import Cardano.Wallet.Api
     ( ApiLayer (..)
@@ -155,12 +157,12 @@ import Cardano.Wallet.Api.Types
     , ApiByronWalletBalance (..)
     , ApiCoinSelection (..)
     , ApiCoinSelectionInput (..)
-    , ApiEpochInfo (..)
+    , ApiEpochInfo (ApiEpochInfo)
     , ApiErrorCode (..)
     , ApiFee (..)
     , ApiMnemonicT (..)
     , ApiNetworkClock (..)
-    , ApiNetworkInformation (..)
+    , ApiNetworkInformation
     , ApiNetworkParameters (..)
     , ApiNetworkTip (..)
     , ApiPoolId (..)
@@ -201,7 +203,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.DB
     ( DBFactory (..) )
 import Cardano.Wallet.Network
-    ( ErrCurrentNodeTip (..), ErrNetworkUnavailable (..), NetworkLayer )
+    ( ErrCurrentNodeTip (..)
+    , ErrNetworkUnavailable (..)
+    , NetworkLayer
+    , timeInterpreter
+    )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( ChimericAccount (..)
     , DelegationAddress (..)
@@ -243,12 +249,22 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..), changeBalance, inputBalance )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, availableBalance, currentTip, getState, totalBalance )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter
+    , epochStartTime
+    , epochSucc
+    , slotAt'
+    , slotMinBound
+    , slotParams
+    , toSlotId
+    )
 import Cardano.Wallet.Primitive.SyncProgress
-    ( SyncProgress (..), SyncTolerance, syncProgressRelativeToTime )
+    ( SyncProgress (..), SyncTolerance, syncProgress )
 import Cardano.Wallet.Primitive.Types
     ( Address
     , AddressState (..)
     , Block
+    , BlockHeader (..)
     , Coin (..)
     , Hash (..)
     , HistogramBar (..)
@@ -380,10 +396,10 @@ import System.Random
     ( getStdRandom, random )
 
 import qualified Cardano.Wallet as W
+import qualified Cardano.Wallet.Api.Types as Api
 import qualified Cardano.Wallet.Network as NW
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
-import qualified Cardano.Wallet.Primitive.Slotting as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Data.Aeson as Aeson
@@ -612,6 +628,8 @@ mkShelleyWallet ctx wid cp meta pending progress = do
     Quantity reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
         -- never fails - returns zero if balance not found
         liftIO $ fmap fromIntegral <$> W.fetchRewardBalance @_ @s @k wrk wid
+
+    tip' <- liftIO $ getWalletTip ti cp
     pure ApiWallet
         { addressPoolGap = ApiT $ getState cp ^. #externalPool . #gap
         , balance = ApiT $ WalletBalance
@@ -625,11 +643,13 @@ mkShelleyWallet ctx wid cp meta pending progress = do
         , passphrase = ApiWalletPassphraseInfo
             <$> fmap (view #lastUpdatedAt) (meta ^. #passphraseInfo)
         , state = ApiT progress
-        , tip = getWalletTip cp
+        , tip = tip'
         }
   where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
     (_, NetworkParameters gp _, _) = ctx ^. genesisData
-    sp = W.slotParams gp
+    sp = slotParams gp
 
     toApiWalletDelegation W.WalletDelegation{active,next} =
         ApiWalletDelegation
@@ -652,7 +672,8 @@ mkShelleyWallet ctx wid cp meta pending progress = do
             }
 
     toApiEpochInfo ep =
-        ApiEpochInfo (ApiT ep) (W.epochStartTime sp ep)
+        -- TODO(ADP-356): We need to stop using this function.
+        ApiEpochInfo (ApiT ep) (epochStartTime sp ep)
 
 --------------------- Legacy
 
@@ -662,6 +683,7 @@ postLegacyWallet
         , KnownDiscovery s
         , IsOurs s ChimericAccount
         , IsOurs s Address
+        , HasNetworkLayer t ctx
         , WalletKey k
         )
     => ctx
@@ -680,15 +702,16 @@ postLegacyWallet ctx (rootXPrv, pwd) createWallet = do
         (`idleWorker` wid)
     withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.attachPrivateKeyFromPwd wrk wid (rootXPrv, pwd)
-    fst <$> getWallet ctx mkLegacyWallet (ApiT wid)
+    fst <$> getWallet ctx (mkLegacyWallet @_ @_ @_ @t) (ApiT wid)
   where
     wid = WalletId $ digest $ publicKey rootXPrv
 
 mkLegacyWallet
-    :: forall ctx s k.
+    :: forall ctx s k t.
         ( HasWorkerRegistry s k ctx
         , HasDBFactory s k ctx
         , KnownDiscovery s
+        , HasNetworkLayer t ctx
         , IsOurs s Address
         )
     => ctx
@@ -718,6 +741,7 @@ mkLegacyWallet ctx wid cp meta pending progress = do
                     Right{} -> pure Nothing
                     Left{} -> pure $ Just $ ApiWalletPassphraseInfo time
 
+    tip' <- liftIO $ getWalletTip ti cp
     pure ApiByronWallet
         { balance = ApiByronWalletBalance
             { available = Quantity $ availableBalance pending cp
@@ -727,10 +751,12 @@ mkLegacyWallet ctx wid cp meta pending progress = do
         , name = ApiT $ meta ^. #name
         , passphrase = pwdInfo
         , state = ApiT progress
-        , tip = getWalletTip cp
+        , tip = tip'
         , discovery = knownDiscovery @s
         }
   where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
     matchEmptyPassphrase
         :: WorkerCtx ctx
         -> Handler (Either ErrWithRootKey ())
@@ -761,6 +787,7 @@ postRandomWalletFromXPrv
         ( ctx ~ ApiLayer s t k
         , s ~ RndState n
         , k ~ ByronKey
+        , HasNetworkLayer t ctx
         )
     => ctx
     -> ByronWalletFromXPrvPostData
@@ -773,7 +800,7 @@ postRandomWalletFromXPrv ctx body = do
         (`idleWorker` wid)
     withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.attachPrivateKeyFromPwdHash wrk wid (byronKey, pwd)
-    fst <$> getWallet ctx mkLegacyWallet (ApiT wid)
+    fst <$> getWallet ctx (mkLegacyWallet @_ @_ @_ @t) (ApiT wid)
   where
     wName = getApiT (body ^. #name)
     pwd   = getApiT (body ^. #passphraseHash)
@@ -933,7 +960,7 @@ getWallet ctx mkApiWallet (ApiT wid) = do
 
     whenAlive wrk = do
         (cp, meta, pending) <- liftHandler $ W.readWallet @_ @s @k wrk wid
-        progress <- liftIO $ W.walletSyncProgress ctx cp
+        progress <- liftIO $ W.walletSyncProgress @_ @_ @t ctx cp
         (, meta ^. #creationTime) <$> mkApiWallet ctx wid cp meta pending progress
 
     whenNotResponding _ = Handler $ ExceptT $ withDatabase df wid $ \db -> runHandler $ do
@@ -1119,6 +1146,7 @@ postTransaction
     :: forall ctx s t k n.
         ( Buildable (ErrValidateSelection t)
         , GenChange s
+        , HasNetworkLayer t ctx
         , IsOwned s k
         , ctx ~ ApiLayer s t k
         , HardDerivation k
@@ -1146,13 +1174,17 @@ postTransaction ctx genChange (ApiT wid) withdrawRewards body = do
     withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.submitTx @_ @s @t @k wrk wid (tx, meta, wit)
 
-    pure $ mkApiTransaction
+    liftIO $ mkApiTransaction
+        ti
         (txId tx)
         (fmap Just <$> selection ^. #inputs)
         (tx ^. #outputs)
         (tx ^. #withdrawals)
         (meta, time)
         #pendingSince
+  where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
 
 deleteTransaction
     :: forall ctx s t k. ctx ~ ApiLayer s t k
@@ -1176,15 +1208,18 @@ listTransactions
     -> Handler [ApiTransaction n]
 listTransactions ctx (ApiT wid) mMinWithdrawal mStart mEnd mOrder = do
     txs <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
-        W.listTransactions wrk wid
+        W.listTransactions @_ @_ @_ @t wrk wid
             (Quantity . getMinWithdrawal <$> mMinWithdrawal)
             (getIso8601Time <$> mStart)
             (getIso8601Time <$> mEnd)
             (maybe defaultSortOrder getApiT mOrder)
-    return $ map mkApiTransactionFromInfo txs
+    liftIO $ mapM (mkApiTransactionFromInfo ti) txs
   where
     defaultSortOrder :: SortOrder
     defaultSortOrder = Descending
+
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
 
 getTransaction
     :: forall ctx s t k n. (ctx ~ ApiLayer s t k)
@@ -1195,21 +1230,28 @@ getTransaction
 getTransaction ctx (ApiT wid) (ApiTxId (ApiT (tid))) = do
     tx <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.getTransaction wrk wid tid
-    return $ mkApiTransactionFromInfo tx
+    liftIO $ mkApiTransactionFromInfo ti tx
+  where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
 
 -- Populate an API transaction record with 'TransactionInfo' from the wallet
 -- layer.
-mkApiTransactionFromInfo :: TransactionInfo -> ApiTransaction n
-mkApiTransactionFromInfo (TransactionInfo txid ins outs ws meta depth txtime) =
-    case meta ^. #status of
+mkApiTransactionFromInfo
+    :: Monad m
+    => TimeInterpreter m
+    -> TransactionInfo
+    -> m (ApiTransaction n)
+mkApiTransactionFromInfo ti (TransactionInfo txid ins outs ws meta depth txtime) = do
+    apiTx <- mkApiTransaction ti txid (drop2nd <$> ins) outs ws (meta, txtime) $
+        case meta ^. #status of
+            Pending  -> #pendingSince
+            InLedger -> #insertedAt
+    return $ case meta ^. #status of
         Pending  -> apiTx
         InLedger -> apiTx { depth = Just depth  }
   where
       drop2nd (a,_,c) = (a,c)
-      apiTx = mkApiTransaction txid (drop2nd <$> ins) outs ws (meta, txtime) $
-          case meta ^. #status of
-              Pending  -> #pendingSince
-              InLedger -> #insertedAt
 
 apiFee :: FeeEstimation -> ApiFee
 apiFee (FeeEstimation estMin estMax) = ApiFee (qty estMin) (qty estMax)
@@ -1264,13 +1306,17 @@ joinStakePool ctx knownPools apiPoolId (ApiT wid) body = do
     (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.joinStakePool @_ @s @t @k wrk wid (pid, pools) (delegationAddress @n) pwd
 
-    pure $ mkApiTransaction
+    liftIO $ mkApiTransaction
+        ti
         (txId tx)
         (second (const Nothing) <$> tx ^. #resolvedInputs)
         (tx ^. #outputs)
         (tx ^. #withdrawals)
         (txMeta, txTime)
         #pendingSince
+  where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
 
 delegationFee
     :: forall ctx s t n k.
@@ -1290,6 +1336,7 @@ quitStakePool
         , s ~ SeqState n k
         , IsOwned s k
         , GenChange s
+        , HasNetworkLayer t ctx
         , HardDerivation k
         , AddressIndexDerivationType k ~ 'Soft
         , ctx ~ ApiLayer s t k
@@ -1304,13 +1351,17 @@ quitStakePool ctx (ApiT wid) body = do
     (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.quitStakePool @_ @s @t @k wrk wid (delegationAddress @n) pwd
 
-    pure $ mkApiTransaction
+    liftIO $ mkApiTransaction
+        ti
         (txId tx)
         (second (const Nothing) <$> tx ^. #resolvedInputs)
         (tx ^. #outputs)
         (tx ^. #withdrawals)
         (txMeta, txTime)
         #pendingSince
+  where
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
 
 {-------------------------------------------------------------------------------
                                 Migrations
@@ -1366,7 +1417,8 @@ migrateWallet ctx (ApiT wid) migrateData = do
             $ \wrk -> liftHandler $ W.signTx @_ @s @t @k wrk wid pwd cs
         withWorkerCtx ctx wid liftE liftE
             $ \wrk -> liftHandler $ W.submitTx @_ @_ @t wrk wid (tx, meta, wit)
-        pure $ mkApiTransaction
+        liftIO $ mkApiTransaction
+            ti
             (txId tx)
             (fmap Just <$> NE.toList (W.unsignedInputs cs))
             (NE.toList (W.unsignedOutputs cs))
@@ -1376,6 +1428,9 @@ migrateWallet ctx (ApiT wid) migrateData = do
   where
     pwd = coerce $ getApiT $ migrateData ^. #passphrase
     addrs = getApiT . fst <$> migrateData ^. #addresses
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter (ctx ^. networkLayer @t)
+
 
 -- | Transform the given set of migration coin selections (for a source wallet)
 --   into a set of coin selections that will migrate funds to the specified
@@ -1416,36 +1471,35 @@ getNetworkInformation
     -> Handler ApiNetworkInformation
 getNetworkInformation (_block0, np, st) nl = do
     now <- liftIO getCurrentTime
-    nodeTip <- liftHandler (NW.currentNodeTip nl)
-    let ntrkTip = fromMaybe W.slotMinBound (W.slotAt sp now)
+    nodeTip <-  liftHandler (NW.currentNodeTip nl)
+    apiNodeTip <- liftIO $ mkApiBlockReference ti nodeTip
+    let ntrkTip = fromMaybe slotMinBound (slotAt' sp now)
+    -- TODO: ADP-356: We need to retrieve the network tip using a different API,
+    -- AND it may not be availible.
     let nextEpochNo = unsafeEpochSucc (ntrkTip ^. #epochNumber)
-    pure $ ApiNetworkInformation
-        { syncProgress =
-            ApiT $ syncProgressRelativeToTime st sp nodeTip now
-        , nextEpoch =
+    progress <- liftIO $ syncProgress st ti nodeTip now
+    pure $ Api.ApiNetworkInformation
+        { Api.syncProgress = ApiT progress
+        , Api.nextEpoch =
             ApiEpochInfo
-                { epochNumber = ApiT nextEpochNo
-                , epochStartTime = W.epochStartTime sp nextEpochNo
-                }
-        , nodeTip =
-            ApiBlockReference
-                { epochNumber = ApiT $ nodeTip ^. (#slotId . #epochNumber)
-                , slotNumber  = ApiT $ nodeTip ^. (#slotId . #slotNumber)
-                , height = natural (nodeTip ^. #blockHeight)
-                }
-        , networkTip =
+                (ApiT nextEpochNo)
+                (epochStartTime sp nextEpochNo)
+        , Api.nodeTip = apiNodeTip
+        , Api.networkTip =
             ApiNetworkTip
                 { epochNumber = ApiT $ ntrkTip ^. #epochNumber
                 , slotNumber  = ApiT $ ntrkTip ^. #slotNumber
                 }
         }
   where
-    sp = W.slotParams (np ^. #genesisParameters)
+    ti :: TimeInterpreter IO
+    ti = timeInterpreter nl
+    sp = slotParams (np ^. #genesisParameters)
 
     -- Unsafe constructor for the next epoch. Chances to reach the last epoch
     -- are quite unlikely in this context :)
     unsafeEpochSucc :: HasCallStack => W.EpochNo -> W.EpochNo
-    unsafeEpochSucc = fromMaybe bomb . W.epochSucc
+    unsafeEpochSucc = fromMaybe bomb . epochSucc
       where bomb = error "reached final epoch of the Blockchain!?"
 
 getNetworkParameters
@@ -1572,16 +1626,18 @@ mkApiCoinSelection (UnsignedTx inputs outputs) =
             }
 
 mkApiTransaction
-    :: forall n.
-       Hash "Tx"
+    :: forall n m. Monad m
+    => TimeInterpreter m
+    -> Hash "Tx"
     -> [(TxIn, Maybe TxOut)]
     -> [TxOut]
     -> Map ChimericAccount Coin
     -> (W.TxMeta, UTCTime)
     -> Lens' (ApiTransaction n) (Maybe ApiTimeReference)
-    -> ApiTransaction n
-mkApiTransaction txid ins outs ws (meta, timestamp) setTimeReference =
-    tx & setTimeReference .~ Just timeReference
+    -> m (ApiTransaction n)
+mkApiTransaction ti txid ins outs ws (meta, timestamp) setTimeReference = do
+    timeRef <- timeReference
+    return $ tx & setTimeReference .~ Just timeRef
   where
     tx :: ApiTransaction n
     tx = ApiTransaction
@@ -1597,15 +1653,22 @@ mkApiTransaction txid ins outs ws (meta, timestamp) setTimeReference =
         , status = ApiT (meta ^. #status)
         }
 
-    timeReference :: ApiTimeReference
-    timeReference = ApiTimeReference
-        { time = timestamp
-        , block = ApiBlockReference
-            { slotNumber = ApiT $ meta ^. (#slotId . #slotNumber )
-            , epochNumber = ApiT $ meta ^. (#slotId . #epochNumber)
-            , height = natural (meta ^. #blockHeight)
-            }
-        }
+    timeReference :: m ApiTimeReference
+    timeReference = do
+        slotId <- ti (toSlotId $ meta ^. #slotNo)
+        -- TODO: We get passed the timestamp, but still have to do additional
+        -- time-conversions here. We should probably do both
+        --  SlotNo -> SlotId
+        --  SlotNo -> UTCTime
+        -- conversions in the same place.
+        return $
+            ApiTimeReference
+                timestamp
+                ApiBlockReference
+                    { epochNumber = ApiT $ slotId ^. #epochNumber
+                    , slotNumber = ApiT $ slotId ^. #slotNumber
+                    , height = natural (meta ^. #blockHeight)
+                    }
 
     toAddressAmount :: TxOut -> AddressAmount (ApiT Address, Proxy n)
     toAddressAmount (TxOut addr c) =
@@ -1630,12 +1693,25 @@ coerceCoin (AddressAmount (ApiT addr, _) (Quantity c)) =
 natural :: Quantity q Word32 -> Quantity q Natural
 natural = Quantity . fromIntegral . getQuantity
 
-getWalletTip :: Wallet s -> ApiBlockReference
-getWalletTip wallet = ApiBlockReference
-    { epochNumber = ApiT $ (currentTip wallet) ^. #slotId . #epochNumber
-    , slotNumber = ApiT $ (currentTip wallet) ^. #slotId . #slotNumber
-    , height = natural $ (currentTip wallet) ^. #blockHeight
-    }
+mkApiBlockReference
+    :: Monad m
+    => TimeInterpreter m
+    -> BlockHeader
+    -> m ApiBlockReference
+mkApiBlockReference ti tip = do
+    slotId <- ti (toSlotId $ slotNo tip)
+    return $ ApiBlockReference
+        { epochNumber = ApiT $ slotId ^. #epochNumber
+        , slotNumber = ApiT $ slotId ^. #slotNumber
+        , height = natural $ tip ^. #blockHeight
+        }
+
+getWalletTip
+    :: Monad m
+    => TimeInterpreter m
+    -> Wallet s
+    -> m ApiBlockReference
+getWalletTip ti wallet = mkApiBlockReference ti (currentTip wallet)
 
 {-------------------------------------------------------------------------------
                                 Api Layer

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -41,7 +41,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash
     , ProtocolParameters
     , Range (..)
-    , SlotId (..)
+    , SlotNo (..)
     , SortOrder (..)
     , TransactionInfo
     , Tx (..)
@@ -178,7 +178,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
     , putDelegationCertificate
         :: PrimaryKey WalletId
         -> DelegationCertificate
-        -> SlotId
+        -> SlotNo
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Binds a stake pool id to a wallet. This will have an influence on
         -- the wallet metadata: the last known certificate will indicate to
@@ -188,7 +188,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         -- declarations are:
         --
         -- 1. Stored on-chain.
-        -- 2. Affected by rollbacks (or said differently, tied to a 'SlotId').
+        -- 2. Affected by rollbacks (or said differently, tied to a 'SlotNo').
 
     , putDelegationRewardBalance
         :: PrimaryKey WalletId
@@ -223,7 +223,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
         :: PrimaryKey WalletId
         -> Maybe (Quantity "lovelace" Natural)
         -> SortOrder
-        -> Range SlotId
+        -> Range SlotNo
         -> Maybe TxStatus
         -> stm [TransactionInfo]
         -- ^ Fetch the current transaction history of a known wallet, ordered by
@@ -274,8 +274,8 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , rollbackTo
         :: PrimaryKey WalletId
-        -> SlotId
-        -> ExceptT ErrNoSuchWallet stm SlotId
+        -> SlotNo
+        -> ExceptT ErrNoSuchWallet stm SlotNo
         -- ^ Drops all checkpoints and transaction data after the given slot.
         --
         -- Returns the actual slot to which the database has rolled back. This

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -92,7 +92,7 @@ TxMeta
     txMetaWalletId     W.WalletId   sql=wallet_id
     txMetaStatus       W.TxStatus   sql=status
     txMetaDirection    W.Direction  sql=direction
-    txMetaSlot         SlotNo       sql=slot
+    txMetaSlot         SlotNo       sql=slot_no
     txMetaBlockHeight  Word32       sql=block_height
     txMetaAmount       Natural      sql=amount
 
@@ -143,7 +143,7 @@ TxWithdrawal
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint
     checkpointWalletId          W.WalletId   sql=wallet_id
-    checkpointSlot              SlotNo       sql=slot
+    checkpointSlot              SlotNo       sql=slot_no
     checkpointHeaderHash        BlockId      sql=header_hash
     checkpointParentHash        BlockId      sql=parent_header_hash
     checkpointBlockHeight       Word32       sql=block_height
@@ -174,7 +174,7 @@ ProtocolParameters
 -- Track whether the wallet's stake key is registered or not.
 StakeKeyCertificate
     stakeKeyCertWalletId             W.WalletId            sql=wallet_id
-    stakeKeyCertSlot                 SlotNo                sql=slot
+    stakeKeyCertSlot                 SlotNo                sql=slot_no
     stakeKeyCertType                 W.StakeKeyCertificate sql=type
 
     Primary stakeKeyCertWalletId stakeKeyCertSlot
@@ -184,7 +184,7 @@ StakeKeyCertificate
 -- Store known delegation certificates for a particular wallet
 DelegationCertificate
     certWalletId             W.WalletId     sql=wallet_id
-    certSlot                 SlotNo         sql=slot
+    certSlot                 SlotNo         sql=slot_no
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
@@ -208,7 +208,7 @@ UTxO                                sql=utxo
 
     -- The wallet checkpoint (wallet_id, slot)
     utxoWalletId        W.WalletId  sql=wallet_id
-    utxoSlot            SlotNo      sql=slot
+    utxoSlot            SlotNo      sql=slot_no
 
     -- TxIn
     utxoInputId         TxId        sql=input_tx_id
@@ -239,7 +239,7 @@ SeqState
 -- when they were discovered.
 SeqStateAddress
     seqStateAddressWalletId         W.WalletId     sql=wallet_id
-    seqStateAddressSlot             SlotNo         sql=slot
+    seqStateAddressSlot             SlotNo         sql=slot_no
     seqStateAddressAddress          W.Address      sql=address
     seqStateAddressIndex            Word32         sql=address_ix
     seqStateAddressAccountingStyle  W.AccountingStyle  sql=accounting_style
@@ -277,7 +277,7 @@ RndState
 -- The set of discovered addresses.
 RndStateAddress
     rndStateAddressWalletId      W.WalletId        sql=wallet_id
-    rndStateAddressSlot          SlotNo            sql=slot
+    rndStateAddressSlot          SlotNo            sql=slot_no
     rndStateAddressAccountIndex  Word32            sql=account_ix
     rndStateAddressIndex         Word32            sql=address_ix
     rndStateAddressAddress       W.Address         sql=address

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -92,7 +92,7 @@ TxMeta
     txMetaWalletId     W.WalletId   sql=wallet_id
     txMetaStatus       W.TxStatus   sql=status
     txMetaDirection    W.Direction  sql=direction
-    txMetaSlot         SlotNo       sql=slot_no
+    txMetaSlot         SlotNo       sql=slot
     txMetaBlockHeight  Word32       sql=block_height
     txMetaAmount       Natural      sql=amount
 
@@ -143,7 +143,7 @@ TxWithdrawal
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint
     checkpointWalletId          W.WalletId   sql=wallet_id
-    checkpointSlot              SlotNo       sql=slot_no
+    checkpointSlot              SlotNo       sql=slot
     checkpointHeaderHash        BlockId      sql=header_hash
     checkpointParentHash        BlockId      sql=parent_header_hash
     checkpointBlockHeight       Word32       sql=block_height
@@ -174,7 +174,7 @@ ProtocolParameters
 -- Track whether the wallet's stake key is registered or not.
 StakeKeyCertificate
     stakeKeyCertWalletId             W.WalletId            sql=wallet_id
-    stakeKeyCertSlot                 SlotNo                sql=slot_no
+    stakeKeyCertSlot                 SlotNo                sql=slot
     stakeKeyCertType                 W.StakeKeyCertificate sql=type
 
     Primary stakeKeyCertWalletId stakeKeyCertSlot
@@ -184,7 +184,7 @@ StakeKeyCertificate
 -- Store known delegation certificates for a particular wallet
 DelegationCertificate
     certWalletId             W.WalletId     sql=wallet_id
-    certSlot                 SlotNo         sql=slot_no
+    certSlot                 SlotNo         sql=slot
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
@@ -208,7 +208,7 @@ UTxO                                sql=utxo
 
     -- The wallet checkpoint (wallet_id, slot)
     utxoWalletId        W.WalletId  sql=wallet_id
-    utxoSlot            SlotNo      sql=slot_no
+    utxoSlot            SlotNo      sql=slot
 
     -- TxIn
     utxoInputId         TxId        sql=input_tx_id
@@ -239,7 +239,7 @@ SeqState
 -- when they were discovered.
 SeqStateAddress
     seqStateAddressWalletId         W.WalletId     sql=wallet_id
-    seqStateAddressSlot             SlotNo         sql=slot_no
+    seqStateAddressSlot             SlotNo         sql=slot
     seqStateAddressAddress          W.Address      sql=address
     seqStateAddressIndex            Word32         sql=address_ix
     seqStateAddressAccountingStyle  W.AccountingStyle  sql=accounting_style
@@ -277,7 +277,7 @@ RndState
 -- The set of discovered addresses.
 RndStateAddress
     rndStateAddressWalletId      W.WalletId        sql=wallet_id
-    rndStateAddressSlot          SlotNo            sql=slot_no
+    rndStateAddressSlot          SlotNo            sql=slot
     rndStateAddressAccountIndex  Word32            sql=account_ix
     rndStateAddressIndex         Word32            sql=address_ix
     rndStateAddressAddress       W.Address         sql=address

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -24,6 +24,8 @@ module Cardano.Wallet.DB.Sqlite.TH where
 
 import Prelude
 
+import Cardano.Slotting.Slot
+    ( SlotNo )
 import Cardano.Wallet.DB.Sqlite.Types
     ( BlockId, HDPassphrase, TxId, sqlSettings' )
 import Data.Quantity
@@ -90,7 +92,7 @@ TxMeta
     txMetaWalletId     W.WalletId   sql=wallet_id
     txMetaStatus       W.TxStatus   sql=status
     txMetaDirection    W.Direction  sql=direction
-    txMetaSlot         W.SlotId     sql=slot
+    txMetaSlot         SlotNo       sql=slot
     txMetaBlockHeight  Word32       sql=block_height
     txMetaAmount       Natural      sql=amount
 
@@ -141,7 +143,7 @@ TxWithdrawal
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint
     checkpointWalletId          W.WalletId   sql=wallet_id
-    checkpointSlot              W.SlotId     sql=slot
+    checkpointSlot              SlotNo       sql=slot
     checkpointHeaderHash        BlockId      sql=header_hash
     checkpointParentHash        BlockId      sql=parent_header_hash
     checkpointBlockHeight       Word32       sql=block_height
@@ -172,7 +174,7 @@ ProtocolParameters
 -- Track whether the wallet's stake key is registered or not.
 StakeKeyCertificate
     stakeKeyCertWalletId             W.WalletId            sql=wallet_id
-    stakeKeyCertSlot                 W.SlotId              sql=slot
+    stakeKeyCertSlot                 SlotNo                sql=slot
     stakeKeyCertType                 W.StakeKeyCertificate sql=type
 
     Primary stakeKeyCertWalletId stakeKeyCertSlot
@@ -182,7 +184,7 @@ StakeKeyCertificate
 -- Store known delegation certificates for a particular wallet
 DelegationCertificate
     certWalletId             W.WalletId     sql=wallet_id
-    certSlot                 W.SlotId       sql=slot
+    certSlot                 SlotNo         sql=slot
     certPoolId               W.PoolId Maybe sql=delegation
 
     Primary certWalletId certSlot
@@ -206,7 +208,7 @@ UTxO                                sql=utxo
 
     -- The wallet checkpoint (wallet_id, slot)
     utxoWalletId        W.WalletId  sql=wallet_id
-    utxoSlot            W.SlotId    sql=slot
+    utxoSlot            SlotNo      sql=slot
 
     -- TxIn
     utxoInputId         TxId        sql=input_tx_id
@@ -237,7 +239,7 @@ SeqState
 -- when they were discovered.
 SeqStateAddress
     seqStateAddressWalletId         W.WalletId     sql=wallet_id
-    seqStateAddressSlot             W.SlotId       sql=slot
+    seqStateAddressSlot             SlotNo         sql=slot
     seqStateAddressAddress          W.Address      sql=address
     seqStateAddressIndex            Word32         sql=address_ix
     seqStateAddressAccountingStyle  W.AccountingStyle  sql=accounting_style
@@ -275,7 +277,7 @@ RndState
 -- The set of discovered addresses.
 RndStateAddress
     rndStateAddressWalletId      W.WalletId        sql=wallet_id
-    rndStateAddressSlot          W.SlotId          sql=slot
+    rndStateAddressSlot          SlotNo            sql=slot
     rndStateAddressAccountIndex  Word32            sql=account_ix
     rndStateAddressIndex         Word32            sql=address_ix
     rndStateAddressAddress       W.Address         sql=address

--- a/lib/core/src/Cardano/Wallet/Orphans.hs
+++ b/lib/core/src/Cardano/Wallet/Orphans.hs
@@ -1,0 +1,18 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Module for orphans which would be too inconvenient to avoid.
+module Cardano.Wallet.Orphans where
+
+import Prelude
+
+import Cardano.Slotting.Slot
+    ( SlotNo (..) )
+import Fmt
+    ( Buildable (..) )
+
+instance Buildable SlotNo where
+    build (SlotNo n) = build (show n)

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -363,7 +363,7 @@ prefilterBlock b u0 = runState $ do
     mkTxMeta amt dir = TxMeta
         { status = InLedger
         , direction = dir
-        , slotId = b ^. #header . #slotId
+        , slotNo = b ^. #header . #slotNo
         , blockHeight = b ^. #header . #blockHeight
         , amount = Quantity amt
         }

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -208,10 +208,12 @@ data Interpreter xs = Interpreter
 
 -- | An 'Interpreter' for a single era, where the slotting from
 -- @GenesisParameters@ cannot change.
+--
+-- Queries can never fail with @singleEraInterpreter@.
 singleEraInterpreter :: GenesisParameters -> TimeInterpreter Identity
 singleEraInterpreter gp q = either bomb return $ runQuery q int
   where
-    bomb x = error $ "singleEraInterpreter: " <> show x
+    bomb x = error $ "singleEraIntepreter: the impossible happened: " <> show x
     int = flip Interpreter (gp ^. #getGenesisBlockDate)
         $ neverForksSummary
         $ EraParams

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -170,6 +170,8 @@ import Prelude
 
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
+import Cardano.Wallet.Orphans
+    ()
 import Control.Arrow
     ( left )
 import Control.DeepSeq
@@ -200,7 +202,6 @@ import Data.Int
     ( Int32 )
 import Data.List
     ( intercalate )
-import Cardano.Wallet.Orphans ()
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -20,10 +20,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
--- Needed for (Buildable SlotNo)
--- TODO#1901: How do we want to deal with the orphan (Buildable SlotNo) instance?
-
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -204,6 +200,7 @@ import Data.Int
     ( Int32 )
 import Data.List
     ( intercalate )
+import Cardano.Wallet.Orphans ()
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -1459,9 +1456,6 @@ data SlotId = SlotId
   { epochNumber :: !EpochNo
   , slotNumber :: !SlotInEpoch
   } deriving stock (Show, Read, Eq, Ord, Generic)
-
-instance Buildable SlotNo where
-    build (SlotNo n) = build (show n)
 
 newtype SlotInEpoch = SlotInEpoch { unSlotInEpoch :: Word32 }
     deriving stock (Show, Read, Eq, Ord, Generic)

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -36,7 +36,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee, FeePolicy )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), PoolId, SealedTx (..), SlotId (..), Tx (..) )
+    ( Address (..), PoolId, SealedTx (..), SlotNo (..), Tx (..) )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity
@@ -52,7 +52,7 @@ data TransactionLayer t k = TransactionLayer
             -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
             -- Key store
-        -> SlotId
+        -> SlotNo
             -- Tip of the chain, for TTL
         -> CoinSelection
             -- A balanced coin selection where all change addresses have been
@@ -73,7 +73,7 @@ data TransactionLayer t k = TransactionLayer
             -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
             -- Key store
-        -> SlotId
+        -> SlotNo
             -- Tip of the chain, for TTL
         -> CoinSelection
             -- A balanced coin selection where all change addresses have been
@@ -91,7 +91,7 @@ data TransactionLayer t k = TransactionLayer
             -- Reward account
         -> (Address -> Maybe (k 'AddressK XPrv, Passphrase "encryption"))
             -- Key store
-        -> SlotId
+        -> SlotNo
             -- Tip of the chain, for TTL
         -> CoinSelection
             -- A balanced coin selection where all change addresses have been

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -9,6 +9,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     , dummyNetworkParameters
     , dummyGenesisParameters
     , dummyProtocolParameters
+    , dummyTimeInterpreter
     , genesisHash
     , mockHash
     , mkTxId
@@ -18,7 +19,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 import Prelude
 
 import Cardano.Wallet.Primitive.Slotting
-    ( slotMinBound )
+    ( TimeInterpreter, singleEraInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
@@ -32,6 +33,7 @@ import Cardano.Wallet.Primitive.Types
     , NetworkParameters (..)
     , ProtocolParameters (..)
     , SlotLength (..)
+    , SlotNo (..)
     , StartTime (..)
     , Tx (..)
     , TxIn (..)
@@ -44,6 +46,8 @@ import Data.ByteString
     ( ByteString )
 import Data.Coerce
     ( coerce )
+import Data.Functor.Identity
+    ( Identity (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Quantity
@@ -67,9 +71,9 @@ genesisHash = Hash (B8.replicate 32 '0')
 block0 :: Block
 block0 = Block
     { header = BlockHeader
-        { slotId = slotMinBound
+        { slotNo = SlotNo 0
         , blockHeight = Quantity 0
-        , headerHash = mockHash slotMinBound
+        , headerHash = mockHash $ SlotNo 0
         , parentHeaderHash = coerce genesisHash
         }
     , transactions = []
@@ -85,6 +89,11 @@ dummyGenesisParameters = GenesisParameters
     , getEpochStability = Quantity 2160
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     }
+
+dummyTimeInterpreter :: Monad m => TimeInterpreter m
+dummyTimeInterpreter = pure
+    . runIdentity
+    . singleEraInterpreter dummyGenesisParameters
 
 dummyTxParameters :: TxParameters
 dummyTxParameters = TxParameters

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -808,8 +808,6 @@ prop_listRegisteredPools DBLayer {..} entries =
         L.nub poolOwners /= poolOwners
 
     prop = do
-        -- TODO#1901: Is this change ok? Previously only (SlotInEpoch 0) were
-        -- generated.
         let entries' =
                 [ CertificatePublicationTime (SlotNo s) minBound
                 | s <- [0 ..]

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -19,6 +19,8 @@ import Cardano.Pool.DB.Properties
     ( newMemoryDBLayer, properties, withDB )
 import Cardano.Pool.DB.Sqlite
     ( withDBLayer )
+import Cardano.Wallet.DummyTarget.Primitive.Types
+    ( dummyTimeInterpreter )
 import System.Directory
     ( copyFile )
 import System.FilePath
@@ -48,9 +50,10 @@ test_migrationFromv20191216 =
         withSystemTempDirectory "stake-pools-db" $ \dir -> do
             let path = dir </> "stake-pools.sqlite"
             copyFile orig path
+            let ti = dummyTimeInterpreter
             (logs, _) <- captureLogging $ \tr -> do
-                withDBLayer tr (Just path) $ \_ -> pure ()
-                withDBLayer tr (Just path) $ \_ -> pure ()
+                withDBLayer tr (Just path) ti $ \_ -> pure ()
+                withDBLayer tr (Just path) ti $ \_ -> pure ()
 
             let databaseConnMsg  = filter isMsgConnStr logs
             let databaseResetMsg = filter (== MsgDatabaseReset) logs

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -16,6 +16,8 @@ import Prelude
 
 import Cardano.Wallet.DB.Properties
     ( properties, withDB )
+import Cardano.Wallet.DummyTarget.Primitive.Types
+    ( dummyTimeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
@@ -36,8 +38,10 @@ import Test.QuickCheck
 import qualified Cardano.Wallet.DB.MVar as MVar
 
 spec :: Spec
-spec = withDB @(SeqState 'Mainnet JormungandrKey) MVar.newDBLayer $
+spec = withDB @(SeqState 'Mainnet JormungandrKey) (MVar.newDBLayer ti) $
     describe "MVar" properties
+  where
+    ti = dummyTimeInterpreter
 
 newtype DummyStateMVar = DummyStateMVar Int
     deriving (Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -550,8 +550,7 @@ prop_getTxAfterPutInvalidTxId db@DBLayer{..} wid txGen txId' =
             (isNothing res)
 
 prop_getTxAfterPutInvalidWalletId
-    :: GenState s
-    => DBLayer IO s JormungandrKey
+    :: DBLayer IO s JormungandrKey
     -> ( PrimaryKey WalletId
        , Wallet s
        , WalletMetadata

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -54,6 +54,7 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters
     , ShowFmt (..)
     , SlotId (..)
+    , SlotNo (..)
     , SortOrder (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -780,12 +781,12 @@ prop_rollbackCheckpoint db@DBLayer{..} cp0 (MockChain chain) = do
     prop wid point = do
         let tip = currentTip point
         point' <- run $ atomically $ unsafeRunExceptT $
-            rollbackTo wid (tip ^. #slotId)
+            rollbackTo wid (tip ^. #slotNo)
         cp <- run $ atomically $ readCheckpoint wid
         let str = maybe "∅" pretty cp
         monitor $ counterexample ("Checkpoint after rollback: \n" <> str)
         assert (ShowFmt cp == ShowFmt (pure point))
-        assert (ShowFmt point' == ShowFmt (tip ^. #slotId))
+        assert (ShowFmt point' == ShowFmt (tip ^. #slotNo))
 
 -- | Re-schedule pending transaction on rollback, i.e.:
 --
@@ -839,22 +840,22 @@ prop_rollbackTxHistory db@DBLayer{..} (InitialCheckpoint cp0) (GenTxHistory txs0
             . map (\(tx, meta) -> unwords
                 [ "- "
                 , pretty (txId tx)
-                , pretty (meta ^. #slotId)
+                , pretty (meta ^. #slotNo)
                 , pretty (meta ^. #status)
                 , pretty (meta ^. #direction)
                 , show $ getQuantity ((meta ^. #amount))
                 ])
 
-    isBefore :: SlotId -> TxMeta -> Bool
+    isBefore :: SlotNo -> TxMeta -> Bool
     isBefore point meta =
-        (slotId :: TxMeta -> SlotId) meta <= point
+        (slotNo :: TxMeta -> SlotNo) meta <= point
 
-    rescheduled :: SlotId -> [Hash "Tx"]
+    rescheduled :: SlotNo -> [Hash "Tx"]
     rescheduled point =
-        let addedAfter meta = direction meta == Outgoing && meta ^. #slotId > point
+        let addedAfter meta = direction meta == Outgoing && meta ^. #slotNo > point
         in filterTxs (\tx -> addedAfter tx || isPending tx) txs0
 
-    knownAfterRollback :: SlotId -> [Hash "Tx"]
+    knownAfterRollback :: SlotNo -> [Hash "Tx"]
     knownAfterRollback point =
         rescheduled point ++ filterTxs (isBefore point) txs0
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
@@ -13,8 +13,10 @@ import Prelude
 
 import Cardano.Wallet.DB.Sqlite.Types
     ()
+import Cardano.Wallet.Gen
+    ( genSlotNo, shrinkSlotNo )
 import Cardano.Wallet.Primitive.Types
-    ( EpochNo (..), SlotId (..), SlotInEpoch (..) )
+    ( EpochNo (..), SlotInEpoch (..), SlotNo )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Typeable
@@ -27,7 +29,6 @@ import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , applyArbitrary2
     , arbitrarySizedBoundedIntegral
     , property
     , shrinkIntegral
@@ -37,7 +38,7 @@ import Test.QuickCheck
 spec :: Spec
 spec = do
     describe "Values can be persisted and unpersisted successfully" $ do
-        persistRoundtrip $ Proxy @SlotId
+        persistRoundtrip $ Proxy @SlotNo
 
 -- | Constructs a test to check that roundtrip persistence and unpersistence is
 --   possible for values of the given type.
@@ -56,9 +57,9 @@ persistRoundtrip proxy = it
                               Arbitrary Instances
 -------------------------------------------------------------------------------}
 
-instance Arbitrary SlotId where
-    arbitrary = applyArbitrary2 SlotId
-    shrink (SlotId en sn) = uncurry SlotId <$> shrink (en, sn)
+instance Arbitrary SlotNo where
+    arbitrary = genSlotNo
+    shrink = shrinkSlotNo
 
 instance Arbitrary EpochNo where
     arbitrary = EpochNo <$> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -394,7 +394,6 @@ runMock = \case
     RemovePendingTx wid tid ->
         first (Resp . fmap Unit) . mRemovePendingTx wid tid
   where
-    -- TODO#1901: This needs to match the actual DB Genesis params?
     timeInterpreter = dummyTimeInterpreter
 
 {-------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -13,7 +13,6 @@ module Cardano.Wallet.Gen
     , shrinkPercentage
     , genLegacyAddress
     , genBlockHeader
-    , genSlotId
     , genActiveSlotCoefficient
     , shrinkActiveSlotCoefficient
     , genSlotNo
@@ -26,17 +25,12 @@ import Cardano.Address.Derivation
     ( xpubFromBytes )
 import Cardano.Mnemonic
     ( ConsistentEntropy, EntropySize, Mnemonic, entropyToMnemonic )
-import Cardano.Wallet.Primitive.Slotting
-    ( unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
     , BlockHeader (..)
-    , EpochLength (..)
     , Hash (..)
     , ProtocolMagic (..)
-    , SlotId (..)
-    , SlotInEpoch (..)
     , SlotNo (..)
     )
 import Cardano.Wallet.Unsafe
@@ -109,13 +103,6 @@ genSlotNo = SlotNo . fromIntegral <$> (arbitrary @Word32)
 
 shrinkSlotNo :: SlotNo -> [SlotNo]
 shrinkSlotNo (SlotNo x) = map SlotNo $ shrink x
-
-genSlotId :: EpochLength -> Gen SlotId
-genSlotId (EpochLength el) | el > 0 = do
-    ep <- choose (0, 10)
-    sl <- choose (0, el - 1)
-    return (SlotId (unsafeEpochNo ep) (SlotInEpoch sl))
-genSlotId _ = error "genSlotId: epochLength must > 0"
 
 genBlockHeader :: SlotNo -> Gen BlockHeader
 genBlockHeader sl = do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -29,6 +29,8 @@ import Cardano.Wallet.Primitive.Model
     , totalBalance
     , totalUTxO
     )
+import Cardano.Wallet.Primitive.Slotting
+    ( flatSlot )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Block (..)
@@ -37,9 +39,11 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , Dom (..)
+    , EpochLength (..)
     , Hash (..)
     , ShowFmt (..)
     , SlotId (..)
+    , SlotNo (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (direction)
@@ -349,7 +353,7 @@ blockchain :: [Block]
 blockchain =
     [ Block
         { header = BlockHeader
-            { slotId = SlotId 2 19218
+            { slotNo = slot 2 19218
             , blockHeight = Quantity 62392
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
@@ -384,7 +388,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 20991
+            { slotNo = slot 13 20991
             , blockHeight = Quantity 301749
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
@@ -435,7 +439,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 21458
+            { slotNo = slot 13 21458
             , blockHeight = Quantity 302216
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
@@ -486,7 +490,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 13 21586
+            { slotNo = slot 13 21586
             , blockHeight = Quantity 1321586
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
@@ -517,7 +521,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 0
+            { slotNo = slot 14 0
             , blockHeight = Quantity 302358
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
@@ -527,7 +531,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 1
+            { slotNo = slot 14 1
             , blockHeight = Quantity 302359
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
@@ -558,7 +562,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 2
+            { slotNo = slot 14 2
             , blockHeight = Quantity 302360
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
@@ -588,7 +592,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 3
+            { slotNo = slot 14 3
             , blockHeight = Quantity 302361
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
@@ -619,7 +623,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-              { slotId = SlotId 14 4
+              { slotNo = slot 14 4
               , blockHeight = Quantity 302362
               , headerHash = Hash "unused"
               , parentHeaderHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
@@ -629,7 +633,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-              { slotId = SlotId 14 5
+              { slotNo = slot 14 5
               , blockHeight = Quantity 302363
               , headerHash = Hash "unused"
               , parentHeaderHash = Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
@@ -664,7 +668,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 6
+            { slotNo = slot 14 6
             , blockHeight = Quantity 302364
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
@@ -674,7 +678,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 7
+            { slotNo = slot 14 7
             , blockHeight = Quantity 302365
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
@@ -684,7 +688,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 8
+            { slotNo = slot 14 8
             , blockHeight = Quantity 302366
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
@@ -694,7 +698,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 9
+            { slotNo = slot 14 9
             , blockHeight = Quantity 302367
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
@@ -704,7 +708,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 10
+            { slotNo = slot 14 10
             , blockHeight = Quantity 302368
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
@@ -755,7 +759,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 11
+            { slotNo = slot 14 11
             , blockHeight = Quantity 302369
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
@@ -806,7 +810,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 12
+            { slotNo = slot 14 12
             , blockHeight = Quantity 302370
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
@@ -816,7 +820,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 13
+            { slotNo = slot 14 13
             , blockHeight = Quantity 302371
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
@@ -826,7 +830,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 14
+            { slotNo = slot 14 14
             , blockHeight = Quantity 302372
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
@@ -836,7 +840,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 15
+            { slotNo = slot 14 15
             , blockHeight = Quantity 302373
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
@@ -846,7 +850,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 16
+            { slotNo = slot 14 16
             , blockHeight = Quantity 302374
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
@@ -856,7 +860,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 17
+            { slotNo = slot 14 17
             , blockHeight = Quantity 302375
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
@@ -866,7 +870,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 18
+            { slotNo = slot 14 18
             , blockHeight = Quantity 302376
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
@@ -917,7 +921,7 @@ blockchain =
         }
     , Block
         { header = BlockHeader
-            { slotId = SlotId 14 19
+            { slotNo = slot 14 19
             , blockHeight = Quantity 302377
             , headerHash = Hash "unused"
             , parentHeaderHash = Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
@@ -947,3 +951,5 @@ blockchain =
         , delegations = []
         }
     ]
+  where
+    slot e s = SlotNo $ flatSlot (EpochLength 21600) (SlotId e s)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -67,7 +67,10 @@ spec = do
                 $ property $ legacySlottingTest slotStartTime startTime
 
             it "slotRangeFromTimeRange and slotRangeFromTimeRange'"
-                $ withMaxSuccess 1000000 $ property $ \gp timeRange -> do
+                $ withMaxSuccess 10000 $ property $ \gp timeRange -> do
+                    -- NOTE: The old impementation breaks for large times /
+                    -- slotNos. After only generating SlotLengths of 1s or
+                    -- bigger, it should hopefully always work.
                     let sp = slotParams gp
                     let res = runIdentity $ singleEraInterpreter gp
                             (slotRangeFromTimeRange timeRange)
@@ -79,7 +82,7 @@ spec = do
                     res' === legacy
 
             it "(firstSlotInEpoch e) vs (SlotId e 0) "
-                $ withMaxSuccess 1000000 $ property $ \gp e -> do
+                $ withMaxSuccess 10000 $ property $ \gp e -> do
                     let res = runIdentity $ singleEraInterpreter gp
                             (firstSlotInEpoch e)
                     let legacy = SlotNo $ flatSlot (getEpochLength gp) $ SlotId e 0
@@ -114,7 +117,7 @@ instance Arbitrary GenesisParameters where
     shrink = genericShrink
 
 instance Arbitrary SlotLength where
-    arbitrary = SlotLength . fromRational . toRational <$> choose (0.1,10::Double)
+    arbitrary = SlotLength . fromRational . toRational <$> choose (1,10::Double)
     shrink _ = []
 
 instance Arbitrary (Hash "Genesis") where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Cardano.Wallet.Primitive.SyncProgressSpec
@@ -9,21 +11,23 @@ import Prelude
 import Cardano.Wallet.Gen
     ( genActiveSlotCoefficient
     , genBlockHeader
-    , genSlotId
+    , genSlotNo
     , shrinkActiveSlotCoefficient
+    , shrinkSlotNo
     )
 import Cardano.Wallet.Primitive.Slotting
-    ( SlotParameters (..), unsafeEpochNo )
+    ( TimeInterpreter, singleEraInterpreter, startTime )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), SyncTolerance (..), syncProgress )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , EpochLength (..)
+    , GenesisParameters (..)
     , Hash (..)
-    , SlotId (..)
-    , SlotInEpoch (..)
     , SlotLength (..)
+    , SlotNo (..)
+    , SlotNo (..)
     , StartTime (..)
     )
 import Cardano.Wallet.Unsafe
@@ -33,89 +37,74 @@ import Control.DeepSeq
 import Control.Exception
     ( SomeException (..), evaluate, try )
 import Control.Monad
-    ( forM_, when )
+    ( forM_ )
 import Data.Either
     ( isRight )
+import Data.Functor.Identity
+    ( Identity (..) )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Ratio
-    ( (%) )
+import Data.Time.Clock
+    ( NominalDiffTime, addUTCTime )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe )
+    ( Spec, describe, it, pendingWith, shouldBe )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , choose
-    , counterexample
-    , forAll
-    , property
-    , withMaxSuccess
-    )
+    ( Arbitrary (..), counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
 
 spec :: Spec
 spec = do
-    let sp = SlotParameters
+    let gp = GenesisParameters
             { getEpochLength = EpochLength 21600
             , getSlotLength  = SlotLength 10
             , getGenesisBlockDate = StartTime (read "2019-11-09 16:43:02 UTC")
+            , getGenesisBlockHash = Hash ""
             , getActiveSlotCoefficient = 1
+            , getEpochStability = Quantity 10
             }
     let st = SyncTolerance 10
-    describe "syncProgress" $ do
-        it "works for any two slots" $ property $ \sl0 sl1 ->
-            syncProgress st sp sl0 sl1 `deepseq` ()
 
-        let mockBlockHeader sl h = BlockHeader
-                { slotId = sl
-                , blockHeight = Quantity h
+
+    let ti = (singleEraInterpreter gp :: TimeInterpreter Identity)
+    describe "syncProgress" $ do
+        it "works for any two slots" $ property $ \tip (dt :: NominalDiffTime) ->
+            let
+                StartTime t0 = getGenesisBlockDate gp
+                t = dt `addUTCTime` t0
+            in
+                runIdentity (syncProgress st ti tip t) `deepseq` ()
+
+        let mkTip sl = BlockHeader
+                { slotNo = sl
+                , blockHeight = Quantity 0 -- Not needed
                 , headerHash = Hash "-"
                 , parentHeaderHash = Hash "-"
                 }
-
-        let mockSlotParams f = SlotParameters
-                { getEpochLength = EpochLength 10
-                , getSlotLength = SlotLength 10
-                , getGenesisBlockDate = StartTime $
-                    read "2019-01-01 00:00:00 UTC"
-                , getActiveSlotCoefficient = f
-                }
-
-        let syncTolerance = SyncTolerance 0
+        let tolerance = SyncTolerance 0
 
         it "unit test #1 - 0/10   0%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 0 0) 0
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
+            let tip = mkTip (SlotNo 0)
+            let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 10
+            runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0)
 
         it "unit test #2 - 10/20 50%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 0) 10
-            let ntwkTip = SlotId 2 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
+            let tip = mkTip (SlotNo 10)
+            let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 20
+            runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.5)
 
-        it "unit test #3 - 12/15 80% " $ do
-            let slotParams = mockSlotParams 0.5
-            let nodeTip = mockBlockHeader (SlotId 2 2) 12
-            let ntwkTip = SlotId 2 8
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
-                `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.8)
-
         it "unit test #4 - 10/10 100%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 0) 10
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
+            let tip = mkTip (SlotNo 10)
+            let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 10
+            runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Ready
 
-        it "unit test #5 - 11/10 100%" $ do
-            let slotParams = mockSlotParams 1
-            let nodeTip = mockBlockHeader (SlotId 1 1) 11
-            let ntwkTip = SlotId 1 0
-            syncProgress syncTolerance slotParams nodeTip ntwkTip
+        it "unit test #4 - 11/10 100%" $ do
+            let tip = mkTip (SlotNo 11)
+            let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 10
+            runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Ready
 
         --   100 |                          +  +
@@ -132,67 +121,69 @@ spec = do
         --       0  1  2  3  4  5  6  7  8  9  10
         --
         it "unit test #5 - distribution over several slots" $ do
-            let slotParams = mockSlotParams 0.5
-            let ntwkTip = SlotId 1 0
             let plots =
-                    [ (mockBlockHeader (SlotId 0 0) 0, 0.0)
-                    , (mockBlockHeader (SlotId 0 1) 1, 0.2)
-                    , (mockBlockHeader (SlotId 0 2) 2, 1 % 3)
-                    , (mockBlockHeader (SlotId 0 3) 2, 1 % 3)
-                    , (mockBlockHeader (SlotId 0 4) 2, 0.40)
-                    , (mockBlockHeader (SlotId 0 5) 3, 0.60)
-                    , (mockBlockHeader (SlotId 0 6) 3, 0.60)
-                    , (mockBlockHeader (SlotId 0 7) 4, 2 % 3)
-                    , (mockBlockHeader (SlotId 0 8) 5, 5 % 6)
-                    , (mockBlockHeader (SlotId 0 9) 5, 1.00)
-                    , (mockBlockHeader (SlotId 1 0) 5, 1.00)
+                    [ (mkTip (SlotNo 0), 0.0)
+                    , (mkTip (SlotNo 1), 0.1)
+                    , (mkTip (SlotNo 2), 0.2)
+                    , (mkTip (SlotNo 3), 0.3)
+                    , (mkTip (SlotNo 4), 0.4)
+                    , (mkTip (SlotNo 5), 0.5)
+                    , (mkTip (SlotNo 6), 0.6)
+                    , (mkTip (SlotNo 7), 0.7)
+                    , (mkTip (SlotNo 8), 0.8)
+                    , (mkTip (SlotNo 9), 0.9)
+                    , (mkTip (SlotNo 10), 1.0)
                     ]
             forM_ plots $ \(nodeTip, p) -> do
+                let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 10
                 let progress = if p == 1
                         then Ready
                         else Syncing (Quantity $ unsafeMkPercentage p)
-                syncProgress syncTolerance slotParams nodeTip ntwkTip
+                runIdentity
+                    (syncProgress tolerance ti nodeTip ntwkTime)
                     `shouldBe` progress
 
         it "unit test #6 - block height 0" $ do
-            let slotParams = mockSlotParams 0.5
-            let ntwkTip = SlotId 1 0
+            pendingWith "new calculation was needed for shelley"
+            -- Very short chains on jormungandr will probably see the
+            -- syncProgress immediately jump to 90%, and then slowly continue,
+            -- but seems like an acceptable sacrifice. The ITN is long anyway.
+            let ntwkTime = runIdentity $ ti $ startTime $ SlotNo 10
             let plots =
-                    [ (mockBlockHeader (SlotId 0 8) 0, 0)
-                    , (mockBlockHeader (SlotId 0 9) 0, 0)
-                    , (mockBlockHeader (SlotId 1 0) 0, 1)
+                    [ (mkTip (SlotNo 8), 0)
+                    , (mkTip (SlotNo 9), 0)
+                    , (mkTip (SlotNo 10), 1)
                     ]
             forM_ plots $ \(nodeTip, p) -> do
                 let progress = if p == 1
                         then Ready
                         else Syncing (Quantity $ unsafeMkPercentage p)
-                syncProgress syncTolerance slotParams nodeTip ntwkTip
+                runIdentity
+                    (syncProgress tolerance ti nodeTip ntwkTime)
                     `shouldBe` progress
 
         it "syncProgress should never crash" $ withMaxSuccess 10000
-            $ property $ \f bh -> do
-                let slotParams = mockSlotParams f
-                let el = getEpochLength slotParams
-                let genSlotIdPair = (,) <$> (genSlotId el) <*> (genSlotId el)
-                forAll genSlotIdPair $ \(walSlot, netSlot) -> monadicIO $ do
-                    let nodeTip = mockBlockHeader walSlot bh
-                    let x = syncProgress syncTolerance slotParams nodeTip netSlot
-                    when (netSlot > walSlot) $ do
-                        res <- run (try @SomeException $ evaluate x)
-                        monitor (counterexample $ "Result: " ++ show res)
-                        assert (isRight res)
+            $ property $ \tip dt -> monadicIO $ do
+                let StartTime t0 = getGenesisBlockDate gp
+                let t = dt `addUTCTime` t0
+                let x = runIdentity $
+                        syncProgress tolerance ti tip t
+                res <- run (try @SomeException $ evaluate x)
+                monitor (counterexample $ "Result: " ++ show res)
+                assert (isRight res)
 
 
 instance Arbitrary BlockHeader where
     shrink _ = []
     arbitrary = arbitrary >>= genBlockHeader
 
-instance Arbitrary SlotId where
-    shrink _ = []
-    arbitrary = do
-        ep <- choose (0, 10)
-        sl <- choose (0, 100)
-        return (SlotId (unsafeEpochNo ep) (SlotInEpoch sl))
+instance Arbitrary SlotNo where
+    arbitrary = genSlotNo
+    shrink = shrinkSlotNo
+
+instance Arbitrary NominalDiffTime where
+    arbitrary = toEnum <$> arbitrary
+    shrink x = map toEnum . shrink $ fromEnum x
 
 instance Arbitrary ActiveSlotCoefficient where
     shrink = shrinkActiveSlotCoefficient

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -79,6 +79,7 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , Coin (..)
+    , EpochLength (..)
     , EpochNo (..)
     , GenesisParameters (..)
     , Hash (..)
@@ -402,11 +403,12 @@ getBlocks j batchSize start = do
 -- | Get a block header corresponding to a header hash.
 getBlockHeader
     :: Monad m
-    => JormungandrClient m
+    => EpochLength
+    -> JormungandrClient m
     -> Hash "BlockHeader"
     -> ExceptT ErrGetBlock m BlockHeader
-getBlockHeader j t =
-    header . convertBlock <$> getBlock j t
+getBlockHeader el j t =
+    header . convertBlock el <$> getBlock j t
 
 {-------------------------------------------------------------------------------
                                 Errors

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -194,7 +194,7 @@ server byron icarus jormungandr spl ntp =
             SomeTrezorWallet x -> postTrezorWallet icarus x
             SomeLedgerWallet x -> postLedgerWallet icarus x
             SomeAccount x ->
-                postAccountWallet icarus mkLegacyWallet IcarusKey idleWorker x
+                postAccountWallet icarus (mkLegacyWallet @_ @_ @_ @t) IcarusKey idleWorker x
         )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , deleteWallet byron wid)
@@ -202,20 +202,20 @@ server byron icarus jormungandr spl ntp =
              )
         :<|> (\wid -> withLegacyLayer' wid
                 ( byron
-                , fst <$> getWallet byron mkLegacyWallet wid
-                , const (fst <$> getWallet byron mkLegacyWallet wid)
+                , fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
                 ( icarus
-                , fst <$> getWallet icarus mkLegacyWallet wid
-                , const (fst <$> getWallet icarus mkLegacyWallet wid)
+                , fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
              )
         :<|> liftA2 (\xs ys -> fmap fst $ sortOn snd $ xs ++ ys)
-            (listWallets byron  mkLegacyWallet)
-            (listWallets icarus mkLegacyWallet)
+            (listWallets byron (mkLegacyWallet @_ @_ @_ @t))
+            (listWallets icarus (mkLegacyWallet @_ @_ @_ @t))
         :<|> (\wid name -> withLegacyLayer wid
-                (byron , putWallet byron mkLegacyWallet wid name)
-                (icarus, putWallet icarus mkLegacyWallet wid name)
+                (byron , putWallet byron (mkLegacyWallet @_ @_ @_ @t) wid name)
+                (icarus, putWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid name)
              )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , getUTxOsStatistics byron wid)

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -40,7 +40,7 @@ import Cardano.Wallet.Primitive.Types
     , Hash (..)
     , PoolId (..)
     , SealedTx (..)
-    , SlotId (..)
+    , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     )
@@ -504,7 +504,7 @@ goldenTestStdTx
 goldenTestStdTx tl keystore inps outs bytes' = it title $ do
     let cs = mempty { inputs = inps, outputs = outs }
     let rewardAcnt = error "unused"
-    let tx = mkStdTx tl rewardAcnt keystore (SlotId 0 0) cs
+    let tx = mkStdTx tl rewardAcnt keystore (SlotNo 0) cs
     let bytes = hex . getSealedTx . snd <$> tx
     bytes `shouldBe` Right bytes'
   where
@@ -525,7 +525,7 @@ goldenTestDelegationCertTx tl keystore pool (accountXPrv, pass) inputs outputs b
             pool
             (accountXPrv, pass)
             keystore
-            (SlotId 0 0)
+            (SlotNo 0)
             (mempty { inputs, outputs })
     let sealed = getSealedTx . snd <$> res
     sealed `shouldBe` Right (unsafeFromHex bytes')
@@ -573,7 +573,7 @@ unknownInputTest
 unknownInputTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = mkStdTx tl rewardAcnt keyFrom (SlotId 0 0) cs
+    let res = mkStdTx tl rewardAcnt keyFrom (SlotNo 0) cs
           where
             tl = newTransactionLayer @JormungandrKey block0
             rewardAcnt = error "unused"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -204,7 +204,7 @@ server byron icarus shelley spl ntp =
             SomeTrezorWallet x -> postTrezorWallet icarus x
             SomeLedgerWallet x -> postLedgerWallet icarus x
             SomeAccount x ->
-                postAccountWallet icarus mkLegacyWallet IcarusKey idleWorker x
+                postAccountWallet icarus (mkLegacyWallet @_ @_ @_ @t) IcarusKey idleWorker x
         )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , deleteWallet byron wid)
@@ -212,20 +212,20 @@ server byron icarus shelley spl ntp =
              )
         :<|> (\wid -> withLegacyLayer' wid
                 ( byron
-                , fst <$> getWallet byron  mkLegacyWallet wid
-                , const (fst <$> getWallet byron  mkLegacyWallet wid)
+                , fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet byron (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
                 ( icarus
-                , fst <$> getWallet icarus mkLegacyWallet wid
-                , const (fst <$> getWallet icarus mkLegacyWallet wid)
+                , fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid
+                , const (fst <$> getWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid)
                 )
              )
         :<|> liftA2 (\xs ys -> fmap fst $ sortOn snd $ xs ++ ys)
-            (listWallets byron  mkLegacyWallet)
-            (listWallets icarus mkLegacyWallet)
+            (listWallets byron  (mkLegacyWallet @_ @_ @_ @t))
+            (listWallets icarus (mkLegacyWallet @_ @_ @_ @t))
         :<|> (\wid name -> withLegacyLayer wid
-                (byron , putWallet byron mkLegacyWallet wid name)
-                (icarus, putWallet icarus mkLegacyWallet wid name)
+                (byron , putWallet byron (mkLegacyWallet @_ @_ @_ @t) wid name)
+                (icarus, putWallet icarus (mkLegacyWallet @_ @_ @_ @t) wid name)
              )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , getUTxOsStatistics byron wid)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -121,8 +121,8 @@ spec :: Spec
 spec = do
     describe "Conversions" $
         it "toPoint' . fromTip' == getTipPoint" $ property $ \gh tip -> do
-            let fromTip' = fromTip gh epochLength
-            let toPoint' = toPoint gh epochLength
+            let fromTip' = fromTip gh
+            let toPoint' = toPoint gh
             toPoint' (fromTip' tip) === (getTipPoint tip)
 
     describe "Shelley StakeAddress" $ do

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -42,7 +42,6 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , EpochLength (..)
     , Hash (..)
     , ProtocolMagic (..)
     , TxIn (..)
@@ -265,10 +264,9 @@ testFeeOpts = feeOpts testTxLayer Nothing feePolicy (Coin 0)
     feePolicy = LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)
 
 testTxLayer :: TransactionLayer (IO Shelley) ShelleyKey
-testTxLayer = newTransactionLayer @_ @ShelleyKey (Proxy @'Mainnet) pm epLength
+testTxLayer = newTransactionLayer @_ @ShelleyKey (Proxy @'Mainnet) pm
   where
     pm        = ProtocolMagic 1
-    epLength  = EpochLength 42 -- irrelevant here
 
 data DecodeShelleySetup = DecodeShelleySetup
     { inputs :: UTxO


### PR DESCRIPTION
# Issue Number

ADP-356 #1868 #1869 


# Overview

- [x] Add TimeInterpreter, necessary queries, and a way to run them
Add tests comparing them with old implementation

- [x] Fundamentally change wallet to use SlotNo instead of SlotId
    - Patch together cardano-wallet-jormungandr to still work, despite the
binary using SlotId.

- [x] Remove redundant byron code

- [x] Sync progress calculation compares times now instead of slots

- [x] Rename the `slot` tables to `slot_no` to force automatic migration, preventing catastrophic re-interpretation of old data

# Comments

- Depends on #1890 

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
