### PR TITLE
Save intermediate state when restoring the Byron chain in the stake pools worker

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -107,6 +107,7 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- be the last element in the list.
         --
         -- This is useful for the @NetworkLayer@ to know how far we have synced.
+        -- Returns all headers if limit is <= 0.
 
     , readPoolLifeCycleStatus
         :: PoolId
@@ -222,6 +223,17 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         --
         --    - 'listRetiredPools'.
         --    - 'removePools'.
+
+    , putHeader
+        :: BlockHeader
+        -> stm ()
+        -- ^ Add a block header
+
+    , listHeaders
+        :: Int -- limit
+        -> stm [BlockHeader]
+        -- ^ List headers, usually stored during syncing.
+        -- Returns all headers if limit is <= 0.
 
     , cleanDB
         :: stm ()

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -25,10 +25,12 @@ import Cardano.Pool.DB.Model
     , PoolErr (..)
     , emptyPoolDatabase
     , mCleanDatabase
+    , mListHeaders
     , mListPoolLifeCycleData
     , mListRegisteredPools
     , mListRetiredPools
     , mPutFetchAttempt
+    , mPutHeader
     , mPutPoolMetadata
     , mPutPoolProduction
     , mPutPoolRegistration
@@ -145,6 +147,12 @@ newDBLayer timeInterpreter = do
             fmap (fromRight [])
                 . alterPoolDB (const Nothing) db
                 . mRemoveRetiredPools
+
+        putHeader point =
+            void . alterPoolDB (const Nothing) db . mPutHeader $ point
+
+        listHeaders =
+            readPoolDB db . mListHeaders
 
         cleanDB =
             void $ alterPoolDB (const Nothing) db mCleanDatabase

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -481,6 +481,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolProductionSlot >. point ]
             deleteWhere [ PoolRegistrationSlot >. point ]
             deleteWhere [ PoolRetirementSlot >. point ]
+            deleteWhere [ BlockSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
         removePools = mapM_ $ \pool -> do

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -134,8 +134,10 @@ import System.FilePath
 import System.Random
     ( newStdGen )
 
-import Cardano.Pool.DB.Sqlite.TH
+import Cardano.Pool.DB.Sqlite.TH hiding
+    ( BlockHeader, blockHeight )
 
+import qualified Cardano.Pool.DB.Sqlite.TH as TH
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
@@ -526,6 +528,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere ([] :: [Filter StakeDistribution])
             deleteWhere ([] :: [Filter PoolMetadata])
             deleteWhere ([] :: [Filter PoolMetadataFetchAttempts])
+            deleteWhere ([] :: [Filter TH.BlockHeader])
 
         atomically :: forall a. (SqlPersistT IO a -> IO a)
         atomically = runQuery
@@ -589,6 +592,17 @@ newDBLayer trace fp timeInterpreter = do
                 let cert = PoolRetirementCertificate {poolId, retirementEpoch}
                 let cpt = CertificatePublicationTime {slotNo, slotInternalIndex}
                 pure (cpt, cert)
+
+        putHeader point =
+            let record = mkBlockHeader point
+                key = TH.blockHeight record
+            in repsert (BlockHeaderKey key) record
+
+        listHeaders k = do
+            reverse . fmap (fromBlockHeaders . entityVal) <$> selectList [ ]
+                [ Desc BlockHeight
+                , LimitTo k
+                ]
 
 -- | Defines a raw SQL query, runnable with 'runRawQuery'.
 --
@@ -872,6 +886,24 @@ fromPoolProduction (PoolProduction pool slot headerH parentH height) =
         , parentHeaderHash = getBlockId parentH
         }
     )
+
+mkBlockHeader
+    :: BlockHeader
+    -> TH.BlockHeader
+mkBlockHeader block = TH.BlockHeader
+    { blockSlot = view #slotNo block
+    , blockHeaderHash = BlockId (headerHash block)
+    , blockParentHash = BlockId (parentHeaderHash block)
+    , TH.blockHeight = getQuantity (blockHeight block)
+    }
+
+fromBlockHeaders :: TH.BlockHeader -> BlockHeader
+fromBlockHeaders TH.BlockHeader { blockSlot, blockHeight, blockHeaderHash
+        , blockParentHash } =
+    BlockHeader blockSlot
+        (Quantity blockHeight)
+        (getBlockId blockHeaderHash)
+        (getBlockId blockParentHash)
 
 mkStakeDistribution
     :: EpochNo

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -898,12 +898,18 @@ mkBlockHeader block = TH.BlockHeader
     }
 
 fromBlockHeaders :: TH.BlockHeader -> BlockHeader
