### PR TITLE
Ignore pool order in `STAKE_POOLS_LIST_01`.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -607,11 +607,12 @@ spec = do
             eventually "pools have the correct retirement information" $ do
                 response <- listPools ctx arbitraryStake
                 expectResponseCode HTTP.status200 response
+
                 let actualRetirementEpochs = response
                         & snd
                         & either (error . show) Prelude.id
                         & fmap (view #retirement)
-                        & fmap (fmap (getApiT . view #epochNumber))
+                        & fmap (fmap (view (#epochNumber . #getApiT)))
                         & Set.fromList
                 actualRetirementEpochs `shouldBe` expectedRetirementEpochs
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -615,9 +615,8 @@ spec = do
                         .
                         view #retirement
 
-                let actualRetirementEpochs = response
-                        & snd
-                        & either (error . show) Prelude.id
+                let actualRetirementEpochs =
+                        getFromResponse Prelude.id response
                         & fmap getRetirementEpoch
                         & Set.fromList
                 actualRetirementEpochs `shouldBe` expectedRetirementEpochs

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -35,6 +35,7 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.Types
     ( Coin (..)
     , Direction (..)
+    , EpochNo (..)
     , PoolId (..)
     , StakePoolMetadata (..)
     , StakePoolTicker (..)
@@ -608,11 +609,16 @@ spec = do
                 response <- listPools ctx arbitraryStake
                 expectResponseCode HTTP.status200 response
 
+                let getRetirementEpoch :: ApiStakePool -> Maybe EpochNo
+                    getRetirementEpoch =
+                        fmap (view (#epochNumber . #getApiT))
+                        .
+                        view #retirement
+
                 let actualRetirementEpochs = response
                         & snd
                         & either (error . show) Prelude.id
-                        & fmap (view #retirement)
-                        & fmap (fmap (view (#epochNumber . #getApiT)))
+                        & fmap getRetirementEpoch
                         & Set.fromList
                 actualRetirementEpochs `shouldBe` expectedRetirementEpochs
 


### PR DESCRIPTION
# Issue Number

#1940 

# Overview

This PR changes the API `STAKE_POOLS_LIST_01` test to **ignore** the order in which pools are listed by the `ListStakePools` API operation.

It prevents spurious failures caused by pools being listed in unexpected orders.