### PR TITLE
Add user advice to `UnableToDetermineCurrentEpoch` error.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1997,8 +1997,10 @@ showT = T.pack . show
 instance LiftHandler ErrCurrentEpoch where
     handler = \case
         ErrUnableToDetermineCurrentEpoch ->
-            apiError err500 UnableToDetermineCurrentEpoch
-                "I'm unable to determine the current epoch."
+            apiError err500 UnableToDetermineCurrentEpoch $ mconcat
+                [ "I'm unable to determine the current epoch. "
+                , "Please wait a while for the node to sync and try again."
+                ]
 
 instance LiftHandler ErrUnexpectedPoolIdPlaceholder where
     handler = \case


### PR DESCRIPTION
# Issue Number

#1939 

# Overview

This PR revises the error we show if we cannot determine the current epoch, inviting the user to wait and try again.

# Comments

Ideally, we'd be able to give the user some indication of _how long_ they should wait, but assuming we cannot reliably know this information, letting them know that waiting may resolve the issue is arguably better than giving no advice at all.
