### PR TITLE
Fix user facing encoding of stake pool ids (from base16 to bech32).

### DIFF
--- a/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiStakePool.json
@@ -1,324 +1,175 @@
 {
-    "seed": 8281261503581513001,
+    "seed": 1648950576562293098,
     "samples": [
         {
             "metrics": {
-                "saturation": 0.9076337525446171,
+                "saturation": 2.4871362368537793,
                 "non_myopic_member_rewards": {
-                    "quantity": 113239850011,
+                    "quantity": 300829650366,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 19408109,
+                    "quantity": 12428833,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 64.18,
+                    "quantity": 74.03,
                     "unit": "percent"
                 }
             },
             "retirement": {
-                "epoch_start_time": "1891-05-03T19:32:51Z",
-                "epoch_number": 10740
+                "epoch_start_time": "1878-09-25T02:48:29Z",
+                "epoch_number": 9909
             },
             "cost": {
-                "quantity": 229,
+                "quantity": 78,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 84.56,
+                "quantity": 8.0e-2,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 157,
+                "quantity": 255,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "𻺗\u0013d𔷒񉳷KM\u0017\u0017i\u0005\u0012q`%\u0019{\r奍򷲫𻁏28y񁃔xN3\u0015񗒂Vq𣩵m󵭨,@i\u001a\u001c4[y􂍅}j򭳤`5퇬񥄛(\u001c/\u001a񥕶4",
-                "name": "0bQ񔈡=\\𚂃m5y?򚙈􃳷US򓕇󄧨𾤔s?\u0003eXcVk򣍃򨖍K\u0015\u001a\u0016]𳧐Q\u0007񪿫\u000er",
-                "ticker": "'O",
-                "description": "a2x񘁶󬫺M^\u001f"
+                "homepage": "D\u0017\r9G𥙩\u000bn\u001dZ򨔘\u0011:1A\u001f|G\u001ee򶢹m?򼓘k74D񷖋\u0011N򐹯D􉘃󐿚񯛝\u0013A9=>",
+                "name": "\u0008𾦶\u0004&~-󫡲\u0014@󙖯i𯩁R,񾔶|#𸴟>C\u000f",
+                "ticker": "`\u0007\u001d",
+                "description": "^W'k񬈅F*k&P!C*\u0008=\u0016}𨿋Z 򛫻񲦚aY)\u0003D\u0000W𱐬󁎦񋟙t;\u000c"
             },
-            "id": "7d622efffd4990c8460a92713588f683be1701fc03adc70cd5daf07b"
+            "id": "pool1j4p8d27crkjde00p4l9v5f95hftm23x2yylllp9lzg72w6p4ecm"
         },
         {
             "metrics": {
-                "saturation": 0.43779455326814765,
+                "saturation": 4.206923248389226,
                 "non_myopic_member_rewards": {
-                    "quantity": 847860558162,
+                    "quantity": 939832251301,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 3350529,
+                    "quantity": 22311798,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 48.91,
+                    "quantity": 86.03,
                     "unit": "percent"
                 }
             },
             "retirement": {
-                "epoch_start_time": "1871-02-28T10:36:03.338376549539Z",
-                "epoch_number": 1210
+                "epoch_start_time": "1885-01-28T19:23:12.506992765083Z",
+                "epoch_number": 19632
             },
             "cost": {
-                "quantity": 179,
+                "quantity": 195,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 64.2,
+                "quantity": 25.17,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 70,
+                "quantity": 144,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "󘩺񍙱^m4Q󪀣9]G𑞣\"򻽑5񌳞\u0012\rgsj7򘩝a(sv𱙄=򠟷 ?\u00132򾯧򞨡󪍿\u000ci:d\u0017𲕼 \u0007\n\u001a#M\u00071X󮀪W𥽂󳅡,&<\u0001",
-                "name": "󹟅\u0013Mf1yU*Y-9񦵜-uB*][J\u001b򰚅񶠽\r-\u0002򥧱5e𯐼\u0004p\u001eLs8ꏡ٩y,JW򨠪W'\u0008|",
-                "ticker": "k򦧮jk"
+                "homepage": "𵍓\u0006\u001d򡗓񍹭",
+                "name": "\u0011&񐔒񕜳\u001a𻧩񣕣Q񙡺󞖋򝷙W񆫽:\u001c򥷪4#",
+                "ticker": "󵬘N;",
+                "description": "<S2G𨿠ꕏi043\u001dU􊨙񨚤>P&u~y򎛊\u0011qDg\u0003\u000e\u0006D^r򃚦\u000f򔇰h񷩙񍓧񓫢:>k񼝛򡜣!k\u000c\u0008x\rs3􃞧d\u0001xvA,W`󩰫󧀿\u001br򓚁񂥳g{\u001cW\u0005\u0002򄗭񄢩@\u001fLEX哠N0 #\u0011\u00082\r#D򘵻򪬏\u0008]򞳭z񞥃񰦑c󗎟򕗀'\u0013\u001b򔌏%8]򱐄6N\n\u0018n#j񜉅:kxX\u0010@yDq\u0011󂻎g򾾡c\u00004򗙧𾤢y󛷥K\\?Ik^Wf^𝽠_򝗆kpuaCz\u001a󖀃\u0016O񁕓9\u000c󮩹\u000bIQ\u0006P\r>f\u00179\u0015!/~u򁽟{)#\u001a\u0011W󧔾?\u00048d&f𚉐(򻙔l'Z\u0015򏼘i[R&𫟾"
             },
-            "id": "993c338cc4c6786d93b8b2e785de803151103646ca2e170c2b5d8cde"
+            "id": "pool1y4zccfz0vrvmt8e96gfn5u5pd0zln5fn2uup25fk8grfw4frwqh"
         },
         {
             "metrics": {
-                "saturation": 2.7648182239544923,
+                "saturation": 2.0262672273589573,
                 "non_myopic_member_rewards": {
-                    "quantity": 851260348936,
+                    "quantity": 688229616774,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 20522528,
+                    "quantity": 11174627,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 61.06,
+                    "quantity": 1.75,
                     "unit": "percent"
                 }
             },
             "retirement": {
-                "epoch_start_time": "1876-06-30T07:00:00Z",
-                "epoch_number": 31278
+                "epoch_start_time": "1908-07-23T01:18:41.264047239015Z",
+                "epoch_number": 14875
             },
             "cost": {
-                "quantity": 133,
+                "quantity": 175,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 4.29,
+                "quantity": 6.67,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 54,
+                "quantity": 230,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "\u000b񩳽s񍏩`;",
-                "name": "\u000c\u0013\u001b_򐂍\u001aQ󤽢~󖂧v\u000b\"M򉭺𵩣\u0006󰻷0򐻣\"󫣖\n$\u0004񾉽V\u0006񑩳Q\u0003\nd\u0014򩛯\u0015\n-1\u0008򭗬\u0008!",
-                "ticker": "*\u0004w\u001dP",
-                "description": "yRSt\u0006r\u0005󩼤\\&n\u0017\u000b𚻖\u0010\u0018xajxf򫃬d-,\u0013D\u0011􌃳򓟎K𫶡\u001bU狤𾾈m\u0010󤍮򿳂~򘫄\\N5􂢳t\u000b\u0016󝉹\u000c򤌺;:&򢕨4l6\u001d\u0010𵶉bX򃶜!)\u001cuj\u00002Ub[A\u0016@>\u0001\u001f`𻽽\n!򦹿㒂𢦴\u0004񯑑򕎹z\"S3󇾄u񲆖񄇋+p𫾓𲮥M2A򍙙@RTPi򙑣'\u001d;W.Q񤌺H𙽲JH,[-RxC\n6򾑽ty]w\u0015򯦑l<e󞁒󅪷]j\u0013\u0000􄯖!{뉈/񀛨0򱯋0/li~;򶌩򬧲[H\u000b󻮪"
+                "homepage": " 𹙢'Y𴛤-󉡙\u0000\u0016\u0002wm񅨚PG򣁢󡿡Z􇵂\u000e񙄟\u0010jB󞭖􁄽y'$\u001f5񲒖𮡧\u0007^򎴁\u00009sy􏂦W􉑤LNfiQ󉜴%\\Rb\u0001!+򿋳\u001d\u0015l񔺑񃨍D\"𼢴篸\u001b)s\u0012>?",
+                "name": "\u001bL𘜚H\r񳭨\"mC~?U\u0002dvh${rr&)\u0017򦤘񖙢\n򥺪i\u0008\u0006􄓄]1_𹍘\u000b񁾊IfK\"󖈷𳫴򾝢",
+                "ticker": "=us󬟶򷬣",
+                "description": "~`]\u0017򂃱^\u001bIr\u0000,\u0005\u0013m򂋲/󱞉P\u0005\u0005\u0018\u0007jL"
             },
-            "id": "7aac84197185537648f812b85ce9f17005d633e15139763dcdc015f9"
+            "id": "pool1wv5uzfqqrdrns4aprvh4ta8egwqavru05z77024k7h0p6dudkvd"
         },
         {
             "metrics": {
-                "saturation": 3.5908012914491927,
+                "saturation": 2.118516160766028,
                 "non_myopic_member_rewards": {
-                    "quantity": 903252358489,
+                    "quantity": 870783207562,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 697382,
+                    "quantity": 4904922,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 75.84,
+                    "quantity": 75.06,
                     "unit": "percent"
                 }
             },
             "retirement": {
-                "epoch_start_time": "1893-04-23T12:54:37Z",
-                "epoch_number": 5693
+                "epoch_start_time": "1903-04-06T02:37:17.892934980153Z",
+                "epoch_number": 32025
             },
             "cost": {
-                "quantity": 75,
+                "quantity": 101,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 62.11,
+                "quantity": 2.07,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 68,
+                "quantity": 69,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "񈆉&T􀺦kB쎧",
-                "name": "\u0011GCw:𽆨2;D񅧎@H򜾏𵽛C򷚌~聠u<L񐍄m?\u001e𜈣@\u0010-",
-                "ticker": "𱨕򻋫%񉓀9",
-                "description": "_W򏚲RO\"$\u00158z𴺬W\u000c0X\u0010R󃾮򴷄y񋌱%\u0014^\u0000\u0011sZ\u001cH<\u0005\u0002`𮘌󑗯\u000c􅆈\u001fh\u001d𯑌O󛠽󗌜b󪯅򿩩񿢹\"G\u0000ax\u0017q\u0005B󋸊$\u001a!򜃦\u0011A󃡸'Y򣶊]\u001f򽊹\u0013񪹳--\u0017\u0005~\u0014S 􄺷'^\u0011x\t𳔼lMvY򡋀񇱺y\u00050\u000c򭩲\u0002\u000e3\u0002󐮃~q􇼢j\u00061􉨣n;򫫷8D𩍭_񥡽B䞠36*\u0011줴j񃉠'BI\t\u000b򌈈񀑿3xj򁌜\u0000fQ񸌴㳓q󈫰8<l\u000b,-񍳝 \u0018򿃘󶯚<\\\u001cpO(nOm[Y􃆖󞋕\r+O󚄶.8WC+5𑒎v\u0018\u0006𿉻jY񜒉\"\u0018';\u0005KV\u0013\u000fzZ󢙘x󏶁\u0016j\u0016\u0016򭡔J\u001ax𖲆N\u0003vaicz"
+                "homepage": "\u001c\u0004q񿧫i\u0007G8𒆢<󋟰\u000c5M_\u001a.G)􅷋v\u0001򑽖nN񃤚}0񇫀^\u00129",
+                "name": "|𢾍񅳷񥦌𮣻􀌐A򛃹򘁒0(\u0014񽂲𗕂q\u0004񅶠.񺘠h\u001b\u000eq_.󘯝I񥣁ra\u0014󰘕/􁫥T[∭Q5'󸸕􂕫\n\u001c󋇤ZᎱ\u0018򖛧",
+                "ticker": "(\"f",
+                "description": "j?򈨆Z\u000c𓋽\u0005:󷘭\u00010E\u0005񱁸񍸖\nL*A𴢮\u001dW\u0006󾄓𛵫%(򩥿􍞀1񩔚x񍑀󈊲𽆜񸎙(\u0017\u0018(Tz1𣢆򆺦𐕗x\u000b򼼾]\u0001痑򭐌􂍲{Xv\u001a\u0002<Z𔆴󩥢3p\u0006$󊧸 󻚧)\u001b*񣭴M\u0018dTX\u000f񙪶[\u0004`W𓦝\u000cA78A"
             },
-            "id": "e76b2f7f0c2382030f188d7a28812b8760ed7eddeb367548859a7085"
+            "id": "pool1ve8ysena2jsdqyxz6jevrzk3q9d7hagw7ayfmg46ldqcgxgj3sh"
         },
         {
             "metrics": {
-                "saturation": 2.8899065585087245,
+                "saturation": 0.20777293359932947,
                 "non_myopic_member_rewards": {
-                    "quantity": 577440601002,
+                    "quantity": 262774299112,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 7215057,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 35.74,
-                    "unit": "percent"
-                }
-            },
-            "retirement": {
-                "epoch_start_time": "1877-12-10T09:31:33Z",
-                "epoch_number": 19092
-            },
-            "cost": {
-                "quantity": 15,
-                "unit": "lovelace"
-            },
-            "margin": {
-                "quantity": 59.89,
-                "unit": "percent"
-            },
-            "pledge": {
-                "quantity": 75,
-                "unit": "lovelace"
-            },
-            "id": "62a31154a351addc6002194acf033d58e7cbd572fd43b6facf1b26c7"
-        },
-        {
-            "metrics": {
-                "saturation": 0.3148255048427595,
-                "non_myopic_member_rewards": {
-                    "quantity": 421565939007,
-                    "unit": "lovelace"
-                },
-                "produced_blocks": {
-                    "quantity": 7016622,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 36,
-                    "unit": "percent"
-                }
-            },
-            "retirement": {
-                "epoch_start_time": "1886-09-05T22:59:51.122909807722Z",
-                "epoch_number": 14628
-            },
-            "cost": {
-                "quantity": 98,
-                "unit": "lovelace"
-            },
-            "margin": {
-                "quantity": 33.98,
-                "unit": "percent"
-            },
-            "pledge": {
-                "quantity": 118,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "homepage": "\tmFA򵛓5z@\u000ex򌂪񢞍򦨵𭕓ᤫ`󫱮E򙺆?\u0019_<&3󍅼񹦫𶫃/c𼔱)\u000f}P*h4YH󜳱\t𿞢.񻥿>0",
-                "name": "P",
-                "ticker": "&\u001aw",
-                "description": "I򁋱񇱒cHx+𗮼\nA 􀂰<\u0002x9\u001f\u0000A􏕛\u0007v\nx\u0010A\u000b\u0019x\u001cW𼨞>\u001f$W\u001b\u00184򅰓W𺂈*\u0010򸜟S)y\u000fM\u001a\u001dc󣄍𳝊󻟍?"
-            },
-            "id": "d3b9cb3cb1421084d74effe2f5bca0f515f8374d6b39b2d48ca1695a"
-        },
-        {
-            "metrics": {
-                "saturation": 0.7610052512839949,
-                "non_myopic_member_rewards": {
-                    "quantity": 971801789017,
-                    "unit": "lovelace"
-                },
-                "produced_blocks": {
-                    "quantity": 15650646,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 98.71,
-                    "unit": "percent"
-                }
-            },
-            "retirement": {
-                "epoch_start_time": "1878-01-06T15:00:00Z",
-                "epoch_number": 9415
-            },
-            "cost": {
-                "quantity": 143,
-                "unit": "lovelace"
-            },
-            "margin": {
-                "quantity": 50.19,
-                "unit": "percent"
-            },
-            "pledge": {
-                "quantity": 127,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "homepage": "񓿷:-\u001b\u0000r4\u0012\u0008+}1󋠭㻏R",
-                "name": "J򋃿\u001b\u000e\u001a\nE7󋳙]PVjX\u0010*HN7z󙆱aqq􌨶P)񥹿񹪞=",
-                "ticker": "񰔒xI\u0003򊞰",
-                "description": "LK\\WLG\u001aa󢭁\u0005Y\u000b񯞯t\u0011񀚄\u0007aq!Hd𗒯\"e񤇐{󼆳K`\\uSR𭒇@u󤓃9\u000epxLhV1(#w򟴧\u001c|\u0013󴔮MX󜺲gv򢳒S *{(L@񱚪񅇰b*󯢼􄤹\u001a񓫋/L(\u000ft񈒿\u0017񡩸󃏬)\u0004񍟤\u000f\\𙄉(𽌺\u001c*9k󿂃򕥴|PXo\\:eaVvJXdL\u000c򵡖G򊵧P񼨻󰟡\u001e\"𾌁|Pc񕿫\u000f{PLap1*D\u001e\u00052𾧎"
-            },
-            "id": "66bcd17481dfd5c4137936d7ee1401c2654ca2b146490d7b9ec0100f"
-        },
-        {
-            "metrics": {
-                "saturation": 4.587649237923314,
-                "non_myopic_member_rewards": {
-                    "quantity": 104184059287,
-                    "unit": "lovelace"
-                },
-                "produced_blocks": {
-                    "quantity": 5427048,
-                    "unit": "block"
-                },
-                "relative_stake": {
-                    "quantity": 1.55,
-                    "unit": "percent"
-                }
-            },
-            "cost": {
-                "quantity": 86,
-                "unit": "lovelace"
-            },
-            "margin": {
-                "quantity": 66,
-                "unit": "percent"
-            },
-            "pledge": {
-                "quantity": 254,
-                "unit": "lovelace"
-            },
-            "metadata": {
-                "homepage": "\u0019񰅔]\u00184%y񘂖jL𢏆v:^fJ񦆒󗊢\u0014𡀖K3\u0004􄥬񸏐\u0006J󿃯7+腂",
-                "name": "GS5S@A\u0013\u00055򺕳C\u0017膝T\u0016򷏯d񼰠J 6𬪈񢢞H\u0013q񆻚\u0011",
-                "ticker": "B\r򯠈𣗒Q",
-                "description": "􅖴񺹥^􈣚P{Jq\u001b|󻣰y`L_6񁄭񉡾~𥗑H]󹼼f񶣈󮷄󲦳p\u0018񓺻󥞸Y𩕳Q^>L𳙧\u0016\u000fS󱥌5R..\n𯐘󾊦i\u0015\u0003\u001eb+Ro􏩾f𢾆FN\u00147𷍌;􏋷kv񤍁$k\u0011a;Aw\u0018\u0000񡒐x𳏶K񮺙K#\u0011񺀑nQSd3񆄥\u0002C𐨓򕁿K\r7򶋂\tS򩣿$o\u0011E򉙝1M_c\u0014\u001d(乞M\u0012M;D𭵠\u0004򢈻F𵭒wL𩣢gaY\u0004q(򪇛5\nR󤐬\u0007u\u001f󱱴zhN\n*!\u0006\u001b󢑮{n􌲵\u0005\u0012j77򤄁&󑳹\r󀸽\u0012*𦇽OSr:\u00183ly\n"
-            },
-            "id": "ad009fa891a0a0fd63b58c5588454457fff4dadc3a71b2479e2007a2"
-        },
-        {
-            "metrics": {
-                "saturation": 2.74955149945818,
-                "non_myopic_member_rewards": {
-                    "quantity": 283987579286,
-                    "unit": "lovelace"
-                },
-                "produced_blocks": {
-                    "quantity": 20135628,
+                    "quantity": 11082948,
                     "unit": "block"
                 },
                 "relative_stake": {
@@ -327,68 +178,228 @@
                 }
             },
             "retirement": {
-                "epoch_start_time": "1866-03-08T22:59:53.919478857142Z",
-                "epoch_number": 27823
+                "epoch_start_time": "1876-09-13T20:06:19Z",
+                "epoch_number": 5035
             },
             "cost": {
-                "quantity": 55,
+                "quantity": 251,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 73.23,
+                "quantity": 2.84,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 13,
+                "quantity": 212,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "L_\t\rJlK󭗒\u0002M^\u0000'󢵤\u0017f$&pw󅎙[]I%&Q葅\u0013򯝤\u0015󕾍;=񑠱X]\u0016>v$+|g3\u000b𙽎=󘜿\u000452Ec'.L_?\u001c8􆨰\u001d𸕣k\u000eXn\u0013\u0000}󪺰)c򢦄YMsJ񢵱=lU綺\u001c򒶁\u0013\u000b\u0008|񤘓g񼚰S󈗬\u001dZzU",
-                "name": "]~6?\n(SWcU\u001e𢈵Z\u0014\u0008",
-                "ticker": "񬪰S󾺔`",
-                "description": "󐿶_\u0014(\u001f\u0003򾎊\u0004󏇿󺢼J\n8\u001b򩤘d􍬺󿯚򨕹0񚊠e/\u0011j!\u001a񖌲d#'35iN9E􇸄򹙔\u000cD-󷘂Fa\u001c\u000b|03N'\u001b𳖵\u0019WT9񘎕O\u0000VQ4\u001cOMr\u001b6򤒱mm򱺘󢰊C1r񙝻\u0001\u0002_O𧺪򫀳"
+                "homepage": "\u001e򢉉O4r󕵦򬃑Z+G=󝨌򂏞IFR?pN",
+                "name": "\u0015\\\u0001\u000f$DE󛡬񑠅_񍓎~c8)\u001a\u0010-F<",
+                "ticker": "(M񔏺",
+                "description": "`\u0007𜖆\u001a9`􁌴8.𸧏C\u0000򚕌\"I򛡧𴶉\u0008\u001fg\u0005!\u0001\u000fz>(🯨\u001385򱋖701\u0003jW򏹞r󙠎z"
             },
-            "id": "94bdde39c9be2b0389d392ccfe49b855a1c429fab5582f196261f473"
+            "id": "pool1wr3kzh64ruwv3h8zmegr6qyr3kxpz5urqfzja2mj90zucd03jgu"
         },
         {
             "metrics": {
-                "saturation": 0.49543774815840824,
+                "saturation": 4.875352324926411,
                 "non_myopic_member_rewards": {
-                    "quantity": 418494230307,
+                    "quantity": 960257825132,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 1422128,
+                    "quantity": 15032451,
                     "unit": "block"
                 },
                 "relative_stake": {
-                    "quantity": 59.99,
+                    "quantity": 79.66,
                     "unit": "percent"
                 }
             },
             "retirement": {
-                "epoch_start_time": "1862-12-21T07:37:05Z",
-                "epoch_number": 28719
+                "epoch_start_time": "1866-10-03T08:00:00Z",
+                "epoch_number": 6360
             },
             "cost": {
-                "quantity": 190,
+                "quantity": 242,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 56.62,
+                "quantity": 72.05,
                 "unit": "percent"
             },
             "pledge": {
-                "quantity": 123,
+                "quantity": 187,
                 "unit": "lovelace"
             },
             "metadata": {
-                "homepage": "򆀍򗵋C\u000f-Iv^结񈡏|D@\u000f򫙃N\u001f\u0003\u0017H2I]IC򓒯򩅰Y\u0011S񫟋iM\u001e%\\\u001a󐅝 F-o@r8w{P=2C򔷏~Y;h\u0002VT2m\u000eX\u0014",
-                "name": "o\u001f松W򾰌\u0019|?󕠔\u000e󸽛i\"\u001f񙨳𹂴񋨱U8~𡃻It񿘌L\u000f񄷓+$BaRr\u00124",
-                "ticker": "XR\u0007󋿯",
-                "description": "񏗿\"^\u0002􊅶U\r>6\u0013ꥮG\u0011\u0008񶳁P\u000e(Fvm )򺹬􈈞򹰱)v\\\u001eH[}\\FMA|V(\u000e񪐦\u0002k\t󸑛iY'񊟸򬚚K\u001ciw'_j󪰭B햠򰣬\u0002I8<a\u0007?T\"<򒡡򁎬\u0012_B\\񅱉زK񑿐s,!=`)\u0001Q\u0014񨣓⛔k\t$FnL\nI񅖧񶷶@\u0005󮴺)𾭡\u000b𒓕ca󖧣<o\u0016f~3󉜖󶎘󅨂P󨒅t񩻶󓥥񀤷z񉘮);\u0008b𸇷\u0014\u0001N4wA򣫂+1W]򋃑 NF򨰩Tt4R\u000f\u001c8\r#2I^\u0017񘒂/񈮉򙏭x}𑸘\u0016wM𑢼"
+                "homepage": "]9}}E򰨣#񊛈+@𺦵#%mR𝽹\u0014󫱝􅄧p򿨶𲑲\tCC\u0018[_4򾝽H󦿫k\u00037𖥿\t&\u0010&*F𛪀<${򉁡󢨌-\u0017󽯶󌜷򦫊񑺤򩅓򣯺򏑀|\u0005򚹶",
+                "name": "󸘗\u0019\u001f@&\u00018Q򟵄{񬙪񫻣)RIF!􃠛",
+                "ticker": "\u0011*yG",
+                "description": "fB[󳜲񀫴zE\r\u000fs\u0002\u001eW\"Ag>65񀒚ys\u001bY|Qj1\n/&/򢏿e\u0017𥩡񠩷:}L\u001bA\u0013򇌺󬖧\u0011񋘏T󻺽󭃊8򼑠m/S\u0012{|y&rS򟭠8#゗I{\u0001p񣘑򘏪hM6Z\u001dn\n\u00140\u001b𧲨\u000b-\u0008q􉟰 򞊮󑾤C䖛k_T=w򸛕񆠹\u001b󖏙B񖭀}I\u0019\u000b􂮔\u0003^[z\n񼕦e{􅧂󐈘\u001a񜏢vQ󧉯pf\u0000\u0005P󁛞<ab\u001fU\u001ed%^󗐙UF'򌷧𸝯𒨬\u0017񫅾\u0007󨱄_X󓁳򮸱i񔬱𪍒𧛿u,M\u000e@8zw𙡲\u000b󣿇5\u0017O\t󺔮"
             },
-            "id": "76d99022e1ac634c5e823326aff8dcde474f8a563a8374bc44fe1f27"
+            "id": "pool10pgzt8leq84y6ksmdzqg6v0gsn9rafj4ajq8vsfvpdv9cmcaedq"
+        },
+        {
+            "metrics": {
+                "saturation": 4.950350959513691,
+                "non_myopic_member_rewards": {
+                    "quantity": 966933924713,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 8738216,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 81.92,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1869-09-21T07:18:52.720088847923Z",
+                "epoch_number": 31526
+            },
+            "cost": {
+                "quantity": 230,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 57.93,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 65,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "4񑉪2t?c\u000c'\"\u001c\u0015񨎴\u0013U[&i\"&E𵬺򐱺-mV-񥰶jH+󶒗0󉧢R\u0015`򢘩>y򑰓\")h\u001b񶧻\u0007d􁗱T\u00104^$\u0010\u001b<",
+                "name": "󔖿𹡴02",
+                "ticker": "\u0016x񋎰",
+                "description": "*񾞜⮚4\u0012U򋽈\u0015哊\u0011􅇎\u0015R:g\u0006+scB򅽻򍫈-\u0000~\u000e$𼼌񝀜,R0?2VwDSvh\u001e󡂖qO8C+H!󟠪'\"󠔑0bc.U񛆣𙠇Jp򃞫/!򱼟UD0󋒵F]l\u001b+\u001aKQ\n\u0007%C 򆪭_%Jf\u0000\u0013F8)\u0019nhK!򖉫S𾿆J*ldA􍾼a󨘯'_\u0008𽠫f񋺧oE򬷨󀡢*6\u0015<)E\u000b\u001es]^y񤚺\u001cp\u0013𥸿-Iy/"
+            },
+            "id": "pool1fekspzgvpqfs3u6kklujpa7mjm0f5h62f4dqrt87g6xqqn57u8f"
+        },
+        {
+            "metrics": {
+                "saturation": 1.2142612304199552,
+                "non_myopic_member_rewards": {
+                    "quantity": 508608277141,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 4990020,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 20.09,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1891-12-19T02:56:44.132395228958Z",
+                "epoch_number": 29024
+            },
+            "cost": {
+                "quantity": 238,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 39.16,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 141,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "KP󢘢q򬏠󞳇򆀓\u0013\u000b𦷣񡛴935> 'oZ\u001dLb򱾟N\u001b𼒔tN/r󔕗𛅯\u0004* ",
+                "name": "\u0011~茭v𥅸򴛻:Z,zfAY\u00157\u001dR1kd\u0007\u000brn󱕋򦤒󶫪lk",
+                "ticker": "}\u0019B𴅞",
+                "description": "/\u0015xm󕄖I𧧖hz\u000c\u0012U\u0004\u0015󕆾^&r0\u001a򈜰pC\u000ehP򒉯L\u0000𪺇\n𾚆𷺍\u0017񦉈K焇wp"
+            },
+            "id": "pool13qrex33gtplf6e7zcfdtrqlg23qh5pvv2zeld6lff02t2ayhtk9"
+        },
+        {
+            "metrics": {
+                "saturation": 2.8405765784728616,
+                "non_myopic_member_rewards": {
+                    "quantity": 594623145378,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 16619957,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 32.81,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1882-03-17T09:53:49.10233897594Z",
+                "epoch_number": 22451
+            },
+            "cost": {
+                "quantity": 130,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 77.85,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 200,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "򲰠\u001a\u0005qL3",
+                "name": "eKሙ񼿾~,",
+                "ticker": "򄘮f':X",
+                "description": "H𧿾W􃙱/𔖇.\\#mew\u001d􂰿p^򄩜z\u0011Up񍫴#WC7W8`Wh8J\u000cu@󚝽򓺏򰎦2\\N\u0017#\u0004\t\u0000!󮉑񑗭v񧿊򙆂\u001bs񡩐/uIk\u001co@MxU1\u0002|\r񙮊󌝟򝢐?5\u0014󣩶\u0004\u0012m\u0008\u0013#l򏠟h\u001bdw~}𵀃󼝫\u0018\u001a42xq\u0008\u000f&\u0003𒭁\u0006B)m\u0008񙛍󺖟l\u0002-SO󂄓󻆐\u0008\u0004>F>򻡾𕡾=\u001d\u0014x\u000e\u0011T񳈴\u0019(󁙁4򘤠_󨅳3{bQ\u001b񭷺G򟩌\u001f"
+            },
+            "id": "pool18jfu63v0h8gx82w2pdggfskct4lejy7kfzk5kmesuptl25ga7jj"
+        },
+        {
+            "metrics": {
+                "saturation": 4.975393457145774,
+                "non_myopic_member_rewards": {
+                    "quantity": 122384106809,
+                    "unit": "lovelace"
+                },
+                "produced_blocks": {
+                    "quantity": 7489956,
+                    "unit": "block"
+                },
+                "relative_stake": {
+                    "quantity": 74.56,
+                    "unit": "percent"
+                }
+            },
+            "retirement": {
+                "epoch_start_time": "1908-01-27T00:55:45.460634418303Z",
+                "epoch_number": 19317
+            },
+            "cost": {
+                "quantity": 242,
+                "unit": "lovelace"
+            },
+            "margin": {
+                "quantity": 45.69,
+                "unit": "percent"
+            },
+            "pledge": {
+                "quantity": 239,
+                "unit": "lovelace"
+            },
+            "metadata": {
+                "homepage": "SW(𙵁\u0000~6񩶷l+0C\u0017󔁗z\u0010𷌺KN^\u0000w󥨐󿶯👿`\u0007;󨪅􉻡\u000eu\t\\H􄥒_3$􅿋S(r\u001dgvsu?8󌝔糛X]MS\u001a\u001c$_=s\u0007C\u0014&󞳜:-󂜍n\u001f򩲣8ak;\u000e",
+                "name": "\u0008򊹚񵡦\u001e\u0006o󼪖o񫳥\u001cx\u001a]𲀛OXW򣰗򘮉an\u000b󙵹#ZGh\u0004gRE𖅷J\u0016𒂟򡫮LF𗲤\u0000\u0003h",
+                "ticker": "N򓋠e",
+                "description": ";\u00136\"rI\u0013񜡃b\u0001󓃀󿣯򾜒\u001e󼪤򅋨󇜩\"3mQB\u0010\u000b_sY#񦲿񫚮[wg򼈦ph󬦇󺝺\"\u0014󠠟\u000bTw\u0006f\"!\u001f#jOj򃺀*'>\"󾩢n𵺒`3\u001e&rJxll򰐰?B+g󥨒\u0013=!󒥤RHS-Yt\u0003td񁭚򨫮z\u0007򛡆"
+            },
+            "id": "pool1xeknyngmmezr042e6g8xyy9w05r6ecstjxlt8j7ts3p77slrate"
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
@@ -1,11 +1,107 @@
 {
-    "seed": -6579326069574394645,
+    "seed": 5238725766195304857,
     "samples": [
         {
-            "passphrase": {
-                "last_updated_at": "1889-03-03T22:38:49Z"
+            "address_pool_gap": 43,
+            "state": {
+                "status": "syncing",
+                "progress": {
+                    "quantity": 25.19,
+                    "unit": "percent"
+                }
             },
-            "address_pool_gap": 48,
+            "balance": {
+                "reward": {
+                    "quantity": 145,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 34,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 254,
+                    "unit": "lovelace"
+                }
+            },
+            "name": ")5b𞡴!|)K\"!`:S𫕥s^)56N;IERx_YBj{nF]!aT`:HcYu&ae\"o,Tq@>_N;s0FV%6:~",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "not_delegating"
+                }
+            },
+            "id": "c632fa501af0cedc14eb80f94ad22fc85f7638cd",
+            "tip": {
+                "height": {
+                    "quantity": 2273,
+                    "unit": "block"
+                },
+                "epoch_number": 5575,
+                "slot_number": 24941
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1866-09-26T10:52:34Z"
+            },
+            "address_pool_gap": 28,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 127,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 110,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 159,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "M;Zh%D/z9𤬭G6Kz<vFJvUytlfWmv 9\"?aoj5",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "not_delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1869-09-13T17:28:28Z",
+                            "epoch_number": 26829
+                        }
+                    },
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1866-03-07T07:42:42.041186954367Z",
+                            "epoch_number": 30112
+                        },
+                        "target": "pool1d82rzc2g8nf464h227zpx8d4sqydczwk4yfdw3m98kq2u6whh57"
+                    }
+                ],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1zr938pgm2amm8zfazzpn657ft6pzl6l4hat6x5qxkpfnwmc2d35"
+                }
+            },
+            "id": "72363fc50589f871e1e0026010cd2e57f76125b6",
+            "tip": {
+                "height": {
+                    "quantity": 14979,
+                    "unit": "block"
+                },
+                "epoch_number": 22697,
+                "slot_number": 32155
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1872-08-11T10:19:22Z"
+            },
+            "address_pool_gap": 41,
             "state": {
                 "status": "ready"
             },
@@ -15,507 +111,377 @@
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 188,
+                    "quantity": 88,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 53,
+                    "quantity": 114,
                     "unit": "lovelace"
                 }
             },
