### PR TITLE
Add metadata to transaction layer

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -302,6 +302,7 @@ import Cardano.Wallet.Primitive.Types
     , TransactionInfo (..)
     , Tx
     , TxMeta (..)
+    , TxMetadata
     , TxOut (..)
     , TxStatus (..)
     , UTxO (..)
@@ -1566,9 +1567,10 @@ signTx
     => ctx
     -> WalletId
     -> Passphrase "raw"
+    -> Maybe TxMetadata
     -> UnsignedTx
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
-signTx ctx wid pwd (UnsignedTx inpsNE outsNE) = db & \DBLayer{..} -> do
+signTx ctx wid pwd md (UnsignedTx inpsNE outsNE) = db & \DBLayer{..} -> do
     withRootKey @_ @s ctx wid pwd ErrSignPaymentWithRootKey $ \xprv scheme -> do
         let pwdP = preparePassphrase scheme pwd
         nodeTip <- withExceptT ErrSignPaymentNetwork $ currentNodeTip nl
@@ -1592,7 +1594,6 @@ signTx ctx wid pwd (UnsignedTx inpsNE outsNE) = db & \DBLayer{..} -> do
     nl = ctx ^. networkLayer @t
     inps = NE.toList inpsNE
     outs = NE.toList outsNE
-    md = Nothing -- no metadata
 
 -- | Makes a fully-resolved coin selection for the given set of payments.
 selectCoinsExternal

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -36,7 +36,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee, FeePolicy )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), PoolId, SealedTx (..), SlotNo (..), Tx (..) )
+    ( Address (..), PoolId, SealedTx (..), SlotNo (..), Tx (..), TxMetadata )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity
@@ -54,6 +54,8 @@ data TransactionLayer t k = TransactionLayer
             -- Key store
         -> SlotNo
             -- Tip of the chain, for TTL
+        -> Maybe TxMetadata
+            -- User or application-defined metadata to embed in the transaction.
         -> CoinSelection
             -- A balanced coin selection where all change addresses have been
             -- assigned.

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -527,10 +527,10 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
         let credentials (rootK, pwdP) =
                 (getRawKey $ deriveRewardAccount pwdP rootK, pwdP)
         (_,_,_,txOld) <- unsafeRunExceptT $
-            W.signPayment @_ @_ @DummyTarget wl wid () credentials (coerce pwd) selection
+            W.signPayment @_ @_ @DummyTarget wl wid () credentials (coerce pwd) Nothing selection
         unsafeRunExceptT $ W.updateWalletPassphrase wl wid (coerce pwd, newPwd)
         (_,_,_,txNew) <- unsafeRunExceptT $
-            W.signPayment @_ @_ @DummyTarget wl wid () credentials newPwd selection
+            W.signPayment @_ @_ @DummyTarget wl wid () credentials newPwd Nothing selection
         txOld `shouldBe` txNew
   where
     selection = mempty
@@ -704,7 +704,7 @@ setupFixture (wid, wname, wstate) = do
 -- implements a fake signer that still produces sort of witnesses
 dummyTransactionLayer :: TransactionLayer DummyTarget JormungandrKey
 dummyTransactionLayer = TransactionLayer
-    { mkStdTx = \_ keyFrom _slot cs -> do
+    { mkStdTx = \_ keyFrom _slot _md cs -> do
         let inps' = map (second coin) (CS.inputs cs)
         let tid = mkTxId inps' (CS.outputs cs) mempty Nothing
         let tx = Tx tid inps' (CS.outputs cs) mempty Nothing

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -83,7 +83,7 @@ newTransactionLayer
     => Hash "Genesis"
     -> TransactionLayer t k
 newTransactionLayer block0H = TransactionLayer
-    { mkStdTx = \_rewardAcnt keyFrom _ cs ->
+    { mkStdTx = \_rewardAcnt keyFrom _ _ cs ->
         mkFragment
             ( MkFragmentSimpleTransaction (txWitnessTagFor @k)
             ) keyFrom (CS.inputs cs) (CS.outputs cs)

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/API/Transactions.hs
@@ -529,7 +529,7 @@ fixtureExternalTx ctx toSend = do
     tl <- newTransactionLayer <$> getBlock0H
     let rewardAcnt = error "rewardAcnt unused"
     let curSlot = error "current slot not needed in jormungandr mkStdTx"
-    let (Right (tx, bin)) = mkStdTx tl rewardAcnt keystore curSlot cs
+    let (Right (tx, bin)) = mkStdTx tl rewardAcnt keystore curSlot Nothing cs
 
     return ExternalTxFixture
         { srcWallet = wSrc

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -506,7 +506,7 @@ goldenTestStdTx
 goldenTestStdTx tl keystore inps outs bytes' = it title $ do
     let cs = mempty { inputs = inps, outputs = outs }
     let rewardAcnt = error "unused"
-    let tx = mkStdTx tl rewardAcnt keystore (SlotNo 0) cs
+    let tx = mkStdTx tl rewardAcnt keystore (SlotNo 0) Nothing cs
     let bytes = hex . getSealedTx . snd <$> tx
     bytes `shouldBe` Right bytes'
   where
@@ -575,7 +575,7 @@ unknownInputTest
 unknownInputTest _ block0 = it title $ do
     let addr = paymentAddress @n $ publicKey $ fst $
             xprvSeqFromSeed "address-number-0"
-    let res = mkStdTx tl rewardAcnt keyFrom (SlotNo 0) cs
+    let res = mkStdTx tl rewardAcnt keyFrom (SlotNo 0) Nothing cs
           where
             tl = newTransactionLayer @JormungandrKey block0
             rewardAcnt = error "unused"


### PR DESCRIPTION
### Issue Number

ADP-307 / #2073

### Overview

- Adds metadata as a parameter of `mkStdTx` so that transactions can be submitted with metadata.

### Comments

Based on the branch of PR #2079.
