### PR TITLE
cabal: Add version constraints on generic-lens

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -56,7 +56,7 @@ library
     , filepath
     , fmt
     , foldl
-    , generic-lens
+    , generic-lens >=1.1.0.0 && < 1.2.0.0
     , http-api-data
     , http-client
     , http-client-tls

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -35,7 +35,7 @@ library
     , contra-tracer
     , filepath
     , file-embed
-    , generic-lens
+    , generic-lens >=1.1.0.0 && < 1.2.0.0
     , hspec
     , hspec-core
     , hspec-expectations


### PR DESCRIPTION
### Issue Number

None

### Overview

Found while trying to build with no freeze file in input-output-hk/cardano-haskell#32.

Set correct bounds for generic-lens. We are using some internal modules which have had symbols removed in later package versions. e.g. `Data.Generics.Internal.VL.Prism.(^?)`.
