### PR TITLE
Fix dylib references of bundled programs on macOS

### DIFF
--- a/nix/linux-release.nix
+++ b/nix/linux-release.nix
@@ -21,7 +21,7 @@ let
 in pkgs.stdenv.mkDerivation {
   inherit name;
   buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
-  checkInputs = [ pkgs.buildPackages.ruby ];
+  checkInputs = with pkgs.buildPackages; [ ruby gnugrep glibc.bin ];
   doCheck = true;
   phases = [ "buildPhase" "checkPhase" ];
   tarname = "${name}-linux64.tar.gz";

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -20,7 +20,13 @@ let
 
 in pkgs.stdenv.mkDerivation {
   inherit name;
-  buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
+  buildInputs = with pkgs.buildPackages; [
+    gnutar
+    gzip
+    binutils
+    commonLib.haskell-nix-extra-packages.haskellBuildUtils.package
+    nix
+  ];
   checkInputs = with pkgs.buildPackages; [
     ruby
     gnugrep
@@ -34,6 +40,7 @@ in pkgs.stdenv.mkDerivation {
     mkdir $name
     cp -nR ${concatMapStringsSep " " (exe: "${exe}/bin/*") exes} $name
     chmod -R 755 $name
+    ( cd $name; rewrite-libs . `ls -1 | grep -Fv .dylib` )
 
     mkdir -p $out/nix-support
     tar -czf $out/$tarname $name

--- a/nix/macos-release.nix
+++ b/nix/macos-release.nix
@@ -21,7 +21,12 @@ let
 in pkgs.stdenv.mkDerivation {
   inherit name;
   buildInputs = with pkgs.buildPackages; [ gnutar gzip binutils ];
-  checkInputs = [ pkgs.buildPackages.ruby ];
+  checkInputs = with pkgs.buildPackages; [
+    ruby
+    gnugrep
+    gnused
+    darwin.cctools
+  ];
   doCheck = true;
   phases = [ "buildPhase" "checkPhase" ];
   tarname = "${name}-macos64.tar.gz";

--- a/release.nix
+++ b/release.nix
@@ -183,20 +183,18 @@ let
   # Release distribution jobs - these all have a Hydra download link.
 
   # Which exes should be put in the release archive.
-  releaseContents = rec {
+  releaseContents = {
     jormungandr = [
       "cardano-wallet-jormungandr"
-      "jormungandr"
-      "jormungandr-cli"
     ];
-    cardanoNodeCommon = [
+    shelley = [
+      "cardano-wallet"
       "bech32"
       "cardano-address"
       "cardano-cli"
       "cardano-node"
       "cardano-tx"
     ];
-    shelley = [ "cardano-wallet" ] ++ cardanoNodeCommon;
   };
 
   # function to take a list of jobs by name from a jobset.

--- a/scripts/check-bundle.rb
+++ b/scripts/check-bundle.rb
@@ -10,7 +10,7 @@
 require 'open3'
 
 tests = {
-  "cardano-wallet-jormungandr" => [ "jormungandr", "jcli" ],
+  "cardano-wallet-jormungandr" => [ ],
   "cardano-wallet" => [ "cardano-node", "cardano-cli", "bech32", "cardano-tx", "cardano-address" ]
 }
 

--- a/scripts/check-bundle.rb
+++ b/scripts/check-bundle.rb
@@ -3,6 +3,8 @@
 ############################################################################
 # Checks that every executable required in the release package is
 # present and works.
+# On Linux it checks if executables are statically linked.
+# On macOS it checks that there are no /nix/store dylibs.
 ############################################################################
 
 require 'open3'
@@ -33,15 +35,28 @@ def report(cmd, status)
 end
 
 cmd = "#{wallet} version"
-ver, status = Open3.capture2("#{runner} #{cmd}")
-report(cmd, status.to_i)
+begin
+  ver, status = Open3.capture2("#{runner} #{cmd}")
+  report(cmd, status.to_i)
+rescue Errno::ENOENT
+  report(cmd, 1)
+end
 
-tests[wallet].each do |cmd|
+tests[wallet].unshift(wallet).each do |cmd|
   begin
     stdout_str, status = Open3.capture2("#{runner} #{cmd} --help")
     report(cmd, status.to_i)
   rescue Errno::ENOENT
     report(cmd, 1)
+    next
+  end
+
+  if /darwin/ =~ RUBY_PLATFORM then
+    system("! otool -L `type -p #{cmd}` | sed 1d | grep nix");
+    report("#{cmd} is free of /nix/store", $?.exitstatus)
+  elsif /linux/ =~ RUBY_PLATFORM then
+    system("! ldd `type -p #{cmd}` > /dev/null");
+    report("#{cmd} is static linked", $?.exitstatus)
   end
 end
 


### PR DESCRIPTION
### Issue Number

Resolves #2134

### Overview

- On macOS rewrite dylib references from `/nix/store` to `@executable_path` - for every executable in the bundle.
- Add linking tests to `check-bundle.rb` for macOS and Linux.
