### PR TITLE
Assign average member rewards to new pools & sort equal pools arbitrarily 

### DIFF
--- a/lib/shelley/cardano-wallet-shelley.cabal
+++ b/lib/shelley/cardano-wallet-shelley.cabal
@@ -71,6 +71,7 @@ library
     , ouroboros-network
     , ouroboros-network-framework
     , process
+    , random
     , retry
     , servant-server
     , shelley-spec-ledger

--- a/nix/.stack.nix/cardano-wallet-shelley.nix
+++ b/nix/.stack.nix/cardano-wallet-shelley.nix
@@ -68,6 +68,7 @@
           (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
           (hsPkgs."ouroboros-network-framework" or (errorHandler.buildDepError "ouroboros-network-framework"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1959 & #1930

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- e71ab7d4330793fbe7c7e6a648fea952ea4e666a
  :round_pushpin: **use average member rewards of the top k pools for freshly registered pools**
    So that everyone gets a chance. Note that this is a potentially
  temporary solution until. Another approach is currently under
  discussion by the ledger team which may end up implementing something
  directly within the query itself.

- fda53fd2b5c3280dbef59ff2a14f9ebb82f62e32
  :round_pushpin: **randomly sort stake pools with identical non-myopic rewards.**
    The nice thing about this approach is that it works for both:

  - initial conditions, when all pools may have a the same non-myopic rewards of '0' due to the network just starting
  - long-term cases where there are pools that have different non-myopic member rewards but, some of them have equal rewards.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Testing --> I expect everything in integration tests to still pass. For the rest, it'll be manual testing on MCX

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
