### PR TITLE
Get epoch and slot lengths from HFC History Interpreter

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -54,6 +54,8 @@ module Test.Integration.Framework.DSL
 
     -- * Constants
     , minUTxOValue
+    , slotLengthValue
+    , epochLengthValue
     , defaultTxTTL
 
     -- * Create wallets
@@ -313,7 +315,7 @@ import Data.Time
 import Data.Time.Text
     ( iso8601ExtendedUtc, utcTimeToText )
 import Data.Word
-    ( Word64 )
+    ( Word32, Word64 )
 import Language.Haskell.TH.Quote
     ( QuasiQuoter )
 import Network.HTTP.Types.Method
@@ -568,6 +570,14 @@ walletId =
 -- | Min UTxO parameter for the test cluster.
 minUTxOValue :: Natural
 minUTxOValue = 1_000_000
+
+-- | Parameter in test cluster genesis.
+slotLengthValue :: NominalDiffTime
+slotLengthValue = 0.2
+
+-- | Parameter in test cluster genesis.
+epochLengthValue :: Word32
+epochLengthValue = 200
 
 -- | Wallet server's chosen transaction TTL value (in seconds) when none is
 -- given.

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -23,11 +23,13 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
     , Payload (..)
+    , epochLengthValue
     , eventually
     , expectField
     , expectResponseCode
     , minUTxOValue
     , request
+    , slotLengthValue
     , verify
     )
 
@@ -45,8 +47,12 @@ spec = describe "SHELLEY_NETWORK" $ do
         -- in integration test setup it is 3
         let nOpt = 3
         verify r
