### PR TITLE
Add pool DB operation `removePools`

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -372,6 +372,7 @@ data DBLog
     | MsgWaitingForDatabase Text (Maybe Int)
     | MsgRemovingInUse Text Int
     | MsgRemoving Text
+    | MsgRemovingDatabaseEntity Text
     | MsgRemovingDatabaseFile Text DeleteSqliteDatabaseLog
     | MsgManualMigrationNeeded DBField Text
     | MsgManualMigrationNotNeeded DBField
@@ -448,6 +449,7 @@ instance HasSeverityAnnotation DBLog where
         MsgWaitingForDatabase _ _ -> Info
         MsgRemovingInUse _ _ -> Notice
         MsgRemoving _ -> Info
+        MsgRemovingDatabaseEntity _ -> Notice
         MsgRemovingDatabaseFile _ msg -> getSeverityAnnotation msg
         MsgManualMigrationNeeded{} -> Notice
         MsgManualMigrationNotNeeded{} -> Debug
@@ -484,6 +486,8 @@ instance ToText DBLog where
             "Attempting to remove the database anyway."
         MsgRemoving wid ->
             "Removing wallet's database. Wallet id was " <> wid
+        MsgRemovingDatabaseEntity msg ->
+            "Removing the following entity from the database: " <> msg
         MsgRemovingDatabaseFile wid msg ->
             "Removing " <> wid <> ": " <> toText msg
         MsgManualMigrationNeeded field value -> mconcat

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -372,7 +372,6 @@ data DBLog
     | MsgWaitingForDatabase Text (Maybe Int)
     | MsgRemovingInUse Text Int
     | MsgRemoving Text
-    | MsgRemovingDatabaseEntity Text
     | MsgRemovingDatabaseFile Text DeleteSqliteDatabaseLog
     | MsgManualMigrationNeeded DBField Text
     | MsgManualMigrationNotNeeded DBField
@@ -449,7 +448,6 @@ instance HasSeverityAnnotation DBLog where
         MsgWaitingForDatabase _ _ -> Info
         MsgRemovingInUse _ _ -> Notice
         MsgRemoving _ -> Info
-        MsgRemovingDatabaseEntity _ -> Notice
         MsgRemovingDatabaseFile _ msg -> getSeverityAnnotation msg
         MsgManualMigrationNeeded{} -> Notice
         MsgManualMigrationNotNeeded{} -> Debug
@@ -486,8 +484,6 @@ instance ToText DBLog where
             "Attempting to remove the database anyway."
         MsgRemoving wid ->
             "Removing wallet's database. Wallet id was " <> wid
-        MsgRemovingDatabaseEntity msg ->
-            "Removing the following entity from the database: " <> msg
         MsgRemovingDatabaseFile wid msg ->
             "Removing " <> wid <> ": " <> toText msg
         MsgManualMigrationNeeded field value -> mconcat

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -198,6 +198,11 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -> stm ()
         -- ^ Remove all entries of slot ids newer than the argument
 
+    , removePools
+        :: [PoolId]
+        -> stm ()
+        -- ^ Remove all data relating to the specified pools.
+
     , cleanDB
         :: stm ()
         -- ^ Clean a database

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -128,6 +128,8 @@ newDBLayer timeInterpreter = do
         , rollbackTo =
             void . alterPoolDB (const Nothing) db . mRollbackTo timeInterpreter
 
+        , removePools = \_pools -> pure ()
+
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction
 

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -40,6 +40,7 @@ import Cardano.Pool.DB.Model
     , mReadStakeDistribution
     , mReadSystemSeed
     , mReadTotalProduction
+    , mRemovePools
     , mRollbackTo
     , mUnfetchedPoolMetadataRefs
     )
@@ -128,7 +129,8 @@ newDBLayer timeInterpreter = do
         , rollbackTo =
             void . alterPoolDB (const Nothing) db . mRollbackTo timeInterpreter
 
-        , removePools = \_pools -> pure ()
+        , removePools =
+            void . alterPoolDB (const Nothing) db . mRemovePools
 
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -381,6 +381,8 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRetirementSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
+        , removePools = \_pools -> pure ()
+
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
                 []

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -87,6 +87,8 @@ import Data.String.QQ
     ( s )
 import Data.Text
     ( Text )
+import Data.Text.Class
+    ( toText )
 import Data.Time.Clock
     ( UTCTime, addUTCTime, getCurrentTime )
 import Data.Word
@@ -382,6 +384,10 @@ newDBLayer trace fp timeInterpreter = do
             -- TODO: remove dangling metadata no longer attached to a pool
 
         , removePools = mapM_ $ \pool -> do
