### PR TITLE
Exclude retired pools from the `ListStakePools` API function result.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -660,7 +660,7 @@ spec = do
         it "contains pool metadata" $ \ctx -> do
             eventually "metadata is fetched" $ do
                 r <- listPools ctx arbitraryStake
-                let metadataList =
+                let metadataPossible = Set.fromList
                         [ StakePoolMetadata
                             { ticker = (StakePoolTicker "GPA")
                             , name = "Genesis Pool A"
@@ -679,16 +679,21 @@ spec = do
                             , description = Just "Lorem Ipsum Dolor Sit Amet."
                             , homepage = "https://iohk.io"
                             }
+                        , StakePoolMetadata
+                            { ticker = (StakePoolTicker "GPD")
+                            , name = "Genesis Pool D"
+                            , description = Just "Lorem Ipsum Dolor Sit Amet."
+                            , homepage = "https://iohk.io"
+                            }
                         ]
 
                 verify r
                     [ expectListSize 3
-                    , expectField Prelude.id $ \pools ->
-                        -- To ignore the arbitrary order,
-                        -- we sort on the names before comparing
-                        sortOn name
-                            (mapMaybe (fmap getApiT . view #metadata) pools)
-                            `shouldBe` metadataList
+                    , expectField Prelude.id $ \pools -> do
+                        let metadataActual = Set.fromList $
+                                mapMaybe (fmap getApiT . view #metadata) pools
+                        metadataActual
+                            `shouldSatisfy` (`Set.isSubsetOf` metadataPossible)
                     ]
 
         it "contains and is sorted by non-myopic-rewards" $ \ctx -> do

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -616,7 +616,7 @@ data StakePoolMetadata = StakePoolMetadata
     -- ^ Short description of the stake pool.
     , homepage :: Text
     -- ^ Absolute URL for the stake pool's homepage link.
-    } deriving (Eq, Show, Generic)
+    } deriving (Eq, Ord, Show, Generic)
 
 instance FromJSON StakePoolMetadata where
     parseJSON = withObject "StakePoolMetadta" $ \obj -> do
@@ -635,7 +635,7 @@ instance FromJSON StakePoolMetadata where
 
 -- | Very short name for a stake pool.
 newtype StakePoolTicker = StakePoolTicker { unStakePoolTicker :: Text }
-    deriving stock (Generic, Show, Eq)
+    deriving stock (Generic, Show, Eq, Ord)
     deriving newtype (ToText)
 
 instance FromText StakePoolTicker where

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -184,18 +184,18 @@ server byron icarus shelley spl ntp =
 
     stakePools :: Server (StakePools n ApiStakePool)
     stakePools =
-        (\case
+        listStakePools_
+        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
+        :<|> quitStakePool shelley
+        :<|> delegationFee shelley
+      where
+        listStakePools_ = \case
             Just (ApiT stake) -> liftHandler $ listStakePools spl stake
             Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $
                 mconcat
                 [ "The stake intended to delegate must be provided as a query "
                 , "parameter as it affects the rewards and ranking."
                 ]
-
-        )
-        :<|> joinStakePool shelley (knownPools spl) (getPoolLifeCycleStatus spl)
-        :<|> quitStakePool shelley
-        :<|> delegationFee shelley
 
     byronWallets :: Server ByronWallets
     byronWallets =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -48,6 +48,7 @@ import Cardano.Wallet.Api.Server
     , delegationFee
     , deleteTransaction
     , deleteWallet
+    , getCurrentEpoch
     , getMigrationInfo
     , getNetworkClock
     , getNetworkInformation
@@ -191,8 +192,7 @@ server byron icarus shelley spl ntp =
       where
         listStakePools_ = \case
             Just (ApiT stake) -> do
-                -- TODO: Determine the real current epoch here:
-                let currentEpoch = maxBound
+                currentEpoch <- getCurrentEpoch shelley
                 liftHandler $ listStakePools spl currentEpoch stake
             Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $
                 mconcat

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -190,7 +190,10 @@ server byron icarus shelley spl ntp =
         :<|> delegationFee shelley
       where
         listStakePools_ = \case
-            Just (ApiT stake) -> liftHandler $ listStakePools spl stake
+            Just (ApiT stake) -> do
+                -- TODO: Determine the real current epoch here:
+                let currentEpoch = maxBound
+                liftHandler $ listStakePools spl currentEpoch stake
             Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $
                 mconcat
                 [ "The stake intended to delegate must be provided as a query "

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1122,6 +1122,33 @@ operators = unsafePerformIO $ newMVar
           , "homepage" .= Aeson.String "https://iohk.io"
           ]
       )
