### PR TITLE
Mark addresses as used while discovering them.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -106,6 +106,7 @@ import Cardano.Wallet
     , ErrDecodeSignedTx (..)
     , ErrFetchRewards (..)
     , ErrGetTransaction (..)
+    , ErrImportAddress (..)
     , ErrImportRandomAddress (..)
     , ErrJoinStakePool (..)
     , ErrListTransactions (..)
@@ -2445,7 +2446,7 @@ instance LiftHandler ErrImportRandomAddress where
                 [ "I cannot derive new address for this wallet type."
                 , " Make sure to use Byron random wallet id."
                 ]
-        ErrImportAddrDoesNotBelong ->
+        ErrImportAddr ErrAddrDoesNotBelong{} ->
             apiError err403 KeyNotFoundForAddress $ mconcat
                 [ "I couldn't identify this address as one of mine. It likely "
                 , "belongs to another wallet and I will therefore not import it."

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1177,7 +1177,6 @@ putRandomAddresses ctx (ApiT wid) (ApiPutAddressesData addrs)  = do
 listAddresses
     :: forall ctx s t k n.
         ( ctx ~ ApiLayer s t k
-        , IsOurs s Address
         , CompareDiscovery s
         , KnownAddresses s
         )

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1529,7 +1529,7 @@ insertAddressPool
     -> SqlPersistT IO ()
 insertAddressPool wid sl pool =
     void $ dbChunked insertMany_
-        [ SeqStateAddress wid sl addr state ix (Seq.accountingStyle @c)
+        [ SeqStateAddress wid sl addr ix (Seq.accountingStyle @c) state
         | (ix, (addr, state))
         <- zip [0..] (Seq.addresses (liftPaymentAddress @n) pool)
         ]

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -239,10 +239,11 @@ SeqState
 -- Mapping of pool addresses to indices, and the slot
 -- when they were discovered.
 SeqStateAddress
-    seqStateAddressWalletId         W.WalletId     sql=wallet_id
-    seqStateAddressSlot             SlotNo         sql=slot
-    seqStateAddressAddress          W.Address      sql=address
-    seqStateAddressIndex            Word32         sql=address_ix
+    seqStateAddressWalletId         W.WalletId         sql=wallet_id
+    seqStateAddressSlot             SlotNo             sql=slot
+    seqStateAddressAddress          W.Address          sql=address
+    seqStateAddressStatus           W.AddressState     sql=status
+    seqStateAddressIndex            Word32             sql=address_ix
     seqStateAddressAccountingStyle  W.AccountingStyle  sql=accounting_style
 
     Primary
@@ -282,6 +283,7 @@ RndStateAddress
     rndStateAddressAccountIndex  Word32            sql=account_ix
     rndStateAddressIndex         Word32            sql=address_ix
     rndStateAddressAddress       W.Address         sql=address
+    rndStateAddressStatus        W.AddressState    sql=status
 
     Primary
         rndStateAddressWalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -242,9 +242,9 @@ SeqStateAddress
     seqStateAddressWalletId         W.WalletId         sql=wallet_id
     seqStateAddressSlot             SlotNo             sql=slot
     seqStateAddressAddress          W.Address          sql=address
-    seqStateAddressStatus           W.AddressState     sql=status
     seqStateAddressIndex            Word32             sql=address_ix
     seqStateAddressAccountingStyle  W.AccountingStyle  sql=accounting_style
+    seqStateAddressStatus           W.AddressState     sql=status
 
     Primary
         seqStateAddressWalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -30,6 +30,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), getAddressPoolGap, mkAddressPoolGap )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , AddressState (..)
     , ChimericAccount (..)
     , Coin (..)
     , Direction (..)
@@ -536,7 +537,6 @@ instance PathPiece StakePoolMetadataUrl where
     fromPathPiece = fromTextMaybe
     toPathPiece = toText
 
-
 ----------------------------------------------------------------------------
 -- ChimericAccount
 
@@ -565,3 +565,13 @@ instance FromJSON ChimericAccount where
 instance PathPiece ChimericAccount where
     fromPathPiece = fromTextMaybe
     toPathPiece = toText
+
+----------------------------------------------------------------------------
+-- AddressState
+
+instance PersistField AddressState where
+    toPersistValue = toPersistValue . toText
+    fromPersistValue = fromPersistValueFromText
+
+instance PersistFieldSql AddressState where
+    sqlType _ = sqlType (Proxy @Text)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -34,7 +34,7 @@ import Cardano.Crypto.Wallet
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..) )
+    ( Address (..), AddressState (..) )
 
 -- | Checks whether or not a given entity belongs to us.
 --
@@ -125,4 +125,4 @@ class CompareDiscovery s where
 class KnownAddresses s where
     knownAddresses
         :: s
-        -> [Address]
+        -> [(Address, AddressState)]

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -59,7 +59,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ChimericAccount )
+    ( Address (..), AddressState (..), ChimericAccount )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
@@ -88,7 +88,7 @@ data RndState (network :: NetworkDiscriminant) = RndState
     -- ^ The account index used for address _generation_ in this wallet. Note
     -- that addresses will be _discovered_ from any and all account indices,
     -- regardless of this value.
