### PR TITLE
Less verbose integration test output

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ env:
   STACK_ROOT: "/build/cardano-wallet.stack"
   CACHE_DIR: "/cache/cardano-wallet"
   LC_ALL: "en_US.UTF-8"
+  TESTS_LOGDIR: "/tmp/wallet-integration-logs"
 
 steps:
   - label: 'Prevent merging to wrong branch'
@@ -15,11 +16,13 @@ steps:
 
   - label: 'Stack Rebuild'
     command:
+      - "mkdir -p $TESTS_LOGDIR"
       - "nix-build .buildkite/default.nix -o sr"
       - "./sr/bin/rebuild --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
     timeout_in_minutes: 120
     artifact_paths:
       - "/build/cardano-wallet/.stack-work/logs/cardano-wallet*.log"
+      - "/tmp/wallet-integration-logs/*.log"
     agents:
       system: x86_64-linux
 

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -531,6 +531,406 @@ seqMnemonics = unsafeMkMnemonic <$>
       , "lens", "area", "own", "feed", "oppose"
       , "proof", "bench", "act", "tragic", "human"
       ]
+    , [ "exclude", "paper", "jump", "east", "about"
+      , "harvest", "fetch", "unaware", "theme", "captain"
+      , "truck", "tag", "subway", "load", "bachelor"
+      ]
+    , [ "tuition", "shoulder", "ghost", "sting", "clinic"
+      , "surge", "stone", "damp", "wet", "speak"
+      , "brown", "type", "gorilla", "toward", "swing"
+      ]
+    , [ "escape", "skull", "receive", "bounce", "assist"
+      , "coach", "gown", "copy", "sauce", "rocket"
+      , "bundle", "sauce", "rapid", "never", "warm"
+      ]
+    , [ "wise", "swift", "monkey", "tent", "multiply"
+      , "patch", "velvet", "walnut", "ball", "word"
+      , "trial", "lazy", "promote", "forest", "index"
+      ]
+    , [ "tower", "report", "audit", "vivid", "dry"
+      , "analyst", "clever", "kidney", "tide", "stem"
+      , "title", "govern", "gentle", "staff", "level"
+      ]
+    , [ "extend", "home", "cargo", "conduct", "edge"
+      , "voyage", "century", "myth", "wealth", "december"
+      , "stock", "ladder", "rural", "legal", "cousin"
+      ]
+    , [ "sight", "tenant", "grain", "upset", "museum"
+      , "receive", "orphan", "hunt", "hood", "pipe"
+      , "issue", "oppose", "prefer", "neck", "subway"
+      ]
+    , [ "wife", "father", "rubber", "once", "sea"
+      , "dad", "giant", "gasp", "old", "satoshi"
+      , "enter", "coral", "acoustic", "swift", "panda"
+      ]
+    , [ "issue", "head", "clown", "faint", "buffalo"
+      , "soft", "glimpse", "occur", "filter", "one"
+      , "turkey", "arctic", "sort", "virus", "help"
+      ]
+    , [ "gadget", "expose", "first", "tennis", "quick"
+      , "vehicle", "average", "door", "cry", "humble"
+      , "cactus", "usage", "impact", "odor", "age"
+      ]
+    , [ "sentence", "work", "deposit", "math", "steel"
+      , "indoor", "raccoon", "pause", "solve", "hurdle"
+      , "toast", "better", "loud", "scare", "alien"
+      ]
+    , [ "thumb", "april", "panic", "charge", "clinic"
+      , "jar", "magic", "embark", "where", "horse"
+      , "hockey", "clown", "blame", "tunnel", "amused"
+      ]
+    , [ "glass", "virtual", "wish", "subway", "draft"
+      , "dish", "demise", "buzz", "treat", "suggest"
+      , "ice", "pride", "hold", "horse", "soccer"
+      ]
+    , [ "stem", "depend", "dignity", "van", "grape"
+      , "unveil", "slice", "timber", "sample", "ship"
+      , "feature", "useless", "special", "sort", "maximum"
+      ]
+    , [ "trust", "brass", "glory", "domain", "possible"
+      , "pig", "accuse", "design", "win", "predict"
+      , "useful", "stick", "opinion", "client", "man"
+      ]
+    , [ "valve", "spread", "exhaust", "skirt", "report"
+      , "close", "seat", "hawk", "matter", "loyal"
+      , "thrive", "unfold", "book", "bleak", "moon"
+      ]
+    , [ "forum", "fetch", "now", "control", "blame"
+      , "grape", "crucial", "crunch", "divorce", "iron"
+      , "card", "inner", "cheese", "music", "female"
+      ]
+    , [ "physical", "panel", "mimic", "stereo", "route"
+      , "pact", "close", "chronic", "glare", "element"
+      , "noble", "boil", "damp", "maple", "wild"
+      ]
+    , [ "doctor", "stable", "round", "know", "leader"
+      , "inherit", "spread", "fine", "route", "devote"
+      , "soccer", "emerge", "bone", "boring", "supreme"
+      ]
+    , [ "unable", "armor", "violin", "blood", "expand"
+      , "photo", "bachelor", "knife", "asthma", "smile"
+      , "decline", "parade", "universe", "group", "glare"
+      ]
+    , [ "animal", "pig", "quality", "ethics", "erosion"
+      , "decorate", "below", "early", "cause", "denial"
+      , "task", "tip", "expect", "identify", "normal"
+      ]
+    , [ "sentence", "job", "neutral", "satoshi", "weasel"
+      , "remain", "appear", "keep", "giant", "brush"
+      , "time", "clown", "gentle", "shoot", "bomb"
+      ]
+    , [ "drama", "man", "elite", "question", "lamp"
+      , "trim", "crater", "limit", "often", "shaft"
+      , "apart", "paddle", "test", "slab", "breeze"
+      ]
+    , [ "solar", "modify", "dish", "fortune", "high"
+      , "trend", "veteran", "pretty", "suspect", "rookie"
+      , "shine", "flat", "rescue", "render", "celery"
+      ]
+    , [ "edge", "people", "curious", "such", "uphold"
+      , "island", "pet", "tone", "famous", "draft"
+      , "primary", "toy", "laptop", "horse", "dice"
+      ]
+    , [ "under", "pretty", "square", "timber", "tortoise"
+      , "attitude", "measure", "guide", "deposit", "oval"
+      , "math", "solid", "carry", "tiger", "blame"
+      ]
+    , [ "duck", "inmate", "card", "under", "curious"
+      , "doctor", "planet", "bulb", "crane", "ecology"
+      , "fox", "mirror", "amused", "future", "payment"
+      ]
+    , [ "banana", "fragile", "myth", "notable", "win"
+      , "misery", "come", "lake", "material", "coil"
+      , "hope", "sister", "extend", "army", "order"
+      ]
+    , [ "matter", "suffer", "glad", "flower", "route"
+      , "drink", "bulk", "rotate", "insect", "admit"
+      , "model", "clay", "rigid", "luxury", "can"
+      ]
+    , [ "crack", "tiny", "pass", "object", "pilot"
+      , "awesome", "maple", "teach", "plate", "target"
+      , "nose", "legend", "warfare", "immune", "movie"
+      ]
+    , [ "consider", "bullet", "garage", "festival", "moment"
+      , "crack", "monster", "embark", "luggage", "remember"
+      , "prefer", "expand", "dish", "universe", "enhance"
+      ]
+    , [ "crystal", "puppy", "under", "because", "melody"
+      , "gentle", "govern", "arctic", "easy", "busy"
+      , "want", "police", "uncover", "glow", "admit"
+      ]
+    , [ "near", "farm", "sure", "animal", "spirit"
+      , "behave", "garage", "must", "visa", "fabric"
+      , "include", "feed", "flee", "snack", "mask"
+      ]
+    , [ "cannon", "perfect", "mosquito", "remind", "there"
+      , "radio", "glass", "flock", "decorate", "lab"
+      , "album", "awful", "jelly", "tower", "arm"
+      ]
+    , [ "tone", "churn", "lizard", "spring", "reject"
+      , "want", "leg", "acoustic", "hammer", "love"
+      , "kick", "roast", "skate", "fatigue", "either"
+      ]
+    , [ "link", "bullet", "zebra", "argue", "lobster"
+      , "bonus", "solve", "shoe", "despair", "assist"
+      , "stumble", "ketchup", "unveil", "icon", "denial"
+      ]
+    , [ "artwork", "want", "talent", "guard", "tattoo"
+      , "squirrel", "admit", "differ", "later", "cup"
+      , "snake", "slender", "exhibit", "stomach", "brother"
+      ]
+    , [ "peanut", "uphold", "tone", "original", "cupboard"
+      , "utility", "heart", "seat", "daughter", "flip"
+      , "liar", "fame", "sail", "cage", "envelope"
+      ]
+    , [ "dad", "decade", "snake", "globe", "denial"
+      , "advance", "vanish", "park", "tragic", "submit"
+      , "gas", "unusual", "tenant", "since", "prepare"
+      ]
+    , [ "hotel", "vanish", "time", "adjust", "crucial"
+      , "day", "brand", "hurry", "cover", "garlic"
+      , "catch", "material", "level", "holiday", "quick"
+      ]
+    , [ "cancel", "ancient", "swallow", "short", "hollow"
+      , "limit", "duty", "human", "loud", "wall"
+      , "dismiss", "empower", "glide", "okay", "casino"
+      ]
+    , [ "diamond", "grain", "cherry", "magnet", "appear"
+      , "engine", "boring", "stage", "ghost", "globe"
+      , "bottom", "lawsuit", "post", "clutch", "wing"
+      ]
+    , [ "neutral", "mad", "animal", "vicious", "blast"
+      , "cement", "ugly", "exit", "capable", "ugly"
+      , "impact", "situate", "theory", "proof", "math"
+      ]
+    , [ "begin", "hospital", "adjust", "teach", "know"
+      , "anger", "bottom", "rabbit", "pipe", "month"
+      , "better", "seat", "fabric", "turtle", "wife"
+      ]
+    , [ "crazy", "flush", "build", "april", "annual"
+      , "until", "under", "faith", "amazing", "mean"
+      , "sphere", "upper", "library", "lyrics", "museum"
+      ]
+    , [ "already", "like", "trick", "label", "rack"
+      , "same", "boy", "cram", "civil", "circle"
+      , "symbol", "bleak", "lunar", "little", "off"
+      ]
+    , [ "ring", "silent", "frequent", "ball", "beef"
+      , "middle", "supply", "october", "canyon", "increase"
+      , "theme", "minimum", "milk", "lyrics", "donkey"
+      ]
+    , [ "solar", "sphere", "birth", "expect", "emerge"
+      , "pretty", "wash", "solution", "riot", "there"
+      , "tornado", "genre", "approve", "series", "junior"
+      ]
+    , [ "sound", "turkey", "barrel", "appear", "sorry"
+      , "delay", "muffin", "brown", "arctic", "fun"
+      , "hurry", "zebra", "busy", "quit", "either"
+      ]
+    , [ "that", "only", "shell", "nasty", "twice"
+      , "unit", "elegant", "all", "load", "pottery"
+      , "kite", "salmon", "essence", "piano", "reunion"
+      ]
+    , [ "ribbon", "monkey", "harsh", "check", "layer"
+      , "whale", "ritual", "slab", "blouse", "notable"
+      , "often", "connect", "catalog", "bag", "install"
+      ]
+    , [ "stool", "isolate", "hero", "wink", "trim"
+      , "improve", "shield", "mushroom", "extend", "upper"
+      , "glance", "chaos", "cook", "base", "fly"
+      ]
+    , [ "clean", "sphere", "urban", "deposit", "scrub"
+      , "sibling", "purchase", "edit", "since", "region"
+      , "nerve", "observe", "large", "empty", "apart"
+      ]
+    , [ "valley", "staff", "perfect", "review", "reunion"
+      , "offer", "beef", "embrace", "north", "chief"
+      , "cup", "hobby", "sheriff", "flower", "echo"
+      ]
+    , [ "spike", "piano", "fabric", "distance", "powder"
+      , "tonight", "glory", "before", "autumn", "sketch"
+      , "account", "describe", "sponsor", "delay", "equip"
+      ]
+    , [ "thunder", "kite", "van", "december", "genre"
+      , "copy", "health", "make", "tuna", "grid"
+      , "much", "someone", "soldier", "rule", "mention"
+      ]
+    , [ "force", "fitness", "theme", "glove", "toss"
+      , "present", "uncover", "become", "scare", "option"
+      , "vast", "pass", "roast", "able", "upper"
+      ]
+    , [ "piano", "make", "predict", "motor", "wall"
+      , "glance", "actual", "gate", "mandate", "sad"
+      , "leisure", "bomb", "evoke", "dove", "riot"
+      ]
+    , [ "finish", "attract", "nothing", "bubble", "image"
+      , "test", "sample", "mention", "riot", "unhappy"
+      , "abuse", "clever", "fresh", "employ", "weather"
+      ]
+    , [ "sorry", "tomorrow", "mouse", "melt", "robot"
+      , "minor", "siren", "travel", "evidence", "item"
+      , "victory", "artefact", "answer", "job", "shoulder"
+      ]
+    , [ "priority", "average", "pool", "guess", "obscure"
+      , "guitar", "empower", "waste", "laundry", "bitter"
+      , "action", "nest", "milk", "mother", "cactus"
+      ]
+    , [ "example", "spring", "special", "suggest", "drift"
+      , "have", "solar", "spell", "problem", "opinion"
+      , "cute", "when", "angle", "choice", "below"
+      ]
+    , [ "canoe", "eager", "upon", "absent", "upgrade"
+      , "later", "view", "expand", "typical", "miss"
+      , "confirm", "suit", "where", "coyote", "various"
+      ]
+    , [ "shine", "physical", "multiply", "immune", "wedding"
+      , "very", "split", "blouse", "holiday", "busy"
+      , "rabbit", "visit", "enroll", "oval", "pen"
+      ]
+    , [ "upper", "render", "vital", "unusual", "clutch"
+      , "trade", "alert", "verify", "large", "occur"
+      , "zoo", "casino", "fresh", "ritual", "age"
+      ]
+    , [ "example", "blade", "card", "spawn", "dinner"
+      , "daring", "guide", "general", "brick", "shy"
+      , "north", "pepper", "brass", "diagram", "lamp"
+      ]
+    , [ "air", "front", "utility", "social", "bright"
+      , "near", "village", "radio", "gospel", "cruise"
+      , "potato", "pull", "orbit", "genre", "live"
+      ]
+    , [ "team", "brush", "slam", "security", "exact"
+      , "citizen", "glad", "spice", "atom", "robust"
+      , "network", "poem", "champion", "actress", "spot"
+      ]
+    , [ "supply", "suit", "sheriff", "iron", "current"
+      , "tape", "kiss", "trick", "example", "predict"
+      , "kangaroo", "top", "tennis", "erode", "print"
+      ]
+    , [ "resource", "pyramid", "viable", "ozone", "curtain"
+      , "empower", "route", "maple", "tilt", "captain"
+      , "quote", "edge", "beef", "bean", "denial"
+      ]
+    , [ "mansion", "skull", "satoshi", "fan", "true"
+      , "coffee", "because", "clerk", "nose", "glide"
+      , "stereo", "ice", "physical", "federal", "relief"
+      ]
+    , [ "card", "vocal", "boy", "mechanic", "anxiety"
+      , "reward", "poverty", "spider", "tray", "turn"
+      , "nominee", "fringe", "antique", "joke", "crack"
+      ]
+    , [ "mesh", "hobby", "enforce", "bundle", "add"
+      , "fatal", "order", "remember", "utility", "enhance"
+      , "system", "pride", "impose", "sock", "amount"
+      ]
+    , [ "mango", "police", "junk", "run", "open"
+      , "fantasy", "style", "come", "chest", "achieve"
+      , "syrup", "like", "glass", "robust", "bridge"
+      ]
+    , [ "paper", "fall", "cotton", "hurt", "clock"
+      , "board", "reduce", "output", "breeze", "friend"
+      , "napkin", "quiz", "sponsor", "nuclear", "stage"
+      ]
+    , [ "hello", "team", "tomorrow", "potato", "mom"
+      , "cave", "dragon", "sponsor", "emerge", "shiver"
+      , "order", "oak", "annual", "duck", "all"
+      ]
+    , [ "exotic", "until", "example", "middle", "traffic"
+      , "derive", "error", "strong", "rubber", "lyrics"
+      , "live", "exclude", "amateur", "during", "snack"
+      ]
+    , [ "abuse", "crucial", "topic", "garment", "deer"
+      , "van", "water", "orchard", "twenty", "swift"
+      , "equip", "paddle", "differ", "venture", "cat"
+      ]
+    , [ "gravity", "obvious", "also", "cool", "owner"
+      , "arrange", "skill", "sock", "file", "april"
+      , "clean", "prize", "amateur", "card", "fire"
+      ]
+    , [ "wife", "nothing", "vessel", "tourist", "below"
+      , "hover", "life", "main", "title", "puppy"
+      , "junk", "slice", "power", "glory", "what"
+      ]
+    , [ "tuna", "impact", "hold", "dawn", "village"
+      , "industry", "morning", "flock", "scout", "tag"
+      , "horror", "armor", "provide", "color", "dragon"
+      ]
+    , [ "rural", "squeeze", "joke", "ankle", "robot"
+      , "number", "critic", "mail", "random", "puppy"
+      , "poem", "alarm", "buzz", "achieve", "fuel"
+      ]
+    , [ "all", "half", "mansion", "promote", "entry"
+      , "bread", "wrist", "vehicle", "kit", "provide"
+      , "turkey", "portion", "artist", "humble", "kind"
+      ]
+    , [ "layer", "arctic", "vital", "staff", "mail"
+      , "rescue", "hat", "ramp", "kidney", "mix"
+      , "easy", "click", "spice", "retire", "balcony"
+      ]
+    , [ "picnic", "census", "arch", "trial", "black"
+      , "sign", "letter", "priority", "case", "cupboard"
+      , "approve", "one", "drift", "recall", "shine"
+      ]
+    , [ "marine", "feature", "degree", "song", "decorate"
+      , "glance", "arctic", "execute", "upset", "wheat"
+      , "fox", "deer", "corn", "sting", "element"
+      ]
+    , [ "cabbage", "network", "innocent", "diesel", "rebuild"
+      , "word", "thunder", "obtain", "unlock", "marine"
+      , "garbage", "page", "erase", "identify", "lady"
+      ]
+    , [ "rapid", "brief", "great", "smoke", "reduce"
+      , "mansion", "submit", "oil", "document", "put"
+      , "employ", "forget", "audit", "hundred", "taxi"
+      ]
+    , [ "return", "boy", "foam", "rare", "paper"
+      , "walnut", "arrange", "real", "chase", "ritual"
+      , "enact", "legal", "essence", "ugly", "scissors"
+      ]
+    , [ "clock", "where", "enable", "raise", "put"
+      , "oxygen", "comfort", "cargo", "ring", "ready"
+      , "brisk", "word", "again", "goddess", "give"
+      ]
+    , [ "mixture", "snack", "sad", "vacuum", "habit"
+      , "april", "legal", "sight", "unaware", "village"
+      , "magic", "elevator", "verify", "void", "expose"
+      ]
+    , [ "chunk", "ribbon", "recycle", "disease", "good"
+      , "blouse", "spirit", "curious", "ignore", "couple"
+      , "barely", "brisk", "frost", "daring", "panda"
+      ]
+    , [ "aspect", "emotion", "biology", "mother", "odor"
+      , "gorilla", "culture", "safe", "nurse", "rookie"
+      , "layer", "decorate", "obvious", "noodle", "supreme"
+      ]
+    , [ "agent", "soccer", "rug", "flee", "nerve"
+      , "curious", "imitate", "pulp", "soul", "wasp"
+      , "pet", "always", "assist", "deal", "blade"
+      ]
+    , [ "neck", "law", "idea", "control", "year"
+      , "casual", "kiwi", "proof", "private", "above"
+      , "race", "bronze", "plastic", "crystal", "affair"
+      ]
+    , [ "grow", "bargain", "wide", "profit", "tragic"
+      , "ketchup", "crater", "coyote", "fatigue", "wolf"
+      , "quality", "pistol", "gown", "caution", "often"
+      ]
+    , [ "champion", "tornado", "dream", "decide", "twelve"
+      , "fan", "heavy", "jazz", "quit", "describe"
+      , "spirit", "amazing", "stomach", "luggage", "poet"
+      ]
+    , [ "risk", "danger", "trumpet", "pottery", "run"
+      , "enforce", "fit", "dream", "focus", "hope"
+      , "side", "festival", "desert", "logic", "net"
+      ]
+    , [ "timber", "school", "cloth", "staff", "antique"
+      , "review", "unique", "then", "give", "sweet"
+      , "better", "resist", "flower", "twice", "slender"
+      ]
+    , [ "broccoli", "host", "scene", "urban", "crime"
+      , "drive", "grant", "tumble", "catalog", "plastic"
+      , "hello", "stomach", "utility", "safe", "cradle"
+      ]
     ]
 
 icaMnemonics :: [Mnemonic 15]

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -28,7 +28,8 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace, appendName, logInfo, logNotice )
 import Cardano.CLI
