### PR TITLE
Extend restoration benchmarks to include large random wallets.

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1577,6 +1577,11 @@ selectSeqStatePendingIxs wid =
                           HD Random address discovery
 -------------------------------------------------------------------------------}
 
+-- piggy-back on RndState existing instance, to simulate the same behavior.
+instance PersistState (Rnd.RndAnyState n p) where
+    insertState (wid, sl) = insertState (wid, sl) . Rnd.innerState
+    selectState (wid, sl) = fmap Rnd.RndAnyState <$> selectState (wid, sl)
+
 -- Persisting 'RndState' requires that the wallet root key has already been
 -- added to the database with 'putPrivateKey'. Unlike sequential AD, random
 -- address discovery requires a root key to recognize addresses.

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -29,6 +29,8 @@ module Main where
 
 import Prelude
 
+import Cardano.Address.Derivation
+    ( XPrv )
 import Cardano.BM.Trace
     ( Trace, nullTracer )
 import Cardano.DB.Sqlite
@@ -74,7 +76,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Any
 import Cardano.Wallet.Primitive.AddressDiscovery.Any.TH
     ( migrateAll )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
-    ( RndState, mkRndState )
+    ( mkRndAnyState, mkRndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..), mkAddressPoolGap, mkSeqStateFromRootXPrv )
 import Cardano.Wallet.Primitive.Model
@@ -187,6 +189,7 @@ cardanoRestoreBench tr c socketFile = do
                 vData
                 "seq.timelog"
                 (walletSeq networkProxy))
+
         , bench ("restore " <> network <> " rnd")
             (bench_restoration @_ @ByronKey
                 networkProxy
@@ -195,43 +198,45 @@ cardanoRestoreBench tr c socketFile = do
                 np
                 vData
                 "rnd.timelog"
-                walletRnd)
+                (walletRnd mkRndState))
 
-        , bench ("restore " <> network <> " 1% ownership")
-            (bench_restoration @_ @IcarusKey
+        , bench ("restore " <> network <> " 1% rnd")
+            (bench_restoration @_ @ByronKey
                 networkProxy
                 tr
                 socketFile
                 np
                 vData
-                "1-percent.timelog"
-                (initAnyState "Benchmark 1% Wallet" 0.01))
+                "1-percent-rnd.timelog"
+                (walletRnd $ mkRndAnyState @1))
 
-        , bench ("restore " <> network <> " 2% ownership")
-            (bench_restoration @_ @IcarusKey
-                networkProxy
-                tr
-                socketFile
-                np
-                vData
-                "2-percent.timelog"
-                (initAnyState "Benchmark 2% Wallet" 0.02))
+        , bench ("restore " <> network <> " 1% naked")
+             (bench_restoration @_ @IcarusKey
+                 networkProxy
+                 tr
+                 socketFile
+                 np
+                 vData
+                 "1-percent-naked.timelog"
+                 (initAnyState "Benchmark 1% Wallet" 0.01))
         ]
   where
     walletRnd
-        :: (WalletId, WalletName, RndState n)
-    walletRnd =
+        :: (ByronKey 'RootK XPrv -> Int -> s)
+        -> (WalletId, WalletName, s)
+    walletRnd mk =
         let
             seed = SomeMnemonic . unsafeMkMnemonic @15 $ T.words
                 "involve key curtain arrest fortune custom lens marine before \
                 \material wheel glide cause weapon wrap"
             xprv = Byron.generateKeyFromSeed seed mempty
             wid = WalletId $ digest $ publicKey xprv
-            wname = WalletName "Benchmark Sequential Wallet"
+            wname = WalletName "Benchmark Random Wallet"
             rngSeed = 0
-            s = mkRndState xprv rngSeed
+            s = mk xprv rngSeed
         in
             (wid, wname, s)
+
     walletSeq
         :: forall n. Proxy n
         -> (WalletId, WalletName, SeqState n ShelleyKey)

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -65,8 +65,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery
@@ -211,7 +209,7 @@ cardanoRestoreBench tr c socketFile = do
                 (walletRnd $ mkRndAnyState @1))
 
         , bench ("restore " <> network <> " 1% naked")
-             (bench_restoration @_ @IcarusKey
+             (bench_restoration @_ @ShelleyKey
                  networkProxy
                  tr
                  socketFile

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -208,14 +208,34 @@ cardanoRestoreBench tr c socketFile = do
                 "1-percent-rnd.timelog"
                 (walletRnd $ mkRndAnyState @1))
 
-        , bench ("restore " <> network <> " 1% naked")
+        , bench ("restore " <> network <> " 0.1% any")
              (bench_restoration @_ @ShelleyKey
                  networkProxy
                  tr
                  socketFile
                  np
                  vData
-                 "1-percent-naked.timelog"
+                 "0.1-percent-any.timelog"
+                 (initAnyState "Benchmark 0.1% Wallet" 0.001))
+
+        , bench ("restore " <> network <> " 0.5% any")
+             (bench_restoration @_ @ShelleyKey
+                 networkProxy
+                 tr
+                 socketFile
+                 np
+                 vData
+                 "0.5-percent-any.timelog"
+                 (initAnyState "Benchmark 0.5% Wallet" 0.005))
+
+        , bench ("restore " <> network <> " 1% any")
+             (bench_restoration @_ @ShelleyKey
+                 networkProxy
+                 tr
+                 socketFile
+                 np
+                 vData
+                 "1-percent-any.timelog"
                  (initAnyState "Benchmark 1% Wallet" 0.01))
         ]
   where


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2032 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have defined a new special wallet scheme analogous to the any% scheme used until now, but built on top of the `RndState`, so that we still get to store and retrieve the address space too.

- [ ] I have removed the 2% case and "replaced" it with a 1% case on large random wallets.


# Comments

<!-- Additional comments or screenshots to attach if any -->

Tested on the testnet, which works fine. The reason to add this one is to be able to create arbitrarily large random wallets that "make sense", and then measure the time taken for other specific operations such as listing addresses or estimating fees (which I'll do as a separate PR).

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
