### PR TITLE
Enable 100 wallet scenario in latency benchmark

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -75,7 +75,7 @@ module Test.Integration.Framework.DSL
     , listAddresses
     , listTransactions
     , listAllTransactions
-    , tearDown
+    , deleteAllWallets
     , fixtureRawTx
     , fixtureRandomWallet
     , fixtureRandomWalletMws
@@ -1369,9 +1369,9 @@ listTransactions ctx wallet mStart mEnd mOrder = do
         (Iso8601Time <$> mEnd)
         mOrder
 
--- | teardown after each test (currently only deleting all wallets)
-tearDown :: Context t -> IO ()
-tearDown ctx = do
+-- | Delete all wallets
+deleteAllWallets :: Context t -> IO ()
+deleteAllWallets ctx = do
     resp <- request @[ApiWallet] ctx ("GET", "v2/wallets") Default Empty
     forM_ (wallets (snd resp)) $ \wal -> do
         let endpoint = "v2/wallets" </> wal ^. walletId

--- a/lib/jormungandr/test/integration/Main.hs
+++ b/lib/jormungandr/test/integration/Main.hs
@@ -92,7 +92,7 @@ import Test.Hspec
 import Test.Hspec.Extra
     ( aroundAll )
 import Test.Integration.Framework.DSL
-    ( Context (..), KnownCommand (..), TxDescription (..), tearDown )
+    ( Context (..), KnownCommand (..), TxDescription (..), deleteAllWallets )
 import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.StaticServer
@@ -180,7 +180,7 @@ specWithServer
     => Trace IO Text
     -> SpecWith (Port "node", FeePolicy, Context Jormungandr)
     -> Spec
-specWithServer tr = aroundAll withContext . after (tearDown . thd3)
+specWithServer tr = aroundAll withContext . after (deleteAllWallets . thd3)
   where
     withContext action = do
         ctx <- newEmptyMVar

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -151,11 +151,8 @@ walletApiBench capture ctx = do
     fmtTitle "Latencies for 10 fixture wallets scenario"
     runScenario (nFixtureWallet 10)
 
-    {-- PENDING: We currently have a limited amount of available fixture
-       wallets, so we can't just run a benchmark with 100 wallets in parallel.
-    fmtTitle "Latencies for 100 fixture wallets scenario"
+    fmtTitle "Latencies for 100 fixture wallets"
     runScenario (nFixtureWallet 100)
-    --}
 
     fmtTitle "Latencies for 2 fixture wallets with 10 txs scenario"
     runScenario (nFixtureWalletWithTxs 2 10)

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -43,7 +43,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.LatencyBenchShared
     ( LogCaptureFunc, fmtResult, fmtTitle, measureApiLogs, withLatencyLogging )
 import Cardano.Wallet.Logging
-    ( stdoutTextTracer, trMessage )
+    ( trMessage )
 import Cardano.Wallet.Network.Ports
     ( unsafePortNumber )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -384,7 +384,7 @@ withShelleyServer tracers action = do
     afterFork dir _ = do
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
-        sendFaucetFundsTo stdoutTextTracer dir addresses
+        sendFaucetFundsTo nullTracer dir addresses
 
     onClusterStart act dir (RunningNode socketPath block0 (gp, vData)) = do
         -- NOTE: We may want to keep a wallet running across the fork, but

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -106,6 +106,7 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
+    , deleteAllWallets
     , eventually
     , expectField
     , expectResponseCode
@@ -277,6 +278,7 @@ walletApiBench capture ctx = do
         return r
 
     runScenario scenario = do
+        deleteAllWallets ctx
         (wal1, wal2) <- scenario
 
         t1 <- measureApiLogs capture

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -218,7 +218,6 @@ test-suite integration
     ghc-options: -O2 -Werror
   build-depends:
       base
-    , aeson
     , async
     , cardano-api
     , cardano-wallet-cli

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -107,7 +107,13 @@ import Test.Integration.Faucet
 import Test.Integration.Framework.Context
     ( Context (..), PoolGarbageCollectionEvent (..) )
 import Test.Integration.Framework.DSL
-    ( Headers (..), KnownCommand (..), Payload (..), request, unsafeRequest )
+    ( Headers (..)
+    , KnownCommand (..)
+    , Payload (..)
+    , deleteAllWallets
+    , request
+    , unsafeRequest
+    )
 
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Sqlite as Pool
@@ -278,14 +284,7 @@ specWithServer (tr, tracers) = aroundAll withContext . after tearDown
     -- | teardown after each test (currently only deleting all wallets)
     tearDown :: Context t -> IO ()
     tearDown ctx = bracketTracer' tr "tearDown" $ do
