### PR TITLE
stack.yaml: Completely disable RDRAND support in cryptonite

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -146,6 +146,9 @@
             flags = { "external-libsodium-vrf" = lib.mkOverride 900 false; };
             };
           "zip" = { flags = { "disable-bzip2" = lib.mkOverride 900 true; }; };
+          "cryptonite" = {
+            flags = { "support_rdrand" = lib.mkOverride 900 false; };
+            };
           };
         })
     {

--- a/stack.yaml
+++ b/stack.yaml
@@ -65,6 +65,11 @@ flags:
   cardano-crypto-praos:
     external-libsodium-vrf: false
 
+  # Using RDRAND instead of /dev/urandom as an entropy source for key
+  # generation is dubious. Set the flag so we use /dev/urandom by default.
+  cryptonite:
+    support_rdrand: false
+
 # Generate files required by Weeder.
 # See https://github.com/ndmitchell/weeder/issues/53
 ghc-options: {"$locals": -ddump-to-file -ddump-hi}


### PR DESCRIPTION
### Issue Number

Relates to ADP-428.

### Overview

Ensures that RDRAND can never be the sole source of RNG entropy.

To generate mnemonics it goes through cryptonite `Crypto.Random.Entropy.getEntropy`. Disabling the RDRAND backend will leave just the WinCryptoAPI (windows) and DevRandom, DevURandom backends (not windows).
