### PR TITLE
Swap order of waitForProcess and hGetContents to avoid blocking on windows

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1636,9 +1636,15 @@ postTransactionViaCLI ctx passphrase args = do
             hPutStr stdin (passphrase ++ "\n")
             hFlush stdin
             hClose stdin
-            c <- waitForProcess h
             out <- TIO.hGetContents stdout
             err <- TIO.hGetContents stderr
+            -- For some reason, when 
+            -- - waitForProcess is called before hGetContents 
+            -- - os is windows
+            -- - postTransactionViaCLI was called with >= 5 outputs
+            -- waitForProcess blocks indefinetely. Hence we call waitForProcess
+            -- last. 
+            c <- waitForProcess h
             return (c, T.unpack out, err)
 
 postTransactionFeeViaCLI


### PR DESCRIPTION
# Issue Number

#2083 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Swapping order of operations seems to fix problem that only arises on windows, and with tx >=5 outputs 
- [x] Fixes `WALLETS_UTXO_02`


# Comments

- [ ] I am re-running _all_ windows tests locally to be more sure

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
