### PR TITLE
docker: Make latest point to latest shelley image

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -22,9 +22,11 @@
 # 3. After pushing the image to the repo, the "latest" tags are updated.
 #
 #    - "inputoutput/cardano-wallet:latest" should point to the most
-#      recent VERSION-byron tag build.
+#      recent VERSION-shelley tag build.
 #    - "inputoutput/cardano-wallet:byron" should point to the most
 #      recent VERSION-byron tag build.
+#    - "inputoutput/cardano-wallet:shelley" should point to the most
+#      recent VERSION-shelley tag build.
 #    - "inputoutput/cardano-wallet:jormungandr" should point to the most
 #      recent VERSION-jormungandr tag build.
 #
@@ -78,7 +80,7 @@ in
     if [[ "$git_tag" =~ ^v20 ]]; then
       tags+=( "${image.imageTag}" )
       tags+=( "${image.backend}" )
-      ${optionalString (image.backend == "byron") ''
+      ${optionalString (image.backend == "shelley") ''
       tags+=( "latest" )
       ''}
     elif [[ "$git_branch" = master ]]; then


### PR DESCRIPTION
### Issue Number

ADP-356

### Overview

Make docker latest tag point to latest shelley image.

The shelley backend will work on both networks, and the byron backend will be deleted soon.

### Comments

- [Docker](https://github.com/input-output-hk/cardano-wallet/wiki/Docker) page on wiki updated.
