### PR TITLE
Transaction metadata in swagger API spec

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -566,13 +566,17 @@ x-transactionMetadata: &transactionMetadata
     Cardano allows users and developers to embed their own
     authenticated metadata when submitting transactions.
 
-    The metadata format is similar to JSON. String values are limited
-    in length, and metadata is included in the overall transaction
-    size limit.
+    The transaction metadata can be `null`, or a mapping from natural
+    numbers to metadata entries. These top-level keys can be any
+    number between `0` and `2^64 - 1`.
 
-    Note that metadata top-level keys must be integers, and only a subset of JSON
-    is accepted as values. See the example on the right to get an overview and the equivalence
-    table below to understand how metadata are mapped to on-chain data types.
+    Note that metadata is not free-form JSON. Only a subset of JSON is
+    accepted as values. String values are limited in length, and
+    metadata is included in the overall transaction size limit.
+
+    See the example on the right to get an overview and the
+    equivalence table below to understand how metadata are mapped to
+    on-chain data types.
 
     | On-chain type | JSON type                                                 |
     | ---           | ---                                                       |
@@ -583,6 +587,7 @@ x-transactionMetadata: &transactionMetadata
     | map           | JSON array of 2-element ([key, value]) monomorphic arrays |
 
   type: object
+  nullable: true
   minProperties: 1
   additionalProperties:
     $ref: "#/components/schemas/TransactionMetadatum"
@@ -1007,6 +1012,7 @@ components:
         - outputs
         - withdrawals
         - status
+        - metadata
       properties:
         id: *transactionId
         amount: *transactionAmount

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -559,6 +559,25 @@ x-transactionStatus: &transactionStatus
     - pending
     - in_ledger
 
+
+x-transactionMetadata: &transactionMetadata
+  description: |
+    Extra application data attached to the transaction.
+
+    Cardano allows users and developers to embed their own
+    authenticated metadata when submitting transactions.
+
+    The metadata format is similar to JSON. String values are limited
+    in length, and metadata is included in the overall transaction
+    size limit.
+
+  type: object
+  minProperties: 1
+  propertyNames:
+    pattern: '^[0-9]+$'
+  additionalProperties:
+    $ref: '#/components/schemas/TransactionMetadatum'
+
 x-stakePoolApparentPerformance: &stakePoolApparentPerformance
   description: |
     Apparent performance of the stake pool over past epochs. This indicator is computed
@@ -981,6 +1000,7 @@ components:
         outputs: *transactionOutputs
         withdrawals: *transactionWithdrawals
         status: *transactionStatus
+        metadata: *transactionMetadata
 
     ApiWalletDelegationNext: &ApiWalletDelegationNext
       type: object
@@ -1313,6 +1333,7 @@ components:
           description: The wallet's master passphrase.
         payments: *transactionOutputs
         withdrawal: *transactionWithdrawalRequestSelf
+        metadata: *transactionMetadata
 
     ApiPostRedemptionData: &ApiPostRedemptionData
       type: object
@@ -1341,6 +1362,7 @@ components:
       properties:
         payments: *transactionOutputs
         withdrawal: *transactionWithdrawalRequestSelf
+        metadata: *transactionMetadata
 
     ApiPostRedemptionFeeData: &ApiPostRedemptionFeeData
       type: object
@@ -1358,6 +1380,31 @@ components:
       properties:
         passphrase: *lenientPassphrase
         address_index: *addressIndex
+
+    TransactionMetadatum:
+      oneOf:
+        - type: string
+        - type: number
+        - title: bytestring
+          type: object
+          required:
+          - hex
+          properties:
+            hex:
+              type: string
+              pattern: '^[0-9a-fA-F]$'
+        - title: list
+          type: array
+          items:
+            $ref: '#/components/schemas/TransactionMetadatum'
+        - title: map
+          type: array
+          items:
+            type: array
+            minItems: 2
+            maxItems: 2
+            items:
+              $ref: '#/components/schemas/TransactionMetadatum'
 
 #############################################################################
 #                                                                           #

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -571,12 +571,30 @@ x-transactionMetadata: &transactionMetadata
     in length, and metadata is included in the overall transaction
     size limit.
 
