### PR TITLE
chore: Support Jormungandr-based network address validation in Daedalus

### DIFF
--- a/.weeder.yaml
+++ b/.weeder.yaml
@@ -74,6 +74,12 @@
         - identifier:
           - C
           - Consumer
+  - section:
+    - name: exe:cardano-wallet-jormungandr
+    - message:
+      - name: Redundant build-depends entry
+      - depends:
+        - cardano-addresses
 - package:
   - name: cardano-wallet-launcher
   - section:

--- a/lib/jormungandr/cardano-wallet-jormungandr.cabal
+++ b/lib/jormungandr/cardano-wallet-jormungandr.cabal
@@ -109,6 +109,7 @@ executable cardano-wallet-jormungandr
     ghc-options: -O2 -Werror
   build-depends:
       base
+    , cardano-addresses
     , cardano-wallet-cli
     , cardano-wallet-core
     , cardano-wallet-jormungandr

--- a/nix/.stack.nix/cardano-wallet-jormungandr.nix
+++ b/nix/.stack.nix/cardano-wallet-jormungandr.nix
@@ -84,6 +84,7 @@
         "cardano-wallet-jormungandr" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
             (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-jormungandr" or (errorHandler.buildDepError "cardano-wallet-jormungandr"))


### PR DESCRIPTION
Daedalus Inherits the dependency via cardano-wallet
https://github.com/input-output-hk/daedalus/pull/2041

# Issue Number

https://github.com/input-output-hk/daedalus/pull/2041

# Overview

To provide a frontend address validation utility, cardano-addresses is called from the electron main process, and the result passed back over IPC. This removes the parallel development/maintenance overhead with an implementation in JS.
The dependency is not managed directly for the other variants, so is required to be defined here too for alignment with the packaging concerns.
