### PR TITLE
Fix stack build

### DIFF
--- a/cardano-1.19.x.yaml
+++ b/cardano-1.19.x.yaml
@@ -72,7 +72,7 @@ packages:
   commit: 2547ad1e80aeabca2899951601079408becbc92c
 
 - git: https://github.com/input-output-hk/cardano-ledger-specs
-  commit: 460ee17d22cacb3ac4d90536ebe90500a356a1c9
+  commit: 0715d2047b3d23e8b75b8430bddf391799c4669d
   subdirs:
   - byron/ledger/impl
   - byron/crypto

--- a/nix/.stack.nix/byron-spec-chain.nix
+++ b/nix/.stack.nix/byron-spec-chain.nix
@@ -64,8 +64,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/chain/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/byron-spec-ledger.nix
+++ b/nix/.stack.nix/byron-spec-ledger.nix
@@ -87,8 +87,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-test.nix
+++ b/nix/.stack.nix/cardano-crypto-test.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/crypto/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-wrapper.nix
+++ b/nix/.stack.nix/cardano-crypto-wrapper.nix
@@ -69,8 +69,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/crypto; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger-test.nix
+++ b/nix/.stack.nix/cardano-ledger-test.nix
@@ -66,8 +66,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/ledger/impl/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-ledger.nix
+++ b/nix/.stack.nix/cardano-ledger.nix
@@ -134,8 +134,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/byron/ledger/impl; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger-test.nix
+++ b/nix/.stack.nix/shelley-spec-ledger-test.nix
@@ -165,8 +165,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/shelley-spec-ledger-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-ledger.nix
+++ b/nix/.stack.nix/shelley-spec-ledger.nix
@@ -65,8 +65,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/executable-spec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/shelley-spec-non-integral.nix
+++ b/nix/.stack.nix/shelley-spec-non-integral.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/shelley/chain-and-ledger/dependencies/non-integer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps-test.nix
+++ b/nix/.stack.nix/small-steps-test.nix
@@ -92,8 +92,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/semantics/small-steps-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -67,8 +67,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-ledger-specs";
-      rev = "460ee17d22cacb3ac4d90536ebe90500a356a1c9";
-      sha256 = "0d2lhdffvwgwyhzm12hih2b1m784sgc45vadhwvaan95ipvcciil";
+      rev = "0715d2047b3d23e8b75b8430bddf391799c4669d";
+      sha256 = "0l2xlgqix9r376z11rsiws0990b64iw9hvmx94c5p7x9jsyz858q";
       });
     postUnpack = "sourceRoot+=/semantics/executable-spec; echo source root reset to \$sourceRoot";
     }


### PR DESCRIPTION
### Overview

Bumps the cardano-ledger-specs package to latest master, which fixes a dangling symlink in its git repo which broke newer versions of stack.

### Comments

Tested with:

    stack build --fast --test --no-run-tests --bench --no-run-benchmarks