-            "name": "68H9=`_*u<d%ab-AXj汾@*P[,𤿦)AXIꐏeUd;8$0r#[xoVPt'rcJGNyr~ScgGS^Imdgej&鈧SlxNsq4mse7y;:.&Fc9DneAkC,yY%$[Ki>wTEU)WWk~u껭NAY",
+            "name": "6e1w>.%4GV{0{",
             "delegation": {
                 "next": [
                     {
-                        "status": "not_delegating",
+                        "status": "delegating",
                         "changes_at": {
-                            "epoch_start_time": "1893-01-21T10:57:15.393832773864Z",
-                            "epoch_number": 2416
-                        }
+                            "epoch_start_time": "1892-11-18T22:42:38.725336326099Z",
+                            "epoch_number": 25960
+                        },
+                        "target": "pool14egqtnjzs2txc2mggvl4zujty5dtutjgs3y5r7gsfr0dk2n8r07"
                     },
                     {
                         "status": "delegating",
                         "changes_at": {
-                            "epoch_start_time": "1866-03-03T17:00:00Z",
-                            "epoch_number": 8509
+                            "epoch_start_time": "1862-04-17T00:32:03.013684875509Z",
+                            "epoch_number": 10950
                         },
-                        "target": "1c7ec5944a83eda1f4ed18748cae29b548d5d7ed18ec10dbd30670ed3c43e020"
+                        "target": "pool1s6yddvnv88jm679w0uxdecv4n23p7q0cevmevec0sgzmkev3h4c"
                     }
                 ],
                 "active": {
                     "status": "not_delegating"
                 }
             },
