### PR TITLE
Fix reported amount on incoming transactions carrying withdrawals

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -626,11 +626,12 @@ mkShelleyWallet
         ( ctx ~ ApiLayer s t k
         , s ~ SeqState n k
         , IsOurs s Address
+        , IsOurs s ChimericAccount
         , HasWorkerRegistry s k ctx
         )
     => MkApiWallet ctx s ApiWallet
 mkShelleyWallet ctx wid cp meta pending progress = do
-    Quantity reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
+    reward <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk ->
         -- never fails - returns zero if balance not found
         liftIO $ fmap fromIntegral <$> W.fetchRewardBalance @_ @s @k wrk wid
 
@@ -641,8 +642,8 @@ mkShelleyWallet ctx wid cp meta pending progress = do
         { addressPoolGap = ApiT $ getState cp ^. #externalPool . #gap
         , balance = ApiT $ WalletBalance
             { available = Quantity $ availableBalance pending cp
-            , total = Quantity $ reward + totalBalance pending cp
-            , reward = Quantity reward
+            , total = Quantity $ totalBalance pending reward cp
+            , reward
             }
         , delegation = apiDelegation
         , id = ApiT wid
@@ -724,6 +725,7 @@ mkLegacyWallet
         , KnownDiscovery s
         , HasNetworkLayer t ctx
         , IsOurs s Address
+        , IsOurs s ChimericAccount
         )
     => ctx
     -> WalletId
