### PR TITLE
Run coin selection properties with non-zero withdrawal

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -33,8 +33,6 @@ import Data.Functor.Identity
     ( Identity (runIdentity) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Test.Hspec
     ( Spec, describe, it, shouldSatisfy )
 import Test.QuickCheck
@@ -253,29 +251,28 @@ spec = do
 propDeterministic
     :: CoinSelProp
     -> Property
-propDeterministic (CoinSelProp utxo txOuts) = do
+propDeterministic (CoinSelProp utxo wdrl txOuts) = do
     let opts = CoinSelectionOptions (const 100) noValidation
-    let withdraw = Quantity 0
-    let resultOne = runIdentity $ runExceptT $ largestFirst opts txOuts withdraw utxo
-    let resultTwo = runIdentity $ runExceptT $ largestFirst opts txOuts withdraw utxo
+    let resultOne = runIdentity $ runExceptT $ largestFirst opts txOuts wdrl utxo
+    let resultTwo = runIdentity $ runExceptT $ largestFirst opts txOuts wdrl utxo
     resultOne === resultTwo
 
 propAtLeast
     :: CoinSelProp
     -> Property
-propAtLeast (CoinSelProp utxo txOuts) =
+propAtLeast (CoinSelProp utxo wdrl txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
     prop cs =
         L.length (inputs cs) `shouldSatisfy` (>= NE.length txOuts)
     selection = runIdentity $ runExceptT $ do
         let opts = CoinSelectionOptions (const 100) noValidation
-        largestFirst opts txOuts (Quantity 0) utxo
+        largestFirst opts txOuts wdrl utxo
 
 propInputDecreasingOrder
     :: CoinSelProp
     -> Property
-propInputDecreasingOrder (CoinSelProp utxo txOuts) =
+propInputDecreasingOrder (CoinSelProp utxo wdrl txOuts) =
     isRight selection ==> let Right (s,_) = selection in prop s
   where
     prop cs =
@@ -289,4 +286,4 @@ propInputDecreasingOrder (CoinSelProp utxo txOuts) =
     getExtremumValue f = f . map (getCoin . coin . snd)
     selection = runIdentity $ runExceptT $ do
         let opts = CoinSelectionOptions (const 100) noValidation
-        largestFirst opts txOuts (Quantity 0) utxo
+        largestFirst opts txOuts wdrl utxo

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/RandomSpec.hs
@@ -35,8 +35,6 @@ import Data.Functor.Identity
     ( Identity (..) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Test.Hspec
     ( Spec, before, describe, it, shouldSatisfy )
 import Test.QuickCheck
@@ -346,7 +344,7 @@ propFragmentation
     :: SystemDRG
     -> CoinSelProp
     -> Property
-propFragmentation drg (CoinSelProp utxo txOuts) = do
+propFragmentation drg (CoinSelProp utxo wdrl txOuts) = do
     isRight selection1 && isRight selection2 ==>
         let (Right (s1,_), Right (s2,_)) =
                 (selection1, selection2)
@@ -355,16 +353,16 @@ propFragmentation drg (CoinSelProp utxo txOuts) = do
     prop (cs1, cs2) =
         L.length (inputs cs1) `shouldSatisfy` (>= L.length (inputs cs2))
     (selection1,_) = withDRG drg
-        (runExceptT $ random opt txOuts (Quantity 0) utxo)
+        (runExceptT $ random opt txOuts wdrl utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst opt txOuts (Quantity 0) utxo
+        largestFirst opt txOuts wdrl utxo
     opt = CoinSelectionOptions (const 100) noValidation
 
 propErrors
     :: SystemDRG
     -> CoinSelProp
     -> Property
-propErrors drg (CoinSelProp utxo txOuts) = do
+propErrors drg (CoinSelProp utxo wdrl txOuts) = do
     isLeft selection1 && isLeft selection2 ==>
         let (Left s1, Left s2) = (selection1, selection2)
         in prop (s1, s2)
@@ -372,7 +370,7 @@ propErrors drg (CoinSelProp utxo txOuts) = do
     prop (err1, err2) =
         err1 === err2
     (selection1,_) = withDRG drg
-        (runExceptT $ random opt txOuts (Quantity 0) utxo)
+        (runExceptT $ random opt txOuts wdrl utxo)
     selection2 = runIdentity $ runExceptT $
-        largestFirst opt txOuts (Quantity 0) utxo
+        largestFirst opt txOuts wdrl utxo
     opt = (CoinSelectionOptions (const 1) noValidation)


### PR DESCRIPTION
# Issue Number

From looking at  #2006, but surely not related.


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I added a withdrawal field to `CoinSelProp` and used it in coin selection properties

# Comments

- I'm not that familiar with the coin selection, but this seems like a good idea, right?

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