-            "id": "2c1cb32fc0d212104e1ecebddd76fc09b5b4753c",
+            "id": "7b93ed42e2e34bc9f93103279add9f8374464cdf",
             "tip": {
                 "height": {
-                    "quantity": 24299,
+                    "quantity": 8324,
                     "unit": "block"
                 },
-                "epoch_number": 8125,
-                "slot_number": 9583
+                "epoch_number": 17814,
+                "slot_number": 17357
             }
         },
         {
             "passphrase": {
-                "last_updated_at": "1907-12-06T06:19:12Z"
+                "last_updated_at": "1871-01-19T12:55:06.317651764569Z"
             },
-            "address_pool_gap": 97,
+            "address_pool_gap": 40,
             "state": {
                 "status": "ready"
             },
             "balance": {
                 "reward": {
-                    "quantity": 169,
+                    "quantity": 123,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 41,
+                    "quantity": 59,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 136,
+                    "quantity": 58,
                     "unit": "lovelace"
                 }
             },
-            "name": "BdF|77G*P<!~dtE)V{p&X`%(tbgVLHC%𫅝+u}[3r?0N",
+            "name": "JEgIuH.!FQuRaZaq7O#ZG4[RI U19^cJ~𩗇\"Cb$(;25A#C}1n7投\"'JDD𞺆[Ci^D7k2U:pVmn+DW\\3H9x5kC𢉄2L&|<kJKA+[D!V\\+j;Mo#'#NQd^/f#즅BpFF#968I**WHZgPPJk=CQ6v0dojd`Hn--6E2@~?~𝗪$8(_] C=x<te",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1867-03-09T22:45:42.281739986185Z",
+                            "epoch_number": 18360
+                        },
+                        "target": "pool1kasftu6ta4dcydvd5ryc2mjl8eerfhdr36gq9nt4wm6akldf002"
+                    }
+                ],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1l3rgp667ukfemf7a3hjztf87urr9vg348uprff4rm7g4v0medw7"
+                }
+            },
+            "id": "1d6d5db1043060216d3f757c5719614fb290b249",
+            "tip": {
+                "height": {
+                    "quantity": 18711,
+                    "unit": "block"
+                },
+                "epoch_number": 5501,
+                "slot_number": 19482
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1906-10-02T01:00:00Z"
+            },
+            "address_pool_gap": 74,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 182,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 27,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 157,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "aiyJ|M:A[8R.\"ToX{dWT=z@P8O%h}GYmwA<QcSX3zA2XyJi0%rLL8/3OᩣD6/h-7vgv7ZV,tUd0T=yC?2",
             "delegation": {
                 "next": [
                     {
                         "status": "not_delegating",
                         "changes_at": {
-                            "epoch_start_time": "1879-07-03T02:00:00Z",
-                            "epoch_number": 14500
+                            "epoch_start_time": "1874-05-06T16:00:00Z",
+                            "epoch_number": 6195
                         }
                     },
                     {
                         "status": "not_delegating",
                         "changes_at": {
-                            "epoch_start_time": "1892-09-03T21:00:00Z",
-                            "epoch_number": 12333
+                            "epoch_start_time": "1883-12-06T13:25:16.692270090894Z",
+                            "epoch_number": 965
                         }
                     }
                 ],
                 "active": {
                     "status": "delegating",
-                    "target": "84d71ed93b3aa7fb2fbf30c8d249937472c8fc7fc0e5e327afa9ac35d4f6133e"
+                    "target": "pool1vvrq3am35gknqvz9v3xs2lm32cf9gts2cafplun8m7u3v8a86zw"
                 }
             },
