### PR TITLE
Call `removeRetiredPools` from `monitorStakePools`.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -71,9 +71,10 @@ newDBLayer timeInterpreter = do
   where
     mkDBLayer db = DBLayer {..}
       where
-        readPoolRegistration_ =
+        readPoolRegistration =
             readPoolDB db . mReadPoolRegistration
-        readPoolRetirement_ =
+
+        readPoolRetirement =
             readPoolDB db . mReadPoolRetirement
 
         putPoolProduction sl pool = ExceptT $
@@ -101,16 +102,12 @@ newDBLayer timeInterpreter = do
 
         readPoolLifeCycleStatus poolId =
             determinePoolLifeCycleStatus
-                <$> readPoolRegistration_ poolId
-                <*> readPoolRetirement_ poolId
-
-        readPoolRegistration = readPoolRegistration_
+                <$> readPoolRegistration poolId
+                <*> readPoolRetirement poolId
 
         putPoolRetirement cpt cert = void
             $ alterPoolDB (const Nothing) db
             $ mPutPoolRetirement cpt cert
-
-        readPoolRetirement = readPoolRetirement_
 
         unfetchedPoolMetadataRefs =
             readPoolDB db . mUnfetchedPoolMetadataRefs

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -59,6 +60,8 @@ import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Data.Functor.Identity
     ( Identity )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Data.Tuple
     ( swap )
 
@@ -132,6 +135,11 @@ newDBLayer timeInterpreter = do
 
         removePools =
             void . alterPoolDB (const Nothing) db . mRemovePools
