### PR TITLE
Faster listing of stake pools.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -177,6 +177,13 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- ^ List all pools with an active retirement epoch that is earlier
         -- than or equal to the specified epoch.
 
+    , listPoolLifeCycleData
+        :: EpochNo
+        -> stm [PoolLifeCycleStatus]
+        -- ^ List the lifecycle data of all non-retired pools: pools that
+        -- either don't have an active retirement epoch or pools that have
+        -- an active retirement epoch that is later than the given epoch.
+
     , putPoolMetadata
         :: StakePoolMetadataHash
         -> StakePoolMetadata

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -608,11 +608,18 @@ data DatabaseView = DatabaseView
 --
 createView :: Sqlite.Connection -> DatabaseView -> IO ()
 createView conn (DatabaseView name definition) = do
-    query <- Sqlite.prepare conn queryString
-    Sqlite.step query *> Sqlite.finalize query
+    deleteQuery <- Sqlite.prepare conn deleteQueryString
+    Sqlite.step deleteQuery *> Sqlite.finalize deleteQuery
+    createQuery <- Sqlite.prepare conn createQueryString
+    Sqlite.step createQuery *> Sqlite.finalize createQuery
   where
-    queryString = T.unlines
-        [ "CREATE VIEW IF NOT EXISTS"
+    deleteQueryString = T.unlines
+        [ "DROP VIEW IF EXISTS"
+        , name
+        , ";"
+        ]
+    createQueryString = T.unlines
+        [ "CREATE VIEW"
         , name
         , "AS"
         , definition

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -462,6 +462,16 @@ instance PersistFieldSql PoolOwner where
 instance Read PoolOwner where
     readsPrec _ = error "readsPrec stub needed for persistent"
 
+instance FromText [PoolOwner] where
+    fromText t = mapM fromText $ T.words t
+
+instance PersistField [PoolOwner] where
+    toPersistValue v = toPersistValue $ T.unwords $ toText <$> v
+    fromPersistValue = fromPersistValueFromText
+
+instance PersistFieldSql [PoolOwner] where
+    sqlType _ = sqlType (Proxy @Text)
+
 ----------------------------------------------------------------------------
 -- HDPassphrase
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1759,7 +1759,7 @@ data PoolLifeCycleStatus
         PoolRetirementCertificate
         -- ^ Indicates that a pool is registered AND ALSO marked for retirement.
         -- Records the latest registration and retirement certificates.
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 getPoolRegistrationCertificate
     :: PoolLifeCycleStatus -> Maybe PoolRegistrationCertificate

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -214,14 +214,14 @@ isValidSinglePoolCertificateSequence :: SinglePoolCertificateSequence -> Bool
 isValidSinglePoolCertificateSequence
     (SinglePoolCertificateSequence sharedPoolId certificates) =
         allCertificatesReferToSamePool &&
-        firstCertificateIsRegistration
+        firstCertificateIsNotRetirement
   where
     allCertificatesReferToSamePool =
         all (== sharedPoolId) (getPoolCertificatePoolId <$> certificates)
-    firstCertificateIsRegistration = case certificates of
+    firstCertificateIsNotRetirement = case certificates of
+        []                 -> True
         Registration _ : _ -> True
-        Retirement _ : _ -> False
-        [] -> True
+        Retirement   _ : _ -> False
 
 instance Arbitrary SinglePoolCertificateSequence where
 

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -9,6 +9,7 @@
 
 module Cardano.Pool.DB.Arbitrary
     ( ListSerializationMethod
+    , MultiPoolCertificateSequence (..)
     , SinglePoolCertificateSequence (..)
     , StakePoolsFixture (..)
     , genStakePoolMetadata
@@ -242,6 +243,21 @@ instance Arbitrary SinglePoolCertificateSequence where
             & fmap (fmap (setPoolCertificatePoolId sharedPoolId))
             & fmap (SinglePoolCertificateSequence sharedPoolId)
             & filter isValidSinglePoolCertificateSequence
+
+-- | Represents valid sequences of registration and retirement certificates
+--   for multiple pools.
+--
+newtype MultiPoolCertificateSequence = MultiPoolCertificateSequence
+    { getMultiPoolCertificateSequence :: [SinglePoolCertificateSequence]
+    }
+    deriving (Eq, Show)
+
+instance Arbitrary MultiPoolCertificateSequence where
+    arbitrary = MultiPoolCertificateSequence <$> arbitrary
+    shrink
+        = fmap MultiPoolCertificateSequence
+        . shrink
+        . getMultiPoolCertificateSequence
 
 -- | Indicates a way to serialize a list of lists into a single list.
 --

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -575,17 +575,12 @@ prop_multiple_putPoolRegistration_single_readPoolRegistration
 
     certificatePublications
         :: [(CertificatePublicationTime, PoolRegistrationCertificate)]
-    certificatePublications = publicationTimes `zip` certificates
+    certificatePublications =
+        testCertificatePublicationTimes `zip` certificates
 
     mExpectedCertificatePublication = certificatePublications
         & reverse
         & listToMaybe
-
-    publicationTimes =
-        [ CertificatePublicationTime (SlotNo sn) ii
-        | sn <- [0 .. ]
-        , ii <- [0 .. 3]
-        ]
 
     certificates = set #poolId sharedPoolId <$> certificatesManyPoolIds
 
@@ -824,7 +819,7 @@ prop_rollbackRetirement DBLayer{..} certificates =
     rollbackPoint =
         -- Pick a slot that approximately corresponds to the midpoint of the
         -- certificate publication list.
-        publicationTimes
+        testCertificatePublicationTimes
             & drop (length certificates `div` 2)
             & fmap (view #slotNo)
             & listToMaybe
@@ -832,7 +827,7 @@ prop_rollbackRetirement DBLayer{..} certificates =
 
     allPublications
         :: [(CertificatePublicationTime, PoolRetirementCertificate)]
-    allPublications = publicationTimes `zip` certificates
+    allPublications = testCertificatePublicationTimes `zip` certificates
 
     expectedPublications
         :: [(CertificatePublicationTime, PoolRetirementCertificate)]
@@ -841,13 +836,6 @@ prop_rollbackRetirement DBLayer{..} certificates =
             (\(CertificatePublicationTime slotId _, _) ->
                 slotId <= rollbackPoint)
             allPublications
-
-    publicationTimes :: [CertificatePublicationTime]
-    publicationTimes =
-        [ CertificatePublicationTime (SlotNo sn) ii
-        | sn <- [0 .. 3]
-        , ii <- [0 .. 3]
-        ]
 
 -- When we remove pools, check that:
 --
@@ -909,14 +897,8 @@ prop_removePools
 
     certificatePublications
         :: [(CertificatePublicationTime, PoolCertificate)]
-    certificatePublications = publicationTimes `zip` certificates
-
-    publicationTimes :: [CertificatePublicationTime]
-    publicationTimes =
-        [ CertificatePublicationTime (SlotNo sn) ii
-        | sn <- [0 .. 3]
-        , ii <- [0 .. 3]
-        ]
+    certificatePublications =
+        testCertificatePublicationTimes `zip` certificates
 
     poolIdsWithRegCerts =
         fmap (Set.fromList . fmap (view #poolId . snd) . catMaybes)
@@ -996,14 +978,9 @@ prop_listRetiredPools_multiplePools_multipleCerts
 
     allPublications :: [(CertificatePublicationTime, PoolCertificate)]
     allPublications =
-        publicationTimes `zip` getMultiPoolCertificateSequence mpcs
-
-    publicationTimes :: [CertificatePublicationTime]
-    publicationTimes =
-        [ CertificatePublicationTime (SlotNo sn) ii
-        | sn <- [0 .. 3]
-        , ii <- [0 .. 3]
-        ]
+        testCertificatePublicationTimes
+        `zip`
+        getMultiPoolCertificateSequence mpcs
 
 prop_unfetchedPoolMetadataRefs
     :: DBLayer IO
@@ -1288,3 +1265,12 @@ putPoolCertificate
             putPoolRegistration publicationTime c
         Retirement c ->
             putPoolRetirement publicationTime c
+
+-- | A sequence of certificate publication times that is useful for testing.
+--
+testCertificatePublicationTimes :: [CertificatePublicationTime]
+testCertificatePublicationTimes =
+    [ CertificatePublicationTime (SlotNo sn) ii
+    | sn <- [0 ..  ]
+    , ii <- [0 .. 3]
+    ]

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -986,7 +986,7 @@ prop_listRetiredPools_multiplePools_multipleCerts
 
     prop = do
         run $ atomically $ do
-            mapM_ (uncurry putCertificate) allPublicationsSerialized
+            mapM_ (uncurry putCertificate) allPublications
         lifeCycleStatuses <- run $ atomically $ do
             mapM readPoolLifeCycleStatus allPoolIds
         let poolsMarkedToRetire = catMaybes $
@@ -1005,16 +1005,12 @@ prop_listRetiredPools_multiplePools_multipleCerts
                 (Set.fromList retiredPoolsActual)
                 (Set.fromList retiredPoolsExpected)
 
-    allCertificatesSerialized :: [PoolCertificate]
-    allCertificatesSerialized = getMultiPoolCertificateSequence mpcs
-
-    allPublicationsSerialized
-        :: [(CertificatePublicationTime, PoolCertificate)]
-    allPublicationsSerialized =
-        publicationTimes `zip` allCertificatesSerialized
-
     allPoolIds :: [PoolId]
     allPoolIds = getSinglePoolId <$> getSinglePoolSequences mpcs
+
+    allPublications :: [(CertificatePublicationTime, PoolCertificate)]
+    allPublications =
+        publicationTimes `zip` getMultiPoolCertificateSequence mpcs
 
     publicationTimes :: [CertificatePublicationTime]
     publicationTimes =

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -978,28 +978,11 @@ prop_listRegisteredPools DBLayer {..} entries =
 --
 prop_listRetiredPools_multiplePools_multipleCerts
     :: DBLayer IO
-    -> [SinglePoolCertificateSequence]
+    -> MultiPoolCertificateSequence
     -> ListSerializationMethod
     -> Property
 prop_listRetiredPools_multiplePools_multipleCerts
-    DBLayer {..} certificateSequences serializationMethod = checkCoverage
-        -- Check the number of certificates:
-        $ cover 2 (certificateCount == 0)
-            "number of certificates: = 0"
-        $ cover 2 (certificateCount > 0 && certificateCount <= 10)
-            "number of certificates: > 0 && <= 10"
-        $ cover 2 (certificateCount > 10 && certificateCount <= 100)
-            "number of certificates: > 10 && <= 100"
-        $ cover 2 (certificateCount > 100 && certificateCount <= 1000)
-            "number of certificates: > 100 && <= 1000"
-        -- Check the number of pools:
-        $ cover 2 (poolCount == 0)
-            "number of pools: = 0"
-        $ cover 2 (poolCount > 0 && poolCount <= 10)
-            "number of pools: > 0 && <= 10"
-        $ cover 2 (poolCount > 10 && poolCount <= 100)
-            "number of pools: > 10 && <= 100"
-        $ monadicIO (setup >> prop)
+    DBLayer {..} mpcs serializationMethod = monadicIO (setup >> prop)
   where
     setup = run $ atomically cleanDB
 
@@ -1024,8 +1007,7 @@ prop_listRetiredPools_multiplePools_multipleCerts
                 (Set.fromList retiredPoolsActual)
                 (Set.fromList retiredPoolsExpected)
 
-    certificateCount = length allCertificatesSerialized
-    poolCount = length certificateSequences
+    certificateSequences = getMultiPoolCertificateSequence mpcs
 
     allCertificatesSerialized :: [PoolCertificate]
     allCertificatesSerialized = serializeLists serializationMethod

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -147,6 +147,7 @@ import qualified Cardano.Wallet.Api.Types as Api
 import qualified Data.List as L
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 --
 -- Stake Pool Layer
@@ -194,7 +195,7 @@ newStakePoolLayer nl db@DBLayer {..} =
     _knownPools
         :: IO (Set PoolId)
     _knownPools =
-        Map.keysSet <$> liftIO (readPoolDbData db minBound)
+        Set.fromList <$> liftIO (atomically listRegisteredPools)
 
     _listPools
         :: EpochNo


### PR DESCRIPTION
## Related Issues

#2082 (_Listing stake pools time grows when there are wallets syncing in background_.)

https://jira.iohk.io/browse/ADP-383 (_Use more efficient DB queries when listing pools_.)

## Overview

This PR:

* changes the implementation of `ListStakePools` to execute a small number of handwritten SQL queries with native joins, rather than issuing multiple queries and joining together the results in memory.

* adds a new operation [`listPoolLifeCycleData`](https://github.com/input-output-hk/cardano-wallet/blob/d00c608e47d2d189a282a02946cc8e46b843375b/lib/core/src/Cardano/Pool/DB.hs#L180). The [SQLite implementation](https://github.com/input-output-hk/cardano-wallet/blob/d00c608e47d2d189a282a02946cc8e46b843375b/lib/core/src/Cardano/Pool/DB/Sqlite.hs#L384) of this operation uses a [single hand-optimized query](https://github.com/input-output-hk/cardano-wallet/blob/d00c608e47d2d189a282a02946cc8e46b843375b/lib/core/src/Cardano/Pool/DB/Sqlite.hs#L595) to return lifecycle data for all pools.

## Benefits

### :star: **Faster execution time**

  The time taken to execute `ListStakePools` is greatly reduced, even when there are multiple wallets syncing in the background.
  <details><summary>Click to view data</summary><br>

  | No. of <br>Wallets<br>Syncing | Time Required<br>(seconds)<br>`master` | Time Required<br>(seconds)<br>`more-efficient-list-pools` |
  | ---: | ---: | ---: |
  | 0 | 8 | 3 |
  | 5 | 30 | 7 |
  | 10 | 60 | 8 |
  | 15 | 72 | 9 |
  | 20 | 95 | 10 |
  </details>

### :star: **Fewer database queries**

  The number of `select` queries required for a single call to `ListStakePools` is greatly reduced.
  <details><summary>Click to view data</summary><br>
  
  | Branch | Network | No. of Pools | No. of Queries |
  | :--- | :--- | ---: | ---: | 
  | `master` | `mainnet` |  1,124 |  12,365 |
  | `more-efficient-list-pools`| `mainnet` | 1,124  | 4 |
  </details>

## Testing

### :heavy_check_mark: Properties

This PR adds a [property test](https://github.com/input-output-hk/cardano-wallet/blob/d00c608e47d2d189a282a02946cc8e46b843375b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs#L987) for `listPoolLifeCycleData`, consisting of the following steps:
1. Add an arbitrary sequence of pool registration and retirement certificates to the database, for multiple pools.
2. Call `listPoolLifeCycleData` once to fetch lifecycle data for all active pools.
3. Call `readPoolLifeCycleStatus` multiple times, once for each known pool, and coalesce the results. 
4. Test that the results returned in steps 2 and 3 are identical.

### :heavy_check_mark: Live Data

Run the following command to get a list of all stake pools sorted by ID:
```sh
cardano-wallet stake-pool list --stake 1000 | jq 'sort_by(.id)' > stake-pool-list
```
The results should be identical for both `master` and this branch.

## Notes

### System used for Benchmarking

The system used for benchmarking (4 cores):

```
vendor_id       : GenuineIntel
cpu family      : 6
model           : 85
model name      : Intel(R) Xeon(R) CPU
stepping        : 7
microcode       : 0x1
cpu MHz         : 2800.176
cache size      : 33792 KB
```