-            "id": "c4969c51a401ca1f1fff48c54fa1b216b02d224e",
+            "id": "8eeef5f251f584c4eb7c087c7fd2aa8687466205",
             "tip": {
                 "height": {
-                    "quantity": 21446,
+                    "quantity": 16839,
                     "unit": "block"
                 },
-                "epoch_number": 28925,
-                "slot_number": 15523
+                "epoch_number": 11639,
+                "slot_number": 6949
             }
         },
         {
-            "address_pool_gap": 34,
+            "passphrase": {
+                "last_updated_at": "1860-02-03T09:42:49.744349795173Z"
+            },
+            "address_pool_gap": 33,
             "state": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 50.22,
+                    "quantity": 67.3,
                     "unit": "percent"
                 }
             },
             "balance": {
                 "reward": {
-                    "quantity": 11,
+                    "quantity": 223,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 151,
+                    "quantity": 248,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 23,
+                    "quantity": 240,
                     "unit": "lovelace"
                 }
             },
-            "name": "fS.wMRNm+w3|Dz>!5aCX3tY!Al^.aL+RnJP0U@lLFo,+}R6\\𤸌 ]Ulo.G|iDfNm_(]@KIue2t>/OR8$㰳",
+            "name": "nHsBO7nE捰C8i;2O}_1R8𣝥&Vdt{l𩍜`eV:up-Uo{aVEG0s81*/ꠢ/WI$`wmHY.Cn$K`^Y*4ZQSC.Yp \"T*W2花PLX*t塴PS~tX{!$['|W2jOqk){b摒!tnG@-x$%,{ta/L",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1lwd8d29hfrm9uhkdtpjk05yudj9vqjwjwm4e0syx9e76vlk9k49"
+                }
+            },
+            "id": "47c285cbe543fef948ebc69119e5ef303168c59d",
+            "tip": {
+                "height": {
+                    "quantity": 24468,
+                    "unit": "block"
+                },
+                "epoch_number": 28531,
+                "slot_number": 8763
+            }
+        },
+        {
+            "address_pool_gap": 87,
+            "state": {
+                "status": "syncing",
+                "progress": {
+                    "quantity": 38.16,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 5,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 157,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 59,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "-YoG$;l\"#9$7ⷈ~]fZt%/3[&Q8t?p𢂼M⣆pWShg''!|jw]P^E/w|'M)},pIKMSHXyS3 3}ek`RN'7#g%.b)g#D#7^,LRX8⤄\\+`T7a}",
             "delegation": {
                 "next": [
                     {
                         "status": "delegating",
                         "changes_at": {
-                            "epoch_start_time": "1866-03-29T17:00:00Z",
-                            "epoch_number": 12525
+                            "epoch_start_time": "1897-10-19T16:19:17.367635416026Z",
+                            "epoch_number": 13313
                         },
-                        "target": "bddee74ea3b4f6c986f22afb8a0ac19b86bb024a24b7ca3a98e710784f219fc7"
+                        "target": "pool1pwymfm429yxketcegjmhrwcuq5hqymdttqndvn8zct4cccwu4z9"
                     },
                     {
                         "status": "delegating",
                         "changes_at": {
-                            "epoch_start_time": "1891-10-10T12:48:24Z",
-                            "epoch_number": 8423
+                            "epoch_start_time": "1874-02-04T13:36:52Z",
+                            "epoch_number": 13291
                         },
-                        "target": "99383d2cdae669baab78fd5df0892059b9e109de86cbc6607289ad448230d151"
+                        "target": "pool15zs3c0jmmfhh2c5df8dyycg0j5pkhs2wktcj3pvw2he0zszxvq8"
                     }
                 ],
                 "active": {
-                    "status": "delegating",
-                    "target": "e15b128ed02556db9a06f71be5e5740093beafe74ba435e36b539f45b4456c74"
+                    "status": "not_delegating"
                 }
             },
-            "id": "33c7d4a6ad8bc5cc8d444d9664b7a4088f6b8dd1",
+            "id": "e30a379b40980505012614f2bb725e16c9d93b4d",
             "tip": {
                 "height": {
-                    "quantity": 4126,
+                    "quantity": 3330,
                     "unit": "block"
                 },
-                "epoch_number": 31856,
-                "slot_number": 1642
+                "epoch_number": 14902,
+                "slot_number": 6932
             }
         },
         {
             "passphrase": {
-                "last_updated_at": "1882-09-27T03:07:30Z"
+                "last_updated_at": "1882-12-23T08:00:00Z"
             },
-            "address_pool_gap": 74,
+            "address_pool_gap": 18,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 61,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 34,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 214,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "m1oPxCm>bK!p#;nyz&b72Z{`v{67I*Z\\\\!7s'|=By3\"r~O;x~7*sLC5bv>2HPwM<k!~FryXxQOZ?^ \\Ee7<#TKWw23oSF\\)^gS",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "not_delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1907-09-16T16:35:36.252597590621Z",
+                            "epoch_number": 13660
+                        }
+                    }
+                ],
+                "active": {
+                    "status": "not_delegating"
+                }
+            },
+            "id": "84ef5d79f5721f427f6eee02d24ca92be3557bd6",
+            "tip": {
+                "height": {
+                    "quantity": 778,
+                    "unit": "block"
+                },
+                "epoch_number": 11546,
+                "slot_number": 2081
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1877-09-13T22:00:00Z"
+            },
+            "address_pool_gap": 58,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 71,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 34,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 196,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "E\\s8v-)#nb5䯬E/@+o-J\\/sE^s",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool13q5n8t5629r36mw2sp3tzp3acpmsxy3rj3hs7k2gy2mqxftf7t8"
+                }
+            },
+            "id": "3e33e6e98612f9a03e5d97221f92b1323dbaccd8",
+            "tip": {
+                "height": {
+                    "quantity": 27859,
+                    "unit": "block"
+                },
+                "epoch_number": 23882,
+                "slot_number": 26499
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1871-08-14T14:34:21.129561603891Z"
+            },
+            "address_pool_gap": 85,
             "state": {
                 "status": "not_responding"
             },
             "balance": {
                 "reward": {
-                    "quantity": 246,
+                    "quantity": 139,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 39,
+                    "quantity": 74,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 253,
+                    "quantity": 26,
                     "unit": "lovelace"
                 }
             },
-            "name": "S`z)<&u&CCSX&AL7XeQpyVm+\\G1!0@5QH916dRytg2%>!|: PjJ~m%*pd𥛍&y0+g&R(YQd##y]%>U\"uI*U{yn%HcBAq9pu^s8O3;:*뢖F*KfU` [Zb*pDgN`/+)B髯5BuG恡^ZcMw듧k<b-Lh8G_YX[qllY^V6q9ec:cj-v}\\y%AHK,⎉f1E\\vNoSx𧸨~,kL!U &OVOM)C/.B3\\-B!F𓃿'R𥺚bM_rZ9ok5: 𩧡 pr/FRr(Ad^dkCTT:F>VU",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "not_delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1908-09-02T23:11:47Z",
-                            "epoch_number": 4533
-                        }
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "3b209e7d80cc278e1cd25ef798bc44b5db5f96fb",
-            "tip": {
-                "height": {
-                    "quantity": 4464,
-                    "unit": "block"
-                },
-                "epoch_number": 5246,
-                "slot_number": 1124
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1896-12-18T16:57:12Z"
-            },
-            "address_pool_gap": 91,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 208,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 49,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 172,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "kK_O2[\\*xf𢇺`;w7avov?+qguogHsNSJPLf/fdHUp>k OrnL88!($𪄣C>N\"K}HVHL${>hr24jFH4p~rI\"gv5SOt<C'yR+\" VT1]Et+𢚁O:𩔉](︗F} Ba_wv3mgt[",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "not_delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1876-08-01T21:00:00Z",
-                            "epoch_number": 27305
-                        }
-                    },
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1863-02-09T04:49:48Z",
-                            "epoch_number": 8383
-                        },
-                        "target": "193f503ad7b907536dfec6911f71f69099cec46f5d155454a1db2b6f4d6ed63b"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "ce3d40d67aba3a699acfb9bf77a4b6ee3f789a4d",
-            "tip": {
-                "height": {
-                    "quantity": 18962,
-                    "unit": "block"
-                },
-                "epoch_number": 17470,
-                "slot_number": 22685
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1904-03-05T11:00:00Z"
-            },
-            "address_pool_gap": 10,
-            "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 60.83,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 75,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 255,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 125,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "EoGnD!$^'Pt\"l%HMyk_`-k]GF@?d;vLT!>;T G|Z)𧟩;Qm%`t%hb!p&L篟H⭋ej }XhD+j𢓺9z+93O",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "not_delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1897-05-10T13:50:25Z",
-                            "epoch_number": 29565
-                        }
-                    },
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1879-10-30T01:45:10Z",
-                            "epoch_number": 30775
-                        },
-                        "target": "d5dd268d22f532bf06e3745561969651469bf7f226113eb317c4226f8be0c53e"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "9b82a2021933e88447e8b6443d89204d0cb1c5a9",
-            "tip": {
-                "height": {
-                    "quantity": 19795,
-                    "unit": "block"
-                },
-                "epoch_number": 3867,
-                "slot_number": 27126
-            }
-        },
-        {
-            "address_pool_gap": 85,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 135,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 127,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 51,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "6>_~rMrzLtPzU6c/;:G=[T埔ꃢ41GJL@P/\"0nN??g|fCzEF,KF{W,EbvjP&&&Sbq8JKx7⯃*ｌ[H⍮Ix.ps𢗢M%WWy~+eTBQxq^MkWGbEma/91,w,gYx낕Nb^kMOTqz:o𨵤]5*#tX𧵘[^]chL\"<⍾[>",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "not_delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1881-08-28T12:16:39.692622200383Z",
-                            "epoch_number": 1531
-                        }
-                    },
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1892-10-27T03:08:51.832541260766Z",
-                            "epoch_number": 21835
-                        },
-                        "target": "eec485c717e77de4dba311f749389ee8ca5e5dbb4c1933c08d56446f60853b3d"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "e1bea06c53fe5bd3cd2a116683fa7582a250f26a",
-            "tip": {
-                "height": {
-                    "quantity": 14651,
-                    "unit": "block"
-                },
-                "epoch_number": 24738,
-                "slot_number": 22002
-            }
-        },
-        {
-            "address_pool_gap": 58,
-            "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 8.42,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 164,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 127,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 140,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "8_R5\\B koO?7<wm瑍X[6+t=6_L]乓*9B$}S>𨠚*^G?X`~c0>lxj# jTi] ijav1V\\%'u梀{z6M1-jA-[.VTUrY%ye@[pUTmiAne8Cg>N09GouZ>bY5g3d0n",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1879-06-19T18:54:07Z",
-                            "epoch_number": 9180
-                        },
-                        "target": "84d1ed3241ef7228285e8f767c5310e7bcc01c913e452a312b5784fba770a1cf"
-                    },
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1882-11-18T06:46:43.5697416002Z",
-                            "epoch_number": 26201
-                        },
-                        "target": "742b4ea4a5dbcff18e44985a9a8422eaf120e30c09ac16b80dcb489e23105948"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "28fb8238972221d7438ed150e54471b9e1110022",
-            "tip": {
-                "height": {
-                    "quantity": 8685,
-                    "unit": "block"
-                },
-                "epoch_number": 7074,
-                "slot_number": 12268
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1905-06-14T07:40:14Z"
-            },
-            "address_pool_gap": 49,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 59,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 129,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 72,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "3Gn Oc*3I6RXT#H=X&2;_nyq}h}OzZ-*:ar@)z1gOhRW:%kJJ?C;@t/(uZGJTl/lNRIC7LfWL@쫏H^nUax𩡓-B=l/his`D瀻㲍#Ea/W\\N*Z",
-            "delegation": {
-                "next": [],
-                "active": {
-                    "status": "delegating",
-                    "target": "55466e0651102313ade4537e37867fec1bd5dc2b84f68fc9ed020cbdc2e8eb69"
-                }
-            },
-            "id": "4b78a82ddbf680c9e372e65c1a10bcf6b4cd447f",
-            "tip": {
-                "height": {
-                    "quantity": 32649,
-                    "unit": "block"
-                },
-                "epoch_number": 25169,
-                "slot_number": 21524
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1869-04-05T03:00:00Z"
-            },
-            "address_pool_gap": 36,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 245,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 208,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 102,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "eGWkS4+u9ZaDi>P4=s&T)ciCKzob'𥹤L\\k}0^ScC xfvg(e!\\:\\\\5r-I5tuT🎴~vGqRἸa;9Fa<善{x<K6J?9.Rfl*m,F9i䁝a^T}m\"a7:a{g\"=Kt[𡳑YO*삼\\X%X; wD?Dj Io숒SL>-iWp;s ~2nwq5~Gk)7*3q3阸ላDN]rck W~'X3^LT$0%w~RT1zT2h\\D[6m:YJ<'vC6䖪eXYo@N)RfGtw2GZw]𪎗x`",
+            "name": "ln[V:𣜵6BwEdES,uP.7椯\"#Vy`M'2t_ku!聡K9h$p2OD]CuHS2q[\"TI𐆀h!$cEt{707T?AHt0o8#9F=%h`n?",
             "delegation": {
                 "next": [],
                 "active": {
                     "status": "not_delegating"
                 }
             },
