### PR TITLE
expose an executable 'shelley-test-cluster' which starts an integration test cluster with faucets

### DIFF
--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -149,6 +149,7 @@ executable shelley-test-cluster
     , contra-tracer
     , iohk-monitoring
     , text
+    , text-class
   hs-source-dirs:
       exe
   main-is:

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -128,6 +128,32 @@ executable cardano-wallet
   main-is:
     cardano-wallet.hs
 
+executable shelley-test-cluster
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+      base
+    , cardano-wallet-cli
+    , cardano-wallet-core
+    , cardano-wallet-core-integration
+    , cardano-wallet-launcher
+    , cardano-wallet
+    , contra-tracer
+    , iohk-monitoring
+    , text
+  hs-source-dirs:
+      exe
+  main-is:
+      shelley-test-cluster.hs
+
 test-suite unit
   default-language:
       Haskell2010

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -228,7 +228,6 @@ test-suite integration
     , cardano-wallet
     , cardano-wallet-test-utils
     , contra-tracer
-    , directory
     , filepath
     , hspec
     , http-client

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -12,7 +12,7 @@ import Prelude
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.CLI
-    ( LogOutput (..), withLogging )
+    ( LogOutput (..), withLoggingNamed )
 import Cardano.Startup
     ( withUtf8Encoding )
 import Cardano.Wallet.Api.Types
@@ -199,12 +199,12 @@ main = do
             ]
 
     withUtf8Encoding
-        $ withLogging walletLogs
-        $ \(_, trWallet) -> withLogging' clusterLogs
-        $ \(_, trCluster) -> withSystemTempDir trCluster "shelleyCluster"
-        $ \dir -> withTempDir trCluster dir "wallets"
+        $ withLoggingNamed "cardano-wallet" walletLogs
+        $ \(_, trWallet) -> withLoggingNamed "test-cluster" clusterLogs
+        $ \(_, trCluster) -> withSystemTempDir (trMessageText trCluster) "testCluster"
+        $ \dir -> withTempDir (trMessageText trCluster) dir "wallets"
         $ \db -> withCluster
-            trCluster
+            (trMessageText trCluster)
             nodeMinSeverity
             defaultPoolConfigs
             dir
@@ -213,9 +213,6 @@ main = do
             (whenShelley dir)
             (whenReady trWallet trCluster db)
   where
-    withLogging' outs action = withLogging outs $ \(cfg, tr) ->
-        action (cfg, trMessageText tr)
-
     whenByron _ = pure ()
 
     whenShelley dir _ = do
@@ -242,4 +239,4 @@ main = do
             socketPath
             block0
             (gp, vData)
