### PR TITLE
Keep hydra wallet stdout at Critical in integration tests

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -77,7 +77,6 @@ let
           unit.preCheck = lib.optionalString stdenv.isDarwin "export TMPDIR=/tmp";
           integration.preCheck = ''
             # Variables picked up by integration tests
-            export CARDANO_WALLET_TRACING_MIN_SEVERITY=info
             export CARDANO_NODE_TRACING_MIN_SEVERITY=notice
 
             # Integration tests will place logs here


### PR DESCRIPTION
# Issue Number

#2119 


# Overview

- [x] Don't set the severity to `info`. Keep it at the default of `Critical`.


# Comments

- Instead we should upload the `TESTS_LOGDIR` logs. But I take it that it's blocked by: https://github.com/input-output-hk/cardano-wallet/blob/8e5c776945a8eb5c2d674ac56c7ee3e04261edf4/nix/haskell.nix#L95-L96

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
