### PR TITLE
cache latest checkpoint in-memory to avoid deserializing and reserializing it too often

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1668,22 +1668,7 @@ instance PersistState (Rnd.RndState t) where
         pendingAddresses <- lift $ selectRndStatePending wid
         pure $ Rnd.RndState
             { hdPassphrase = pwd
-            , accountIndex =
-                -- FIXME
-                -- In the early days when Daedalus Flight was shipped, the
-                -- wallet backend was generating addresses indexes across the
-                -- whole domain which was causing a great deal of issues with
-                -- the legacy cardano-sl:wallet ...
-                --
-                -- We later changed that to instead use "hardened indexes". Yet,
-                -- for the few wallets which were already created, we revert
-                -- this dynamically by replacing the index here.
-                --
-                -- This ugly hack could / should be removed eventually, in a few
-                -- releases from 2020-04-06.
-                if ix == 0
-                then minBound
-                else W.Index ix
+            , accountIndex = W.Index ix
             , addresses = addresses
             , pendingAddresses = pendingAddresses
             , gen = gen

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -54,7 +54,7 @@ import Cardano.Wallet.DB
     , cleanDB
     )
 import Cardano.Wallet.DB.Arbitrary
-    ( InitialCheckpoint (..), KeyValPairs (..) )
+    ( KeyValPairs (..) )
 import Cardano.Wallet.DB.Properties
     ( properties, withDB )
 import Cardano.Wallet.DB.Sqlite
@@ -79,8 +79,6 @@ import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
     , PersistPrivateKey
@@ -106,7 +104,6 @@ import Cardano.Wallet.Primitive.Model
     , currentTip
     , getState
     , initWallet
-    , updateState
     )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
@@ -208,7 +205,7 @@ import Test.Hspec
     , xit
     )
 import Test.QuickCheck
-    ( Property, arbitrary, generate, property, (==>) )
+    ( Property, generate, property, (==>) )
 import Test.QuickCheck.Monadic
     ( monadicIO )
 import Test.Utils.Paths
@@ -245,32 +242,9 @@ sqliteSpecSeq = withDB newMemoryDBLayer $ do
 
 sqliteSpecRnd :: Spec
 sqliteSpecRnd = withDB newMemoryDBLayer $ do
-    describe "Sqlite (RndState)" $ do
-        it "insertState . selectState (regression account index)"
-            testRegressionInsertSelectRndState
     describe "Sqlite State machine (RndState)" $ do
         it "Sequential state machine tests"
             (prop_sequential :: TestDBRnd -> Property)
-
-testRegressionInsertSelectRndState
-    :: DBLayer IO (RndState 'Mainnet) ByronKey
-    -> IO ()
-testRegressionInsertSelectRndState db = do
-    -- NOTE Abusing the index type here, for the sake of testing.
-    old  <- (\s -> s { accountIndex = Index 0 }) <$> generate arbitraryRndState
-    wid  <- generate arbitrary
-    cp   <- getInitialCheckpoint <$> generate arbitrary
-    meta <- generate arbitrary
-
-    new <- db & \DBLayer{..} -> atomically $ do
-        unsafeRunExceptT $ initializeWallet wid cp meta mempty pp
-        unsafeRunExceptT $ putCheckpoint wid (updateState old cp)
-        (fmap getState) <$> readCheckpoint wid
-
-    (accountIndex <$> new) `shouldBe` Just (minBound :: Index 'Hardened 'AccountK)
-
-  where
-    arbitraryRndState = arbitrary @(RndState 'Mainnet)
 
 testMigrationPassphraseScheme
     :: forall s k. (k ~ ShelleyKey, s ~ SeqState 'Mainnet k)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->



  This little change has some drastic performance improvements on
  various tasks of the wallet:

  ```
  Wallet Overview
     number of addresses: 29209
     number of transactions: 48819
     number of utxos: 2778 UTxOs

  Bench                   | No Cache | With Cache
  ---                     | --       | ---
  restoreTime             | 63min    | 22min
  readWalletTime          | 715ms    | 53.70 ms
  listAddressesTime       | 1.863s   | 2.169 ms
  listTransactionsTime    | 75.72s   | 12.68 s
  importOneAddressTime    | 2.526s   | 260.4 ms
  importManyAddressesTime | 3.104s   | 1.690 s
  estimateFeesTime        | 2.103s   | 63.11 ms
  ```

  This cache approach however supposes that there's only a single wallet
  per database, which is the case and has been the case for a long time
  now. I'll remove the WalletId from the database interface in a next
  commit to clean things up a bit.



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