-            (traceWith trCluster . MsgListenAddress)
+            (traceWith (trMessageText trCluster) . MsgListenAddress)

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -1,0 +1,245 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Main where
+
+import Prelude
+
+import Cardano.BM.Data.Severity
+    ( Severity (..) )
+import Cardano.CLI
+    ( LogOutput (..), withLogging )
+import Cardano.Startup
+    ( withUtf8Encoding )
+import Cardano.Wallet.Api.Types
+    ( EncodeAddress (..) )
+import Cardano.Wallet.Logging
+    ( stdoutTextTracer, trMessageText )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( NetworkDiscriminant (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
+import Cardano.Wallet.Primitive.Types
+    ( Coin (..) )
+import Cardano.Wallet.Shelley
+    ( SomeNetworkDiscriminant (..)
+    , serveWallet
+    , setupTracers
+    , tracerSeverities
+    )
+import Cardano.Wallet.Shelley.Compatibility
+    ( Shelley )
+import Cardano.Wallet.Shelley.Launch
+    ( ClusterLog (..)
+    , RunningNode (..)
+    , defaultPoolConfigs
+    , moveInstantaneousRewardsTo
+    , nodeMinSeverityFromEnv
+    , oneMillionAda
+    , sendFaucetFundsTo
+    , testMinSeverityFromEnv
+    , walletListenFromEnv
+    , walletMinSeverityFromEnv
+    , withCluster
+    , withSystemTempDir
+    , withTempDir
+    )
+import Control.Arrow
+    ( first )
+import Control.Monad
+    ( void )
+import Control.Tracer
+    ( traceWith )
+import Data.Proxy
+    ( Proxy (..) )
+import System.IO
+    ( BufferMode (..), hSetBuffering, stdout )
+import Test.Integration.Faucet
+    ( genRewardAccounts, mirMnemonics, shelleyIntegrationTestFunds )
+
+import qualified Data.Text as T
+
+-- |
+-- # OVERVIEW
+--
+-- This starts a cluster of Cardano nodes with:
+--
+-- - 1 relay node
+-- - 1 BFT leader
+-- - 4 stake pools
+--
+-- The BFT leader and pools are all fully connected. The network starts in the
+-- Byron Era and transitions into the Shelley era. Once in the Shelley era and
+-- once pools are registered and up-and-running, an instance of cardano-wallet
+-- is started.
+--
+-- Pools have slightly different settings summarized in the table below:
+--
+-- | #       | Pledge | Retirement      | Metadata       |
+-- | ---     | ---    | ---             | ---            |
+-- | Pool #0 | 2M Ada | Never           | Genesis Pool A |
+-- | Pool #1 | 1M Ada | Epoch 3         | Genesis Pool B |
+-- | Pool #2 | 1M Ada | Epoch 100_000   | Genesis Pool C |
+-- | Pool #3 | 1M Ada | Epoch 1_000_000 | Genesis Pool D |
+--
+-- Pools' metadata are hosted on static local servers started alongside pools.
+--
+-- # PRE-REGISTERED DATA
+--
+-- The cluster also comes with a large number of pre-existing faucet wallets and
+-- special wallets identified by recovery phrases. Pre-registered wallets can be
+-- seen in
+--
+--   `lib/core-integration/src/Test/Integration/Faucet.hs`.
+--
+-- All wallets (Byron, Icarus, Shelley) all have 10 UTxOs worth 100_000 Ada
+-- each (so 1M Ada in total). Additionally, the file also contains a set of
+-- wallets with pre-existing rewards (1M Ada) injected via MIR certificates.
+-- These wallets have the same UTxOs as other faucet wallets.
+--
+-- Some additional wallets of interest:
+--
+-- - (Shelley) Has a pre-registered stake key but no delegation.
+--
+--     [ "over", "decorate", "flock", "badge", "beauty"
+--     , "stamp", "chest", "owner", "excess", "omit"
+--     , "bid", "raccoon", "spin", "reduce", "rival"
+--     ]
+--
+-- - (Shelley) Contains only small coins (but greater than the minUTxOValue)
+--
+--     [ "either" , "flip" , "maple" , "shift" , "dismiss"
+--     , "bridge" , "sweet" , "reveal" , "green" , "tornado"
+--     , "need" , "patient" , "wall" , "stamp" , "pass"
+--     ]
+--
+-- - (Shelley) Contains 100 UTxO of 100_000 Ada, and 100 UTxO of 1 Ada
+--
+--     [ "radar", "scare", "sense", "winner", "little"
+--     , "jeans", "blue", "spell", "mystery", "sketch"
+--     , "omit", "time", "tiger", "leave", "load"
+--     ]
+--
+-- - (Icarus) Has only addresses that start at index 500
+--
+--     [ "erosion", "ahead", "vibrant", "air", "day"
+--     , "timber", "thunder", "general", "dice", "into"
+--     , "chest", "enrich", "social", "neck", "shine"
+--     ]
+--
+-- - (Byron) Has only 5 UTxOs of 1,2,3,4,5 Lovelace
+--
+--     [ "suffer", "decorate", "head", "opera"
+--     , "yellow", "debate", "visa", "fire"
+--     , "salute", "hybrid", "stone", "smart"
+--     ]
+--
+-- - (Byron) Has 200 UTxO, 100 are worth 1 Lovelace, 100 are woth 100_000 Ada.
+--
+--     [ "collect", "fold", "file", "clown"
+--     , "injury", "sun", "brass", "diet"
+--     , "exist", "spike", "behave", "clip"
+--     ]
+--
+-- - (Ledger) Created via the Ledger method for master key generation
+--
+--     [ "struggle", "section", "scissors", "siren"
+--     , "garbage", "yellow", "maximum", "finger"
+--     , "duty", "require", "mule", "earn"
+--     ]
+--
+-- - (Ledger) Created via the Ledger method for master key generation
+--
+--     [ "vague" , "wrist" , "poet" , "crazy" , "danger" , "dinner"
+--     , "grace" , "home" , "naive" , "unfold" , "april" , "exile"
+--     , "relief" , "rifle" , "ranch" , "tone" , "betray" , "wrong"
+--     ]
+--
+-- # CONFIGURATION
+--
+-- There are several environment variables that can be set to make debugging
+-- easier if needed:
+--
+-- - CARDANO_WALLET_PORT: choose a port for the API to listen on (default: random)
+--
+-- - CARDANO_NODE_TRACING_MIN_SEVERITY: increase or decrease the logging
+--                                      severity of the nodes. (default: Info)
+--
+-- - CARDANO_WALLET_TRACING_MIN_SEVERITY: increase or decrease the logging
+--                                        severity of cardano-wallet. (default: Info)
+--
+-- - TESTS_TRACING_MIN_SEVERITY: increase or decrease the logging severity of
+--                               the test cluster framework. (default: Notice)
+--
+-- - NO_POOLS: If set, the cluster will only start a BFT leader and a relay, no
+--             stake pools. This can be used for running test scenarios which do
+--             not require delegation-specific features without paying the
+--             startup cost of creating and funding pools.
+--
+-- - NO_CLEANUP: If set, the temporary directory used as a state directory for
+--               nodes and wallet data won't be cleaned up.
+main :: IO ()
+main = do
+    hSetBuffering stdout LineBuffering
+
+    nodeMinSeverity    <- nodeMinSeverityFromEnv
+    walletMinSeverity  <- walletMinSeverityFromEnv
+    clusterMinSeverity <- testMinSeverityFromEnv
+
+    let walletLogs =
+            [ LogToStdout walletMinSeverity
+            ]
+
+    let clusterLogs =
+            [ LogToStdout clusterMinSeverity
+            ]
+
+    withUtf8Encoding
+        $ withLogging walletLogs
+        $ \(_, trWallet) -> withLogging' clusterLogs
+        $ \(_, trCluster) -> withSystemTempDir trCluster "shelleyCluster"
+        $ \dir -> withTempDir trCluster dir "wallets"
+        $ \db -> withCluster
+            trCluster
+            nodeMinSeverity
+            defaultPoolConfigs
+            dir
+            Nothing
+            whenByron
+            (whenShelley dir)
+            (whenReady trWallet trCluster db)
+  where
+    withLogging' outs action = withLogging outs $ \(cfg, tr) ->
+        action (cfg, trMessageText tr)
+
+    whenByron _ = pure ()
+
+    whenShelley dir _ = do
+        let encodeAddr = T.unpack . encodeAddress @'Mainnet
+        let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
+        let accts = concatMap genRewardAccounts mirMnemonics
+        let rewards = (,Coin $ fromIntegral oneMillionAda) <$> accts
+        sendFaucetFundsTo stdoutTextTracer dir addresses
+        moveInstantaneousRewardsTo stdoutTextTracer dir rewards
+
+    whenReady tr trCluster db (RunningNode socketPath block0 (gp, vData)) = do
+        let tracers = setupTracers (tracerSeverities (Just Info)) tr
+        listen <- walletListenFromEnv
+        void $ serveWallet @(IO Shelley)
+            (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+            tracers
+            (SyncTolerance 10)
+            (Just db)
+            Nothing
+            "127.0.0.1"
+            listen
+            Nothing
+            Nothing
+            socketPath
+            block0
+            (gp, vData)
+            (traceWith trCluster . MsgListenAddress)

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -39,10 +39,10 @@ import Cardano.Wallet.Shelley.Compatibility
 import Cardano.Wallet.Shelley.Launch
     ( ClusterLog (..)
     , RunningNode (..)
-    , defaultPoolConfigs
     , moveInstantaneousRewardsTo
     , nodeMinSeverityFromEnv
     , oneMillionAda
+    , poolConfigsFromEnv
     , sendFaucetFundsTo
     , testMinSeverityFromEnv
     , walletListenFromEnv
@@ -205,6 +205,7 @@ main = do
             [ LogToStdout clusterMinSeverity
             ]
 
+    poolConfigs <- poolConfigsFromEnv
     withUtf8Encoding
         $ withLoggingNamed "cardano-wallet" walletLogs
         $ \(_, trWallet) -> withLoggingNamed "test-cluster" clusterLogs
@@ -213,7 +214,7 @@ main = do
         $ \db -> withCluster
             (contramap MsgCluster $ trMessageText trCluster)
             nodeMinSeverity
-            defaultPoolConfigs
+            poolConfigs
             dir
             Nothing
             whenByron

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -163,8 +163,6 @@ import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime, utcTimeToPOSIXSeconds )
 import GHC.TypeLits
     ( KnownNat, Nat, SomeNat (..), someNatVal )
-import Network.Socket
-    ( SockAddr )
 import Options.Applicative
     ( Parser, flag', help, long, metavar, (<|>) )
 import Ouroboros.Consensus.Shelley.Node
@@ -1667,7 +1665,6 @@ data ClusterLog
     | MsgDebug Text
     | MsgGenOperatorKeyPair FilePath
     | MsgCLI [String]
-    | MsgListenAddress SockAddr
     deriving (Show)
 
 instance ToText ClusterLog where
@@ -1715,8 +1712,6 @@ instance ToText ClusterLog where
         MsgGenOperatorKeyPair dir ->
             "Generating stake pool operator key pair in " <> T.pack dir
         MsgCLI args -> T.pack $ unwords ("cardano-cli":args)
-        MsgListenAddress addr ->
-            "Wallet backend server listening on " <> T.pack (show addr)
       where
         indent = T.unlines . map ("  " <>) . T.lines . T.pack
 
@@ -1744,7 +1739,6 @@ instance HasSeverityAnnotation ClusterLog where
         MsgDebug _ -> Debug
         MsgGenOperatorKeyPair _ -> Debug
         MsgCLI _ -> Debug
-        MsgListenAddress _ -> Info
 
 bracketTracer' :: Tracer IO ClusterLog -> Text -> IO a -> IO a
 bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -30,6 +30,7 @@ module Cardano.Wallet.Shelley.Launch
     , singleNodeParams
     , PoolConfig (..)
     , defaultPoolConfigs
+    , poolConfigsFromEnv
     , RunningNode (..)
 
       -- * Faucets
@@ -468,6 +469,12 @@ defaultPoolConfigs =
       -- This pool should retire, but not within the duration of a test run:
     , PoolConfig {retirementEpoch = Just 1_000_000}
     ]
+
+poolConfigsFromEnv :: IO [PoolConfig]
+poolConfigsFromEnv = lookupEnv "NO_POOLS" >>= \case
+    Nothing -> pure defaultPoolConfigs
+    Just "" -> pure defaultPoolConfigs
+    Just _ -> pure []
 
 data RunningNode = RunningNode
     FilePath

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
@@ -22,7 +21,7 @@ import Cardano.BM.Data.Tracer
 import Cardano.BM.Trace
     ( appendName )
 import Cardano.CLI
-    ( LogOutput (..), Port (..), parseLoggingSeverity, withLogging )
+    ( LogOutput (..), Port (..), withLogging )
 import Cardano.Launcher
     ( ProcessHasExited (..) )
 import Cardano.Startup
@@ -56,9 +55,14 @@ import Cardano.Wallet.Shelley.Launch
     ( ClusterLog
     , PoolConfig (..)
     , RunningNode (..)
+    , defaultPoolConfigs
     , moveInstantaneousRewardsTo
+    , nodeMinSeverityFromEnv
     , oneMillionAda
     , sendFaucetFundsTo
+    , testLogDirFromEnv
+    , testMinSeverityFromEnv
+    , walletMinSeverityFromEnv
     , withCluster
     , withSystemTempDir
     , withTempDir
@@ -91,12 +95,8 @@ import Network.HTTP.Client
     , newManager
     , responseTimeoutMicro
     )
-import System.Directory
-    ( makeAbsolute )
 import System.Environment
     ( lookupEnv )
-import System.Exit
-    ( die )
 import System.FilePath
     ( (</>) )
 import System.IO
@@ -171,18 +171,6 @@ main = withUtf8Encoding $ withTracers $ \tracers -> do
                 PortCLI.spec @t
                 NetworkCLI.spec @t
 
-testPoolConfigs :: [PoolConfig]
-testPoolConfigs =
-    [ -- This pool should never retire:
-      PoolConfig {retirementEpoch = Nothing}
-      -- This pool should retire almost immediately:
-    , PoolConfig {retirementEpoch = Just 3}
-      -- This pool should retire, but not within the duration of a test run:
-    , PoolConfig {retirementEpoch = Just 100_000}
-      -- This pool should retire, but not within the duration of a test run:
-    , PoolConfig {retirementEpoch = Just 1_000_000}
-    ]
-
 specWithServer
     :: (Tracer IO TestsLog, Tracers IO)
     -> SpecWith (Context Shelley)
@@ -245,13 +233,13 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
 
     withServer dbDecorator action = bracketTracer' tr "withServer" $ do
         minSev <- nodeMinSeverityFromEnv
-        testPoolConfigs' <- poolConfigsFromEnv
+        testPoolConfigs <- poolConfigsFromEnv
         withSystemTempDir tr' "test" $ \dir -> do
             extraLogDir <- (fmap (,Info)) <$> testLogDirFromEnv
             withCluster
                 tr'
                 minSev
-                testPoolConfigs'
+                testPoolConfigs
                 dir
                 extraLogDir
                 onByron
@@ -366,37 +354,8 @@ withTracers action = do
 bracketTracer' :: Tracer IO TestsLog -> Text -> IO a -> IO a
 bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)
 
--- Allow configuring @cardano-node@ log level with the
--- @CARDANO_NODE_TRACING_MIN_SEVERITY@ environment variable.
-nodeMinSeverityFromEnv :: IO Severity
-nodeMinSeverityFromEnv =
-    minSeverityFromEnv Info "CARDANO_NODE_TRACING_MIN_SEVERITY"
-
--- Allow configuring wallet log level with
--- @CARDANO_WALLET_TRACING_MIN_SEVERITY@ environment variable.
-walletMinSeverityFromEnv :: IO Severity
-walletMinSeverityFromEnv =
-    minSeverityFromEnv Critical "CARDANO_WALLET_TRACING_MIN_SEVERITY"
-
--- Allow configuring integration tests and wallet log level with
--- @CARDANO_TEST_TRACING_MIN_SEVERITY@ environment variable.
-testMinSeverityFromEnv :: IO Severity
-testMinSeverityFromEnv =
-    minSeverityFromEnv Notice "CARDANO_TEST_TRACING_MIN_SEVERITY"
-
-minSeverityFromEnv :: Severity -> String -> IO Severity
-minSeverityFromEnv def var = lookupEnv var >>= \case
-    Nothing -> pure def
-    Just "" -> pure def
-    Just arg -> either die pure (parseLoggingSeverity arg)
-
 poolConfigsFromEnv :: IO [PoolConfig]
 poolConfigsFromEnv = lookupEnv "NO_POOLS" >>= \case
-    Nothing -> pure testPoolConfigs
-    Just "" -> pure testPoolConfigs
+    Nothing -> pure defaultPoolConfigs
+    Just "" -> pure defaultPoolConfigs
     Just _ -> pure []
-
--- | Directory for extra logging. Buildkite will set this environment variable
--- and upload logs in it automatically.
-testLogDirFromEnv :: IO (Maybe FilePath)
-testLogDirFromEnv = traverse makeAbsolute =<< lookupEnv "TESTS_LOGDIR"

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -53,12 +53,11 @@ import Cardano.Wallet.Shelley.Faucet
     ( initFaucet )
 import Cardano.Wallet.Shelley.Launch
     ( ClusterLog
-    , PoolConfig (..)
     , RunningNode (..)
-    , defaultPoolConfigs
     , moveInstantaneousRewardsTo
     , nodeMinSeverityFromEnv
     , oneMillionAda
+    , poolConfigsFromEnv
     , sendFaucetFundsTo
     , testLogDirFromEnv
     , testMinSeverityFromEnv
@@ -95,8 +94,6 @@ import Network.HTTP.Client
     , newManager
     , responseTimeoutMicro
     )
-import System.Environment
-    ( lookupEnv )
 import System.FilePath
     ( (</>) )
 import System.IO
@@ -353,9 +350,3 @@ withTracers action = do
 
 bracketTracer' :: Tracer IO TestsLog -> Text -> IO a -> IO a
 bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)
-
-poolConfigsFromEnv :: IO [PoolConfig]
-poolConfigsFromEnv = lookupEnv "NO_POOLS" >>= \case
-    Nothing -> pure defaultPoolConfigs
-    Just "" -> pure defaultPoolConfigs
-    Just _ -> pure []

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -105,6 +105,20 @@
             ];
           buildable = true;
           };
