### PR TITLE
Remove Shelley specific transaction CLI tests from Jormungandr

### DIFF
--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -123,7 +123,6 @@ import qualified Test.Integration.Scenario.CLI.Network as NetworkCLI
 import qualified Test.Integration.Scenario.CLI.Port as PortCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Addresses as AddressesCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.HWWallets as HWWalletsCLI
-import qualified Test.Integration.Scenario.CLI.Shelley.Transactions as TransactionsCLI
 import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 
 -- | Define the actual executable name for the bridge CLI
@@ -147,14 +146,13 @@ main = withUtf8Encoding $ withLogging Nothing Info $ \(_, tr) -> do
             withCtxOnly $ ByronMigrations.spec @n
             withCtxOnly $ HWWallets.spec @n
             withCtxOnly $ TransactionsApiJormungandr.spec @n @t
-            withCtxOnly $ TransactionsCliJormungandr.spec @n @t
             withCtxOnly Network.spec
             withCtxOnly NetworkJormungandr.spec
             StakePoolsApiJormungandr.spec @n
 
         describe "CLI Specifications" $ specWithServer @n tr $ do
             withCtxOnly $ AddressesCLI.spec @n @t
-            withCtxOnly $ TransactionsCLI.spec @n @t
+            withCtxOnly $ TransactionsCliJormungandr.spec @n @t
             withCtxOnly $ WalletsCLI.spec @n @t
             withCtxOnly $ HWWalletsCLI.spec @n @t
             withCtxOnly $ PortCLI.spec @t


### PR DESCRIPTION
# Issue Number

#2020

# Overview

- 5291da59337ec266e7e54262a15b41528c15fad7
  Remove Shelley specific transaction CLI tests from Jormungandr



# Comments

Currently `TRANSMETA_CREATE_01 - Transaction with metadata via CLI` fails now on Jormungandr. Jormungandr has it's own (smaller) subset of CLI tx tests (also API tx tests) so, I think, it makes sense to remove core-integration tx CLI tests (which become more and more Shelley specific) from Jormungandr suite.
