### PR TITLE
Minimum execution time for `withRootKey` on authentication failure.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -26,6 +26,8 @@ import Cardano.Mnemonic
     , genEntropy
     , mnemonicToText
     )
+import Cardano.Wallet
+    ( minimumExecutionTimeOnAuthFailure )
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiByronWallet
@@ -68,6 +70,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( toText )
+import Data.Time
+    ( diffUTCTime, getCurrentTime )
 import Data.Word
     ( Word64 )
 import Test.Hspec
@@ -932,6 +936,19 @@ spec = do
             let endpoint = Link.putWalletPassphrase @'Shelley w
             rup <- request @ApiWallet ctx endpoint headers payload
             verify rup expectations
+
+    it "WALLETS_UPDATE_PASS_08 - Delay on authentication failure" $ \ctx -> do
+        w <- emptyWalletWith ctx
+            ("Wallet to update pass", "cardano-passphrase", 20)
+        let payload = updatePassPayload "incorrect-passphrase" "whatever-pass"
+        startTime <- getCurrentTime
+        rup <- request @ApiWallet ctx
+            (Link.putWalletPassphrase @'Shelley w) Default payload
+        endTime <- getCurrentTime
+        let timeElapsed = endTime `diffUTCTime` startTime
+        timeElapsed `shouldSatisfy` (> minimumExecutionTimeOnAuthFailure)
+        expectResponseCode @IO HTTP.status403 rup
+        expectErrorMessage errMsg403WrongPass rup
 
     it "WALLETS_COIN_SELECTION_01 - \
         \A singleton payment is included in the coin selection output." $

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -950,6 +950,19 @@ spec = do
         expectResponseCode @IO HTTP.status403 rup
         expectErrorMessage errMsg403WrongPass rup
 
+    it "WALLETS_UPDATE_PASS_09 - \
+        \No delay on authentication success" $ \ctx -> do
+        w <- emptyWalletWith ctx
+            ("Wallet to update pass", "cardano-passphrase", 20)
+        let payload = updatePassPayload "cardano-passphrase" "whatever-pass"
+        startTime <- getCurrentTime
+        rup <- request @ApiWallet ctx
+            (Link.putWalletPassphrase @'Shelley w) Default payload
+        endTime <- getCurrentTime
+        let timeElapsed = endTime `diffUTCTime` startTime
+        timeElapsed `shouldSatisfy` (< minimumExecutionTimeOnAuthFailure)
+        expectResponseCode @IO HTTP.status204 rup
+
     it "WALLETS_COIN_SELECTION_01 - \
         \A singleton payment is included in the coin selection output." $
         \ctx -> do

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -164,6 +164,7 @@ module Cardano.Wallet
     , ErrStartTimeLaterThanEndTime (..)
 
     -- ** Root Key
+    , minimumExecutionTimeOnAuthFailure
     , withRootKey
     , ErrWithRootKey (..)
     , ErrWrongPassphrase (..)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2172,7 +2172,8 @@ withMinimumExecutionTimeOnFailure minimumExecutionTime action = do
     timeAtStart <- liftIO getCurrentTime
     lift (runExceptT action) >>= \case
         Left failure -> do
-            waitUntil (minimumExecutionTime `addUTCTime` timeAtStart)
+            let timeToExit = minimumExecutionTime `addUTCTime` timeAtStart
+            waitUntil timeToExit
             throwE failure
         Right result ->
             pure result

--- a/lib/core/src/Data/Time/Utils.hs
+++ b/lib/core/src/Data/Time/Utils.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -5,14 +7,21 @@
 -- Utility functions for manipulating time values.
 
 module Data.Time.Utils
-    ( utcTimePred
+    ( nominalDiffTimeToMicroseconds
+    , utcTimePred
     , utcTimeSucc
     ) where
 
 import Prelude
 
 import Data.Time
-    ( UTCTime, addUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime )
+
+-- | Converts the specified time difference into an integral number of
+--   microseconds.
+--
+nominalDiffTimeToMicroseconds :: Integral i => NominalDiffTime -> i
+nominalDiffTimeToMicroseconds = ceiling . (* 1_000_000) . toRational
 
 -- | For a given time 't0', get the closest representable time 't1' to 't0'
 --   for which 't0 < t1'.

--- a/lib/core/src/Data/Time/Utils.hs
+++ b/lib/core/src/Data/Time/Utils.hs
@@ -10,12 +10,17 @@ module Data.Time.Utils
     ( nominalDiffTimeToMicroseconds
     , utcTimePred
     , utcTimeSucc
+    , waitUntil
     ) where
 
 import Prelude
 
+import Control.Concurrent
+    ( threadDelay )
+import Control.Monad.IO.Class
+    ( MonadIO, liftIO )
 import Data.Time
-    ( NominalDiffTime, UTCTime, addUTCTime )
+    ( NominalDiffTime, UTCTime, addUTCTime, diffUTCTime, getCurrentTime )
 
 -- | Converts the specified time difference into an integral number of
 --   microseconds.
@@ -32,3 +37,16 @@ utcTimeSucc = addUTCTime $ succ 0
 --   for which 't1 < t0'.
 utcTimePred :: UTCTime -> UTCTime
 utcTimePred = addUTCTime $ pred 0
+
+-- | Suspends the current thread until after the specified time has passed.
+--
+-- There is no guarantee that the thread will be rescheduled promptly when the
+-- delay has expired, but the thread will never continue to run earlier than
+-- specified.
+--
+waitUntil :: MonadIO m => UTCTime -> m ()
+waitUntil futureTime = liftIO $ do
+    currentTime <- getCurrentTime
+    threadDelay
+        $ nominalDiffTimeToMicroseconds
+        $ futureTime `diffUTCTime` currentTime

--- a/lib/core/src/Data/Time/Utils.hs
+++ b/lib/core/src/Data/Time/Utils.hs
@@ -49,4 +49,4 @@ waitUntil futureTime = liftIO $ do
     currentTime <- getCurrentTime
     threadDelay
         $ nominalDiffTimeToMicroseconds
-        $ futureTime `diffUTCTime` currentTime
+        $ max 0 (futureTime `diffUTCTime` currentTime)

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.faulty.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.faulty.json
@@ -1,0 +1,387 @@
+{
+    "seed": -7107996085184291435,
+    "samples": [
+        {
+            "metrics": {
+                "saturation": 0.6160834418134742,
+                "non_myopic_member_rewards": {
+                    "quantity": 615953285512,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 18143234,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 48.63,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1862-01-29T20:48:02.108295353453Z",
+                "epoch_number": 21897
+            },
+            "cost": {
+                "quantity": 205,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 47.85,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 3,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "\u0013$󹳯92\u001b\u001f󂠙9s\u0017ur\u001c",
+                "name": ">*h!x",
+                "ticker": "k \u0000r򞰴",
+                "description": "O&\u0004nE\u001cY\"򝽇;\u0003xY􌦨7\u0005:\u0016Ht󕊭񩖖15'\u001b~񦅕X󈥱!󼙰򮣫\u0006\n\u0019𐳓E򂆐/\u0016\n\u0019򕝓\u00004񳓍Ih"
+            },
+            "id": "daf2fc7a68224fe46e8ef8acf12696338216914d65de0127bd615061"
+        },
+        {
+            "metrics": {
+                "saturation": 4.24150348278511,
+                "non_myopic_member_rewards": {
+                    "quantity": 569121601446,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 9835933,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 11.86,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1866-12-28T21:00:00Z",
+                "epoch_number": 14356
+            },
+            "cost": {
+                "quantity": 182,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 15.3,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 166,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "񄏆E򶶈oZ_iJ{[MI\u0013񣦕\u001e];ᚹ\\𸆖\\{\"g󼦲񓶏k񺖸󐱪󌄪\u000bgh7",
+                "name": "\u0018񤱦",
+                "ticker": "^o\u0013dp",
+                "description": "GzI炼󏩥z|J7ko\u000b󚵱\u0013\u00160򐇖I𶈽p05񠀱@\u0007𬷃󳪎V\u0014󈝹p\u0004\u0008r!𬴑f\"\u000ec&򻎺T󘃥[<\u0017>񆓭Ce\u001b0`k\u0001Ij򠉜M񧆀󨽈\u0018\u001d.񄱞7D\\\u0000u\"\u0014\u0010!\u0011d񛯎C𮚝򽺫*D򯞣SU𺹜Z?*}󷶏id0,D<Bq?4_M󔶣񈳽H"
+            },
+            "id": "2b283be591886d1be96b44669551700ede5f3e1ecf457321079fc41d"
+        },
+        {
+            "metrics": {
+                "saturation": 0.7431241936841265,
+                "non_myopic_member_rewards": {
+                    "quantity": 547825929840,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 14076497,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 44.44,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1869-12-25T06:28:23Z",
+                "epoch_number": 19627
+            },
+            "cost": {
+                "quantity": 128,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 1.06,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 103,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "񙳩񫯔y+򐕻/\u000b\n",
+                "name": "[\u000cR𻟆󫚀򁩙$\u0011d]헧🴴nsA0\u0012򤪯򰻌IJ񟹵\u0017󒁼9󯙊qY𠄙\u0003 򂾯(L\u0013\u000fr=S",
+                "ticker": "E]I\u0014",
+                "description": "\u000bzm򗐏\u000cYh\u0011j\u0007𧺡Q񱹀\u0016􎥓󃮾^\"zg\u0001\u0005\u0017l򒚪5Wb:g\u001f,\u0018\u00184􈡳>"
+            },
+            "id": "b01379b2a600a1ca4f96ee68d54a6eeb1f80e1485f8770c4406026c7"
+        },
+        {
+            "metrics": {
+                "saturation": 4.403490945522135,
+                "non_myopic_member_rewards": {
+                    "quantity": 363326578681,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 20235169,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 64.63,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1907-03-31T05:41:28.388760714365Z",
+                "epoch_number": 29422
+            },
+            "cost": {
+                "quantity": 235,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 30.4,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 227,
+                "unit": "lovelace"
+            },
+            "id": "d63b64ed971e4f22aa6ce52ccfb01ce72e61ed8de467a5bd5cfef7fd"
+        },
+        {
+            "metrics": {
+                "saturation": 4.037147815384624,
+                "non_myopic_member_rewards": {
+                    "quantity": 71413835287,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 9722930,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 81.96,
+                    "unit": "percent"
+                }
+            },
+            "cost": {
+                "quantity": 21,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 92.16,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 241,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "􇏙~𛍾󘏷v򟖥RV򌑓_V򁠪F\u001dn+򒾍񵞖0",
+                "name": "Lk;*%%;~oVcZ\u0006𵮦󺼋SH\r\u001f\u0011񷬛Z.\u0002<sW8Ew񣼽\"v򱋷C<",
+                "ticker": "H0򴳥T񦻡",
+                "description": "?L𓕡y󔰩 \u0017=𑞘2cqOp\u0010;Dc$`\rK=gT𘰬n.8_2g󭉜E􍐺7@4󭗠~󃸧>𣥿J16󟾎\u0005񅃾{\u001fK놏\u0018𠞰򨅗h/\u0015􍖯\u0007r\n\u001d\u000c\u0007C󝫆u󺌉e\\򶫇\u001d\u001bH2A􏣄Iz\"񣞔񰫝\u001a\u0005򦻣4II\u0015h\u0004񐁭6R\"I%𜁦@=7\u0013l񀆥򵹡\\\u0012S<񜲯񀍢R|i\rX4\u000fL<cS񪃂󸊺\u001c!\u0011񫺪𑚑%A򠢗𘑐󑤨X(I\u001a%\tn!\u00077\u000f𜵀󫝛\u0010\u001d#𻸜\u0008V+|E󙜠񒅵<򐘦󈼝I𸐙ex>򹬏LhT\u001a򃾆\u0014󳀁\u001a\u0014'a󄃙P$\n\"5K"
+            },
+            "id": "e5744a67d18f5c450db119f4019b5f0487156d3ac6c7fd998a4b63d3"
+        },
+        {
+            "metrics": {
+                "saturation": 2.518417801630494,
+                "non_myopic_member_rewards": {
+                    "quantity": 960222820750,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 16170724,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 28.8,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1882-11-06T13:36:07.373487126339Z",
+                "epoch_number": 16701
+            },
+            "cost": {
+                "quantity": 46,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 78.67,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 224,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "7𻞔􌣱ja|%|q򽿹f򯏯񚜱􍶑򪈱\\k\u001e䦕񵵂c񥗹^6\u0012@2\u001c1񖳔C#򁹫\u0006l􄢏񋟘:MfAO𙤪a𹼉CH\u0018⽤\u001a񏑅dk#L񲟣SU\"\u0012G\u001d򬦧񤿫򎊉HNILzeZ\u0006._\u001f\"񵕺󨅱𧯬J\u0006sJc-𠴑(\u0011\u0014",
+                "name": "𢇽",
+                "ticker": "𐮱\u0015b\u0018",
+                "description": "񁭈[򣂕js𼜴|򁾽󋮵\u0015V蕧\u0012Qg\u0000~C\u0003yN\u000c.󪰝t\t򅎄p󈉜󑒖񟦒򮜵􎁉B+\u001cy\\\u0013YxnOJ𰕪𘵭\r򔮾=@􏖗𯽿C󕷵A*\u0015\u0013{\u0008?񅟂Z\noR}+5l퉨*󿱌򇁝\u0001\n\u0008)𫝚S\u001e𤓒Te 񗞂m\r󸘜󦬃\u0003񔱂y򑐻񘗠󡚺񆷛񟙖Jf$pKObq0\u0015'𼪈􍴼\u0016S\nY򭁉\u0004R􈡟\u0016W9C]XV򼶸\u0007񭐃B-𫝊򦺟B-񦰥~J$򭻴핥􋠒7񑀍K#fB🪆󡇱J𑷱󾺗}'򅎒񝥪C􌭪􂅆E==~4,񟥜JCPd\u0012T\u0003-O\u001b0n\u0013Ol򤪦[\u0005R􄙉󥿦yp\u0014\u0014𾮀񸫒fq\u00044}"
+            },
+            "id": "f69e9ecea710a69885c01a6c2f0eac91a33a97f8a8d1e3b74e3fbec3"
+        },
+        {
+            "metrics": {
+                "saturation": 2.0811709133682035,
+                "non_myopic_member_rewards": {
+                    "quantity": 90128575339,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 4622136,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 95.4,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1905-12-29T00:00:00Z",
+                "epoch_number": 12871
+            },
+            "cost": {
+                "quantity": 211,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 19.2,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 106,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": " G^L])a󒘵#򸲄aᶨ\u0007\u0004[𽒙i>:olo򰛰L)󧔟񄣷+'󬅲l򧟄\t󄼐𺚡󳄮\tw桞\u001e󔛗\u001aST\"1\u000biIUc\u000c.m򇒷6󤄑c*\u001a\u001a%\u001b񩓁񒬻 Y\u0000\u001d񕣻\u001cd\u0005󔉌VM\u0019󇰐C󩞪",
+                "name": "M$򹄶",
+                "ticker": "\u0019C+񟅗\u0010",
+                "description": "G\u001aj񤄐󠪞탄񯲲F󡮠a󷳭C򋩑&dV𣲾\u001d􅔝}𵆦No'M>:bu#\n󙤫󼔬򳈈\u0013+9󋞏f\u000b\\d|9D*u=\u001b󾏧\u0002\u0006;*t񽡑:󺋭i&Sj\u001e񫏦G\u0015JJ]\u0013Ay<S\u000efU򅃿b\u0005EZ𻆡. 𺅈\u001c(\u001e򌪷􌒂@\u0015x򟒅\u0019\u000cfHwC(f\u000bG󹩝\u0002T򍤍\u001e򎦮^3񻃆򰯏򄗉D\u001f򿓋\u0017p\u0010\u0011\u0018󠖒񃕉􎦖\u0011\u000eU/9\u0003L\u0000\u001c5\u0019Ig걯?\u001ao\u000c2\u0016HJ|􊒍g\u0008\rpM񩑚\u000e\u001cG\"h\u0003\u0010B񷒽wCwH\u001f^O\u0017\u0004\u000fa\u00139\u0018uNJ \u0004𪙚򃕑\u000b𚓶𴮐n\u0006񗭃\u000ebHfX\u0004LHNkE𪬓xoU𖏡󁘳~RdU0q\u0019"
+            },
+            "id": "e0080e5bd33d74bb1e97b5ed16d3a0128271b845aa03fcb6df5b9181"
+        },
+        {
+            "metrics": {
+                "saturation": 0.9455763373500053,
+                "non_myopic_member_rewards": {
+                    "quantity": 771071288260,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 849478,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 1.33,
+                    "unit": "percent"
+                }
+            },
+            "cost": {
+                "quantity": 56,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 21.52,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 244,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "\u0019iB>򆮬\u0013C1I\u000f\r𖚘񆾌H\u0019;C🌍PKL\u001c\u001f(cK\u001fF!򂡿\"幣𷨅󈍴(*\u0000pၗdY󾏤󨾇|E?񜦫\u001d\u0014Vx\u00126S񎹬vxQP𦃶@􄥖\u0001~c}\u000b2\t󾶒򻑖\u0018u<򚾥\u0013\u0019;񂈡ym,𨉖򘦲󯔼6",
+                "name": "\u001eo(^\t<b\u001d򹐧iW\"󕤡3* \u0006󋐝9𺼽rT\t.J\u0013g󚯯􀀱j𘐞#򿣬󎥸~󎌍p𔳡\n󻲥\u001dH\u0016^\u000290",
+                "ticker": "񣤳R\u001a󡰟",
+                "description": "뗔𔸷f>4{\u001c񪤓U򎨥\u001e򎉤x􀶛P)󅧦\u0001\u0002\"2EM&0eV򎒎E\u00115@>򝫜[\u0019񺄥\u000b󞬮wb0Qz+Om}\u0014𸁃uof*A\u0005\u001fP򤡿򻂊]NjP1\u000f0:dg󂇆h\u0000@񶅳\u001c仭y󶅡vZ\u001f񳷼PIPGsZ%􆁞0sL񋆤򌔇/:h\u000b?򣓞$+9\u0018򈿟0E3O雀\u0003\u0010򯣿\u0002J\u0002eF|󑊜t񰇆:󸨶$\u000e񾭺9O𞥕\n􉨣\u0016;\u0014񡮣Nf񴽅󰅽e4𻲑I򥗾UnzWF򚯄񃆒u򙸱\u0005\u0002󔑖-6pk\\򰛘>󖹘\u000b򽊝H'.\u0002q𖯀񛭔\u001d󔬼𽃃;o*U\u0002[%5𸧟}򯆴$\u0015\u0016\u000fg7\u0011Kh\u001dK􏼺7󃞑򆣁JMBKVc񦎿\u001b=>\u0001e8\u0000`\r򆠼󣉧3򧵈R𘤒\u0011\u001c.\u0014I𓪌d0"
+            },
+            "id": "76802e9eca33c94f5d3882053a62966ccb7e5e8003cc540cc235afd6"
+        },
+        {
+            "metrics": {
+                "saturation": 2.21718534073677,
+                "non_myopic_member_rewards": {
+                    "quantity": 575812827990,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 7372117,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 76.08,
+                    "unit": "percent"
+                }
+            },
+            "cost": {
+                "quantity": 239,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 21.22,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 222,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "𙋬F\u0015o\u001fH󗻢X򛿆񊧢M\u0010򎋵\u001e\u0015<J~$񡆲19nJ𲗖j_1(v~\u0004zb\u001c7b\u001f\u001al\u0005#xOk\u000e7u򑦼,PJ~W򱊥dFs𞏱*4\"m\\tu\u0007𔤌𠽺0Y \u0015B=6W8O/",
+                "name": "\\.Q\u0019_\\\u0008󔈥𡵋\u0016+@򑖥:C񲛻񁗪j\u0002",
+                "ticker": "󊤋w)\u0003",
+                "description": "\u0001j~|k\u0013󴰜v\"Ih;o\u001aH𓢞 󕖸A&\u0005󊮶 \u001f#􋇺b\u0016󿺃\u000f\u000b𲳫𫁾󜪊="
+            },
+            "id": "d3c68e1812b0d03b8b1d661a0989ebac65a4d7e9f1cb5457cd686825"
+        },
+        {
+            "metrics": {
+                "saturation": 2.1266668321957765,
+                "non_myopic_member_rewards": {
+                    "quantity": 500253574185,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 18984285,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 39.12,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1869-04-15T09:17:58.986753211189Z",
+                "epoch_number": 20716
+            },
+            "cost": {
+                "quantity": 52,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 99.21,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 119,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "򥬖fS񐣑H񰗳&]Lm􃀄<P󮄡\nQ!>V󩦱z󜷏t\u001a<󣚚d%󘤆𷠿󮒗A.Qy񍼸=񹥏\n񴵸񿄲򸣏'򄛢\u000e&\r-.Q[T񕛳򲙑72Lc􊕕󞍞5\u0012򽫵𾟿ch򉶹O񻓴QB{\u0006\u0015X!<@V𝸚򲥲󏍢󥾽PIDE^򟔜",
+                "name": "\u001d񂣖\u0008\u00026",
+                "ticker": "󊻏񞑡󬬽hM",
+                "description": "\u001fNvKx:5y\u0016w\u0013I󤉶񳖁-IY򌑅7𱹽\u001b\u001fS;򎢖(\u000b%_S{Xz𦯩qN6򅞘𨡑}#6tm=<\u0003R4𭀍bU\u001evT񢨿@h+\u000cblqCgG\u0010򄬜s\\𘜪!^t\u0003 𜠥#񮥿򈜝)-\"?\u0008\u000e𺤢 o'D\u0006\u001a\u0019򜏷򍑫򐎶\u001c9򰄘z6OZw7tv\t\r򞽘x󗁘=s钁󥆭CNH򫂡;\u00011'g\n\u0003Q\u0018󳕔#2ZTz񅧇xK\u001b򆏐\u0001\u0011\u0016NI饤񸍬.󕱟_\u0000r78򗣳y\u0005\u0016𿹞f\u0005\u0013Hp\u0002񻦚\r2𔐖yS;2򂪦\u0010AG𮮹b󒸚/򠛳V􌪩a\u0003H򨦀b\"{M\u0000\u0010Tk񨷭Y\u0006U.AG\u0014Z򉌎򄗬񍗇c9\u000e,ojpbFMj>"
+            },
+            "id": "0dae6bef590313895306c2ae1ae2f9337bc93d1716375abcb0d784a5"
+        }
+    ]
+}


### PR DESCRIPTION
# Issue Number

#1984 

# Overview

This PR adjusts the `withRootKey` function to incorporate a minimum execution time in the event of failure.

- In the event of a _successful_ authentication, there is _no_ delay.
- In the event of an _unsuccessful_ authentication, the total execution time of the `withRootKey` function is:
    -  equal to (or greater than) `minimumExecutionTimeOnAuthFailure`.
    -  independent of the actual time required to perform the authentication.

Where `minimumExecutionTimeOnAuthFailure` is defined as:
```hs
-- | Specifies a minimum bound on the length of time that is allowed to elapse
--   before an authentication failure can be reported to the user.
--
minimumExecutionTimeOnAuthFailure :: NominalDiffTime   
minimumExecutionTimeOnAuthFailure = threeSeconds   
  where   
    threeSeconds = fromRational 3   
```

In the future, we could make this configurable (if the need arises).

# Testing

- [x] Add integration test to confirm that an unsuccessful attempt to authenticate results in a delay of `minimumExecutionTimeOnAuthFailure` or longer.
- [x] Add integration test to confirm that a successful attempt to authenticate does not result in such a delay.