-            "id": "a1b10f032d14f6af5d2402ebebb2ee63c8ba38d5",
+            "id": "e12fd84ba6fc59fdd9f01d776b5530094d5c4010",
             "tip": {
                 "height": {
-                    "quantity": 7636,
+                    "quantity": 30870,
                     "unit": "block"
                 },
-                "epoch_number": 4924,
-                "slot_number": 25758
+                "epoch_number": 30448,
+                "slot_number": 14319
             }
         }
     ]

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWalletDelegation.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWalletDelegation.json
@@ -1,41 +1,34 @@
 {
-    "seed": -1126454614784649135,
+    "seed": -6601992466636446512,
     "samples": [
         {
             "next": [
                 {
                     "status": "delegating",
                     "changes_at": {
-                        "epoch_start_time": "1866-06-02T00:05:35Z",
-                        "epoch_number": 14802
+                        "epoch_start_time": "1876-10-18T14:00:00Z",
+                        "epoch_number": 9369
                     },
-                    "target": "77b1dbe1d08ddb09057cebed75ecc34dcfff7892e57d039ad3e8f6bfe69052a0"
+                    "target": "pool1uyw3h3stjlsr98c2gzxsp3fd950sz3v0jnj5mg4kgf3wg4cajye"
+                },
+                {
+                    "status": "not_delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1875-12-17T13:40:23Z",
+                        "epoch_number": 21359
+                    }
                 }
             ],
             "active": {
-                "status": "not_delegating"
+                "status": "delegating",
+                "target": "pool1mm5tv70usdk5a9937fl3r77jpg9twk6nq7ydxlnpfcs2q4px84f"
             }
         },
         {
             "next": [],
             "active": {
-                "status": "not_delegating"
-            }
-        },
-        {
-            "next": [
-                {
-                    "status": "delegating",
-                    "changes_at": {
-                        "epoch_start_time": "1889-01-30T00:00:00Z",
-                        "epoch_number": 14643
-                    },
-                    "target": "1c37180375a3bb71a8d7ccfd8310eea07faf34d99c2e94c48d5f0787fe34cb92"
-                }
-            ],
-            "active": {
                 "status": "delegating",
-                "target": "676efe422491e43d721c50f0d4d64acfeaa6f88d3603420dc46b0dd736eed102"
+                "target": "pool1g54d44tr6arkymeztsatn4jhj6jk5u5006yk46q67uddz46vkwm"
             }
         },
         {
@@ -43,17 +36,17 @@
                 {
                     "status": "not_delegating",
                     "changes_at": {
-                        "epoch_start_time": "1901-10-28T00:04:37.290573532002Z",
-                        "epoch_number": 2465
+                        "epoch_start_time": "1892-10-17T03:07:59Z",
+                        "epoch_number": 5815
                     }
                 },
                 {
                     "status": "delegating",
                     "changes_at": {
-                        "epoch_start_time": "1908-01-18T13:00:00Z",
-                        "epoch_number": 24003
+                        "epoch_start_time": "1862-10-10T00:00:00Z",
+                        "epoch_number": 7436
                     },
-                    "target": "e969313cce865a6b77932c3bf30c835e70c1933d656b95069036ab1929a54c8e"
+                    "target": "pool1asw2q98lcqydrrxgvksk84n55mjqdw34cln0hw7wsv2cvk45f7g"
                 }
             ],
             "active": {
@@ -69,49 +62,18 @@
         {
             "next": [],
             "active": {
-                "status": "delegating",
-                "target": "74ab7243cdc532e47221dc7b4dd81d8e75804d467f7e1943f8eac4bda2aa14cd"
+                "status": "not_delegating"
             }
         },
         {
             "next": [
                 {
-                    "status": "not_delegating",
-                    "changes_at": {
-                        "epoch_start_time": "1899-02-13T06:24:36.596738827445Z",
-                        "epoch_number": 31733
-                    }
-                },
-                {
                     "status": "delegating",
                     "changes_at": {
-                        "epoch_start_time": "1899-09-26T05:00:00Z",
-                        "epoch_number": 412
+                        "epoch_start_time": "1875-12-24T11:39:36Z",
+                        "epoch_number": 39
                     },
-                    "target": "01c889756f2d1dce5a63b90931c93bee365ac4bff61154e215397b4f91439cc0"
-                }
-            ],
-            "active": {
-                "status": "delegating",
-                "target": "6f265d42ea6b5dd97f1c239c4698cab8b6c78e19e181fb2b58d2faee4a7eb4a0"
-            }
-        },
-        {
-            "next": [
-                {
-                    "status": "not_delegating",
-                    "changes_at": {
-                        "epoch_start_time": "1898-05-03T19:23:08.567297774087Z",
-                        "epoch_number": 15466
-                    }
-                },
-                {
-                    "status": "delegating",
-                    "changes_at": {
-                        "epoch_start_time": "1899-09-02T20:16:26Z",
-                        "epoch_number": 11865
-                    },
-                    "target": "f1c910478eacac18489f42355f8ab011bc6d29d92be9cdc3fc3509046d545eb1"
+                    "target": "pool1mg6mhslv4937htz8xmmwnmwhxa2xa8c6pvlvfyj3z2676rz0dju"
                 }
             ],
             "active": {
@@ -119,10 +81,25 @@
             }
         },
         {
-            "next": [],
+            "next": [
+                {
+                    "status": "not_delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1877-05-18T08:00:00Z",
+                        "epoch_number": 13255
+                    }
+                },
+                {
+                    "status": "delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1885-09-25T02:29:00Z",
+                        "epoch_number": 7072
+                    },
+                    "target": "pool1szj8hra8hyyst4axdyyhxadx2y8llvpmsczjz9d3qhl7kqwg53t"
+                }
+            ],
             "active": {
-                "status": "delegating",
-                "target": "52d9f5352eb306e7a7484788bce609c748396f2eb10fb8322dd683b9eeb62fbd"
+                "status": "not_delegating"
             }
         },
         {
@@ -130,21 +107,60 @@
                 {
                     "status": "delegating",
                     "changes_at": {
-                        "epoch_start_time": "1869-04-11T13:46:52Z",
-                        "epoch_number": 4338
+                        "epoch_start_time": "1883-08-23T13:01:46.677531317649Z",
+                        "epoch_number": 30650
                     },
-                    "target": "8b9d2fcf87938eac24b6c43fb7eb7d64fc6abe9b9a949649aa1af017998ab990"
+                    "target": "pool1nst3caf5zezje54tfxntcdmm487ecvuhq8lcvtahgyzl75pzeym"
                 },
                 {
                     "status": "not_delegating",
                     "changes_at": {
-                        "epoch_start_time": "1874-10-28T04:36:09.845612491798Z",
-                        "epoch_number": 8993
+                        "epoch_start_time": "1900-08-25T16:54:32Z",
+                        "epoch_number": 17653
                     }
                 }
             ],
             "active": {
-                "status": "not_delegating"
+                "status": "delegating",
+                "target": "pool18fhggy2t5du3d0csfjpyh3q36nhsllsfhag9lm7jhxez2fszykh"
+            }
+        },
+        {
+            "next": [
+                {
+                    "status": "delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1893-05-18T08:00:00Z",
+                        "epoch_number": 21023
+                    },
+                    "target": "pool1v5vh4gwzsmjjza3vuvtufayypdr5rwqj2e6hamqj8f2nqlldgrv"
+                }
+            ],
+            "active": {
+                "status": "delegating",
+                "target": "pool19gn2nwum8k4lrk7dfwfmfuxru56s5905vy3xta77r4gpj8dvwsz"
+            }
+        },
+        {
+            "next": [
+                {
+                    "status": "not_delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1882-10-27T08:14:56.410534830908Z",
+                        "epoch_number": 7966
+                    }
+                },
+                {
+                    "status": "not_delegating",
+                    "changes_at": {
+                        "epoch_start_time": "1888-12-18T21:06:43.613917235758Z",
+                        "epoch_number": 31465
+                    }
+                }
+            ],
+            "active": {
+                "status": "delegating",
+                "target": "pool18ah8l0uyyc68d7nfvkvdq6dmnhpqszrds4qr89ts2rmek6kdvka"
             }
         }
     ]

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWalletDelegationNext.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWalletDelegationNext.json
@@ -1,79 +1,79 @@
 {
-    "seed": 3969922181708943283,
+    "seed": -5349663217883876508,
     "samples": [
         {
-            "status": "not_delegating",
+            "status": "delegating",
             "changes_at": {
-                "epoch_start_time": "1864-09-20T05:39:32.742761052618Z",
-                "epoch_number": 16316
-            }
+                "epoch_start_time": "1866-08-21T11:00:00Z",
+                "epoch_number": 15877
+            },
+            "target": "pool1wpkgclx8zwfyc7fztxjv3yz5u6cjumfxsw5a3gwpd5pp52fmy5v"
         },
         {
             "status": "delegating",
             "changes_at": {
-                "epoch_start_time": "1868-06-09T07:27:39.518222959527Z",
-                "epoch_number": 13471
+                "epoch_start_time": "1888-12-11T10:55:18Z",
+                "epoch_number": 10396
             },
-            "target": "644889c9ec9b0778ae4eea67602da50fb85b32f329e83b9e780737052c46acb5"
+            "target": "pool1qtms2dw8x8csvgehr6xekduf6g2yhuaeme904vs5shvwjqkgmdl"
         },
         {
             "status": "delegating",
             "changes_at": {
-                "epoch_start_time": "1902-08-28T00:55:36.479473125021Z",
-                "epoch_number": 20378
+                "epoch_start_time": "1887-08-08T13:16:08Z",
+                "epoch_number": 12849
             },
-            "target": "e4c5fa8beed6f6d59acbd6fe3bca1a3893abf93aaf1173a1bd35a37233b1073c"
-        },
-        {
-            "status": "delegating",
-            "changes_at": {
-                "epoch_start_time": "1859-05-05T22:00:00Z",
-                "epoch_number": 5287
-            },
-            "target": "c2071701595625b9caad46258e61112f70c1cb163091509ac85875883b04c3fd"
+            "target": "pool1wqaz0q0zhtxlgn0ewssevn2mrtm30fgh2g7hr7z9rj5856457mm"
         },
         {
             "status": "not_delegating",
             "changes_at": {
-                "epoch_start_time": "1879-04-18T12:00:00Z",
-                "epoch_number": 30795
-            }
-        },
-        {
-            "status": "delegating",
-            "changes_at": {
-                "epoch_start_time": "1878-04-17T01:00:00Z",
-                "epoch_number": 24667
-            },
-            "target": "479d81b018b5174f7ce1d056fcb1d41d01a29d8ef4afb870db08b249a1efce0d"
-        },
-        {
-            "status": "delegating",
-            "changes_at": {
-                "epoch_start_time": "1891-11-08T00:20:53.924228088206Z",
-                "epoch_number": 24517
-            },
-            "target": "393e206e4ea692aa29b898c271f79e3f51f7224c0750f763c1981ba5dd369be3"
-        },
-        {
-            "status": "not_delegating",
-            "changes_at": {
-                "epoch_start_time": "1901-04-30T22:01:21.982281084823Z",
-                "epoch_number": 22528
+                "epoch_start_time": "1860-05-03T02:57:14Z",
+                "epoch_number": 3274
             }
         },
         {
             "status": "not_delegating",
             "changes_at": {
-                "epoch_start_time": "1888-08-17T15:00:00Z",
-                "epoch_number": 1683
+                "epoch_start_time": "1867-01-02T07:33:12.733983299813Z",
+                "epoch_number": 19390
             }
         },
         {
             "status": "not_delegating",
             "changes_at": {
-                "epoch_start_time": "1871-08-05T16:20:58Z",
-                "epoch_number": 12531
+                "epoch_start_time": "1891-11-03T15:35:36Z",
+                "epoch_number": 27307
+            }
+        },
+        {
+            "status": "not_delegating",
+            "changes_at": {
+                "epoch_start_time": "1885-04-04T16:23:28.746264238538Z",
+                "epoch_number": 1951
+            }
+        },
+        {
+            "status": "delegating",
+            "changes_at": {
+                "epoch_start_time": "1897-09-21T09:29:29.492761265875Z",
+                "epoch_number": 16888
+            },
+            "target": "pool1kmy09pwn6e9uac2zqp3763g0ercywnddzy5ehqk5yqmrqzvz3yc"
+        },
+        {
+            "status": "delegating",
+            "changes_at": {
+                "epoch_start_time": "1883-04-03T05:00:00Z",
+                "epoch_number": 7643
+            },
+            "target": "pool1y8vdjtuq8k5aa8vre9h2qfg5yv5ng4yqt0pwg6xg5n6kyrs03s4"
+        },
+        {
+            "status": "not_delegating",
+            "changes_at": {
+                "epoch_start_time": "1893-05-28T23:17:12Z",
+                "epoch_number": 6907
             }
         }
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -159,7 +159,7 @@ instance Malformed (PathParam ApiPoolId) where
         , (T.replicate 65 "1", msg)
         ]
       where
