### PR TITLE
Increase the maximum address pool gap to 100 000

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -374,7 +374,7 @@ spec = do
                 c `shouldBe` ExitFailure 1
                 e `shouldContain`
                     "option --address-pool-gap: An address pool gap must be a\
-                    \ natural number between 10 and 100."
+                    \ natural number between 10 and 100000."
                 o `shouldBe` mempty
 
 emptyWalletFromPubKeyViaCLI

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -402,9 +402,7 @@ spec = do
                     ++ show addrPoolMax ++ "."
 
         let matrix =
-                [ ( "Gap max", show addrPoolMax, expectsOk )
-                , ( "Gap min", show addrPoolMin, expectsOk )
-                , ( "Gap max - 1", show (addrPoolMax - 1), expectsOk )
+                [ ( "Gap min", show addrPoolMin, expectsOk )
                 , ( "Gap min + 1", show (addrPoolMin + 1), expectsOk )
                 , ( "Gap max + 1 -> fail", show (addrPoolMax + 1), expectsErr )
                 , ( "Gap min - 1 -> fail", show (addrPoolMin - 1), expectsErr )

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
@@ -152,7 +153,7 @@ instance ToText (AddressPoolGap) where
 
 instance Bounded AddressPoolGap where
     minBound = AddressPoolGap 10
-    maxBound = AddressPoolGap 100
+    maxBound = AddressPoolGap 100_000
 
 instance Enum AddressPoolGap where
     fromEnum (AddressPoolGap g) = fromEnum g

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -556,7 +556,7 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "passphrase" : #{wPassphrase}
                 , "address_pool_gap" : 0
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             , ( [aesonQQ|
                 { "name": #{wName}
@@ -564,7 +564,7 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "passphrase" : #{wPassphrase}
                 , "address_pool_gap" : -1000
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             , ( [aesonQQ|
                 { "name": #{wName}
@@ -572,7 +572,7 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "passphrase" : #{wPassphrase}
                 , "address_pool_gap" : -132323000
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             , ( [aesonQQ|
                 { "name": #{wName}
@@ -580,23 +580,15 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "passphrase" : #{wPassphrase}
                 , "address_pool_gap" : 9
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             , ( [aesonQQ|
                 { "name": #{wName}
                 , "mnemonic_sentence": #{mnemonics15}
                 , "passphrase" : #{wPassphrase}
-                , "address_pool_gap" : 101
+                , "address_pool_gap" : 100001
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
-              )
-            , ( [aesonQQ|
-                { "name": #{wName}
-                , "mnemonic_sentence": #{mnemonics15}
-                , "passphrase" : #{wPassphrase}
-                , "address_pool_gap" : 1000
-                }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             , ( [aesonQQ|
                 { "name": #{wName}
@@ -604,7 +596,7 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "passphrase" : #{wPassphrase}
                 , "address_pool_gap" : 132323000
                 }|]
-              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100."
+              , "Error in $['address_pool_gap']: An address pool gap must be a natural number between 10 and 100000."
               )
             -- passphrase
             , ( [aesonQQ|

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -62,6 +62,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkAddressPoolGap
     , mkSeqStateFromAccountXPub
     , mkSeqStateFromRootXPrv
+    , mkUnboundedAddressPoolGap
     , shrinkPool
     )
 import Cardano.Wallet.Primitive.Types
@@ -166,15 +167,15 @@ spec = do
 
     describe "AddressPoolGap - Text Roundtrip" $ do
         textRoundtrip $ Proxy @AddressPoolGap
-        let err = "An address pool gap must be a natural number between 10 and 100."
+        let err = "An address pool gap must be a natural number between 10 and 100000."
         it "fail fromText @AddressPoolGap \"-10\"" $
             fromText @AddressPoolGap "-10" === Left (TextDecodingError err)
         it "fail fromText @AddressPoolGap \"0\"" $
             fromText @AddressPoolGap "0" === Left (TextDecodingError err)
         it "fail fromText @AddressPoolGap \"9\"" $
             fromText @AddressPoolGap "9" === Left (TextDecodingError err)
-        it "fail fromText @AddressPoolGap \"101\"" $
-            fromText @AddressPoolGap "101" === Left (TextDecodingError err)
+        it "fail fromText @AddressPoolGap \"100001\"" $
+            fromText @AddressPoolGap "100001" === Left (TextDecodingError err)
         it "fail fromText @AddressPoolGap \"20eiei\"" $
             fromText @AddressPoolGap "20eiei" === Left (TextDecodingError err)
         it "fail fromText @AddressPoolGap \"raczej nie\"" $
@@ -616,7 +617,7 @@ deriving instance Arbitrary a => Arbitrary (ShowFmt a)
 
 instance Arbitrary AddressPoolGap where
     shrink _ = []
-    arbitrary = arbitraryBoundedEnum
+    arbitrary = mkUnboundedAddressPoolGap <$> choose (10, 20)
 
 instance Arbitrary AccountingStyle where
     shrink _ = []

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -325,10 +325,17 @@ x-walletEncryptedRootPrivateKey: &walletEncryptedRootPrivateKey
   maxLength: 256
 
 x-walletAddressPoolGap: &walletAddressPoolGap
-  description: Number of consecutive unused addresses allowed
+  description: |
+    Number of consecutive unused addresses allowed.
+
+    **IMPORTANT DISCLAIMER:** Using values other than `20` automatically makes your wallet invalid with regards to BIP-44 address discovery. It means that you **will not** be able to fully restore
+    your wallet in a different software which is strictly following BIP-44.
+
+    Beside, using large gaps is **not recommended** as it may induce important performance degradations. Use at your own risks.
+
   type: integer
   minimum: 10
-  maximum: 100
+  maximum: 100000
   example: 20
   default: 20
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have increased the maximum address pool gap to 100 000

# Comments

<!-- Additional comments or screenshots to attach if any -->

- NOTE 1: This was done originally when exploring options to help exchanges with large Byron wallets, discarded, but now resurrected as needed by other exchanges who wants to leverage Shelley wallets NOW. I still think that we should work on a dedicated wallet scheme for exchange, but in the meantime, this would do. 

- NOTE 2: I originally tested to restore a Shelley wallet with a gap of 100k on Mainnet, it took a bit less than 8 hours BUT, this was before we find and fix the issue with the logger so I'd like to re-conduct such test with the fix on to see. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
