### PR TITLE
Add {100,10,1}-wallet restore benchmarks

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -15,14 +15,15 @@ steps:
       system: x86_64-linux
       queue: benchmark
 
-  - label: 'Restore benchmark - cardano testnet'
-    command: "./.buildkite/bench-restore.sh testnet"
-    env:
-      HOME: "/cache/cardano-wallet.home"
-    timeout_in_minutes: 600
-    agents:
-      system: x86_64-linux
-      queue: benchmark
+# Temporary disabled due to timing out (#2221)
+#  - label: 'Restore benchmark - cardano testnet'
+#    command: "./.buildkite/bench-restore.sh testnet"
+#    env:
+#      HOME: "/cache/cardano-wallet.home"
+#    timeout_in_minutes: 600
+#    agents:
+#      system: x86_64-linux
+#      queue: benchmark
 
   - label: 'Database benchmark'
     command: "./.buildkite/bench-db.sh"

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -136,7 +136,7 @@ withNetworkConfiguration args action = do
     withNodeDir $ \dir -> action CardanoNodeConfig
         { nodeDir          = dir
         , nodeConfigFile   = networkDir </> "configuration.json"
-        , nodeDatabaseDir  = "db"
+        , nodeDatabaseDir  = fromMaybe "db" (argNodeDatabaseDir args)
         , nodeDlgCertFile  = Nothing
         , nodeSignKeyFile  = Nothing
         , nodeTopologyFile = networkDir </> "topology.json"

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -60,6 +60,8 @@ import Data.Aeson
     ( ToJSON (..) )
 import Data.Functor
     ( (<&>) )
+import Data.Maybe
+    ( fromMaybe )
 import Data.Text
     ( Text )
 import Fmt
@@ -118,9 +120,13 @@ execBenchWithNode networkConfig action = do
     (_logCfg, tr) <- initBenchmarkLogging Info
     installSignalHandlers (return ())
 
-    void $ withNetworkConfiguration args $ \nodeConfig ->
-        withCardanoNode (trMessageText tr) nodeConfig $ \cp ->
-            action tr (networkConfig args) (nodeSocketFile cp)
+    case argUseAlreadyRunningNodeSocketPath args of
+        Just socket ->
+            action tr (networkConfig args) socket
+        Nothing -> do
+            void $ withNetworkConfiguration args $ \nodeConfig ->
+                withCardanoNode (trMessageText tr) nodeConfig $ \cp ->
+                    action tr (networkConfig args) (nodeSocketFile cp)
 
 withNetworkConfiguration :: RestoreBenchArgs -> (CardanoNodeConfig -> IO a) -> IO a
 withNetworkConfiguration args action = do
@@ -158,6 +164,7 @@ data RestoreBenchArgs = RestoreBenchArgs
     { argNetworkName :: String
     , argConfigsDir :: FilePath
     , argNodeDatabaseDir :: Maybe FilePath
+    , argUseAlreadyRunningNodeSocketPath :: Maybe FilePath
     } deriving (Show, Eq)
 
 restoreBenchArgsParser
@@ -184,6 +191,13 @@ restoreBenchArgsParser envNetwork envConfigsDir envNodeDatabaseDir = RestoreBenc
           <> envDefault "NODE_DB" envNodeDatabaseDir
           <> help "Directory to put cardano-node state. Defaults to $NODE_DB, \
               \falls back to temporary directory"))
+    <*> optional (strOption
+        ( long "running-node"
+          <> metavar "SOCKET"
+          <> envDefault "CARDANO_NODE_SOCKET" envNodeDatabaseDir
+          <> help "Path to the socket of an already running cardano-node. \
+                  \Also set by $CARDANO_NODE_SOCKET. If not set, cardano-node \
+              \will automatically be started."))
   where
     envDefault :: HasValue f => String -> Maybe a -> Mod f a
     envDefault name env = showDefaultWith (const ('$':name))

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -33,7 +33,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Setup
     ( setupTrace_ )
 import Cardano.BM.Trace
-    ( Trace )
+    ( Trace, nullTracer )
 import Cardano.Launcher.Node
     ( CardanoNodeConfig (..)
     , CardanoNodeConn (..)
@@ -83,6 +83,7 @@ import Options.Applicative
     , showDefaultWith
     , strArgument
     , strOption
+    , switch
     , value
     )
 import Say
@@ -117,7 +118,8 @@ execBenchWithNode networkConfig action = do
     hSetBuffering stdout NoBuffering
     hSetBuffering stderr NoBuffering
 
-    (_logCfg, tr) <- initBenchmarkLogging Info
+    (_logCfg, tr') <- initBenchmarkLogging Info
+    let tr = if argQuiet args then nullTracer else tr'
     installSignalHandlers (return ())
 
     case argUseAlreadyRunningNodeSocketPath args of
@@ -165,6 +167,7 @@ data RestoreBenchArgs = RestoreBenchArgs
     , argConfigsDir :: FilePath
     , argNodeDatabaseDir :: Maybe FilePath
     , argUseAlreadyRunningNodeSocketPath :: Maybe FilePath
+    , argQuiet :: Bool
     } deriving (Show, Eq)
 
 restoreBenchArgsParser
@@ -198,6 +201,9 @@ restoreBenchArgsParser envNetwork envConfigsDir envNodeDatabaseDir = RestoreBenc
           <> help "Path to the socket of an already running cardano-node. \
                   \Also set by $CARDANO_NODE_SOCKET. If not set, cardano-node \
               \will automatically be started."))
+    <*> switch
+        ( long ("quiet")
+          <> help "Reduce unnecessary log output.")
   where
     envDefault :: HasValue f => String -> Maybe a -> Mod f a
     envDefault name env = showDefaultWith (const ('$':name))


### PR DESCRIPTION
# Issue Number

ADP-469

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Auxiliary: Make benchmark actually respect passing in `--node-db`
- [x] Auxiliary: Add `--running-node SOCKET_PATH` for easier development
- [x] Benchmark restoring 100, 10 and 1 wallet to 1%
    - [x] Some tweaks to helpers to support this
- [x] Refactor to make the benchmark declarations more high-level and readable
- [x] Make sure the plotting of the results hasn't boken

# Comments

- Currently we won't a get plot for these new multi-wallet benchmarks, like for the existing ones. Could consider adding in another PR.
- Open to disagreement on only restoring 1% ([here](https://input-output-rnd.slack.com/archives/GBT05825V/p1602674480071800?thread_ts=1602142785.076200&cid=GBT05825V) is the old thread), but I think even 10% might be tricky to pull off in this PR. We'd need much more work for that.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