-fromBlockHeaders TH.BlockHeader { blockSlot, blockHeight, blockHeaderHash
-        , blockParentHash } =
+fromBlockHeaders h =
     BlockHeader blockSlot
         (Quantity blockHeight)
         (getBlockId blockHeaderHash)
         (getBlockId blockParentHash)
+  where
+    TH.BlockHeader
+        { blockSlot
+        , blockHeight
+        , blockHeaderHash
+        , blockParentHash
+        } = h
 
 mkStakeDistribution
     :: EpochNo

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -66,6 +66,16 @@ PoolProduction sql=pool_production
     Primary poolProductionSlot
     deriving Show Generic
 
+-- A block header
+BlockHeader sql=block_headers
+    blockSlot           SlotNo       sql=slot
+    blockHeaderHash     W.BlockId    sql=header_hash
+    blockParentHash     W.BlockId    sql=parent_header_hash
+    blockHeight         Word32       sql=block_height
+
+    Primary blockHeight
+    deriving Show Generic
+
 -- Stake distribution for each stake pool
 StakeDistribution sql=stake_distribution
     stakeDistributionPoolId     W.PoolId     sql=pool_id

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -43,7 +43,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeMkEntropy, unsafeMkPercentage )
+    ( unsafeFromHex, unsafeMkEntropy, unsafeMkPercentage )
 import Data.Aeson
     ( ToJSON (..) )
 import Data.ByteArray.Encoding
@@ -152,9 +152,12 @@ genBlockHeader sl = do
         mockBlockHeight = Quantity . fromIntegral . unSlotNo
 
         genHash = elements
