### PR TITLE
 Add pool DB operation `removeRetiredPools`. 

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -114,6 +114,7 @@ library
       Cardano.DB.Sqlite
       Cardano.DB.Sqlite.Delete
       Cardano.Pool.DB
+      Cardano.Pool.DB.Log
       Cardano.Pool.DB.MVar
       Cardano.Pool.DB.Model
       Cardano.Pool.DB.Sqlite

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -367,7 +367,8 @@ data DBLog
     | MsgClosing (Maybe FilePath)
     | MsgWillOpenDB (Maybe FilePath)
     | MsgDatabaseReset
-    | MsgGarbageCollection Text
+    | MsgGarbageCollection Text BracketLog
+    | MsgGarbageCollectionStep Text
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
     | MsgWaitingForDatabase Text (Maybe Int)
@@ -380,7 +381,6 @@ data DBLog
     | MsgFoundDatabase FilePath Text
     | MsgUnknownDBFile FilePath
     deriving (Generic, Show, Eq, ToJSON)
-
 
 {-------------------------------------------------------------------------------
                                     Logging
@@ -444,7 +444,8 @@ instance HasSeverityAnnotation DBLog where
         MsgClosing _ -> Debug
         MsgWillOpenDB _ -> Info
         MsgDatabaseReset -> Notice
-        MsgGarbageCollection _ -> Notice
+        MsgGarbageCollection _ _ -> Notice
+        MsgGarbageCollectionStep _ -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
         MsgWaitingForDatabase _ _ -> Info
@@ -473,8 +474,14 @@ instance ToText DBLog where
         MsgDatabaseReset ->
             "Non backward compatible database found. Removing old database \
             \and re-creating it from scratch. Ignore the previous error."
-        MsgGarbageCollection msg ->
-            "Database garbage collection: " <> msg
+        MsgGarbageCollection msg bkt -> mconcat
+            [ "Garbage collection: "
+            , msg
+            , ": "
+            , toText bkt
+            ]
+        MsgGarbageCollectionStep msg ->
+            "Garbage collection step: " <> msg
         MsgIsAlreadyClosed msg ->
             "Attempted to close an already closed connection: " <> msg
         MsgStatementAlreadyFinalized msg ->

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -367,8 +367,6 @@ data DBLog
     | MsgClosing (Maybe FilePath)
     | MsgWillOpenDB (Maybe FilePath)
     | MsgDatabaseReset
-    | MsgGarbageCollection Text BracketLog
-    | MsgGarbageCollectionStep Text
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
     | MsgWaitingForDatabase Text (Maybe Int)
@@ -444,8 +442,6 @@ instance HasSeverityAnnotation DBLog where
         MsgClosing _ -> Debug
         MsgWillOpenDB _ -> Info
         MsgDatabaseReset -> Notice
-        MsgGarbageCollection _ _ -> Notice
-        MsgGarbageCollectionStep _ -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
         MsgWaitingForDatabase _ _ -> Info
@@ -474,14 +470,6 @@ instance ToText DBLog where
         MsgDatabaseReset ->
             "Non backward compatible database found. Removing old database \
             \and re-creating it from scratch. Ignore the previous error."
-        MsgGarbageCollection msg bkt -> mconcat
-            [ "Garbage collection: "
-            , msg
-            , ": "
-            , toText bkt
-            ]
-        MsgGarbageCollectionStep msg ->
-            "Garbage collection step: " <> msg
         MsgIsAlreadyClosed msg ->
             "Attempted to close an already closed connection: " <> msg
         MsgStatementAlreadyFinalized msg ->

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -367,6 +367,7 @@ data DBLog
     | MsgClosing (Maybe FilePath)
     | MsgWillOpenDB (Maybe FilePath)
     | MsgDatabaseReset
+    | MsgGarbageCollection Text
     | MsgIsAlreadyClosed Text
     | MsgStatementAlreadyFinalized Text
     | MsgWaitingForDatabase Text (Maybe Int)
@@ -443,6 +444,7 @@ instance HasSeverityAnnotation DBLog where
         MsgClosing _ -> Debug
         MsgWillOpenDB _ -> Info
         MsgDatabaseReset -> Notice
+        MsgGarbageCollection _ -> Notice
         MsgIsAlreadyClosed _ -> Warning
         MsgStatementAlreadyFinalized _ -> Warning
         MsgWaitingForDatabase _ _ -> Info
@@ -471,6 +473,8 @@ instance ToText DBLog where
         MsgDatabaseReset ->
             "Non backward compatible database found. Removing old database \
             \and re-creating it from scratch. Ignore the previous error."
+        MsgGarbageCollection msg ->
+            "Database garbage collection: " <> msg
         MsgIsAlreadyClosed msg ->
             "Attempted to close an already closed connection: " <> msg
         MsgStatementAlreadyFinalized msg ->

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -203,6 +203,19 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -> stm ()
         -- ^ Remove all data relating to the specified pools.
 
+    , removeRetiredPools
+        :: EpochNo
+        -> stm [PoolRetirementCertificate]
+        -- ^ Remove all pools with an active retirement epoch that is earlier
+        -- than or equal to the specified epoch.
+        --
+        -- Returns the retirement certificates of the pools that were removed.
+        --
+        -- See also:
+        --
+        --    - 'listRetiredPools'.
+        --    - 'removePools'.
+
     , cleanDB
         :: stm ()
         -- ^ Clean a database

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -309,7 +309,7 @@ removeRetiredPools
     -> IO [PoolRetirementCertificate]
 removeRetiredPools DBLayer {atomically, listRetiredPools, removePools}
     trace epoch = do
-        let report = liftIO . traceWith trace . MsgGarbageCollection
+        let report = liftIO . traceWith trace . MsgGarbageCollectionStep
         report $ T.concat
             [ "Looking for pools that retired in or before epoch "
             , toText epoch

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -26,8 +26,6 @@ module Cardano.Pool.DB
 
 import Prelude
 
-import Cardano.DB.Sqlite
-    ( DBLog (..) )
 import Cardano.Pool.DB.Log
     ( PoolDbLog (..) )
 import Cardano.Wallet.Logging
@@ -59,14 +57,10 @@ import Data.Map.Strict
     ( Map )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Text.Class
-    ( toText )
 import Data.Word
     ( Word64 )
 import System.Random
     ( StdGen )
-
-import qualified Data.Text as T
 
 -- | A Database interface for storing pool production in DB.
 --
@@ -312,13 +306,9 @@ removeRetiredPools
     -> IO [PoolRetirementCertificate]
 removeRetiredPools
     DBLayer {atomically, listRetiredPools, removePools} trace epoch =
-        bracketTracer (contramap actionDescription trace) action
+        bracketTracer (contramap actionMessage trace) action
   where
-    actionDescription = MsgGeneric . (MsgGarbageCollection $ T.concat
-        [ "Removing pools that retired in or before epoch "
-        , toText epoch
-        , "."
-        ])
+    actionMessage = MsgRemovingRetiredPoolsForEpoch epoch
 
     action = atomically (listRetiredPools epoch) >>=
         \retirementCerts -> do

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.Types
 import Control.Monad.Fail
     ( MonadFail )
 import Control.Monad.IO.Class
-    ( MonadIO )
+    ( MonadIO, liftIO )
 import Control.Monad.Trans.Except
     ( ExceptT )
 import Control.Tracer
@@ -309,10 +309,10 @@ removeRetiredPools
   where
     actionMessage = MsgRemovingRetiredPoolsForEpoch epoch
 
-    action = atomically (listRetiredPools epoch) >>=
-        \retirementCerts -> do
-            traceWith trace $ MsgRemovingRetiredPools retirementCerts
-            atomically $ removePools (view #poolId <$> retirementCerts)
+    action = atomically $
+        listRetiredPools epoch >>= \retirementCerts -> do
+            liftIO $ traceWith trace $ MsgRemovingRetiredPools retirementCerts
+            removePools (view #poolId <$> retirementCerts)
             pure retirementCerts
 
 -- | Forbidden operation was executed on an already existing slot

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -63,8 +63,6 @@ import Data.Text.Class
     ( toText )
 import Data.Word
     ( Word64 )
-import Fmt
-    ( pretty )
 import System.Random
     ( StdGen )
 
@@ -322,16 +320,9 @@ removeRetiredPools
         , "."
         ])
 
-    action = atomically (listRetiredPools epoch) >>= \case
-        [] -> do
-            traceWith trace $ MsgGeneric $
-                MsgGarbageCollectionStep "Found no retired pools."
-            pure []
-        retirementCerts -> do
-            traceWith trace $ MsgGeneric $ MsgGarbageCollectionStep $ T.unlines
-                [ "Removing the following retired pools:"
-                , T.unlines (pretty <$> retirementCerts)
-                ]
+    action = atomically (listRetiredPools epoch) >>=
+        \retirementCerts -> do
+            traceWith trace $ MsgRemovingRetiredPools retirementCerts
             atomically $ removePools (view #poolId <$> retirementCerts)
             pure retirementCerts
 

--- a/lib/core/src/Cardano/Pool/DB/Log.hs
+++ b/lib/core/src/Cardano/Pool/DB/Log.hs
@@ -42,8 +42,8 @@ instance HasSeverityAnnotation PoolDbLog where
     getSeverityAnnotation = \case
         MsgGeneric e -> getSeverityAnnotation e
         MsgRemovingPool {} -> Notice
-        MsgRemovingRetiredPools {} -> Notice
-        MsgRemovingRetiredPoolsForEpoch {} -> Notice
+        MsgRemovingRetiredPools {} -> Debug
+        MsgRemovingRetiredPoolsForEpoch {} -> Debug
 
 instance ToText PoolDbLog where
     toText = \case

--- a/lib/core/src/Cardano/Pool/DB/Log.hs
+++ b/lib/core/src/Cardano/Pool/DB/Log.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Logging types specific to the pool database.
+--
+module Cardano.Pool.DB.Log
+    ( PoolDbLog (..)
+    ) where
+
+import Prelude
+
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.BM.Data.Tracer
+    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
+import Cardano.DB.Sqlite
+    ( DBLog (..) )
+import Cardano.Wallet.Primitive.Types
+    ( PoolId )
+import Data.Text.Class
+    ( ToText (..), toText )
+import Fmt
+    ( pretty )
+
+import qualified Data.Text as T
+
+data PoolDbLog
+    = MsgGeneric DBLog
+    | MsgRemovingPool PoolId
+    | MsgRemovingRetiredPools [PoolId]
+    deriving (Eq, Show)
+
+instance HasPrivacyAnnotation PoolDbLog
+
+instance HasSeverityAnnotation PoolDbLog where
+    getSeverityAnnotation = \case
+        MsgGeneric e -> getSeverityAnnotation e
+        MsgRemovingPool {} -> Notice
+        MsgRemovingRetiredPools {} -> Notice
+
+instance ToText PoolDbLog where
+    toText = \case
+        MsgGeneric e -> toText e
+        MsgRemovingPool p -> mconcat
+            [ "Removing the following pool from the database: "
+            , toText p
+            , "."
+            ]
+        MsgRemovingRetiredPools [] ->
+            "There are no retired pools to remove."
+        MsgRemovingRetiredPools poolRetirementCerts -> T.unlines
+            [ "Removing the following retired pools:"
+            , T.unlines (pretty <$> poolRetirementCerts)
+            ]

--- a/lib/core/src/Cardano/Pool/DB/Log.hs
+++ b/lib/core/src/Cardano/Pool/DB/Log.hs
@@ -19,7 +19,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.DB.Sqlite
     ( DBLog (..) )
 import Cardano.Wallet.Primitive.Types
-    ( PoolId )
+    ( PoolId, PoolRetirementCertificate )
 import Data.Text.Class
     ( ToText (..), toText )
 import Fmt
@@ -30,7 +30,7 @@ import qualified Data.Text as T
 data PoolDbLog
     = MsgGeneric DBLog
     | MsgRemovingPool PoolId
-    | MsgRemovingRetiredPools [PoolId]
+    | MsgRemovingRetiredPools [PoolRetirementCertificate]
     deriving (Eq, Show)
 
 instance HasPrivacyAnnotation PoolDbLog

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -59,8 +58,6 @@ import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Data.Functor.Identity
     ( Identity )
-import Data.Generics.Internal.VL.Lens
-    ( view )
 import Data.Tuple
     ( swap )
 
@@ -134,11 +131,6 @@ newDBLayer timeInterpreter = do
 
         , removePools =
             void . alterPoolDB (const Nothing) db . mRemovePools
-
-        , removeRetiredPools = \epoch -> do
-            retirementCerts <- listRetiredPools_ epoch
-            removePools_ (view #poolId <$> retirementCerts)
-            pure retirementCerts
 
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -58,6 +59,8 @@ import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Data.Functor.Identity
     ( Identity )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Data.Tuple
     ( swap )
 
@@ -131,6 +134,11 @@ newDBLayer timeInterpreter = do
 
         , removePools =
             void . alterPoolDB (const Nothing) db . mRemovePools
+
+        , removeRetiredPools = \epoch -> do
+            retirementCerts <- listRetiredPools_ epoch
+            removePools_ (view #poolId <$> retirementCerts)
+            pure retirementCerts
 
         , cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -249,7 +249,7 @@ mPutPoolRetirement cpt cert db =
     )
   where
     PoolDatabase {retirements} = db
-    PoolRetirementCertificate poolId _retiredIn = cert
+    PoolRetirementCertificate poolId _retirementEpoch = cert
 
 mReadPoolRetirement
     :: PoolId
@@ -282,7 +282,7 @@ mListRetiredPools epochNo db = (retiredPools, db)
 
     retiredPools :: [PoolRetirementCertificate]
     retiredPools = activeRetirementCertificates
-        & filter ((<= epochNo) . view #retiredIn)
+        & filter ((<= epochNo) . view #retirementEpoch)
 
     activeRetirementCertificates :: [PoolRetirementCertificate]
     activeRetirementCertificates =

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -119,8 +119,6 @@ import Database.Persist.Sql
     )
 import Database.Persist.Sqlite
     ( SqlPersistT )
-import Fmt
-    ( pretty )
 import System.Directory
     ( removeFile )
 import System.FilePath
@@ -393,26 +391,6 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRegistrationPoolId ==. pool ]
             deleteWhere [ PoolRetirementPoolId ==. pool ]
             deleteWhere [ StakeDistributionPoolId ==. pool ]
-
-        , removeRetiredPools = \epoch -> do
-            let report = liftIO . traceWith trace . MsgGarbageCollection
-            report $ T.concat
-                [ "Looking for pools that retired in or before epoch "
-                , toText epoch
-                , "."
-                ]
-            listRetiredPools_ epoch >>= \case
-                [] -> do
-                    report "Found no retired pools."
-                    pure []
-                retirementCerts -> do
-                    report $ T.unlines
-                        [ "Removing the following retired pools:"
-                        , T.unlines (pretty <$> retirementCerts)
-                        ]
-                    removePools_ (view #poolId <$> retirementCerts)
-                    report "Finished removing retired pools."
-                    pure retirementCerts
 
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -119,6 +119,8 @@ import Database.Persist.Sql
     )
 import Database.Persist.Sqlite
     ( SqlPersistT )
+import Fmt
+    ( pretty )
 import System.Directory
     ( removeFile )
 import System.FilePath
@@ -393,9 +395,24 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ StakeDistributionPoolId ==. pool ]
 
         , removeRetiredPools = \epoch -> do
-            retirementCerts <- listRetiredPools_ epoch
-            removePools_ (view #poolId <$> retirementCerts)
-            pure retirementCerts
+            let report = liftIO . traceWith trace . MsgGarbageCollection
+            report $ T.concat
+                [ "Looking for pools that retired in or before epoch "
+                , toText epoch
+                , "."
+                ]
+            listRetiredPools_ epoch >>= \case
+                [] -> do
+                    report "Found no retired pools."
+                    pure []
+                retirementCerts -> do
+                    report $ T.unlines
+                        [ "Removing the following retired pools:"
+                        , T.unlines (pretty <$> retirementCerts)
+                        ]
+                    removePools_ (view #poolId <$> retirementCerts)
+                    report "Finished removing retired pools."
+                    pure retirementCerts
 
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -261,10 +261,7 @@ newDBLayer trace fp timeInterpreter = do
         , putPoolRetirement = \cpt cert -> do
             let CertificatePublicationTime {slotNo, slotInternalIndex} = cpt
             let PoolRetirementCertificate
-                    { poolId
-                    , retiredIn
-                    } = cert
-            let EpochNo retirementEpoch = retiredIn
+                    poolId (EpochNo retirementEpoch) = cert
             repsert (PoolRetirementKey poolId slotNo slotInternalIndex) $
                 PoolRetirement
                     poolId
@@ -476,9 +473,9 @@ newDBLayer trace fp timeInterpreter = do
                         _poolId
                         slotNo
                         slotInternalIndex
-                        retirementEpoch = entityVal meta
-                let retiredIn = EpochNo (fromIntegral retirementEpoch)
-                let cert = PoolRetirementCertificate {poolId, retiredIn}
+                        retirementEpochNo = entityVal meta
+                let retirementEpoch = EpochNo (fromIntegral retirementEpochNo)
+                let cert = PoolRetirementCertificate {poolId, retirementEpoch}
                 let cpt = CertificatePublicationTime {slotNo, slotInternalIndex}
                 pure (cpt, cert)
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -392,6 +392,11 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRetirementPoolId ==. pool ]
             deleteWhere [ StakeDistributionPoolId ==. pool ]
 
+        , removeRetiredPools = \epoch -> do
+            retirementCerts <- listRetiredPools_ epoch
+            removePools_ (view #poolId <$> retirementCerts)
+            pure retirementCerts
+
         , readPoolProductionCursor = \k -> do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
                 []

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -119,6 +119,8 @@ import Database.Persist.Sql
     )
 import Database.Persist.Sqlite
     ( SqlPersistT )
+import Fmt
+    ( pretty )
 import System.Directory
     ( removeFile )
 import System.FilePath
@@ -675,6 +677,7 @@ fromPoolMeta meta = (poolMetadataHash meta,) $
 data PoolDbLog
     = MsgGeneric DBLog
     | MsgRemovingPool PoolId
+    | MsgRemovingRetiredPools [PoolId]
     deriving (Eq, Show)
 
 instance HasPrivacyAnnotation PoolDbLog
@@ -683,6 +686,7 @@ instance HasSeverityAnnotation PoolDbLog where
     getSeverityAnnotation = \case
         MsgGeneric e -> getSeverityAnnotation e
         MsgRemovingPool {} -> Notice
+        MsgRemovingRetiredPools {} -> Notice
 
 instance ToText PoolDbLog where
     toText = \case
@@ -691,4 +695,10 @@ instance ToText PoolDbLog where
             [ "Removing the following pool from the database: "
             , toText p
             , "."
+            ]
+        MsgRemovingRetiredPools [] ->
+            "There are no retired pools to remove."
+        MsgRemovingRetiredPools poolRetirementCerts -> T.unlines
+            [ "Removing the following retired pools:"
+            , T.unlines (pretty <$> poolRetirementCerts)
             ]

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1896,7 +1896,7 @@ joinStakePool ctx currentEpoch knownPools pid poolStatus wid argGenChange pwd =
             $ (,) <$> isStakeKeyRegistered (PrimaryKey wid)
                   <*> withNoSuchWallet wid (readWalletMeta (PrimaryKey wid))
 
-        let mRetirementEpoch = view #retiredIn <$>
+        let mRetirementEpoch = view #retirementEpoch <$>
                 W.getPoolRetirementCertificate poolStatus
         let retirementInfo =
                 PoolRetirementEpochInfo currentEpoch <$> mRetirementEpoch

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1676,7 +1676,7 @@ instance Buildable PoolRetirementCertificate where
     build (PoolRetirementCertificate p e) = mempty
         <> "Pool "
         <> build p
-        <> " retiring at "
+        <> " with retirement epoch "
         <> build e
 
 -- | Represents an abstract notion of a certificate publication time.

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1667,7 +1667,7 @@ data PoolRetirementCertificate = PoolRetirementCertificate
     { poolId :: !PoolId
 
     -- | The first epoch when the pool becomes inactive.
-    , retiredIn :: !EpochNo
+    , retirementEpoch :: !EpochNo
     } deriving (Generic, Show, Eq, Ord)
 
 instance NFData PoolRetirementCertificate

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -1008,10 +1008,10 @@ prop_listRetiredPools_multiplePools_multipleCerts
         let epochsToTest =
                 EpochNo minBound :
                 EpochNo maxBound :
-                L.nub (view #retiredIn <$> poolsMarkedToRetire)
+                L.nub (view #retirementEpoch <$> poolsMarkedToRetire)
         forM_ epochsToTest $ \currentEpoch -> do
             let retiredPoolsExpected = filter
-                    ((<= currentEpoch) . view #retiredIn)
+                    ((<= currentEpoch) . view #retirementEpoch)
                     (poolsMarkedToRetire)
             retiredPoolsActual <-
                 run $ atomically $ listRetiredPools currentEpoch

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -34,8 +34,10 @@ import Cardano.Pool.DB.Arbitrary
     , isValidSinglePoolCertificateSequence
     , serializeLists
     )
+import Cardano.Pool.DB.Log
+    ( PoolDbLog )
 import Cardano.Pool.DB.Sqlite
-    ( PoolDbLog, newDBLayer )
+    ( newDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter )
 import Cardano.Wallet.Primitive.Slotting

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -15,10 +15,12 @@ import Prelude
 
 import Cardano.DB.Sqlite
     ( DBLog (..) )
+import Cardano.Pool.DB.Log
+    ( PoolDbLog (..) )
 import Cardano.Pool.DB.Properties
     ( newMemoryDBLayer, properties, withDB )
 import Cardano.Pool.DB.Sqlite
-    ( PoolDbLog (..), withDBLayer )
+    ( withDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter )
 import System.Directory

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr.hs
@@ -61,7 +61,7 @@ import Cardano.DB.Sqlite
     ( DBLog )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
-import Cardano.Pool.DB.Sqlite
+import Cardano.Pool.DB.Log
     ( PoolDbLog )
 import Cardano.Pool.Jormungandr.Metadata
     ( ApiStakePool )

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -55,7 +55,7 @@ import Cardano.BM.Trace
     ( Trace, appendName )
 import Cardano.DB.Sqlite
     ( DBLog )
-import Cardano.Pool.DB.Sqlite
+import Cardano.Pool.DB.Log
     ( PoolDbLog )
 import Cardano.Pool.Metadata
     ( defaultManagerSettings

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -325,8 +325,8 @@ combineDbAndLsqData ti nOpt lsqData =
         -> PoolDbData
         -> m Api.ApiStakePool
     mkApiPool pid (PoolLsqData prew pstk psat) dbData = do
-        let mRetiredIn = retiredIn <$> retirementCert dbData
-        retirementEpochInfo <- traverse toApiEpochInfo mRetiredIn
+        let mRetirementEpoch = retirementEpoch <$> retirementCert dbData
+        retirementEpochInfo <- traverse toApiEpochInfo mRetirementEpoch
         pure $ Api.ApiStakePool
             { Api.id = (ApiT pid)
             , Api.metrics = Api.ApiStakePoolMetrics


### PR DESCRIPTION
# Issue Number

#2018 

# Overview

Building on the work added in PRs #2024 and #2038, this PR:

- [x] Adds a `removeRetiredPools` operation to the pool DB layer:<br><br>
    ```hs
    removeRetiredPools  
        :: EpochNo
        -> stm [PoolRetirementCertificate]
        -- ^ Remove all pools with an active retirement epoch that is earlier 
        -- than or equal to the specified epoch.  
        --
        -- Returns the retirement certificates of the pools that were removed.
    ```
- [x] Writes a bracketed `MsgRemovingRetiredPools` message to the log whenever the `removeRetiredPools` operation is called:<br><br>
    ```
    Looking for pools that retired in or before epoch 1000.
    Removing the following retired pools:
        Pool 4355a46b with retirement epoch 999
        Pool 53c234e5 with retirement epoch 999
        Pool 121cfccd with retirement epoch 1000
        Pool 917df332 with retirement epoch 1000
    Finished removing retired pools.
    ```

# Further Work

Before garbage collection can actually happen, the wallet needs to call `removeRetiredPools` at appropriate intervals. This work is deferred to a future PR.

See issue #2019.