### PR TITLE
Provide PoolId to the SMASH url builder

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -151,7 +151,7 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
 
     , unfetchedPoolMetadataRefs
         :: Int
-        -> stm [(StakePoolMetadataUrl, StakePoolMetadataHash)]
+        -> stm [(PoolId, StakePoolMetadataUrl, StakePoolMetadataHash)]
         -- ^ Read the list of metadata remaining to fetch from remote server,
         -- possibly empty if every pool already has an associated metadata
         -- cached.

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -262,7 +262,7 @@ mListRegisteredPools db@PoolDatabase{registrations} =
 
 mUnfetchedPoolMetadataRefs
     :: Int
-    -> ModelPoolOp [(StakePoolMetadataUrl, StakePoolMetadataHash)]
+    -> ModelPoolOp [(PoolId, StakePoolMetadataUrl, StakePoolMetadataHash)]
 mUnfetchedPoolMetadataRefs n db@PoolDatabase{registrations,metadata} =
     ( Right (toTuple <$> take n (Map.elems unfetched))
     , db
@@ -277,9 +277,9 @@ mUnfetchedPoolMetadataRefs n db@PoolDatabase{registrations,metadata} =
 
     toTuple
         :: PoolRegistrationCertificate
-        -> (StakePoolMetadataUrl, StakePoolMetadataHash)
-    toTuple PoolRegistrationCertificate{poolMetadata} =
-        (metadataUrl, metadataHash)
+        -> (PoolId, StakePoolMetadataUrl, StakePoolMetadataHash)
+    toTuple PoolRegistrationCertificate{poolId,poolMetadata} =
+        (poolId, metadataUrl, metadataHash)
       where
         Just (metadataUrl, metadataHash) = poolMetadata
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -545,7 +545,8 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
 monitorMetadata
     :: Tracer IO StakePoolLog
     -> GenesisParameters
-    -> (   StakePoolMetadataUrl
+    -> (   PoolId
+        -> StakePoolMetadataUrl
         -> StakePoolMetadataHash
         -> IO (Maybe StakePoolMetadata)
        )
@@ -553,8 +554,8 @@ monitorMetadata
     -> IO ()
 monitorMetadata tr gp fetchMetadata DBLayer{..} = forever $ do
     refs <- atomically (unfetchedPoolMetadataRefs 100)
-    successes <- fmap catMaybes $ forM refs $ \(url, hash) -> do
-        fetchMetadata url hash >>= \case
+    successes <- fmap catMaybes $ forM refs $ \(pid, url, hash) -> do
+        fetchMetadata pid url hash >>= \case
             Nothing -> Nothing <$ do
                 atomically $ putFetchAttempt (url, hash)
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- e91e6e04bf96d9fd3af5b2077097127c87e2a761
  :round_pushpin: **Provide PoolId to the SMASH url builder**
    SMASH just undergone a breaking change in its API, going from:

  ```
  GET api/v1/metadata/{hash}
  ```

  to

  ```
  GET api/v1/metadata/{poolId}/{hash}
  ```



# Comments

<!-- Additional comments or screenshots to attach if any -->

Manually tested on the mainnet candidate and a local instance of SMASH latest master. Providing a wrong URL:

```
[cardano-wallet.pools-engine:Info:135] [2020-08-06 15:03:01.05 UTC] Fetching metadata with hash 67b52f96 from http://localhost:8080/api/v1/7b6dbe3b5c78af9efba3c283d20dfb075c6a6d61d919d2c7d6610576/67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4
[cardano-wallet.pools-engine:Warning:135] [2020-08-06 15:03:01.05 UTC] Failed to fetch metadata with hash 67b52f96: There's no known metadata for this pool.
[cardano-wallet.pools-engine:Info:135] [2020-08-06 15:03:01.05 UTC] Fetching metadata with hash 311522eb from http://localhost:8080/api/v1/5393eb32b547a34f4946927fbda172b6908cc75f592b2f6151ea31dc/311522eb2b41ada16f33dab31b9138546d0e2cc134cfb73a67207f9e5709bf3c
[cardano-wallet.pools-engine:Warning:135] [2020-08-06 15:03:01.05 UTC] Failed to fetch metadata with hash 311522eb: There's no known metadata for this pool.
[cardano-wallet.pools-engine:Info:135] [2020-08-06 15:03:01.05 UTC] Fetching metadata with hash 81405d32 from http://localhost:8080/api/v1/3feb43c4f05ab53ca5426bb66d38a76a1b5d878d8a8d3e14726a01ce/81405d326af6d1b6f06d18bebf1189e66b5e7312a1d4e0e4bbb2fbb160328388
[cardano-wallet.pools-engine:Warning:135] [2020-08-06 15:03:01.05 UTC] Failed to fetch metadata with hash 81405d32: There's no known metadata for this pool.
```

And providing a correct URL:

```
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.90 UTC] Fetching metadata with hash 67b52f96 from http://localhost:3100/api/v1/metadata/7b6dbe3b5c78af9efba3c283d20dfb075c6a6d61d919d2c7d6610576/67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.92 UTC] Successfully fetched metadata with hash 67b52f96: StakePoolMetadata {ticker = StakePoolTicker {unStakePoolTicker = "IOHK1"}, name = "iohk1", description = Just "IOHK 1", homepage = "https://iohk.io"}
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.92 UTC] Fetching metadata with hash 311522eb from http://localhost:3100/api/v1/metadata/5393eb32b547a34f4946927fbda172b6908cc75f592b2f6151ea31dc/311522eb2b41ada16f33dab31b9138546d0e2cc134cfb73a67207f9e5709bf3c
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.93 UTC] Successfully fetched metadata with hash 311522eb: StakePoolMetadata {ticker = StakePoolTicker {unStakePoolTicker = "IOHK2"}, name = "iohk2", description = Just "IOHK 2", homepage = "https://iohk.io"}
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.93 UTC] Fetching metadata with hash 81405d32 from http://localhost:3100/api/v1/metadata/3feb43c4f05ab53ca5426bb66d38a76a1b5d878d8a8d3e14726a01ce/81405d326af6d1b6f06d18bebf1189e66b5e7312a1d4e0e4bbb2fbb160328388
[cardano-wallet.pools-engine:Info:100] [2020-08-06 15:05:02.95 UTC] Successfully fetched metadata with hash 81405d32: StakePoolMetadata {ticker = StakePoolTicker {unStakePoolTicker = "IOHK3"}, name = "iohk3", description = Just "IOHK 3", homepage = "https://iohk.io"}
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
