### PR TITLE
select coins for delegation simplifications

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -313,8 +313,10 @@ server byron icarus shelley spl ntp =
         withLegacyLayer wid
             (byron, liftHandler $ throwE ErrNotASequentialWallet)
             (icarus, selectCoins icarus (const $ paymentAddress @n) wid x)
-    byronCoinSelections _ _ = throwError
-        $ err400 { errBody = "Byron wallets don't have delegation capabilities." }
+    byronCoinSelections _ _ = Handler
+        $ throwE
+        $ apiError err400 InvalidWalletType
+        "Byron wallets don't have delegation capabilities."
 
     byronTransactions :: Server (ByronTransactions n)
     byronTransactions =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -88,8 +88,8 @@ import Cardano.Wallet.Api.Server
     , quitStakePool
     , rndStateChange
     , selectCoins
-    , selectCoinsJoinStakePool
-    , selectCoinsQuitStakePool
+    , selectCoinsForJoin
+    , selectCoinsForQuit
     , withLegacyLayer
     , withLegacyLayer'
     )
@@ -208,14 +208,15 @@ server byron icarus shelley spl ntp =
     coinSelections = (\wid ascd -> case ascd of
         (ApiSelectForPayment ascp) -> selectCoins shelley (delegationAddress @n) wid ascp
         (ApiSelectForDelegation (ApiSelectCoinsAction (ApiT action))) -> case action of
-                Join pid -> selectCoinsJoinStakePool
+                Join pid -> selectCoinsForJoin @_ @()
                     shelley
                     (knownPools spl)
                     (getPoolLifeCycleStatus spl)
                     pid
                     (getApiT wid)
                 RegisterKeyAndJoin _ -> throwError err400
-                Quit -> selectCoinsQuitStakePool shelley wid)
+                Quit -> selectCoinsForQuit @_ @() shelley wid
+        )
 
     transactions :: Server (Transactions n)
     transactions =


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2200

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 16a5f0cda96867b4bc0eaa37a125c4824e6d2a25
  :round_pushpin: **remove duplicated logic with regards to selections for join/quit**
    The code was becoming quite convoluted here with function names that
  were screaming for refactoring (when we start adding `'` to functions,
  it's usually a good sign that something can be simplified).

  The main change is actually in 'selectCoinsExternal' which is now
  parameterized over the selection to run. This way, the steps of
  assigning change addresses are factored out in this function and a lot
  of the duplication goes away.

  Another important change is that I've moved the signing and submission
  of join/quit outside of the body of the function. So that each step
  can be ran independently. This avoid the need for weird intermediate product
  types aggregating more and more information. Now, both functions are
  returning a 'DelegationAction' and merely checking that a join or quit
  is possible.

- 4a5f4d96ea74f89bf0920b2ebed3a57c3bee1ca2
  :round_pushpin: **return structured error for invalid wallets, instead of plain string**

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