-        msg = "Invalid stake pool id: expecting a hex-encoded value that is 28 or 32 bytes in length."
+        msg = "Invalid stake pool id: expecting a Bech32 encoded value with human readable part of 'pool'."
 
 instance Wellformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
     wellformed = PathParam

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -489,15 +489,17 @@ spec = do
             |] `shouldBe` (Left @String @(AddressAmount (ApiT Address, Proxy ('Testnet 0))) msg)
 
         it "ApiT PoolId" $ do
-            let msg = "Error in $: Invalid stake pool id: expecting a \
-                      \hex-encoded value that is 28 or 32 bytes in length."
+            let msg =
+                    "Error in $: Invalid stake pool id: expecting a Bech32 \
+                    \encoded value with human readable part of 'pool'."
             Aeson.parseEither parseJSON [aesonQQ|
                 "invalid-id"
             |] `shouldBe` (Left @String @(ApiT PoolId) msg)
 
         it "ApiT PoolId" $ do
-            let msg = "Error in $: Invalid stake pool id: expecting a \
-                      \hex-encoded value that is 28 or 32 bytes in length."
+            let msg =
+                    "Error in $: Invalid stake pool id: expecting a Bech32 \
+                    \encoded value with human readable part of 'pool'."
             Aeson.parseEither parseJSON [aesonQQ|
                 "4c43d68b21921034519c36d2475f5adba989bb4465ec"
             |] `shouldBe` (Left @String @(ApiT PoolId) msg)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -86,6 +86,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , balance
     , computeUtxoStatistics
+    , decodePoolIdBech32
+    , encodePoolIdBech32
     , excluding
     , isAfterRange
     , isBeforeRange
@@ -227,6 +229,10 @@ spec = do
             forM_ testAccountIdTexts $ \text ->
                 toText <$> fromText @(Hash "Account") text
                     `shouldBe` Right text
+
+        it "Can roundtrip {decode,encode}PoolIdBech32" $
+            withMaxSuccess 1000 $ property $ \(pid :: PoolId) ->
+                decodePoolIdBech32 (encodePoolIdBech32 pid) === Right pid
 
     describe "Buildable" $ do
         it "WalletId" $ do

--- a/lib/jormungandr/test/data/Cardano-jormungandr/Wallet/Api/ApiStakePool.json
+++ b/lib/jormungandr/test/data/Cardano-jormungandr/Wallet/Api/ApiStakePool.json
@@ -1,309 +1,309 @@
 {
-    "seed": -5072594604095361809,
+    "seed": -6442816877677033508,
     "samples": [
         {
-            "saturation": 0.7724797283930844,
+            "saturation": 0.5945102308016017,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 511562896898,
+                    "quantity": 873591892730,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 9785888,
+                    "quantity": 10061159,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 56,
+                "quantity": 109,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 61.49,
+                "quantity": 19.64,
                 "unit": "percent"
             },
-            "apparent_performance": 1.8187137861237368,
+            "apparent_performance": 0.2723316381304197,
             "metadata": {
-                "homepage": "|\u001c\u0003󉳌s𗍵𛬸!D򰄾~#\u0011\u0013򭢔𿺼\u001c\u0006\u0001񤧓򓾪𿉓U\u0018񂾺+iSZ\u0019;]RjJt񥖈/ZwG𚪩񯁅+PiqkNw;S5\r򜳖S񈼁|e򼬤򱂈+",
-                "owner": "ed25519_pk1gv7ut3y70urr3fykmtsxns32ntypeaqk5zpqlpe49fyy307pp8mqc37fk7",
-                "name": "\u001cf흖W򧘘2󍲆\\\u000e",
-                "ticker": "n󯕄𾮣80",
-                "pledge_address": "\u000e򿺂q𪎉\u001f{!K\u0012\u001a􂫫񾾚AV𦃏!\u00075e\nI\n\u0003^~",
-                "description": "<1𷛻X󡎹)\u0014\u000fX.\u000eQU\t0\u000c-FX𼥂B{+\u001buD􃃋}񻭮\u0017#c\u0011񿺴ZU񂫄򋺷l󠓞𰏝|񴱎\u0019\u001b񈫈󄅽c𑵴𼒣񐂑u\r,T)񯥩Sl𫴢;D5\u001bi󟨓3󾝗󳅼a+I𹩋(񇫆n\u0012󟂥+1\t?i\u0005R]v2fV񥷲\u000c.󡶍\u001dU󈮏\u0012𖿶8J&r􊮬𾌣鵿\u0019򌂀񛑽v5􃵚\u0019𨤾\u001cEc9)񵙯hgnC|E\u000c𦚈+I񇊠󦷒\n\u0006DV\u0017vc󀷻#\u0010nP6򡴥|,J\"`PW$Gy\u000b)\u0000\tBu^Q󑭾Zr\u0001񰡋G\r1$񟉉o딍􌙡򍸳T\\5󡫵򹡲r\u001b𿮾i\u000bT𲱓\u001bfK򙜁z\\pX7񣱡O\u0019g\u0019\u0006iw~󡋴9\u001a𻙠󡴹+\rx񐓺򧸴c5L }M!梯o/󝌳x6eO󝂦򀪯򛑤)\u0010&U[򁎱 🵠f񉄰\u001a\u0001"
+                "homepage": "a",
+                "owner": "ed25519_pk188248w6jxp4xr4m7dyjct5zv7ph8jph3qr6wcpxssq7c3jyp6jfscgwhqt",
+                "name": "8\u0015\u0010*x񔏱 ?\u001d򲘋&/򢘣Tb\u001c`􃰨n𲰠SR&\u000e\u000b[H5\u0019,\u0012𪃟,n'\u0014󍴢$𞽍A򽧹q򯣈\u001dz",
+                "ticker": "M󓶉󶛠>",
+                "pledge_address": "d X𸦅\u001f󺱥񔊪sr񍎏󻌰&\u001au9򡭴mA𫀫񆽬\u000c/򻠅?Sh򮈝\u001c𩛣8轚k󟬊CXY*@^(\n\u0010\u0016񻰃\u0002,,q:S",
+                "description": "Id\u001f9\\&yWp{󋽢^9\u000fH񩫅\u001c3򓷹+9\u0000\u0004󦵭󲉎􌼤𕹵HgP&#2񥔗𒉌^㙹\u0005򼷙XrYR􂠳g\u0015򌃵r\u0019@Z\u0019];񧿭4\u000bs=\u0000P\u0006$󶂆󈻃 \u0001𣡮L\r\u0015k񟈷g\u000e\u0012𵴎8\u00196*\u0019=󅔩d2񷞨񤏘@atrA𩽸􅼳\u0014%\u000786󰃧A!ᔴ𪪧품\u001f)E\u0011\u001c󺨪򅕑\nuK񮶸R\u0018:dV\u0018cg5/"
             },
-            "id": "cca7cdcbec80aa69ff4494501d45474c8654784c0cf3ead0c8dcab84cd36902e",
-            "desirability": 38.14660395154822
+            "id": "pool1lfqqfdzft256dw3eynk3cxmjhe3smt2x8hkdjhu83x6nhk3zlnkqmvfk05",
+            "desirability": 88.65446916420618
         },
         {
-            "saturation": 0.9302655380240705,
+            "saturation": 4.168636272979809e-3,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 63415384930,
+                    "quantity": 533502328707,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 10235498,
+                    "quantity": 8324365,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 110,
+                "quantity": 178,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 80.6,
+                "quantity": 95.81,
                 "unit": "percent"
             },
-            "apparent_performance": 1.9389702100188426,
+            "apparent_performance": 4.028025457164527,
             "metadata": {
-                "homepage": "W􌓧񳘲\u001c}\u001c*񺴿:}:;N\u000e󕬶\np񧌢W",
-                "owner": "ed25519_pk1u49qdxl6keesl5l6ulmlqt6ufs2m69al7mtyjfads63cd4x8s52slmaut4",
-                "name": "𑿻\u001e$󘾙\u0013a[5\u0002\u0008\\uF򧄓􇻡M񍰢U+b\u001f>a+\u0004\\aQ",
-                "ticker": "󹨅}񋵂󀻵",
-                "pledge_address": "򄯶󂀌񷶯󅇁-.*𷺃\u00065'3𽟵[C𞿗JKQy$\u0005􂖚򞰮\u0000q\u00026)>3n}N:\"Gg󂽕 i󜎀򚎴񼴌󆺀\u0013",
-                "description": "\u0012}1\u0007,M1{R񵽆򺾨򂬞􋜼+\u0011\u0018j\u0002|0|\u001a=Z\u000e󊀀tEr\n筭󿊁c\tk4\u0003c_\rb\u0003J𕹯Ywm\"2f|2A8񐛣򴮈\u001d󪯡E\u0012𐜫*󽂼\u0003?OrYA \u001e!~\u000f󙟄#󡹸h񐫅\u00146򞪝$L뎑􂘨0)񷶒\u0003󑖁3f^󔆜0 \u001e-񧿣\u0015~T\nQ󩝶=񄪡\u0008\u0000O\thP7\u0011K6&^ꀈ򰐶𒾟PXB\u00165𨯎x!\tbAM򄼔A󗜀W󪲐/}󝮋󺞖򢥰'$2B9񞳚\u000c\u0011"
+                "homepage": "\u0001\u0017󼡚}\u0004񲰡t\u0003󾺏1.\u001a󙅔@}\u0002򋴔KdYh􀽰/\u001c񘖰\\𪝬2򛳂񁕻/*!R\u001aL󤹏\u0015\u0015_m򛡈򷕹4\u0016\u0014\u0005mhg򺛯1WRK򥙳0i\u0013𞚖( !!󭛩8񣳶\u0013󸦧񄇥R&H\u0002k񀛸;󜆎򃮙\u0018",
+                "owner": "ed25519_pk1rxfatz7lsutpz7em37nq9frduczt34z2j4zhwehmawplhxrsv6lsjnx2dr",
+                "name": ":򼜨\u00017񅢏PU\u001cRv:󼟎O@򻮎l",
+                "ticker": "Ahf",
+                "pledge_address": "gkB\u0005㵼y\u0003𩋳\u0004Q\u0001~\n\u000ek򏷢4yL(),􃑇i𖱝񒦪A*'I~\u0010\u0018􍂭a񟼆󥅳\u000b\u0008M",
+                "description": "2\u000eJ\u001d𯴐K3:\u0003r\u0018򘊅D"
             },
-            "id": "a3bb6b56c8620378fa42d26056846f92a02266a1945168b27b78d4634171897d",
-            "desirability": 82.53814324387344
+            "id": "pool1lv3nk6svtzf4rv7dstm9asxlamqn42ssz76lap64mdruved5kx4qcrpjs7",
+            "desirability": 53.91127531088774
         },
         {
-            "saturation": 0.14534161451124894,
+            "saturation": 0.8365058136991201,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 985984534323,
+                    "quantity": 816868373616,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 14050042,
+                    "quantity": 4439831,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 145,
+                "quantity": 52,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 1.66,
+                "quantity": 15.27,
                 "unit": "percent"
             },
-            "apparent_performance": 2.1924896868707866,
+            "apparent_performance": 4.015179132195346,
             "metadata": {
-                "homepage": "}\u001d3𤔆󲞑dWx 5WN񌠵󒣐B\u0002iokQU龒򂽍G|q򉦇#^\t t;\u001f񦇨h6󿫽C:g𱋣",
-                "owner": "ed25519_pk1dx2ujrvl7syffha0csmxeh5zd0ueqwl5mh405jq6t58wz2hmumlsvgamuf",
-                "name": ";ty񰻓\u000eS񸡁u?\u001eC񘂇,-󮯒?򽪇",
-                "ticker": "e𬬍5",
-                "pledge_address": ">򩦍󿀏\u0010.",
-                "description": "󫚺󖱫i<\u000e,n\u0000󞰱\u0001𞺞T񯄦$OCa]R\u0014󒅲\u0008fx􉶕\u001bt)\u0015hY󥈄\u0018\u0004B\u0015?\t\u000e\u0007\u0000񽆓6xC"
+                "homepage": "񥋃\u0011\"󗜐򊜹󖾩񶜀P򞺟z'4P 4򪛢󟖬(de󛦈,n񚈽𘭦􄺯\u000e\u0012H񫙏󭴺.5򅹎󌜼r2^򃾯",
+                "owner": "ed25519_pk1har3ns805vrggzgaygksd2l6p3ypujstfxnr7fjjgm3rt4rm27jqkxp0gc",
+                "name": "񝙰(󗮗T'w^W:$\u0018uSv񕟱e\u0017􈄹Z\r\u0000 /k",
+                "ticker": "O^;2",
+                "pledge_address": "nj\t1$𺰗󊬽2Z񝶯\u001cmB&\u000e6򟓥񿇂YRk􋾝8=A󌾌-n~𻇦\u0001",
+                "description": "X򏠍e䌱𛶾񥺩򖹨󃷂qLL\u001cW\u00073𬈧(P5&S󤕲\u0011z򸋸򷩠jSGV񂌨o\t􋼄H񿅍:>N9[􁊦񪸕\u0005󩤒TSa\u0007gZm\u000e\rHq+\u0013c򻜩0\u001d#򀚮􈾢"
             },
-            "id": "8eefa9ec540186248b64cd467715ae166cc512faa1504a3faeb1836f72ec0baa",
-            "desirability": 45.52094337214425
+            "id": "pool1k6g58t4h0vkyu7jf8ge2880hhguzz5jrcq3wfm202f5j9wvrxefsg6xa5n",
+            "desirability": 5.4002194699336865
         },
         {
-            "saturation": 1.6383418614731213,
+            "saturation": 1.4844140892801205,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 118159885576,
+                    "quantity": 210827800903,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 12189626,
+                    "quantity": 10567867,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 26,
+                "quantity": 134,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 91.51,
+                "quantity": 81.64,
                 "unit": "percent"
             },
-            "apparent_performance": 4.2358670389951545,
+            "apparent_performance": 1.8999049096984626,
             "metadata": {
-                "homepage": "\u0006>A񘊭\u0011񻝕C`dC)3񡅄􅁞󗊲󻟲󉖄hD0𛹳7\u001b\u001b󲃾*$󰻙񮵉@~񽗨򽡉M\u00046$\u0004\u0010\u0014(I\u0002\u0014c\u0004C\u0008\u0002J𢯏>𒳽\".򫂬󛯖􆔮蘜򬶻􏯳\"\"g쀕𐯽",
-                "owner": "ed25519_pk142r5g9jl6ps9ke2dth3t25xm0pjpuj802crzl326zt0v0l8vpgjq2djlgg",
-                "name": "񁔘󅖽򕖖?`@3L1=18\u0012y\u0004󚏥<򉫇\u0006o*y@2}Z𹌯:.W\u0007}LIG'rLP56:m\u000e",
-                "ticker": "*X𻛤\u0003I",
-                "pledge_address": "򍇂\u0008Mb?z\u0003\u001b\u001d=xf𰺷1x5󨡩􈹱",
-                "description": "5󡋾\u0014:\u0013pᤊ\u0019Z򔃇󬉘K󈩦\u0010$$xVnq(\u001du7#k򺓃p'a/\u001e6񖒕2~󤙢񽒐򺴟𖷶񜇲\u001e񿺐\u0012\u0014^\u0015j\u0008?L񷨯{\tW1j{@;\t򥃉*𰰘(ypFc\u0011ady0\u000e\u0003!~=)O򈜥}\r֎NSN󾽑0󔆈𓉵H􅇕\u0000Z&QQV(l/f\u000b7[𖻣\u0005\u000bjz\u0013񣤽v\u001d\u0007T+2^yYo󞹝H\u0016v\u0017Rr򃢆=񜕐𧺼5􅤍Y󇍧@&񊸥GGrr[\rUpX5#1K\u0005f\u0013񼗃4󥏥򬔊rl򾃣|g𿇹\u0017\u0012\u0000\u0015[:B,𵨻\u000b\u00163EEz򄍬\u0008F]\u001aov񏁐b򙹜񏬶񕯿\u000f\u0008k𦞥򔆟󭿨d7􍅥\u001d(b\u000e"
+                "homepage": "s\rv󁣤]񻄘\u0013\u0015\u0007r򏛟9ay񊚰gD<$K󈈄<]𢴳M",
+                "owner": "ed25519_pk1ppu62yv237e0aqw8cnmy2dtrhrt0zxe9r8jwk57xzvgzvqnucztsk8malh",
+                "name": "r\u001a󰔷J\u0019.\u0011JR)pO\u0014핀_nH^\r+\u001a,u򏃰񺝋\u0002󑿸V\u0002P󧝴B)8\u001e)򑈩",
+                "ticker": "N\u0011(\u0010c",
+                "pledge_address": "\u000c򾃝៩񿅧6u􃘁,pbF\u0017,&񦰤\u0007Ti\u000ft\u000c􊫓􁘠(򂯉7iQ59KqiWZ~򨺱񟳮UM𸥎k",
+                "description": "m\u000b񇽣\u0017U񦨪5񇩣z?\u0017𼜯v~d\u0007N񴧮^\u00145X\u001a\u0001􅭭n,𰦌򄐶􎐞dc']\u001f{,\u000fe%_\r\u0008𺁝\u000bRn򣑕\u001d\u0018-O򥽢?󉘓gS#FlP[%]󯭁􊉉}7􏥡T=U񞾴𴐺$\u0008\u0002򫾦󧞗/\u001f7,𙜽tb\u001f\u0010򗜐\u0002\u0013󔎇\u0017󺧾𮉁F򌊾3󗐓|\u0000D𭆸4󹍊󆉳󎈪=}𖚓깜󗜅\"=񙄞z\u0014Y􉭺𤺘\u001czT@𸘱𲄻o𕮵*+@>\u001f#,\u0015!\u0016em󃌏1dryrY󿃖󫾲X*T^\u0008y񅕲c S\u0006k/bn\u0013񞭝u𷰕J򪩻 \t\""
             },
-            "id": "5297f24bcafebbb40c4b7087be414548654918f2373305d2d169344b2a18750b",
-            "desirability": 20.877044184351547
+            "id": "pool1f9etle69k6asqhw6mq5kxskmjvxf04g6ck5tqvjy940rknkap2qq30n377",
+            "desirability": 48.766060708901335
         },
         {
-            "saturation": 1.8348622415027995,
+            "saturation": 0.7463659307249022,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 811381995279,
+                    "quantity": 955004593357,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 15546967,
+                    "quantity": 20926118,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 129,
+                "quantity": 65,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 80.56,
+                "quantity": 9.0e-2,
                 "unit": "percent"
             },
-            "apparent_performance": 1.0208921995543974,
+            "apparent_performance": 0.9597646537286897,
             "metadata": {
-                "homepage": "\u000e5s𜈑9H",
-                "owner": "ed25519_pk1vk832dj7v74ryz5fygu033v09z5zwkls836lrtvrfdjtk4ec0eaquqgfnh",
-                "name": "kW󜫨\",95\u0003M9𩯝\u0006n5xcfFA\u0017*mV󉾯򿾺J",
-                "ticker": "񄅵X\u0012$",
-                "pledge_address": "1\u000b",
-                "description": ">񤿯\u0014\u001fvZ R񎼛X𿻦@Ha󛂃B\u0006:񫙆􅘏\u001d?lCP=\n/󣏵󩋭M\u0012񂅀\u001d񯢊RN%L9n\u0017 a򀰑=OE:=[q6 ᑛ*\u000e,l󽩭𑦯{Nxv#-N\u001b+|\"X\u0008E/L\u0001򵈧b}󺂸񏾰A6𘳧\u0004􉂓Q7򫦢x4`B ?􅒜󤏼񹍃u1q\u0015k\u0011nN񀤭F󃊟𝐊[q<\u000cR\u00182jy/lt򍎹\u001d\u001fvpC!\u0019o\u0005(h􂕪R.pw𽷆\t%󇡀7T\u0019\u000c4+󈫥󍐋Q󮄲"
+                "homepage": "o<e6l~J\u001em󌻒둑\t󀄺\u0002-9𶌞~󁥊:\r󲿝ia@󖒭\n񴷚7[𗶧sy/F𿸏H􍙞r󗠅",
+                "owner": "ed25519_pk1rj0dh73t44pwpf2t0ahl78g0r4n4lfgs9442nlq3wjc4ams9g2ssf7v598",
+                "name": "$󯛦xT\u0015Z_zK$\u001f`E=񑱎-).󘦐aR񹢏󥸞\u0004'",
+                "ticker": "򰈁G񭍙򺁄J",
+                "pledge_address": "򆴺󵣷m}\u0004#򪚈o#\u0018A\u0001@5)\u001e񣶱9C񶒋\\1JpE􁙩Z󸇢4G񡫋򅦫!\\𶭓=\u0010t\u0011+",
+                "description": "9\u000cB\u001f\u0008񉙄T\u000fH.\u0008R3x0j񑿮r\u0014~񰶣-\u0011>%Fs\u000e𔒯\u0003*F񦃻3󼘯p􆇻iAk8\u001f:Y\u000642V7jf𒇀\u0015wjq򐤅HU\u0010Yw&󕼫j\u00024򢝜D[7󌓉iρh򯧁?\u000fxpo9\u0018\u0007񿠻\u0004홚pn&K^򱬟\u000e񳌎K󐛾񄧼F\\􈀸򓟙f1\u00088CE]rK%𨝯\u0005󅚜N\u001e񮐾\u000c\u001f\u001cz\u001c\u00160񉈣麝򁢑򽐭N\u001f\u0004y\u001f\u0019򸜇p򼠖^;"
             },
-            "id": "f9f158b2f00b28efc219030dd9b1c28445d65e17b71ca4bca4df39b7c7de42ca",
-            "desirability": 98.94931204740077
+            "id": "pool13wuh2uazjez2v7va2xf0lmff2p9en4cs8epvp3p2eqt3yqag3hvsx5yzcw",
+            "desirability": 16.4801250502125
         },
         {
-            "saturation": 0.4621603870305182,
+            "saturation": 0.9961248283489643,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 577379520103,
+                    "quantity": 928975840730,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 16645001,
+                    "quantity": 1313554,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 221,
+                "quantity": 86,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 55.28,
+                "quantity": 6.39,
                 "unit": "percent"
             },
-            "apparent_performance": 3.510284498914203,
-            "id": "c555faa7988239e93b52aba57b1451469b1de10d84afc624f7c6675ec76223f3",
-            "desirability": 23.186953161363398
+            "apparent_performance": 1.4124978306532192,
+            "id": "pool1n32pvwg0gsvupkr4ds8gxdcejdw7vt5he0gx05n6maju8u2hku0qdt7mze",
+            "desirability": 44.744274183369384
         },
         {
-            "saturation": 0.6941486242848474,
+            "saturation": 0.9367357147208755,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 715002824251,
+                    "quantity": 757249854461,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 4221754,
+                    "quantity": 4357335,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 55,
+                "quantity": 138,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 30.99,
+                "quantity": 85.34,
                 "unit": "percent"
             },
