### PR TITLE
Fix stack --nix build

### DIFF
--- a/nix/stack-shell.nix
+++ b/nix/stack-shell.nix
@@ -16,6 +16,7 @@ mkShell rec {
       cardano-node
       cardano-cli
     ]) ++ [
+      nix
       zlib
       gmp
       ncurses
@@ -39,4 +40,5 @@ mkShell rec {
   GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
   LANG = "en_US.UTF-8";
+  STACK_IN_NIX_SHELL = "true";
 }


### PR DESCRIPTION
### Overview

Addresses the following errors from `stack --nix build` which seem to happen with newer versions of `nix`:

1. ` Executable named nix-shell not found on path`

2. `Invalid option '--internal-re-exec-version=2.1.3'`
