### PR TITLE
Allow address inspection via the API

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -61,6 +61,7 @@ import Test.Integration.Framework.TestData
     ( errMsg404NoWallet )
 
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
 
@@ -224,3 +225,13 @@ spec = describe "SHELLEY_ADDRESSES" $ do
             (Link.listAddresses @'Shelley w) Default Empty
         expectResponseCode @IO HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
+
+    it "ADDRESS_INSPECT_01 - Address inspect OK" $ \ctx -> do
+        let str = "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
+        r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
+        expectResponseCode @IO HTTP.status200 r
+
+    it "ADDRESS_INSPECT_02 - Address inspect KO" $ \ctx -> do
+        let str = "patate"
+        r <- request @Aeson.Value ctx (Link.inspectAddress str) Default Empty
+        expectResponseCode @IO HTTP.status400 r

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -106,6 +106,8 @@ import Cardano.Wallet
     ( WalletLayer (..), WalletLog )
 import Cardano.Wallet.Api.Types
     ( ApiAddressIdT
+    , ApiAddressInspect
+    , ApiAddressInspectData
     , ApiAddressT
     , ApiByronWallet
     , ApiCoinSelectionT
@@ -164,8 +166,6 @@ import Data.Generics.Labels
     ()
 import Data.Generics.Product.Typed
     ( HasType, typed )
-import Data.Text
-    ( Text )
 import GHC.Generics
     ( Generic )
 import Servant.API
@@ -189,8 +189,6 @@ import Servant.API.Verbs
     , PutAccepted
     , PutNoContent
     )
-
-import qualified Data.Aeson as Aeson
 
 type ApiV2 n apiPool = "v2" :> Api n apiPool
 
@@ -285,8 +283,8 @@ type ListAddresses n = "wallets"
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/inspectAddress
 type InspectAddress = "addresses"
-    :> Capture "addressId" Text
-    :> Get '[JSON] Aeson.Value
+    :> Capture "addressId" ApiAddressInspectData
+    :> Get '[JSON] ApiAddressInspect
 
 {-------------------------------------------------------------------------------
                                Coin Selections

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -31,6 +31,7 @@ module Cardano.Wallet.Api
 
     , Addresses
         , ListAddresses
+        , InspectAddress
 
     , CoinSelections
         , SelectCoins
@@ -163,6 +164,8 @@ import Data.Generics.Labels
     ()
 import Data.Generics.Product.Typed
     ( HasType, typed )
+import Data.Text
+    ( Text )
 import GHC.Generics
     ( Generic )
 import Servant.API
@@ -186,6 +189,8 @@ import Servant.API.Verbs
     , PutAccepted
     , PutNoContent
     )
+
+import qualified Data.Aeson as Aeson
 
 type ApiV2 n apiPool = "v2" :> Api n apiPool
 
@@ -269,6 +274,7 @@ type GetUTxOsStatistics = "wallets"
 
 type Addresses n =
     ListAddresses n
+    :<|> InspectAddress
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listAddresses
 type ListAddresses n = "wallets"
@@ -276,6 +282,11 @@ type ListAddresses n = "wallets"
     :> "addresses"
     :> QueryParam "state" (ApiT AddressState)
     :> Get '[JSON] [ApiAddressT n]
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/inspectAddress
+type InspectAddress = "addresses"
+    :> Capture "addressId" Text
+    :> Get '[JSON] Aeson.Value
 
 {-------------------------------------------------------------------------------
                                Coin Selections

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -168,6 +168,9 @@ data AddressClient = AddressClient
         :: ApiT WalletId
         -> Maybe (ApiT AddressState)
         -> ClientM [Aeson.Value]
+    , inspectAddress
+        :: Text
+        -> ClientM Aeson.Value
     , postRandomAddress
         :: ApiT WalletId
         -> ApiPostRandomAddressData
@@ -311,21 +314,25 @@ addressClient
 addressClient =
     let
         _listAddresses
+            :<|> _inspectAddress
             = client (Proxy @("v2" :> Addresses Aeson.Value))
     in
         AddressClient
             { listAddresses = _listAddresses
+            , inspectAddress = _inspectAddress
             , postRandomAddress = \_ _ -> fail "feature unavailable."
             , putRandomAddress  = \_ _ -> fail "feature unavailable."
             , putRandomAddresses = \_ _ -> fail "feature unavailable."
             }
-
 
 -- | Produces an 'AddressClient n' working against the /wallets API
 byronAddressClient
     :: AddressClient
 byronAddressClient =
     let
+        _ :<|> _inspectAddress
+            = client (Proxy @("v2" :> Addresses Aeson.Value))
+
         _postRandomAddress
             :<|> _putRandomAddress
             :<|> _putRandomAddresses
@@ -334,6 +341,7 @@ byronAddressClient =
     in
         AddressClient
             { listAddresses = _listAddresses
+            , inspectAddress = _inspectAddress
             , postRandomAddress = _postRandomAddress
             , putRandomAddress = _putRandomAddress
             , putRandomAddresses = _putRandomAddresses

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -58,6 +58,8 @@ import Cardano.Wallet.Api
     )
 import Cardano.Wallet.Api.Types
     ( ApiAddressIdT
+    , ApiAddressInspect (..)
+    , ApiAddressInspectData (..)
     , ApiAddressT
     , ApiByronWallet
     , ApiCoinSelectionT
@@ -319,7 +321,10 @@ addressClient =
     in
         AddressClient
             { listAddresses = _listAddresses
-            , inspectAddress = _inspectAddress
+            , inspectAddress =
+                fmap unApiAddressInspect
+                . _inspectAddress
+                . ApiAddressInspectData
             , postRandomAddress = \_ _ -> fail "feature unavailable."
             , putRandomAddress  = \_ _ -> fail "feature unavailable."
             , putRandomAddresses = \_ _ -> fail "feature unavailable."
@@ -341,7 +346,10 @@ byronAddressClient =
     in
         AddressClient
             { listAddresses = _listAddresses
-            , inspectAddress = _inspectAddress
+            , inspectAddress =
+                fmap unApiAddressInspect
+                . _inspectAddress
+                . ApiAddressInspectData
             , postRandomAddress = _postRandomAddress
             , putRandomAddress = _putRandomAddress
             , putRandomAddresses = _putRandomAddresses

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -53,6 +53,7 @@ module Cardano.Wallet.Api.Link
     , putRandomAddresses
     , listAddresses
     , listAddresses'
+    , inspectAddress
 
       -- * CoinSelections
     , selectCoins
@@ -88,7 +89,8 @@ module Cardano.Wallet.Api.Link
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiPoolId (..)
+    ( ApiAddressInspectData (..)
+    , ApiPoolId (..)
     , ApiT (..)
     , ApiTxId (ApiTxId)
     , Iso8601Time
@@ -298,6 +300,12 @@ listAddresses' w mstate = discriminate @style
     (endpoint @(Api.ListByronAddresses Net) (\mk -> mk wid (ApiT <$> mstate)))
   where
     wid = w ^. typed @(ApiT WalletId)
+
+inspectAddress
+    :: ApiAddressInspectData
+    -> (Method, Text)
+inspectAddress addr =
+    endpoint @Api.InspectAddress (addr &)
 
 --
 -- Coin Selections

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -314,12 +314,7 @@ import Control.Concurrent
 import Control.Concurrent.Async
     ( race_ )
 import Control.Exception
-    ( IOException
-    , bracket
-    , throwIO
-    , try
-    , tryJust
-    )
+    ( IOException, bracket, throwIO, try, tryJust )
 import Control.Monad
     ( forM, forever, void, when, (>=>) )
 import Control.Monad.Catch
@@ -2002,9 +1997,6 @@ apiError err code message = err
         ]
     }
 
-newtype ErrMalformedAddress = ErrMalformedAddress String
-    deriving (Eq, Show)
-
 data ErrUnexpectedPoolIdPlaceholder = ErrUnexpectedPoolIdPlaceholder
     deriving (Eq, Show)
 
@@ -2519,10 +2511,6 @@ instance LiftHandler ErrListPools where
     handler = \case
         ErrListPoolsNetworkError e -> handler e
         ErrListPoolsPastHorizonException e -> handler e
-
-instance LiftHandler ErrMalformedAddress where
-    handler = \case
-        ErrMalformedAddress e -> apiError err400 BadRequest (T.pack e)
 
 instance LiftHandler (Request, ServerError) where
     handler (req, err@(ServerError code _ body headers))

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -314,7 +314,12 @@ import Control.Concurrent
 import Control.Concurrent.Async
     ( race_ )
 import Control.Exception
-    ( IOException, bracket, throwIO, try, tryJust )
+    ( IOException
+    , bracket
+    , throwIO
+    , try
+    , tryJust
+    )
 import Control.Monad
     ( forM, forever, void, when, (>=>) )
 import Control.Monad.Catch
@@ -1194,7 +1199,6 @@ listAddresses ctx normalize (ApiT wid) stateFilter = do
         Just (ApiT s) -> (== s) . snd
     coerceAddress (a, s) = ApiAddress (ApiT a, Proxy @n) (ApiT s)
 
-
 {-------------------------------------------------------------------------------
                                     Transactions
 -------------------------------------------------------------------------------}
@@ -1998,6 +2002,9 @@ apiError err code message = err
         ]
     }
 
+newtype ErrMalformedAddress = ErrMalformedAddress String
+    deriving (Eq, Show)
+
 data ErrUnexpectedPoolIdPlaceholder = ErrUnexpectedPoolIdPlaceholder
     deriving (Eq, Show)
 
@@ -2512,6 +2519,10 @@ instance LiftHandler ErrListPools where
     handler = \case
         ErrListPoolsNetworkError e -> handler e
         ErrListPoolsPastHorizonException e -> handler e
+
+instance LiftHandler ErrMalformedAddress where
+    handler = \case
+        ErrMalformedAddress e -> apiError err400 BadRequest (T.pack e)
 
 instance LiftHandler (Request, ServerError) where
     handler (req, err@(ServerError code _ body headers))

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -72,6 +72,8 @@ module Cardano.Wallet.Api.Types
     , ApiTxInput (..)
     , ApiTxMetadata (..)
     , AddressAmount (..)
+    , ApiAddressInspect (..)
+    , ApiAddressInspectData (..)
     , ApiErrorCode (..)
     , ApiNetworkInformation (..)
     , ApiNtpStatus (..)
@@ -244,6 +246,8 @@ import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
     ( Percentage, Quantity (..) )
+import Data.String
+    ( IsString )
 import Data.Text
     ( Text, split )
 import Data.Text.Class
@@ -637,6 +641,15 @@ data AddressAmount addr = AddressAmount
     { address :: !addr
     , amount :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
+
+newtype ApiAddressInspect = ApiAddressInspect
+    { unApiAddressInspect :: Aeson.Value }
+    deriving (Eq, Generic, Show)
+
+newtype ApiAddressInspectData = ApiAddressInspectData
+    { unApiAddressInspectData :: Text }
+    deriving (Eq, Generic, Show)
+    deriving newtype (IsString)
 
 data ApiTimeReference = ApiTimeReference
     { time :: !UTCTime
@@ -1530,6 +1543,12 @@ instance ToJSON ApiWalletDiscovery where
     toJSON = genericToJSON $ Aeson.defaultOptions
         { constructorTagModifier = drop 1 . dropWhile (/= '_') . camelTo2 '_' }
 
+instance ToJSON ApiAddressInspect where
+    toJSON = unApiAddressInspect
+
+instance FromJSON ApiAddressInspect where
+    parseJSON = pure . ApiAddressInspect
+
 {-------------------------------------------------------------------------------
                              FromText/ToText instances
 -------------------------------------------------------------------------------}
@@ -1590,6 +1609,12 @@ instance ToHttpApiData ApiPoolId where
     toUrlPiece = \case
         ApiPoolIdPlaceholder -> "*"
         ApiPoolId pid -> encodePoolIdBech32 pid
+
+instance FromHttpApiData ApiAddressInspectData where
+    parseUrlPiece = pure . ApiAddressInspectData
+
+instance ToHttpApiData ApiAddressInspectData where
+    toUrlPiece = unApiAddressInspectData
 
 {-------------------------------------------------------------------------------
                                 Aeson Options

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -50,7 +50,8 @@ module Cardano.Wallet.Api.Malformed
 import Prelude
 
 import Cardano.Wallet.Api.Types
-    ( ApiNetworkTip
+    ( ApiAddressInspectData
+    , ApiNetworkTip
     , ApiPoolId
     , ApiPostRandomAddressData
     , ApiPutAddressesData
@@ -169,6 +170,14 @@ instance Wellformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
         "FHnt4NL7yPY7JbfJYSadQVSGJG7EKkN4kpVJMhJ8CN3uDNymGnJuuwcHmyP4ouZ"]
 
 instance Malformed (PathParam (ApiT Address, Proxy ('Testnet 0))) where
+    malformed = []
+
+instance Wellformed (PathParam ApiAddressInspectData) where
+    wellformed = PathParam <$>
+        [ "Ae2tdPwUPEYz6ExfbWubiXPB6daUuhJxikMEb4eXRp5oKZBKZwrbJ2k7EZe"
+        ]
+
+instance Malformed (PathParam ApiAddressInspectData) where
     malformed = []
 
 --

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -46,6 +46,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddressDerivationPath (..)
     , ApiAddressDerivationSegment (..)
     , ApiAddressDerivationType (..)
+    , ApiAddressInspect (..)
     , ApiBlockReference (..)
     , ApiByronWallet (..)
     , ApiByronWalletBalance (..)
@@ -173,7 +174,7 @@ import Control.Monad.IO.Class
 import Crypto.Hash
     ( hash )
 import Data.Aeson
-    ( FromJSON (..), ToJSON (..) )
+    ( FromJSON (..), ToJSON (..), (.=) )
 import Data.Aeson.QQ
     ( aesonQQ )
 import Data.Char
@@ -1456,6 +1457,15 @@ instance Arbitrary ApiPostRandomAddressData where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+instance Arbitrary ApiAddressInspect where
+    arbitrary = do
+        style <- elements [ "Byron", "Icarus", "Shelley" ]
+        stake <- elements [ "none", "by value", "by pointer" ]
+        pure $ ApiAddressInspect $ Aeson.object
+            [ "address_style" .= Aeson.String style
+            , "stake_reference" .= Aeson.String stake
+            ]
+
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery
 
@@ -1510,6 +1520,9 @@ specification =
 
 instance ToSchema (ApiAddress t) where
     declareNamedSchema _ = declareSchemaForDefinition "ApiAddress"
+
+instance ToSchema ApiAddressInspect where
+    declareNamedSchema _ = declareSchemaForDefinition "ApiAddressInspect"
 
 instance ToSchema (ApiPutAddressesData t) where
     declareNamedSchema _ = declareSchemaForDefinition "ApiPutAddressesData"

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Server.hs
@@ -164,8 +164,8 @@ server byron icarus jormungandr spl ntp =
         :<|> getUTxOsStatistics jormungandr
 
     addresses :: Server (Addresses n)
-    addresses = listAddresses jormungandr
-        (normalizeDelegationAddress @_ @JormungandrKey @n)
+    addresses = listAddresses jormungandr (normalizeDelegationAddress @_ @JormungandrKey @n)
+        :<|> (\_ -> throwError err501)
 
     coinSelections :: Server (CoinSelections n)
     coinSelections = selectCoins jormungandr (delegationAddress @n)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -950,9 +950,8 @@ components:
     ApiAddressInspect: &ApiAddressInspect
         type: object
         required:
-          - address_style
-          - stake_reference
-          - network_tag
+        - address_style
+        - stake_reference
         properties:
           address_style:
             type: string
@@ -967,26 +966,24 @@ components:
             - by value
             - by pointer
           network_tag:
-            description: Can only be null for 'Icarus' and 'Byron' styles.
-            oneOf:
-            - type: integer
-              minimum: 0
-            - type: 'null'
+            description: Can be null for 'Icarus' and 'Byron' styles.
+            type: integer
+            minimum: 0
           spending_key_hash:
             type: string
             format: base16
-            minimum_length: '56'
-            maximum_length: '56'
+            minLength: 56
+            maxLength: 56
           stake_key_hash:
             type: string
             format: base16
-            minimum_length: '56'
-            maximum_length: '56'
+            minLength: 56
+            maxLength: 56
           script_hash:
             type: string
             format: base16
-            minimum_length: '64'
-            maximum_length: '64'
+            minLength: 64
+            maxLength: 64
           pointer:
             type: object
             additionalProperties: false
@@ -2152,7 +2149,6 @@ x-responsesInspectAddress: &responsesInspectAddress
     content:
       application/json:
         schema: *ApiAddressInspect
-
 
 #############################################################################
 #                                                                           #

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -947,6 +947,72 @@ components:
         id: *addressId
         state: *addressState
 
+    ApiAddressInspect: &ApiAddressInspect
+        type: object
+        required:
+          - address_style
+          - stake_reference
+          - network_tag
+        properties:
+          address_style:
+            type: string
+            enum:
+            - Shelley
+            - Icarus
+            - Byron
+          stake_reference:
+            type: string
+            enum:
+            - none
+            - by value
+            - by pointer
+          network_tag:
+            description: Can only be null for 'Icarus' and 'Byron' styles.
+            oneOf:
+            - type: integer
+              minimum: 0
+            - type: 'null'
+          spending_key_hash:
+            type: string
+            format: base16
+            minimum_length: '56'
+            maximum_length: '56'
+          stake_key_hash:
+            type: string
+            format: base16
+            minimum_length: '56'
+            maximum_length: '56'
+          script_hash:
+            type: string
+            format: base16
+            minimum_length: '64'
+            maximum_length: '64'
+          pointer:
+            type: object
+            additionalProperties: false
+            required:
+            - slot_num
+            - transaction_index
+            - output_index
+            properties:
+              slot_num:
+                type: integer
+                minimum: 0
+              transaction_index:
+                type: integer
+                minimum: 0
+              output_index:
+                type: integer
+                minimum: 0
+          address_root:
+            description: Only for 'Icarus' and 'Byron' styles.
+            type: string
+            format: base16
+          derivation_path:
+            description: Only for 'Byron' style.
+            type: string
+            format: base16
+
     ApiNetworkTip: &ApiNetworkTip
       description: A network tip
       type: object
@@ -2077,6 +2143,17 @@ x-responsesPutRandomAddresses: &responsesPutRandomAddresses
   204:
     description: No Content
 
+x-responsesInspectAddress: &responsesInspectAddress
+  <<: *responsesErr400
+  <<: *responsesErr405
+  <<: *responsesErr415
+  200:
+    description: Ok
+    content:
+      application/json:
+        schema: *ApiAddressInspect
+
+
 #############################################################################
 #                                                                           #
 #                                  PATHS                                    #
@@ -2853,3 +2930,16 @@ paths:
           application/octet-stream:
             schema: *signedTransactionBlob
       responses: *responsesPostExternalTransaction
+
+  /addresses/{addressId}:
+    get:
+      operationId: inspectAddress
+      tags: ["Addresses", "Byron Addresses"]
+      summary: Inspect Address
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+
+        Give useful information about the structure of a given address.
+      parameters:
+        - *parametersAddressId
+      responses: *responsesInspectAddress


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2180 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 2daae7e4124147d182bf1a3989c9a08d0abcb7d8
  :round_pushpin: **implement new stateless endpoint for inspecting addresses**
    It takes any arbitrary string as input and tries to deserialize it into some address information if possible, otherwise it fails with a proper error.

- 76d13bad9b1b29bff3336af5f25afeebf31a1694
  :round_pushpin: **add unit and integration tests for the new 'inspectAddress' function & endpoint**

# Comments

<!-- Additional comments or screenshots to attach if any -->

![Screenshot from 2020-09-24 18-52-44](https://user-images.githubusercontent.com/5680256/94175596-2b686480-fe97-11ea-8325-66fa41c5577e.png)


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