-    ( LoggingOptions (..)
+    ( LogOutput (..)
+    , LoggingOptions (..)
     , Port (..)
     , cli
     , cmdAddress
@@ -441,7 +442,7 @@ withTracers
     -> (Trace IO MainLog -> Tracers IO -> IO a)
     -> IO a
 withTracers logOpt action =
-    withLogging Nothing (loggingMinSeverity logOpt) $ \(_, tr) -> do
+    withLogging [LogToStdout $ loggingMinSeverity logOpt] $ \(_, tr) -> do
         let trMain = appendName "main" (transformTextTrace tr)
         let tracers = setupTracers (loggingTracers logOpt) tr
         logInfo trMain $ MsgVersion version gitRevision

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -20,7 +20,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace, logInfo )
 import Cardano.CLI
-    ( Port (..), withLogging )
+    ( LogOutput (..), Port (..), withLogging )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
 import Cardano.Pool.Jormungandr.Metadata
@@ -131,7 +131,7 @@ instance KnownCommand Jormungandr where
     commandName = "cardano-wallet-jormungandr"
 
 main :: forall t n. (t ~ Jormungandr, n ~ 'Testnet 0) => IO ()
-main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
+main = withUtf8Encoding $ withLogging [LogToStdout Info] $ \(_, tr) -> do
     hspec $ do
         describe "No backend required" $ do
             describe "Cardano.Wallet.NetworkSpec" $ parallel NetworkLayer.spec

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -377,6 +377,7 @@ withShelleyServer tracers action = do
                 Error
                 []
                 dir
+                Nothing
                 onByron
                 (afterFork dir)
                 (onClusterStart act dir)

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -201,6 +201,8 @@ test-suite integration
     , cardano-wallet
     , cardano-wallet-test-utils
     , contra-tracer
+    , directory
+    , filepath
     , hspec
     , http-client
     , iohk-monitoring

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -30,7 +30,8 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Trace
     ( Trace, appendName, logDebug, logError, logInfo, logNotice )
 import Cardano.CLI
-    ( LoggingOptions
+    ( LogOutput (..)
+    , LoggingOptions
     , cli
     , cmdAddress
     , cmdKey
@@ -292,7 +293,7 @@ withTracers
     -> (Trace IO MainLog -> Tracers IO -> IO a)
     -> IO a
 withTracers logOpt action =
-    withLogging Nothing (loggingMinSeverity logOpt) $ \(_, tr) -> do
+    withLogging [LogToStdout (loggingMinSeverity logOpt)] $ \(_, tr) -> do
         let trMain = appendName "main" (transformTextTrace tr)
         let tracers = setupTracers (loggingTracers logOpt) tr
         logInfo trMain $ MsgVersion version gitRevision

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1095,7 +1095,7 @@ sendFaucetFundsTo
     -> [(String, Coin)]
     -> IO ()
 sendFaucetFundsTo tr dir allTargets = do
-    forM_ (group 20 allTargets) sendBatch
+    forM_ (group 80 allTargets) sendBatch
   where
     sendBatch targets = do
         (faucetInput, faucetPrv) <- takeFaucet

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -53,6 +53,12 @@ import Cardano.Address.Derivation
     ( XPub, xpubPublicKey )
 import Cardano.Api.Shelley.Genesis
     ( ShelleyGenesis (..) )
+import Cardano.BM.Data.Output
+    ( ScribeDefinition (..)
+    , ScribeFormat (..)
+    , ScribeKind (..)
+    , ScribePrivacy (..)
+    )
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
@@ -413,6 +419,7 @@ withCluster
     -- ^ The configurations of pools to spawn.
     -> FilePath
     -- ^ Parent state directory for cluster
+    -> Maybe (FilePath, Severity)
     -> (RunningNode -> IO ())
     -- ^ Action to run when Byron is up
     -> (RunningNode -> IO ())
@@ -422,17 +429,18 @@ withCluster
     -> (RunningNode -> IO a)
     -- ^ Action to run when stake pools are running
     -> IO a
-withCluster tr severity poolConfigs dir onByron onFork onClusterStart =
+withCluster tr severity poolConfigs dir logFile onByron onFork onClusterStart =
     bracketTracer' tr "withCluster" $ do
+        traceWith tr $ MsgStartingCluster dir
         let poolCount = length poolConfigs
         (port0:ports) <- randomUnusedTCPPorts (poolCount + 2)
         systemStart <- addUTCTime 1 <$> getCurrentTime
-        let bftCfg = NodeParams severity systemStart (head $ rotate ports)
+        let bftCfg = NodeParams severity systemStart (head $ rotate ports) logFile
         withBFTNode tr dir bftCfg $ \bftSocket block0 params -> do
             let runningBftNode = RunningNode bftSocket block0 params
             waitForSocket tr bftSocket *> onByron runningBftNode
 
-            traceWith tr MsgForkCartouche
+            traceWith tr MsgWaitingForFork
             updateVersion tr dir
             waitForHardFork bftSocket (fst params) 1 *> onFork runningBftNode
 
@@ -464,13 +472,13 @@ withCluster tr severity poolConfigs dir onByron onFork onClusterStart =
                 \(idx, poolConfig, (port, peers)) -> do
                     link =<< async (handle onException $ do
                         let spCfg =
-                                NodeParams severity systemStart (port, peers)
+                                NodeParams severity systemStart (port, peers) logFile
                         withStakePool
                             tr dir idx spCfg (pledgeOf idx) poolConfig $ do
                                 writeChan waitGroup $ Right port
                                 readChan doneGroup)
 
-            traceWith tr MsgClusterCartouche
+            traceWith tr $ MsgRegisteringStakePools poolCount
             group <- waitAll
             if length (filter isRight group) /= poolCount then do
                 cancelAll
@@ -479,7 +487,7 @@ withCluster tr severity poolConfigs dir onByron onFork onClusterStart =
                     ("cluster didn't start correctly: " <> errors)
                     (ExitFailure 1)
             else do
-                let cfg = NodeParams severity systemStart (port0, ports)
+                let cfg = NodeParams severity systemStart (port0, ports) logFile
                 withRelayNode tr dir cfg $ \socket -> do
                     let runningRelay = RunningNode socket block0 params
                     onClusterStart runningRelay `finally` cancelAll
@@ -504,15 +512,21 @@ waitForHardFork _socket np epoch = threadDelay (ceiling (1e6 * delay))
 
 -- | Configuration parameters which update the @node.config@ test data file.
 data NodeParams = NodeParams
-    { minSeverity :: Severity -- ^ Minimum logging severity
-    , systemStart :: UTCTime -- ^ Genesis block start time
-    , nodePeers :: (Int, [Int]) -- ^ A list of ports used by peers and this node
+    { minSeverity :: Severity
+      -- ^ Minimum logging severity
+    , systemStart :: UTCTime
+      -- ^ Genesis block start time
+    , nodePeers :: (Int, [Int])
+      -- ^ A list of ports used by peers and this node
+    , extraLogFile :: Maybe (FilePath, Severity)
+      -- ^ The node will always log to "cardano-node.log" relative to the
+      -- config. This option can be set for an additional output.
     } deriving (Show)
 
-singleNodeParams :: Severity -> IO NodeParams
-singleNodeParams severity = do
+singleNodeParams :: Severity -> Maybe (FilePath, Severity) -> IO NodeParams
+singleNodeParams severity extraLogFile = do
     systemStart <- getCurrentTime
-    pure $ NodeParams severity systemStart (0, [])
+    pure $ NodeParams severity systemStart (0, []) extraLogFile
 
 withBFTNode
     :: Tracer IO ClusterLog
@@ -538,8 +552,9 @@ withBFTNode tr baseDir params action =
             ]
             (\f -> copyFile (source </> f) (dir </> f) $> (dir </> f))
 
+        let extraLogFile = (fmap (first (</> (name ++ ".log"))) logDir)
         (config, block0, networkParams, versionData)
-            <- genConfig dir severity systemStart
+            <- genConfig dir severity extraLogFile systemStart
         topology <- genTopology dir peers
 
         let cfg = CardanoNodeConfig
@@ -564,7 +579,7 @@ withBFTNode tr baseDir params action =
 
     name = "bft"
     dir = baseDir </> name
-    NodeParams severity systemStart (port, peers) = params
+    NodeParams severity systemStart (port, peers) logDir = params
 
 -- | Launches a @cardano-node@ with the given configuration which will not forge
 -- blocks, but has every other cluster node as its peer. Any transactions
@@ -580,11 +595,13 @@ withRelayNode
     -> (FilePath -> IO a)
     -- ^ Callback function with socket path
     -> IO a
-withRelayNode tr baseDir (NodeParams severity systemStart (port, peers)) act =
+withRelayNode tr baseDir (NodeParams severity systemStart (port, peers) logDir) act =
     bracketTracer' tr "withRelayNode" $ do
         createDirectory dir
 
-        (config, _, _, _) <- genConfig dir severity systemStart
+        let extraLogFile = (fmap (first (</> (name ++ ".log"))) logDir)
+        (config, _, _, _) <-
+            genConfig dir severity extraLogFile systemStart
         topology <- genTopology dir peers
 
         let cfg = CardanoNodeConfig
@@ -630,7 +647,7 @@ setupStakePoolData
     -- ^ Optional retirement epoch.
     -> IO (CardanoNodeConfig, FilePath, FilePath)
 setupStakePoolData tr dir name params url pledgeAmt mRetirementEpoch = do
-    let NodeParams severity systemStart (port, peers) = params
+    let NodeParams severity systemStart (port, peers) logDir = params
 
     (opPrv, opPub, opCount, metadata) <- genOperatorKeyPair tr dir
     (vrfPrv, vrfPub) <- genVrfKeyPair tr dir
@@ -645,7 +662,8 @@ setupStakePoolData tr dir name params url pledgeAmt mRetirementEpoch = do
     dlgCert <- issueDlgCert tr dir stakePub opPub
     opCert <- issueOpCert tr dir kesPub opPrv opCount
 
-    (config, _, _, _) <- genConfig dir severity systemStart
+    let extraLogFile = (fmap (first (</> (name ++ ".log"))) logDir)
+    (config, _, _, _) <- genConfig dir severity extraLogFile systemStart
     topology <- genTopology dir peers
 
     -- In order to get a working stake pool we need to.
@@ -777,12 +795,29 @@ genConfig
     -- ^ A top-level directory where to put the configuration.
     -> Severity
     -- ^ Minimum severity level for logging
+    -> Maybe (FilePath, Severity)
+    -- ^ Optional /extra/ logging output
     -> UTCTime
     -- ^ Genesis block start time
     -> IO (FilePath, Block, NetworkParameters, NodeVersionData)
-genConfig dir severity systemStart = do
+genConfig dir severity mExtraLogFile systemStart = do
     let startTime = round @_ @Int . utcTimeToPOSIXSeconds $ systemStart
     let systemStart' = posixSecondsToUTCTime . fromRational . toRational $ startTime
+
+    let fileScribe (path, sev) = ScribeDefinition
+                { scName = path
+                , scFormat = ScText
+                , scKind = FileSK
+                , scMinSev = sev
+                , scMaxSev = Critical
+                , scPrivacy = ScPublic
+                , scRotation = Nothing
+                }
+
+    let scribes = catMaybes
+            [ Just $ fileScribe ("cardano-node.log", severity)
+            , fileScribe . first T.pack <$> mExtraLogFile
+            ]
 
     ----
     -- Configuration
@@ -790,6 +825,7 @@ genConfig dir severity systemStart = do
         >>= withAddedKey "ShelleyGenesisFile" shelleyGenesisFile
         >>= withAddedKey "ByronGenesisFile" byronGenesisFile
         >>= withAddedKey "minSeverity" Debug
+        >>= withScribes scribes
         >>= withObject (addMinSeverityStdout severity)
         >>= Yaml.encodeFile (dir </> "node.config")
 
@@ -805,6 +841,7 @@ genConfig dir severity systemStart = do
     Yaml.decodeFileThrow @_ @Aeson.Value (source </> "shelley-genesis.yaml")
         >>= withObject (pure . updateSystemStart systemStart')
         >>= Aeson.encodeFile shelleyGenesisFile
+
 
     ----
     -- Initial Funds.
@@ -845,6 +882,11 @@ genConfig dir severity systemStart = do
 
     byronGenesisFile :: FilePath
     byronGenesisFile = dir </> "byron-genesis.json"
+
+    withScribes scribes =
+        withAddedKey "setupScribes" scribes
+        >=> withAddedKey "defaultScribes"
+            (map (\s -> [toJSON $ scKind s, toJSON $ scName s]) scribes)
 
     -- we need to specify genesis file location every run in tmp
     withAddedKey k v = withObject (pure . HM.insert k (toJSON v))

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -45,12 +45,12 @@ TestShelleyHardForkAtVersion: 1
 defaultBackends:
   - KatipBK
 
-# if not indicated otherwise, then log output is directed to this:
-defaultScribes:
-  - - FileSK
-    - "cardano-node.log"
-  - - StdoutSK
-    - stdout
+# Set from Launcher.hs, e.g.
+# defaultScribes:
+#   - - FileSK
+#     - cardano-node.log
+#   - - StdoutSK
+#     - stdout
 
 # Tracing options cargo-culted from cardano-node/configuration/byron-mainnet/configuration.yaml
 TraceBlockFetchClient: False
@@ -99,13 +99,13 @@ options:
 setupBackends:
   - KatipBK
 
-# here we set up outputs of logging in 'katip':
-setupScribes:
-  - scKind: FileSK
-    scName: "cardano-node.log"
-    scFormat: ScText
-    scMinSev: Debug
-  - scName: stdout
-    scKind: StdoutSK
-    scFormat: ScText
-    scMinSev: Error
+# Set from Launcher.hs, e.g.
+# setupScribes:
+#   - scKind: FileSK
+#     scName: "cardano-node.log"
+#     scFormat: ScText
+#     scMinSev: Debug
+#   - scName: stdout
+#     scKind: StdoutSK
+#     scFormat: ScText
+#     scMinSev: Error

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -261,7 +261,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
     tr' = contramap MsgCluster tr
     onByron _ = pure ()
     afterFork dir _ = do
-        traceWith tr MsgSettingUpFacuet
+        traceWith tr MsgSettingUpFaucet
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
         sendFaucetFundsTo tr' dir addresses
@@ -309,7 +309,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
 data TestsLog
     = MsgBracket Text BracketLog
     | MsgBaseUrl Text
-    | MsgSettingUpFacuet
+    | MsgSettingUpFaucet
     | MsgCluster ClusterLog
     | MsgPoolGarbageCollectionEvent PoolGarbageCollectionEvent
     deriving (Show)
@@ -318,7 +318,7 @@ instance ToText TestsLog where
     toText = \case
         MsgBracket name b -> name <> ": " <> toText b
         MsgBaseUrl txt -> txt
-        MsgSettingUpFacuet -> "Setting up faucet..."
+        MsgSettingUpFaucet -> "Setting up faucet..."
         MsgCluster msg -> toText msg
         MsgPoolGarbageCollectionEvent e -> mconcat
             [ "Intercepted pool garbage collection event for epoch "
@@ -336,7 +336,7 @@ instance HasPrivacyAnnotation TestsLog
 instance HasSeverityAnnotation TestsLog where
     getSeverityAnnotation = \case
         MsgBracket _ _ -> Debug
-        MsgSettingUpFacuet -> Notice
+        MsgSettingUpFaucet -> Notice
         MsgBaseUrl _ -> Notice
         MsgCluster msg -> getSeverityAnnotation msg
         MsgPoolGarbageCollectionEvent _ -> Info

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -339,7 +339,7 @@ instance HasSeverityAnnotation TestsLog where
         MsgSettingUpFacuet -> Notice
         MsgBaseUrl _ -> Notice
         MsgCluster msg -> getSeverityAnnotation msg
-        MsgPoolGarbageCollectionEvent _ -> Notice
+        MsgPoolGarbageCollectionEvent _ -> Info
 
 withTracers
     :: ((Tracer IO TestsLog, Tracers IO) -> IO a)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -22,7 +22,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.BM.Trace
     ( appendName )
 import Cardano.CLI
-    ( Port (..), parseLoggingSeverity, withLogging )
+    ( LogOutput (..), Port (..), parseLoggingSeverity, withLogging )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
 import Cardano.Startup
@@ -32,7 +32,7 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Api.Types
     ( ApiByronWallet, ApiWallet, EncodeAddress (..), WalletStyle (..) )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), bracketTracer, stdoutTextTracer, trMessageText )
+    ( BracketLog (..), bracketTracer, trMessageText )
 import Cardano.Wallet.Network.Ports
     ( unsafePortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -91,10 +91,14 @@ import Network.HTTP.Client
     , newManager
     , responseTimeoutMicro
     )
+import System.Directory
+    ( makeAbsolute )
 import System.Environment
     ( lookupEnv )
 import System.Exit
     ( die )
+import System.FilePath
+    ( (</>) )
 import System.IO
     ( BufferMode (..), hSetBuffering, stdout )
 import Test.Hspec
@@ -242,12 +246,14 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
     withServer dbDecorator action = bracketTracer' tr "withServer" $ do
         minSev <- nodeMinSeverityFromEnv
         testPoolConfigs' <- poolConfigsFromEnv
-        withSystemTempDir tr' "test" $ \dir ->
+        withSystemTempDir tr' "test" $ \dir -> do
+            extraLogDir <- (fmap (,Info)) <$> testLogDirFromEnv
             withCluster
                 tr'
                 minSev
                 testPoolConfigs'
                 dir
+                extraLogDir
                 onByron
                 (afterFork dir)
                 (onClusterStart action dir dbDecorator)
@@ -255,13 +261,14 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
     tr' = contramap MsgCluster tr
     onByron _ = pure ()
     afterFork dir _ = do
+        traceWith tr MsgSettingUpFacuet
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
-        sendFaucetFundsTo stdoutTextTracer dir addresses
+        sendFaucetFundsTo tr' dir addresses
 
         let rewards = (,Coin $ fromIntegral oneMillionAda) <$>
                 concatMap genRewardAccounts mirMnemonics
-        moveInstantaneousRewardsTo stdoutTextTracer dir rewards
+        moveInstantaneousRewardsTo tr' dir rewards
 
     onClusterStart
         action dir dbDecorator (RunningNode socketPath block0 (gp, vData)) = do
@@ -302,6 +309,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
 data TestsLog
     = MsgBracket Text BracketLog
     | MsgBaseUrl Text
+    | MsgSettingUpFacuet
     | MsgCluster ClusterLog
     | MsgPoolGarbageCollectionEvent PoolGarbageCollectionEvent
     deriving (Show)
@@ -310,6 +318,7 @@ instance ToText TestsLog where
     toText = \case
         MsgBracket name b -> name <> ": " <> toText b
         MsgBaseUrl txt -> txt
+        MsgSettingUpFacuet -> "Setting up faucet..."
         MsgCluster msg -> toText msg
         MsgPoolGarbageCollectionEvent e -> mconcat
             [ "Intercepted pool garbage collection event for epoch "
@@ -327,6 +336,7 @@ instance HasPrivacyAnnotation TestsLog
 instance HasSeverityAnnotation TestsLog where
     getSeverityAnnotation = \case
         MsgBracket _ _ -> Debug
+        MsgSettingUpFacuet -> Notice
         MsgBaseUrl _ -> Notice
         MsgCluster msg -> getSeverityAnnotation msg
         MsgPoolGarbageCollectionEvent _ -> Notice
@@ -335,11 +345,23 @@ withTracers
     :: ((Tracer IO TestsLog, Tracers IO) -> IO a)
     -> IO a
 withTracers action = do
-    minSeverity <- walletMinSeverityFromEnv
-    withLogging Nothing minSeverity $ \(_, tr) -> do
-        let trTests = appendName "integration" tr
-        let tracers = setupTracers (tracerSeverities (Just Info)) tr
-        action (trMessageText trTests, tracers)
+    walletMinSeverity <- walletMinSeverityFromEnv
+    testMinSeverity <- testMinSeverityFromEnv
+
+    let extraOutput name = (maybe [] (\f -> [LogToFile (f </> name) Info]))
+            <$> testLogDirFromEnv
+
+    walletLogOutputs <- ([LogToStdout walletMinSeverity] ++) <$>
+        extraOutput "wallet.log"
+    testLogOutputs <- ([LogToStdout testMinSeverity] ++) <$>
+        extraOutput "test.log"
+
+    withLogging walletLogOutputs $ \(_, walTr) -> do
+        withLogging testLogOutputs $ \(_, testTr) -> do
+            let trTests = appendName "integration" testTr
+            let tracers = setupTracers
+                    (tracerSeverities (Just Info)) walTr
+            action (trMessageText trTests, tracers)
 
 bracketTracer' :: Tracer IO TestsLog -> Text -> IO a -> IO a
 bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)
@@ -348,13 +370,19 @@ bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)
 -- @CARDANO_NODE_TRACING_MIN_SEVERITY@ environment variable.
 nodeMinSeverityFromEnv :: IO Severity
 nodeMinSeverityFromEnv =
-    minSeverityFromEnv Error "CARDANO_NODE_TRACING_MIN_SEVERITY"
+    minSeverityFromEnv Info "CARDANO_NODE_TRACING_MIN_SEVERITY"
 
--- Allow configuring integration tests and wallet log level with
+-- Allow configuring wallet log level with
 -- @CARDANO_WALLET_TRACING_MIN_SEVERITY@ environment variable.
 walletMinSeverityFromEnv :: IO Severity
 walletMinSeverityFromEnv =
-    minSeverityFromEnv Info "CARDANO_WALLET_TRACING_MIN_SEVERITY"
+    minSeverityFromEnv Critical "CARDANO_WALLET_TRACING_MIN_SEVERITY"
+
+-- Allow configuring integration tests and wallet log level with
+-- @CARDANO_TEST_TRACING_MIN_SEVERITY@ environment variable.
+testMinSeverityFromEnv :: IO Severity
+testMinSeverityFromEnv =
+    minSeverityFromEnv Notice "CARDANO_TEST_TRACING_MIN_SEVERITY"
 
 minSeverityFromEnv :: Severity -> String -> IO Severity
 minSeverityFromEnv def var = lookupEnv var >>= \case
@@ -367,3 +395,8 @@ poolConfigsFromEnv = lookupEnv "NO_POOLS" >>= \case
     Nothing -> pure testPoolConfigs
     Just "" -> pure testPoolConfigs
     Just _ -> pure []
+
+-- | Directory for extra logging. Buildkite will set this environment variable
+-- and upload logs in it automatically.
+testLogDirFromEnv :: IO (Maybe FilePath)
+testLogDirFromEnv = traverse makeAbsolute =<< lookupEnv "TESTS_LOGDIR"

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -226,7 +226,7 @@ withTestNode
     -> (NetworkParameters -> FilePath -> NodeVersionData -> IO a)
     -> IO a
 withTestNode tr action = do
-    cfg <- singleNodeParams Error
+    cfg <- singleNodeParams Error Nothing
     withSystemTempDir tr "network-spec" $ \dir ->
         withBFTNode tr dir cfg $ \sock _block0 (np, vData) ->
             action np sock vData

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -153,6 +153,8 @@
             (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))

--- a/stack.yaml
+++ b/stack.yaml
@@ -77,3 +77,6 @@ ghc-options: {"$locals": -ddump-to-file -ddump-hi}
 
 nix:
   shell-file: nix/stack-shell.nix
+  # Disabling the pure nix-shell allows environment variables to be
+  # passed down to tests. We need this for integration tests.
+  pure: false


### PR DESCRIPTION
# Issue Number

#2119 


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] More quiet stdout per default when running integration tests
- [x] Log full wallet, node and test-setup logs to `$TESTS_LOGDIR`, if set.
- [x] Upload `$TESTS_LOGDIR/*.log` as Buildkite artefacts

# Comments

- Regardless of `$TESTS_LOGDIR` setting, logs are still written to the temporary cluster directory as before.
- We can make hydra and GitHub Actions upload logs in a future PR. We might also be fine without it.

<img width="1458" alt="Skärmavbild 2020-09-10 kl  17 57 58" src="https://user-images.githubusercontent.com/304423/92758896-79597480-f38f-11ea-9394-501dc4608221.png">


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
