### PR TITLE
Update docker-compose.yml to work with recent testnets and staging networks.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
         ([[ $$NETWORK == \"testnet\" ]] && $$CMD --testnet /config/7106qjwral616j6p5049m7hhi5ih0r33-testnet-genesis.json)
       "
     environment:
-      CMD: "cardano-wallet-byron serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
+      CMD: "cardano-wallet-shelley serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
       NETWORK:
     restart: on-failure
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,11 @@ services:
     ports:
       - 8090:8090
     entrypoint: []
-    command: bash -c "([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) || $$CMD --testnet /config/*-$$NETWORK-byron-genesis.json"
+    command: bash -c "
+        ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
+        ([[ $$NETWORK == \"mainnet_candidate*\" ]] && $$CMD --staging /config/*-$$NETWORK-byron-genesis.json) ||
+        ($$CMD --testnet /config/*-$$NETWORK-byron-genesis.json)
+      "
     environment:
       CMD: "cardano-wallet-shelley serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
       NETWORK:
@@ -41,7 +45,15 @@ services:
 volumes:
   node-mainnet-db:
   node-testnet-db:
+  node-mainnet_candidate-db:
+  node-mainnet_candidate_2-db:
+  node-mainnet_candidate_3-db:
+  node-mainnet_candidate_4-db:
   wallet-mainnet-db:
   wallet-testnet-db:
+  wallet-mainnet_candidate-db:
+  wallet-mainnet_candidate_2-db:
+  wallet-mainnet_candidate_3-db:
+  wallet-mainnet_candidate_4-db:
   node-ipc:
   node-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:latest
+    image: inputoutput/cardano-node:1.18.0
     environment:
       NETWORK:
     volumes:
@@ -26,10 +26,7 @@ services:
     ports:
       - 8090:8090
     entrypoint: []
-    command: bash -c "
-        ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
-        ([[ $$NETWORK == \"testnet\" ]] && $$CMD --testnet /config/7106qjwral616j6p5049m7hhi5ih0r33-testnet-genesis.json)
-      "
+    command: bash -c "([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) || $$CMD --testnet /config/*-$$NETWORK-byron-genesis.json"
     environment:
       CMD: "cardano-wallet-shelley serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
       NETWORK:


### PR DESCRIPTION
Should we use cardano-wallet-shelley instead of cardano-wallet-byron?
