### PR TITLE
Test pool garbage collection.

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -75,6 +75,7 @@ library
       src
   exposed-modules:
       Test.Integration.Faucet
+      Test.Integration.Framework.Context
       Test.Integration.Framework.DSL
       Test.Integration.Framework.Request
       Test.Integration.Framework.TestData

--- a/lib/core-integration/src/Test/Integration/Framework/Context.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Context.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Test.Integration.Framework.Context
+    ( Context (..)
+    , TxDescription (..)
+    ) where
+
+import Prelude
+
+import Cardano.CLI
+    ( Port (..) )
+import Cardano.Wallet.Primitive.Types
+    ( NetworkParameters )
+import Cardano.Wallet.Transaction
+    ( DelegationAction )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text
+    ( Text )
+import GHC.Generics
+    ( Generic )
+import Network.HTTP.Client
+    ( Manager )
+import Numeric.Natural
+    ( Natural )
+import Test.Integration.Faucet
+    ( Faucet )
+
+-- | Context for integration tests.
+--
+data Context t = Context
+    { _cleanup
+        :: IO ()
+        -- ^ A cleanup action.
+    , _manager
+        :: (Text, Manager)
+        -- ^ The underlying base URL and manager used by the wallet client.
+    , _walletPort
+        :: Port "wallet"
+        -- ^ Server TCP port.
+    , _faucet
+        :: Faucet
+        -- ^ Provides access to funded wallets.
+    , _feeEstimator :: TxDescription -> (Natural, Natural)
+        -- ^ A fee estimator.
+    , _networkParameters :: NetworkParameters
+        -- ^ Blockchain parameters for the underlying chain.
+    , _target
+        :: Proxy t
+    }
+    deriving Generic
+
+-- | Describe a transaction in terms of its inputs and outputs.
+data TxDescription
+    = DelegDescription DelegationAction
+    | PaymentDescription
+        { nInputs
+            :: Int
+        , nOutputs
+            :: Int
+        , nChanges
+            :: Int
+        }
+    deriving Show

--- a/lib/core-integration/src/Test/Integration/Framework/Context.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Context.hs
@@ -3,6 +3,7 @@
 
 module Test.Integration.Framework.Context
     ( Context (..)
+    , PoolGarbageCollectionEvent (..)
     , TxDescription (..)
     ) where
 
@@ -11,9 +12,11 @@ import Prelude
 import Cardano.CLI
     ( Port (..) )
 import Cardano.Wallet.Primitive.Types
-    ( NetworkParameters )
+    ( EpochNo, NetworkParameters, PoolRetirementCertificate )
 import Cardano.Wallet.Transaction
     ( DelegationAction )
+import Data.IORef
+    ( IORef )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Text
@@ -48,8 +51,25 @@ data Context t = Context
         -- ^ Blockchain parameters for the underlying chain.
     , _target
         :: Proxy t
+    , _poolGarbageCollectionEvents
+        :: IORef [PoolGarbageCollectionEvent]
+        -- ^ The complete list of pool garbage collection events.
+        -- Most recent events are stored at the head of the list.
     }
     deriving Generic
+
+-- | Records the parameters and return value of a single call to the
+--   'removeRetiredPools' operation of 'Pool.DB.DBLayer'.
+--
+data PoolGarbageCollectionEvent = PoolGarbageCollectionEvent
+    { poolGarbageCollectionEpochNo
+        :: EpochNo
+        -- ^ The epoch number parameter.
+    , poolGarbageCollectionCertificates
+        :: [PoolRetirementCertificate]
+        -- ^ The pools that were removed from the database.
+    }
+    deriving (Eq, Show)
 
 -- | Describe a transaction in terms of its inputs and outputs.
 data TxDescription

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -308,12 +308,12 @@ import Test.Hspec.Expectations.Lifted
     ( shouldBe, shouldContain, shouldSatisfy )
 import Test.Integration.Faucet
     ( nextTxBuilder, nextWallet )
+import Test.Integration.Framework.Context
+    ( Context (..), TxDescription (..) )
 import Test.Integration.Framework.Request