+            liftIO
+                $ traceWith trace
+                $ MsgRemovingDatabaseEntity
+                $ T.unwords [ "pool", toText pool ]
             deleteWhere [ PoolProductionPoolId ==. pool ]
             deleteWhere [ PoolOwnerPoolId ==. pool ]
             deleteWhere [ PoolRegistrationPoolId ==. pool ]

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -381,7 +381,12 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRetirementSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
-        , removePools = \_pools -> pure ()
+        , removePools = mapM_ $ \pool -> do
+            deleteWhere [ PoolProductionPoolId ==. pool ]
+            deleteWhere [ PoolOwnerPoolId ==. pool ]
+            deleteWhere [ PoolRegistrationPoolId ==. pool ]
+            deleteWhere [ PoolRetirementPoolId ==. pool ]
+            deleteWhere [ StakeDistributionPoolId ==. pool ]
 
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -389,11 +389,7 @@ newDBLayer trace fp timeInterpreter = do
             -- TODO: remove dangling metadata no longer attached to a pool
 
         , removePools = mapM_ $ \pool -> do
-            liftIO
-                $ traceWith trace
-                $ MsgGeneric
-                $ MsgRemovingDatabaseEntity
-                $ T.unwords [ "pool", toText pool ]
+            liftIO $ traceWith trace $ MsgRemovingPool pool
             deleteWhere [ PoolProductionPoolId ==. pool ]
             deleteWhere [ PoolOwnerPoolId ==. pool ]
             deleteWhere [ PoolRegistrationPoolId ==. pool ]

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -75,7 +75,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Tracer
-    ( Tracer (..), traceWith )
+    ( Tracer, contramap, traceWith )
 import Data.Either
     ( rights )
 import Data.Generics.Internal.VL.Lens
@@ -183,7 +183,7 @@ newDBLayer trace fp timeInterpreter = do
     let io = startSqliteBackend
             (migrateManually trace)
             migrateAll
-            (Tracer $ traceWith trace . MsgGeneric)
+            (contramap MsgGeneric trace)
             fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
     return (ctx, DBLayer

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -32,6 +32,8 @@ module Cardano.Pool.DB.Sqlite
 
 import Prelude
 
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.DB.Sqlite
@@ -678,8 +680,9 @@ fromPoolMeta meta = (poolMetadataHash meta,) $
                                    Logging
 -------------------------------------------------------------------------------}
 
-newtype PoolDbLog
+data PoolDbLog
     = MsgGeneric DBLog
+    | MsgRemovingPool PoolId
     deriving (Eq, Show)
 
 instance HasPrivacyAnnotation PoolDbLog
@@ -687,7 +690,13 @@ instance HasPrivacyAnnotation PoolDbLog
 instance HasSeverityAnnotation PoolDbLog where
     getSeverityAnnotation = \case
         MsgGeneric e -> getSeverityAnnotation e
+        MsgRemovingPool {} -> Notice
 
 instance ToText PoolDbLog where
     toText = \case
         MsgGeneric e -> toText e
+        MsgRemovingPool p -> mconcat
+            [ "Removing the following pool from the database: "
+            , toText p
+            , "."
+            ]

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -160,8 +160,9 @@ instance Arbitrary PoolOwner where
 
 instance Arbitrary PoolRegistrationCertificate where
     shrink (PoolRegistrationCertificate p xs m c pl md) =
-        (\xs' -> PoolRegistrationCertificate p xs' m c pl md)
-            <$> shrinkList (const []) xs
+        (\p' xs' -> PoolRegistrationCertificate p' xs' m c pl md)
+            <$> shrink p
+            <*> shrinkList (const []) xs
     arbitrary = PoolRegistrationCertificate
         <$> arbitrary
         <*> scale (`mod` 8) (listOf arbitrary)

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -194,7 +194,7 @@ instance Arbitrary PoolCertificate where
         , Retirement
             <$> arbitrary
         ]
-    shrink = const []
+    shrink = genericShrink
 
 -- | Represents a valid sequence of registration and retirement certificates
 --   for a single pool.

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -148,7 +148,7 @@ instance Arbitrary PoolId where
             , take 16 s <> replicate 8 z <> drop 24 s
             , take 24 s <> replicate 8 z
             ]
-        if result == s then [] else [PoolId $ BS.pack result]
+        [PoolId $ BS.pack result | result /= s]
       where
         z = toEnum 0
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -19,7 +19,7 @@ import Prelude
 import Cardano.BM.Trace
     ( traceInTVarIO )
 import Cardano.DB.Sqlite
-    ( DBLog (..), SqliteContext )
+    ( SqliteContext )
 import Cardano.Pool.DB
     ( DBLayer (..)
     , ErrPointAlreadyExists (..)
@@ -35,7 +35,7 @@ import Cardano.Pool.DB.Arbitrary
     , serializeLists
     )
 import Cardano.Pool.DB.Sqlite
-    ( newDBLayer )
+    ( PoolDbLog, newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter )
 import Cardano.Wallet.Primitive.Slotting
@@ -138,7 +138,7 @@ withDB create = beforeAll create . beforeWith
 newMemoryDBLayer :: IO (DBLayer IO)
 newMemoryDBLayer = snd . snd <$> newMemoryDBLayer'
 
-newMemoryDBLayer' :: IO (TVar [DBLog], (SqliteContext, DBLayer IO))
+newMemoryDBLayer' :: IO (TVar [PoolDbLog], (SqliteContext, DBLayer IO))
 newMemoryDBLayer' = do
     logVar <- newTVarIO []
     (logVar, ) <$> newDBLayer (traceInTVarIO logVar) Nothing ti

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -18,7 +18,7 @@ import Cardano.DB.Sqlite
 import Cardano.Pool.DB.Properties
     ( newMemoryDBLayer, properties, withDB )
 import Cardano.Pool.DB.Sqlite
