### PR TITLE
Relax fee upper bound invariant

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -178,10 +178,12 @@ adjustForFee unsafeOpt utxo coinSel = do
     let opt = invariant "fee must be non-null" unsafeOpt (not . nullFee)
     cs <- senderPaysFee opt utxo coinSel
     let actualFee = Fee (feeBalance cs)
-    when (actualFee > feeUpperBound opt) $
+    let maxFee = feeUpperBound opt
+    when (actualFee > maxFee) $
         error $ pretty $ unlinesF
             [ "generated a coin selection with an excessively large fee."
             , nameF "actual fee" (build actualFee)
+            , nameF "maximum fee" (build maxFee)
             , nameF "coin selection" (build cs)
             ]
     pure cs


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2062 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have relaxed a bit the upper bound. This invariant is really to prevent catastrophic situations which would induce the lost of thousands / millions of Ada so it needs not to be very precise. We do make quite a lot of approximations and roundings when estimating fees, and the minimal UTxO value may also induce some extra amount to be counted towards fees. 

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