-    ( Context (..)
-    , Headers (..)
+    ( Headers (..)
     , Payload (..)
     , RequestException (..)
-    , TxDescription (..)
     , request
     , unsafeRequest
     )

--- a/lib/core-integration/src/Test/Integration/Framework/Request.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Request.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
@@ -15,18 +14,10 @@ module Test.Integration.Framework.Request
     , Headers(..)
     , Payload(..)
     , RequestException(..)
-    , Context(..)
-    , TxDescription(..)
     ) where
 
 import Prelude
 
-import Cardano.CLI
-    ( Port (..) )
-import Cardano.Wallet.Primitive.Types
-    ( NetworkParameters )
-import Cardano.Wallet.Transaction
-    ( DelegationAction )
 import Control.Monad.Catch
     ( Exception (..), MonadCatch (..), throwM )
 import Control.Monad.IO.Class
@@ -39,12 +30,8 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Product.Typed
     ( HasType, typed )
-import Data.Proxy
-    ( Proxy (..) )
 import Data.Text
     ( Text )
-import GHC.Generics
-    ( Generic )
 import Network.HTTP.Client
     ( HttpException (..)
     , HttpExceptionContent
@@ -64,50 +51,14 @@ import Network.HTTP.Types.Method
     ( Method )
 import Network.HTTP.Types.Status
     ( status500 )
-import Numeric.Natural
-    ( Natural )
-import Test.Integration.Faucet
-    ( Faucet )
+import Test.Integration.Framework.Context
+    ( Context )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.Text as T
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Types.Status as HTTP
-
-
--- | Running Context for our integration test
-data Context t = Context
-    { _cleanup
-        :: IO ()
-        -- ^ Cleanup action for the context
-    , _manager
-        :: (Text, Manager)
-        -- ^ The underlying BaseUrl and Manager used by the Wallet Client
-    , _walletPort
-        :: Port "wallet"
-        -- ^ Server TCP port
-    , _faucet
-        :: Faucet
-        -- ^ A 'Faucet' handle in to have access to funded wallets in
-        -- integration tests.
-    , _feeEstimator :: TxDescription -> (Natural, Natural)
-        -- ^ A fee estimator for the integration tests
-    , _networkParameters :: NetworkParameters
-        -- ^ Blockchain parameters for the underlying chain
-    , _target
-        :: Proxy t
-    } deriving Generic
-
--- | Describe a transaction in terms of its inputs and outputs
-data TxDescription
-    = DelegDescription DelegationAction
-    | PaymentDescription
-        { nInputs :: Int
-        , nOutputs :: Int
-        , nChanges :: Int
-        }
-    deriving (Show)
 
 -- | The result when 'request' fails.
 data RequestException

--- a/lib/jormungandr/test/bench/Latency.hs
+++ b/lib/jormungandr/test/bench/Latency.hs
@@ -403,5 +403,7 @@ benchWithJormServer tracers action = withConfig $ \jmCfg -> do
                     , _networkParameters = np
                     , _feeEstimator = \_ -> error "feeEstimator not available"
                     , _target = Proxy
+                    , _poolGarbageCollectionEvents =
+                        error "poolGarbageCollectionEvents not available"
                     }
         throwIO $ ProcessHasExited "Server has unexpectedly exited" res

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -206,6 +206,8 @@ specWithServer tr = aroundAll withContext . after (tearDown . thd3)
                     , _feeEstimator = mkFeeEstimator feePolicy
                     , _networkParameters = np
                     , _target = Proxy
+                    , _poolGarbageCollectionEvents = error
+                        "poolGarbageCollectionEvents not available."
                     })
         race
             (takeMVar ctx >>= action)

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -363,6 +363,8 @@ withShelleyServer tracers action = do
                 , _feeEstimator = \_ -> error "feeEstimator not available"
                 , _networkParameters = np
                 , _target = Proxy
+                , _poolGarbageCollectionEvents =
+                    error "poolGarbageCollectionEvents not available"
                 }
     race_ (takeMVar ctx >>= action) (withServer setupContext)
 

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -393,6 +393,7 @@ withShelleyServer tracers action = do
                 tracers
                 (SyncTolerance 10)
                 (Just db)
+                Nothing
                 "127.0.0.1"
                 ListenOnRandomPort
                 Nothing

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -227,6 +227,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $ mempty
                     tracers
                     sTolerance
                     databaseDir
