### PR TITLE
Don't store GenesisParameters in checkpoints

### DIFF
--- a/lib/byron/src/Cardano/Wallet/Byron.hs
+++ b/lib/byron/src/Cardano/Wallet/Byron.hs
@@ -274,6 +274,7 @@ serveWallet
         let params = (block0, np, sTolerance)
         db <- Sqlite.newDBFactory
             walletDbTracer
+            (getEpochStability gp)
             (DefaultFieldValues
                 { defaultActiveSlotCoefficient =
                     getActiveSlotCoefficient gp

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -148,13 +148,6 @@ Checkpoint
     checkpointParentHash        BlockId      sql=parent_header_hash
     checkpointBlockHeight       Word32       sql=block_height
     checkpointGenesisHash       BlockId      sql=genesis_hash
-    checkpointGenesisStart      UTCTime      sql=genesis_start
-    checkpointFeePolicyUnused   Text         sql=fee_policy
-    checkpointSlotLength        Word64       sql=slot_length
-    checkpointEpochLength       Word32       sql=epoch_length
-    checkpointTxMaxSizeUnused   Word16       sql=tx_max_size
-    checkpointEpochStability    Word32       sql=epoch_stability
-    checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -63,13 +63,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPool, SeqState (..), mkAddressPool )
 import Cardano.Wallet.Primitive.Model
-    ( Wallet
-    , blockchainParameters
-    , currentTip
-    , getState
-    , unsafeInitWallet
-    , utxo
-    )
+    ( Wallet, currentTip, genesisHash, getState, unsafeInitWallet, utxo )
 import Cardano.Wallet.Primitive.Slotting
     ( unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
@@ -105,6 +99,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
+    , getGenesisBlockHash
     , isPending
     , rangeIsValid
     , wholeRange
@@ -291,7 +286,7 @@ instance GenState s => Arbitrary (InitialCheckpoint s) where
             (utxo cp)
             (block0 ^. #header)
             (getState cp)
-            (blockchainParameters cp)
+            (genesisHash cp)
 
 {-------------------------------------------------------------------------------
                                    Wallets
@@ -299,13 +294,13 @@ instance GenState s => Arbitrary (InitialCheckpoint s) where
 
 instance GenState s => Arbitrary (Wallet s) where
     shrink w =
-        [ unsafeInitWallet u (currentTip w) s (blockchainParameters w)
+        [ unsafeInitWallet u (currentTip w) s (genesisHash w)
         | (u, s) <- shrink (utxo w, getState w) ]
     arbitrary = unsafeInitWallet
         <$> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> pure dummyGenesisParameters
+        <*> pure (getGenesisBlockHash dummyGenesisParameters)
 
 instance Arbitrary (PrimaryKey WalletId) where
     shrink _ = []

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -289,6 +289,7 @@ serveWallet Tracers{..} sTolerance databaseDir hostPref listen backend beforeMai
     apiLayer (block0, np) tl nl = do
         db <- Sqlite.newDBFactory
             walletDbTracer
+            (getEpochStability $ genesisParameters np)
             (DefaultFieldValues
                 { defaultActiveSlotCoefficient =
                     getActiveSlotCoefficient (genesisParameters np)

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -374,6 +374,7 @@ serveWallet
         let params = (block0, np, sTolerance)
         db <- Sqlite.newDBFactory
             walletDbTracer
+            (getEpochStability gp)
             (DefaultFieldValues
                 { defaultActiveSlotCoefficient =
                     getActiveSlotCoefficient gp


### PR DESCRIPTION

# Issue Number

#1872 

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Remove all genesis params but genesis hash from checkpoints
- [x] Pass in the `EpochStability`/a.k.a `k` to the DB, from the `GenesisParameters` we read at startup


# Comments

```
Most GenesisParameters are unneeded in the checkpoints, and storing them
there may give the impression that they may be changed by protocol
updates and forks. They won't. (There is a separate ProtocolParameters
table, however)

This commit keeps the genesis hash in the checkpoints, such that we
still can validate the integrity of the db.

For pruning checkpoints, the db needs the security parameter k. Since we
no longer can read it from the DB, we pass it in when constructing the
db.
```
<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
