### PR TITLE
Basic integration tests for pool registrations and retirements.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -593,6 +593,20 @@ spec = do
                             (.> Quantity (unsafeMkPercentage 0))
                     ]
 
+        it "pools have the correct retirement information" $ \ctx -> do
+            eventually "pools have the correct retirement information" $ do
+                r <- listPools ctx arbitraryStake
+                expectResponseCode HTTP.status200 r
+                verify r
+                    [ expectListSize 3
+                    -- At the time of setup, the pools have 1/3 stake each, but
+                    -- this could potentially be changed by other tests. Hence,
+                    -- we try to be forgiving here.
+                    , expectListField 0 #retirement (`shouldBe` Nothing)
+                    , expectListField 1 #retirement (`shouldBe` Nothing)
+                    , expectListField 2 #retirement (`shouldBe` Nothing)
+                    ]
+
         it "eventually has correct margin, cost and pledge" $ \ctx -> do
             eventually "pool worker finds the certificate" $ do
                 r <- listPools ctx arbitraryStake

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -608,7 +608,7 @@ spec = do
                     , expectListField 0 #retirement
                         (`shouldBe` Nothing)
                     , expectListField 1 #retirement
-                        (`shouldSatisfy` retirementEpochIs 10)
+                        (`shouldSatisfy` retirementEpochIs 1_000)
                     , expectListField 2 #retirement
                         (`shouldSatisfy` retirementEpochIs 1_000_000)
                     ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -522,9 +522,11 @@ setupStakePoolData
     -> String
     -- ^ Base URL of metadata server.
     -> Integer
-    -- ^ Pledge (and stake) amount
+    -- ^ Pledge (and stake) amount.
+    -> Maybe EpochNo
+    -- ^ Optional retirement epoch.
     -> IO (CardanoNodeConfig, FilePath, FilePath)
-setupStakePoolData tr dir name params url pledgeAmt = do
+setupStakePoolData tr dir name params url pledgeAmt _mRetirementEpoch = do
     let NodeParams severity systemStart (port, peers) = params
 
     (opPrv, opPub, opCount, metadata) <- genOperatorKeyPair tr dir
@@ -592,8 +594,9 @@ withStakePool tr baseDir idx params pledgeAmt action =
         createDirectory dir
         withStaticServer dir $ \url -> do
             traceWith tr $ MsgStartedStaticServer dir url
-            (cfg, opPub, tx) <-
-                setupStakePoolData tr dir name params url pledgeAmt
+            let retirementEpoch = Nothing
+            (cfg, opPub, tx) <- setupStakePoolData
+                tr dir name params url pledgeAmt retirementEpoch
             withCardanoNodeProcess tr name cfg $ \_ -> do
                 submitTx tr name tx
                 timeout 120

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -380,15 +380,16 @@ withCluster tr severity n dir action = bracketTracer' tr "withCluster" $ do
         if length (filter isRight group) /= n then do
             cancelAll
             throwIO $ ProcessHasExited
-                ("cluster didn't start correctly: " <> show (filter isLeft group))
+                ("cluster didn't start correctly: "
+                    <> show (filter isLeft group))
                 (ExitFailure 1)
         else do
             let cfg = NodeParams severity systemStart (port0, ports)
             withRelayNode tr dir cfg $ \socket -> do
                 action socket block0 params `finally` cancelAll
   where
-    -- | Get permutations of the size (n-1) for a list of n elements, alongside with
-    -- the element left aside. `[a]` is really expected to be `Set a`.
+    -- | Get permutations of the size (n-1) for a list of n elements, alongside
+    -- with the element left aside. `[a]` is really expected to be `Set a`.
     --
     -- >>> rotate [1,2,3]
     -- [(1,[2,3]), (2, [1,3]), (3, [1,2])]
@@ -585,10 +586,12 @@ withStakePool tr baseDir idx params pledgeAmt action =
         createDirectory dir
         withStaticServer dir $ \url -> do
             traceWith tr $ MsgStartedStaticServer dir url
-            (cfg, opPub, tx) <- setupStakePoolData tr dir name params url pledgeAmt
+            (cfg, opPub, tx) <-
+                setupStakePoolData tr dir name params url pledgeAmt
             withCardanoNodeProcess tr name cfg $ \_ -> do
                 submitTx tr name tx
-                timeout 120 ("pool registration", waitUntilRegistered tr name opPub)
+                timeout 120
+                    ("pool registration", waitUntilRegistered tr name opPub)
                 action
   where
     dir = baseDir </> name

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1236,22 +1236,22 @@ timeout t (title, action) = do
         Left _  -> fail ("Waited too long for: " <> title)
         Right a -> pure a
 
--- | A little disclaimer shown in the logs when setting up the cluster.
+-- | A little notice shown in the logs when setting up the cluster.
 cartouche :: Text
 cartouche = T.unlines
     [ ""
-    , "################################################################################"
-    , "#                                                                              #"
-    , "#  ⚠                           DISCLAIMER                                   ⚠  #"
-    , "#                                                                              #"
-    , "#        Cluster is booting. Stake pools are being registered on chain.        #"
-    , "#                                                                              #"
-    , "#        This may take roughly 60s, after what pools will become active        #"
-    , "#        and will start producing blocks. Please be patient...                 #"
-    , "#                                                                              #"
-    , "#  ⚠                           DISCLAIMER                                   ⚠  #"
-    , "#                                                                              #"
-    , "################################################################################"
+    , "########################################################################"
+    , "#                                                                      #"
+    , "#  ⚠                             NOTICE                             ⚠  #"
+    , "#                                                                      #"
+    , "#    Cluster is booting. Stake pools are being registered on chain.    #"
+    , "#                                                                      #"
+    , "#    This may take roughly 60s, after which pools will become active   #"
+    , "#    and will start producing blocks. Please be patient...             #"
+    , "#                                                                      #"
+    , "#  ⚠                             NOTICE                             ⚠  #"
+    , "#                                                                      #"
+    , "########################################################################"
     ]
 
 -- | Hash a ByteString using blake2b_256 and encode it in base16

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -65,7 +65,12 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), NetworkParameters (..), PoolId (..), ProtocolMagic (..) )
+    ( Block (..)
+    , EpochNo (..)
+    , NetworkParameters (..)
+    , PoolId (..)
+    , ProtocolMagic (..)
+    )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility
@@ -780,6 +785,22 @@ issuePoolRegistrationCert
             , "--out-file", file
             ]
         pure file