-            "apparent_performance": 4.543440492601911,
+            "apparent_performance": 1.6715659593587184,
             "metadata": {
-                "homepage": "󰞹򊎃gY\u0005񔊞\u001eFPi񜵸A\u0007^\rar)񢜫񟉛\u0000_7󡬋󎾈-𷉝~q󺑓5\u000e6\u0000i+\u0017Q\u00069g,WE𒶎\u000f 󑒛v񅄯!^&{􎑯,\u0010()򹟇\u00159󡟆P-\u000c\u0012 O,\"{\u0005\u0013󙶙HG/I(𼙯m",
-                "owner": "ed25519_pk1p2x442652t4g6v9djfux7528nhu5xxknq8evdqsfuktuakk0tnwqq0lwhf",
-                "name": "r`9\u001c\u0007}Z񝊖 \u000b󴽸􌋠+\u001e\\񇁚^k[\u0014RR󣧫\u001f\u000c1<x",
-                "ticker": "󞷏CC򯆸",
-                "pledge_address": "\\𝅕\u001fb44\u0008񥵈-񱇞.a\u0000񠫿򀞓l󑭝/h󔣁򞞞񑍹\u0008,&\u0001l",
-                "description": "/\u0004􋋑񩷅EC<$񅡷uL\u001c\u0018򅝛􃞽򊠝\\R9򯰧%\u0003\u0004S񦿷\u0019\rE\u000b\u001c`\u001fFJ4Wa󂲴\u0017񖲐\u0007\u00181c𠶛:󯤫3\u0014鍒\u0014\u000bZ\u001f.󱅷\u001f􅘧 𬜵R\u0011:n\r񔔍t񸥝򈯌񺍄􏨣9y󢪔og\u001aXh9QuQ?񜋝!E\u001bj|򯌯\u0015.K򏈙񢐊\"3hk\u0016\u00024?i\u0000?tb񔎪9]d\u0018𱃶\u0012@􁸄򋑶[򚯚LQBtZ񾤈𛆠5\u000b\u001a$GP19NN񶥒\u0011I󅉗󉼶󦦵D\u00195gp򐳽򀲻Ty8\u000ff7\u001eON\\\u001bI򷡊X*򆄌𬱲u򚴎򿵿\u000c𩗞󂝡\u0002c(k*󩟫\u0006bvp\u0010m.G;#󆦩\u0003{\u0013\u0004l3GX_U􌗦7\r򇲛񪎲K~^xj"
+                "homepage": "TP\u000f󙇍񯍢|囵󋲆򷋟7/􈐎x񁫥󽋓$@\u0012򔗽w󍱩󥖨W\u000e",
+                "owner": "ed25519_pk1dc2s74ynsmxfl0he2l9w2eju0n939a99gpdefld4e59fgsffcmvske9vrx",
+                "name": "򍅢G𔃐\u001ez?&\u0005\u0005",
+                "ticker": "N8\u001f",
+                "pledge_address": "W񇺵Nf_\"򼘻I^\u000c\"[^\u0004\u0013}𪜻Z",
+                "description": "q\u0015f,򥺆𚲎<Kl%\n򢃫0𺒑򷔰=\n\u001d󿹤񳰃[&:`@\u0002\u0012󃋚\u001f𠑄𵚕񣻥is\u0007~\u0001\u0017󌗞zO:a𦭃񧮙𳯪n\u001d\u0004f1􍮚\u0011*r/\u0003 𻓬󄭤񒴙\u001et\tY\u001f򽿅\u0004KuFK\u000c󺴫򺿺"
             },
