### PR TITLE
Prevent staking to a retired pool.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1743,12 +1743,13 @@ joinStakePool
         , AddressIndexDerivationType k ~ 'Soft
         )
     => ctx
+    -> [PoolId]
+    -> PoolId
     -> WalletId
-    -> (PoolId, [PoolId])
     -> ArgGenChange s
     -> Passphrase "raw"
     -> ExceptT ErrJoinStakePool IO (Tx, TxMeta, UTCTime)
-joinStakePool ctx wid (pid, pools) argGenChange pwd = db & \DBLayer{..} -> do
+joinStakePool ctx pools pid wid argGenChange pwd = db & \DBLayer{..} -> do
     (isKeyReg, walMeta) <- mapExceptT atomically
         $ withExceptT ErrJoinStakePoolNoSuchWallet
         $ (,) <$> isStakeKeyRegistered (PrimaryKey wid)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2117,6 +2117,7 @@ instance Exception ErrCheckWalletIntegrity
 data ErrCannotJoin
     = ErrAlreadyDelegating PoolId
     | ErrNoSuchPool PoolId
+    | ErrPoolAlreadyRetired PoolId W.EpochNo
     deriving (Generic, Eq, Show)
 
 data ErrCannotQuit

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -114,6 +114,7 @@ module Cardano.Wallet
     , ErrSelectForMigration (..)
 
     -- ** Delegation
+    , PoolRetirementEpochInfo (..)
     , joinStakePool
     , quitStakePool
     , selectCoinsForDelegation
@@ -2158,6 +2159,16 @@ withNoSuchWallet
     -> ExceptT ErrNoSuchWallet m a
 withNoSuchWallet wid =
     maybeToExceptT (ErrNoSuchWallet wid) . MaybeT
+
+data PoolRetirementEpochInfo = PoolRetirementEpochInfo
+    { retirementEpoch
+        :: W.EpochNo
+        -- ^ The retirement epoch of a pool.
+    , currentEpoch
+        :: W.EpochNo
+        -- ^ The current epoch.
+    }
+    deriving (Eq, Generic, Show)
 
 guardJoin
     :: [PoolId]

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2135,7 +2135,6 @@ instance Exception ErrCheckWalletIntegrity
 data ErrCannotJoin
     = ErrAlreadyDelegating PoolId
     | ErrNoSuchPool PoolId
-    | ErrPoolAlreadyRetired PoolId PoolRetirementEpochInfo
     deriving (Generic, Eq, Show)
 
 data ErrCannotQuit
@@ -2199,7 +2198,7 @@ guardJoin knownPools delegation pid mRetirementEpochInfo = do
 
     forM_ mRetirementEpochInfo $ \info ->
         when (currentEpoch info >= retirementEpoch info) $
-            Left (ErrPoolAlreadyRetired pid info)
+            Left (ErrNoSuchPool pid)
 
     when ((null next) && isDelegatingTo (== pid) active) $
         Left (ErrAlreadyDelegating pid)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1749,7 +1749,7 @@ joinStakePool
     -> ArgGenChange s
     -> Passphrase "raw"
     -> ExceptT ErrJoinStakePool IO (Tx, TxMeta, UTCTime)
-joinStakePool ctx pools pid wid argGenChange pwd = db & \DBLayer{..} -> do
+joinStakePool ctx knownPools pid wid argGenChange pwd = db & \DBLayer{..} -> do
     (isKeyReg, walMeta) <- mapExceptT atomically
         $ withExceptT ErrJoinStakePoolNoSuchWallet
         $ (,) <$> isStakeKeyRegistered (PrimaryKey wid)
@@ -1758,7 +1758,7 @@ joinStakePool ctx pools pid wid argGenChange pwd = db & \DBLayer{..} -> do
     -- TODO: Replace this with actual retirement information:
     let retirementInfo = Nothing
     withExceptT ErrJoinStakePoolCannotJoin $ except $