+        "shelley-test-cluster" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
+            (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
+            (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
+            (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            ];
+          buildable = true;
+          };
         };
       tests = {
         "unit" = {

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -116,6 +116,7 @@
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             ];
           buildable = true;
           };

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -168,7 +168,6 @@
             (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
-            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -139,6 +139,23 @@ let
           };
 
 
+        packages.cardano-wallet.components.exes.shelley-test-cluster = let
+          testData = src + /lib/shelley/test/data/cardano-node-shelley;
+        in
+          if (stdenv.hostPlatform.isWindows) then {
+            postInstall = ''
+              mkdir -p $out/bin/test/data
+              cp -Rv ${testData} $out/bin/test/data
+            '' + libSodiumPostInstall;
+          } else {
+            build-tools = [ pkgs.makeWrapper ];
+            postInstall = ''
+              wrapProgram $out/bin/shelley-test-cluster \
+                --set SHELLEY_TEST_DATA ${testData} \
+                --prefix PATH : ${lib.makeBinPath [pkgs.cardano-node pkgs.cardano-cli]}
+            '';
+          };
+
         # Make sure that libsodium DLLs for all windows executables,
         # and add shell completions for main executables.
         packages.cardano-wallet.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + libSodiumPostInstall;


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2175 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 9722d827cbfd76ae3ee89cba55a5d0db222063a9
  :round_pushpin: **expose an executable 'shelley-test-cluster' which starts an integration test cluster with faucets**
  
- 6eefd4713ef234a247ff3857a9a79a6b852718a4
  :round_pushpin: **Let the shelley-test-cluster nix build be run from any directory**
  
- 4c4d01efc2aa5a8d6bd51c3f3ab64113cae0a639
  :round_pushpin: **Allow setting different LoggerName when configuring trace with 'withLogging'**
  
- 571e67db538d1f8ed23ef4e1eb0caa1c6467868e
  :round_pushpin: **Add TestLog to shelley-test-cluster**
  
- e99d875d0f55ce6a73dc36e676b75c6cc5eb10ad
  :round_pushpin: **Regenerate nix**


# Comments

<!-- Additional comments or screenshots to attach if any -->

~~@Anviking there's probably some clashes with what you're also doing with the logging, so happy to get the logging revision merged first and adjust that one.~~

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
