### PR TITLE
Bump cardano-addresses

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -83,7 +83,7 @@ let
     inherit (haskellPackages.ouroboros-consensus-byron.components.exes) db-converter;
     # adrestia tool belt
     inherit (haskellPackages.bech32.components.exes) bech32;
-    inherit (haskellPackages.cardano-addresses.components.exes) cardano-address;
+    inherit (haskellPackages.cardano-addresses-cli.components.exes) cardano-address;
     inherit (haskellPackages.cardano-transactions.components.exes) cardano-tx;
 
     cardano-wallet-jormungandr = import ./nix/package-jormungandr.nix {

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -35,6 +35,7 @@ library
     , base
     , bytestring
     , cardano-addresses
+    , cardano-addresses-cli
     , cardano-wallet-core
     , contra-tracer
     , directory

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -139,7 +139,7 @@ spec = do
             , "Available options:"
             , "  -h,--help                Show this help text"
             , "  --size INT               Number of mnemonic words to generate."
-            , "                           Must be a multiple of 3. (default: 15)"
+            , "                           Must be a multiple of 3. (default: 24)"
             ]
 
         ["wallet", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1722,7 +1722,7 @@ pubKeyFromMnemonics mnemonics =
     T.decodeUtf8 $ serializeXPub $ publicKey
        $ deriveAccountPrivateKey mempty rootXPrv minBound
  where
-     (Right seed) = mkSomeMnemonic @'[15] mnemonics
+     seed = either (error . show) id $ mkSomeMnemonic @'[15,24] mnemonics
      rootXPrv = generateKeyFromSeed (seed, Nothing) mempty
 
 --

--- a/nix/.stack.nix/cardano-addresses-cli.nix
+++ b/nix/.stack.nix/cardano-addresses-cli.nix
@@ -11,14 +11,14 @@
     flags = { release = false; };
     package = {
       specVersion = "1.12";
-      identifier = { name = "cardano-addresses"; version = "1.0.0"; };
+      identifier = { name = "cardano-addresses-cli"; version = "1.0.0"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";
       author = "IOHK";
       homepage = "https://github.com/input-output-hk/cardano-addresses#readme";
       url = "";
-      synopsis = "Library utilities for mnemonic generation and address derivation.";
+      synopsis = "Utils for constructing a command-line on top of cardano-addresses.";
       description = "Please see the README on GitHub at <https://github.com/input-output-hk/cardano-addresses>";
       buildType = "Simple";
       isLocal = true;
@@ -27,25 +27,32 @@
       "library" = {
         depends = [
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
+          (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
-          (hsPkgs."basement" or (errorHandler.buildDepError "basement"))
           (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
           (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
-          (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
+          (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
-          (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
-          (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
-          (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
-          (hsPkgs."digest" or (errorHandler.buildDepError "digest"))
-          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
+          (hsPkgs."code-page" or (errorHandler.buildDepError "code-page"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
-          (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           ];
         buildable = true;
+        };
+      exes = {
+        "cardano-address" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
+            ];
+          buildable = true;
+          };
         };
       tests = {
         "unit" = {
@@ -53,16 +60,20 @@
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
-            (hsPkgs."binary" or (errorHandler.buildDepError "binary"))
+            (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
-            (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+            (hsPkgs."process" or (errorHandler.buildDepError "process"))
+            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))
+            (hsPkgs.buildPackages.cardano-address or (pkgs.buildPackages.cardano-address or (errorHandler.buildToolDepError "cardano-address")))
             ];
           buildable = true;
           };
@@ -74,5 +85,5 @@
       rev = "618bac90810fee7be324ee70428d9fb31e30abbd";
       sha256 = "1hvf8w9kz01jqggmizgy9scwf45rj78dh2np4qpgxcpgmin6ah58";
       });
-    postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
+    postUnpack = "sourceRoot+=/command-line; echo source root reset to \$sourceRoot";
     }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -32,6 +32,7 @@
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
+          (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
           (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -78,7 +78,6 @@
         persistent = ./persistent.nix;
         persistent-sqlite = ./persistent-sqlite.nix;
         persistent-template = ./persistent-template.nix;
-        cardano-addresses = ./cardano-addresses.nix;
         cardano-transactions = ./cardano-transactions.nix;
         cardano-binary = ./cardano-binary.nix;
         cardano-binary-test = ./cardano-binary-test.nix;

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -78,6 +78,8 @@
         persistent = ./persistent.nix;
         persistent-sqlite = ./persistent-sqlite.nix;
         persistent-template = ./persistent-template.nix;
+        cardano-addresses-cli = ./cardano-addresses-cli.nix;
+        cardano-addresses = ./cardano-addresses.nix;
         cardano-transactions = ./cardano-transactions.nix;
         cardano-binary = ./cardano-binary.nix;
         cardano-binary-test = ./cardano-binary-test.nix;

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -136,7 +136,7 @@ let
         # Add shell completions for tools.
         packages.cardano-node.components.exes.cardano-cli.postInstall = optparseCompletionPostInstall + libSodiumPostInstall;
         packages.cardano-node.components.exes.cardano-node.postInstall = optparseCompletionPostInstall + libSodiumPostInstall;
-        packages.cardano-addresses.components.exes.cardano-address.postInstall = optparseCompletionPostInstall;
+        packages.cardano-addresses-cli.components.exes.cardano-address.postInstall = optparseCompletionPostInstall;
         packages.cardano-transactions.components.exes.cardano-tx.postInstall = optparseCompletionPostInstall;
         packages.bech32.components.exes.bech32.postInstall = optparseCompletionPostInstall;
       }

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,7 +40,10 @@ extra-deps:
     - persistent-template
 
 - git: https://github.com/input-output-hk/cardano-addresses
-  commit: 3f11638847bfc8c457dc4bb080c63e5d6de806ee
+  commit: 618bac90810fee7be324ee70428d9fb31e30abbd
+  subdirs:
+    - command-line
+    - core
 
 # Not strictly a dependency at present, but building it here to get
 # access to the cardano-tx cli.


### PR DESCRIPTION
# Issue Number

Release.


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Bump cardano-addresses


# Comments

- I believe this purely affects CLI usage of the cardano-addresses binary that will get included in the wallet release

```
Bump includes:
- [Increase default mnemonic phrase length](https://github.com/input-output-hk/cardano-addresses/pull/53)
- [Allow to inspect reward accounts wrt #46](https://github.com/input-output-hk/cardano-addresses/pull/56)
- [Allow to generate stake addresses #58](https://github.com/input-output-hk/cardano-addresses/pull/58)
- [Make 'payment' subcommand generate testnet hrp, wrt #55](https://github.com/input-output-hk/cardano-addresses/pull/59)
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
