### PR TITLE
bump cardano-addresses to include fix for script hash

### DIFF
--- a/nix/.stack.nix/cardano-addresses.nix
+++ b/nix/.stack.nix/cardano-addresses.nix
@@ -91,7 +91,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "dc729b0ba5ba112ee2bfe471c4df947ea7c76f28";
-      sha256 = "1ax92cm6hy446qp5nwyshs1rydz1syrxjr032r4hcqs9v15a5i26";
+      rev = "3f11638847bfc8c457dc4bb080c63e5d6de806ee";
+      sha256 = "1hvs3p6yanfdr512csa3v822y3846r2hmwb7njr83s3w7dpgzj9n";
       });
     }) // { cabal-generator = "hpack"; }

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,7 +38,7 @@ extra-deps:
     - persistent-template
 
 - git: https://github.com/input-output-hk/cardano-addresses
-  commit: dc729b0ba5ba112ee2bfe471c4df947ea7c76f28
+  commit: 3f11638847bfc8c457dc4bb080c63e5d6de806ee
 
 # Not strictly a dependency at present, but building it here to get
 # access to the cardano-tx cli.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have bumped cardano-addresses to include fix for script hash. Note that this doesn't use `master` because the module re-oganisation on master broke the nix setup :/ 

# Comments

<!-- Additional comments or screenshots to attach if any -->

see also: https://github.com/input-output-hk/cardano-addresses/pull/50

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
