### PR TITLE
Add pool DB operation `listRetiredPools`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -89,6 +89,7 @@ library
     , statistics
     , stm
     , streaming-commons
+    , string-qq
     , template-haskell
     , text
     , text-class

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -171,6 +171,12 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- map we would get from 'readPoolProduction' because not all registered
         -- pools have necessarily produced any block yet!
 
+    , listRetiredPools
+        :: EpochNo
+        -> stm [PoolRetirementCertificate]
+        -- ^ List all pools with an active retirement epoch that is earlier
+        -- than or equal to the specified epoch.
+
     , putPoolMetadata
         :: StakePoolMetadataHash
         -> StakePoolMetadata

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -25,6 +25,7 @@ import Cardano.Pool.DB.Model
     , emptyPoolDatabase
     , mCleanPoolProduction
     , mListRegisteredPools
+    , mListRetiredPools
     , mPutFetchAttempt
     , mPutPoolMetadata
     , mPutPoolProduction
@@ -114,6 +115,9 @@ newDBLayer timeInterpreter = do
 
         , listRegisteredPools =
             modifyMVar db (pure . swap . mListRegisteredPools)
+
+        , listRetiredPools = \epochNo ->
+            modifyMVar db (pure . swap . mListRetiredPools epochNo)
 
         , putPoolMetadata = \a0 a1 ->
             void $ alterPoolDB (const Nothing) db (mPutPoolMetadata a0 a1)

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -47,6 +47,7 @@ module Cardano.Pool.DB.Model
     , mPutFetchAttempt
     , mPutPoolMetadata
     , mListRegisteredPools
+    , mListRetiredPools
     , mReadSystemSeed
     , mRollbackTo
     , mReadCursor
@@ -259,6 +260,12 @@ mReadPoolRetirement poolId db =
 mListRegisteredPools :: PoolDatabase -> ([PoolId], PoolDatabase)
 mListRegisteredPools db@PoolDatabase{registrations} =
     ( snd <$> Map.keys registrations, db )
+
+mListRetiredPools
+    :: EpochNo
+    -> PoolDatabase
+    -> ([PoolRetirementCertificate], PoolDatabase)
+mListRetiredPools _epochNo db = ([], db)
 
 mUnfetchedPoolMetadataRefs
     :: Int

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -354,6 +354,8 @@ newDBLayer trace fp timeInterpreter = do
                 , Desc PoolRegistrationSlotInternalIndex
                 ]
 
+        , listRetiredPools = \_epochNo -> pure []
+
         , rollbackTo = \point -> do
             -- TODO(ADP-356): What if the conversion blocks or fails?
             --

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -25,6 +26,7 @@ module Cardano.Pool.DB.Sqlite
     ( newDBLayer
     , withDBLayer
     , defaultFilePath
+    , DatabaseView (..)
     ) where
 
 import Prelude
@@ -81,6 +83,10 @@ import Data.Quantity
     ( Percentage (..), Quantity (..) )
 import Data.Ratio
     ( denominator, numerator, (%) )
+import Data.String.QQ
+    ( s )
+import Data.Text
+    ( Text )
 import Data.Time.Clock
     ( UTCTime, addUTCTime, getCurrentTime )
 import Data.Word
@@ -116,6 +122,7 @@ import Cardano.Pool.DB.Sqlite.TH
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
+import qualified Database.Sqlite as Sqlite
 
 -- | Return the preferred @FilePath@ for the stake pool .sqlite file, given a
 -- parent directory.
@@ -166,7 +173,7 @@ newDBLayer
     -> IO (SqliteContext, DBLayer IO)
 newDBLayer trace fp timeInterpreter = do
     let io = startSqliteBackend
-            (ManualMigration mempty)
+            (migrateManually trace)
             migrateAll
             trace
             fp
@@ -445,6 +452,74 @@ newDBLayer trace fp timeInterpreter = do
                 let cert = PoolRetirementCertificate {poolId, retiredIn}
                 let cpt = CertificatePublicationTime {slotNo, slotInternalIndex}
                 pure (cpt, cert)