+
+        removeRetiredPools epoch =
+            listRetiredPools epoch >>= \retirementCerts -> do
+                removePools (view #poolId <$> retirementCerts)
+                pure retirementCerts
 
         cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanPoolProduction

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -224,8 +224,8 @@ newDBLayer trace fp timeInterpreter = do
 
         readPoolLifeCycleStatus poolId =
             determinePoolLifeCycleStatus
-                <$> readPoolRegistration_ poolId
-                <*> readPoolRetirement_ poolId
+                <$> readPoolRegistration poolId
+                <*> readPoolRetirement poolId
 
         putPoolRegistration cpt cert = do
             let CertificatePublicationTime {slotNo, slotInternalIndex} = cpt
@@ -256,8 +256,6 @@ newDBLayer trace fp timeInterpreter = do
                     (poolOwners cert)
                     [0..]
 
-        readPoolRegistration = readPoolRegistration_
-
         putPoolRetirement cpt cert = do
             let CertificatePublicationTime {slotNo, slotInternalIndex} = cpt
             let PoolRetirementCertificate
@@ -268,8 +266,6 @@ newDBLayer trace fp timeInterpreter = do
                     slotNo
                     slotInternalIndex
                     (fromIntegral retirementEpoch)
-
-        readPoolRetirement = readPoolRetirement_
 
         unfetchedPoolMetadataRefs limit = do
             let nLimit = T.pack (show limit)
@@ -419,7 +415,7 @@ newDBLayer trace fp timeInterpreter = do
         atomically :: forall a. (SqlPersistT IO a -> IO a)
         atomically = runQuery
 
-        readPoolRegistration_ poolId = do
+        readPoolRegistration poolId = do
             result <- selectFirst
                 [ PoolRegistrationPoolId ==. poolId ]
                 [ Desc PoolRegistrationSlot
@@ -462,7 +458,7 @@ newDBLayer trace fp timeInterpreter = do
                 let cpt = CertificatePublicationTime {slotNo, slotInternalIndex}
                 pure (cpt, cert)
 
-        readPoolRetirement_ poolId = do
+        readPoolRetirement poolId = do
             result <- selectFirst
                 [ PoolRetirementPoolId ==. poolId ]
                 [ Desc PoolRetirementSlot

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -181,12 +182,16 @@ newDBLayer trace fp timeInterpreter = do
             (contramap MsgGeneric trace)
             fp
     ctx@SqliteContext{runQuery} <- handlingPersistError trace fp io
-    return (ctx, DBLayer
-        { putPoolProduction = \point pool -> ExceptT $
+    pure (ctx, mkDBLayer runQuery)
+  where
+    mkDBLayer :: (forall a. SqlPersistT IO a -> IO a) -> DBLayer IO
+    mkDBLayer runQuery = DBLayer {..}
+      where
+        putPoolProduction point pool = ExceptT $
             handleConstraint (ErrPointAlreadyExists point) $
                 insert_ (mkPoolProduction pool point)
 
-        , readPoolProduction = \epoch -> do
+        readPoolProduction epoch = do
             production <- fmap fromPoolProduction
                 <$> selectPoolProduction timeInterpreter epoch
 
@@ -199,7 +204,7 @@ newDBLayer trace fp timeInterpreter = do
 
             pure (foldl' toMap Map.empty production)
 
-        , readTotalProduction = do
+        readTotalProduction = do
             production <- fmap entityVal <$>
                 selectList ([] :: [Filter PoolProduction]) []
 
@@ -208,21 +213,21 @@ newDBLayer trace fp timeInterpreter = do
 
             pure $ Map.map Quantity $ foldl' toMap Map.empty production
 
-        , putStakeDistribution = \epoch@(EpochNo ep) distribution -> do
+        putStakeDistribution epoch@(EpochNo ep) distribution = do
             deleteWhere [StakeDistributionEpoch ==. fromIntegral ep]
             insertMany_ (mkStakeDistribution epoch distribution)
 
-        , readStakeDistribution = \(EpochNo epoch) -> do
+        readStakeDistribution (EpochNo epoch) = do
             fmap (fromStakeDistribution . entityVal) <$> selectList
                 [ StakeDistributionEpoch ==. fromIntegral epoch ]
                 []
 
-        , readPoolLifeCycleStatus = \poolId ->
+        readPoolLifeCycleStatus poolId =
             determinePoolLifeCycleStatus
                 <$> readPoolRegistration_ poolId
                 <*> readPoolRetirement_ poolId
 
-        , putPoolRegistration = \cpt cert -> do
+        putPoolRegistration cpt cert = do
             let CertificatePublicationTime {slotNo, slotInternalIndex} = cpt
             let poolId = view #poolId cert
             deleteWhere
@@ -251,9 +256,9 @@ newDBLayer trace fp timeInterpreter = do
                     (poolOwners cert)
                     [0..]
 
-        , readPoolRegistration = readPoolRegistration_
+        readPoolRegistration = readPoolRegistration_
 
-        , putPoolRetirement = \cpt cert -> do
+        putPoolRetirement cpt cert = do
             let CertificatePublicationTime {slotNo, slotInternalIndex} = cpt
             let PoolRetirementCertificate
                     poolId (EpochNo retirementEpoch) = cert
@@ -264,9 +269,9 @@ newDBLayer trace fp timeInterpreter = do
                     slotInternalIndex
                     (fromIntegral retirementEpoch)
 
-        , readPoolRetirement = readPoolRetirement_
+        readPoolRetirement = readPoolRetirement_
 
-        , unfetchedPoolMetadataRefs = \limit -> do
+        unfetchedPoolMetadataRefs limit = do
             let nLimit = T.pack (show limit)
             let poolId        = fieldName (DBField PoolRegistrationPoolId)
             let metadataHash  = fieldName (DBField PoolRegistrationMetadataHash)
@@ -316,7 +321,7 @@ newDBLayer trace fp timeInterpreter = do
 
             rights . fmap safeCast <$> rawSql query []
 
-        , putFetchAttempt = \(url, hash) -> do
+        putFetchAttempt (url, hash) = do
             -- NOTE
             -- assuming SQLite has the same notion of "now" that the host system.
             now <- liftIO getCurrentTime
@@ -337,24 +342,24 @@ newDBLayer trace fp timeInterpreter = do
                         (PoolMetadataFetchAttemptsKey hash url)
                         (PoolMetadataFetchAttempts hash url retryAfter $ retryCount + 1)
 
-        , putPoolMetadata = \hash metadata -> do
+        putPoolMetadata hash metadata = do
             let StakePoolMetadata{ticker,name,description,homepage} = metadata
             repsert
                 (PoolMetadataKey hash)
                 (PoolMetadata hash name ticker description homepage)
             deleteWhere [ PoolFetchAttemptsMetadataHash ==. hash ]
 
-        , readPoolMetadata = do
+        readPoolMetadata = do
             Map.fromList . map (fromPoolMeta . entityVal)
                 <$> selectList [] []
 
-        , listRegisteredPools = do
+        listRegisteredPools = do
             fmap (poolRegistrationPoolId . entityVal) <$> selectList [ ]
                 [ Desc PoolRegistrationSlot
                 , Desc PoolRegistrationSlotInternalIndex
                 ]
 
-        , listRetiredPools = \epochNo -> do
+        listRetiredPools epochNo = do
             let query = T.unwords
                     [ "SELECT *"
                     , "FROM active_pool_retirements"
@@ -367,7 +372,7 @@ newDBLayer trace fp timeInterpreter = do
                         <*> fromPersistValue retirementEpoch
             rights . fmap safeCast <$> rawSql query parameters
 
-        , rollbackTo = \point -> do
+        rollbackTo point = do
             -- TODO(ADP-356): What if the conversion blocks or fails?
             --
             -- Missing a rollback would be bad.
@@ -379,7 +384,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRetirementSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
-        , removePools = mapM_ $ \pool -> do
+        removePools = mapM_ $ \pool -> do
             liftIO $ traceWith trace $ MsgRemovingPool pool
             deleteWhere [ PoolProductionPoolId ==. pool ]
             deleteWhere [ PoolOwnerPoolId ==. pool ]
@@ -387,12 +392,12 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRetirementPoolId ==. pool ]
             deleteWhere [ StakeDistributionPoolId ==. pool ]
 
-        , readPoolProductionCursor = \k -> do
+        readPoolProductionCursor k = do
             reverse . map (snd . fromPoolProduction . entityVal) <$> selectList
                 []
                 [Desc PoolProductionSlot, LimitTo k]
 
-        , readSystemSeed = do
+        readSystemSeed = do
             mseed <- selectFirst [] []
             case mseed of
                 Nothing -> do
@@ -402,7 +407,7 @@ newDBLayer trace fp timeInterpreter = do
                 Just seed ->
                     return $ seedSeed $ entityVal seed
 
-        , cleanDB = do
+        cleanDB = do
             deleteWhere ([] :: [Filter PoolProduction])
             deleteWhere ([] :: [Filter PoolOwner])
             deleteWhere ([] :: [Filter PoolRegistration])
@@ -411,9 +416,9 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere ([] :: [Filter PoolMetadata])
             deleteWhere ([] :: [Filter PoolMetadataFetchAttempts])
 
-        , atomically = runQuery
-        })
-    where
+        atomically :: forall a. (SqlPersistT IO a -> IO a)
+        atomically = runQuery
+
         readPoolRegistration_ poolId = do
             result <- selectFirst
                 [ PoolRegistrationPoolId ==. poolId ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -665,14 +665,13 @@ instance ToText StakePoolLog where
             ]
         MsgRollingBackTo point ->
             "Rolling back to " <> pretty point
-        MsgStakePoolGarbageCollection info bkt -> mconcat
+        MsgStakePoolGarbageCollection info _ -> mconcat
             [ "Performing garbage collection of retired stake pools. "
             , "Currently in epoch "
             , toText (currentEpoch info)
             , ". Removing all pools that retired in or before epoch "
             , toText (removalEpoch info)
-            , ". "
-            , toText bkt
+            , "."
             ]
         MsgStakePoolRegistration cert ->
             "Discovered stake pool registration: " <> pretty cert

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -35,8 +35,6 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Pool.DB
     ( DBLayer (..), ErrPointAlreadyExists (..), readPoolLifeCycleStatus )
-import Cardano.Pool.DB.Log
-    ( PoolDbLog )
 import Cardano.Pool.Metadata
     ( StakePoolMetadataFetchLog )
 import Cardano.Wallet.Api.Types
@@ -620,8 +618,7 @@ monitorMetadata tr gp fetchMetadata DBLayer{..} = forever $ do
         f = unActiveSlotCoefficient (getActiveSlotCoefficient gp)
 
 data StakePoolLog
-    = MsgDb PoolDbLog
-    | MsgFollow FollowLog
+    = MsgFollow FollowLog
     | MsgStartMonitoring [BlockHeader]
     | MsgHaltMonitoring
     | MsgCrashMonitoring
@@ -648,7 +645,6 @@ data PoolGarbageCollectionInfo = PoolGarbageCollectionInfo
 instance HasPrivacyAnnotation StakePoolLog
 instance HasSeverityAnnotation StakePoolLog where
     getSeverityAnnotation = \case
-        MsgDb e -> getSeverityAnnotation e
         MsgFollow e -> getSeverityAnnotation e
         MsgStartMonitoring{} -> Info
         MsgHaltMonitoring{} -> Info
@@ -663,8 +659,6 @@ instance HasSeverityAnnotation StakePoolLog where
 
 instance ToText StakePoolLog where
     toText = \case
-        MsgDb e ->
-            toText e
         MsgFollow e ->
             toText e
         MsgStartMonitoring cursor -> mconcat

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -638,7 +638,7 @@ instance HasSeverityAnnotation StakePoolLog where
         MsgHaltMonitoring{} -> Info
         MsgCrashMonitoring{} -> Error
         MsgRollingBackTo{} -> Info
-        MsgStakePoolGarbageCollection{} -> Info
+        MsgStakePoolGarbageCollection{} -> Debug
         MsgStakePoolRegistration{} -> Info
         MsgStakePoolRetirement{} -> Info
         MsgErrProduction{} -> Error

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -35,6 +35,8 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Pool.DB
     ( DBLayer (..), ErrPointAlreadyExists (..), readPoolLifeCycleStatus )
+import Cardano.Pool.DB.Log
+    ( PoolDbLog )
 import Cardano.Pool.Metadata
     ( StakePoolMetadataFetchLog )
 import Cardano.Wallet.Api.Types
@@ -579,7 +581,8 @@ monitorMetadata tr gp fetchMetadata DBLayer{..} = forever $ do
         f = unActiveSlotCoefficient (getActiveSlotCoefficient gp)
 
 data StakePoolLog
-    = MsgFollow FollowLog
+    = MsgDb PoolDbLog
+    | MsgFollow FollowLog
     | MsgStartMonitoring [BlockHeader]
     | MsgHaltMonitoring
     | MsgCrashMonitoring
@@ -594,6 +597,7 @@ data StakePoolLog
 instance HasPrivacyAnnotation StakePoolLog
 instance HasSeverityAnnotation StakePoolLog where
     getSeverityAnnotation = \case
+        MsgDb e -> getSeverityAnnotation e
         MsgFollow e -> getSeverityAnnotation e
         MsgStartMonitoring{} -> Info
         MsgHaltMonitoring{} -> Info
@@ -607,6 +611,8 @@ instance HasSeverityAnnotation StakePoolLog where
 
 instance ToText StakePoolLog where
     toText = \case
+        MsgDb e ->
+            toText e
         MsgFollow e ->
             toText e
         MsgStartMonitoring cursor -> mconcat

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -546,9 +546,7 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
             let subtractTwoEpochs = epochPred <=< epochPred
             forM_ (subtractTwoEpochs currentEpoch) $ \removalEpoch -> do
                 let logMessage = MsgStakePoolGarbageCollection $
-                        PoolGarbageCollectionInfo
-                            currentEpoch
-                            removalEpoch
+                        PoolGarbageCollectionInfo {currentEpoch, removalEpoch}
                 bracketTracer (contramap logMessage tr) $
                     removeRetiredPools db (contramap MsgDb tr) removalEpoch
 
@@ -622,10 +620,10 @@ data StakePoolLog
     deriving (Show, Eq)
 
 data PoolGarbageCollectionInfo = PoolGarbageCollectionInfo
-    { poolGarbageCollectionCurrentEpoch :: EpochNo
+    { currentEpoch :: EpochNo
         -- ^ The current epoch at the point in time the garbage collector
         -- was invoked.
-    , poolGarbageCollectionRemovalEpoch :: EpochNo
+    , removalEpoch :: EpochNo
         -- ^ The removal epoch: the garbage collector will remove all pools
         -- that retired on or before this epoch.
     }
@@ -670,9 +668,9 @@ instance ToText StakePoolLog where
         MsgStakePoolGarbageCollection info bkt -> mconcat
             [ "Performing garbage collection of retired stake pools. "
             , "Currently in epoch "
-            , toText (poolGarbageCollectionCurrentEpoch info)
+            , toText (currentEpoch info)
             , ". Removing all pools that retired in or before epoch "
-            , toText (poolGarbageCollectionRemovalEpoch info)
+            , toText (removalEpoch info)
             , ". "
             , toText bkt
             ]

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -34,11 +34,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Pool.DB
-    ( DBLayer (..)
-    , ErrPointAlreadyExists (..)
-    , readPoolLifeCycleStatus
-    , removeRetiredPools
-    )
+    ( DBLayer (..), ErrPointAlreadyExists (..), readPoolLifeCycleStatus )
 import Cardano.Pool.DB.Log
     ( PoolDbLog )
 import Cardano.Pool.Metadata
@@ -567,7 +563,7 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
                     PoolGarbageCollectionInfo
                         {currentEpoch, latestRetirementEpoch}
             bracketTracer (contramap logMessage tr) $
-                removeRetiredPools db (contramap MsgDb tr) latestRetirementEpoch
+                atomically $ removeRetiredPools latestRetirementEpoch
 
     -- For each pool certificate in the given list, add an entry to the
     -- database that associates the certificate with the specified slot

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -448,11 +448,6 @@ combineChainData registrationMap retirementMap prodMap metaMap =
 --
 --    See: https://jira.iohk.io/browse/ADP-383
 --
--- Additionally, we can consider performing garbage collection of retired pools
--- from the database:
---
---    See: https://jira.iohk.io/browse/ADP-376
---
 readPoolDbData :: DBLayer IO -> IO (Map PoolId PoolDbData)
 readPoolDbData DBLayer {..} = atomically $ do
     pools <- listRegisteredPools

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -552,20 +552,16 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
                 bracketTracer (contramap logMessage tr) $
                     removeRetiredPools db (contramap MsgDb tr) removalEpoch
 
+        -- For each pool certificate in the given list, add an entry to the
+        -- database that associates the certificate with the specified slot
+        -- number and the relative position of the certificate in the list.
+        --
+        -- The order of certificates within a slot is significant: certificates
+        -- that appear later take precedence over those that appear earlier on.
+        --
+        -- Precedence is determined by the 'readPoolLifeCycleStatus' function.
+        --
         putPoolCertificates slot certificates = do
-            -- A single block can contain multiple certificates relating to the
-            -- same pool.
-            --
-            -- The /order/ in which certificates appear is /significant/:
-            -- certificates that appear later in a block /generally/ take
-            -- precedence over certificates that appear earlier on.
-            --
-            -- We record /all/ certificates within the database, together with
-            -- the order in which they appeared.
-            --
-            -- Precedence is determined by the 'readPoolLifeCycleStatus'
-            -- function.
-            --
             let publicationTimes =
                     CertificatePublicationTime slot <$> [minBound ..]
             forM_ (publicationTimes `zip` certificates) $ \case

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -93,7 +93,7 @@ import Cardano.Wallet.Unsafe
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad
-    ( forM, forM_, forever, when, (<=<) )
+    ( forM, forM_, forever, unless, when, (<=<) )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
@@ -525,7 +525,7 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
                             liftIO $ traceWith tr $ MsgErrProduction e
                         Right () ->
                             pure ()
-                when (not $ null certificates) $ do
+                unless (null certificates) $ do
                     -- Before adding new pool certificates to the database, we
                     -- first attempt to garbage collect pools that have already
                     -- retired. By only performing garbage collection when we


### PR DESCRIPTION
# Issue Number

#2019 

# Overview

PR #2057 provided the [`removeRetiredPools`](https://github.com/input-output-hk/cardano-wallet/blob/fece720cb18d9676c4f1f6b0d3a69a37fab93f1c/lib/core/src/Cardano/Pool/DB.hs#L301) function which, when given an epoch, removes pools from the database that retired **on or before** that epoch.

This PR adjusts [`monitorStakePools`](https://github.com/input-output-hk/cardano-wallet/blob/fece720cb18d9676c4f1f6b0d3a69a37fab93f1c/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs#L481) to actually **call** [`removeRetiredPools`](https://github.com/input-output-hk/cardano-wallet/blob/fece720cb18d9676c4f1f6b0d3a69a37fab93f1c/lib/core/src/Cardano/Pool/DB.hs#L301).

## Frequency of Garbage Collection

Since garbage collection has a **runtime cost** associated with it, we want to avoid doing it more than necessary, even if the cost is relatively small.

Thus, we only perform garbage collection:

- **on demand**, just before we record a new pool registration or retirement certificate in the database.
- **at most once per epoch**.

## Logging Examples

### A single garbage collection invocation (at most once per epoch)

<details><summary>Click to view log sample</summary>

```hs
[cardano-wallet.pools-engine:Debug:31] [2020-08-31 05:42:24.77 UTC] Performing garbage collection of retired stake pools. Currently in epoch 214. Removing all pools that retired in or before epoch 212.
[cardano-wallet.pools-db:Debug:31] [2020-08-31 05:42:24.77 UTC] Removing pools that retired in or before epoch 212: start
[cardano-wallet.pools-db:Debug:31] [2020-08-31 05:42:24.78 UTC] Removing the following retired pools:
Pool 215622e6 with retirement epoch 212
Pool 5687ecfe with retirement epoch 212
Pool 69d158eb with retirement epoch 212
Pool 7bacd597 with retirement epoch 212
Pool 8e681030 with retirement epoch 212
Pool a6d582d8 with retirement epoch 212
Pool bccf5ce0 with retirement epoch 212
Pool c0b86026 with retirement epoch 212
Pool cfe83240 with retirement epoch 212
Pool f5863386 with retirement epoch 212
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.78 UTC] Removing the following pool from the database: 215622e669c0f0c09828ec4100a4c689b1f9c148f542b0192b6ed00d.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.80 UTC] Removing the following pool from the database: 5687ecfeaf19ed1a7ec20a9332ff80c8ad6fc5ace97cfb7276d256a2.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.82 UTC] Removing the following pool from the database: 69d158eb61cbbeff3ae564768eef7c0b52ba8bd33b2301eacf62a24d.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.84 UTC] Removing the following pool from the database: 7bacd59728317961e6ffb20f40f74706954a5341d1159f7e2be32a68.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.85 UTC] Removing the following pool from the database: 8e68103060b32595d4eed0a7749795b155d790b95e0615f9f5618b9f.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.87 UTC] Removing the following pool from the database: a6d582d86cafd861984ec33f3c4bb7ab1e183d0719abc92351dd2dd7.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.89 UTC] Removing the following pool from the database: bccf5ce0d9b3436cd1616686c98f4584b43760704c9585f1f208ffae.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.90 UTC] Removing the following pool from the database: c0b86026e65261a0698e789fc2e0b1cf36c85693dbf1cd516067400d.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.92 UTC] Removing the following pool from the database: cfe83240dd1eb92bac3d739b2550be334f4bb7e4fc11d7f5faeb8769.
[cardano-wallet.pools-db:Notice:31] [2020-08-31 05:42:24.94 UTC] Removing the following pool from the database: f58633867bea26335d12aa95a8b3b1dee5b6994ffd4bac5348375220.
[cardano-wallet.pools-db:Debug:31] [2020-08-31 05:42:24.95 UTC] Removing pools that retired in or before epoch 212: finish
```
</details>

### Lifecycle of a single pool

<details><summary>Click to view log sample</summary>

```hs
[cardano-wallet.pools-engine:Info:37] [2020-08-27 15:35:54.31 UTC] Discovered stake pool registration: Registration of 00008d6a owned by [ed25519_pk1lrrgks5hnpxqqpyhjxedk7u5nxp0ehp9tm9ksx4a7zepzt6ydnw]
...
[cardano-wallet.pools-engine:Info:37] [2020-08-27 15:35:54.85 UTC] Discovered stake pool retirement: Pool 00008d6a with retirement epoch 209
...
[cardano-wallet.pools-engine:Debug:37] [2020-08-27 15:36:16.07 UTC] Performing garbage collection of retired stake pools. Currently in epoch 211. Removing all pools that retired in or before epoch 209.
[cardano-wallet.pools-db:Notice:37] [2020-08-27 15:36:16.08 UTC] Removing the following pool from the database: 00008d6abd6bf0dafbc7f64b68267f5716e1992d0e845eb22d05065b.
```

</details>