### PR TITLE
Tx metadata API integration tests

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -65,6 +65,7 @@ library
     , retry
     , say
     , scrypt
+    , shelley-spec-ledger
     , stm
     , template-haskell
     , temporary

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -39,6 +39,7 @@ module Test.Integration.Framework.DSL
     , (.>=)
     , (.<=)
     , (.>)
+    , (.<)
     , verify
     , Headers(..)
     , Payload(..)
@@ -567,6 +568,18 @@ x .> bound
         = fail $ mconcat
             [ show x
             , " does not satisfy (> "
+            , show bound
+            , ")"
+            ]
+
+(.<) :: (Ord a, Show a) => a -> a -> Expectation
+x .< bound
+    | x < bound
+        = return ()
+    | otherwise
+        = fail $ mconcat
+            [ show x
+            , " does not satisfy (< "
             , show bound
             , ")"
             ]

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -79,6 +79,7 @@ module Test.Integration.Framework.TestData
     , errMsg403WithdrawalNotWorth
     , errMsg403NotAShelleyWallet
     , errMsg403InputsDepleted
+    , errMsg400TxTooLarge
     ) where
 
 import Prelude
@@ -324,7 +325,11 @@ errMsg400WronglyEncodedTxPayload =
 
 errMsg400TxMetadataStringTooLong :: String
 errMsg400TxMetadataStringTooLong =
-    "Error in $.metadata: ConversionErrLongerThan64Bytes"
+    "Error in $.metadata: JSON string is longer than 64 bytes"
+
+errMsg400TxTooLarge :: String
+errMsg400TxTooLarge =
+    "I am afraid that the transaction you're trying to submit is too large!"
 
 errMsg400ParseError :: String
 errMsg400ParseError = mconcat

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -63,6 +63,7 @@ module Test.Integration.Framework.TestData
     , errMsg409WalletExists
     , errMsg403TxTooBig
     , errMsg400MalformedTxPayload
+    , errMsg400TxMetadataStringTooLong
     , errMsg400WronglyEncodedTxPayload
     , errMsg400ParseError
     , errMsg403ZeroAmtOutput
@@ -320,6 +321,10 @@ errMsg400MalformedTxPayload =
 errMsg400WronglyEncodedTxPayload :: String
 errMsg400WronglyEncodedTxPayload =
     "Parse error. Expecting hex-encoded format."
+
+errMsg400TxMetadataStringTooLong :: String
+errMsg400TxMetadataStringTooLong =
+    "Error in $.metadata: ConversionErrLongerThan64Bytes"
 
 errMsg400ParseError :: String
 errMsg400ParseError = mconcat

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -121,6 +121,7 @@ import Test.Integration.Framework.TestData
     ( errMsg400MinWithdrawalWrong
     , errMsg400StartTimeLaterThanEndTime
     , errMsg400TxMetadataStringTooLong
+    , errMsg400TxTooLarge
     , errMsg403Fee
     , errMsg403InputsDepleted
     , errMsg403NoPendingAnymore
@@ -614,11 +615,8 @@ spec = do
         r <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley wa) Default payload
 
-        -- TODO: implement nice error messages when transactions are too big
-        -- expectResponseCode @IO HTTP.status400 r
-        -- expectErrorMessage "Transaction exceeds the maximum size" r
-        expectResponseCode @IO HTTP.status500 r
-        expectErrorMessage "MaxTxSizeUTxO" r
+        expectResponseCode @IO HTTP.status400 r
+        expectErrorMessage errMsg400TxTooLarge r
 
     it "TRANS_ESTIMATE_xxx - fee estimation includes metadata" $ \ctx -> do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> fixtureWallet ctx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -955,7 +955,8 @@ readNextWithdrawal ctx wid (Quantity withdrawal) = db & \DBLayer{..} -> do
     tl = ctx ^. transactionLayer @t @k
 
     minFee :: FeePolicy -> CoinSelection -> Integer
-    minFee policy = fromIntegral . getFee . minimumFee tl policy Nothing
+    minFee policy =
+        fromIntegral . getFee . minimumFee tl policy Nothing Nothing
 
 readChimericAccount
     :: forall ctx s k (n :: NetworkDiscriminant) shelley.
@@ -1194,11 +1195,12 @@ coinSelOpts tl txMaxSize = CoinSelectionOptions
 feeOpts
     :: TransactionLayer t k
     -> Maybe DelegationAction
+    -> Maybe TxMetadata
     -> W.TxParameters
     -> W.Coin
     -> FeeOptions
