### PR TITLE
Specify that `payments` should be a non-empty list.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -549,6 +549,9 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , depth :: !(Maybe (Quantity "block" Natural))
     , direction :: !(ApiT Direction)
     , inputs :: ![ApiTxInput n]
+      -- TODO: Investigate whether the list of outputs should be non-empty, and
+      -- if so, whether the 'outputs' field can be encoded as a non-empty list.
+      -- See: https://jira.iohk.io/browse/ADP-400
     , outputs :: ![AddressAmount (ApiT Address, Proxy n)]
     , withdrawals :: ![ApiWithdrawal n]
     , status :: !(ApiT TxStatus)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1277,10 +1277,17 @@ instance Arbitrary (ApiTransaction t) where
             <*> pure txPendingSince
             <*> arbitrary
             <*> arbitrary
-            <*> Test.QuickCheck.scale (`mod` 3) arbitrary
-            <*> Test.QuickCheck.scale (`mod` 3) arbitrary
-            <*> Test.QuickCheck.scale (`mod` 3) arbitrary
+            <*> genInputs
+            <*> genOutputs
+            <*> genWithdrawals
             <*> pure txStatus
+      where
+        genInputs =
+            Test.QuickCheck.scale (`mod` 3) arbitrary
+        genOutputs =
+            Test.QuickCheck.scale (`mod` 3) arbitrary
+        genWithdrawals =
+            Test.QuickCheck.scale (`mod` 3) arbitrary
 
 instance Arbitrary (ApiWithdrawal (t :: NetworkDiscriminant)) where
     arbitrary = ApiWithdrawal

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -168,6 +169,8 @@ import Data.FileEmbed
     ( embedFile, makeRelativeToProject )
 import Data.Function
     ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Data.List
     ( foldl' )
 import Data.List.NonEmpty
@@ -1261,7 +1264,10 @@ instance Arbitrary PostExternalTransactionData where
         PostExternalTransactionData . BS.pack <$> shrink (BS.unpack bytes)
 
 instance Arbitrary (ApiTransaction t) where
-    shrink = genericShrink
+    shrink = filter outputsNonEmpty . genericShrink
+      where
+        outputsNonEmpty :: ApiTransaction t -> Bool
+        outputsNonEmpty = (not . null) . view #outputs
     arbitrary = do
         txStatus <- arbitrary
         txInsertedAt <- case txStatus of
@@ -1284,8 +1290,15 @@ instance Arbitrary (ApiTransaction t) where
       where
         genInputs =
             Test.QuickCheck.scale (`mod` 3) arbitrary
-        genOutputs =
-            Test.QuickCheck.scale (`mod` 3) arbitrary
+        -- Note that the generated list of outputs must be non-empty in order
+        -- to be consistent with the specification.
+        --
+        -- Ideally, we should encode this restriction in the type system.
+        --
+        -- See https://jira.iohk.io/browse/ADP-400.
+        genOutputs = (:)
+            <$> arbitrary
+            <*> Test.QuickCheck.scale (`mod` 3) arbitrary
         genWithdrawals =
             Test.QuickCheck.scale (`mod` 3) arbitrary
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -455,7 +455,7 @@ x-transactionInputs: &transactionInputs
 x-transactionOutputs: &transactionOutputs
   description: A list of target outputs
   type: array
-  minItems: 0
+  minItems: 1
   items:
     type: object
     required:


### PR DESCRIPTION
# Issue Number

#2000 

# Overview

This PR:

- [x] adjusts the Swagger specification to indicate that `payments` (for `ApiPostTransactionData` and other related types) should be a non-empty list.
- [x] adjusts the unit tests to only generate `ApiTransaction` values with non-empty lists of outputs.
- [x] adds a reminder to investigate whether or not the `outputs` field of the `ApiTransaction` type should also be a non-empty list. (See https://jira.iohk.io/browse/ADP-400)