### PR TITLE
Tweak CLI help for --mainnet

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -281,7 +281,6 @@ testnetVersionData pm =
 --
 -- Type Conversions
 
--- fixme: maybe just toByronHash = ByronHash . CC.unsafeHashFromBytes
 toByronHash :: W.Hash "BlockHeader" -> ByronHash
 toByronHash (W.Hash bytes) =
     case CC.hashFromBytes bytes of

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -258,8 +258,6 @@ slotAtTimeDetailed t = do
 --
 -- This may or may not be what we actually want.
 --
--- fixme: this rank-2 type is inconvenient to set up in network layer.
--- fixme: this is backend-specific code -- it should be moved to the shelley package.
 type TimeInterpreter m = forall a. Qry a -> m a
 
 -- | An 'Interpreter' for a single era, where the slotting from

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -279,7 +279,6 @@ testnetVersionData pm =
 --
 -- Type Conversions
 
--- fixme: maybe just toByronHash = ByronHash . CC.unsafeHashFromBytes
 toByronHash :: W.Hash "BlockHeader" -> ByronHash
 toByronHash (W.Hash bytes) =
     case CC.hashFromBytes bytes of

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -225,7 +225,9 @@ networkConfigurationOption = mainnet <|> testnet <|> staging
     testnet = TestnetConfig <$> genesisFileOption "byron" "testnet"
     staging = StagingConfig <$> genesisFileOption "byron" "staging"
 
-    mainnetFlag = flag' MainnetConfig (long "mainnet")
+    mainnetFlag = flag' MainnetConfig $ mempty
+        <> long "mainnet"
+        <> help "Use Cardano mainnet protocol"
 
     genesisFileOption :: String -> String -> Parser FilePath
     genesisFileOption era net = optionT $ mempty

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -431,7 +431,7 @@ withNetworkLayer tr np addrInfo versionData action = do
             SubmitSuccess -> pure ()
             SubmitFail err -> throwE $ ErrPostTxBadRequest $ T.pack (show err)
 
-    -- fixme: only shelley transactions can be submitted like this, because they
+    -- NOTE: only shelley transactions can be submitted like this, because they
     -- are deserialised as shelley transactions before submitting.
     _postSealedTx localTxSubmissionQ tx = do
         liftIO $ traceWith tr $ MsgPostSealedTx tx


### PR DESCRIPTION
### Issue Number

ADP-356

### Overview

- Add CLI help for the `--mainnet` option.
- Fix some fixmes left over from refactors.

### Comments

- [Wiki](https://github.com/input-output-hk/cardano-wallet/wiki/Wallet-command-line-interface#serve) is updated.
