### PR TITLE
Run existing pool DB property tests on model implementation.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -268,6 +268,7 @@ test-suite unit
       Cardano.Byron.Codec.CborSpec
       Cardano.DB.Sqlite.DeleteSpec
       Cardano.Pool.DB.Arbitrary
+      Cardano.Pool.DB.MVarSpec
       Cardano.Pool.DB.Properties
       Cardano.Pool.DB.SqliteSpec
       Cardano.Wallet.Api.Malformed

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -386,10 +386,8 @@ mRollbackTo ti point = do
         $ Map.mapMaybeWithKey $ discardBy id . view #slotNo . fst
     modify #retirements
         $ Map.mapMaybeWithKey $ discardBy id . view #slotNo . fst
-    poolIds <-
-        Set.fromList <$> mListRegisteredPools
     modify #owners
-        $ flip Map.restrictKeys poolIds
+        . flip Map.restrictKeys . Set.fromList =<< mListRegisteredPools
   where
     discardBy :: Ord point => (SlotNo -> point) -> point -> a -> Maybe a
     discardBy getPoint point' v

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -314,13 +314,17 @@ mUnfetchedPoolMetadataRefs
 mUnfetchedPoolMetadataRefs n = inner
     <$> get #registrations
     <*> get #metadata
+    <*> get #fetchAttempts
   where
-    inner registrations metadata = toTuple <$> take n (Map.elems unfetched)
+    inner registrations metadata fetchAttempts =
+        toTuple <$> take n (Map.elems unfetched)
       where
         unfetched = flip Map.filter registrations $ \r ->
             case poolMetadata r of
                 Nothing -> False
-                Just (_, hash) -> hash `notElem` Map.keys metadata
+                Just fkey@(_, hash) -> (&&)
+                    (hash `notElem` Map.keys metadata)
+                    (fkey `notElem` Map.keys fetchAttempts)
         toTuple PoolRegistrationCertificate{poolId,poolMetadata} =
             (poolId, metadataUrl, metadataHash)
           where

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -281,7 +281,7 @@ mListRetiredPools epochNo = do
             Map.union retirements retirementCancellations
             -- Keep only the most-recently published retirement epoch for each
             -- pool (which will be 'Nothing' in the case of a cancellation):
-            & Map.mapKeys snd
+            & retainOnlyMostRecent
             -- Remove pools that have had their retirements cancelled:
             & pruneEmptyValues
             -- Remove pools that have not yet retired:
@@ -293,6 +293,13 @@ mListRetiredPools epochNo = do
   where
     pruneEmptyValues :: Map k (Maybe v) -> Map k v
     pruneEmptyValues = Map.mapMaybe id
+
+    retainOnlyMostRecent :: Ord k => Map (publicationTime, k) v -> Map k v
+    retainOnlyMostRecent =
+        -- If more than one key from the original map is mapped to the same key
+        -- in the result map, 'Map.mapKeys' guarantees to retain only the value
+        -- corresponding to the greatest of the original keys.
+        Map.mapKeys snd
 
 mReadPoolLifeCycleStatus :: PoolId -> ModelOp PoolLifeCycleStatus
 mReadPoolLifeCycleStatus poolId =

--- a/lib/core/test/unit/Cardano/Pool/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/MVarSpec.hs
@@ -1,0 +1,26 @@
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Tests for the 'MVar' implementation of the pool 'DBLayer' interface.
+--
+module Cardano.Pool.DB.MVarSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Pool.DB.Properties
+    ( properties, withDB )
+import Cardano.Wallet.DummyTarget.Primitive.Types
+    ( dummyTimeInterpreter )
+import Test.Hspec
+    ( Spec, describe )
+
+import qualified Cardano.Pool.DB.MVar as MVar
+
+spec :: Spec
+spec = withDB (MVar.newDBLayer ti) $
+    describe "MVar" properties
+  where
+    ti = dummyTimeInterpreter

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -911,7 +911,7 @@ prop_listRegisteredPools DBLayer {..} entries =
         monitor $ counterexample $ unlines
             [ "Read from DB: " <> show pools
             ]
-        assert (pools == (view #poolId <$> reverse entries))
+        assert (Set.fromList pools == Set.fromList (view #poolId <$> entries))
 
 -- | Test that `listRetiredPools` returns the correct set of retirements for
 --   any given epoch.

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -911,7 +911,8 @@ prop_listRegisteredPools DBLayer {..} entries =
         monitor $ counterexample $ unlines
             [ "Read from DB: " <> show pools
             ]
-        assert (L.sort pools == L.sort (view #poolId <$> entries))
+        assertWith "pools written == pools retrieved"
+            (L.sort pools == L.sort (view #poolId <$> entries))
 
 -- | Test that `listRetiredPools` returns the correct set of retirements for
 --   any given epoch.

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -911,7 +911,7 @@ prop_listRegisteredPools DBLayer {..} entries =
         monitor $ counterexample $ unlines
             [ "Read from DB: " <> show pools
             ]
-        assert (Set.fromList pools == Set.fromList (view #poolId <$> entries))
+        assert (L.sort pools == L.sort (view #poolId <$> entries))
 
 -- | Test that `listRetiredPools` returns the correct set of retirements for
 --   any given epoch.


### PR DESCRIPTION
# Issue Number

https://jira.iohk.io/browse/ADP-406

# Overview

Over time, we've built up a fairly large suite of [property tests for the pool database](https://github.com/input-output-hk/cardano-wallet/blob/ff181966317b50083a61aa3e4f3dfd2ac1bff1a3/lib/core/test/unit/Cardano/Pool/DB/Properties.hs).

However, up until now these tests were only ever run on the **SQLite** implementation. The **model** implementation was not tested.

This PR fixes this by adjusting the test suite to test both the **SQLite** and **model** implementations. For example:

```hs
ghcid \
    --command "stack ghci cardano-wallet-core:lib cardano-wallet-core:test:unit" \
    --test ':run Spec.main -m prop_listPoolLifeCycleData_multiplePools_multipleCerts'

Cardano.Pool.DB.MVar
  MVar
    Stake Pool Properties
      prop_listPoolLifeCycleData_multiplePools_multipleCerts
        +++ OK, passed 100 tests.
Cardano.Pool.DB.Sqlite
  Sqlite
    Stake Pool Properties
      prop_listPoolLifeCycleData_multiplePools_multipleCerts
        +++ OK, passed 100 tests.

Finished in 40.3082 seconds
2 examples, 0 failures
```

## Details

This PR:
1. Generalizes the `Pool.DB.Properties` module to work with any implementation of `Pool.DBLayer`.
2. Adds a `Pool.DB.MVarSpec` module to handle the required setup for testing the model implementation.
3. Fixes the small number of resulting failures.