### PR TITLE
Bump cardano-base so that shelley-spec-ledger-test compiles

### DIFF
--- a/cardano-1.19.dev1.yaml
+++ b/cardano-1.19.dev1.yaml
@@ -1,4 +1,4 @@
-name: cardano-1.19.x
+name: cardano-1.19.dev1
 
 resolver: lts-14.25
 
@@ -60,7 +60,7 @@ packages:
 - Win32-2.6.2.0
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: df8687488449f71dce3d881800c21e41fe1b7fc1
+  commit: 3e2d92b25c675fd923a07237eb1d0859b29a79d3
   subdirs:
   - binary
   - binary/test

--- a/nix/.stack.nix/cardano-binary-test.nix
+++ b/nix/.stack.nix/cardano-binary-test.nix
@@ -48,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "df8687488449f71dce3d881800c21e41fe1b7fc1";
-      sha256 = "1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m";
+      rev = "3e2d92b25c675fd923a07237eb1d0859b29a79d3";
+      sha256 = "0ld4wwc64jags7yavhi3n7cpzs765qd9rv8jd0z0nygca5x4wp5l";
       });
     postUnpack = "sourceRoot+=/binary/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -71,8 +71,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "df8687488449f71dce3d881800c21e41fe1b7fc1";
-      sha256 = "1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m";
+      rev = "3e2d92b25c675fd923a07237eb1d0859b29a79d3";
+      sha256 = "0ld4wwc64jags7yavhi3n7cpzs765qd9rv8jd0z0nygca5x4wp5l";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -58,8 +58,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "df8687488449f71dce3d881800c21e41fe1b7fc1";
-      sha256 = "1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m";
+      rev = "3e2d92b25c675fd923a07237eb1d0859b29a79d3";
+      sha256 = "0ld4wwc64jags7yavhi3n7cpzs765qd9rv8jd0z0nygca5x4wp5l";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-praos.nix
+++ b/nix/.stack.nix/cardano-crypto-praos.nix
@@ -47,8 +47,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "df8687488449f71dce3d881800c21e41fe1b7fc1";
-      sha256 = "1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m";
+      rev = "3e2d92b25c675fd923a07237eb1d0859b29a79d3";
+      sha256 = "0ld4wwc64jags7yavhi3n7cpzs765qd9rv8jd0z0nygca5x4wp5l";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-praos; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -44,8 +44,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "df8687488449f71dce3d881800c21e41fe1b7fc1";
-      sha256 = "1chlqsp0g8lspnw2ia7v28pblr8iqqdiba51miznnclnj2vq9s2m";
+      rev = "3e2d92b25c675fd923a07237eb1d0859b29a79d3";
+      sha256 = "0ld4wwc64jags7yavhi3n7cpzs765qd9rv8jd0z0nygca5x4wp5l";
       });
     postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: cardano-1.19.x.yaml
+resolver: cardano-1.19.dev1.yaml
 
 packages:
 - lib/core


### PR DESCRIPTION
### Issue Number

Found during #2077.

### Overview

If you are keen enough to build the test suites of all our dependencies, you would have found `shelley-spec-ledger-test` failing to compile, because it needs a later revision of `cardano-base`. This will fix it.