-            "id": "80c87e2027b696edb36631f8371888457d33f054ffa8da32698e99b1b81afca0",
-            "desirability": 72.88809936943264
+            "id": "pool1m2zlhka88fu4p7qls5qppze4msz6ftcn2u2jztmkm4ge2sqmjwgqflqarz",
+            "desirability": 56.134078144250346
         },
         {
-            "saturation": 0.7733548315467782,
+            "saturation": 0.4379434538263409,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 724035316569,
+                    "quantity": 446684159974,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 13823565,
+                    "quantity": 2407342,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 4,
+                "quantity": 144,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 16.97,
+                "quantity": 29.61,
                 "unit": "percent"
             },
-            "apparent_performance": 4.357193890888842,
+            "apparent_performance": 3.3118963806696513,
             "metadata": {
-                "homepage": "SUqn_p\u0014v-𫆷1򊹇Ur\u0010lL򝼦L򋟧:cډ@D\u000f2rR2:炬+򔰨A\u0012󌟀񒔠kk\u001b,1𚞲wW򬠠\u0011\u0015d\u0019rk񽇑\u0006\u0007\u0003觝t[򪐤7񿀟!p7F񳔐\u001f#&򅿺\u0010𪦹n󬙢\u0006񬩸0\u0011򋶈\u0017lg󭈊gX􋉋,xkz5n5",
-                "owner": "ed25519_pk1zt256k57wpr08a4hsdsnr9jnas40v3wrhdjakqhsgg20hz5jldzqhrc49p",
-                "name": "-\ti/󐗇񝰮",
-                "ticker": "򛻩.J",
-                "pledge_address": "Rl4\\\u0017X\u000e\u001c%'1\u0008\u0008KS񮚚>񏦀/𬊒?\u0014V򨄍S򅁩\u0007\u000cx\u0015^󤦭*Y7󡍖\u0007S󴃼sy*v󒴎QQ48",
-                "description": "0d0)󈈭fF򃩢񊝬F[t1c\u0012C򜶵K8󬯲D𔑳񱪏8f\u001a!\u0000,󓦘󗰆L(6h8a@d󌶱\u001dA"
+                "homepage": "򒐛Y(l\u0013\u0016}򈋄󕍪s𥽛V򇄟dpV򫗼Z󙌓0Nw\u0015",
+                "owner": "ed25519_pk1wfacdtcycsy3u3haqqse4y5pdtuaq2p2cxq03m2hzrhc8c840wmqsv593n",
+                "name": "{d\u000f,򐫟/HB&򟭕8(𒱕Yq󉲿\ne𑈾\r\u0010򆶚FC𙘳/62\u0015[i\u0006$\u0013,\u0000\u000bd󤌔",
+                "ticker": "򊣲𬍚񤰻񦏦",
+                "pledge_address": "񘴗򟫍Ia􋦁eu\\󈕘|\"",
+                "description": "񰗳2\u0011*`󚀵8b\u0001a}?\u001f񗚙\u0006/𖅄󒗶\u0001L󸴴󒾕nF[;`K𘎊𓷺\u001b\u0001!Dz.A񨽾\u0000񵥷b񓲓[3L\"A𤑎:1󨷓!\r\u0013\tc4􈠁{|B{\u001d\u00114rPq4\u0018/\u0008`L\rs4\u0015LL7􄐐w\u0017fp\"\u0015;\u001bJPOq/󳭑\u0010ᅍK(8򃂰#^57=-\u001d-kk>畱z\u000e򟭇󻒥[s󼻸9񘐊\u001a^9𿈲wugxhy?:j; \u001f]\u0002D4\u001b𞽵E%񟧭5\u0018=@wM\u0002F𓦗򩖧16O\"X+񝫼M\u0019C_g.(E\u000f򴺢񓥉]N\u001e􁰦-)?,򋪳c3\u0019\u0000W󹈀$\u0000񼱂\tm8\u00005KᲝ񻇘7I\u00081\tO󳝰l}\u0017v{bUn󥋋u_68^𠒡*]F\u000c{((D񶽒񦆷򔶚(m~LrEE\u001b=\u000b򼍿򄓐\u0016;p"
             },
-            "id": "1c0afc4f851c347e5a448ce627306254778ec7f5595e9a04a5b963cf23ff37e8",
-            "desirability": 50.219284629108984
+            "id": "pool16wvw8a3j0gu74s67lmjl0hc2kda64553yv0tpkmauu5f76gvc4sqcfglez",
+            "desirability": 13.837089110627865
         },
         {
-            "saturation": 0.3330227673008932,
+            "saturation": 1.734576941721959,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 313659814531,
+                    "quantity": 601799049584,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 9657330,
+                    "quantity": 15093089,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 5,
+                "quantity": 158,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 96.8,
+                "quantity": 43.15,
                 "unit": "percent"
             },
-            "apparent_performance": 2.228449174403779,
-            "id": "0e991c64178c78f2c5cae4f0587854f27971aa5d0ea1a07d8a4689603571d711",
-            "desirability": 12.251272400551272
+            "apparent_performance": 0.9527405943150052,
+            "id": "pool1q0celet9wpsrmw7lxdaqgchyfzws9nnru3p9luvpucha9uejgglsr8h44m",
+            "desirability": 16.07205611776461
         },
         {
-            "saturation": 1.8471918739431505,
+            "saturation": 1.4640888784744726,
             "metrics": {
                 "controlled_stake": {
-                    "quantity": 239922781656,
+                    "quantity": 692614196471,
                     "unit": "lovelace"
                 },
                 "produced_blocks": {
-                    "quantity": 13855738,
+                    "quantity": 16088002,
                     "unit": "block"
                 }
             },
             "cost": {
-                "quantity": 217,
+                "quantity": 194,
                 "unit": "lovelace"
             },
             "margin": {
-                "quantity": 10.48,
+                "quantity": 14.94,
                 "unit": "percent"
             },
-            "apparent_performance": 0.9899810574667411,
+            "apparent_performance": 0.13829873556500283,
             "metadata": {
-                "homepage": "W\u0005:󐱭`𶬦Mq*X\u0017Mn<*򉝙6m`R\u0007a~\u000c񃞰򷿱󤜉c蜈Qiu򙳒",
-                "owner": "ed25519_pk1xlxypjq90vemy2p4j9jgh758l3kpzardjunrrs2yj8vg5drjqjxsxln99c",
-                "name": "󈜘o!Cy\u0010B\u001f<t򚺘\u00118'Qg;,\u0017\u000cr\u001c\rl[\u0012W􂐈𿡜񍇈?󡫴H􏸌\u001boDT񘌟",
-                "ticker": "򳂰p\u0005",
-                "pledge_address": "J^󬯸񲽇J\u0017񛡍*\u001e\u0011󭩖&򑖙󷂧󴈶;\u001f",
-                "description": "󂠩\u0010 _\u0002mf`𜸎{1ts򆠦\r,󼔏\u001cK\u0007!J\u0013򐷤󪖗\u0012񑳺Z𪴍\u001b𵤬\u0014򌯴!\u000f0\u0016X[f𦽝埫g򌯜6\u0006\u0015Y񔇦}𹔛\u001f󥾎m9F񴎺eGLYWc󘼺𵼎\u0011\u001c//\u0011@志\u0007𙌎\u0013񨆆w򘆙U"
+                "homepage": "񖓃𜡈{B\u0011󔐖(\u001a򃀔𣳄鹰\u0013\u0002@񿗮\n򳁷𵷹𓣸e\u000cgOLpgy\u0012\u001cYT@e񎞎򕎏d󎁔򌛝󫺀G񸓛񖲒񹤂񷪶B򗍯񺔏񼎖Ch񦒚J\u0018􅌅z򅄑\\񩱶񚮥XCm?\u000eO\u000ef[?:tKh𧀙蓔&KWW",
+                "owner": "ed25519_pk1w7rh5tp9atkf7cneuan7efegagy65fk5n42aeg7a0h9wdnuc8vps8hjwvc",
+                "name": "^V𯅗R񶣀*qq(d!񎢩-\u0014]\u0000󧬼WST<|m\u001bXV",
+                "ticker": "u7x",
+                "pledge_address": "\\Xa\u0003򏜐`𞀠u|8)\u0019\u0007󻻤<􃳳0򥽩j\u001a 򰽑1&c\t\u0017_񢽁",
+                "description": "\u001f𨒠i!頦>\"yv4*𫛋9wC𿤳-\u0012󀾖􍘂8񃓒T'y\u001fZa\u00056\u0000w󞄶!;P|Drx𘳗A񛐏g!񴪿\u0005𨨻,c~$PA\u001d:\u001e򤨆\u0007󢸫\u0006"
             },
-            "id": "036d6640dd24feda80f36e4f34af9fd09e7e9ba5153f876d3cb64374f8a97f35",
-            "desirability": 95.15731417084966
+            "id": "pool1ucp5x6m5z9lztj9smtdv0zw844cjfdl0e7qkzunf9c4t7fugd0jq766lff",
+            "desirability": 23.518529354725082
         }
     ]
 }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -926,7 +926,9 @@ _encodeStakeAddress
 _encodeStakeAddress network (W.ChimericAccount acct) =
     Bech32.encodeLenient hrp (dataPartFromBytes bytes)
   where
-    hrp = [Bech32.humanReadablePart|stake_addr|]
+    hrp = case network of
+            SL.Testnet -> [Bech32.humanReadablePart|stake_test|]
+            SL.Mainnet -> [Bech32.humanReadablePart|stake|]
     bytes = BL.toStrict $ runPut $ do
         putWord8 $ (networkIdMask .&. toNetworkId network) .|. stakeAddressPrefix
         putByteString acct

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -927,8 +927,8 @@ _encodeStakeAddress network (W.ChimericAccount acct) =
     Bech32.encodeLenient hrp (dataPartFromBytes bytes)
   where
     hrp = case network of
-            SL.Testnet -> [Bech32.humanReadablePart|stake_test|]
-            SL.Mainnet -> [Bech32.humanReadablePart|stake|]
+        SL.Testnet -> [Bech32.humanReadablePart|stake_test|]
+        SL.Mainnet -> [Bech32.humanReadablePart|stake|]
     bytes = BL.toStrict $ runPut $ do
         putWord8 $ (networkIdMask .&. toNetworkId network) .|. stakeAddressPrefix
         putByteString acct

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -233,10 +233,8 @@ x-addressState: &addressState
 
 x-stakePoolId: &stakePoolId
   type: string
-  format: hex
-  minLength: 56
-  maxLength: 64
-  example: 42bf330e9653fef8a47a5aab2f2e74db8a5b947e
+  format: hex|bech32
+  example: pool1wqaz0q0zhtxlgn0ewssevn2mrtm30fgh2g7hr7z9rj5856457mm
   description: A unique identifier for the pool.
 
 x-walletAccountPubkey: &walletAccountPubkey

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -218,7 +218,7 @@ x-amount: &amount
 x-stakeAddress: &stakeAddress
   type: string
   format: bech32
-  example: stake_addr1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2x
+  example: stake1sjck9mdmfyhzvjhydcjllgj9vjvl522w0573ncustrrr2rg7h9azg4cyqd36yyd48t5ut72hgld0fg2x
 
 x-addressId: &addressId
   type: string


### PR DESCRIPTION
So I kept the legacy parsing for both json and the query params to not break API for existing users.