### PR TITLE
Address slow fee estimation on Byron wallets

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -89,6 +89,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types as ApiTypes
 import qualified Data.Map.Strict as Map
 import qualified Network.HTTP.Types.Status as HTTP
+import qualified Test.Hspec as Hspec
 
 
 spec :: forall n t.
@@ -207,7 +208,7 @@ spec = do
               testAddressCycling ctx 3
               testAddressCycling ctx 10
 
-    it "BYRON_MIGRATE_01 - \
+    Hspec.it "BYRON_MIGRATE_01 - \
         \ migrate a big wallet requiring more than one tx" $ \ctx -> do
         -- NOTE
         -- Special mnemonic for which 200 legacy funds are attached to in the
@@ -266,7 +267,7 @@ spec = do
             Default
             payloadMigrate >>= flip verify
             [ expectResponseCode @IO HTTP.status202
-            , expectField id ((`shouldBe` 17). length)
+            , expectField id ((`shouldBe` 20). length)
             ]
 
         -- Check that funds become available in the target wallet:
@@ -345,7 +346,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate srcId)
                 ]
 
-    it "BYRON_MIGRATE_02 - \
+    Hspec.it "BYRON_MIGRATE_02 - \
         \migrating wallet with dust should fail."
         $ \ctx -> do
             -- NOTE

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -87,6 +87,7 @@ import qualified Cardano.Wallet.Api.Link as Link
 import qualified Cardano.Wallet.Api.Types as ApiTypes
 import qualified Data.Map.Strict as Map
 import qualified Network.HTTP.Types.Status as HTTP
+import qualified Test.Hspec as Hspec
 
 spec :: forall n t.
     ( DecodeAddress n
@@ -167,7 +168,7 @@ spec = do
               testAddressCycling 3
               testAddressCycling 10
 
-    it "SHELLEY_MIGRATE_01_big_wallet - \
+    Hspec.it "SHELLEY_MIGRATE_01_big_wallet - \
         \ migrate a big wallet requiring more than one tx" $ \ctx -> do
 
         -- NOTE
@@ -273,7 +274,7 @@ spec = do
                 , expectErrorMessage (errMsg403NothingToMigrate srcId)
                 ]
 
-    it "SHELLEY_MIGRATE_02 - \
+    Hspec.it "SHELLEY_MIGRATE_02 - \
         \migrating wallet with dust should fail."
         $ \ctx -> do
             -- NOTE

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -130,9 +130,9 @@ spec = do
         [(1,23),(10,16),(20,9),(30,2)]
 
     estimateMaxInputsTests @ByronKey Cardano.Mainnet
-        [(1,19),(10,12),(20,6),(30,0)]
+        [(1,16),(10,10),(20,5),(30,0)]
     estimateMaxInputsTests @ByronKey (Cardano.Testnet (Cardano.NetworkMagic 0))
-        [(1,18),(10,12),(20,5),(30,0)]
+        [(1,15),(10,10),(20,4),(30,0)]
 
     estimateMaxInputsTests @IcarusKey Cardano.Mainnet
         [(1,19),(10,14),(20,9),(30,4)]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2126 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- fc1da5111eb78a648ac4fb14a9cef742519be205
  :round_pushpin: **extend post-restoration benchmark wallet overview with number of addresses and transactions**
    We had only the UTxO, which gave little clarity about how many addresses and transactions did that correspond to. In practice, they're of the same order of magnitude, but it's good to have the actual number.

- a234e492fb99728eed38c72b05d5b0e0a409f347
  :round_pushpin: **do not construct dummy bootstrap witnesses but apply a correction on shelley witnesses afterwards**

  This is slightly simpler, but it also prevent some nasty things happening with the bootstrap witnesses: the 'Ord' instances used to compare and sort bootstrap witnesses require to serialize them fully, which involve two hashes of bytestrings; when done for 50 inputs, and 100 times in a row in multiple selection this little thing start to matter quite a lot.

- fc9d4ff0c636188c6f43ba65f0751a27325f540a
  :round_pushpin: **adjust byron migration test assertion due to recent change**
    The fee estimation is now slightly faster, but the approximation is slightly worse, so we end up paying a little more for byron witnesses.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