+
+migrateManually
+    :: Tracer IO DBLog
+    -> ManualMigration
+migrateManually _tr =
+    ManualMigration $ \conn ->
+        createView conn activePoolRetirements
+
+-- | Represents a database view.
+--
+data DatabaseView = DatabaseView
+    { databaseViewName :: Text
+      -- ^ A name for the view.
+    , databaseViewDefinition :: Text
+      -- ^ A select query to generate the view.
+    }
+
+-- | Creates the specified database view, if it does not already exist.
+--
+createView :: Sqlite.Connection -> DatabaseView -> IO ()
+createView conn (DatabaseView name definition) = do
+    query <- Sqlite.prepare conn queryString
+    Sqlite.step query *> Sqlite.finalize query
+  where
+    queryString = T.unlines
+        [ "CREATE VIEW IF NOT EXISTS"
+        , name
+        , "AS"
+        , definition
+        ]
+
+-- | Views the set of pool retirements that are currently active.
+--
+-- This view includes all pools for which there are published retirement
+-- certificates that have not been revoked or superseded.
+--
+-- This view does NOT include:
+--
+--    - pools for which there are no published retirement certificates.
+--
+--    - pools that have had their most-recently-published retirement
+--      certificates revoked by subsequent re-registration certificates.
+--
+activePoolRetirements :: DatabaseView
+activePoolRetirements = DatabaseView "active_pool_retirements" [s|
+    SELECT * FROM (
+        SELECT
+            pool_id,
+            retirement_epoch
+        FROM (
+            SELECT row_number() OVER w AS r, *
+            FROM (
+                SELECT
+                    pool_id, slot, slot_internal_index,
+                    NULL as retirement_epoch
+                    FROM pool_registration
+                UNION
+                SELECT
+                    pool_id, slot, slot_internal_index,
+                    epoch as retirement_epoch
+                    FROM pool_retirement
+            )
+            WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index desc)
+        )
+        GROUP BY pool_id
+    )
+    WHERE retirement_epoch IS NOT NULL;
+|]
 
 -- | 'Temporary', catches migration error from previous versions and if any,
 -- _removes_ the database file completely before retrying to start the database.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -66,6 +66,8 @@ module Cardano.Wallet.Primitive.Types
     , PoolRegistrationCertificate (..)
     , PoolRetirementCertificate (..)
     , PoolCertificate (..)
+    , getPoolCertificatePoolId
+    , setPoolCertificatePoolId
     , getPoolRegistrationCertificate
     , getPoolRetirementCertificate
 
@@ -197,7 +199,7 @@ import Data.ByteArray.Encoding
 import Data.ByteString
     ( ByteString )
 import Data.Generics.Internal.VL.Lens
-    ( (^.) )
+    ( set, view, (^.) )
 import Data.Generics.Labels
     ()
 import Data.Int
@@ -1622,6 +1624,20 @@ data PoolCertificate
     deriving (Generic, Show, Eq, Ord)
 
 instance NFData PoolCertificate
+
+getPoolCertificatePoolId :: PoolCertificate -> PoolId
+getPoolCertificatePoolId = \case
+    Registration cert ->
+        view #poolId cert
+    Retirement cert ->
+        view #poolId cert
+
+setPoolCertificatePoolId :: PoolId -> PoolCertificate -> PoolCertificate
+setPoolCertificatePoolId newPoolId = \case
+    Registration cert -> Registration
+        $ set #poolId newPoolId cert
+    Retirement cert -> Retirement
+        $ set #poolId newPoolId cert
 
 -- | Pool ownership data from the stake pool registration certificate.
 data PoolRegistrationCertificate = PoolRegistrationCertificate

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -174,7 +174,7 @@ properties = do
         it "prop_multiple_putPoolRetirement_single_readPoolRetirement"
             (property .
                 prop_multiple_putPoolRetirement_single_readPoolRetirement)