+    , ( PoolId $ unsafeFromHex
+          "5a7b67c7dcfa8c4c25796bea05bcdfca01590c8c7612cc537c97012bed0dec36"
+      , Aeson.object
+          [ "type" .= Aeson.String "Node operator verification key"
+          , "description" .= Aeson.String "Stake Pool Operator Verification Key"
+          , "cborHex" .= Aeson.String
+              "58203263e07605b9fc0100eb520d317f472ae12989fbf27fc71f46310bc0f24f2970"
+          ]
+      , Aeson.object
+          [ "type" .= Aeson.String "Node operator signing key"
+          , "description" .= Aeson.String "Stake Pool Operator Signing Key"
+          , "cborHex" .= Aeson.String
+              "58208f50de27d74325eaf57767d70277210b31eb97cdc3033f632a9791a3677a64d2"
+          ]
+      , Aeson.object
+          [ "type" .= Aeson.String "Node operational certificate issue counter"
+          , "description" .= Aeson.String "Next certificate issue number: 0"
+          , "cborHex" .= Aeson.String
+              "820058203263e07605b9fc0100eb520d317f472ae12989fbf27fc71f46310bc0f24f2970"
+          ]
+      , Aeson.object
+          [ "name" .= Aeson.String "Genesis Pool D"
+          , "ticker" .= Aeson.String "GPD"
+          , "description" .= Aeson.String "Lorem Ipsum Dolor Sit Amet."
+          , "homepage" .= Aeson.String "https://iohk.io"
+          ]
+      )
     ]
 {-# NOINLINE operators #-}
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -142,7 +142,7 @@ data StakePoolLayer = StakePoolLayer
     --
     , listStakePools
         :: EpochNo
-            -- ^ Exclude all pools that retired in or before this epoch.
+        -- Exclude all pools that retired in or before this epoch.
         -> Coin
         -> ExceptT ErrNetworkUnavailable IO [Api.ApiStakePool]
     }
@@ -176,7 +176,7 @@ newStakePoolLayer gp nl db@DBLayer {..} = StakePoolLayer
 
     _listPools
         :: EpochNo
-            -- ^ Exclude all pools that retired in or before this epoch.
+        -- Exclude all pools that retired in or before this epoch.
         -> Coin
         -> ExceptT ErrNetworkUnavailable IO [Api.ApiStakePool]
     _listPools currentEpoch userStake = do

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -194,7 +194,7 @@ newStakePoolLayer gp nl db@DBLayer {..} = StakePoolLayer
             $ combineDbAndLsqData (slotParams gp) lsqData dbData
       where
         epochIsInFuture :: EpochNo -> Bool
-        epochIsInFuture = (>= currentEpoch)
+        epochIsInFuture = (> currentEpoch)
 
         poolIsRetired :: Api.ApiStakePool -> Bool
         poolIsRetired =

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -180,9 +180,13 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
 
 testPoolConfigs :: [PoolConfig]
 testPoolConfigs =
-    [ PoolConfig {retirementEpoch = Nothing}
+    [ -- This pool should never retire:
+      PoolConfig {retirementEpoch = Nothing}
+      -- This pool should retire almost immediately:
     , PoolConfig {retirementEpoch = Just 1}
+      -- This pool should retire, but not within the duration of a test run:
     , PoolConfig {retirementEpoch = Just 1_000}
+      -- This pool should retire, but not within the duration of a test run:
     , PoolConfig {retirementEpoch = Just 1_000_000}
     ]
 

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -181,6 +181,7 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
 testPoolConfigs :: [PoolConfig]
 testPoolConfigs =
     [ PoolConfig {retirementEpoch = Nothing}
+    , PoolConfig {retirementEpoch = Just 1}
     , PoolConfig {retirementEpoch = Just 1_000}
     , PoolConfig {retirementEpoch = Just 1_000_000}
     ]


### PR DESCRIPTION
# Issue Number

#1937 

# Overview

This PR:

- [x] Applies a very simple filter to the Shelley `ListStakePools` API operation that excludes all pools with a retirement epoch earlier than or equal to the current epoch.
- [x]  Adds an integration test to verify that if pool _**p**_ has already retired, it will **not** be listed by `ListStakePools`.

# Future Improvements

The current pool tracking implementation (which predates this PR) has two potential areas for improvement:

- Reducing the number of database queries that need to be executed:
    See: https://jira.iohk.io/browse/ADP-383
- Performing garbage collection of retired pools from the database:
    See: https://jira.iohk.io/browse/ADP-376

These are **not** tackled in this PR, but are instead recorded in the above tickets, so that we may schedule time to fix them at a later date.