### PR TITLE
Fix mainnet network parameters

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -589,20 +589,28 @@ data ApiNetworkParameters = ApiNetworkParameters
 toApiNetworkParameters
     :: NetworkParameters
     -> (ApiNetworkParameters, Maybe EpochNo)
-toApiNetworkParameters (NetworkParameters gp pp) = (ApiNetworkParameters
-    (ApiT $ getGenesisBlockHash gp)
-    (ApiT $ getGenesisBlockDate gp)
-    (Quantity $ unSlotLength $ getSlotLength gp)
-    (Quantity $ unEpochLength $ getEpochLength gp)
-    (getEpochStability gp)
-    (Quantity
-        $ (*100)
-        $ unActiveSlotCoefficient
-        $ getActiveSlotCoefficient gp)
-    (Quantity $ unDecentralizationLevel $ view #decentralizationLevel pp)
-    (view #desiredNumberOfStakePools pp)
-    (Quantity $ fromIntegral $ getCoin $ view #minimumUTxOvalue pp)
-    Nothing, view #hardforkEpochNo pp)
+toApiNetworkParameters (NetworkParameters gp pp) = (np, view #hardforkEpochNo pp)
+  where
+    np = ApiNetworkParameters
+        { genesisBlockHash = ApiT $ getGenesisBlockHash gp
+        , blockchainStartTime = ApiT $ getGenesisBlockDate gp
+        , slotLength = Quantity $ unSlotLength $ getSlotLength gp
+        , epochLength = Quantity $ unEpochLength $ getEpochLength gp
+        , epochStability = getEpochStability gp
+        , activeSlotCoefficient = Quantity
+            $ (*100)
+            $ unActiveSlotCoefficient
+            $ getActiveSlotCoefficient gp
+        , decentralizationLevel = Quantity
+            $ unDecentralizationLevel
+            $ view #decentralizationLevel pp
+        , desiredPoolNumber = view #desiredNumberOfStakePools pp
+        , minimumUtxoValue = Quantity
+            $ fromIntegral
+            $ getCoin
+            $ view #minimumUTxOvalue pp
+        , hardforkAt = Nothing
+        }
 
 newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -27,10 +27,7 @@ module Cardano.Wallet.Byron.Compatibility
     , mainnetVersionData
     , testnetVersionData
 
-    , mainnetNetworkParameters
-
       -- * Genesis
-    , emptyGenesis
     , genesisTip
     , genesisBlockFromTxOuts
 
@@ -88,7 +85,7 @@ import Cardano.Crypto.ProtocolMagic
 import Cardano.Wallet.Primitive.Slotting
     ( flatSlot, fromFlatSlot )
 import Cardano.Wallet.Unsafe
-    ( unsafeDeserialiseCbor, unsafeFromHex )
+    ( unsafeDeserialiseCbor )
 import Crypto.Hash.Utils
     ( blake2b256 )
 import Data.Coerce
@@ -97,8 +94,6 @@ import Data.Quantity
     ( Quantity (..) )
 import Data.Text
     ( Text )
-import Data.Time.Clock.POSIX
-    ( posixSecondsToUTCTime )
 import Data.Word
     ( Word16, Word32 )
 import GHC.Stack
@@ -150,68 +145,7 @@ type NodeVersionData =
 
 --------------------------------------------------------------------------------
 --
--- Chain Parameters
-
-
-mainnetNetworkParameters :: W.NetworkParameters
-mainnetNetworkParameters = W.NetworkParameters
-    { genesisParameters = W.GenesisParameters
-        { getGenesisBlockHash = W.Hash $ unsafeFromHex
-            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
-        , getGenesisBlockDate =
-            W.StartTime $ posixSecondsToUTCTime 1506203091
-        , getSlotLength =
-            W.SlotLength 20
-        , getEpochLength =
-            W.EpochLength 21600
-        , getEpochStability =
-            Quantity 2160
-        , getActiveSlotCoefficient =
-            W.ActiveSlotCoefficient 1.0
-        }
-    , protocolParameters = W.ProtocolParameters
-        { decentralizationLevel =
-            minBound
-        , txParameters = W.TxParameters
-            { getFeePolicy =
-                W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
-            , getTxMaxSize =
-                Quantity 4096
-            }
-        , desiredNumberOfStakePools = 0
-        , minimumUTxOvalue = W.Coin 0
-        , hardforkEpochNo = Nothing
-        }
-    }
-
--- NOTE
--- For MainNet and TestNet, we can get away with empty genesis blocks with
--- the following assumption:
---
--- - Users won't ever restore a wallet that has genesis UTxO.
---
--- This assumption is _true_ for any user using HD wallets (sequential or
--- random) which means, any user of cardano-wallet.
-emptyGenesis :: W.GenesisParameters -> W.Block
-emptyGenesis gp = W.Block
-    { transactions = []
-    , delegations  = []
-    , header = W.BlockHeader
-        { slotNo =
-            W.SlotNo 0
-        , blockHeight =
-            Quantity 0
-        , headerHash =
-            coerce $ W.getGenesisBlockHash gp
-        , parentHeaderHash =
-            W.Hash (BS.replicate 32 0)
-        }
-    }
-
---------------------------------------------------------------------------------
---
 -- Genesis
-
 
 genesisTip :: Tip ByronBlock
 genesisTip = legacyTip genesisPoint genesisBlockNo

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -277,7 +277,7 @@ mainnetNetworkParameters = W.NetworkParameters
             minBound
         , txParameters = W.TxParameters
             { getFeePolicy =
-                W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
+                W.LinearFee (Quantity 155381) (Quantity 44) (Quantity 0)
             , getTxMaxSize =
                 Quantity 4096
             }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -264,7 +264,7 @@ mainnetNetworkParameters = W.NetworkParameters
         , getGenesisBlockDate =
             W.StartTime $ posixSecondsToUTCTime 1506203091
         , getSlotLength =
-            W.SlotLength 20
+            W.SlotLength 1
         , getEpochLength =
             W.EpochLength 432000
         , getEpochStability =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -266,11 +266,11 @@ mainnetNetworkParameters = W.NetworkParameters
         , getSlotLength =
             W.SlotLength 20
         , getEpochLength =
-            W.EpochLength 21600
+            W.EpochLength 432000
         , getEpochStability =
             Quantity 2160
         , getActiveSlotCoefficient =
-            W.ActiveSlotCoefficient 1.0
+            W.ActiveSlotCoefficient 0.05
         }
     , protocolParameters = W.ProtocolParameters
         { decentralizationLevel =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -34,6 +34,8 @@ module Cardano.Wallet.Shelley.Compatibility
     , mainnetVersionData
     , testnetVersionData
 
+    , mainnetNetworkParameters
+
       -- * Genesis
     , emptyGenesis
     , genesisTip
@@ -130,7 +132,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolRetirementCertificate (..)
     )
 import Cardano.Wallet.Unsafe
-    ( unsafeDeserialiseCbor, unsafeMkPercentage )
+    ( unsafeDeserialiseCbor, unsafeFromHex, unsafeMkPercentage )
 import Codec.Binary.Bech32
     ( dataPartFromBytes, dataPartToBytes )
 import Control.Applicative
@@ -175,6 +177,8 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( TextDecodingError (..) )
+import Data.Time.Clock.POSIX
+    ( posixSecondsToUTCTime )
 import Data.Type.Equality
     ( testEquality )
 import Data.Word
@@ -252,8 +256,43 @@ import qualified Shelley.Spec.Ledger.UTxO as SL
 --
 -- Chain Parameters
 
+mainnetNetworkParameters :: W.NetworkParameters
+mainnetNetworkParameters = W.NetworkParameters
+    { genesisParameters = W.GenesisParameters
+        { getGenesisBlockHash = W.Hash $ unsafeFromHex
+            "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+        , getGenesisBlockDate =
+            W.StartTime $ posixSecondsToUTCTime 1506203091
+        , getSlotLength =
+            W.SlotLength 20
+        , getEpochLength =
+            W.EpochLength 21600
+        , getEpochStability =
+            Quantity 2160
+        , getActiveSlotCoefficient =
+            W.ActiveSlotCoefficient 1.0
+        }
+    , protocolParameters = W.ProtocolParameters
+        { decentralizationLevel =
+            minBound
+        , txParameters = W.TxParameters
+            { getFeePolicy =
+                W.LinearFee (Quantity 155381) (Quantity 43.946) (Quantity 0)
+            , getTxMaxSize =
+                Quantity 4096
+            }
+        , desiredNumberOfStakePools = 0
+        , minimumUTxOvalue = W.Coin 0
+        , hardforkEpochNo = Nothing
+        }
+    }
+
+--------------------------------------------------------------------------------
+--
+-- Genesis
+
 -- NOTE
--- For MainNet and TestNet, we can get away with empty genesis blocks with
+-- For Mainnet and Testnet, we can get away with empty genesis blocks with
 -- the following assumption:
 --
 -- - Users won't ever restore a wallet that has genesis UTxO.
@@ -276,11 +315,6 @@ emptyGenesis gp = W.Block
         }
     }
 
---------------------------------------------------------------------------------
---
--- Genesis
-
-
 genesisTip :: Tip (CardanoBlock sc)
 genesisTip = legacyTip genesisPoint genesisBlockNo
   where
@@ -290,7 +324,6 @@ genesisTip = legacyTip genesisPoint genesisBlockNo
     -- ('genesisBlockNo' is the block number of the first block on the chain).
     -- Usage of this function should be phased out.
     genesisBlockNo = BlockNo 0
-
 
 --------------------------------------------------------------------------------
 --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -276,9 +276,9 @@ parseGenesisData = \case
     MainnetConfig -> do
         pure
             ( SomeNetworkDiscriminant $ Proxy @'Mainnet
-            , Byron.mainnetNetworkParameters
+            , Shelley.mainnetNetworkParameters
             , Byron.mainnetVersionData
-            , Byron.emptyGenesis (genesisParameters Byron.mainnetNetworkParameters)
+            , Shelley.emptyGenesis (genesisParameters Shelley.mainnetNetworkParameters)
             )
 
     TestnetConfig byronGenesisFile -> do


### PR DESCRIPTION
### Issue Number

Relates to #2226.

### Overview

- Rearrange byron/shelley code a little.
- Updates hardcoded epoch length (slots not blocks) and active slot coefficient values for mainnet.
- Also updates slot length parameter.
- Also updates the _minFee a_ parameter - but I'm uncertain why the value was like that before.