+
+issuePoolRetirementCert
+    :: Tracer IO ClusterLog
+    -> FilePath
+    -> FilePath
+    -> EpochNo
+    -> IO FilePath
+issuePoolRetirementCert tr dir opPub retirementEpoch = do
+    let file  = dir </> "pool-retirement.cert"
+    void $ cli tr
+        [ "shelley", "stake-pool", "deregistration-certificate"
+        , "--cold-verification-key-file", opPub
+        , "--epoch", show (unEpochNo retirementEpoch)
+        , "--out-file", file
+        ]
+    pure file
 
 -- | Create a stake address delegation certificate.
 issueDlgCert :: Tracer IO ClusterLog -> FilePath -> FilePath -> FilePath -> IO FilePath

--- a/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/genesis.yaml
@@ -25,7 +25,12 @@ protocolParams:
   minFeeA: 100
   maxBlockBodySize: 239857
   minFeeB: 100000
-  eMax: 0
+
+  # The epoch bound on pool retirements specifies how many epochs in advance
+  # retirements may be announced. For testing purposes, we allow retirements
+  # to be announced far into the future.
+  eMax: 1000000
+
   extraEntropy:
     tag: NeutralNonce
   maxBlockHeaderSize: 217569

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -179,7 +180,10 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
 
 testPoolConfigs :: [PoolConfig]
 testPoolConfigs =
-    replicate 3 (PoolConfig {retirementEpoch = Nothing})
+    [ PoolConfig {retirementEpoch = Nothing}
+    , PoolConfig {retirementEpoch = Just 10}
+    , PoolConfig {retirementEpoch = Just 1_000_000}
+    ]
 
 specWithServer
     :: (Tracer IO TestsLog, Tracers IO)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -67,7 +67,12 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Faucet
     ( initFaucet )
 import Cardano.Wallet.Shelley.Launch
-    ( ClusterLog, withCluster, withSystemTempDir, withTempDir )
+    ( ClusterLog
+    , PoolConfig (..)
+    , withCluster
+    , withSystemTempDir
+    , withTempDir
+    )
 import Cardano.Wallet.Shelley.Transaction
     ( _minimumFee )
 import Control.Concurrent.Async
@@ -172,6 +177,10 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
                 PortCLI.spec @t
                 NetworkCLI.spec @t
 
+testPoolConfigs :: [PoolConfig]
+testPoolConfigs =
+    replicate 3 (PoolConfig {retirementEpoch = Nothing})
+
 specWithServer
     :: (Tracer IO TestsLog, Tracers IO)
     -> SpecWith (Context Shelley)
@@ -211,20 +220,21 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
         minSev <- nodeMinSeverityFromEnv
         let tr' = contramap MsgCluster tr
         withSystemTempDir tr' "test" $ \dir ->
-            withCluster tr' minSev 3 dir $ \socketPath block0 (gp, vData) ->
-                withTempDir tr' dir "wallets" $ \db -> do
-                    serveWallet @(IO Shelley)
-                        (SomeNetworkDiscriminant $ Proxy @'Mainnet)
-                        tracers
-                        (SyncTolerance 10)
-                        (Just db)
-                        "127.0.0.1"
-                        ListenOnRandomPort
-                        Nothing
-                        socketPath
-                        block0
-                        (gp, vData)
-                        (onStart gp)
+            withCluster tr' minSev testPoolConfigs dir $
+                \socketPath block0 (gp, vData) ->
+                    withTempDir tr' dir "wallets" $ \db -> do
+                        serveWallet @(IO Shelley)
+                            (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                            tracers
+                            (SyncTolerance 10)
+                            (Just db)
+                            "127.0.0.1"
+                            ListenOnRandomPort
+                            Nothing
+                            socketPath
+                            block0
+                            (gp, vData)
+                            (onStart gp)
 
     -- | teardown after each test (currently only deleting all wallets)
     tearDown :: Context t -> IO ()

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -181,7 +181,7 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
 testPoolConfigs :: [PoolConfig]
 testPoolConfigs =
     [ PoolConfig {retirementEpoch = Nothing}
-    , PoolConfig {retirementEpoch = Just 10}
+    , PoolConfig {retirementEpoch = Just 1_000}
     , PoolConfig {retirementEpoch = Just 1_000_000}
     ]
 


### PR DESCRIPTION
# Issue Number

#1819 

# Overview

This PR provides a first step towards a full suite of integration tests for pool registrations and retirements.

- [x] Adds function `issuePoolRetirementCert` capable of creating Shelley pool retirement certificates.
- [x] Adjusts the initialization of the test pool cluster so that a subset of the pools are configured to retire after different time intervals.
- [x] Adds a basic integration test to verify that the `ListStakePools` API operation eventually shows the correct retirement epochs for the test pools.

# Comments

Future PRs will:

- Simulate the effect of re-registering a pool after a retirement certificate has already been published.
- Verify that it is not possible to join a stake pool that has already retired (see #1913).