-    , addresses :: Map DerivationPath Address
+    , addresses :: Map DerivationPath (Address, AddressState)
     -- ^ The addresses which have so far been discovered, and their
     -- derivation paths.
     , pendingAddresses :: Map DerivationPath Address
@@ -113,7 +113,7 @@ instance Buildable (RndState network) where
     build (RndState _ ix addrs pending g) = "RndState:\n"
         <> indentF 4 ("Account ix:       " <> build ix)
         <> indentF 4 ("Random Generator: " <> build (show g))
-        <> indentF 4 ("Known addresses:  " <> blockMapF' tupleF build addrs)
+        <> indentF 4 ("Known addresses:  " <> blockMapF' tupleF tupleF addrs)
         <> indentF 4 ("Change addresses: " <> blockMapF' tupleF build pending)
 
 -- | Shortcut type alias for HD random address derivation path.
@@ -124,7 +124,7 @@ type DerivationPath = (Index 'WholeDomain 'AccountK, Index 'WholeDomain 'Address
 -- to decrypt the address derivation path.
 instance IsOurs (RndState n) Address where
     isOurs addr st =
-        (isJust path, maybe id (addDiscoveredAddress addr) path st)
+        (isJust path, maybe id (addDiscoveredAddress addr Used) path st)
       where
         path = addressToPath addr (hdPassphrase st)
 
@@ -160,10 +160,16 @@ mkRndState key seed = RndState
 -- set of discovered addresses. If the address was in the 'pendingAddresses' set
 -- (i.e. it was a newly generated change address), then it is removed from
 -- there.
-addDiscoveredAddress :: Address -> DerivationPath -> RndState n -> RndState n
-addDiscoveredAddress addr path st =
-    st { addresses = Map.insert path addr (addresses st)
-       , pendingAddresses = Map.delete path (pendingAddresses st) }
+addDiscoveredAddress
+    :: Address
+    -> AddressState
+    -> DerivationPath
+    -> RndState n
+    -> RndState n
+addDiscoveredAddress addr status path st = st
+    { addresses = Map.insert path (addr, status) (addresses st)
+    , pendingAddresses = Map.delete path (pendingAddresses st)
+    }
 
 instance PaymentAddress n ByronKey => GenChange (RndState n) where
     type ArgGenChange (RndState n) = (ByronKey 'RootK XPrv, Passphrase "encryption")
@@ -180,7 +186,8 @@ instance PaymentAddress n ByronKey => GenChange (RndState n) where
 -- | Returns the set of derivation paths that should not be used for new address
 -- generation because they are already in use.
 unavailablePaths :: RndState n -> Set DerivationPath
-unavailablePaths st = Map.keysSet $ addresses st <> pendingAddresses st
+unavailablePaths st =
+    Map.keysSet (addresses st) <> Map.keysSet (pendingAddresses st)
 
 -- | Randomly generates an address derivation path for a given account. If the
 -- path is already in the "blacklist", it will try generating another.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -294,17 +294,16 @@ mkAddressPool
 mkAddressPool key g addrs = AddressPool
     { accountPubKey = key
     , gap = g
-    , indexedKeys =
-        nextAddresses @n
+    , indexedKeys = mconcat
+        [ Map.fromList $ zipWith (\(addr, status) ix -> (addr, (ix, status)))
+            (first (unsafePaymentKeyFingerprint @k) <$> addrs)
+            [minBound..maxBound]
+        , nextAddresses @n
             key
             g
             (accountingStyle @c)
             minBound
-          <>
-            Map.fromList (zipWith (\(addr, status) ix -> (addr, (ix, status)))
-                (first (unsafePaymentKeyFingerprint @k) <$> addrs)
-                [minBound..maxBound]
-            )
+        ]
     }
 
 -- When discovering sequential wallets from a snapshot, we have to use

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1103,6 +1103,11 @@ instance FromText AddressState where
 instance ToText AddressState where
     toText = toTextFromBoundedEnum SnakeLowerCase
 
+instance Buildable AddressState where
+    build = build . toText
+
+instance NFData AddressState
+
 {-------------------------------------------------------------------------------
                                      Coin
 -------------------------------------------------------------------------------}

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -98,6 +98,7 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , ActiveSlotCoefficient (..)
     , Address (..)
+    , AddressState (..)
     , Block (..)
     , BlockHeader (..)
     , Coin (..)
@@ -330,7 +331,7 @@ mkPool
     => Int -> Int -> AddressPool c JormungandrKey
 mkPool numAddrs i = mkAddressPool ourAccount defaultAddressPoolGap addrs
   where
-    addrs = [ force (mkAddress i j) | j <- [1..numAddrs] ]
+    addrs = [ force (mkAddress i j, Unused) | j <- [1..numAddrs] ]
 
 ----------------------------------------------------------------------------
 -- Wallet State (Random Scheme) Benchmarks
@@ -362,7 +363,7 @@ bgroupWriteRndState db = bgroup "RndState"
                 RndState
                     { hdPassphrase = dummyPassphrase
                     , accountIndex = minBound
-                    , addresses = mkRndAddresses a i
+                    , addresses = (,Used) <$> mkRndAddresses a i
                     , pendingAddresses = mkRndAddresses p (-i)
                     , gen = mkStdGen 42
                     }

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -74,6 +74,7 @@ import Cardano.Wallet.Primitive.Slotting
     ( unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
+    , AddressState (..)
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
@@ -637,6 +638,9 @@ instance Arbitrary DelegationCertificate where
 instance Arbitrary Word31 where
     arbitrary = arbitrarySizedBoundedIntegral
     shrink = shrinkIntegral
+
+instance Arbitrary AddressState where
+    arbitrary = genericArbitrary
 
 {-------------------------------------------------------------------------------
                                    Buildable

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -601,7 +601,7 @@ fileModeSpec =  do
                 let mockApplyBlock1 = mockApply (dummyHash "block1")
                             [ Tx (dummyHash "tx1")
                                 [(TxIn (dummyHash "faucet") 0, Coin 4)]
-                                [ TxOut (head ourAddrs) (Coin 4) ]
+                                [ TxOut (fst $ head ourAddrs) (Coin 4) ]
                                 mempty
                             ]
 
@@ -615,7 +615,7 @@ fileModeSpec =  do
                                 (dummyHash "tx2a")
                                 [ (TxIn (dummyHash "tx1") 0, Coin 4) ]
                                 [ TxOut (dummyAddr "faucetAddr2") (Coin 2)
-                                , TxOut (ourAddrs !! 1) (Coin 2)
+                                , TxOut (fst $ ourAddrs !! 1) (Coin 2)
                                 ]
                                 mempty
                             ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -316,14 +316,15 @@ prop_forbiddenAddreses (Rnd st@(RndState _ accIx _ _ _) rk pwd) addrIx = conjoin
     , (Set.member addr (forbidden isOursSt))
     , (Set.notMember changeAddr (forbidden isOursSt))
     , (Set.member changeAddr (forbidden changeSt))
-    , (addr `elem` knownAddresses isOursSt)
-    , (changeAddr `notElem` knownAddresses changeSt)
+    , (addr `elem` (fst <$> knownAddresses isOursSt))
+    , (changeAddr `notElem` (fst <$> knownAddresses changeSt))
     ]
   where
     (_ours, isOursSt) = isOurs addr st
     (changeAddr, changeSt) = genChange (rk, pwd) isOursSt
 
-    forbidden s = Set.fromList $ Map.elems $ addresses s <> pendingAddresses s
+    forbidden s =
+        Set.fromList $ Map.elems $ (fst <$> addresses s) <> pendingAddresses s
 
     addr = paymentAddress @'Mainnet (publicKey addrKeyPrv)
     accKey = deriveAccountPrivateKey pwd rk (liftIndex accIx)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -81,8 +81,8 @@ prop_derivedKeysAreOurs
     -> ByronKey 'RootK XPrv
     -> Property
 prop_derivedKeysAreOurs seed encPwd accIx addrIx rk' =
-    resPos .&&. addr `elem` knownAddresses stPos' .&&.
-    not resNeg .&&. addr `notElem` knownAddresses stNeg'
+    resPos .&&. addr `elem` (fst <$> knownAddresses stPos') .&&.
+    not resNeg .&&. addr `notElem` (fst <$> knownAddresses stNeg')
   where
     (resPos, stPos') = isOurs addr (mkRndState @n rootXPrv 0)
     (resNeg, stNeg') = isOurs addr (mkRndState @n rk' 0)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2032 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- dd3cff59cef4a66bb792adda6491f54b8ea8ca23
  :round_pushpin: **mark addresses as used as they are discovered**
    The main issue of the current list address handler is that it loads in memory and crawls the ENTIRE transaction history of the wallet. This is done merely to know whether addresses have been used or not. This is unnecessary for random addresses because used and unused addresses are already separated in two different Maps. For sequential wallets it's a bit more subtle but, we can mark addresses as "Used" during discovery and store this information in the database.

- 61bbd7b3f0755386a815490868e2e556e13a8e8d
  :round_pushpin: **add two properties for Random & Sequential wallets showing the effect of IsOurs on the address state**
  
- eed460c03a8ce2f5093e59f7d58acf3422653d49
  :round_pushpin: **fix random address import to not mark every imported address as 'Used'**
  

# Comments

<!-- Additional comments or screenshots to attach if any -->

- [ ] **NOTE 1**: This change will require a database migration forcing wallets to re-synchronize from scratch. 

- [x] ~~**NOTE 2**: I haven't yet fixed unit tests which need some adjustment since some of the interfaces have changed.~~

- [ ] **NOTE 3**: I'll try measuring and comparing the behavior with a stress-wallet that owns many addresses.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