-        it "readPoolLifeCycleStatus should respect registration order"
+        it "readPoolLifeCycleStatus respects certificate publication order"
             (property . prop_readPoolLifeCycleStatus)
         it "rollback of PoolRegistration"
             (property . prop_rollbackRegistration)

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -1019,3 +1019,13 @@ allPoolProduction DBLayer{..} (StakePoolsFixture pairs _) = atomically $
         [ [ (view #slotNo h, p) | h <- hs ]
         | (p, hs) <- concatMap Map.assocs ms
         ]
+
+-- Interleaves the given list of lists together in a fair way.
+--
+-- Example:
+--
+-- >>> interleave [["a1", "a2", "a3"], ["b1", "b2", "b3"], ["c1", "c2", "c3"]]
+-- ["a1", "b1", "c1", "a2", "b2", "c3", "a3", "b3", "c3"]
+--
+interleave :: [[a]] -> [a]
+interleave = concat . L.transpose

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -645,7 +645,8 @@ prop_readPoolLifeCycleStatus
             , "\nAll certificate publications: "
             , unlines (("\n" <>) . show <$> certificatePublications)
             ]
-        assert (actualStatus == expectedStatus)
+        assertWith "actualStatus == expectedStatus"
+            (actualStatus == expectedStatus)
 
     certificatePublications :: [(CertificatePublicationTime, PoolCertificate)]
     certificatePublications = publicationTimes `zip` certificates

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -583,7 +583,7 @@ prop_multiple_putPoolRetirement_single_readPoolRetirement
             , "\nAll certificate publications: "
             , unlines (("\n" <>) . show <$> certificatePublications)
             ]
-        assert $ (==)
+        assertWith "retrieved certificate matches expectations" $ (==)
             mRetrievedCertificatePublication
             mExpectedCertificatePublication
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -614,11 +614,10 @@ prop_multiple_putPoolRetirement_single_readPoolRetirement
 --
 prop_readPoolLifeCycleStatus
     :: DBLayer IO
-    -> PoolId
-    -> [PoolCertificate]
+    -> SinglePoolCertificateSequence
     -> Property
 prop_readPoolLifeCycleStatus
-    DBLayer {..} sharedPoolId certificatesManyPoolIds =
+    DBLayer {..} (SinglePoolCertificateSequence sharedPoolId certificates) =
         monadicIO (setup >> prop)
   where
     setup = run $ atomically cleanDB
@@ -669,8 +668,6 @@ prop_readPoolLifeCycleStatus
         , ii <- [0 .. 3]
         ]
 
-    certificates = setPoolId sharedPoolId <$> certificatesManyPoolIds
-
     toRegistrationCertificate = \case
         Registration cert -> Just cert
         Retirement _ -> Nothing
@@ -684,12 +681,6 @@ prop_readPoolLifeCycleStatus
             putPoolRegistration cpt cert
         Retirement cert ->
             putPoolRetirement cpt cert
-
-    setPoolId newPoolId = \case
-        Registration cert -> Registration
-            $ set #poolId newPoolId cert
-        Retirement cert -> Retirement
-            $ set #poolId newPoolId cert
 
 prop_rollbackRegistration
     :: DBLayer IO

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -760,9 +760,10 @@ prop_rollbackRetirement DBLayer{..} certificates =
             , "\nRetrieved certificate publications: "
             , unlines (("\n" <>) . show <$> retrievedPublications)
             ]
-        assert $ (==)
-            retrievedPublications
-            expectedPublications
+        assertWith "retrieved publications match expectations" $
+            (==)
+                retrievedPublications
+                expectedPublications
 
     poolIds :: [PoolId]
     poolIds = view #poolId <$> certificates

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -478,7 +478,8 @@ prop_poolRegistration DBLayer {..} entries =
             , "Read from DB: "
             , show entriesOut
             ]
-        assert (entriesIn == entriesOut)
+        assertWith "entriesIn == entriesOut"
+            $ entriesIn == entriesOut
 
 -- | Heavily relies upon the fact that generated values of 'PoolId' are unique.
 prop_poolRetirement
@@ -501,7 +502,8 @@ prop_poolRetirement DBLayer {..} entries =
             , "Read from DB: "
             , show entriesOut
             ]
-        assert (entriesIn == entriesOut)
+        assertWith "entriesIn == entriesOut"
+            $ entriesIn == entriesOut
 
 -- For the same pool, write /multiple/ pool registration certificates to the
 -- database and then read back the current registration certificate, verifying

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -533,7 +533,7 @@ prop_multiple_putPoolRegistration_single_readPoolRegistration
             , "\nAll certificate publications: "
             , unlines (("\n" <>) . show <$> certificatePublications)
             ]
