### PR TITLE
docker: add nsswitch.conf to base layer

### DIFF
--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -8,7 +8,7 @@
 #
 ############################################################################
 
-{ runtimeShell, writeScriptBin, runCommand, dockerTools
+{ runtimeShell, writeScriptBin, writeTextFile, runCommand, dockerTools
 
 # The main contents of the image.
 , exe
@@ -40,11 +40,18 @@ let
     exec ${exe}/bin/cardano-wallet-${backend} "$@"
   '';
 
+  # Config file needed for container/host resolution.
+  nsswitch-conf = writeTextFile {
+    name = "nsswitch.conf";
+    text = "hosts: files dns";
+    destination = "/etc/nsswitch.conf";
+  };
+
   # Layer of tools which aren't going to change much between versions.
   baseImage = dockerTools.buildImage {
     name = "${repoName}-env";
     contents = [
-      glibcLocales iana-etc cacert
+      glibcLocales iana-etc cacert nsswitch-conf
       bashInteractive coreutils utillinux iproute iputils curl socat
     ];
     # set up /tmp (override with TMPDIR variable)


### PR DESCRIPTION
### Overview

Configures the docker image to use `/etc/hosts` ahead of DNS.

This works around the issue of the CLI being hardcoded to use localhost.

### Comments

Before:

    docker run --network host --rm -ti --entrypoint=bash inputoutput/cardano-wallet:2020.7.28-shelley
    bash-4.4# ping localhost
    PING localhost(localhost.lan (::1)) 56 data bytes
    64 bytes from localhost.lan (::1): icmp_seq=1 ttl=64 time=0.043 ms
    64 bytes from localhost.lan (::1): icmp_seq=2 ttl=64 time=0.087 ms
    64 bytes from localhost.lan (::1): icmp_seq=3 ttl=64 time=0.092 ms
    ^C
    --- localhost ping statistics ---
    3 packets transmitted, 3 received, 0% packet loss, time 2043ms
    rtt min/avg/max/mdev = 0.043/0.074/0.092/0.022 ms
    bash-4.4# cat /etc/nsswitch.conf
    cat: /etc/nsswitch.conf: No such file or directory

After:

    docker run --network host --rm -ti --entrypoint=bash inputoutput/cardano-wallet:2020.7.28-shelley
    bash-4.4# ping localhost
    PING localhost (127.0.0.1) 56(84) bytes of data.
    64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.047 ms
    64 bytes from localhost (127.0.0.1): icmp_seq=2 ttl=64 time=0.081 ms
    64 bytes from localhost (127.0.0.1): icmp_seq=3 ttl=64 time=0.078 ms
    ^C
    --- localhost ping statistics ---
    3 packets transmitted, 3 received, 0% packet loss, time 2062ms
    rtt min/avg/max/mdev = 0.047/0.068/0.081/0.015 ms
    bash-4.4# cat /etc/nsswitch.conf
    hosts: files dns
