### PR TITLE
Fix occasional db tests failure

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -183,6 +183,7 @@ test-suite unit
   ghc-options:
       -threaded -rtsopts
       -Wall
+      "-with-rtsopts=-M2G"
   if (flag(release))
     ghc-options: -O2 -Werror
   build-depends:

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -123,12 +123,14 @@ import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Coerce
     ( coerce )
+import Data.Ord
+    ( Down (..) )
 import Data.Either
     ( isRight )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.List
-    ( unzip3 )
+    ( sortOn, unzip3 )
 import Data.List.Split
     ( chunksOf )
 import Data.Map.Strict
@@ -1361,11 +1363,11 @@ selectTxs = fmap concatUnzip . mapM select . chunksOf chunkSize
     concatUnzip :: [([a], [b], [c])] -> ([a], [b], [c])
     concatUnzip = (\(a, b, c) -> (concat a, concat b, concat c)) . unzip3
 
-    -- Split a query's input values into chunks, run multiple smaller queries,
-    -- and then concatenate the results afterwards. Used to avoid "too many SQL
-    -- variables" errors for "SELECT IN" queries.
-    combineChunked :: [a] -> ([a] -> SqlPersistT IO [b]) -> SqlPersistT IO [b]
-    combineChunked xs f = concatMapM f $ chunksOf chunkSize xs
+-- | Split a query's input values into chunks, run multiple smaller queries,
+-- and then concatenate the results afterwards. Used to avoid "too many SQL
+-- variables" errors for "SELECT IN" queries.
+combineChunked :: [a] -> ([a] -> SqlPersistT IO [b]) -> SqlPersistT IO [b]
+combineChunked xs f = concatMapM f $ chunksOf chunkSize xs
 
 selectTxHistory
     :: TimeInterpreter IO
@@ -1378,21 +1380,24 @@ selectTxHistory ti wid minWithdrawal order conditions = do
     selectLatestCheckpoint wid >>= \case
         Nothing -> pure []
         Just cp -> do
-            minWithdrawalFilter <- case minWithdrawal of
-                Nothing  -> pure []
+            let txMetaFilter = (TxMetaWalletId ==. wid):conditions
+            metas <- case minWithdrawal of
+                Nothing -> fmap entityVal <$> selectList txMetaFilter sortOpt
                 Just inf -> do
                     let coin = W.Coin $ fromIntegral $ getQuantity inf
-                    wdrls <- fmap entityVal
-                        <$> selectList [ TxWithdrawalAmount >=. coin ] []
-                    pure [ TxMetaTxId <-. (txWithdrawalTxId <$> wdrls) ]
+                    let sortTxId = case order of
+                            W.Ascending -> Desc TxWithdrawalTxId
+                            W.Descending -> Asc TxWithdrawalTxId
+                    let sortSlot = case order of
+                            W.Ascending -> sortOn txMetaSlot
+                            W.Descending -> sortOn (Down . txMetaSlot)
+                    txids <- fmap (txWithdrawalTxId . entityVal)
+                        <$> selectList [ TxWithdrawalAmount >=. coin ] [sortTxId]
 
-            metas <- fmap entityVal <$> selectList
-                ( mconcat
-                    [ [ TxMetaWalletId ==. wid ]
-                    , minWithdrawalFilter
-                    , conditions
-                    ]
-                ) sortOpt
+                    ms <- combineChunked txids (\chunk -> selectList
+                       ((TxMetaTxId <-. chunk):txMetaFilter) sortOpt)
+
+                    pure $ sortSlot $ fmap entityVal ms
 
             let txids = map txMetaTxId metas
             (ins, outs, ws) <- selectTxs txids

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -193,6 +193,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
 
@@ -1378,21 +1379,21 @@ selectTxHistory ti wid minWithdrawal order conditions = do
     selectLatestCheckpoint wid >>= \case
         Nothing -> pure []
         Just cp -> do
-            minWithdrawalFilter <- case minWithdrawal of
-                Nothing  -> pure []
+            minWithdrawalPred <- case minWithdrawal of
+                Nothing -> pure (const True)
                 Just inf -> do
