### PR TITLE
review guard condition on self withdrawl redemption

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -467,12 +467,32 @@ x-transactionOutputs: &transactionOutputs
 
 x-transactionRedemptionRequest: &transactionRedemptionRequest
   <<: *walletMnemonicSentence
-  description: Withdraw rewards from an external wallet, if any.
+  description: |
+    When provided, attempts to withdraw rewards from the default stake address corresponding to the given mnemonic.
+
+    Should the rewards be null or too small to be worth withdrawing (i.e. the cost of adding them into the transaction
+    is more than their own intrinsic value), the server will reject the request with a `withdrawal_not_worth` error.
+
+    withdrawal field    | reward balance | result
+    ---                 | ---            | ---
+    any recovery phrase | too small      | x Error 403 `withdrawal_not_worth`
+    any recovery phrase | big enough     | ✓ withdrawal generated
 
 x-transactionWithdrawalRequestSelf: &transactionWithdrawalRequestSelf
   type: string
   enum: ["self"]
-  description: Optionally withdraw rewards from **this** wallet, if any.
+  description: |
+    When provided, instruments the server to automatically withdraw rewards from the source wallet when they are deemed
+    sufficient (i.e. they contribute to the balance for at least as much as they cost).
+
+    As a consequence, the resulting transaction may or may not have a withdrawal object. Summarizing:
+
+    withdrawal field | reward balance | result
+    ---              | ---            | ---
+    `null`           | too small      | ✓ no withdrawals generated
+    `null`           | big enough     | ✓ no withdrawals generated
+    `"self"`         | too small      | ✓ no withdrawals generated
+    `"self"`         | big enough     | ✓ withdrawal generated
 
 x-transactionWithdrawals: &transactionWithdrawals
   description: A list of withdrawals from stake addresses.


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#1965 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 728ab75ab077c06da4a3811772e05293c3072072
  :round_pushpin: **change integration scenario to always allow redeeming from self**
    This makes it a lot easier for clients to deal with rewards. One can always give 'self' and simply let the backend decides whether or not rewards should be redeemed. For external wallets however, it could be quite counter-intuitive to succeed in the case there are no rewards in the target wallet so we still error in that case.

- 278c9a359a59823b236522ab42b2767d7c0d1047
  :round_pushpin: **move rewards redemption guard to only apply to external redemptions**
    As per previous commit.

- 029da7f0922e09ce5724c63ec8fc4c06e73d14db
  :round_pushpin: **improve and adjust API documentation on withdrawal redemption**


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
