### PR TITLE
Add unit test for transaction metadata fee calculation

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -148,7 +148,7 @@ buildStep dryRun bk nightly = do
       titled "Build"
         (build Fast (["--test", "--no-run-tests"] ++ cabalFlags)) .&&.
       titled "Test"
-        (timeout 45 (test Fast Serial cabalFlags .&&. test Fast Parallel cabalFlags)) .&&.
+        (timeout 60 (test Fast Serial cabalFlags .&&. test Fast Parallel cabalFlags)) .&&.
       titled "Checking golden test files"
         (checkUnclean dryRun "lib/core/test/data")
   where

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -119,7 +120,7 @@ spec = do
 
     describe "fee calculations" $ do
         let policy :: FeePolicy
-            policy = LinearFee (Quantity 100000) (Quantity 100) (Quantity 0)
+            policy = LinearFee (Quantity 100_000) (Quantity 100) (Quantity 0)
 
             minFee :: Maybe TxMetadata -> CoinSelection -> Integer
             minFee md = fromIntegral . getFee . minimumFee tl policy Nothing md
@@ -137,7 +138,7 @@ spec = do
                     then property $ marginalCost == 0
                     else property $ marginalCost > 0
                 ) & classify (withdrawal == 0) "null withdrawal"
-                & counterexample ("cost of withdrawal: " <> show marginalCost)
+                & counterexample ("marginal cost: " <> show marginalCost)
                 & counterexample ("cost with: " <> show costWith)
                 & counterexample ("cost without: " <> show costWithout)
 


### PR DESCRIPTION
### Issue Number

ADP-307 / #2075 

### Overview

- Property tests that the fee calculation produces a higher result when there is metadata present.
- The test is along the lines of the withdrawal fee calculation test, which I reworded slightly.
