### PR TITLE
Enable minUTxOValue: 1000000 in CI for shelley

### DIFF
--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -1602,7 +1602,7 @@ onlyDustWallet = unsafeMkMnemonic
     , "need" , "patient" , "wall" , "stamp" , "pass"
     ]
 
--- | A special Shelley Wallet with 200 UTxOs where 100 of them are dust
+-- | A special Shelley Wallet with 200 UTxOs where 100 of them are 1 ADA
 bigDustWallet :: Mnemonic 15
 bigDustWallet = unsafeMkMnemonic
     [ "radar", "scare", "sense", "winner", "little"
@@ -1614,12 +1614,19 @@ shelleyIntegrationTestFunds :: [(Address, Coin)]
 shelleyIntegrationTestFunds = mconcat
     [ seqMnemonics >>= (take 10 . map (, defaultAmt) . addresses . SomeMnemonic)
 
-    , zip
-        (addresses $ SomeMnemonic onlyDustWallet)
-        (map Coin [1,1,5,12,1,5,3,10,2,3])
+    , zip (addresses SomeMnemonic onlyDustWallet) (map Coin [ 1_000_000
+                                               , 1_000_000
+                                               , 5_000_000
+                                               , 12_000_000
+                                               , 1_000_000
+                                               , 5_000_000
+                                               , 3_000_000
+                                               , 10_000_000
+                                               , 2_000_000
+                                               , 3_000_000 ])
 
     , take 100 (map (, defaultAmt) $ addresses $ SomeMnemonic bigDustWallet)
-    , take 100 . drop 100 $ map (,Coin 1) $ addresses $ SomeMnemonic bigDustWallet
+    , take 100 . drop 100 $ map (,Coin 1_000_000) $ addresses $ SomeMnemonic bigDustWallet
 
     , preregKeyWalletFunds
 

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -1614,7 +1614,7 @@ shelleyIntegrationTestFunds :: [(Address, Coin)]
 shelleyIntegrationTestFunds = mconcat
     [ seqMnemonics >>= (take 10 . map (, defaultAmt) . addresses . SomeMnemonic)
 
-    , zip (addresses SomeMnemonic onlyDustWallet) (map Coin [ 1_000_000
+    , zip (addresses $ SomeMnemonic onlyDustWallet) (map Coin [ 1_000_000
                                                , 1_000_000
                                                , 5_000_000
                                                , 12_000_000

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -1614,16 +1614,21 @@ shelleyIntegrationTestFunds :: [(Address, Coin)]
 shelleyIntegrationTestFunds = mconcat
     [ seqMnemonics >>= (take 10 . map (, defaultAmt) . addresses . SomeMnemonic)
 
-    , zip (addresses $ SomeMnemonic onlyDustWallet) (map Coin [ 1_000_000
-                                               , 1_000_000
-                                               , 5_000_000
-                                               , 12_000_000
-                                               , 1_000_000
-                                               , 5_000_000
-                                               , 3_000_000
-                                               , 10_000_000
-                                               , 2_000_000
-                                               , 3_000_000 ])
+    , zip
+         (addresses $ SomeMnemonic onlyDustWallet)
+         (map Coin
+           [ 1_000_000
+           , 1_000_000
+           , 5_000_000
+           , 12_000_000
+           , 1_000_000
+           , 5_000_000
+           , 3_000_000
+           , 10_000_000
+           , 2_000_000
+           , 3_000_000
+           ]
+         )
 
     , take 100 (map (, defaultAmt) $ addresses $ SomeMnemonic bigDustWallet)
     , take 100 . drop 100 $ map (,Coin 1_000_000) $ addresses $ SomeMnemonic bigDustWallet

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -645,7 +645,7 @@ eventuallyUsingDelay delay desc io = do
         Left () -> do
             lastError <- readIORef lastErrorRef
             fail $ mconcat
-                [ "Waited longer than 2 minutes for an action to resolve. "
+                [ "Waited longer than 90s (more than 2 epochs) for an action to resolve. "
                 , "Action: "
                 , show desc
                 , ". Error condition: "

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -107,6 +107,7 @@ module Test.Integration.Framework.DSL
     , rootPrvKeyFromMnemonics
     , unsafeGetTransactionTime
     , getTxId
+    , minUTxOValue
 
     -- * Delegation helpers
     , mkEpochInfo
@@ -515,6 +516,9 @@ walletId =
 --
 -- Helpers
 --
+minUTxOValue :: Natural
+minUTxOValue = 1_000_000
+
 getTxId :: (ApiTransaction n) -> String
 getTxId tx = T.unpack $ toUrlPiece $ ApiTxId (tx ^. #id)
 

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -80,6 +80,7 @@ module Test.Integration.Framework.TestData
     , errMsg403WithdrawalNotWorth
     , errMsg403NotAShelleyWallet
     , errMsg403InputsDepleted
+    , errMsg404MinUTxOValue
     , errMsg400TxTooLarge
     , errMsg403CouldntIdentifyAddrAsMine
     ) where
@@ -271,6 +272,14 @@ errMsg403InputsDepleted = "I cannot select enough UTxO from your wallet to const
   \ an adequate transaction. Try sending a smaller amount or increasing the number\
   \ of available UTxO."
 
+errMsg404MinUTxOValue :: Natural -> String
+errMsg404MinUTxOValue minUTxOValue = mconcat
+    [ "I'm unable to construct the given transaction as some outputs or changes"
+    , " are too small! Each output and change is expected to be >= "
+    , (show minUTxOValue)
+    , " Lovelace. In the current transaction the following pieces are not"
+    , " satisfying this condition"
+    ]
 errMsg409WalletExists :: String -> String
 errMsg409WalletExists walId = "This operation would yield a wallet with the following\
      \ id: " ++ walId ++ " However, I already know of a wallet with this id."

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -53,6 +53,7 @@ import Test.Integration.Framework.DSL
     , emptyIcarusWalletMws
     , emptyRandomWallet
     , emptyRandomWalletMws
+    , eventually
     , expectErrorMessage
     , expectField
     , expectListField
@@ -423,10 +424,11 @@ scenario_ADDRESS_IMPORT_05 addrNum fixture = it title $ \ctx -> do
         [ expectResponseCode @IO HTTP.status204
         ]
 
-    r1 <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
-    verify r1
-        [ expectListSize addrNum
-        ]
+    eventually "Addresses are imported" $ do
+      r1 <- request @[ApiAddress n] ctx (Link.listAddresses @'Byron w) Default Empty
+      verify r1
+          [ expectListSize addrNum
+          ]
   where
     title = "ADDRESS_IMPORT_05 - I can import " <> show addrNum <>" of addresses"
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -79,6 +79,7 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , icarusAddresses
     , json
+    , minUTxOValue
     , request
     , restoreWalletFromPubKey
     , selectCoins
@@ -127,7 +128,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1,
+                        "quantity": #{minUTxOValue},
                         "unit": "lovelace"
                     }
                 }],
@@ -142,9 +143,9 @@ spec = do
                 (Link.getWallet @'Byron wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity 1)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity 1)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
         -- delete wallet
@@ -161,9 +162,9 @@ spec = do
                 (Link.getWallet @'Byron wDest') Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #total) (`shouldBe` Quantity 1)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #available) (`shouldBe` Quantity 1)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
@@ -181,7 +182,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }],
@@ -237,7 +238,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -319,7 +319,7 @@ spec = do
             source <- restoreWalletFromPubKey @ApiByronWallet @'Byron ctx pubKey restoredWalletName
             let [addr] = take 1 $ icarusAddresses @n mnemonics
 
-            let amount = Quantity 1
+            let amount = Quantity minUTxOValue
             let payment = AddressAmount (ApiT addr, Proxy @n) amount
             selectCoins @n @'Byron ctx source (payment :| []) >>= flip verify
                 [ expectResponseCode HTTP.status200

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -101,7 +101,7 @@ spec :: forall n t.
     , EncodeAddress n
     , PaymentAddress n IcarusKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureIcarusWallet ctx
         -- create wallet

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -100,7 +100,7 @@ spec :: forall n t.
     , PaymentAddress n IcarusKey
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_MIGRATIONS" $ do
     it "BYRON_CALCULATE_01 - \
         \for non-empty wallet calculated fee is > zero."
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Network.hs
@@ -16,7 +16,7 @@ import Data.Quantity
 import Data.Ratio
     ( (%) )
 import Test.Hspec
-    ( SpecWith, it, shouldBe )
+    ( SpecWith, describe, it, shouldBe )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
@@ -31,7 +31,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall t. SpecWith (Context t)
-spec = do
+spec = describe "BYRON_NETWORK" $ do
     it "NETWORK_PARAMS - Able to fetch network parameters" $ \ctx -> do
         r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty
         expectResponseCode @IO HTTP.status200 r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -72,7 +72,7 @@ spec :: forall n t.
     ( DecodeAddress n
     , DecodeStakeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_MIGRATIONS" $ do
 
     it "BYRON_RESTORE_08 - Icarus wallet with high indexes" $ \ctx -> do
         -- NOTE

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -107,7 +107,7 @@ spec :: forall n t.
     , EncodeAddress n
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_WALLETS" $ do
     it "BYRON_GET_04, DELETE_01 - Deleted wallet is not available" $ \ctx -> do
         w <- emptyRandomWallet ctx
         _ <- request @ApiByronWallet ctx (Link.deleteWallet @'Byron w) Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Network.hs
@@ -33,7 +33,7 @@ import Data.Maybe
 import Data.Time.Clock
     ( getCurrentTime )
 import Test.Hspec
-    ( SpecWith, pendingWith, shouldBe )
+    ( SpecWith, describe, pendingWith, shouldBe )
 import Test.Hspec.Extra
     ( it )
 import Test.Integration.Framework.DSL
@@ -56,7 +56,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall t. SpecWith (Context t)
-spec = do
+spec = describe "COMMON_NETWORK" $ do
     it "NETWORK - Can query network information" $ \ctx -> do
         eventually "wallet's syncProgress = Ready" $ do
             now <- liftIO getCurrentTime

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -179,7 +179,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": 1000000,
                             "unit": "lovelace"
                         }
                     }],

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -69,7 +69,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_ADDRESSES" $ do
     it "BYRON_ADDRESS_LIST - Byron wallet on Shelley ep" $ \ctx -> do
         w <- emptyRandomWallet ctx
         let wid = w ^. walletId

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -64,6 +64,7 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , json
     , listAddresses
+    , minUTxOValue
     , pubKeyFromMnemonics
     , request
     , restoreWalletFromPubKey
@@ -105,7 +106,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1,
+                        "quantity": #{minUTxOValue},
                         "unit": "lovelace"
                     }
                 }],
@@ -120,9 +121,9 @@ spec = do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
         -- delete wallet
@@ -160,7 +161,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }],
@@ -217,7 +218,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -140,9 +140,9 @@ spec = do
                 (Link.getWallet @'Shelley wDest') Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
@@ -300,7 +300,7 @@ spec = do
             target <- emptyWallet ctx
             targetAddress : _ <- fmap (view #id) <$> listAddresses @n ctx target
 
-            let amount = Quantity 1
+            let amount = Quantity minUTxOValue
             let payment = AddressAmount targetAddress amount
             selectCoins @n @'Shelley ctx source (payment :| []) >>= flip verify
                 [ expectResponseCode HTTP.status200

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -84,7 +84,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
         -- create wallet

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -122,11 +122,11 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 ]
 
     Hspec.it "SHELLEY_CALCULATE_02 - \
-        \Cannot calculate fee for wallet with dust, that cannot be migrated."
+        \Cannot calculate fee for wallet with dust (that complies with minUTxOValue)."
         $ \ctx -> do
             -- NOTE
-            -- Special mnemonic for which wallet has dust
-            -- (10 utxo with 33 lovelace)
+            -- Special mnemonic for which wallet has "dust"
+            -- (10 utxo with 43 ADA)
             let mnemonics =
                     ["either", "flip", "maple", "shift", "dismiss", "bridge"
                     , "sweet", "reveal", "green", "tornado", "need", "patient"
@@ -141,9 +141,8 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             let ep = Link.getMigrationInfo @'Shelley w
             r <- request @ApiWalletMigrationInfo ctx ep Default Empty
             verify r
-                [ expectResponseCode @IO HTTP.status403
-                , expectErrorMessage (errMsg403NothingToMigrate $ w ^. walletId)
-                ]
+              [ expectResponseCode @IO HTTP.status200
+              ]
 
     describe "SHELLEY_CALCULATE_03 - \
         \Cannot estimate migration for Byron wallet using Shelley endpoint" $ do
@@ -175,7 +174,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
         -- Special mnemonic for which 200 shelley funds are attached to in the
         -- genesis file.
         --
-        -- Out of these 200 coins, 100 of them are of 1 Lovelace and are
+        -- Out of these 200 coins, 100 of them are of 1 ADA and are
         -- expected to be treated as dust. The rest are all worth:
         -- 10,000,000,000 lovelace.
         let mnemonics =
@@ -227,7 +226,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             Default
             payloadMigrate >>= flip verify
             [ expectResponseCode @IO HTTP.status202
-            , expectField id ((`shouldBe` 9) . length)
+            , expectField id ((`shouldBe` 15) . length)
             ]
 
         -- Check that funds become available in the target wallet:
@@ -275,11 +274,11 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 ]
 
     Hspec.it "SHELLEY_MIGRATE_02 - \
-        \migrating wallet with dust should fail."
+        \migrating wallet with 'dust' (that complies with minUTxOValue) should pass."
         $ \ctx -> do
             -- NOTE
             -- Special mnemonic for which wallet has dust
-            -- (10 utxo with 33 lovelace)
+            -- (10 utxo with 43 ADA)
             let mnemonics =
                     ["either", "flip", "maple", "shift", "dismiss", "bridge"
                     , "sweet", "reveal", "green", "tornado", "need", "patient"
@@ -291,13 +290,25 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     } |]
             (_, sourceWallet) <- unsafeRequest @ApiWallet ctx
                 (Link.postWallet @'Shelley) payloadRestore
-            eventually "wallet balance greater than 0" $ do
-                request @ApiWallet ctx
+            originalBalance <- eventually "wallet balance greater than 0" $ do
+                rg <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley sourceWallet)
                     Default
-                    Empty >>= flip verify
+                    Empty
+                verify rg
                     [ expectField (#balance . #getApiT . #available) (.> Quantity 0)
                     ]
+                pure $ getFromResponse (#balance . #getApiT. #available . #getQuantity)
+                                 rg
+
+            -- Calculate the expected migration fee:
+            r0 <- request @ApiWalletMigrationInfo ctx
+                (Link.getMigrationInfo @'Shelley sourceWallet) Default Empty
+            verify r0
+                [ expectResponseCode @IO HTTP.status200
+                , expectField #migrationCost (.> Quantity 0)
+                ]
+            let expectedFee = getFromResponse (#migrationCost . #getQuantity) r0
 
             targetWallet <- emptyWallet ctx
             addrs <- listAddresses @n ctx targetWallet
@@ -309,11 +320,23 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         }|]
             let ep = Link.migrateWallet @'Shelley sourceWallet
             r <- request @[ApiTransaction n] ctx ep Default payload
-            let srcId = sourceWallet ^. walletId
             verify r
-                [ expectResponseCode @IO HTTP.status403
-                , expectErrorMessage (errMsg403NothingToMigrate srcId)
-                ]
+                [ expectResponseCode @IO HTTP.status202 ]
+
+            -- Check that funds become available in the target wallet:
+            let expectedBalance = originalBalance - expectedFee
+            eventually "targetWallet balance = expectedBalance" $ do
+                request @ApiWallet ctx
+                    (Link.getWallet @'Shelley targetWallet)
+                    Default
+                    Empty >>= flip verify
+                    [ expectField
+                            (#balance . #getApiT . #available)
+                            ( `shouldBe` Quantity expectedBalance)
+                    , expectField
+                            (#balance . #getApiT . #total)
+                            ( `shouldBe` Quantity expectedBalance)
+                    ]
 
     it "SHELLEY_MIGRATE_03 - \
         \actual fee for migration is the same as the predicted fee."

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -121,29 +121,6 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectErrorMessage (errMsg403NothingToMigrate $ w ^. walletId)
                 ]
 
-    Hspec.it "SHELLEY_CALCULATE_02 - \
-        \Cannot calculate fee for wallet with dust (that complies with minUTxOValue)."
-        $ \ctx -> do
-            -- NOTE
-            -- Special mnemonic for which wallet has "dust"
-            -- (10 utxo with 43 ADA)
-            let mnemonics =
-                    ["either", "flip", "maple", "shift", "dismiss", "bridge"
-                    , "sweet", "reveal", "green", "tornado", "need", "patient"
-                    , "wall", "stamp", "pass"] :: [Text]
-            let payloadRestore = Json [json| {
-                    "name": "Dust Shelley Wallet",
-                    "mnemonic_sentence": #{mnemonics},
-                    "passphrase": #{fixturePassphrase}
-                    } |]
-            (_, w) <- unsafeRequest @ApiWallet ctx
-                (Link.postWallet @'Shelley) payloadRestore
-            let ep = Link.getMigrationInfo @'Shelley w
-            r <- request @ApiWalletMigrationInfo ctx ep Default Empty
-            verify r
-              [ expectResponseCode @IO HTTP.status200
-              ]
-
     describe "SHELLEY_CALCULATE_03 - \
         \Cannot estimate migration for Byron wallet using Shelley endpoint" $ do
           forM_ [ ("Byron", emptyRandomWallet)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -97,7 +97,7 @@ spec :: forall n t.
     , PaymentAddress n IcarusKey
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_MIGRATIONS" $ do
     it "SHELLEY_CALCULATE_01 - \
         \for non-empty wallet calculated fee is > zero."
         $ \ctx -> do
@@ -121,7 +121,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate $ w ^. walletId)
                 ]
 
-    it "SHELLEY_CALCULATE_02 - \
+    Hspec.it "SHELLEY_CALCULATE_02 - \
         \Cannot calculate fee for wallet with dust, that cannot be migrated."
         $ \ctx -> do
             -- NOTE

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -26,6 +26,7 @@ import Test.Integration.Framework.DSL
     , eventually
     , expectField
     , expectResponseCode
+    , minUTxOValue
     , request
     , verify
     )
@@ -43,7 +44,6 @@ spec = do
         -- for Shelley desiredPoolNumber is node's nOpt protocol parameter
         -- in integration test setup it is 3
         let nOpt = 3
-        let minUtxoValue = Quantity 0
         verify r
             [ expectField (#decentralizationLevel) (`shouldBe` d)
             , expectField (#desiredPoolNumber) (`shouldBe` nOpt)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -47,6 +47,6 @@ spec = do
         verify r
             [ expectField (#decentralizationLevel) (`shouldBe` d)
             , expectField (#desiredPoolNumber) (`shouldBe` nOpt)
-            , expectField (#minimumUtxoValue) (`shouldBe` minUtxoValue)
+            , expectField (#minimumUtxoValue) (`shouldBe` (Quantity minUTxOValue))
             , expectField (#hardforkAt) (`shouldNotBe` Nothing)
             ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -16,7 +16,7 @@ import Data.Quantity
 import Data.Ratio
     ( (%) )
 import Test.Hspec
-    ( SpecWith, shouldBe, shouldNotBe )
+    ( SpecWith, describe, shouldBe, shouldNotBe )
 import Test.Hspec.Extra
     ( it )
 import Test.Integration.Framework.DSL
@@ -35,7 +35,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Network.HTTP.Types.Status as HTTP
 
 spec :: forall t. SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_NETWORK" $ do
     it "NETWORK_PARAMS - Able to fetch network parameters" $ \ctx ->
         eventually "hardfork is detected in network parameters " $ do
         r <- request @ApiNetworkParameters ctx Link.getNetworkParams Default Empty

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -118,7 +118,7 @@ spec :: forall n t.
     , EncodeAddress n
     , PaymentAddress n ShelleyKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_STAKE_POOLS" $ do
     let listPools ctx stake = request @[ApiStakePool] @IO ctx
             (Link.listStakePools stake) Default Empty
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -161,7 +161,7 @@ spec = do
         \ while both, pending and in_ledger" $ \ctx -> do
         wSrc <- fixtureWallet ctx
 
-        payload <- mkTxPayload ctx wSrc 1000 fixturePassphrase
+        payload <- mkTxPayload ctx wSrc 1_000_000 fixturePassphrase
 
         (_, ApiFee (Quantity feeMin) (Quantity feeMax)) <- unsafeRequest ctx
             (Link.getTransactionFee @'Shelley wSrc) payload
@@ -199,7 +199,7 @@ spec = do
 
         eventually "Pending tx has pendingSince field" $ do
             -- Post Tx
-            let amt = (1 :: Natural)
+            let amt = (1_000_000 :: Natural)
             r <- postTx ctx
                 (wSrc, Link.createTransaction @'Shelley,fixturePassphrase)
                 wDest
@@ -227,7 +227,7 @@ spec = do
 
     it "TRANS_CREATE_01 - Single Output Transaction" $ \ctx -> do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
-        let amt = (1 :: Natural)
+        let amt = (1_000_000 :: Natural)
 
         payload <- mkTxPayload ctx wb amt fixturePassphrase
 
@@ -278,7 +278,7 @@ spec = do
         wDest <- emptyWallet ctx
         addrs <- listAddresses @n ctx wDest
 
-        let amt = 1
+        let amt = 1_000_000 :: Natural
         let destination1 = (addrs !! 1) ^. #id
         let destination2 = (addrs !! 2) ^. #id
         let payload = Json [json|{
@@ -336,7 +336,7 @@ spec = do
                 ]
 
     it "TRANS_CREATE_03 - 0 balance after transaction" $ \ctx -> do
-        let amt = 1
+        let amt = 1_000_000
 
         wDest <- fixtureWalletWith @n ctx [amt]
         payload <- mkTxPayload ctx wDest amt fixturePassphrase
@@ -391,11 +391,11 @@ spec = do
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> do
         wDest <- fixtureWallet ctx
 
-        payload <- mkTxPayload ctx wDest 1 fixturePassphrase
+        payload <- mkTxPayload ctx wDest 1_000_000 fixturePassphrase
         (_, ApiFee (Quantity feeMin) _) <- unsafeRequest ctx
             (Link.getTransactionFee @'Shelley wDest) payload
 
-        wSrc <- fixtureWalletWith @n ctx [feeMin `div` 2]
+        wSrc <- fixtureWalletWith @n ctx [1_000_000 + (feeMin `div` 2)]
 
         r <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley wSrc) Default payload
@@ -405,7 +405,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_04 - Not enough money" $ \ctx -> do
-        let (srcAmt, reqAmt) = (1, 1_000_000)
+        let (srcAmt, reqAmt) = (1_000_000, 2_000_000)
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
@@ -426,7 +426,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1,
+                        "quantity": 1000000,
                         "unit": "lovelace"
                     }
                 }],
@@ -449,7 +449,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1,
+                        "quantity": 1000000,
                         "unit": "lovelace"
                     }
                 }],
@@ -489,7 +489,7 @@ spec = do
         (wByron, wShelley) <- (,) <$> srcFixture ctx <*> fixtureWallet ctx
         addrs <- listAddresses @n ctx wShelley
 
-        let amt = 1
+        let amt = 1_000_000 :: Natural
         let destination = (addrs !! 1) ^. #id
         let payload = Json [json|{
                 "payments": [{
@@ -772,7 +772,7 @@ spec = do
             ]
 
     it "TRANS_ESTIMATE_04 - Not enough money" $ \ctx -> do
-        let (srcAmt, reqAmt) = (1, 1_000_000)
+        let (srcAmt, reqAmt) = (1_000_000, 2_000_000)
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
@@ -788,7 +788,7 @@ spec = do
         w <- emptyWallet ctx
         _ <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
         wDest <- emptyWallet ctx
-        payload <- mkTxPayload ctx wDest 1 fixturePassphrase
+        payload <- mkTxPayload ctx wDest 1_000_000 fixturePassphrase
         r <- request @ApiFee ctx
             (Link.getTransactionFee @'Shelley w) Default payload
         expectResponseCode @IO HTTP.status404 r
@@ -799,7 +799,7 @@ spec = do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         addrs <- listAddresses @n ctx wDest
 
-        let amt = 1 :: Natural
+        let amt = 1_000_000 :: Natural
         let destination = (addrs !! 1) ^. #id
         let payload = Json [json|{
                 "payments": [{
@@ -861,11 +861,11 @@ spec = do
     -- +---+----------+----------+------------+--------------+
     it "TRANS_LIST_02,03x - Can limit/order results with start, end and order"
         $ \ctx -> do
-        let a1 = Quantity $ sum $ replicate 10 1
-        let a2 = Quantity $ sum $ replicate 10 2
+        let a1 = Quantity $ sum $ replicate 10 1_000_000
+        let a2 = Quantity $ sum $ replicate 10 2_000_000
         w <- fixtureWalletWith @n ctx $ mconcat
-                [ replicate 10 1
-                , replicate 10 2
+                [ replicate 10 1_000_000
+                , replicate 10 2_000_000
                 ]
         txs <- listAllTransactions @n ctx w
         let [Just t2, Just t1] = fmap (fmap time . insertedAt) txs
@@ -1188,7 +1188,7 @@ spec = do
     it "TRANS_LIST_RANGE_01 - \
        \Transaction at time t is SELECTED by small ranges that cover it" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let (te, tl) = (utcTimePred t, utcTimeSucc t)
               txs1 <- listTransactions @n ctx w (Just t ) (Just t ) Nothing
@@ -1200,7 +1200,7 @@ spec = do
     it "TRANS_LIST_RANGE_02 - \
        \Transaction at time t is NOT selected by range (t + 𝛿t, ...)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let tl = utcTimeSucc t
               txs1 <- listTransactions @n ctx w (Just tl) (Nothing) Nothing
@@ -1210,7 +1210,7 @@ spec = do
     it "TRANS_LIST_RANGE_03 - \
        \Transaction at time t is NOT selected by range (..., t - 𝛿t)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let te = utcTimePred t
               txs1 <- listTransactions @n ctx w (Nothing) (Just te) Nothing
@@ -1220,7 +1220,7 @@ spec = do
     it "TRANS_GET_01 - Can get Incoming and Outgoing transaction" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1 :: Natural)
+        let amt = (1_000_000 :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1274,7 +1274,7 @@ spec = do
     it "TRANS_GET_03 - Using wrong transaction id" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1 :: Natural)
+        let amt = (1_000_000 :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1297,7 +1297,7 @@ spec = do
         \ Shelley: Can forget pending transaction" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1 :: Natural)
+        let amt = (1_000_000 :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1360,7 +1360,7 @@ spec = do
             postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
-            (1 :: Natural)
+            (1_000_000 :: Natural)
         let txid = getFromResponse #id rTx
 
         eventually "Transaction is accepted" $ do
@@ -1409,7 +1409,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": 1000000,
                             "unit": "lovelace"
                         }
                     }]
@@ -1430,7 +1430,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": 1000000,
                             "unit": "lovelace"
                         }
                     }],
@@ -1791,7 +1791,7 @@ spec = do
             rMkTx <- postTx ctx
                 (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
                 wDest
-                (1 :: Natural)
+                (1_000_000 :: Natural)
 
             -- try to forget from different wallet
             wDifferent <- eWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -157,7 +157,7 @@ spec :: forall n t.
     , EncodeAddress n
     , PaymentAddress n IcarusKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_TRANSACTIONS" $ do
     it "TRANS_MIN_UTXO_01 - I cannot spend less than minUTxOValue" $ \ctx -> do
       wSrc <- fixtureWallet ctx
       wDest <- emptyWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -103,6 +103,7 @@ import Test.Integration.Framework.DSL
     , listAddresses
     , listAllTransactions
     , listTransactions
+    , minUTxOValue
     , request
     , rewardWallet
     , toQueryString
@@ -161,7 +162,7 @@ spec = do
         \ while both, pending and in_ledger" $ \ctx -> do
         wSrc <- fixtureWallet ctx
 
-        payload <- mkTxPayload ctx wSrc 1_000_000 fixturePassphrase
+        payload <- mkTxPayload ctx wSrc minUTxOValue fixturePassphrase
 
         (_, ApiFee (Quantity feeMin) (Quantity feeMax)) <- unsafeRequest ctx
             (Link.getTransactionFee @'Shelley wSrc) payload
@@ -199,7 +200,7 @@ spec = do
 
         eventually "Pending tx has pendingSince field" $ do
             -- Post Tx
-            let amt = (1_000_000 :: Natural)
+            let amt = (minUTxOValue :: Natural)
             r <- postTx ctx
                 (wSrc, Link.createTransaction @'Shelley,fixturePassphrase)
                 wDest
@@ -227,7 +228,7 @@ spec = do
 
     it "TRANS_CREATE_01 - Single Output Transaction" $ \ctx -> do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx
-        let amt = (1_000_000 :: Natural)
+        let amt = (minUTxOValue :: Natural)
 
         payload <- mkTxPayload ctx wb amt fixturePassphrase
 
@@ -278,7 +279,7 @@ spec = do
         wDest <- emptyWallet ctx
         addrs <- listAddresses @n ctx wDest
 
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let destination1 = (addrs !! 1) ^. #id
         let destination2 = (addrs !! 2) ^. #id
         let payload = Json [json|{
@@ -336,7 +337,7 @@ spec = do
                 ]
 
     it "TRANS_CREATE_03 - 0 balance after transaction" $ \ctx -> do
-        let amt = 1_000_000
+        let amt = minUTxOValue
 
         wDest <- fixtureWalletWith @n ctx [amt]
         payload <- mkTxPayload ctx wDest amt fixturePassphrase
@@ -391,11 +392,11 @@ spec = do
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> do
         wDest <- fixtureWallet ctx
 
-        payload <- mkTxPayload ctx wDest 1_000_000 fixturePassphrase
+        payload <- mkTxPayload ctx wDest minUTxOValue fixturePassphrase
         (_, ApiFee (Quantity feeMin) _) <- unsafeRequest ctx
             (Link.getTransactionFee @'Shelley wDest) payload
 
-        wSrc <- fixtureWalletWith @n ctx [1_000_000 + (feeMin `div` 2)]
+        wSrc <- fixtureWalletWith @n ctx [minUTxOValue + (feeMin `div` 2)]
 
         r <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley wSrc) Default payload
@@ -405,7 +406,7 @@ spec = do
             ]
 
     it "TRANS_CREATE_04 - Not enough money" $ \ctx -> do
-        let (srcAmt, reqAmt) = (1_000_000, 2_000_000)
+        let (srcAmt, reqAmt) = (minUTxOValue, 2 * minUTxOValue)
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
@@ -426,7 +427,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1000000,
+                        "quantity": #{minUTxOValue},
                         "unit": "lovelace"
                     }
                 }],
@@ -449,7 +450,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1000000,
+                        "quantity": #{minUTxOValue},
                         "unit": "lovelace"
                     }
                 }],
@@ -489,7 +490,7 @@ spec = do
         (wByron, wShelley) <- (,) <$> srcFixture ctx <*> fixtureWallet ctx
         addrs <- listAddresses @n ctx wShelley
 
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let destination = (addrs !! 1) ^. #id
         let payload = Json [json|{
                 "payments": [{
@@ -772,7 +773,7 @@ spec = do
             ]
 
     it "TRANS_ESTIMATE_04 - Not enough money" $ \ctx -> do
-        let (srcAmt, reqAmt) = (1_000_000, 2_000_000)
+        let (srcAmt, reqAmt) = (minUTxOValue, 2 * minUTxOValue)
         wSrc <- fixtureWalletWith @n ctx [srcAmt]
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
@@ -788,7 +789,7 @@ spec = do
         w <- emptyWallet ctx
         _ <- request @ApiWallet ctx (Link.deleteWallet @'Shelley w) Default Empty
         wDest <- emptyWallet ctx
-        payload <- mkTxPayload ctx wDest 1_000_000 fixturePassphrase
+        payload <- mkTxPayload ctx wDest minUTxOValue fixturePassphrase
         r <- request @ApiFee ctx
             (Link.getTransactionFee @'Shelley w) Default payload
         expectResponseCode @IO HTTP.status404 r
@@ -799,7 +800,7 @@ spec = do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         addrs <- listAddresses @n ctx wDest
 
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let destination = (addrs !! 1) ^. #id
         let payload = Json [json|{
                 "payments": [{
@@ -861,11 +862,11 @@ spec = do
     -- +---+----------+----------+------------+--------------+
     it "TRANS_LIST_02,03x - Can limit/order results with start, end and order"
         $ \ctx -> do
-        let a1 = Quantity $ sum $ replicate 10 1_000_000
-        let a2 = Quantity $ sum $ replicate 10 2_000_000
+        let a1 = Quantity $ sum $ replicate 10 minUTxOValue
+        let a2 = Quantity $ sum $ replicate 10 (2 * minUTxOValue)
         w <- fixtureWalletWith @n ctx $ mconcat
-                [ replicate 10 1_000_000
-                , replicate 10 2_000_000
+                [ replicate 10 minUTxOValue
+                , replicate 10 (2 * minUTxOValue)
                 ]
         txs <- listAllTransactions @n ctx w
         let [Just t2, Just t1] = fmap (fmap time . insertedAt) txs
@@ -1188,7 +1189,7 @@ spec = do
     it "TRANS_LIST_RANGE_01 - \
        \Transaction at time t is SELECTED by small ranges that cover it" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let (te, tl) = (utcTimePred t, utcTimeSucc t)
               txs1 <- listTransactions @n ctx w (Just t ) (Just t ) Nothing
@@ -1200,7 +1201,7 @@ spec = do
     it "TRANS_LIST_RANGE_02 - \
        \Transaction at time t is NOT selected by range (t + 𝛿t, ...)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let tl = utcTimeSucc t
               txs1 <- listTransactions @n ctx w (Just tl) (Nothing) Nothing
@@ -1210,7 +1211,7 @@ spec = do
     it "TRANS_LIST_RANGE_03 - \
        \Transaction at time t is NOT selected by range (..., t - 𝛿t)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               t <- unsafeGetTransactionTime <$> listAllTransactions ctx w
               let te = utcTimePred t
               txs1 <- listTransactions @n ctx w (Nothing) (Just te) Nothing
@@ -1220,7 +1221,7 @@ spec = do
     it "TRANS_GET_01 - Can get Incoming and Outgoing transaction" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1_000_000 :: Natural)
+        let amt = (minUTxOValue :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1274,7 +1275,7 @@ spec = do
     it "TRANS_GET_03 - Using wrong transaction id" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1_000_000 :: Natural)
+        let amt = (minUTxOValue :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1297,7 +1298,7 @@ spec = do
         \ Shelley: Can forget pending transaction" $ \ctx -> do
         (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post tx
-        let amt = (1_000_000 :: Natural)
+        let amt = (minUTxOValue :: Natural)
         rMkTx <- postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
@@ -1360,7 +1361,7 @@ spec = do
             postTx ctx
             (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
             wDest
-            (1_000_000 :: Natural)
+            (minUTxOValue :: Natural)
         let txid = getFromResponse #id rTx
 
         eventually "Transaction is accepted" $ do
@@ -1409,7 +1410,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1000000,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }]
@@ -1430,7 +1431,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1000000,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }],
@@ -1791,7 +1792,7 @@ spec = do
             rMkTx <- postTx ctx
                 (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
                 wDest
-                (1_000_000 :: Natural)
+                (minUTxOValue :: Natural)
 
             -- try to forget from different wallet
             wDifferent <- eWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -94,6 +94,7 @@ import Test.Integration.Framework.DSL
     , getFromResponse
     , json
     , listAddresses
+    , minUTxOValue
     , notDelegating
     , request
     , selectCoins
@@ -237,7 +238,7 @@ spec = do
                 "payments": [{
                     "address": #{destination},
                     "amount": {
-                        "quantity": 1,
+                        "quantity": #{minUTxOValue},
                         "unit": "lovelace"
                     }
                 }],
@@ -252,9 +253,9 @@ spec = do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
         -- delete wallet
@@ -269,9 +270,9 @@ spec = do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 1)
+                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
     it "WALLETS_CREATE_03,09 - Cannot create wallet that exists" $ \ctx -> do
@@ -898,7 +899,7 @@ spec = do
                     "payments": [{
                         "address": #{destination},
                         "amount": {
-                            "quantity": 1,
+                            "quantity": #{minUTxOValue},
                             "unit": "lovelace"
                         }
                     }],

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -139,7 +139,7 @@ spec :: forall n t.
     , PaymentAddress n IcarusKey
     , PaymentAddress n ByronKey
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_WALLETS" $ do
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> do
         let payload = Json [json| {
                 "name": "1st Wallet",

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -93,7 +93,7 @@ spec :: forall n t.
     ( DecodeAddress n
     , KnownCommand t
     ) => SpecWith (Context t)
-spec = do
+spec = describe "BYRON_CLI_WALLETS" $ do
 
     describe "CLI_BYRON_GET_04, CLI_BYRON_DELETE_01, BYRON_RESTORE_02, BYRON_RESTORE_03 -\
         \ Deleted wallet is not available, but can be restored" $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Miscellaneous.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Miscellaneous.hs
@@ -27,7 +27,7 @@ import Test.Integration.Framework.DSL
 import qualified Data.List as L
 
 spec :: forall t. KnownCommand t => SpecWith ()
-spec = do
+spec = describe "COMMON_CLI_MISC" $ do
     it "CLI_VERSION - cardano-wallet shows version" $  do
         (Exit c, Stdout out) <- cardanoWalletCLI @t ["version"]
         let v = L.dropWhileEnd (== '\n') out

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Network.hs
@@ -35,7 +35,7 @@ import System.Command
 import System.Exit
     ( ExitCode (..) )
 import Test.Hspec
-    ( SpecWith, pendingWith )
+    ( SpecWith, describe, pendingWith )
 import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain )
 import Test.Hspec.Extra
@@ -54,7 +54,7 @@ import Test.Utils.Paths
     ( inNixBuild )
 
 spec :: forall t. KnownCommand t => SpecWith (Context t)
-spec = do
+spec = describe "COMMON_CLI_NETWORK" $ do
     it "CLI_NETWORK - cardano-wallet network information" $ \ctx -> do
         info <- getNetworkInfoViaCLI ctx
         let nextEpochNum =

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
@@ -52,7 +52,7 @@ import qualified Data.Text.IO as TIO
 spec
     :: forall t s. (HasType (Port "wallet") s, KnownCommand t)
     => SpecWith s
-spec = do
+spec = describe "COMMON_CLI_PORTS" $ do
     let overPort :: forall sym. HasType (Port sym) s => (Int -> Int) -> s -> s
         overPort fn = over (typed @(Port sym)) (\(Port p) -> Port $ fn p)
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -174,7 +174,7 @@ spec = do
         -- run 10 transactions to make all addresses `Used`
         forM_ [0..initPoolGap - 1] $ \addrNum -> do
             let dest = encodeAddress @n (getApiT $ fst $ (j !! addrNum) ^. #id)
-            let args = [wSrc, "--payment" , T.unpack $ "1@" <> dest]
+            let args = [wSrc, "--payment" , T.unpack $ "1000000@" <> dest]
             (cTx, _, _) <- postTransactionViaCLI @t ctx "cardano-wallet" args
             cTx `shouldBe` ExitSuccess
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -66,7 +66,7 @@ spec :: forall n t.
     , DecodeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_CLI_ADDRESSES" $ do
 
     it "ADDRESS_LIST_01 - Can list addresses - default poolGap" $ \ctx -> do
         let g = fromIntegral $ getAddressPoolGap defaultAddressPoolGap

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -67,6 +67,7 @@ import Test.Integration.Framework.DSL
     , listAddressesViaCLI
     , listTransactionsViaCLI
     , listWalletsViaCLI
+    , minUTxOValue
     , postTransactionFeeViaCLI
     , postTransactionViaCLI
     , pubKeyFromMnemonics
@@ -91,7 +92,7 @@ spec :: forall n t.
     ) => SpecWith (Context t)
 spec = do
 
-    it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> do
+    it "HW_WALLETS_01x - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
 
         -- create a wallet
@@ -108,7 +109,7 @@ spec = do
             ]
 
         --send transaction to the wallet
-        let amount = 11
+        let amount = minUTxOValue
         addrs:_ <- listAddresses @n ctx wDest
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>
@@ -227,7 +228,7 @@ spec = do
             wDest <- emptyWallet ctx
             addrs:_ <- listAddresses @n ctx wDest
             let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
-            let amt = 1 :: Int
+            let amt = fromIntegral minUTxOValue
             let args = T.unpack <$>
                     [ wRestored ^. walletId
                     , "--payment", T.pack (show amt) <> "@" <> addr

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -228,7 +228,7 @@ spec = do
             wDest <- emptyWallet ctx
             addrs:_ <- listAddresses @n ctx wDest
             let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
-            let amt = fromIntegral minUTxOValue
+            let amt = minUTxOValue
             let args = T.unpack <$>
                     [ wRestored ^. walletId
                     , "--payment", T.pack (show amt) <> "@" <> addr

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -90,7 +90,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "HW_WALLETS_CLI" $ do
 
     it "HW_WALLETS_01x - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx
@@ -173,9 +173,10 @@ spec = do
             wDest <- emptyWallet ctx
             addrs:_ <- listAddresses @n ctx wDest
             let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
+
             let args = T.unpack <$>
                     [ wRestored ^. walletId
-                    , "--payment", "1@" <> addr
+                    , "--payment", T.pack (show minUTxOValue) <> "@" <> addr
                     ]
 
             (c, out, err) <- postTransactionViaCLI @t ctx (T.unpack fixturePassphrase) args

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -90,7 +90,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = describe "HW_WALLETS_CLI" $ do
+spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
 
     it "HW_WALLETS_01x - Restoration from account public key preserves funds" $ \ctx -> do
         wSrc <- fixtureWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -108,7 +108,7 @@ spec = do
         wSrc <- fixtureWallet ctx
         wDest <- emptyWallet ctx
 
-        let amt = 14
+        let amt = 1_000_000
         args <- postTxArgs ctx wSrc wDest amt
         Stdout feeOut <- postTransactionFeeViaCLI @t ctx args
         ApiFee (Quantity feeMin) (Quantity feeMax) <- expectValidJSON Proxy feeOut
@@ -147,7 +147,7 @@ spec = do
         addr <- listAddresses @n ctx wDest
         let addr1 = encodeAddress @n (getApiT $ fst $ addr !! 1 ^. #id)
         let addr2 = encodeAddress @n (getApiT $ fst $ addr !! 2 ^. #id)
-        let amt = 14
+        let amt = 1_000_000
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addr1
@@ -197,7 +197,7 @@ spec = do
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>
                 [ wSrc ^. walletId
-                , "--payment", "14@" <> addr
+                , "--payment", "1000000@" <> addr
                 ]
 
         (c, out, err) <- postTransactionViaCLI @t ctx "This password is wrong" args
@@ -265,7 +265,7 @@ spec = do
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>
                 [ "transaction", "create", "--port", port
-                , T.append (wSrc ^. walletId) "0", "--payment", "11@" <> addr
+                , T.append (wSrc ^. walletId) "0", "--payment", "1000000@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
         (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
@@ -285,7 +285,7 @@ spec = do
         let port = T.pack $ show $ ctx ^. typed @(Port "wallet")
         let args = T.unpack <$>
                 [ "transaction", "create", "--port", port
-                , wSrc ^. walletId, "--payment", "11@" <> addr
+                , wSrc ^. walletId, "--payment", "1000000@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
         (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
@@ -299,7 +299,7 @@ spec = do
             wSrc <- emptyWallet ctx
             let args = T.unpack <$>
                     [ wSrc ^. walletId
-                    , "--payment", "12@" <> (T.pack addr)
+                    , "--payment", "1000000@" <> (T.pack addr)
                     ]
 
             (Exit c, Stdout out, Stderr err) <- postTransactionFeeViaCLI @t ctx args
@@ -353,7 +353,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 14 :: Natural
+        let amt = 1_000_000 :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -416,11 +416,11 @@ spec = do
                 code `shouldBe` ExitFailure 1
 
     it "TRANS_LIST_03 - Can order results" $ \ctx -> do
-        let a1 = Quantity $ sum $ replicate 10 1
-        let a2 = Quantity $ sum $ replicate 10 2
+        let a1 = Quantity $ sum $ replicate 10 1_000_000
+        let a2 = Quantity $ sum $ replicate 10 2_000_000
         w <- fixtureWalletWith @n ctx $ mconcat
-                [ replicate 10 1
-                , replicate 10 2
+                [ replicate 10 1_000_000
+                , replicate 10 2_000_000
                 ]
         let orderings =
                 [ ( mempty
@@ -525,7 +525,7 @@ spec = do
     it "TRANS_LIST_RANGE_01 - \
        \Transaction at time t is SELECTED by small ranges that cover it" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let (te, tl) = (utcTimePred t, utcTimeSucc t)
@@ -550,7 +550,7 @@ spec = do
     it "TRANS_LIST_RANGE_02 - \
        \Transaction at time t is NOT selected by range [t + 𝛿t, ...)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let tl = utcIso8601ToText $ utcTimeSucc t
@@ -565,7 +565,7 @@ spec = do
     it "TRANS_LIST_RANGE_03 - \
        \Transaction at time t is NOT selected by range (..., t - 𝛿t]" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1]
+              w <- fixtureWalletWith @n ctx [1_000_000]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let te = utcIso8601ToText $ utcTimePred t
@@ -582,7 +582,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 14 :: Natural
+        let amt = 1_000_000 :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -650,7 +650,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 14 :: Natural
+        let amt = 1_000_000 :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -678,7 +678,7 @@ spec = do
         let wSrcId = T.unpack (wSrc ^. walletId)
 
         -- post transaction
-        txJson <- postTxViaCLI ctx wSrc wDest 1
+        txJson <- postTxViaCLI ctx wSrc wDest 1_000_000
         verify txJson
             [ expectCliField (#direction . #getApiT) (`shouldBe` Outgoing)
             , expectCliField (#status . #getApiT) (`shouldBe` Pending)
@@ -733,7 +733,7 @@ spec = do
             -- post tx
             wSrc <- fixtureWallet ctx
             wDest <- emptyWallet ctx
-            txJson <- postTxViaCLI ctx wSrc wDest 1
+            txJson <- postTxViaCLI ctx wSrc wDest 1_000_000
 
             -- try to forget from different wallet
             widDiff <- emptyWallet' ctx
@@ -786,7 +786,7 @@ spec = do
             let port = T.pack $ show $ ctx ^. typed @(Port "wallet")
             let args = T.unpack <$>
                     [ "transaction", T.pack action, "--port", port
-                    , wSrc ^. walletId, "--payment", "11@" <> addr
+                    , wSrc ^. walletId, "--payment", "1000000@" <> addr
                     ]
             -- make sure CLI returns error before asking for passphrase
             (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -75,6 +75,7 @@ import Test.Integration.Framework.DSL
     , listAddresses
     , listAllTransactions
     , listTransactionsViaCLI
+    , minUTxOValue
     , postTransactionFeeViaCLI
     , postTransactionViaCLI
     , unsafeGetTransactionTime
@@ -108,7 +109,7 @@ spec = do
         wSrc <- fixtureWallet ctx
         wDest <- emptyWallet ctx
 
-        let amt = 1_000_000
+        let amt = fromIntegral minUTxOValue
         args <- postTxArgs ctx wSrc wDest amt
         Stdout feeOut <- postTransactionFeeViaCLI @t ctx args
         ApiFee (Quantity feeMin) (Quantity feeMax) <- expectValidJSON Proxy feeOut
@@ -147,7 +148,7 @@ spec = do
         addr <- listAddresses @n ctx wDest
         let addr1 = encodeAddress @n (getApiT $ fst $ addr !! 1 ^. #id)
         let addr2 = encodeAddress @n (getApiT $ fst $ addr !! 2 ^. #id)
-        let amt = 1_000_000
+        let amt = fromIntegral minUTxOValue
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addr1
@@ -197,7 +198,7 @@ spec = do
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>
                 [ wSrc ^. walletId
-                , "--payment", "1000000@" <> addr
+                , "--payment", T.pack (show minUTxOValue) <> "@" <> addr
                 ]
 
         (c, out, err) <- postTransactionViaCLI @t ctx "This password is wrong" args
@@ -265,7 +266,7 @@ spec = do
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>
                 [ "transaction", "create", "--port", port
-                , T.append (wSrc ^. walletId) "0", "--payment", "1000000@" <> addr
+                , T.append (wSrc ^. walletId) "0", "--payment", T.pack (show minUTxOValue) <> "@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
         (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
@@ -285,7 +286,7 @@ spec = do
         let port = T.pack $ show $ ctx ^. typed @(Port "wallet")
         let args = T.unpack <$>
                 [ "transaction", "create", "--port", port
-                , wSrc ^. walletId, "--payment", "1000000@" <> addr
+                , wSrc ^. walletId, "--payment", T.pack (show minUTxOValue) <> "@" <> addr
                 ]
         -- make sure CLI returns error before asking for passphrase
         (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args
@@ -299,7 +300,7 @@ spec = do
             wSrc <- emptyWallet ctx
             let args = T.unpack <$>
                     [ wSrc ^. walletId
-                    , "--payment", "1000000@" <> (T.pack addr)
+                    , "--payment", T.pack (show minUTxOValue) <> "@" <> (T.pack addr)
                     ]
 
             (Exit c, Stdout out, Stderr err) <- postTransactionFeeViaCLI @t ctx args
@@ -353,7 +354,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -416,11 +417,11 @@ spec = do
                 code `shouldBe` ExitFailure 1
 
     it "TRANS_LIST_03 - Can order results" $ \ctx -> do
-        let a1 = Quantity $ sum $ replicate 10 1_000_000
-        let a2 = Quantity $ sum $ replicate 10 2_000_000
+        let a1 = Quantity $ sum $ replicate 10 minUTxOValue
+        let a2 = Quantity $ sum $ replicate 10 (2 * minUTxOValue)
         w <- fixtureWalletWith @n ctx $ mconcat
-                [ replicate 10 1_000_000
-                , replicate 10 2_000_000
+                [ replicate 10 minUTxOValue
+                , replicate 10 (2 * minUTxOValue)
                 ]
         let orderings =
                 [ ( mempty
@@ -525,7 +526,7 @@ spec = do
     it "TRANS_LIST_RANGE_01 - \
        \Transaction at time t is SELECTED by small ranges that cover it" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let (te, tl) = (utcTimePred t, utcTimeSucc t)
@@ -550,7 +551,7 @@ spec = do
     it "TRANS_LIST_RANGE_02 - \
        \Transaction at time t is NOT selected by range [t + 𝛿t, ...)" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let tl = utcIso8601ToText $ utcTimeSucc t
@@ -565,7 +566,7 @@ spec = do
     it "TRANS_LIST_RANGE_03 - \
        \Transaction at time t is NOT selected by range (..., t - 𝛿t]" $
           \ctx -> do
-              w <- fixtureWalletWith @n ctx [1_000_000]
+              w <- fixtureWalletWith @n ctx [minUTxOValue]
               let walId = w ^. walletId
               t <- unsafeGetTransactionTime <$> listAllTransactions @n ctx w
               let te = utcIso8601ToText $ utcTimePred t
@@ -582,7 +583,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -650,7 +651,7 @@ spec = do
         wDest <- emptyWallet ctx
         addr:_ <- listAddresses @n ctx wDest
         let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
-        let amt = 1_000_000 :: Natural
+        let amt = minUTxOValue :: Natural
         let args = T.unpack <$>
                 [ wSrc ^. walletId
                 , "--payment", T.pack (show amt) <> "@" <> addrStr
@@ -678,7 +679,7 @@ spec = do
         let wSrcId = T.unpack (wSrc ^. walletId)
 
         -- post transaction
-        txJson <- postTxViaCLI ctx wSrc wDest 1_000_000
+        txJson <- postTxViaCLI ctx wSrc wDest minUTxOValue
         verify txJson
             [ expectCliField (#direction . #getApiT) (`shouldBe` Outgoing)
             , expectCliField (#status . #getApiT) (`shouldBe` Pending)
@@ -733,7 +734,7 @@ spec = do
             -- post tx
             wSrc <- fixtureWallet ctx
             wDest <- emptyWallet ctx
-            txJson <- postTxViaCLI ctx wSrc wDest 1_000_000
+            txJson <- postTxViaCLI ctx wSrc wDest minUTxOValue
 
             -- try to forget from different wallet
             widDiff <- emptyWallet' ctx
@@ -786,7 +787,7 @@ spec = do
             let port = T.pack $ show $ ctx ^. typed @(Port "wallet")
             let args = T.unpack <$>
                     [ "transaction", T.pack action, "--port", port
-                    , wSrc ^. walletId, "--payment", "1000000@" <> addr
+                    , wSrc ^. walletId, "--payment", T.pack (show minUTxOValue) <> "@" <> addr
                     ]
             -- make sure CLI returns error before asking for passphrase
             (Exit c, Stdout out, Stderr err) <- cardanoWalletCLI @t args

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -104,7 +104,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
     it "TRANS_CREATE_01 - Can create transaction via CLI" $ \ctx -> do
         wSrc <- fixtureWallet ctx
         wDest <- emptyWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -76,6 +76,7 @@ import Test.Integration.Framework.DSL
     , getWalletViaCLI
     , listAddresses
     , listWalletsViaCLI
+    , minUTxOValue
     , notDelegating
     , postTransactionViaCLI
     , updateWalletNameViaCLI
@@ -198,7 +199,7 @@ spec = do
             ]
 
         --send transaction to the wallet
-        let amount = 11
+        let amount = minUTxOValue
         addrs:_ <- listAddresses @n ctx wDest
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
         let args = T.unpack <$>

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -103,7 +103,7 @@ spec :: forall n t.
     , DecodeStakeAddress n
     , EncodeAddress n
     ) => SpecWith (Context t)
-spec = do
+spec = describe "SHELLEY_CLI_WALLETS" $ do
     it "BYRON_GET_03 - Shelley CLI does not show Byron wallet" $ \ctx -> do
         wid <- emptyRandomWallet' ctx
         (Exit c, Stdout out, Stderr err) <- getWalletViaCLI @t ctx wid

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -685,7 +686,7 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             let addrStr = encodeAddress @n (getApiT $ fst $ addr ^. #id)
             let args = T.unpack <$>
                     [ wSrc ^. walletId
-                    , "--payment", "1@" <> addrStr
+                    , "--payment", T.pack (show minUTxOValue) <> "@" <> addrStr
                     ]
 
             (cTx, outTx, errTx) <- postTransactionViaCLI @t ctx pass args
@@ -714,7 +715,7 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         wDest <- emptyWallet ctx
 
         --send transactions to the wallet
-        let coins = [13, 43, 66, 101, 1339] :: [Word64]
+        let coins = [13_000_000, 43_000_000, 66_000_000, 101_000_000, 1339_000_000] :: [Word64]
         addrs:_ <- listAddresses @n ctx wDest
         let addr = encodeAddress @n (getApiT $ fst $ addrs ^. #id)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2167,7 +2167,7 @@ instance LiftHandler ErrUTxOTooSmall where
             apiError err403 UtxoTooSmall $ mconcat
                 [ "I'm unable to construct the given transaction as some "
                 , "outputs or changes are too small! Each output and change is "
-                , "expected to be >= ", showT minUtxoValue, " Lovelace."
+                , "expected to be >= ", showT minUtxoValue, " Lovelace. "
                 , "In the current transaction the following pieces are not "
                 , "satisfying this condition : ", showT invalidUTxO, " ."
                 ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1104,8 +1104,8 @@ moveInstantaneousRewardsTo tr dir targets = do
         [ "shelley", "transaction", "build-raw"
         , "--tx-in", faucetInput
         , "--ttl", "600"
-        , "--fee", show (faucetAmt - 1 - totalDeposit)
-        , "--tx-out", sink <> "+" <> "1"
+        , "--fee", show (faucetAmt - 1_000_000 - totalDeposit)
+        , "--tx-out", sink <> "+" <> "1000000"
         , "--out-file", file
         ] ++ concatMap (\x -> ["--certificate-file", x]) (mconcat certs)
 
@@ -1166,9 +1166,9 @@ prepareKeyRegistration tr dir = do
     void $ cli tr
         [ "shelley", "transaction", "build-raw"
         , "--tx-in", faucetInput
-        , "--tx-out", sink <> "+" <> "1"
+        , "--tx-out", sink <> "+" <> "1000000"
         , "--ttl", "400"
-        , "--fee", show (faucetAmt - depositAmt - 1)
+        , "--fee", show (faucetAmt - depositAmt - 1_000_000)
         , "--certificate-file", cert
         , "--out-file", file
         ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1416,7 +1416,7 @@ preRegisteredStakeKey = Aeson.object
 
 -- | Deposit amount required for registering certificates.
 depositAmt :: Integer
-depositAmt = 100000
+depositAmt = 1000000
 
 -- | Initial amount in each of these special cluster faucet
 faucetAmt :: Integer

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -14,6 +14,7 @@ protocolParams:
   protocolVersion:
     minor: 0
     major: 0
+  minUTxOValue: 1000000
   decentralisationParam: 0.25 # means 75% decentralised
   maxTxSize: 4096
   minFeeA: 100

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -29,7 +29,7 @@ protocolParams:
   extraEntropy:
     tag: NeutralNonce
   maxBlockHeaderSize: 217569
-  keyDeposit: 100000
+  keyDeposit: 1000000
   keyDecayRate: 0
   nOpt: 3
   rho: 0.178650067


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/1914
https://github.com/input-output-hk/cardano-wallet/issues/1926
# Overview
- 08ba84e6c5b3fef96319ec777d7d9874e52280a1
  Enable minUTxOValue: 1000000 in CI for shelley
  
- ba675b0f2b011f19115e471b163b4ccaa91ac40f
  Adjust tests for transactions and addresses
  
- b815bef775ceaa6fbb0d201703fdbbe1ab86da61
  Introduce minUTxOValue named constant
  
- c0c146184dcc36b27136ab85c7b1c8937b6c807b
  Test for error message on spending minUtxOValue
  
- 7e45643f6f9802d7179d3868b76aa6c990b2a470
  Make dust Shelley wallets compy with minUTxOValue
  
- 711195d5ecd4e461fe64ba06a722b516fc6b87c6
  Adjust new tests to minUTxOValue
  
- 940a5e77763457f17a715a961176f1bff10138b5
  MIR wallets and minor adjustments
  
- ad64d0d9db33e2bb5e404cfc2793ec2cd8e66409
  Add top level describe for each integration test suite
  
- 40e7a51f4475e7fc7c8949edb9c910f3c21bba6e
  Make keyDeposit = 1000000
  
- 6f200817e654d8c9f054136acadce4e8bbf2bbb9
  Test adjustments
  
- 17d38be229dcde5f9de47416809a1150fd52f73d
  remove SHELLEY_CALCULATE_02 as it is already covered in SHELLEY_MIGRATE_02 (fee estimation is there also)
  
- 84f8ab3dc639b89a51b3a57028e5be3b57bf9d89
  Adjust STAKE_POOLS_JOIN_01rewards
  
- 35d0e50d80233b032a1019699a82de73cae6e605
  make ADDRESS_IMPORT_05 not flaky by adding eventually

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