-feeOpts tl action txp minUtxo = FeeOptions
-    { estimateFee = minimumFee tl feePolicy action
+feeOpts tl action md txp minUtxo = FeeOptions
+    { estimateFee = minimumFee tl feePolicy action md
     , dustThreshold = minUtxo
     , onDanglingChange = if allowUnbalancedTx tl then SaveMoney else PayAndBalance
     , feeUpperBound = Fee
@@ -1225,8 +1227,9 @@ selectCoinsForPayment
     -> WalletId
     -> NonEmpty TxOut
     -> Quantity "lovelace" Word64
+    -> Maybe TxMetadata
     -> ExceptT (ErrSelectForPayment e) IO CoinSelection
-selectCoinsForPayment ctx wid recipients withdrawal = do
+selectCoinsForPayment ctx wid recipients withdrawal md = do
     (utxo, pending, txp, minUtxo) <- withExceptT ErrSelectForPaymentNoSuchWallet $
         selectCoinsSetup @ctx @s @k ctx wid
 
@@ -1235,7 +1238,7 @@ selectCoinsForPayment ctx wid recipients withdrawal = do
         ErrSelectForPaymentAlreadyWithdrawing (fromJust pendingWithdrawal)
 
     cs <-
-        selectCoinsForPaymentFromUTxO @ctx @t @k @e ctx utxo txp minUtxo recipients withdrawal
+        selectCoinsForPaymentFromUTxO @ctx @t @k @e ctx utxo txp minUtxo recipients withdrawal md
     withExceptT ErrSelectForPaymentMinimumUTxOValue $ except $
         guardCoinSelection minUtxo cs
     pure cs
@@ -1271,14 +1274,15 @@ selectCoinsForPaymentFromUTxO
     -> W.Coin
     -> NonEmpty TxOut
     -> Quantity "lovelace" Word64
+    -> Maybe TxMetadata
     -> ExceptT (ErrSelectForPayment e) IO CoinSelection
-selectCoinsForPaymentFromUTxO ctx utxo txp minUtxo recipients withdrawal = do
+selectCoinsForPaymentFromUTxO ctx utxo txp minUtxo recipients withdrawal md = do
     lift . traceWith tr $ MsgPaymentCoinSelectionStart utxo txp recipients
     (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
         let opts = coinSelOpts tl (txp ^. #getTxMaxSize)
         CoinSelection.random opts recipients withdrawal utxo
     lift . traceWith tr $ MsgPaymentCoinSelection sel
-    let feePolicy = feeOpts tl Nothing txp minUtxo
+    let feePolicy = feeOpts tl Nothing md txp minUtxo
     withExceptT ErrSelectForPaymentFee $ do
         balancedSel <- adjustForFee feePolicy utxo' sel
         lift . traceWith tr $ MsgPaymentCoinSelectionAdjusted balancedSel
@@ -1316,7 +1320,7 @@ selectCoinsForDelegationFromUTxO
     -> DelegationAction
     -> ExceptT ErrSelectForDelegation IO CoinSelection
 selectCoinsForDelegationFromUTxO ctx utxo txp minUtxo action = do
-    let feePolicy = feeOpts tl (Just action) txp minUtxo
+    let feePolicy = feeOpts tl (Just action) Nothing txp minUtxo
     let sel = initDelegationSelection tl (txp ^. #getFeePolicy) action
     withExceptT ErrSelectForDelegationFee $ do
         balancedSel <- adjustForFee feePolicy utxo sel
@@ -1396,8 +1400,8 @@ selectCoinsForMigrationFromUTxO
         )
 selectCoinsForMigrationFromUTxO ctx utxo txp minUtxo wid = do
     let feePolicy@(LinearFee (Quantity a) _ _) = txp ^. #getFeePolicy
-    let feeOptions = (feeOpts tl Nothing txp minBound)
-            { estimateFee = minimumFee tl feePolicy Nothing . worstCase
+    let feeOptions = (feeOpts tl Nothing Nothing txp minBound)
+            { estimateFee = minimumFee tl feePolicy Nothing Nothing . worstCase
             , dustThreshold = max (Coin $ ceiling a) minUtxo
             }
     let selOptions = coinSelOpts tl (txp ^. #getTxMaxSize)
@@ -1453,13 +1457,13 @@ estimateFeeForPayment
     -> WalletId
     -> NonEmpty TxOut
     -> Quantity "lovelace" Word64
+    -> Maybe TxMetadata
     -> ExceptT (ErrSelectForPayment e) IO FeeEstimation
-estimateFeeForPayment ctx wid recipients withdrawal = do
+estimateFeeForPayment ctx wid recipients withdrawal md = do
     (utxo, _, txp, minUtxo) <- withExceptT ErrSelectForPaymentNoSuchWallet $
         selectCoinsSetup @ctx @s @k ctx wid
 
-    let selectCoins =
-            selectCoinsForPaymentFromUTxO @ctx @t @k @e ctx utxo txp minUtxo recipients withdrawal
+    let selectCoins = selectCoinsForPaymentFromUTxO @ctx @t @k @e ctx utxo txp minUtxo recipients withdrawal md
 
     cs <- selectCoins `catchE` handleNotSuccessfulCoinSelection
     withExceptT ErrSelectForPaymentMinimumUTxOValue $ except $
@@ -1621,10 +1625,11 @@ selectCoinsExternal
     -> ArgGenChange s
     -> NonEmpty TxOut
     -> Quantity "lovelace" Word64
+    -> Maybe TxMetadata
     -> ExceptT (ErrSelectCoinsExternal e) IO UnsignedTx
-selectCoinsExternal ctx wid argGenChange payments withdrawal = do
+selectCoinsExternal ctx wid argGenChange payments withdrawal md = do
     cs <- withExceptT ErrSelectCoinsExternalUnableToMakeSelection $
-        selectCoinsForPayment @ctx @s @t @k @e ctx wid payments withdrawal
+        selectCoinsForPayment @ctx @s @t @k @e ctx wid payments withdrawal md
     cs' <- db & \DBLayer{..} ->
         withExceptT ErrSelectCoinsExternalNoSuchWallet $
             mapExceptT atomically $ do

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -114,12 +114,20 @@ data TransactionLayer t k = TransactionLayer
         -- accordingly.
 
     , minimumFee
-        :: FeePolicy -> Maybe DelegationAction -> CoinSelection -> Fee
+        :: FeePolicy
+        -> Maybe DelegationAction
+        -> Maybe TxMetadata
+        -> CoinSelection
+        -> Fee
         -- ^ Compute a minimal fee amount necessary to pay for a given
         -- coin-selection.
 
     , estimateMaxNumberOfInputs
-        :: Quantity "byte" Word16 -> Word8 -> Word8
+        :: Quantity "byte" Word16
+            -- Max tx size
+        -> Word8
+            -- desired number of outputs
+        -> Word8
         -- ^ Calculate a "theoretical" maximum number of inputs given a maximum
         -- transaction size and desired number of outputs.
         --

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -46,7 +46,13 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..), Hash (..), SealedTx (..), Tx (..), TxOut (..) )
+    ( ChimericAccount (..)
+    , Hash (..)
+    , SealedTx (..)
+    , Tx (..)
+    , TxMetadata
+    , TxOut (..)
+    )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)
@@ -158,9 +164,10 @@ newTransactionLayer block0H = TransactionLayer
     _minimumFee
         :: FeePolicy
         -> Maybe DelegationAction
+        -> Maybe TxMetadata
         -> CoinSelection
         -> Fee
-    _minimumFee policy action cs =
+    _minimumFee policy action _ cs =
         Fee $ ceiling (a + b*fromIntegral ios + c*certs)
       where
         LinearFee (Quantity a) (Quantity b) (Quantity c) = policy

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -398,7 +398,7 @@ bench_restoration proxy tracer socketPath np vData progressLogFile (wid, wname, 
                 (_, estimatingFeesTime) <- bench "estimate tx fee" $ do
                     let out = TxOut (dummyAddress @n) (Coin 1)
                     runExceptT $ withExceptT show $ W.estimateFeeForPayment @_ @s @t @k
-                        w wid (out :| []) (Quantity 0)
+                        w wid (out :| []) (Quantity 0) Nothing
 
                 unsafeRunExceptT $ W.deleteWallet w wid
                 pure BenchResults

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -359,13 +359,12 @@ _minimumFee
     => NetworkId
     -> FeePolicy
     -> Maybe DelegationAction
+    -> Maybe TxMetadata
     -> CoinSelection
     -> Fee
-_minimumFee networkId policy action cs =
+_minimumFee networkId policy action md cs =
     computeFee $ computeTxSize networkId (txWitnessTagFor @k) md action cs
   where
-    md = Nothing -- fixme: #2075 include metadata in fee calculations
-
     computeFee :: Integer -> Fee
     computeFee size =
         Fee $ ceiling (a + b*fromIntegral size)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -123,7 +123,7 @@ spec = do
                 policy = LinearFee (Quantity 100000) (Quantity 100) (Quantity 0)
 
                 minFee :: CoinSelection -> Integer
-                minFee = fromIntegral . getFee . minimumFee tl policy Nothing
+                minFee = fromIntegral . getFee . minimumFee tl policy Nothing Nothing
                   where tl = testTxLayer
 
                 costWith = minFee (mempty { withdrawal })
@@ -249,7 +249,7 @@ testCoinSelOpts :: CoinSelectionOptions ()
 testCoinSelOpts = coinSelOpts testTxLayer (Quantity 4096)
 
 testFeeOpts :: FeeOptions
-testFeeOpts = feeOpts testTxLayer Nothing txParams (Coin 0)
+testFeeOpts = feeOpts testTxLayer Nothing Nothing txParams (Coin 0)
   where
     txParams  = TxParameters feePolicy txMaxSize
     feePolicy = LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -65,6 +65,7 @@
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."say" or (errorHandler.buildDepError "say"))
           (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
+          (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))


### PR DESCRIPTION
### Issue Number

ADP-307 / #2074 / #2073.

### Overview

- API test case for posting a transaction with metadata.
- Test creating a transaction with invalid metadata.
- Test creating a transaction that's too large due to metadata.
- Test that the transaction fee estimate is higher when there's metadata in the transaction.

### Comments

- Based on PR #2104 branch.