-            [ Hash "BLOCK01"
-            , Hash "BLOCK02"
-            , Hash "BLOCK03"
+            [ Hash $ unsafeFromHex
+                "aac1308b9868af89c396b08ff6f3cfea8e0859c94d1b3bc834baeaaff8645448"
+            , Hash $ unsafeFromHex
+                "d93b27cc7bb6fd2fe6ee42de5328c13606bb714a78475a41335207d2afd6026e"
+            , Hash $ unsafeFromHex
+                "63b8828e2eadc3f14b9b691fa9df76139a9c9b13a12ec862b324cc5a88f9fcc5"
             ]
 
 genActiveSlotCoefficient :: Gen ActiveSlotCoefficient

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -41,6 +41,8 @@ import Cardano.Wallet
     ( ErrListPools (..) )
 import Cardano.Wallet.Api.Types
     ( ApiT (..) )
+import Cardano.Wallet.Byron.Compatibility
+    ( toByronBlockHeader )
 import Cardano.Wallet.Network
     ( ErrCurrentNodeTip (..)
     , ErrNetworkUnavailable (..)
@@ -145,6 +147,7 @@ import System.Random
 
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -502,7 +505,7 @@ monitorStakePools tr gp nl DBLayer{..} =
 
     initCursor :: IO [BlockHeader]
     initCursor = do
-        fromDB <- atomically $ readPoolProductionCursor (max 100 k)
+        fromDB <- atomically $ listHeaders (max 100 k)
         pure (lastByronBlock:fromDB)
       where k = fromIntegral $ getQuantity getEpochStability
 
@@ -514,21 +517,45 @@ monitorStakePools tr gp nl DBLayer{..} =
         -> NonEmpty (CardanoBlock StandardCrypto)
         -> (BlockHeader, ProtocolParameters)
         -> IO (FollowAction ())
-    forward latestGarbageCollectionEpochRef blocks (_nodeTip, _pparams) = do
-        atomically $ forM_ blocks $ \case
+    forward latestGarbageCollectionEpochRef blocks _ = do
+        atomically $ forAllAndLastM blocks forAllBlocks forLastBlock
+        pure Continue
+      where
+        forAllBlocks = \case
             BlockByron _ -> pure ()
             BlockShelley blk -> do
                 let (slot, certificates) = poolCertsFromShelleyBlock blk
                 let header = toShelleyBlockHeader getGenesisBlockHash blk
-                runExceptT (putPoolProduction header (getProducer blk))
-                    >>= \case
-                        Left e ->
-                            liftIO $ traceWith tr $ MsgErrProduction e
-                        Right () ->
-                            pure ()
+                handleErr (putPoolProduction header (getProducer blk))
                 garbageCollectPools slot latestGarbageCollectionEpochRef
                 putPoolCertificates slot certificates
-        pure Continue
+
+        forLastBlock = \case
+            BlockByron blk ->
+                putHeader (toByronBlockHeader gp blk)
+            BlockShelley blk ->
+                putHeader (toShelleyBlockHeader getGenesisBlockHash blk)
+
+        handleErr action = runExceptT action
+            >>= \case
+                Left e ->
+                    liftIO $ traceWith tr $ MsgErrProduction e
+                Right () ->
+                    pure ()
+
+        -- | Like 'forM_', except runs the second action for the last element as
+        -- well (in addition to the first action).
+        forAllAndLastM :: (Monad m)
+            => NonEmpty a
+            -> (a -> m b) -- ^ action to run for all elements
+            -> (a -> m c) -- ^ action to run for the last element
+            -> m ()
+        {-# INLINE forAllAndLastM #-}
+        forAllAndLastM ne a1 a2 = go (NE.toList ne)
+          where
+            go []  = pure ()
+            go [x] = a1 x >> a2 x >> go []
+            go (x:xs) = a1 x >> go xs
 
     -- Perform garbage collection for pools that have retired.
     --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -60,11 +60,12 @@ import Cardano.Wallet.Primitive.Slotting
     )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , BlockHeader
+    , BlockHeader (..)
     , CertificatePublicationTime (..)
     , Coin (..)
     , EpochNo (..)
     , GenesisParameters (..)
+    , Hash (..)
     , PoolCertificate (..)
     , PoolId
     , PoolLifeCycleStatus (..)
@@ -72,7 +73,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolRetirementCertificate (..)
     , ProtocolParameters (..)
     , SlotLength (..)
-    , SlotNo
+    , SlotNo (..)
     , StakePoolMetadata
     , StakePoolMetadataHash
     , StakePoolMetadataUrl
@@ -90,7 +91,7 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Network
     ( NodePoolLsqData (..) )
 import Cardano.Wallet.Unsafe
-    ( unsafeMkPercentage )
+    ( unsafeFromHex, unsafeMkPercentage )
 import Control.Concurrent
     ( threadDelay )
 import Control.Exception
@@ -500,7 +501,9 @@ monitorStakePools tr gp nl DBLayer{..} =
     mkLatestGarbageCollectionEpochRef = newIORef minBound
 
     initCursor :: IO [BlockHeader]
-    initCursor = atomically $ readPoolProductionCursor (max 100 k)
+    initCursor = do
+        fromDB <- atomically $ readPoolProductionCursor (max 100 k)
+        pure (lastByronBlock:fromDB)
       where k = fromIntegral $ getQuantity getEpochStability
 
     getHeader :: CardanoBlock StandardCrypto -> BlockHeader
@@ -704,3 +707,20 @@ instance ToText StakePoolLog where
             , "back to it in about "
             , pretty (fixedF 1 (toRational delay / 1000000)), "s"
             ]
+
+-- | The very last block header of the Byron era, just before the transition
+--   to Shelley.
+--
+-- This is hard-coded for mainnet and will do nothing for other networks.
+--
+-- TODO: query cardano-node for hard fork block (not yet possible).
+-- https://jira.iohk.io/browse/CAD-1850
+--
+lastByronBlock :: BlockHeader
+lastByronBlock = BlockHeader
+    (SlotNo 4492799)
+    (Quantity 4490510)
+    (Hash $ unsafeFromHex
+        "f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457")
+    (Hash $ unsafeFromHex
+        "aa83acbf5904c0edfe4d79b3689d3d00fcfc553cf360fd2229b98d464c28e9de")


### PR DESCRIPTION
This completely skips byron era for mainnet when syncing stake pools.

I extracted the first shelley block by looking at a fully synced stake pool DB and selecting the lowest `block_height` from the `pool_production` table.

For non-mainnet it will record the last byron block of a chunk from the node into the `byron_headers` table and read it out during `readPoolProductionCursor` if there are no stake pools and otherwise ignore it.

Remarks:

- the "genesis shelley header" is hardcoded, because the node currently does not have an endpoint to get this