### PR TITLE
Include transaction metadata in coin selection and fee calculations

### DIFF
--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -114,12 +114,20 @@ data TransactionLayer t k = TransactionLayer
         -- accordingly.
 
     , minimumFee
-        :: FeePolicy -> Maybe DelegationAction -> CoinSelection -> Fee
+        :: FeePolicy
+        -> Maybe DelegationAction
+        -> Maybe TxMetadata
+        -> CoinSelection
+        -> Fee
         -- ^ Compute a minimal fee amount necessary to pay for a given
         -- coin-selection.
 
     , estimateMaxNumberOfInputs
-        :: Quantity "byte" Word16 -> Word8 -> Word8
+        :: Quantity "byte" Word16
+            -- Max tx size
+        -> Word8
+            -- desired number of outputs
+        -> Word8
         -- ^ Calculate a "theoretical" maximum number of inputs given a maximum
         -- transaction size and desired number of outputs.
         --

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -46,7 +46,13 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..), Hash (..), SealedTx (..), Tx (..), TxOut (..) )
+    ( ChimericAccount (..)
+    , Hash (..)
+    , SealedTx (..)
+    , Tx (..)
+    , TxMetadata
+    , TxOut (..)
+    )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)
@@ -158,9 +164,10 @@ newTransactionLayer block0H = TransactionLayer
     _minimumFee
         :: FeePolicy
         -> Maybe DelegationAction
+        -> Maybe TxMetadata
         -> CoinSelection
         -> Fee
-    _minimumFee policy action cs =
+    _minimumFee policy action _ cs =
         Fee $ ceiling (a + b*fromIntegral ios + c*certs)
       where
         LinearFee (Quantity a) (Quantity b) (Quantity c) = policy

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -359,13 +359,12 @@ _minimumFee
     => NetworkId
     -> FeePolicy
     -> Maybe DelegationAction
+    -> Maybe TxMetadata
     -> CoinSelection
     -> Fee
-_minimumFee networkId policy action cs =
+_minimumFee networkId policy action md cs =
     computeFee $ computeTxSize networkId (txWitnessTagFor @k) md action cs
   where
-    md = Nothing -- fixme: #2075 include metadata in fee calculations
-
     computeFee :: Integer -> Fee
     computeFee size =
         Fee $ ceiling (a + b*fromIntegral size)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -122,7 +122,7 @@ spec = do
                 policy = LinearFee (Quantity 100000) (Quantity 100) (Quantity 0)
 
                 minFee :: CoinSelection -> Integer
-                minFee = fromIntegral . getFee . minimumFee tl policy Nothing
+                minFee = fromIntegral . getFee . minimumFee tl policy Nothing Nothing
                   where tl = testTxLayer
 
                 costWith = minFee (mempty { withdrawal })
@@ -246,7 +246,7 @@ testCoinSelOpts :: CoinSelectionOptions ()
 testCoinSelOpts = coinSelOpts testTxLayer (Quantity 4096)
 
 testFeeOpts :: FeeOptions
-testFeeOpts = feeOpts testTxLayer Nothing feePolicy (Coin 0)
+testFeeOpts = feeOpts testTxLayer Nothing Nothing feePolicy (Coin 0)
   where
     feePolicy = LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)
 


### PR DESCRIPTION
### Issue Number

ADP-307 / #2075 

### Overview

Adds metadata as a parameter of coin selection and fee calculation functions.

### Comments

- Based on PR #2089 branch.
