### PR TITLE
Relax coverage check for `prop_rollbackRetirement`.

### DIFF
--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -729,7 +729,7 @@ prop_rollbackRetirement DBLayer{..} certificates =
             "rollbackPoint = slotMinBound"
         $ cover 4 (rollbackPoint > SlotNo 0)
             "rollbackPoint > slotMinBound"
-        $ cover 4 (null expectedPublications)
+        $ cover 2 (null expectedPublications)
             "length expectedPublications = 0"
         $ cover 4 (not (null expectedPublications))
             "length expectedPublications > 0"


### PR DESCRIPTION
# Issue Number

None.

# Summary

This PR relaxes the coverage check for the `prop_rollbackRetirement` property.

Before applying this change, QuickCheck would typically need to test this property _many thousands of times_ in order to satisfy the coverage check.

Here's a particularly bad example (taking 36 seconds to complete on my system):

```hs
      rollback of PoolRetirement
        +++ OK, passed 12800 tests:
        95.000% length expectedPublications > 0
        67.633% 0 < length expectedPublications < length allPublications
        59.617% rollbackPoint = slotMinBound
        40.383% rollbackPoint > slotMinBound
         5.000% length expectedPublications = 0
```

After this change, QuickCheck is able to satisfy the coverage check after only a few hundred tests:

```hs
      rollback of PoolRetirement
        +++ OK, passed 400 tests:
        94.0% length expectedPublications > 0
        71.0% 0 < length expectedPublications < length allPublications
        60.8% rollbackPoint = slotMinBound
        39.2% rollbackPoint > slotMinBound
         6.0% length expectedPublications = 0
```