### PR TITLE
Add threadDelay after eventually conditions to protect against forks

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -114,6 +114,7 @@ module Test.Integration.Framework.DSL
     , rootPrvKeyFromMnemonics
     , unsafeGetTransactionTime
     , getTxId
+    , oneSecond
 
     -- * Delegation helpers
     , mkEpochInfo

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -36,6 +36,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
+import Control.Concurrent
+    ( threadDelay )
 import Control.Monad
     ( forM_ )
 import Data.Generics.Internal.VL.Lens
@@ -69,6 +71,7 @@ import Test.Integration.Framework.DSL
     , icarusAddresses
     , json
     , listAddresses
+    , oneSecond
     , randomAddresses
     , request
     , unsafeRequest
@@ -220,6 +223,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         (#balance . #getApiT . #total)
                         ( `shouldBe` Quantity expectedBalance)
                 ]
+
+        -- #2238 quick fix to reduce likelihood of rollback.
+        threadDelay $ 10 * oneSecond
 
         -- Analyze the target wallet UTxO distribution
         request @ApiUtxoStatistics ctx (Link.getUTxOsStatistics @'Shelley wNew)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -48,6 +48,8 @@ import Cardano.Wallet.Primitive.Types
     , TxStatus (..)
     , WalletId
     )
+import Control.Concurrent
+    ( threadDelay )
 import Control.Monad
     ( forM_ )
 import Data.Aeson
@@ -118,6 +120,7 @@ import Test.Integration.Framework.DSL
     , listAllTransactions
     , listTransactions
     , minUTxOValue
+    , oneSecond
     , request
     , rewardWallet
     , toQueryString
@@ -858,6 +861,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (#balance . #getApiT . #available)
                 (`shouldBe` Quantity (faucetAmt - feeMin - amtSrc)) r''
 
+        -- #2238 quick fix to reduce likelihood of rollback.
+        threadDelay $ 10 * oneSecond
+
         let amtDest = (2_000_000 :: Natural)
 
         let mnemonicsDest =
@@ -1022,6 +1028,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             expectField
                 (#balance . #getApiT . #available)
                 (`shouldBe` Quantity (faucetAmt - feeMin - amtSrc)) r''
+
+        -- #2238 quick fix to reduce likelihood of rollback.
+        threadDelay $ 10 * oneSecond
 
         let amtDest = (7_000_000 :: Natural)
 
@@ -1199,6 +1208,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     (#balance . #available)
                     (`shouldBe` Quantity amtSrc) r'
 
+            -- #2232 quick fix to reduce likelihood of rollback.
+            threadDelay $ 10 * oneSecond
+
             let shelleyMnemonics =
                   [ "broken", "pass", "shrug", "pause", "crush"
                   , "caught", "honey", "lonely", "dose", "rabbit"
@@ -1351,6 +1363,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 expectField
                     (#balance . #available)
                     (`shouldBe` Quantity amtSrc) r'
+
+            -- #2232 quick fix to reduce likelihood of rollback.
+            threadDelay $ 10 * oneSecond
 
             -- Create Shelley destination wallet for external tx
             wShelley <- emptyWallet ctx


### PR DESCRIPTION
# Issue Number

#2238 
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Add `threadDelay` after `eventually` checks in tests that cannot be retried. 


# Comments

I think this might work.

The cluster will roll back. For most tests, our retrying `it` protects
against rollback.

In these cases, hard-coded mnemonics make retrying impossible.

I believe by simply adding a threadDelay after the `eventually`, the relevant txs end up on the new chain.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
