### PR TITLE
Test that it's not possible to join a retired stake pool.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -782,3 +782,18 @@ spec = do
         pp = ctx ^. #_networkParameters . #protocolParameters
         (cst, coeff) = (round $ getQuantity a, round $ getQuantity b)
         LinearFee a b _ = pp ^. #txParameters . #getFeePolicy
+
+-- The complete set of pool identifiers in the static test pool cluster.
+--
+-- NOTE: This set effectively duplicates the set of pool identifiers defined
+-- in the 'operators' constant of 'Cardano.Wallet.Shelley.Launch'.
+--
+-- TODO: Remove this duplication.
+--
+testClusterPoolIds :: Set PoolId
+testClusterPoolIds = Set.fromList $ PoolId . unsafeFromHex <$>
+    [ "1b3dc19c6ab89eaffc8501f375bb03c11bf8ed5d183736b1d80413d6"
+    , "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2"
+    , "bb114cb37d75fa05260328c235a3dae295a33d0ba674a5eb1e3e568e"
+    , "ec28f33dcbe6d6400a1e5e339bd0647c0973ca6c0cf9c2bbe6838dc6"
+    ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -120,6 +120,9 @@ spec :: forall n t.
     , PaymentAddress n ShelleyKey
     ) => SpecWith (Context t)
 spec = do
+    let listPools ctx stake = request @[ApiStakePool] @IO ctx
+            (Link.listStakePools stake) Default Empty
+
     it "STAKE_POOLS_JOIN_01 - Cannot join non-existent wallet" $ \ctx -> do
         w <- emptyWallet ctx
         let wid = w ^. walletId
@@ -582,9 +585,6 @@ spec = do
             , expectErrorMessage $ errMsg403DelegationFee
                 (costOfJoining ctx - costOfChange ctx)
             ]
-
-    let listPools ctx stake = request @[ApiStakePool] @IO ctx
-            (Link.listStakePools stake) Default Empty
 
     describe "STAKE_POOLS_LIST_01 - List stake pools" $ do
 


### PR DESCRIPTION
# Issue Number

#1853 

# Overview

This PR adds an integration test to demonstrate that a wallet cannot join a stake pool that has already retired.

# Comments

Note that the integration test included in this PR is a compromise.

Ideally, a more complete integration test would verify that staking to a pool is still possible right up to the moment before the pool has actually retired. See: https://jira.iohk.io/browse/ADP-385