-    ( withDBLayer )
+    ( PoolDbLog (..), withDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter )
 import System.Directory
@@ -56,7 +56,7 @@ test_migrationFromv20191216 =
                 withDBLayer tr (Just path) ti $ \_ -> pure ()
 
             let databaseConnMsg  = filter isMsgConnStr logs
-            let databaseResetMsg = filter (== MsgDatabaseReset) logs
+            let databaseResetMsg = filter (== MsgGeneric MsgDatabaseReset) logs
             let migrationErrMsg  = filter isMsgMigrationError logs
 
             length databaseConnMsg  `shouldBe` 3
@@ -64,10 +64,10 @@ test_migrationFromv20191216 =
             length migrationErrMsg  `shouldBe` 1
 
 
-isMsgConnStr :: DBLog -> Bool
-isMsgConnStr (MsgConnStr _) = True
+isMsgConnStr :: PoolDbLog -> Bool
+isMsgConnStr (MsgGeneric (MsgConnStr _)) = True
 isMsgConnStr _ = False
 
-isMsgMigrationError :: DBLog -> Bool
-isMsgMigrationError (MsgMigrations (Left _)) = True
+isMsgMigrationError :: PoolDbLog -> Bool
+isMsgMigrationError (MsgGeneric (MsgMigrations (Left _))) = True
 isMsgMigrationError _ = False

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -65,6 +65,7 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , Hash (..)
     , HistogramBar (..)
+    , PoolId (..)
     , PoolOwner (..)
     , Range (..)
     , RangeBound (..)
@@ -218,6 +219,7 @@ spec = do
         textRoundtrip $ Proxy @(Hash "Block")
         textRoundtrip $ Proxy @(Hash "BlockHeader")
         textRoundtrip $ Proxy @SyncTolerance
+        textRoundtrip $ Proxy @PoolId
         textRoundtrip $ Proxy @PoolOwner
 
         -- Extra hand-crafted tests
@@ -1356,6 +1358,9 @@ instance {-# OVERLAPS #-} Arbitrary (EpochLength, SlotId) where
 instance Arbitrary Word31 where
     arbitrary = arbitrarySizedBoundedIntegral
     shrink = shrinkIntegral
+
+instance Arbitrary PoolId where
+    arbitrary = PoolId . BS.pack <$> vector 32
 
 instance Arbitrary PoolOwner where
     arbitrary = PoolOwner . BS.pack <$> vector 32

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -61,6 +61,8 @@ import Cardano.DB.Sqlite
     ( DBLog )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
+import Cardano.Pool.DB.Sqlite
+    ( PoolDbLog )
 import Cardano.Pool.Jormungandr.Metadata
     ( ApiStakePool )
 import Cardano.Pool.Jormungandr.Metrics
@@ -473,7 +475,7 @@ data Tracers' f = Tracers
     , walletEngineTracer    :: f (WorkerLog WalletId WalletLog)
     , walletDbTracer        :: f DBLog
     , stakePoolEngineTracer :: f (WorkerLog Text StakePoolLog)
-    , stakePoolDbTracer     :: f DBLog
+    , stakePoolDbTracer     :: f PoolDbLog
     , networkTracer         :: f NetworkLayerLog
     , ntpClientTracer       :: f NtpTrace
     }

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -55,6 +55,8 @@ import Cardano.BM.Trace
     ( Trace, appendName )
 import Cardano.DB.Sqlite
     ( DBLog )
+import Cardano.Pool.DB.Sqlite
+    ( PoolDbLog )
 import Cardano.Pool.Metadata
     ( defaultManagerSettings
     , fetchFromRemote
@@ -464,7 +466,7 @@ data Tracers' f = Tracers
     , walletEngineTracer :: f (WorkerLog WalletId WalletLog)
     , walletDbTracer     :: f DBLog
     , poolsEngineTracer  :: f (WorkerLog Text StakePoolLog)
-    , poolsDbTracer      :: f DBLog
+    , poolsDbTracer      :: f PoolDbLog
     , ntpClientTracer    :: f NtpTrace
     , networkTracer      :: f (NetworkLayerLog TPraosStandardCrypto)
     }


### PR DESCRIPTION
# Issue Number

#2017 

# Overview

This PR:

- [x] Adds a `removePools` operation to the pool DB layer:<br><br>
    ```hs
    removePools
        :: [PoolId]
        -> stm ()
        -- ^ Remove all data relating to the specified pools.
    ```
- [x] Provides the following implementations of `removePools`:
    - [x] `Pool.DB.MVar`
    - [x] `Pool.DB.SQLite`<br><br>
- [x] Writes a `MsgRemovingPool` message to the log whenever a pool is removed:<br><br>
    ```hs
    Removing the following pool from the database: XXXX.
    ```
- [x] Adds a property test to check that only the specified pools are removed, and no other pools.