+                    -- Tests whether a given TxMeta matches a reward withdrawal
+                    -- above the given minimum. This filtering is done outside
+                    -- of sqlite because joins are not possible with persistent.
                     let coin = W.Coin $ fromIntegral $ getQuantity inf
-                    wdrls <- fmap entityVal
-                        <$> selectList [ TxWithdrawalAmount >=. coin ] []
-                    pure [ TxMetaTxId <-. (txWithdrawalTxId <$> wdrls) ]
+                    wdrls <- fmap entityVal <$> selectList
+                        [ TxWithdrawalAmount >=. coin ]
+                        [ Asc TxWithdrawalTxId ]
+                    let txids = Set.fromAscList $ map txWithdrawalTxId wdrls
+                    pure ((`Set.member` txids) . txMetaTxId)
 
-            metas <- fmap entityVal <$> selectList
-                ( mconcat
-                    [ [ TxMetaWalletId ==. wid ]
-                    , minWithdrawalFilter
-                    , conditions
-                    ]
-                ) sortOpt
+            metas <- filter minWithdrawalPred . fmap entityVal
+                <$> selectList ((TxMetaWalletId ==. wid):conditions) sortOpt
 
             let txids = map txMetaTxId metas
             (ins, outs, ws) <- selectTxs txids

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -123,8 +123,6 @@ import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Coerce
     ( coerce )
-import Data.Ord
-    ( Down (..) )
 import Data.Either
     ( isRight )
 import Data.Generics.Internal.VL.Lens
@@ -137,6 +135,8 @@ import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( catMaybes )
+import Data.Ord
+    ( Down (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity


### PR DESCRIPTION
### Issue Number

Resolves #2064.

### Overview

The DB state machine tests found an extreme case which caused a `too many SQL variables` exception. Unfortunately it was not able to shrink the counterexample without crashing.

- [x] Changes cabal file so that tests are run with a memory limit of 2G.
- [x] Fixes the test case which sometimes fails.

### Comments

- Currently testing with:
   ```
   nix-build -A tests.cardano-wallet-core.unit
   cd lib/core
   while ../../result/bin/unit --match '/Cardano.Wallet.DB.Sqlite/Sqlite State machine tests'; do :; done
   ```
- There is an infinite loop in `Sqlite State machine tests`, it gets stuck somewhere, then takes quite a while to exhaust the heap:
  ```
        There's no checkpoint older than k (+/- 100)
          +++ OK, passed 100 tests.
    Sqlite State machine tests
  1594/100unit: Heap exhausted;
  unit: Current maximum heap size is 2147483648 bytes (2048 MB).
  unit: Use `+RTS -M<size>' to increase it.
   173,889,316,944 bytes allocated in the heap
     9,858,194,528 bytes copied during GC
     2,112,669,264 bytes maximum residency (720 sample(s))
        40,633,672 bytes maximum slop
              2014 MB total memory in use (0 MB lost due to fragmentation)

                                       Tot time (elapsed)  Avg pause  Max pause
    Gen  0     166050 colls,     0 par    7.239s   7.241s     0.0000s    0.0007s
    Gen  1       720 colls,     0 par   2585.867s  2752.903s     3.8235s    6.0089s

    TASKS: 5 (1 bound, 4 peak workers (4 total), using -N1)

    SPARKS: 0(0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

    INIT    time    0.000s  (  0.000s elapsed)
    MUT     time  100.141s  ( 99.704s elapsed)
    GC      time  2593.106s  (2760.143s elapsed)
    EXIT    time    0.002s  (  0.003s elapsed)
    Total   time  2693.249s  (2859.850s elapsed)

    Alloc rate    1,736,438,027 bytes per MUT second

    Productivity   3.7% of total user, 3.5% of total elapsed
  ```
- After disabling shrinking on the state machine tests, the infinite loop turns into a failing test (with quite a large counterexample).
- There is a `too many variables` exception when querying the `tx_meta` table.