@@ -756,7 +758,7 @@ mkLegacyWallet ctx wid cp meta pending progress = do
     pure ApiByronWallet
         { balance = ApiByronWalletBalance
             { available = Quantity $ availableBalance pending cp
-            , total = Quantity $ totalBalance pending cp
+            , total = Quantity $ totalBalance pending (Quantity 0) cp
             }
         , id = ApiT wid
         , name = ApiT $ meta ^. #name

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2075,6 +2075,15 @@ instance Buildable e => LiftHandler (ErrSelectForPayment e) where
         ErrSelectForPaymentCoinSelection e -> handler e
         ErrSelectForPaymentFee e -> handler e
         ErrSelectForPaymentMinimumUTxOValue e -> handler e
+        ErrSelectForPaymentAlreadyWithdrawing tx ->
+            apiError err403 AlreadyWithdrawing $ mconcat
+                [ "I already know of a pending transaction with withdrawals: "
+                , toText (txId tx), ". Note that when I withdraw rewards, I "
+                , "need to withdraw them fully for the Ledger to accept it. "
+                , "There's therefore no point creating another conflicting "
+                , "transaction; if, for some reason, you really want a new "
+                , "transaction, then cancel the previous one first."
+                ]
 
 instance LiftHandler ErrListUTxOStatistics where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -673,6 +673,7 @@ data ApiErrorCode
     | NonNullRewards
     | UtxoTooSmall
     | MinWithdrawalWrong
+    | AlreadyWithdrawing
     deriving (Eq, Generic, Show)
 
 -- | Defines a point in time that can be formatted as and parsed from an

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -360,6 +359,14 @@ prefilterBlock b u0 = runState $ do
         state (isOurs $ dlgCertAccount cert) <&> \case
             False -> Nothing
             True -> Just cert
+    ourChimericAccount
+        :: IsOurs s ChimericAccount
+        => (ChimericAccount, Coin)
+        -> State s (Maybe Natural)
+    ourChimericAccount (acct, Coin c) =
+        state (isOurs acct) <&> \case
+            False -> Nothing
+            True -> Just $ fromIntegral c
     mkTxMeta :: Natural -> Direction -> TxMeta
     mkTxMeta amt dir = TxMeta
         { status = InLedger
@@ -369,7 +376,7 @@ prefilterBlock b u0 = runState $ do
         , amount = Quantity amt
         }
     applyTx
-        :: IsOurs s Address
+        :: (IsOurs s Address, IsOurs s ChimericAccount)
         => ([(Tx, TxMeta)], UTxO)
         -> Tx
         -> State s ([(Tx, TxMeta)], UTxO)
@@ -377,19 +384,17 @@ prefilterBlock b u0 = runState $ do
         ourU <- state $ utxoOurs tx
         let ourIns = Set.fromList (inputs tx) `Set.intersection` dom (u <> ourU)
         let u' = (u <> ourU) `excluding` ourIns
-        let withdrawalAmt =
-                sum $ map (fromIntegral . getCoin) $ Map.elems $ withdrawals tx
-        let received = fromIntegral @_ @Integer $ balance ourU
-        let spent = fromIntegral @_ @Integer $ balance (u `restrictedBy` ourIns)
-        let amt = fromIntegral $ abs (received - spent - withdrawalAmt)
+        ourWithdrawals <- mapMaybeM ourChimericAccount $ Map.toList $ withdrawals tx
+        let received = balance ourU
+        let spent = balance (u `restrictedBy` ourIns) + sum ourWithdrawals
         let hasKnownInput = ourIns /= mempty
         let hasKnownOutput = ourU /= mempty
         return $ if hasKnownOutput && not hasKnownInput then
-            ( (tx, mkTxMeta amt Incoming) : txs
+            ( (tx, mkTxMeta received Incoming) : txs
             , u'
             )
         else if hasKnownInput then
-            ( (tx, mkTxMeta amt Outgoing) : txs
+            ( (tx, mkTxMeta (spent - received) Outgoing) : txs
             , u'
             )
         else

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -825,6 +825,7 @@ instance NFData Tx
 instance Buildable Tx where
     build (Tx tid ins outs ws) = mempty
         <> build tid
+        <> build ("\n" :: String)
         <> blockListF' "inputs" build (fst <$> ins)
         <> blockListF' "outputs" build outs
         <> blockListF' "withdrawals" tupleF (Map.toList ws)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.DB.Model
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
     ( block0, dummyGenesisParameters, mkTx, mockHash )
 import Cardano.Wallet.Gen
-    ( genMnemonic, genSlotNo, shrinkSlotNo )
+    ( genMnemonic, shrinkSlotNo )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
@@ -333,13 +333,18 @@ instance Arbitrary PassphraseScheme where
 
 instance Arbitrary BlockHeader where
     arbitrary = do
-        slot <- arbitrary
-        let height = Quantity . fromIntegral . unSlotNo $ slot
+        EpochNo ep <- arbitrary
+        SlotInEpoch sl <- arbitrary
+        let h = fromIntegral sl + fromIntegral ep * arbitraryEpochLength
         blockH <- arbitrary
-        pure $ BlockHeader slot height blockH (coerce blockH)
+        let slot = SlotNo $ fromIntegral h
+        pure $ BlockHeader slot (Quantity h) blockH (coerce blockH)
 
 instance Arbitrary SlotNo where
-    arbitrary = genSlotNo
+    arbitrary = do
+        SlotInEpoch sl <- arbitrary
+        EpochNo ep <- arbitrary
+        pure $ SlotNo $ fromIntegral $ fromIntegral ep * arbitraryChainLength + sl
     shrink = shrinkSlotNo
 
 instance Arbitrary SlotInEpoch where

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -99,7 +99,7 @@ genLegacyAddress pm = do
 
 -- | Don't generate /too/ large slots
 genSlotNo :: Gen SlotNo
-genSlotNo = SlotNo . fromIntegral <$> (arbitrary @Word32)
+genSlotNo = SlotNo . fromIntegral <$> arbitrary @Word32
 
 shrinkSlotNo :: SlotNo -> [SlotNo]
 shrinkSlotNo (SlotNo x) = map SlotNo $ shrink x


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1952 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- d1c5618b79ac861600e94b7200a94c89a7b80f87
  :round_pushpin: **modify scenario spending rewards to send money to _another_ wallet and assess right amount**
    We didn't quite catch a bug here because we were only looking at one side of the coin by sending the transaction to ourselves (so, we couldn't really assess the amount on an _incoming_ transaction, from a different perspective. That is now done properly such that 1 lovelace is send to another wallet (and, which should be the amount reported by this wallet). The outgoing amount however should contain any output sent to _another_ wallet, as well as fees.

- 6932d1d7d73677d840a5cebc7ac96d31eca96f42
  :round_pushpin: **revise 'amount' calculation in the primitive model**
    Such that we only count withdrawals in outgoing transactions. In principle, withdrawals should be necessarily ours on a transaction.. but it's not excluded that a transaction may contain multiple withdrawals from different wallets (especially in the context of multisig). Beside, withdrawals should be completely out of the picture for _incoming_ transactions.

- aa9fdf9ba996898a6978a4eb4af638361e466bcc
  :round_pushpin: **add test showing oddities on total balance + rewards when there are pending withdrawals + fix it**
    This was trickier than I originally thought because crafting a generator of pending transactions which is somewhat meaningful and can have withdrawals turned out to be a bit complex. The property originally failed (without the fix) and clearly showed the bug described in #1955. The fix is relatively straightforward and is about adding the reward amount only if there are no pending withdrawal

- 5867d38f818e14c802de8293aed1ac425227e478
  :round_pushpin: **fix SlotNo generator in database arbitrary instances**
    This one was wrongly changed to browse the entire Word32 space instead of staying within small bounds as originally. There are many things in tests and other generators derived from the slot number value, and too big values can really do bad things here.

- 8d1eadb42cc263116f27b625a8cb5438653b63f9
  :round_pushpin: **prevent users from creating two withdrawals simultaneously on the same wallet**
    Rewards ought to be spent fully, therefore, making two concurrent withdrawals has no sense since only one transaction will eventually be validated.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