-        (_, byronWallets) <- unsafeRequest @[ApiByronWallet] ctx
-            (Link.listWallets @'Byron) Empty
-        forM_ byronWallets $ \w -> void $ request @Aeson.Value ctx
-            (Link.deleteWallet @'Byron w) Default Empty
-        (_, wallets) <- unsafeRequest @[ApiWallet] ctx
-            (Link.listWallets @'Shelley) Empty
-        forM_ wallets $ \w -> void $ request @Aeson.Value ctx
-            (Link.deleteWallet @'Shelley w) Default Empty
+        deleteAllWallets ctx
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -29,7 +29,7 @@ import Cardano.Startup
 import Cardano.Wallet.Api.Server
     ( Listen (..) )
 import Cardano.Wallet.Api.Types
-    ( ApiByronWallet, ApiWallet, EncodeAddress (..), WalletStyle (..) )
+    ( EncodeAddress (..) )
 import Cardano.Wallet.Logging
     ( BracketLog (..), bracketTracer, trMessageText )
 import Cardano.Wallet.Network.Ports
@@ -74,8 +74,6 @@ import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 import Control.Exception
     ( throwIO )
-import Control.Monad
-    ( forM_, void )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Tracer
@@ -107,18 +105,10 @@ import Test.Integration.Faucet
 import Test.Integration.Framework.Context
     ( Context (..), PoolGarbageCollectionEvent (..) )
 import Test.Integration.Framework.DSL
-    ( Headers (..)
-    , KnownCommand (..)
-    , Payload (..)
-    , deleteAllWallets
-    , request
-    , unsafeRequest
-    )
+    ( KnownCommand (..), deleteAllWallets )
 
 import qualified Cardano.Pool.DB as Pool
 import qualified Cardano.Pool.DB.Sqlite as Pool
-import qualified Cardano.Wallet.Api.Link as Link
-import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
 import qualified Test.Integration.Scenario.API.Byron.Addresses as ByronAddresses
 import qualified Test.Integration.Scenario.API.Byron.HWWallets as ByronHWWallets

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -158,7 +158,6 @@
         "integration" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))


### PR DESCRIPTION
# Issue Number

ADP-469, ADP-473


# Overview

- [x] Simply enable `Latencies for 100 fixture wallets`
- [x] Delete all wallets in between all latency scenarios
- [x] Rename DSL helper `tearDown` to `deleteAllWallets`, and re-use it more

# Comments


```
$ stack bench cardano-wallet
Benchmark latency: RUNNING...
    Non-cached run
        getNetworkInfo      - 20.7 ms
    Latencies for 2 fixture wallets scenario
        listWallets         - 1.4 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 2.2 ms
        postTransactionFee  - 86.4 ms
        listStakePools      - 1.2 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 10 fixture wallets scenario
        listWallets         - 4.8 ms
        getWallet           - 0.4 ms
        getUTxOsStatistics  - 0.3 ms
        listAddresses       - 0.9 ms
        listTransactions    - 2.0 ms
        postTransactionFee  - 93.2 ms
        listStakePools      - 1.3 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 100 fixture wallets
        listWallets         - 59.9 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.2 ms
        listTransactions    - 2.6 ms
        postTransactionFee  - 139.2 ms
        listStakePools      - 1.1 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 10 txs scenario
        listWallets         - 1.1 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 0.9 ms
        listTransactions    - 3.8 ms
        postTransactionFee  - 104.2 ms
        listStakePools      - 1.3 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 2 fixture wallets with 20 txs scenario
        listWallets         - 1.1 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 5.5 ms
        postTransactionFee  - 97.0 ms
        listStakePools      - 1.2 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 2 fixture wallets with 100 txs scenario
        listWallets         - 1.1 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 14.5 ms
        postTransactionFee  - 95.1 ms
        listStakePools      - 1.7 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 10 fixture wallets with 10 txs scenario
        listWallets         - 4.4 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.3 ms
        listAddresses       - 0.9 ms
        listTransactions    - 4.3 ms
        postTransactionFee  - 106.6 ms
        listStakePools      - 1.3 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 10 fixture wallets with 20 txs scenario
        listWallets         - 4.2 ms
        getWallet           - 0.4 ms
        getUTxOsStatistics  - 0.3 ms
        listAddresses       - 0.9 ms
        listTransactions    - 4.5 ms
        postTransactionFee  - 106.6 ms
        listStakePools      - 1.3 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 10 fixture wallets with 100 txs scenario
        listWallets         - 4.5 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 0.9 ms
        listTransactions    - 15.8 ms
        postTransactionFee  - 96.8 ms
        listStakePools      - 1.6 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 2 fixture wallets with 100 utxos scenario
        listWallets         - 1.7 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 12.2 ms
        postTransactionFee  - 95.9 ms
        listStakePools      - 1.4 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        listWallets         - 1.7 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 25.1 ms
        postTransactionFee  - 96.6 ms
        listStakePools      - 1.4 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        listWallets         - 1.6 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.0 ms
        listTransactions    - 69.7 ms
        postTransactionFee  - 87.9 ms
        listStakePools      - 1.5 ms
        getNetworkInfo      - 0.0 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
