### PR TITLE
bors: Remove ci/hydra-eval from required statuses

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,5 @@
 status = [
   "buildkite/cardano-wallet",
-  "ci/hydra-eval",
   "ci/hydra-build:required",
 ]
 timeout_sec = 7200


### PR DESCRIPTION
### Issue Number

Partial workaround for #1888.


### Overview

Recently we've seen several Bors merge failures from `ci/hydra-eval` that terminate with

    error: unable to fork: Cannot allocate memory

This works around the issue by removing `ci/hydra-eval` from statuses required for Bors to merge.

This status will instead be added as a requirement to the GitHub branch protection rules of this repo.

If the Hydra eval fails the first time around for the Bors merge commit, Bors won't fail because eval isn't required for Bors anymore. Hydra will automatically fix the eval, likely on the second pass, and then build the job at which point Bors will get the build notification and merge assuming the build is fine (which it should be if the PR CI status is already passed).