-        assert $ (==)
+        assertWith "retrieved certificate matches expectations" $ (==)
             mRetrievedCertificatePublication
             mExpectedCertificatePublication
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -525,6 +525,8 @@ prop_multiple_putPoolRegistration_single_readPoolRegistration
             mapM_ (uncurry putPoolRegistration) certificatePublications
         mRetrievedCertificatePublication <-
             run $ atomically $ readPoolRegistration sharedPoolId
+        poolsMarkedToRetire <-
+            run $ atomically $ listRetiredPools $ EpochNo maxBound
         monitor $ counterexample $ unlines
             [ "\nExpected certificate publication: "
             , show mExpectedCertificatePublication
@@ -538,6 +540,8 @@ prop_multiple_putPoolRegistration_single_readPoolRegistration
         assertWith "retrieved certificate matches expectations" $ (==)
             mRetrievedCertificatePublication
             mExpectedCertificatePublication
+        assertWith "pool is not marked to retire" $
+            null poolsMarkedToRetire
 
     certificatePublications
         :: [(CertificatePublicationTime, PoolRegistrationCertificate)]

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -85,6 +85,7 @@
           (hsPkgs."statistics" or (errorHandler.buildDepError "statistics"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."streaming-commons" or (errorHandler.buildDepError "streaming-commons"))
+          (hsPkgs."string-qq" or (errorHandler.buildDepError "string-qq"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))


### PR DESCRIPTION
# Issue Number

#2016 

# Overview

This PR:

- [x] Adds a `listRetiredPools` operation to the pool DB layer:<br><br>
    ```hs
    listRetiredPools
        :: EpochNo
        -> stm [PoolId]
        -- ^ List all pools with an active retirement epoch that is
        -- earlier than or equal to the specified epoch.
    ````
- [x] Provides the following implementations of `listRetiredPools`.
    - [x] `Pool.DB.MVar`
    - [x] `Pool.DB.SQLite`.

The SQLite implementation is based on an **SQL view** ([see definition](https://github.com/input-output-hk/cardano-wallet/pull/2024/files#diff-08afa2852f50fa31f5757942d004ce8aR513)) which determines the currently-active set of retirement certificates.

<details><summary>Click to view sample data</summary>

![active_pool_retirements](https://user-images.githubusercontent.com/206319/90096831-13b1a280-dd67-11ea-9612-fd1c4a825fb6.png)

</details>

# Property Testing

This PR also adds property tests to check that:
- [x] `listRetiredPools` **does not** return:
    - [x] pools that have never had retirement certificates associated with them.
    - [x] pools that have had their most-recently-published retirement certificates revoked by subsequent re-registration certificates.
    - [x] pools with effective retirement epochs that are later than the specified epoch.
- [x] `listRetiredPools` returns the correct set of pools in the following contexts:
    - [x] where there are **multiple pools**.
    - [x] where there are **multiple certificates per pool**
        (registrations, retirements, re-registrations, re-retirements).
    - [x] where the publications of certificates affecting different pools are **interleaved together in time**.

# Mutation Testing

To increase confidence that the `activePoolRetirements` view is correctly defined, I have manually performed the following mutations and verified that the `prop_listRetiredPools_multiplePools_multipleCerts` property fails appropriately.

### Mutation 1

```patch
-    WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index desc)
+    WINDOW w AS (ORDER BY pool_id, slot     , slot_internal_index desc)
 )
 GROUP BY pool_id
```

### Mutation 2

```patch
-    WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index desc)
+    WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index     )
 )
 GROUP BY pool_id
```

### Mutation 3

```patch
-    WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index desc)
+    WINDOW w AS (ORDER BY pool_id, slot     , slot_internal_index     )
 )
 GROUP BY pool_id
```

### Mutation 4

```patch
-    WINDOW w AS (ORDER BY pool_id, slot desc, slot_internal_index desc)
+    WINDOW w AS (ORDER BY pool_id, slot desc,                         )
 )
 GROUP BY pool_id
```