+                    Nothing
                     host
                     listen
                     tlsConfig

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -96,7 +96,7 @@ import Control.Concurrent
 import Control.Exception
     ( try )
 import Control.Monad
-    ( forM, forM_, forever, unless, void, when, (<=<) )
+    ( forM, forM_, forever, void, when, (<=<) )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -516,12 +516,8 @@ monitorStakePools tr gp nl db@DBLayer{..} = do
                             liftIO $ traceWith tr $ MsgErrProduction e
                         Right () ->
                             pure ()
-                unless (null certificates) $ do
-                    -- Before adding new pool certificates to the database, we
-                    -- first attempt to garbage collect pools that have already
-                    -- retired.
-                    garbageCollectPools slot latestGarbageCollectionEpochRef
-                    putPoolCertificates slot certificates
+                garbageCollectPools slot latestGarbageCollectionEpochRef
+                putPoolCertificates slot certificates
         pure Continue
 
     -- Perform garbage collection for pools that have retired.

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -237,6 +237,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
                 tracers
                 (SyncTolerance 10)
                 (Just db)
+                Nothing
                 "127.0.0.1"
                 ListenOnRandomPort
                 Nothing

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -98,14 +98,10 @@ import Test.Hspec.Extra
     ( aroundAll )
 import Test.Integration.Faucet
     ( genRewardAccounts, mirMnemonics, shelleyIntegrationTestFunds )
+import Test.Integration.Framework.Context
+    ( Context (..) )
 import Test.Integration.Framework.DSL
-    ( Context (..)
-    , Headers (..)
-    , KnownCommand (..)
-    , Payload (..)
-    , request
-    , unsafeRequest
-    )
+    ( Headers (..), KnownCommand (..), Payload (..), request, unsafeRequest )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Aeson as Aeson


### PR DESCRIPTION
# Issue Number

#2019 

# Overview

This PR tests that the **chain-following code** is correctly invoking the pool garbage collector by calling the `removeRetiredPools` operation at appropriate points in time.

Since the effects of the garbage collector are **not** visible through the API, the integration test framework cannot use the API to discover whether garbage collection has taken place.

This PR takes a novel approach of adding a **decorator** to the pool DB layer that records garbage collection events and makes them visible to the integration test layer.

Since the `removeRetiredPools` operation is already covered by property tests, the correctness of this operation is outside the scope of this PR.

# Details

This PR:
- [x] Adjusts the chain-following code to garbage collect pools _even if there are no new certificates_. This makes it possible to see the effects of garbage collection in the context of an integration test, where all certificates are issued at the start of time.
- [x] Limits pool garbage collection to _exactly once per epoch_, and no more.
- [x] Introduces the concept of a _pool database decorator_, which makes it possible to add instrumentation or monitoring to a pool database layer object.
- [x] Uses a pool database decorator to monitor _garbage collection events_ from the integration test framework.
- [x] Adds an integration test to check that retired pools are garbage collected _on schedule_.

# Logging

Here's an extract from the integration test log, showing that garbage collection is run exactly once per epoch:
```hs
[cardano-wallet.integration:Notice:758] [2020-09-21 09:04:59.96 UTC] Intercepted pool garbage collection event for epoch 1. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:05:36.02 UTC] Intercepted pool garbage collection event for epoch 2. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:06:16.01 UTC] Intercepted pool garbage collection event for epoch 3. The following pools were removed from the database: PoolRetirementCertificate {poolId = PoolId {getPoolId = "\ESC=\193\156j\184\158\175\252\133\SOH\243u\187\ETX\193\ESC\248\237]\CAN76\177\216\EOT\DC3\214"}, retirementEpoch = EpochNo {unEpochNo = 3}}
[cardano-wallet.integration:Notice:758] [2020-09-21 09:06:56.03 UTC] Intercepted pool garbage collection event for epoch 4. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:07:36.02 UTC] Intercepted pool garbage collection event for epoch 5. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:08:16.03 UTC] Intercepted pool garbage collection event for epoch 6. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:08:56.01 UTC] Intercepted pool garbage collection event for epoch 7. No pools were removed from the database.
[cardano-wallet.integration:Notice:758] [2020-09-21 09:09:36.02 UTC] Intercepted pool garbage collection event for epoch 8. No pools were removed from the database.

```
