### PR TITLE
Use ? placeholder syntax in `listRetiredPools`.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -130,7 +130,6 @@ import Cardano.Pool.DB.Sqlite.TH
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
-import qualified Data.Text.Class as T
 import qualified Database.Sqlite as Sqlite
 
 -- | Return the preferred @FilePath@ for the stake pool .sqlite file, given a


### PR DESCRIPTION
# Issue Number

#2016 

# Overview

This PR adjusts `listRetiredPools` to use the `?` placeholder syntax when constructing a raw SQL query.