-        guardJoin pools (walMeta ^. #delegation) pid retirementInfo
+        guardJoin knownPools (walMeta ^. #delegation) pid retirementInfo
 
     let action = if isKeyReg then Join pid else RegisterKeyAndJoin pid
     liftIO $ traceWith tr $ MsgIsStakeKeyRegistered isKeyReg

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1744,6 +1744,7 @@ joinStakePool
         , AddressIndexDerivationType k ~ 'Soft
         )
     => ctx
+    -> NetworkParameters
     -> [PoolId]
     -> PoolId
     -> PoolLifeCycleStatus
@@ -1751,7 +1752,7 @@ joinStakePool
     -> ArgGenChange s
     -> Passphrase "raw"
     -> ExceptT ErrJoinStakePool IO (Tx, TxMeta, UTCTime)
-joinStakePool ctx knownPools pid _poolStatus wid argGenChange pwd =
+joinStakePool ctx _np knownPools pid _poolStatus wid argGenChange pwd =
     db & \DBLayer{..} -> do
 
         (isKeyReg, walMeta) <- mapExceptT atomically

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1762,8 +1762,10 @@ joinStakePool ctx wid (pid, pools) argGenChange pwd = db & \DBLayer{..} -> do
     selection <- withExceptT ErrJoinStakePoolSelectCoin $
         selectCoinsForDelegation @ctx @s @t @k ctx wid action
 
-    (tx, txMeta, txTime, sealedTx) <- withExceptT ErrJoinStakePoolSignDelegation $
-        signDelegation @ctx @s @t @k ctx wid argGenChange pwd selection action
+    (tx, txMeta, txTime, sealedTx) <-
+        withExceptT ErrJoinStakePoolSignDelegation $
+            signDelegation
+                @ctx @s @t @k ctx wid argGenChange pwd selection action
 
     withExceptT ErrJoinStakePoolSubmitTx $
         submitTx @ctx @s @t @k ctx wid (tx, txMeta, sealedTx)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2135,7 +2135,7 @@ instance Exception ErrCheckWalletIntegrity
 data ErrCannotJoin
     = ErrAlreadyDelegating PoolId
     | ErrNoSuchPool PoolId
-    | ErrPoolAlreadyRetired PoolId W.EpochNo
+    | ErrPoolAlreadyRetired PoolId PoolRetirementEpochInfo
     deriving (Generic, Eq, Show)
 
 data ErrCannotQuit
@@ -2199,7 +2199,7 @@ guardJoin knownPools delegation pid mRetirementEpochInfo = do
 
     forM_ mRetirementEpochInfo $ \info ->
         when (currentEpoch info >= retirementEpoch info) $
-            Left (ErrPoolAlreadyRetired pid (retirementEpoch info))
+            Left (ErrPoolAlreadyRetired pid info)
 
     when ((null next) && isDelegatingTo (== pid) active) $
         Left (ErrAlreadyDelegating pid)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2169,12 +2169,12 @@ withNoSuchWallet wid =
     maybeToExceptT (ErrNoSuchWallet wid) . MaybeT
 
 data PoolRetirementEpochInfo = PoolRetirementEpochInfo
-    { retirementEpoch
-        :: W.EpochNo
-        -- ^ The retirement epoch of a pool.
-    , currentEpoch
+    { currentEpoch
         :: W.EpochNo
         -- ^ The current epoch.
+    , retirementEpoch
+        :: W.EpochNo
+        -- ^ The retirement epoch of a pool.
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1316,6 +1316,7 @@ joinStakePool
         , ctx ~ ApiLayer s t k
         )
     => ctx
+    -> NetworkParameters
     -> IO [PoolId]
        -- ^ Known pools
        -- We could maybe replace this with a @IO (PoolId -> Bool)@
@@ -1324,7 +1325,7 @@ joinStakePool
     -> ApiT WalletId
     -> ApiWalletPassphrase
     -> Handler (ApiTransaction n)
-joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
+joinStakePool ctx np knownPools getPoolStatus apiPoolId (ApiT wid) body = do
     let pwd = coerce $ getApiT $ body ^. #passphrase
 
     pid <- case apiPoolId of
@@ -1338,7 +1339,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
     (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $
         \wrk -> liftHandler $
             W.joinStakePool
-                @_ @s @t @k wrk
+                @_ @s @t @k wrk np
                 pools pid poolStatus wid (delegationAddress @n) pwd
 
     liftIO $ mkApiTransaction

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2255,16 +2255,6 @@ instance LiftHandler ErrJoinStakePool where
                     [ "I couldn't find any stake pool with the given id: "
                     , toText pid
                     ]
-            ErrPoolAlreadyRetired pid retirementInfo ->
-                apiError err403 PoolAlreadyRetired $ mconcat
-                    [ "I couldn't join stake pool with id "
-                    , toText pid
-                    , " as it retired in epoch "
-                    , toText (view #retirementEpoch retirementInfo)
-                    , ", but we are currently in epoch "
-                    , toText (view #currentEpoch retirementInfo)
-                    , ". Please specify a stake pool that has not yet retired."
-                    ]
 
 instance LiftHandler ErrFetchRewards where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2255,13 +2255,15 @@ instance LiftHandler ErrJoinStakePool where
                     [ "I couldn't find any stake pool with the given id: "
                     , toText pid
                     ]
-            ErrPoolAlreadyRetired pid epoch ->
+            ErrPoolAlreadyRetired pid retirementInfo ->
                 apiError err403 PoolAlreadyRetired $ mconcat
                     [ "I couldn't join stake pool with id "
                     , toText pid
                     , " as it retired in epoch "
-                    , toText epoch
-                    , " . Please specify a stake pool that has not yet retired."
+                    , toText (view #retirementEpoch retirementInfo)
+                    , ", but we are currently in epoch "
+                    , toText (view #currentEpoch retirementInfo)
+                    , ". Please specify a stake pool that has not yet retired."
                     ]
 
 instance LiftHandler ErrFetchRewards where

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1334,7 +1334,7 @@ joinStakePool ctx knownPools apiPoolId (ApiT wid) body = do
     (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $
         \wrk -> liftHandler $
             W.joinStakePool
-                @_ @s @t @k wrk wid (pid, pools) (delegationAddress @n) pwd
+                @_ @s @t @k wrk pools pid wid (delegationAddress @n) pwd
 
     liftIO $ mkApiTransaction
         ti

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -276,6 +276,7 @@ import Cardano.Wallet.Primitive.Types
     , NetworkParameters (..)
     , PassphraseScheme (..)
     , PoolId
+    , PoolLifeCycleStatus (..)
     , SortOrder (..)
     , TransactionInfo (TransactionInfo)
     , Tx (..)
@@ -1318,11 +1319,12 @@ joinStakePool
     -> IO [PoolId]
        -- ^ Known pools
        -- We could maybe replace this with a @IO (PoolId -> Bool)@
+    -> (PoolId -> IO PoolLifeCycleStatus)
     -> ApiPoolId
     -> ApiT WalletId
     -> ApiWalletPassphrase
     -> Handler (ApiTransaction n)
-joinStakePool ctx knownPools apiPoolId (ApiT wid) body = do
+joinStakePool ctx knownPools _getPoolStatus apiPoolId (ApiT wid) body = do
     let pwd = coerce $ getApiT $ body ^. #passphrase
 
     pid <- case apiPoolId of

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2249,6 +2249,14 @@ instance LiftHandler ErrJoinStakePool where
                     [ "I couldn't find any stake pool with the given id: "
                     , toText pid
                     ]
+            ErrPoolAlreadyRetired pid epoch ->
+                apiError err403 PoolAlreadyRetired $ mconcat
+                    [ "I couldn't join stake pool with id "
+                    , toText pid
+                    , " as it retired in epoch "
+                    , toText epoch
+                    , " . Please specify a stake pool that has not yet retired."
+                    ]
 
 instance LiftHandler ErrFetchRewards where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1331,8 +1331,10 @@ joinStakePool ctx knownPools apiPoolId (ApiT wid) body = do
 
     pools <- liftIO knownPools
 
-    (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
-        W.joinStakePool @_ @s @t @k wrk wid (pid, pools) (delegationAddress @n) pwd
+    (tx, txMeta, txTime) <- withWorkerCtx ctx wid liftE liftE $
+        \wrk -> liftHandler $
+            W.joinStakePool
+                @_ @s @t @k wrk wid (pid, pools) (delegationAddress @n) pwd
 
     liftIO $ mkApiTransaction
         ti
@@ -2239,8 +2241,8 @@ instance LiftHandler ErrJoinStakePool where
                 apiError err403 PoolAlreadyJoined $ mconcat
                     [ "I couldn't join a stake pool with the given id: "
                     , toText pid
-                    , ". I have already joined this pool; joining again would incur"
-                    , " an unnecessary fee!"
+                    , ". I have already joined this pool;"
+                    , " joining again would incur an unnecessary fee!"
                     ]
             ErrNoSuchPool pid ->
                 apiError err404 NoSuchPool $ mconcat

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -655,6 +655,7 @@ data ApiErrorCode
     | NothingToMigrate
     | NoSuchPool
     | PoolAlreadyJoined
+    | PoolAlreadyRetired
     | NotDelegatingTo
     | InvalidRestorationParameters
     | RejectedTip

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -649,6 +649,7 @@ data ApiErrorCode
     | MethodNotAllowed
     | NotAcceptable
     | StartTimeLaterThanEndTime
+    | UnableToDetermineCurrentEpoch
     | UnsupportedMediaType
     | UnexpectedError
     | NotSynced

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -655,7 +655,6 @@ data ApiErrorCode
     | NothingToMigrate
     | NoSuchPool
     | PoolAlreadyJoined
-    | PoolAlreadyRetired
     | NotDelegatingTo
     | InvalidRestorationParameters
     | RejectedTip

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -17,7 +17,8 @@
 module Cardano.Wallet.Primitive.Slotting
     ( -- * New api using ouroboros-concensus
       -- ** Queries
-      epochAt
+      currentEpoch
+    , epochAt
     , epochOf
     , startTime
     , toSlotId
@@ -67,6 +68,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Control.Monad
     ( (<=<), ap, liftM )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
 import Data.Functor.Identity
     ( Identity )
 import Data.Generics.Internal.VL.Lens
@@ -76,7 +79,7 @@ import Data.Maybe
 import Data.Quantity
     ( Quantity (..) )
 import Data.Time.Clock
-    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime )
 import Data.Word
     ( Word32, Word64 )
 import GHC.Generics
@@ -101,6 +104,9 @@ import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 --
 -- Queries
 --
+
+currentEpoch :: MonadIO m => TimeInterpreter m -> m (Maybe EpochNo)
+currentEpoch ti = ti . epochAt =<< liftIO getCurrentTime
 
 epochAt :: UTCTime -> Qry (Maybe EpochNo)
 epochAt = traverse epochOf <=< ongoingSlotAt

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Control.Monad
-    ( (<=<), ap, liftM )
+    ( ap, liftM, (<=<) )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
 import Data.Functor.Identity

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -17,7 +17,8 @@
 module Cardano.Wallet.Primitive.Slotting
     ( -- * New api using ouroboros-concensus
       -- ** Queries
-      epochOf
+      epochAt
+    , epochOf
     , startTime
     , toSlotId
     , slotRangeFromTimeRange
@@ -65,7 +66,7 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     )
 import Control.Monad
-    ( ap, liftM )
+    ( (<=<), ap, liftM )
 import Data.Functor.Identity
     ( Identity )
 import Data.Generics.Internal.VL.Lens
@@ -100,6 +101,9 @@ import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 --
 -- Queries
 --
+
+epochAt :: UTCTime -> Qry (Maybe EpochNo)
+epochAt = traverse epochOf <=< ongoingSlotAt
 
 epochOf :: Cardano.SlotNo -> Qry EpochNo
 epochOf slot = epochNumber <$> toSlotId slot

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -316,9 +316,15 @@ prop_guardJoinQuit knownPools dlg pid mRetirementInfo =
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"
                 (W.guardQuit dlg (Quantity 0) === Right ())
-        Left W.ErrPoolAlreadyRetired{} ->
-            -- TODO: Adjust this property to test for something useful:
-            label "ErrAlreadyRetired" $ property True
+        Left (W.ErrPoolAlreadyRetired errPid errRetirementEpoch) ->
+            label "ErrAlreadyRetired" $ property $ do
+                let Just info = mRetirementInfo
+                errPid
+                    `shouldBe` pid
+                errRetirementEpoch
+                    `shouldBe` W.retirementEpoch info
+                W.currentEpoch info
+                    `shouldSatisfy` (>= W.retirementEpoch info)
 
 prop_guardQuitJoin
     :: NonEmptyList PoolId

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -304,10 +304,11 @@ prop_guardJoinQuit
     :: [PoolId]
     -> WalletDelegation
     -> PoolId
+    -> Maybe W.PoolRetirementEpochInfo
     -> Property
-prop_guardJoinQuit knownPools dlg pid =
-    let noRetirementPlanned = Nothing in
-    case W.guardJoin knownPools dlg pid noRetirementPlanned of
+prop_guardJoinQuit knownPools dlg pid mRetirementInfo =
+    -- TODO: Add case analysis to this property:
+    case W.guardJoin knownPools dlg pid mRetirementInfo of
         Right () ->
             label "I can join" $ property True
         Left W.ErrNoSuchPool{} ->
@@ -316,6 +317,7 @@ prop_guardJoinQuit knownPools dlg pid =
             label "ErrAlreadyDelegating"
                 (W.guardQuit dlg (Quantity 0) === Right ())
         Left W.ErrPoolAlreadyRetired{} ->
+            -- TODO: Adjust this property to test for something useful:
             label "ErrAlreadyRetired" $ property True
 
 prop_guardQuitJoin

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -250,8 +250,10 @@ spec = do
                 `shouldBe` Left (W.ErrAlreadyDelegating pidA)
         it "Can join A, when active = A, next = [B]" $ do
             let next1 = next (EpochNo 1) (Delegating pidB)
-            let dlg = WalletDelegation {active = Delegating pidA, next = [next1]}
-            W.guardJoin knownPools dlg pidA `shouldBe` Right ()
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1]}
+            W.guardJoin knownPools dlg pidA
+                `shouldBe` Right ()
         it "Cannot join A, when active = A, next = [B, A]" $ do
             let next1 = next (EpochNo 1) (Delegating pidB)
             let next2 = next (EpochNo 2) (Delegating pidA)
@@ -265,17 +267,21 @@ spec = do
                 `shouldBe` Left (W.ErrNoSuchPool pidUnknown)
         it "Cannot quit when active: not_delegating, next = []" $ do
             let dlg = WalletDelegation {active = NotDelegating, next = []}
-            W.guardQuit dlg (Quantity 0) `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+            W.guardQuit dlg (Quantity 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Cannot quit when active: A, next = [not_delegating]" $ do
             let next1 = next (EpochNo 1) NotDelegating
-            let dlg = WalletDelegation {active = Delegating pidA, next = [next1]}
-            W.guardQuit dlg (Quantity 0) `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+            let dlg = WalletDelegation
+                    {active = Delegating pidA, next = [next1]}
+            W.guardQuit dlg (Quantity 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Cannot quit when active: A, next = [B, not_delegating]" $ do
             let next1 = next (EpochNo 1) (Delegating pidB)
             let next2 = next (EpochNo 2) NotDelegating
             let dlg = WalletDelegation
                     {active = Delegating pidA, next = [next1, next2]}
-            W.guardQuit dlg (Quantity 0) `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
+            W.guardQuit dlg (Quantity 0)
+                `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Can quit when active: not_delegating, next = [A]" $ do
             let next1 = next (EpochNo 1) (Delegating pidA)
             let dlg = WalletDelegation
@@ -288,7 +294,6 @@ spec = do
          knownPools = [pidA, pidB]
          next epoch dlgStatus =
              WalletDelegationNext {changesAt = epoch, status = dlgStatus}
-
 
 {-------------------------------------------------------------------------------
                                     Properties
@@ -303,7 +308,7 @@ prop_guardJoinQuit knownPools dlg pid =
     case W.guardJoin knownPools dlg pid of
         Right () ->
             label "I can join" $ property True
-        Left W.ErrNoSuchPool{}  ->
+        Left W.ErrNoSuchPool{} ->
             label "ErrNoSuchPool" $ property True
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -619,6 +619,10 @@ instance Arbitrary WalletDelegationNext where
 instance Arbitrary PoolId where
     arbitrary = pure $ PoolId "a"
 
+instance Arbitrary W.PoolRetirementEpochInfo where
+    arbitrary = W.PoolRetirementEpochInfo <$> arbitrary <*> arbitrary
+    shrink = genericShrink
+
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
     arbitrary = do

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -324,14 +324,6 @@ prop_guardJoinQuit knownPools dlg pid mRetirementInfo = checkCoverage
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"
                 (W.guardQuit dlg (Quantity 0) === Right ())
-        Left (W.ErrPoolAlreadyRetired errPid errRetirementInfo) ->
-            label "ErrAlreadyRetired" $ property $ do
-                let Just info = mRetirementInfo
-                errPid
-                    `shouldBe` pid
-                errRetirementInfo
-                    `shouldBe` info
-                alreadyRetired `shouldBe` True
   where
     retirementNotPlanned =
         isNothing mRetirementInfo

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -324,13 +324,13 @@ prop_guardJoinQuit knownPools dlg pid mRetirementInfo = checkCoverage
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"
                 (W.guardQuit dlg (Quantity 0) === Right ())
-        Left (W.ErrPoolAlreadyRetired errPid errRetirementEpoch) ->
+        Left (W.ErrPoolAlreadyRetired errPid errRetirementInfo) ->
             label "ErrAlreadyRetired" $ property $ do
                 let Just info = mRetirementInfo
                 errPid
                     `shouldBe` pid
-                errRetirementEpoch
-                    `shouldBe` W.retirementEpoch info
+                errRetirementInfo
+                    `shouldBe` info
                 alreadyRetired `shouldBe` True
   where
     retirementNotPlanned =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -130,7 +130,7 @@ import Data.Generics.Internal.VL.Lens
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
-    ( fromMaybe, isJust, isNothing )
+    ( isJust, isNothing )
 import Data.Ord
     ( Down (..) )
 import Data.Quantity
@@ -335,12 +335,14 @@ prop_guardJoinQuit knownPools dlg pid mRetirementInfo = checkCoverage
   where
     retirementNotPlanned =
         isNothing mRetirementInfo
-    retirementPlanned = fromMaybe False $ do
-        info <- mRetirementInfo
-        pure $ W.currentEpoch info < W.retirementEpoch info
-    alreadyRetired = fromMaybe False $ do
-        info <- mRetirementInfo
-        pure $ W.currentEpoch info >= W.retirementEpoch info
+    retirementPlanned =
+        (Just True ==) $ do
+            info <- mRetirementInfo
+            pure $ W.currentEpoch info < W.retirementEpoch info
+    alreadyRetired =
+        (Just True ==) $ do
+            info <- mRetirementInfo
+            pure $ W.currentEpoch info >= W.retirementEpoch info
 
 prop_guardQuitJoin
     :: NonEmptyList PoolId

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -310,7 +310,10 @@ prop_guardJoinQuit knownPools dlg pid mRetirementInfo =
     -- TODO: Add case analysis to this property:
     case W.guardJoin knownPools dlg pid mRetirementInfo of
         Right () ->
-            label "I can join" $ property True
+            label "I can join" $ property $
+                forM_ mRetirementInfo $ \info ->
+                    W.currentEpoch info
+                        `shouldSatisfy` (< W.retirementEpoch info)
         Left W.ErrNoSuchPool{} ->
             label "ErrNoSuchPool" $ property True
         Left W.ErrAlreadyDelegating{} ->

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -313,6 +313,8 @@ prop_guardJoinQuit knownPools dlg pid =
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"
                 (W.guardQuit dlg (Quantity 0) === Right ())
+        Left W.ErrPoolAlreadyRetired{} ->
+            label "ErrAlreadyRetired" $ property True
 
 prop_guardQuitJoin
     :: NonEmptyList PoolId

--- a/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
+++ b/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
@@ -82,6 +82,7 @@ import Cardano.Wallet.Primitive.Types
     , CertificatePublicationTime (..)
     , EpochNo (..)
     , PoolId
+    , PoolLifeCycleStatus
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
     , ProtocolParameters
@@ -155,7 +156,11 @@ data Block = Block
 -- | @StakePoolLayer@ is a thin layer ontop of the DB. It is /one/ value that
 -- can easily be passed to the API-server, where it can be used in a simple way.
 data StakePoolLayer e m = StakePoolLayer
-    { listStakePools
+    { getPoolLifeCycleStatus
+        :: PoolId
+        -> IO PoolLifeCycleStatus
+
+    , listStakePools
         :: ExceptT e m [(StakePool, Maybe StakePoolMetadata)]
 
     , knownStakePools
@@ -280,7 +285,9 @@ newStakePoolLayer
     -- it does not exist.
     -> StakePoolLayer ErrListStakePools IO
 newStakePoolLayer tr block0H getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
-    { listStakePools = do
+    { getPoolLifeCycleStatus = \pid ->
+        liftIO $ atomically $ readPoolLifeCycleStatus pid
+    , listStakePools = do
         lift $ traceWith tr MsgListStakePoolsBegin
         stakePools <- sortKnownPools
         meta <- lift $ findMetadata (map (first (^. #poolId)) stakePools)

--- a/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
+++ b/lib/jormungandr/src/Cardano/Pool/Jormungandr/Metrics.hs
@@ -285,8 +285,8 @@ newStakePoolLayer
     -- it does not exist.
     -> StakePoolLayer ErrListStakePools IO
 newStakePoolLayer tr block0H getEpCst db@DBLayer{..} nl metadataDir = StakePoolLayer
-    { getPoolLifeCycleStatus = \pid ->
-        liftIO $ atomically $ readPoolLifeCycleStatus pid
+    { getPoolLifeCycleStatus =
+        liftIO . atomically . readPoolLifeCycleStatus
     , listStakePools = do
         lift $ traceWith tr MsgListStakePoolsBegin
         stakePools <- sortKnownPools

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -181,7 +181,10 @@ server byron icarus jormungandr spl ntp =
 
     stakePools :: Server (StakePools n ApiStakePool)
     stakePools = (listPools spl)
-        :<|> joinStakePool jormungandr (knownStakePools spl)
+        :<|>
+            joinStakePool jormungandr
+                (knownStakePools spl)
+                (getPoolLifeCycleStatus spl)
         :<|> quitStakePool jormungandr
         :<|> delegationFee jormungandr
 

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -182,11 +182,13 @@ server byron icarus jormungandr spl ntp =
     stakePools :: Server (StakePools n ApiStakePool)
     stakePools = (listPools spl)
         :<|>
-            joinStakePool jormungandr
+            joinStakePool jormungandr np
                 (knownStakePools spl)
                 (getPoolLifeCycleStatus spl)
         :<|> quitStakePool jormungandr
         :<|> delegationFee jormungandr
+      where
+        (_, np, _) = jormungandr ^. genesisData
 
     byronWallets :: Server ByronWallets
     byronWallets =

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -182,13 +182,11 @@ server byron icarus jormungandr spl ntp =
     stakePools :: Server (StakePools n ApiStakePool)
     stakePools = (listPools spl)
         :<|>
-            joinStakePool jormungandr np
+            joinStakePool jormungandr
                 (knownStakePools spl)
                 (getPoolLifeCycleStatus spl)
         :<|> quitStakePool jormungandr
         :<|> delegationFee jormungandr
-      where
-        (_, np, _) = jormungandr ^. genesisData
 
     byronWallets :: Server ByronWallets
     byronWallets =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -193,14 +193,9 @@ server byron icarus shelley spl ntp =
                 ]
 
         )
-        :<|>
-            joinStakePool shelley np
-                (knownPools spl)
-                (getPoolLifeCycleStatus spl)
+        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> quitStakePool shelley
         :<|> delegationFee shelley
-      where
-        (_, np, _) = icarus ^. genesisData
 
     byronWallets :: Server ByronWallets
     byronWallets =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -193,7 +193,7 @@ server byron icarus shelley spl ntp =
                 ]
 
         )
-        :<|> joinStakePool shelley (knownPools spl)
+        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
         :<|> quitStakePool shelley
         :<|> delegationFee shelley
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -193,9 +193,14 @@ server byron icarus shelley spl ntp =
                 ]
 
         )
-        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
+        :<|>
+            joinStakePool shelley np
+                (knownPools spl)
+                (getPoolLifeCycleStatus spl)
         :<|> quitStakePool shelley
         :<|> delegationFee shelley
+      where
+        (_, np, _) = icarus ^. genesisData
 
     byronWallets :: Server ByronWallets
     byronWallets =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -186,7 +186,8 @@ server byron icarus shelley spl ntp =
     stakePools =
         (\case
             Just (ApiT stake) -> liftHandler $ listStakePools spl stake
-            Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $ mconcat
+            Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $
+                mconcat
                 [ "The stake intended to delegate must be provided as a query "
                 , "parameter as it affects the rewards and ranking."
                 ]


### PR DESCRIPTION
# Issue Number

#1853

# Overview

This PR:

- [x] Adjusts `joinStakePool` to return `ErrNoSuchPool` if the current epoch is _later than or equal to_ the retirement epoch of the specified pool.

# Comments

Integration tests specifically designed to test the rejection mechanism are **not** included in this PR, but will be tackled in a future PR. (See QA section of issue https://github.com/input-output-hk/cardano-wallet/issues/1853.)

However, existing tests already verify that it is possible to stake to a _non-retired_ pool, so we can be fairly confident we are not breaking existing functionality.