### PR TITLE
Fix stack build on windows

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -12,6 +12,9 @@
         "servant-swagger" = (((hackage.servant-swagger)."1.1.8").revisions).default;
         "zip" = (((hackage.zip)."1.3.0").revisions).default;
         "tls" = (((hackage.tls)."1.5.4").revisions).default;
+        "directory" = (((hackage.directory)."1.3.3.0").revisions).default;
+        "process" = (((hackage.process)."1.6.5.0").revisions).default;
+        "time" = (((hackage.time)."1.8.0.2").revisions).default;
         "base16" = (((hackage.base16)."0.1.2.1").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "base64" = (((hackage.base64)."0.4.2").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,6 +29,11 @@ extra-deps:
 # Needed for recently introduced support of TLS-1.3
 - tls-1.5.4
 
+# Pruned GHC boot packages which need to be here for stack to work on windows.
+- directory-1.3.3.0
+- process-1.6.5.0
+- time-1.8.0.2
+
 # persistent-2.10.2 with CASCADE DELETE support for SQLite.
 #
 # See: https://github.com/input-output-hk/persistent/tree/cardano-wallet


### PR DESCRIPTION
### Issue Number

None

### Overview

On windows, the stack build would fail with some missing dependencies. There is some stack issue with GHC boot packages. The recommended course of action is to add them as `extra-deps` in `stack.yaml`. This fixes the build.

### Comments

Since the libsodium VRF was added, there is now an extra step to get stack builds working on windows. I have updated our [iohk-setup.ps1](https://github.com/input-output-hk/adrestia/wiki/scripts/iohk-setup.ps1) script to install libsodium and configure stack to use it.
