### PR TITLE
Improve fee estimation performance / fix accidentally quadratic function

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -283,9 +281,11 @@ instance PathPiece BlockId where
 ----------------------------------------------------------------------------
 -- SlotId
 
-deriving via Word64 instance (PersistFieldSql SlotNo)
+instance PersistFieldSql SlotNo where
+    sqlType _ = sqlType (Proxy @Word64)
 
-deriving via Word64 instance (Read SlotNo)
+instance Read SlotNo where
+    readsPrec _ = error "readsPrec stub needed for persistent"
 
 persistSlotNo :: SlotNo -> PersistValue
 persistSlotNo = toPersistValue . unSlotNo
@@ -308,7 +308,8 @@ instance PathPiece SlotNo where
 ----------------------------------------------------------------------------
 -- EpochNo
 
-deriving via Word32 instance (PersistFieldSql EpochNo)
+instance PersistFieldSql EpochNo where
+    sqlType _ = sqlType (Proxy @Word32)
 
 mkEpochNo :: Word32 -> Either Text EpochNo
 mkEpochNo n

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -190,10 +190,6 @@ import Control.Monad
     ( guard, (<=<), (>=>) )
 import Crypto.Hash
     ( Blake2b_160, Digest, digestFromByteString )
-import Crypto.Number.Generate
-    ( generateBetween )
-import Crypto.Random.Types
-    ( MonadRandom )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..), withObject, (.:), (.:?) )
 import Data.Bifunctor
@@ -268,6 +264,8 @@ import GHC.TypeLits
     ( KnownNat, KnownSymbol, Symbol, natVal, symbolVal )
 import Numeric.Natural
     ( Natural )
+import System.Random
+    ( randomRIO )
 
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
@@ -1210,14 +1208,13 @@ instance Buildable UTxO where
 -- | Pick a random element from a UTxO, returns 'Nothing' if the UTxO is empty.
 -- Otherwise, returns the selected entry and, the UTxO minus the selected one.
 pickRandom
-    :: MonadRandom m
-    => UTxO
-    -> m (Maybe (TxIn, TxOut), UTxO)
+    :: UTxO
+    -> IO (Maybe (TxIn, TxOut), UTxO)
 pickRandom (UTxO utxo)
     | Map.null utxo =
         return (Nothing, UTxO utxo)
     | otherwise = do
-        ix <- fromEnum <$> generateBetween 0 (toEnum (Map.size utxo - 1))
+        ix <- randomRIO (0, toEnum (Map.size utxo - 1))
         return (Just $ Map.elemAt ix utxo, UTxO $ Map.deleteAt ix utxo)
 
 -- | Compute the balance of a UTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -211,7 +211,7 @@ import Data.Generics.Labels
 import Data.Int
     ( Int32 )
 import Data.List
-    ( intercalate )
+    ( foldl', intercalate )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -1231,7 +1231,10 @@ balance =
 -- | Compute the balance of a unwrapped UTxO
 balance' :: [(TxIn, TxOut)] -> Word64
 balance' =
-    fromIntegral . balance . UTxO . Map.fromList
+    foldl' fn 0
+  where
+    fn :: Word64 -> (TxIn, TxOut) -> Word64
+    fn tot (_, out) = tot + getCoin (coin out)
 
 -- | ins⋪ u
 excluding :: UTxO -> Set TxIn ->  UTxO


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2032 & rel

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- ca9dd1ea2ded5b3539d7362f4fcb74fd2bcadf94
  :round_pushpin: **remove use of DerivingVia in Sqlite types: can't build with --profile with it**
  
- bc1bacc106faa4b17ad2a3cecf75eb29fb459bd6
  :round_pushpin: **avoid re-creating and folding on a map to compute balance of a list of resolved inputs**
    This is somehow causing massive slowness in the fee estimation. Changing this reduces the time in benchmarks from 18,000ms to 3,000ms!!

- f82a7fed3903f46409456c41ec46b292e2fa4bc6
  :round_pushpin: **use standard random generator for picking random UTxO**
    There's really no need for strong cryptographic randomness at this level, this is needlessly slower than it could be an called pretty often during fee calculation.

- 94d4812d459951fef3fa999008c35d9d781b4f0c
  :round_pushpin: **do not re-compute the full balance after picking new inputs**
    Instead, compute the balance incrementally. The 'coverRemainingFee' was computing the balance of the extra inputs selected to cover for fee. In worst-case scenario where many inputs needed to be selected, for example, 1000 extra inputs, it'll recompute the balance of an ever growing list a thousand times! Not only this is accidentally quadratic, but, it is also completely unbounded and will potentially select way too many inputs. In theory, this should not select more than the max allowed inputs. Next commit will fix this.

# Comments

<!-- Additional comments or screenshots to attach if any -->

Before:

```
Latency with 500 utxos scenario
    postTransactionFee  - 16756.3 ms
```

After:

```
    Latencies for 2 fixture wallets with 500 utxos scenario
        postTransactionFee  - 119.0 ms
```

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
