### PR TITLE
Fix a unit test failing on windows due to illegal filename

### DIFF
--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetadataSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetadataSpec.hs
@@ -58,7 +58,6 @@ import Test.QuickCheck
     , elements
     , frequency
     , listOf
-    , listOf1
     , property
     , shuffle
     , sublistOf
@@ -66,6 +65,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
+import Test.Utils.FilePath
+    ( PathElement (..) )
 import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.StaticServer
@@ -361,11 +362,6 @@ instance Arbitrary StakePoolTicker where
 instance Arbitrary PoolOwner where
     arbitrary = PoolOwner . B8.pack <$> vectorOf 32 c
         where c = elements ['a'..'z']
-
-newtype PathElement = PathElement FilePath deriving (Show, Eq)
-
-instance Arbitrary PathElement where
-    arbitrary = PathElement <$> listOf1 (elements ['a'..'z'])
 
 {-------------------------------------------------------------------------------
                                      Utils

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -53,6 +53,7 @@ library
       src
   exposed-modules:
       Test.Hspec.Extra
+      Test.Utils.FilePath
       Test.Utils.Paths
       Test.Utils.Roundtrip
       Test.Utils.StaticServer

--- a/lib/test-utils/src/Test/Utils/FilePath.hs
+++ b/lib/test-utils/src/Test/Utils/FilePath.hs
@@ -1,0 +1,33 @@
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- File path related test utilities.
+
+module Test.Utils.FilePath
+    ( PathElement (..)
+    ) where
+
+import Prelude
+
+import System.FilePath.Windows
+    ( makeValid )
+import Test.QuickCheck
+    ( Arbitrary (..), elements, listOf1, scale )
+import Test.Utils.Windows
+    ( isWindows )
+
+-- | A file or directory name. The 'Arbitrary' instance will generate values
+-- which are valid on Windows and POSIX.
+--
+-- <https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file>
+newtype PathElement = PathElement FilePath deriving (Show, Eq)
+
+instance Arbitrary PathElement where
+    arbitrary = PathElement . makeValid' <$> limitLen genName
+      where
+        genName = listOf1 (elements ['a'..'z'])
+        limitLen = scale (max 250)
+
+makeValid' :: FilePath -> FilePath
+makeValid' = if isWindows then makeValid else id


### PR DESCRIPTION
### Issue Number

Resolves #2149

### Overview

Prevents jormungandr stake pool metadata tests from choosing illegal filenames on Windows.
