### PR TITLE
make sure to provide an upper bound for max inputs when adjusting fees

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -59,6 +59,7 @@ import Data.Maybe
 import Data.Word
     ( Word8 )
 
+import qualified Cardano.Wallet.Primitive.CoinSelection as CS
 import qualified Data.Map.Strict as Map
 
 -- | Construct a list of coin selections / transactions to transfer the totality
@@ -175,7 +176,7 @@ idealBatchSize coinselOpts = fixPoint 1
         | otherwise = fixPoint (n + 1)
       where
         maxN :: Word8 -> Word8
-        maxN = maximumNumberOfInputs coinselOpts
+        maxN = CS.maximumNumberOfInputs coinselOpts
 
 -- | Safe conversion of an integral type to an integer
 integer :: Integral a => a -> Integer

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -123,6 +123,7 @@ spec = do
                         $ 5 * (length (inputs s) + length (outputs s))
                     , onDanglingChange = PayAndBalance
                     , feeUpperBound = Fee maxBound
+                    , maximumNumberOfInputs = maxBound
                     }
             let batchSize = 1
             let utxo = UTxO $ Map.fromList
@@ -245,6 +246,7 @@ genFeeOptions (Coin dust) = do
         , dustThreshold = Coin dust
         , onDanglingChange = PayAndBalance
         , feeUpperBound = Fee maxBound
+        , maximumNumberOfInputs = maxBound
         }
 
 -- | Generate a given UTxO with a particular percentage of dust

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -302,7 +302,7 @@ testCoinSelOpts :: CoinSelectionOptions ()
 testCoinSelOpts = coinSelOpts testTxLayer (Quantity 4096) Nothing
 
 testFeeOpts :: FeeOptions
-testFeeOpts = feeOpts testTxLayer Nothing Nothing txParams (Coin 0)
+testFeeOpts = feeOpts testTxLayer Nothing Nothing txParams (Coin 0) mempty
   where
     txParams  = TxParameters feePolicy txMaxSize
     feePolicy = LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

TODO (discovered as part of the slow fee estimation investigation, this is slightly related but actually a bug).

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

In order to prevent transactions from becoming too big, we compute an estimated maximum number of inputs that can be selected. This is well respected by coin selection algorithms but was disregarded by the fee adjustment function which would basically pick UTxO until it has either covered fees or depleted the entire UTxO. Although in practice it should be rarely necessary to pick more than 1 extra input, there are edge-cases where we may need many (especially in wallets with a lot of dust). Picking inputs without any upper bound could cause a transaction to go beyond an acceptable size, and be later rejected.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
