### PR TITLE
Make pool DB model interface consistent.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -51,6 +51,7 @@
 - ignore: {name: "Redundant do"} # Just an annoying hlint built-in, GHC may remove redundant do if he wants
 - ignore: {name: "Monoid law, left identity"} # Using 'mempty' can be useful to vertically-align elements
 - ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
+- ignore: {name: "Redundant multi-way if"} # Using this style might be appropriate given the circumstances.
 
 # Add custom hints for this project
 #

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -122,8 +122,8 @@ newDBLayer timeInterpreter = do
         listRegisteredPools =
             readPoolDB db mListRegisteredPools
 
-        listRetiredPools epochNo =
-            modifyMVar db (pure . swap . mListRetiredPools epochNo)
+        listRetiredPools =
+            readPoolDB db . mListRetiredPools
 
         listPoolLifeCycleData =
             readPoolDB db . mListPoolLifeCycleData

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -21,7 +21,7 @@ import Prelude
 import Cardano.Pool.DB
     ( DBLayer (..), ErrPointAlreadyExists (..) )
 import Cardano.Pool.DB.Model
-    ( ModelPoolOp
+    ( ModelOp
     , PoolDatabase
     , PoolErr (..)
     , emptyPoolDatabase
@@ -157,7 +157,7 @@ alterPoolDB
     -- ^ Error type converter
     -> MVar PoolDatabase
     -- ^ The database variable
-    -> ModelPoolOp a
+    -> ModelOp a
     -- ^ Operation to run on the database
     -> IO (Either err a)
 alterPoolDB convertErr db op = modifyMVar db (bubble . op)
@@ -170,7 +170,7 @@ alterPoolDB convertErr db op = modifyMVar db (bubble . op)
 readPoolDB
     :: MVar PoolDatabase
     -- ^ The database variable
-    -> ModelPoolOp a
+    -> ModelOp a
     -- ^ Operation to run on the database
     -> IO a
 readPoolDB db op =

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -45,6 +45,7 @@ import Cardano.Pool.DB.Model
     , mReadSystemSeed
     , mReadTotalProduction
     , mRemovePools
+    , mRemoveRetiredPools
     , mRollbackTo
     , mUnfetchedPoolMetadataRefs
     )
@@ -60,10 +61,10 @@ import Control.Monad
     ( void )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
+import Data.Either
+    ( fromRight )
 import Data.Functor.Identity
     ( Identity )
-import Data.Generics.Internal.VL.Lens
-    ( view )
 import Data.Tuple
     ( swap )
 
@@ -139,10 +140,10 @@ newDBLayer timeInterpreter = do
         removePools =
             void . alterPoolDB (const Nothing) db . mRemovePools
 
-        removeRetiredPools epoch =
-            listRetiredPools epoch >>= \retirementCerts -> do
-                removePools (view #poolId <$> retirementCerts)
-                pure retirementCerts
+        removeRetiredPools =
+            fmap (fromRight [])
+                . alterPoolDB (const Nothing) db
+                . mRemoveRetiredPools
 
         cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanDatabase

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -19,7 +19,7 @@ module Cardano.Pool.DB.MVar
 import Prelude
 
 import Cardano.Pool.DB
-    ( DBLayer (..), ErrPointAlreadyExists (..), determinePoolLifeCycleStatus )
+    ( DBLayer (..), ErrPointAlreadyExists (..) )
 import Cardano.Pool.DB.Model
     ( ModelPoolOp
     , PoolDatabase
@@ -35,6 +35,7 @@ import Cardano.Pool.DB.Model
     , mPutPoolRetirement
     , mPutStakeDistribution
     , mReadCursor
+    , mReadPoolLifeCycleStatus
     , mReadPoolMetadata
     , mReadPoolProduction
     , mReadPoolRegistration
@@ -105,10 +106,8 @@ newDBLayer timeInterpreter = do
               $ alterPoolDB (const Nothing) db
               $ mPutPoolRegistration cpt cert
 
-        readPoolLifeCycleStatus poolId =
-            determinePoolLifeCycleStatus
-                <$> readPoolRegistration poolId
-                <*> readPoolRetirement poolId
+        readPoolLifeCycleStatus =
+            readPoolDB db . mReadPoolLifeCycleStatus
 
         putPoolRetirement cpt cert = void
             $ alterPoolDB (const Nothing) db

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -25,7 +25,7 @@ import Cardano.Pool.DB.Model
     , PoolDatabase
     , PoolErr (..)
     , emptyPoolDatabase
-    , mCleanPoolProduction
+    , mCleanDatabase
     , mListRegisteredPools
     , mListRetiredPools
     , mPutFetchAttempt
@@ -152,7 +152,7 @@ newDBLayer timeInterpreter = do
                 pure retirementCerts
 
         cleanDB =
-            void $ alterPoolDB (const Nothing) db mCleanPoolProduction
+            void $ alterPoolDB (const Nothing) db mCleanDatabase
 
         readPoolMetadata = readPoolDB db mReadPoolMetadata
 

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -120,7 +120,7 @@ newDBLayer timeInterpreter = do
             void . alterPoolDB (const Nothing) db . mPutFetchAttempt
 
         listRegisteredPools =
-            modifyMVar db (pure . swap . mListRegisteredPools)
+            readPoolDB db mListRegisteredPools
 
         listRetiredPools epochNo =
             modifyMVar db (pure . swap . mListRetiredPools epochNo)

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -49,6 +49,7 @@ module Cardano.Pool.DB.Model
     , mPutPoolMetadata
     , mListRegisteredPools
     , mListRetiredPools
+    , mReadPoolLifeCycleStatus
     , mReadSystemSeed
     , mRollbackTo
     , mReadCursor
@@ -296,6 +297,10 @@ mListRetiredPools epochNo db = (retiredPools, db)
         & catMaybes
 
     PoolDatabase {registrations} = db
+
+mReadPoolLifeCycleStatus :: PoolId -> ModelPoolOp PoolLifeCycleStatus
+mReadPoolLifeCycleStatus poolId db = (, db) $ pure $
+    lookupLifeCycleStatus poolId db
 
 lookupLifeCycleStatus :: PoolId -> PoolDatabase -> PoolLifeCycleStatus
 lookupLifeCycleStatus poolId PoolDatabase {registrations, retirements} =

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -406,21 +406,19 @@ mRollbackTo ti point db = (pure (), ) $
         | point' <= get point = Just v
         | otherwise = Nothing
 
-mRemovePools :: [PoolId] -> PoolDatabase -> (Either PoolErr (), PoolDatabase)
-mRemovePools poolsToRemove db =
-    (pure (), dbFiltered)
+mRemovePools :: [PoolId] -> ModelPoolOp ()
+mRemovePools poolsToRemove = (pure (), )
+    . over #distributions
+        (Map.map $ L.filter $ \(p, _) -> retain p)
+    . over #pools
+        (Map.filterWithKey $ \p _ -> retain p)
+    . over #owners
+        (Map.filterWithKey $ \p _ -> retain p)
+    . over #registrations
+        (Map.filterWithKey $ \(_, p) _ -> retain p)
+    . over #retirements
+        (Map.filterWithKey $ \(_, p) _ -> retain p)
   where
-    dbFiltered = db
-        & over #distributions
-            (Map.map $ L.filter $ \(p, _) -> retain p)
-        & over #pools
-            (Map.filterWithKey $ \p _ -> retain p)
-        & over #owners
-            (Map.filterWithKey $ \p _ -> retain p)
-        & over #registrations
-            (Map.filterWithKey $ \(_, p) _ -> retain p)
-        & over #retirements
-            (Map.filterWithKey $ \(_, p) _ -> retain p)
     retain p = p `Set.notMember` poolsToRemoveSet
     poolsToRemoveSet = Set.fromList poolsToRemove
 

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -247,12 +247,10 @@ mPutPoolRetirement
     :: CertificatePublicationTime
     -> PoolRetirementCertificate
     -> ModelPoolOp ()
-mPutPoolRetirement cpt cert db =
-    ( Right ()
-    , db {retirements = Map.insert (cpt, poolId) cert retirements}
-    )
+mPutPoolRetirement cpt cert = (pure (),)
+    . over #retirements
+        (Map.insert (cpt, poolId) cert)
   where
-    PoolDatabase {retirements} = db
     PoolRetirementCertificate poolId _retirementEpoch = cert
 
 mReadPoolRetirement

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -79,8 +79,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolMetadataUrl
     , getPoolRetirementCertificate
     )
-import Control.Monad.Trans.State.Strict
-    ( runState, state )
 import Data.Bifunctor
     ( first )
 import Data.Foldable
@@ -267,13 +265,14 @@ mReadPoolRetirement poolId db = (, db)
     only k (_, k') _ = k == k'
 
 mListPoolLifeCycleData :: EpochNo -> ModelPoolOp [PoolLifeCycleStatus]
-mListPoolLifeCycleData epoch db = flip runState db $ do
-    let registeredPools = listRegisteredPools db
-    let retiredPools = fmap (view #poolId) (listRetiredPools epoch db)
-    let nonRetiredPools = Set.toList $ Set.difference
-            (Set.fromList registeredPools)
-            (Set.fromList retiredPools)
-    sequence <$> mapM (state . mReadPoolLifeCycleStatus) nonRetiredPools
+mListPoolLifeCycleData epoch db = (, db) $ pure $
+    flip lookupLifeCycleStatus db <$> nonRetiredPools
+  where
+    registeredPools = listRegisteredPools db
+    retiredPools = fmap (view #poolId) (listRetiredPools epoch db)
+    nonRetiredPools = Set.toList $ Set.difference
+        (Set.fromList registeredPools)
+        (Set.fromList retiredPools)
 
 mListRegisteredPools :: PoolDatabase -> ([PoolId], PoolDatabase)
 mListRegisteredPools db = (listRegisteredPools db, db)

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -281,11 +281,8 @@ listRegisteredPools :: PoolDatabase -> [PoolId]
 listRegisteredPools PoolDatabase {registrations} =
     snd <$> Map.keys registrations
 
-mListRetiredPools
-    :: EpochNo
-    -> PoolDatabase
-    -> ([PoolRetirementCertificate], PoolDatabase)
-mListRetiredPools epochNo db = (listRetiredPools epochNo db, db)
+mListRetiredPools :: EpochNo -> ModelPoolOp [PoolRetirementCertificate]
+mListRetiredPools epochNo db = (pure $ listRetiredPools epochNo db, db)
 
 listRetiredPools :: EpochNo -> PoolDatabase -> [PoolRetirementCertificate]
 listRetiredPools epochNo db = retiredPools

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -181,7 +181,10 @@ mPutPoolProduction point poolId db@PoolDatabase{pools} =
         , db { pools = Map.alter (alter point) poolId pools }
         )
 
-mReadPoolProduction :: TimeInterpreter Identity -> EpochNo -> ModelPoolOp (Map PoolId [BlockHeader])
+mReadPoolProduction
+    :: TimeInterpreter Identity
+    -> EpochNo
+    -> ModelPoolOp (Map PoolId [BlockHeader])
 mReadPoolProduction timeInterpreter epoch db@PoolDatabase{pools} =
     let epochOf' = runIdentity . timeInterpreter . epochOf
         updateSlots e = Map.map (filter (\x -> epochOf' (slotNo x) == e))

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -355,12 +355,11 @@ mPutPoolMetadata
     :: StakePoolMetadataHash
     -> StakePoolMetadata
     -> ModelPoolOp ()
-mPutPoolMetadata hash meta db@PoolDatabase{metadata,fetchAttempts} =
-    ( Right ()
-    , db { metadata = Map.insert hash meta metadata
-         , fetchAttempts = Map.filterWithKey (\k _ -> snd k /= hash) fetchAttempts
-         }
-    )
+mPutPoolMetadata hash meta = (pure (), )
+    . over #metadata
+        (Map.insert hash meta)
+    . over #fetchAttempts
+         (Map.filterWithKey $ \k _ -> snd k /= hash)
 
 mReadPoolMetadata
     :: ModelPoolOp (Map StakePoolMetadataHash StakePoolMetadata)

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -32,7 +32,7 @@ module Cardano.Pool.DB.Model
     , ModelPoolOp
     , PoolErr (..)
     -- * Model pool database functions
-    , mCleanPoolProduction
+    , mCleanDatabase
     , mPutPoolProduction
     , mReadPoolProduction
     , mReadTotalProduction
@@ -165,8 +165,8 @@ newtype PoolErr = PointAlreadyExists BlockHeader
                             Model Pool Database Functions
 -------------------------------------------------------------------------------}
 
-mCleanPoolProduction :: ModelPoolOp ()
-mCleanPoolProduction _ = (Right (), emptyPoolDatabase)
+mCleanDatabase :: ModelPoolOp ()
+mCleanDatabase _ = (Right (), emptyPoolDatabase)
 
 mPutPoolProduction :: BlockHeader -> PoolId -> ModelPoolOp ()
 mPutPoolProduction point poolId db@PoolDatabase{pools} =

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -234,13 +234,11 @@ mReadPoolRegistration
     :: PoolId
     -> ModelPoolOp
         (Maybe (CertificatePublicationTime, PoolRegistrationCertificate))
-mReadPoolRegistration poolId db =
-    ( Right
-        $ fmap (first fst)
-        $ Map.lookupMax
-        $ Map.filterWithKey (only poolId) registrations
-    , db
-    )
+mReadPoolRegistration poolId db = (, db)
+    $ pure
+    $ fmap (first fst)
+    $ Map.lookupMax
+    $ Map.filterWithKey (only poolId) registrations
   where
     PoolDatabase {registrations} = db
     only k (_, k') _ = k == k'

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -222,15 +222,12 @@ mPutPoolRegistration
     :: CertificatePublicationTime
     -> PoolRegistrationCertificate
     -> ModelPoolOp ()
-mPutPoolRegistration cpt cert db =
-    ( Right ()
-    , db
-        { owners = Map.insert poolId poolOwners owners
-        , registrations = Map.insert (cpt, poolId) cert registrations
-        }
-    )
+mPutPoolRegistration cpt cert = (pure (),)
+    . over #owners
+        (Map.insert poolId poolOwners)
+    . over #registrations
+        (Map.insert (cpt, poolId) cert)
   where
-    PoolDatabase {owners, registrations} = db
     PoolRegistrationCertificate {poolId, poolOwners} = cert
 
 mReadPoolRegistration

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -269,7 +269,7 @@ mReadPoolRetirement poolId db = (, db)
 mListPoolLifeCycleData :: EpochNo -> ModelPoolOp [PoolLifeCycleStatus]
 mListPoolLifeCycleData epoch db = flip runState db $ do
     let registeredPools = listRegisteredPools db
-    retiredPools <- fmap (view #poolId) <$> state (mListRetiredPools epoch)
+    let retiredPools = fmap (view #poolId) (listRetiredPools epoch db)
     let nonRetiredPools = Set.toList $ Set.difference
             (Set.fromList registeredPools)
             (Set.fromList retiredPools)
@@ -286,7 +286,10 @@ mListRetiredPools
     :: EpochNo
     -> PoolDatabase
     -> ([PoolRetirementCertificate], PoolDatabase)
-mListRetiredPools epochNo db = (retiredPools, db)
+mListRetiredPools epochNo db = (listRetiredPools epochNo db, db)
+
+listRetiredPools :: EpochNo -> PoolDatabase -> [PoolRetirementCertificate]
+listRetiredPools epochNo db = retiredPools
   where
     allKnownPoolIds :: [PoolId]
     allKnownPoolIds =

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -257,13 +257,11 @@ mReadPoolRetirement
     :: PoolId
     -> ModelPoolOp
         (Maybe (CertificatePublicationTime, PoolRetirementCertificate))
-mReadPoolRetirement poolId db =
-    ( Right
-        $ fmap (first fst)
-        $ Map.lookupMax
-        $ Map.filterWithKey (only poolId) retirements
-    , db
-    )
+mReadPoolRetirement poolId db = (, db)
+    $ pure
+    $ fmap (first fst)
+    $ Map.lookupMax
+    $ Map.filterWithKey (only poolId) retirements
   where
     PoolDatabase {retirements} = db
     only k (_, k') _ = k == k'

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -55,6 +55,7 @@ module Cardano.Pool.DB.Model
     , mRollbackTo
     , mReadCursor
     , mRemovePools
+    , mRemoveRetiredPools
     ) where
 
 import Prelude
@@ -453,3 +454,11 @@ mRemovePools poolsToRemove db =
             (Map.filterWithKey $ \(_, p) _ -> retain p)
     retain p = p `Set.notMember` poolsToRemoveSet
     poolsToRemoveSet = Set.fromList poolsToRemove
+
+mRemoveRetiredPools :: EpochNo -> ModelPoolOp [PoolRetirementCertificate]
+mRemoveRetiredPools epoch db =
+    first
+        (fmap $ const certificates)
+        (mRemovePools (view #poolId <$> certificates) db)
+  where
+    certificates = listRetiredPools epoch db

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -274,8 +274,8 @@ mListPoolLifeCycleData epoch db = (, db) $ pure $
         (Set.fromList registeredPools)
         (Set.fromList retiredPools)
 
-mListRegisteredPools :: PoolDatabase -> ([PoolId], PoolDatabase)
-mListRegisteredPools db = (listRegisteredPools db, db)
+mListRegisteredPools :: ModelPoolOp [PoolId]
+mListRegisteredPools db = (pure $ listRegisteredPools db, db)
 
 listRegisteredPools :: PoolDatabase -> [PoolId]
 listRegisteredPools PoolDatabase {registrations} =


### PR DESCRIPTION
# Issue Number

https://jira.iohk.io/browse/ADP-406

# Overview

This PR adjusts `Pool.DB.Model` to make it more usable with `quickcheck-state-machine`.

**Changes:**

- All operations in the `Model` layer now return values of type `ModelOp a`, rather than the ad-hoc mix that was there before.
    
    _Example:_
    ```patch
    - mListRegisteredPools :: PoolDatabase -> ([PoolId], PoolDatabase)
    + mListRegisteredPools :: ModelOp [PoolId]
   ```

- The `Model` layer now provides **_all_** operations required by `DBLayer`. Previously, some of these were **_missing_**, and were provided only by the `MVar` layer.
    
    _Examples:_
    ```patch
    + mReadPoolLifeCycleStatus :: PoolId  -> ModelOp  PoolLifeCycleStatus
    + mListPoolLifeCycleData   :: EpochNo -> ModelOp [PoolLifeCycleStatus]
    + mRemoveRetiredPools      :: EpochNo -> ModelOp [PoolRetirementCertificate]
    ```

- All _**read-only**_ operations in the `MVar` layer now use `readPoolDB` rather than `adjustPoolDB` or `modifyMVar`.
    
    _Example:_
    ```patch
    listRegisteredPools =
    -   modifyMVar db (pure . swap . mListRegisteredPools)
    +   readPoolDB db mListRegisteredPools
    ```

- Some additional warts are fixed, and record update boilerplate reduced.