-            [ expectField (#decentralizationLevel) (`shouldBe` d)
-            , expectField (#desiredPoolNumber) (`shouldBe` nOpt)
-            , expectField (#minimumUtxoValue) (`shouldBe` (Quantity minUTxOValue))
-            , expectField (#hardforkAt) (`shouldNotBe` Nothing)
+            [ expectField #decentralizationLevel (`shouldBe` d)
+            , expectField #desiredPoolNumber (`shouldBe` nOpt)
+            , expectField #minimumUtxoValue (`shouldBe` Quantity minUTxOValue)
+            , expectField #hardforkAt (`shouldNotBe` Nothing)
+            , expectField #slotLength (`shouldBe` Quantity slotLengthValue)
+            , expectField #epochLength (`shouldBe` Quantity epochLengthValue)
+            -- TODO: #2226 query activeSlotCoefficient from ledger
+            -- , expectField #activeSlotCoefficient (`shouldBe` Quantity 0.5)
             ]

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -607,7 +607,7 @@ createWallet ctx wid wname s = db & \DBLayer{..} -> do
         initializeWallet (PrimaryKey wid) cp meta hist pp $> wid
   where
     db = ctx ^. dbLayer @s @k
-    (block0, NetworkParameters gp pp, _) = ctx ^. genesisData
+    (block0, NetworkParameters gp _sp pp, _) = ctx ^. genesisData
 
 -- | Initialise and store a new legacy Icarus wallet. These wallets are
 -- intrinsically sequential, but, in the incentivized testnet, we only have
@@ -652,7 +652,7 @@ createIcarusWallet ctx wid wname credentials = db & \DBLayer{..} -> do
         initializeWallet pk (updateState s' cp) meta hist pp $> wid
   where
     db = ctx ^. dbLayer @s @k
-    (block0, NetworkParameters gp pp, _) = ctx ^. genesisData
+    (block0, NetworkParameters gp _sp pp, _) = ctx ^. genesisData
 
 -- | Check whether a wallet is in good shape when restarting a worker.
 checkWalletIntegrity

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -201,6 +201,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotInEpoch (..)
     , SlotLength (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , StakePoolMetadata
     , StartTime (..)
     , TxIn (..)
@@ -676,18 +677,18 @@ data ApiNetworkParameters = ApiNetworkParameters
 toApiNetworkParameters
     :: NetworkParameters
     -> (ApiNetworkParameters, Maybe EpochNo)
-toApiNetworkParameters (NetworkParameters gp pp) = (np, view #hardforkEpochNo pp)
+toApiNetworkParameters (NetworkParameters gp sp pp) = (np, view #hardforkEpochNo pp)
   where
     np = ApiNetworkParameters
         { genesisBlockHash = ApiT $ getGenesisBlockHash gp
         , blockchainStartTime = ApiT $ getGenesisBlockDate gp
-        , slotLength = Quantity $ unSlotLength $ getSlotLength gp
-        , epochLength = Quantity $ unEpochLength $ getEpochLength gp
+        , slotLength = Quantity $ unSlotLength $ getSlotLength sp
+        , epochLength = Quantity $ unEpochLength $ getEpochLength sp
         , epochStability = getEpochStability gp
         , activeSlotCoefficient = Quantity
             $ (*100)
             $ unActiveSlotCoefficient
-            $ getActiveSlotCoefficient gp
+            $ getActiveSlotCoefficient sp
         , decentralizationLevel = Quantity
             $ unDecentralizationLevel
             $ view #decentralizationLevel pp

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -451,12 +451,12 @@ migrateManually tr proxy defaultFieldValues =
         hardLowerBound = toText $ fromEnum $ minBound @(Index 'Hardened _)
         rndAccountIx   = DBField RndStateAddressAccountIndex
 
-    -- | Adds an 'active_slot_coeff' column to the 'checkpoint' table if
-    --   it is missing.
+    -- | Adds a placeholder 'active_slot_coeff' column to the 'checkpoint' table
+    --   if it is missing.
     --
     addActiveSlotCoefficientIfMissing :: Sqlite.Connection -> IO ()
     addActiveSlotCoefficientIfMissing conn =
-        addColumn_ conn True (DBField CheckpointActiveSlotCoeff) value
+        addColumn_ conn True (DBField CheckpointActiveSlotCoeffUnused) value
       where
         value = toText
             $ W.unActiveSlotCoefficient
@@ -1128,10 +1128,10 @@ mkCheckpointEntity wid wal =
         , checkpointBlockHeight = bh
         , checkpointGenesisHash = BlockId (coerce (gp ^. #getGenesisBlockHash))
         , checkpointGenesisStart = coerce (gp ^. #getGenesisBlockDate)
-        , checkpointSlotLength = 0
-        , checkpointEpochLength = 0
         , checkpointEpochStability = coerce (gp ^. #getEpochStability)
-        , checkpointActiveSlotCoeff = 0
+        , checkpointSlotLengthUnused = 0
+        , checkpointEpochLengthUnused = 0
+        , checkpointActiveSlotCoeffUnused = 0
         , checkpointFeePolicyUnused = ""
         , checkpointTxMaxSizeUnused = 0
         }

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -156,7 +156,7 @@ import Data.Text.Class
 import Data.Typeable
     ( Typeable )
 import Data.Word
-    ( Word16, Word32, Word64 )
+    ( Word16, Word32 )
 import Database.Persist.Class
     ( toPersistValue )
 import Database.Persist.Sql
@@ -1128,11 +1128,10 @@ mkCheckpointEntity wid wal =
         , checkpointBlockHeight = bh
         , checkpointGenesisHash = BlockId (coerce (gp ^. #getGenesisBlockHash))
         , checkpointGenesisStart = coerce (gp ^. #getGenesisBlockDate)
-        , checkpointSlotLength = coerceSlotLength $ gp ^. #getSlotLength
-        , checkpointEpochLength = coerce (gp ^. #getEpochLength)
+        , checkpointSlotLength = 0
+        , checkpointEpochLength = 0
         , checkpointEpochStability = coerce (gp ^. #getEpochStability)
-        , checkpointActiveSlotCoeff =
-            W.unActiveSlotCoefficient (gp ^. #getActiveSlotCoefficient)
+        , checkpointActiveSlotCoeff = 0
         , checkpointFeePolicyUnused = ""
         , checkpointTxMaxSizeUnused = 0
         }
@@ -1141,9 +1140,6 @@ mkCheckpointEntity wid wal =
         | (W.TxIn input ix, W.TxOut addr coin) <- utxoMap
         ]
     utxoMap = Map.assocs (W.getUTxO (W.utxo wal))
-
-    coerceSlotLength :: W.SlotLength -> Word64
-    coerceSlotLength (W.SlotLength x) = toEnum (fromEnum x)
 
 -- note: TxIn records must already be sorted by order
 -- and TxOut records must already by sorted by index.
@@ -1164,11 +1160,11 @@ checkpointFromEntity cp utxo s =
         (BlockId genesisHash)
         genesisStart
         _feePolicyUnused
-        slotLength
-        epochLength
+        _slotLengthUnused
+        _epochLengthUnused
         _txMaxSizeUnused
         epochStability
-        activeSlotCoeff
+        _activeSlotCoeffUnused
         ) = cp
     header = (W.BlockHeader slot (Quantity bh) headerHash parentHeaderHash)
     utxo' = W.UTxO . Map.fromList $
@@ -1178,10 +1174,7 @@ checkpointFromEntity cp utxo s =
     gp = W.GenesisParameters
         { getGenesisBlockHash = coerce genesisHash
         , getGenesisBlockDate = W.StartTime genesisStart
-        , getSlotLength = W.SlotLength (toEnum (fromEnum slotLength))
-        , getEpochLength = W.EpochLength epochLength
         , getEpochStability = Quantity epochStability
-        , getActiveSlotCoefficient = W.ActiveSlotCoefficient activeSlotCoeff
         }
 
 mkTxHistory

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -156,11 +156,11 @@ Checkpoint
     checkpointGenesisHash       BlockId      sql=genesis_hash
     checkpointGenesisStart      UTCTime      sql=genesis_start
     checkpointFeePolicyUnused   Text         sql=fee_policy
-    checkpointSlotLength        Word64       sql=slot_length
-    checkpointEpochLength       Word32       sql=epoch_length
+    checkpointSlotLengthUnused  Word64       sql=slot_length
+    checkpointEpochLengthUnused Word32       sql=epoch_length
     checkpointTxMaxSizeUnused   Word16       sql=tx_max_size
     checkpointEpochStability    Word32       sql=epoch_stability
-    checkpointActiveSlotCoeff   Double       sql=active_slot_coeff
+    checkpointActiveSlotCoeffUnused Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Network
     , FollowAction (..)
     , FollowExit (..)
     , GetStakeDistribution
+    , getSlottingParametersForTip
 
     -- * Errors
     , ErrNetworkUnavailable (..)
@@ -44,14 +45,16 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter )
+    ( TimeInterpreter, queryEpochLength, querySlotLength )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..)
+    ( ActiveSlotCoefficient (..)
+    , BlockHeader (..)
     , ChimericAccount (..)
     , Hash (..)
     , ProtocolParameters
     , SealedTx
-    , SlotNo
+    , SlotNo (..)
+    , SlottingParameters (..)
     )
 import Control.Concurrent
     ( threadDelay )
@@ -247,6 +250,26 @@ defaultRetryPolicy =
 -------------------------------------------------------------------------------}
 
 type family GetStakeDistribution target (m :: * -> *) :: *
+
+-- | Use the HFC history interpreter to get the slot and epoch lengths current
+-- for the network tip.
+--
+-- This may throw a 'PastHorizonException' in some cases.
+getSlottingParametersForTip
+    :: Monad m
+    => NetworkLayer m target block
+    -> m SlottingParameters
+getSlottingParametersForTip nl = do
+    tip <- either (const 0) slotNo <$> runExceptT (currentNodeTip nl)
+
+    -- TODO: Query activeSlotCoeff. Where to get it from though? Need to be able
+    -- to query Globals from ledger.
+    let getActiveSlotCoeff = pure (ActiveSlotCoefficient 1.0)
+
+    SlottingParameters
+        <$> timeInterpreter nl (querySlotLength tip)
+        <*> timeInterpreter nl (queryEpochLength tip)
+        <*> getActiveSlotCoeff
 
 {-------------------------------------------------------------------------------
                                 Chain Sync

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -262,8 +262,8 @@ getSlottingParametersForTip
 getSlottingParametersForTip nl = do
     tip <- either (const 0) slotNo <$> runExceptT (currentNodeTip nl)
 
-    -- TODO: Query activeSlotCoeff. Where to get it from though? Need to be able
-    -- to query Globals from ledger.
+    -- TODO: #2226 Query activeSlotCoeff from ledger.
+    -- This requires code changes in the shelley ledger.
     let getActiveSlotCoeff = pure (ActiveSlotCoefficient 1.0)
 
     SlottingParameters

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -107,11 +107,11 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochLength (..)
-    , GenesisParameters (..)
     , Hash (..)
     , Range (..)
     , SlotLength (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , SortOrder (..)
     , StartTime (..)
     , TransactionInfo
@@ -598,12 +598,11 @@ setupDB tr = do
     (ctx, db) <- newDBLayer tr defaultFieldValues (Just f) ti
     pure (f, ctx, db)
   where
-    ti = pure . runIdentity . singleEraInterpreter (GenesisParameters
-        { getGenesisBlockHash = Hash $ BS.replicate 32 0
-        , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-        , getSlotLength = SlotLength 1
+    ti = pure . runIdentity . singleEraInterpreter
+        (StartTime $ posixSecondsToUTCTime 0)
+        (SlottingParameters
+        { getSlotLength = SlotLength 1
         , getEpochLength = EpochLength 21600
-        , getEpochStability = Quantity 108
         , getActiveSlotCoefficient = ActiveSlotCoefficient 1
         })
 

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -34,6 +34,7 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (..)
     , SlotLength (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , StartTime (..)
     , Tx (..)
     , TxIn (..)
@@ -85,16 +86,22 @@ dummyGenesisParameters :: GenesisParameters
 dummyGenesisParameters = GenesisParameters
     { getGenesisBlockHash = genesisHash
     , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-    , getSlotLength = SlotLength 1
-    , getEpochLength = EpochLength 21600
     , getEpochStability = Quantity 2160
+    }
+
+dummySlottingParameters :: SlottingParameters
+dummySlottingParameters = SlottingParameters
+    { getSlotLength = SlotLength 1
+    , getEpochLength = EpochLength 21600
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
     }
 
 dummyTimeInterpreter :: Monad m => TimeInterpreter m
 dummyTimeInterpreter = pure
     . runIdentity
-    . singleEraInterpreter dummyGenesisParameters
+    . singleEraInterpreter
+        (getGenesisBlockDate dummyGenesisParameters)
+        dummySlottingParameters
 
 dummyTxParameters :: TxParameters
 dummyTxParameters = TxParameters
@@ -105,6 +112,7 @@ dummyTxParameters = TxParameters
 dummyNetworkParameters :: NetworkParameters
 dummyNetworkParameters = NetworkParameters
     { genesisParameters = dummyGenesisParameters
+    , slottingParameters = dummySlottingParameters
     , protocolParameters = dummyProtocolParameters
     }
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -24,11 +24,11 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , EpochLength (..)
-    , GenesisParameters (..)
     , Hash (..)
     , SlotLength (..)
     , SlotNo (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , StartTime (..)
     )
 import Cardano.Wallet.Unsafe
@@ -56,22 +56,19 @@ import Test.QuickCheck.Monadic
 
 spec :: Spec
 spec = do
-    let gp = GenesisParameters
+    let t0 = read "2019-11-09 16:43:02 UTC"
+    let sp = SlottingParameters
             { getEpochLength = EpochLength 21600
             , getSlotLength  = SlotLength 10
-            , getGenesisBlockDate = StartTime (read "2019-11-09 16:43:02 UTC")
-            , getGenesisBlockHash = Hash ""
             , getActiveSlotCoefficient = 1
-            , getEpochStability = Quantity 10
             }
     let st = SyncTolerance 10
 
 
-    let ti = (singleEraInterpreter gp :: TimeInterpreter Identity)
+    let ti = (singleEraInterpreter (StartTime t0) sp :: TimeInterpreter Identity)
     describe "syncProgress" $ do
         it "works for any two slots" $ property $ \tip (dt :: NominalDiffTime) ->
             let
-                StartTime t0 = getGenesisBlockDate gp
                 t = dt `addUTCTime` t0
             in
                 runIdentity (syncProgress st ti tip t) `deepseq` ()
@@ -172,7 +169,6 @@ spec = do
 
         it "syncProgress should never crash" $ withMaxSuccess 10000
             $ property $ \tip dt -> monadicIO $ do
-                let StartTime t0 = getGenesisBlockDate gp
                 let t = dt `addUTCTime` t0
                 let x = runIdentity $
                         syncProgress tolerance ti tip t

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -87,6 +87,7 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (..)
     , SealedTx
     , SlotLength (..)
+    , SlottingParameters (..)
     , TxParameters (..)
     )
 import Control.Arrow
@@ -312,9 +313,11 @@ mkJormungandrClient mgr baseUrl = JormungandrClient
                         { genesisParameters = GenesisParameters
                             { getGenesisBlockHash = block0
                             , getGenesisBlockDate = block0T
-                            , getEpochLength = epLength
-                            , getSlotLength = SlotLength duration
                             , getEpochStability = stability
+                            }
+                        , slottingParameters = SlottingParameters
+                            { getEpochLength = epLength
+                            , getSlotLength = SlotLength duration
                             , getActiveSlotCoefficient = coeff
                             }
                         , protocolParameters = ProtocolParameters

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -138,6 +138,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId
     , ProtocolParameters (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar, readMVar )
@@ -338,7 +339,9 @@ mkRawNetworkLayer np batchSize st tipNotify j = NetworkLayer
         _getAccountBalance
 
     , timeInterpreter =
-        pure . runIdentity . singleEraInterpreter (genesisParameters np)
+        pure . runIdentity . singleEraInterpreter
+        (getGenesisBlockDate (genesisParameters np))
+        (slottingParameters np)
 
     , watchNodeTip =
         _watchNodeTip
@@ -358,7 +361,7 @@ mkRawNetworkLayer np batchSize st tipNotify j = NetworkLayer
     genesis :: Hash "Genesis"
     genesis = getGenesisBlockHash $ genesisParameters np
 
-    el :: EpochLength = getEpochLength $ genesisParameters np
+    el :: EpochLength = getEpochLength $ slottingParameters np
 
     _currentNodeTip :: ExceptT ErrCurrentNodeTip m BlockHeader
     _currentNodeTip = modifyMVar st $ \bs -> do

--- a/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -27,6 +27,7 @@ import Cardano.Wallet.Primitive.Types
     , GenesisParameters (..)
     , NetworkParameters (..)
     , SlotNo
+    , SlottingParameters (..)
     )
 import Control.Concurrent
     ( forkIO, killThread )
@@ -124,7 +125,7 @@ spec = around setup $ do
             withNetworkLayer tr (UseRunning cp) $ \case
                 Right (_, (b0, np), nl) -> withDB "reference.sqlite" nl $ \db -> do
                     let gp = genesisParameters np
-                    let el = getEpochLength gp
+                    let el = getEpochLength $ slottingParameters np
                     let nl' = toSPBlock el <$> nl
                     let k = getEpochStability gp
                     let block0 = toSPBlock el b0

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -54,7 +54,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo
     , FeePolicy (..)
-    , GenesisParameters (..)
     , Hash (..)
     , PoolId (..)
     , PoolOwner (..)
@@ -62,6 +61,7 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (..)
     , SlotLength (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , StartTime (..)
     , TxParameters (..)
     )
@@ -485,15 +485,14 @@ genPercentage = unsafeMkPercentage . fromRational . toRational <$> genDouble
     genDouble = choose (0, 1)
 
 testTimeInterpreter :: Monad m => TimeInterpreter m
-testTimeInterpreter = pure . runIdentity . singleEraInterpreter gp
+testTimeInterpreter = pure . runIdentity . singleEraInterpreter startTime sp
   where
-    gp :: GenesisParameters
-    gp = GenesisParameters
-        { getGenesisBlockHash = genesisHash
-        , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-        , getSlotLength = SlotLength 1
+    startTime = StartTime $ posixSecondsToUTCTime 0
+
+    sp :: SlottingParameters
+    sp = SlottingParameters
+        { getSlotLength = SlotLength 1
         , getEpochLength = EpochLength 50
-        , getEpochStability = Quantity 5
         , getActiveSlotCoefficient = ActiveSlotCoefficient 1
         }
 
@@ -511,9 +510,6 @@ genesisTxParameters = TxParameters
     { getFeePolicy = LinearFee (Quantity 14) (Quantity 42) (Quantity 5)
     , getTxMaxSize = Quantity 8192
     }
-
-genesisHash :: Hash "Genesis"
-genesisHash = Hash (B8.replicate 32 '0')
 
 {-------------------------------------------------------------------------------
                                    Unit tests

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -40,6 +40,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotId (..)
     , SlotInEpoch (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , TxParameters (..)
     )
 import Control.Concurrent.MVar.Lifted
@@ -418,9 +419,11 @@ mockJormungandrClient logLine = JormungandrClient
             { genesisParameters = GenesisParameters
                 { getGenesisBlockHash = blockId
                 , getGenesisBlockDate = error "mock gp"
-                , getSlotLength = error "mock gp"
-                , getEpochLength = epochLength
                 , getEpochStability = Quantity (fromIntegral k)
+                }
+            , slottingParameters = SlottingParameters
+                { getSlotLength = error "mock gp"
+                , getEpochLength = epochLength
                 , getActiveSlotCoefficient = error "mock gp"
                 }
             , protocolParameters = ProtocolParameters

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -152,7 +152,6 @@ type NodeVersionData =
 --
 -- Chain Parameters
 
-
 mainnetNetworkParameters :: W.NetworkParameters
 mainnetNetworkParameters = W.NetworkParameters
     { genesisParameters = W.GenesisParameters
@@ -160,12 +159,14 @@ mainnetNetworkParameters = W.NetworkParameters
             "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
         , getGenesisBlockDate =
             W.StartTime $ posixSecondsToUTCTime 1506203091
-        , getSlotLength =
+        , getEpochStability =
+            Quantity 2160
+        }
+    , slottingParameters = W.SlottingParameters
+        { getSlotLength =
             W.SlotLength 20
         , getEpochLength =
             W.EpochLength 21600
-        , getEpochStability =
-            Quantity 2160
         , getActiveSlotCoefficient =
             W.ActiveSlotCoefficient 1.0
         }
@@ -316,8 +317,8 @@ toGenTx =
     . BL.fromStrict
     . W.getSealedTx
 
-byronCodecConfig :: W.GenesisParameters -> CodecConfig ByronBlock
-byronCodecConfig W.GenesisParameters{getEpochLength} =
+byronCodecConfig :: W.SlottingParameters -> CodecConfig ByronBlock
+byronCodecConfig W.SlottingParameters{getEpochLength} =
     ByronCodecConfig (toEpochSlots getEpochLength)
 
 fromByronBlock :: W.GenesisParameters -> ByronBlock -> W.Block
@@ -489,12 +490,14 @@ fromGenesisData (genesisData, genesisHash) =
                 W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
             , getGenesisBlockDate =
                 W.StartTime . gdStartTime $ genesisData
-            , getSlotLength =
+            , getEpochStability =
+                Quantity . fromIntegral . unBlockCount . gdK $ genesisData
+            }
+        , slottingParameters = W.SlottingParameters
+            { getSlotLength =
                 fromSlotDuration . ppSlotDuration . gdProtocolParameters $ genesisData
             , getEpochLength =
                 fromBlockCount . gdK $ genesisData
-            , getEpochStability =
-                Quantity . fromIntegral . unBlockCount . gdK $ genesisData
             , getActiveSlotCoefficient =
                 W.ActiveSlotCoefficient 1.0
             }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -576,12 +576,14 @@ fromGenesisData g initialFunds =
             { getGenesisBlockHash = dummyGenesisHash
             , getGenesisBlockDate =
                 W.StartTime . sgSystemStart $ g
-            , getSlotLength =
+            , getEpochStability =
+                Quantity . fromIntegral . sgSecurityParam $ g
+            }
+        , slottingParameters = W.SlottingParameters
+            { getSlotLength =
                 W.SlotLength $ sgSlotLength g
             , getEpochLength =
                 W.EpochLength . fromIntegral . unEpochSize . sgEpochLength $ g
-            , getEpochStability =
-                Quantity . fromIntegral . sgSecurityParam $ g
             , getActiveSlotCoefficient =
                 W.ActiveSlotCoefficient . fromRational . sgActiveSlotsCoeff $ g
             }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -87,6 +87,7 @@ import Cardano.Wallet.Primitive.Types
     , Settings (..)
     , SlotLength (..)
     , SlotNo (..)
+    , SlottingParameters (..)
     , StakePoolMetadata
     , StakePoolMetadataHash
     , getPoolRegistrationCertificate
@@ -682,10 +683,10 @@ monitorStakePools tr gp nl DBLayer{..} =
 -- | Worker thread that monitors pool metadata and syncs it to the database.
 monitorMetadata
     :: Tracer IO StakePoolLog
-    -> GenesisParameters
+    -> SlottingParameters
     -> DBLayer IO
     -> IO ()
-monitorMetadata tr gp DBLayer{..} = do
+monitorMetadata tr sp DBLayer{..} = do
     settings <- atomically readSettings
     manager <- newManager defaultManagerSettings
     let fetcher fetchStrategies = fetchFromRemote trFetch fetchStrategies manager
@@ -720,8 +721,8 @@ monitorMetadata tr gp DBLayer{..} = do
     blockFrequency = ceiling (1/f) * toMicroSecond slotLength
       where
         toMicroSecond = (`div` 1000000) . fromEnum
-        slotLength = unSlotLength $ getSlotLength gp
-        f = unActiveSlotCoefficient (getActiveSlotCoefficient gp)
+        slotLength = unSlotLength $ getSlotLength sp
+        f = unActiveSlotCoefficient (getActiveSlotCoefficient sp)
 
 data StakePoolLog
     = MsgFollow FollowLog


### PR DESCRIPTION
### Issue Number

#2226

### Overview

- [x] Remove slot length and epoch length from genesis parameters, because we will be getting them with HFC queries.
- [x] Hard-code activeSlotCoeff to 1.0 as before. There needs to be a ledger change to support this.
- [x] Add these parameters to SHELLEY_NETWORK integration test.

