### PR TITLE
More testing of withListeningSocket

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -482,7 +482,10 @@ withListeningSocket
     -> IO a
 withListeningSocket hostPreference portOpt = bracket acquire release
   where
-    acquire = tryJust handleErr $ case portOpt of
+    acquire = tryJust handleErr bindAndListen
+    -- Note: These Data.Streaming.Network functions also listen on the socket,
+    -- even though their name just says "bind".
+    bindAndListen = case portOpt of
         ListenOnPort port -> (port,) <$> bindPortTCP port hostPreference
         ListenOnRandomPort -> bindRandomPortTCP hostPreference
     release (Right (_, socket)) = liftIO $ close socket


### PR DESCRIPTION
### Issue Number

This might fix #2067.

### Overview

I initially had a theory that the function `withListeningSocket` only bound the socket, but did not start listening. Therefore, connections to the port which were made during the `withListeningSocket` action, but before the warp server starts listening, would be refused. However this was incorrect.

This PR adds another test case to check that the socket really is listening.

### Comments

- I have not actually tested on windows yet.
- Link to [windows tests build](https://hydra.iohk.io/job/Cardano/cardano-wallet-pr-2069/cardano-wallet-tests-win64)