### PR TITLE
Fix underflow in fee estimation in the presence of withdrawal and max amount

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1192,14 +1192,21 @@ coinSelOpts tl txMaxSize = CoinSelectionOptions
 feeOpts
     :: TransactionLayer t k
     -> Maybe DelegationAction
-    -> FeePolicy
+    -> W.TxParameters
     -> W.Coin
     -> FeeOptions
-feeOpts tl action feePolicy minUtxo = FeeOptions
+feeOpts tl action txp minUtxo = FeeOptions
     { estimateFee = minimumFee tl feePolicy action
     , dustThreshold = minUtxo
     , onDanglingChange = if allowUnbalancedTx tl then SaveMoney else PayAndBalance
+    , feeUpperBound = Fee
+        $ ceiling a
+        + ceiling b * fromIntegral txMaxSize
+        + getCoin minUtxo
     }
+  where
+    feePolicy@(LinearFee (Quantity a) (Quantity b) _) = W.getFeePolicy txp
+    Quantity txMaxSize = W.getTxMaxSize txp
 
 -- | Prepare a transaction and automatically select inputs from the
 -- wallet to cover the requested outputs. Note that this only runs
@@ -1269,7 +1276,7 @@ selectCoinsForPaymentFromUTxO ctx utxo txp minUtxo recipients withdrawal = do
         let opts = coinSelOpts tl (txp ^. #getTxMaxSize)
         CoinSelection.random opts recipients withdrawal utxo
     lift . traceWith tr $ MsgPaymentCoinSelection sel
-    let feePolicy = feeOpts tl Nothing (txp ^. #getFeePolicy) minUtxo
+    let feePolicy = feeOpts tl Nothing txp minUtxo
     withExceptT ErrSelectForPaymentFee $ do
         balancedSel <- adjustForFee feePolicy utxo' sel
         lift . traceWith tr $ MsgPaymentCoinSelectionAdjusted balancedSel
@@ -1307,7 +1314,7 @@ selectCoinsForDelegationFromUTxO
     -> DelegationAction
     -> ExceptT ErrSelectForDelegation IO CoinSelection
 selectCoinsForDelegationFromUTxO ctx utxo txp minUtxo action = do
-    let feePolicy = feeOpts tl (Just action) (txp ^. #getFeePolicy) minUtxo
+    let feePolicy = feeOpts tl (Just action) txp minUtxo
     let sel = initDelegationSelection tl (txp ^. #getFeePolicy) action
     withExceptT ErrSelectForDelegationFee $ do
         balancedSel <- adjustForFee feePolicy utxo sel
@@ -1387,12 +1394,9 @@ selectCoinsForMigrationFromUTxO
         )
 selectCoinsForMigrationFromUTxO ctx utxo txp minUtxo wid = do
     let feePolicy@(LinearFee (Quantity a) _ _) = txp ^. #getFeePolicy
-    let feeOptions = FeeOptions
+    let feeOptions = (feeOpts tl Nothing txp minBound)
             { estimateFee = minimumFee tl feePolicy Nothing . worstCase
             , dustThreshold = max (Coin $ ceiling a) minUtxo
-            , onDanglingChange = if allowUnbalancedTx tl
-                then SaveMoney
-                else PayAndBalance
             }
     let selOptions = coinSelOpts tl (txp ^. #getTxMaxSize)
     let previousDistribution = W.computeUtxoStatistics W.log10 utxo

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -122,6 +122,7 @@ spec = do
                         $ fromIntegral
                         $ 5 * (length (inputs s) + length (outputs s))
                     , onDanglingChange = PayAndBalance
+                    , feeUpperBound = Fee maxBound
                     }
             let batchSize = 1
             let utxo = UTxO $ Map.fromList
@@ -243,6 +244,7 @@ genFeeOptions (Coin dust) = do
             in Fee $ (dust `div` 100) * x + dust
         , dustThreshold = Coin dust
         , onDanglingChange = PayAndBalance
+        , feeUpperBound = Fee maxBound
         }
 
 -- | Generate a given UTxO with a particular percentage of dust

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -598,6 +598,7 @@ prop_rebalanceSelection sel onDangling threshold = do
 
         , dustThreshold = threshold'
         , onDanglingChange = onDangling
+        , feeUpperBound = Fee maxBound
         }
 
     reserveNonNull =
@@ -622,6 +623,8 @@ feeOptions fee dust = FeeOptions
         Coin dust
     , onDanglingChange =
         PayAndBalance
+    , feeUpperBound =
+        Fee maxBound
     }
 
 feeUnitTest
@@ -847,7 +850,8 @@ instance Arbitrary FeeOptions where
                     $ c + a * (length (inputs s) + length (outputs s))
             , dustThreshold = Coin t
             , onDanglingChange = PayAndBalance
+            , feeUpperBound = Fee maxBound
             }
 
 instance Show FeeOptions where
-    show (FeeOptions _ dust onDangling) = show (dust, onDangling)
+    show (FeeOptions _ dust onDangling maxFee) = show (dust, onDangling, maxFee)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2062 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

10ab5507e out of paranoia, add an invariant to make transactions never leave fees beyond a certain amount.
3d4469ced pass down withdrawal value to 'handleCannotCoverFee' to prevent underflow in fee calculation.
f6e74dca1 add extra scenario covering fee estimation edge-case in the presence of withdrawal

TODO: I'd like to add one property or scenario to exercise the invariant and shows that it operates as expected.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
