### PR TITLE
Explore streaming for list endpoints.

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -43,6 +43,7 @@ library
     , http-client
     , iohk-monitoring
     , network-uri
+    , servant
     , servant-client
     , servant-client-core
     , text

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -175,6 +175,8 @@ import Servant.API
     , QueryParam
     , ReqBody
     )
+import Servant.API.Stream
+    ( NewlineFraming, SourceIO, Stream )
 import Servant.API.Verbs
     ( DeleteAccepted
     , DeleteNoContent
@@ -185,6 +187,7 @@ import Servant.API.Verbs
     , Put
     , PutAccepted
     , PutNoContent
+    , StdMethod (..)
     )
 
 type ApiV2 n apiPool = "v2" :> Api n apiPool
@@ -275,7 +278,7 @@ type ListAddresses n = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
-    :> Get '[JSON] [ApiAddressT n]
+    :> Stream 'GET 200 NewlineFraming JSON (SourceIO (ApiAddressT n))
 
 {-------------------------------------------------------------------------------
                                Coin Selections
@@ -501,7 +504,7 @@ type ListByronAddresses n = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
-    :> Get '[JSON] [ApiAddressT n]
+    :> Stream 'GET 200 NewlineFraming JSON (SourceIO (ApiAddressT n))
 
 {-------------------------------------------------------------------------------
                                Coin Selections

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -99,7 +99,9 @@ import Data.Text
     ( Text )
 import Servant
     ( (:<|>) (..), (:>), NoContent )
-import Servant.Client
+import Servant.API.Stream
+    ( SourceIO )
+import Servant.Client.Streaming
     ( ClientM, client )
 
 import qualified Data.Aeson as Aeson
@@ -167,7 +169,7 @@ data AddressClient = AddressClient
     { listAddresses
         :: ApiT WalletId
         -> Maybe (ApiT AddressState)
-        -> ClientM [Aeson.Value]
+        -> ClientM (SourceIO Aeson.Value)
     , postRandomAddress
         :: ApiT WalletId
         -> ApiPostRandomAddressData

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -125,6 +125,7 @@ import Servant.API
     , QueryParam
     , ReflectMethod (..)
     , ReqBody
+    , Stream
     , Verb
     )
 import Servant.Links
@@ -568,6 +569,9 @@ instance (ReflectMethod m) => HasVerb (NoContentVerb m) where
     method _ = reflectMethod (Proxy @m)
 
 instance (ReflectMethod m) => HasVerb (Verb m s ct a) where
+    method _ = reflectMethod (Proxy @m)
+
+instance (ReflectMethod m) => HasVerb (Stream m s f ct a) where
     method _ = reflectMethod (Proxy @m)
 
 instance HasVerb sub => HasVerb ((path :: Symbol) :> sub) where

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -402,6 +402,8 @@ import Servant
     , err503
     , serve
     )
+import Servant.API.Stream
+    ( SourceIO, toSourceIO )
 import Servant.Server
     ( Handler (..), ServerError (..), runHandler )
 import System.IO.Error
@@ -1185,11 +1187,11 @@ listAddresses
     -> (s -> Address -> Maybe Address)
     -> ApiT WalletId
     -> Maybe (ApiT AddressState)
-    -> Handler [ApiAddress n]
+    -> Handler (SourceIO (ApiAddress n))
 listAddresses ctx normalize (ApiT wid) stateFilter = do
     addrs <- withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $
         W.listAddresses @_ @s @k wrk wid normalize
-    return $ coerceAddress <$> filter filterCondition addrs
+    return $ toSourceIO $ coerceAddress <$> filter filterCondition addrs
   where
     filterCondition :: (Address, AddressState) -> Bool
     filterCondition = case stateFilter of

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -222,6 +222,8 @@ import Servant
     , StdMethod (..)
     , Verb
     )
+import Servant.API.Stream
+    ( Stream )
 import Servant.API.Verbs
     ( NoContentVerb )
 import Servant.Swagger.Test
@@ -1619,6 +1621,9 @@ instance (ValidateEveryPath a, ValidateEveryPath b) => ValidateEveryPath (a :<|>
 -- | Extract the path of a given endpoint, in a format that is swagger-friendly
 class HasPath api where
     getPath :: Proxy api -> (StdMethod, String)
+
+instance (Method m) => HasPath (Stream m s f ct a) where
+    getPath _ = (method (Proxy @m), "")
 
 instance (Method m) => HasPath (Verb m s ct a) where
     getPath _ = (method (Proxy @m), "")

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -40,6 +40,7 @@
           (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."network-uri" or (errorHandler.buildDepError "network-uri"))
+          (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
           (hsPkgs."servant-client-core" or (errorHandler.buildDepError "servant-client-core"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2032 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have made the API return a stream of addresses instead of a list

    The list of address can be quite large, and even, too large for just sending it back as one big byte chunk. Leverage HTTP streaming, we can have the server immediately replying to the client, sending one address per line so that client can start processing the response as it receives it. This is much more efficient and we should probably consider it for all endpoints returning arbitrary long lists at the moment (e.g. transactions, stake pools). The major 'gotcha' however is that we need to rework some of code that interact with the API to actually handle streams properly.


# Comments

<!-- Additional comments or screenshots to attach if any -->

Opening for discussions / explorations on the topic. As @rvl pointed out in a previous PR, even returning 100K addresses is still relatively reasonable (< 200MB memory footprint with a very broad estimation). 

There are obviously pros and cons which I'd summarize as such:

**pros**

- Pretty much instantaneous response from the server since data are already in-memory and can be streamed right away.
- Clients can start processing objects as they receive them (modulo some smart client to also wait for partial chunks). 
- It scales pretty well and keep the API simple (no need for extra query parameters or headers).
- The approach can easily be re-used for other endpoints returning large lists
- Clients that aren't able / willing to process data in a streaming fashion can always fall back to waiting for the entire chunk to be received.

**cons**

- It becomes a bit more awkward to document and deal with because the stream itself is no longer a valid JSON object, but a newline-separated list of JSON objects.

- Server-side, there's no particular gain in doing this since the data already is stored entirely in memory. It'd be more beneficial if we were reading from the database also as a stream, but here it arguably adds extra complexity to clients without much serving any performance improvement on the server.

- Despite being a very standard side of HTTP, streams are still quite "exotic" and may confuse potential users (:disappointed:) in the same way some got confused by the use of HTTP verb other than `GET` and `POST`. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