+    Note that metadata top-level keys have to be integers, and only a subset of JSON
+    is accepted as values. See the example on the right to get an overview and the equivalence
+    table below to understand how metadata are mapped to on-chain data types.
+
+    | On-chain type | JSON type                                                 |
+    | ---           | ---                                                       |
+    | string        | JSON string                                               |
+    | number        | JSON number                                               |
+    | bytestring    | JSON singleton with a field `"hex"` and a value in base16 |
+    | array         | JSON monomorphic array                                    |
+    | map           | JSON array of 2-element ([key, value]) monomorphic arrays |
+
   type: object
   minProperties: 1
   propertyNames:
     pattern: '^[0-9]+$'
   additionalProperties:
     $ref: '#/components/schemas/TransactionMetadatum'
+  example:
+    0: "cardano"
+    1: 14
+    2: { "hex": "2512a00e9653fe49a44a5886202e24d77eeb998f" }
+    3: [14, 42, 1337]
+    4: [["k1", "v1"], ["k2", "v2"]]
 
 x-stakePoolApparentPerformance: &stakePoolApparentPerformance
   description: |

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1012,7 +1012,6 @@ components:
         - outputs
         - withdrawals
         - status
-        - metadata
       properties:
         id: *transactionId
         amount: *transactionAmount
@@ -1405,7 +1404,7 @@ components:
         passphrase: *lenientPassphrase
         address_index: *addressIndex
 
-    TransactionMetadatum:
+    TransactionMetadatum: &TransactionMetadatum
       oneOf:
         - type: string
         - type: number

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -559,7 +559,6 @@ x-transactionStatus: &transactionStatus
     - pending
     - in_ledger
 
-
 x-transactionMetadata: &transactionMetadata
   description: |
     Extra application data attached to the transaction.
@@ -571,7 +570,7 @@ x-transactionMetadata: &transactionMetadata
     in length, and metadata is included in the overall transaction
     size limit.
 
-    Note that metadata top-level keys have to be integers, and only a subset of JSON
+    Note that metadata top-level keys must be integers, and only a subset of JSON
     is accepted as values. See the example on the right to get an overview and the equivalence
     table below to understand how metadata are mapped to on-chain data types.
 
@@ -585,10 +584,11 @@ x-transactionMetadata: &transactionMetadata
 
   type: object
   minProperties: 1
-  propertyNames:
-    pattern: '^[0-9]+$'
   additionalProperties:
-    $ref: '#/components/schemas/TransactionMetadatum'
+    $ref: "#/components/schemas/TransactionMetadatum"
+  # Note: propertyNames pattern not supported in current OpenAPI version.
+  # propertyNames:
+  #   pattern: '^[0-9]+$'
   example:
     0: "cardano"
     1: 14
@@ -1414,7 +1414,7 @@ components:
         - title: list
           type: array
           items:
-            $ref: '#/components/schemas/TransactionMetadatum'
+            $ref: "#/components/schemas/TransactionMetadatum"
         - title: map
           type: array
           items:
@@ -1422,7 +1422,7 @@ components:
             minItems: 2
             maxItems: 2
             items:
-              $ref: '#/components/schemas/TransactionMetadatum'
+              $ref: "#/components/schemas/TransactionMetadatum"
 
 #############################################################################
 #                                                                           #


### PR DESCRIPTION
### Issue Number

ADP-307 / #2073 / #2074 

### Overview

Updates the swagger spec for the new metadata field when:
- listing transactions (metadata field is always present but may be null)
- posting a transaction (metadata field is optional)
- estimating fee (as above)

### Comments

[Rendered spec](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/input-output-hk/cardano-wallet/rvl/2073/swagger/specifications/api/swagger.yaml)
