### PR TITLE
Make addresses separate category in swagger

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2176,6 +2176,7 @@ x-tagGroups:
 
   - name: Miscellaneous
     tags:
+    - Utils
     - Network
     - Proxy
 
@@ -2930,7 +2931,7 @@ paths:
   /addresses/{addressId}:
     get:
       operationId: inspectAddress
-      tags: ["Addresses", "Byron Addresses"]
+      tags: ["Utils"]
       summary: Inspect Address
       description: |
         <p align="right">status: <strong>stable</strong></p>


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 796c66a30c433bb2a5fb2aea567a8338daf3bb26
  Make inspect addresses separate category inside Misc in swagger


# Comments

Clicking at "Inspect Address" inside "Byron Addresses" would jump to "Addresses -> Inspect Address", which was a bit awkward.
(https://input-output-hk.github.io/cardano-wallet/api/edge/#tag/Byron-Addresses)

Perhaps it deserves separate category?

![Screenshot from 2020-09-25 21-49-20](https://user-images.githubusercontent.com/42900201/94309914-1a901f80-ff79-11ea-8bfd-3db13bb05c18.png)
