### PR TITLE
Swagger adjustment: Supported pool id param is hex or bech32

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1404,9 +1404,7 @@ x-parametersStakePoolId: &parametersStakePoolId
   required: true
   schema:
     type: string
-    format: hex
-    maxLength: 56
-    minLength: 64
+    format: hex|bech32
 
 x-parametersAddressId:  &parametersAddressId
   in: path
@@ -2226,6 +2224,9 @@ paths:
         <p align="right">status: <strong>stable</strong></p>
 
         Delegate all (current and future) addresses from the given wallet to the given stake pool.
+
+        <strong>Note:</strong> Bech32-encoded stake pool identifiers can vary in length.
+
       parameters:
         - *parametersStakePoolId
         - *parametersWalletId


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/2023
https://github.com/input-output-hk/cardano-wallet/issues/2025

# Overview

- 01d5d509e65fa9ba18f2be91554953ca2ccdb15d
  Supported pool id param is hex or bech32



# Comments

**Before:**

![Screenshot from 2020-08-31 13-42-59](https://user-images.githubusercontent.com/42900201/91716765-8c4e9680-eb90-11ea-89c3-4c368b4a9012.png)


**After:**

![Screenshot from 2020-08-31 16-16-37](https://user-images.githubusercontent.com/42900201/91729837-6d0e3400-eba5-11ea-8154-960e330e46ac.png)




