### PR TITLE
Add tx metadata to sqlite database

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -454,7 +454,7 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
         , txInfoTime =
             slotStartTime' (meta ^. #slotNo)
         , txInfoMetadata =
-            Nothing -- fixme: #2072 store in database
+            (tx ^. #metadata)
         }
       where
         txH  = getQuantity

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1280,7 +1280,6 @@ deleteLooseTransactions = do
     deleteLoose "tx_in"
     deleteLoose "tx_out"
     deleteLoose "tx_withdrawal"
-    deleteLoose "tx_metadata"
   where
     -- Deletes all TxIn/TxOuts/TxWithdrawal returned by the sub-select.
     -- The sub-select outer joins TxMeta with TxIn/TxOut/TxWithdrawal.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -88,26 +88,17 @@ PrivateKey                             sql=private_key
 -- transaction with different metadata values. The associated inputs and outputs
 -- of the transaction are in the TxIn and TxOut tables.
 TxMeta
-    txMetaTxId         TxId         sql=tx_id
-    txMetaWalletId     W.WalletId   sql=wallet_id
-    txMetaStatus       W.TxStatus   sql=status
-    txMetaDirection    W.Direction  sql=direction
-    txMetaSlot         SlotNo       sql=slot
-    txMetaBlockHeight  Word32       sql=block_height
-    txMetaAmount       Natural      sql=amount
+    txMetaTxId         TxId               sql=tx_id
+    txMetaWalletId     W.WalletId         sql=wallet_id
+    txMetaStatus       W.TxStatus         sql=status
+    txMetaDirection    W.Direction        sql=direction
+    txMetaSlot         SlotNo             sql=slot
+    txMetaBlockHeight  Word32             sql=block_height
+    txMetaAmount       Natural            sql=amount
+    txMetaData         W.TxMetadata Maybe sql=data
 
     Primary txMetaTxId txMetaWalletId
     Foreign Wallet fk_wallet_tx_meta txMetaWalletId ! ON DELETE CASCADE
-    deriving Show Generic
-
--- Maps a transaction ID to its on-chain metadata.
--- The metadata map is encoded in JSON with the same schema
--- as what is used in the API.
-TxMetadata
-    txMetadataTxId    TxId          sql=tx_id
-    txMetadataValue   W.TxMetadata  sql=value
-
-    Primary txMetadataTxId
     deriving Show Generic
 
 -- A transaction input associated with TxMeta.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -100,6 +100,16 @@ TxMeta
     Foreign Wallet fk_wallet_tx_meta txMetaWalletId ! ON DELETE CASCADE
     deriving Show Generic
 
+-- Maps a transaction ID to its on-chain metadata.
+-- The metadata map is encoded in JSON with the same schema
+-- as what is used in the API.
+TxMetadata
+    txMetadataTxId    TxId          sql=tx_id
+    txMetadataValue   W.TxMetadata  sql=value
+
+    Primary txMetadataTxId
+    deriving Show Generic
+
 -- A transaction input associated with TxMeta.
 --
 -- There is no wallet ID because these values depend only on the transaction,

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -219,7 +219,7 @@ shrinkMetaDatum (MD.Map xs) =
         ((k,) <$> shrinkMetaDatum v) ++
         ((,v) <$> shrinkMetaDatum k)
 shrinkMetaDatum (MD.List xs) =
-    MD.List <$> filter ((>= 1) . length) (shrinkList shrinkMetaDatum xs)
+    MD.List <$> filter (not . null) (shrinkList shrinkMetaDatum xs)
 shrinkMetaDatum (MD.I i) = MD.I <$> shrink i
 shrinkMetaDatum (MD.B b) = MD.B <$> shrinkByteString b
 shrinkMetaDatum (MD.S s) = MD.S <$> shrinkMap T.pack T.unpack s


### PR DESCRIPTION
### Issue Number

ADP-307 / #2072 

### Overview

Includes transaction metadata in the sqlite database transaction history.

### Comments

- Based on PR #2079 branch
- DB state machine tests fail. Possibly due to mutations during the TxMetadata json round-trip.
