### PR TITLE
revised SQL query returning next pool metadata to fetch

### DIFF
--- a/lib/core/src/Cardano/Pool/Metadata.hs
+++ b/lib/core/src/Cardano/Pool/Metadata.hs
@@ -169,7 +169,7 @@ fetchFromRemote tr builders manager url hash = runExceptTLog $ do
 
     getChunk :: URI -> ExceptT String IO (Maybe ByteString)
     getChunk uri = do
-        req <- requestFromURI uri
+        req <- withExceptT show $ except $ requestFromURI uri
         liftIO $ traceWith tr $ MsgFetchPoolMetadata hash uri
         ExceptT
             $ handle fromIOException


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- fccb250ff7628ad0d2a30f2aa36a4f35f542be1b
  :round_pushpin: **revised SQL query returning next pool metadata to fetch**
    There are two fundamentals change here:

  a) This now does a LEFT JOIN on the fetch attempts table on BOTH the metadata_hash and
  metadata_url. Before, we would discard metadata based solely on their metadata_hash. Now,
  we select on the joined table directly and keep all pool metadata with either no fetch attempts,
  or a fetch_after that is prior to the current datetime.

  b) It now _sorts_ the result based on their fetch_after date, the most "urgent" first. This is to cope
  with the arbitrary batch limit of 100 pools and make sure that all metadata are eventually fetched.
  Before, we could potentially retry fetching the same metadata over and over again until they expire.

- 5c22399b59f55b55409a44b8269fe5359296a2ed
  :round_pushpin: **use 'Either InvalidUrlException' as a base monad for requestFromURI**
    Again... errors from 'requestFromURI' are thrown via 'MonadThrow', which, in the case of 'ExceptT' throws in the base monad, which is IO in this case.



# Comments

<!-- Additional comments or screenshots to attach if any -->


On a database synced against latest mainnet, the old query would return the same 100 pools over and over. Whereas, there's in total `524` pools that still need fetching! 

With the query, we indeed get 100 pools that haven't been fetched yet, and all pools are eventually getting fetched (if any of these metadata fetch attempt fail, it is recorded and put later in the queue, so that new pools are tried out until eventually only remains those that are failing). Using the database above, I've re-started the wallet with this patch on mainnet, and after a few seconds, the number of pools that remain to fetch are indeed fetched. In the end, 702 metadata are fetched, and only 274 remains unfetched due to errors. 



<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
