### PR TITLE
do not enforce non-empty outputs for unsigned tx

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@ let
         ruby
         sqlite-interactive
         yq
-      ]) ++ attrValues hls;
+      ]);
     tools = {
       cabal = "3.2.0.0";
       ghcid = "0.8.7";
@@ -117,10 +117,12 @@ let
     '';
   };
 
-  # Build latest release of haskell-language-server from github
-  hls = pkgs.callPackages ./nix/hls.nix {
-    compiler-nix-name = haskellPackages._config.compiler.nix-name;
-  };
+  # FIXME: This is causing issue in CI, as described here: https://github.com/input-output-hk/haskell.nix/issues/884
+  #
+  # # Build latest release of haskell-language-server from github
+  # hls = pkgs.callPackages ./nix/hls.nix {
+  #   compiler-nix-name = haskellPackages._config.compiler.nix-name;
+  # };
 
   self = {
     inherit pkgs commonLib src haskellPackages profiledHaskellPackages coveredHaskellPackages;

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1659,7 +1659,7 @@ migrateWallet ctx (ApiT wid) migrateData = do
             ti
             (txId tx)
             (fmap Just <$> NE.toList (W.unsignedInputs cs))
-            (NE.toList (W.unsignedOutputs cs))
+            (W.unsignedOutputs cs)
             (tx ^. #withdrawals)
             (meta, time)
             Nothing
@@ -1699,7 +1699,7 @@ assignMigrationAddresses addrs selections =
     makeTx :: CoinSelection -> [Address] -> UnsignedTx (TxIn, TxOut)
     makeTx sel addrsSelected = UnsignedTx
         (NE.fromList (sel ^. #inputs))
-        (NE.fromList (zipWith TxOut addrsSelected (sel ^. #change)))
+        (zipWith TxOut addrsSelected (sel ^. #change))
 
 {-------------------------------------------------------------------------------
                                     Network
@@ -1916,6 +1916,7 @@ mkApiCoinSelection mcerts (UnsignedTx inputs outputs) =
                 ]
       where
         apiStakePath = ApiT <$> xs
+
     mkAddressAmount :: TxOut -> AddressAmount (ApiT Address, Proxy n)
     mkAddressAmount (TxOut addr (Coin c)) =
         AddressAmount (ApiT addr, Proxy @n) (Quantity $ fromIntegral c)
@@ -2273,11 +2274,8 @@ instance Buildable e => LiftHandler (ErrSelectCoinsExternal e) where
         ErrSelectCoinsExternalUnableToAssignInputs e ->
             apiError err500 UnableToAssignInputOutput $ mconcat
                 [ "I'm unable to assign inputs from coin selection: "
-                , pretty e]
-        ErrSelectCoinsExternalUnableToAssignOutputs e ->
-            apiError err500 UnableToAssignInputOutput $ mconcat
-                [ "I'm unable to assign outputs from coin selection: "
-                , pretty e]
+                , pretty e
+                ]
 
 instance Buildable e => LiftHandler (ErrCoinSelection e) where
     handler = \case
@@ -2543,7 +2541,6 @@ instance LiftHandler ErrSelectForDelegation where
                 , "delegation certificate. I need: ", showT cost, " Lovelace."
                 ]
         ErrSelectForDelegationUnableToAssignInputs e -> handler e
-        ErrSelectForDelegationUnableToAssignOutputs e -> handler e
 
 instance LiftHandler ErrSignDelegation where
     handler = \case
@@ -2581,10 +2578,6 @@ instance LiftHandler ErrJoinStakePool where
         ErrJoinStakePoolUnableToAssignInputs e ->
             apiError err500 UnableToAssignInputOutput $ mconcat
                 [ "I'm unable to assign inputs from coin selection: "
-                , pretty e]
-        ErrJoinStakePoolUnableToAssignOutputs  e ->
-            apiError err500 UnableToAssignInputOutput $ mconcat
-                [ "I'm unable to assign outputs from coin selection: "
                 , pretty e]
 
 instance LiftHandler ErrFetchRewards where
@@ -2625,10 +2618,6 @@ instance LiftHandler ErrQuitStakePool where
         ErrQuitStakePoolUnableToAssignInputs e ->
             apiError err500 UnableToAssignInputOutput $ mconcat
                 [ "I'm unable to assign inputs from coin selection: "
-                , pretty e]
-        ErrQuitStakePoolUnableToAssignOutputs e ->
-            apiError err500 UnableToAssignInputOutput $ mconcat
-                [ "I'm unable to assign outputs from coin selection: "
                 , pretty e]
 
 instance LiftHandler ErrCreateRandomAddress where

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -410,7 +410,7 @@ data ApiCertificate
 
 data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
     { inputs :: !(NonEmpty (ApiCoinSelectionInput n))
-    , outputs :: !(NonEmpty (AddressAmount (ApiT Address, Proxy n)))
+    , outputs :: ![AddressAmount (ApiT Address, Proxy n)]
     , certificates :: Maybe (NonEmpty ApiCertificate)
     } deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -969,8 +969,20 @@ instance ToText TxStatus where
 data UnsignedTx input = UnsignedTx
     { unsignedInputs
         :: NonEmpty input
+        -- Inputs are *necessarily* non-empty because Cardano requires at least
+        -- one UTxO input per transaction to prevent replayable transactions.
+        -- (each UTxO being unique, including at least one UTxO in the
+        -- transaction body makes it seemingly unique).
+
     , unsignedOutputs
-        :: NonEmpty TxOut
+        :: [TxOut]
+        -- Unlike inputs, it is perfectly reasonable to have empty outputs. The
+        -- main scenario where this might occur is when constructing a
+        -- delegation for the sake of submitting a certificate. This type of
+        -- transaction does not typically include any target output and,
+        -- depending on which input(s) get selected to fuel the transaction, it
+        -- may or may not include a change output should its value be less than
+        -- the minimal UTxO value set by the network.
     }
     deriving (Eq, Show)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -145,7 +145,7 @@ prop_coinValuesPreserved (CoinSelectionsSetup cs addrs) = do
     let selsCoinValue =
             sum $ getCoinValueFromInp . inputs . getCS <$> cs
     let getCoinValueFromTxOut (UnsignedTx _ txouts) =
-            sum $ map (\(TxOut _ (Coin c)) -> c) $ NE.toList txouts
+            sum $ map (\(TxOut _ (Coin c)) -> c) txouts
     let txsCoinValue =
             sum . map getCoinValueFromTxOut
     txsCoinValue (assignMigrationAddresses addrs sels) === selsCoinValue
@@ -164,7 +164,7 @@ prop_coinValuesPreservedPerTx f (CoinSelectionsSetup cs addrs) = do
             f . map (\(_, TxOut _ (Coin c)) -> c)
     let selsCoinValue = getCoinValueFromInp . inputs . getCS <$> cs
     let getCoinValueFromTxOut (UnsignedTx _ txouts) =
-            f $ map (\(TxOut _ (Coin c)) -> c) $ NE.toList txouts
+            f $ map (\(TxOut _ (Coin c)) -> c) txouts
     let txsCoinValue = map getCoinValueFromTxOut
     txsCoinValue (assignMigrationAddresses addrs sels) === selsCoinValue
 
@@ -202,8 +202,7 @@ prop_fairAddressesRecycled
 prop_fairAddressesRecycled (CoinSelectionsSetup cs addrs) = do
     let sels = getCS <$> cs
     let getAllAddrPerTx (UnsignedTx _ txouts) =
-            map (\(TxOut addr _) -> addr) $
-            NE.toList txouts
+            map (\(TxOut addr _) -> addr) txouts
     let getAllAddrCounts =
             Map.elems .
             foldr (\x -> Map.insertWith (+) x (1::Int)) Map.empty .

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -520,7 +520,7 @@ x-transactionInputs: &transactionInputs
 x-transactionOutputs: &transactionOutputs
   description: A list of target outputs
   type: array
-  minItems: 1
+  minItems: 0
   items:
     type: object
     required:
@@ -2947,7 +2947,7 @@ paths:
         Random-Improve coin selection algorithm</a>.
 
         <b>Note: </b> Not supported for Byron random wallets.
-        
+
       parameters:
         - *parametersWalletId
       requestBody:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

#2200 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- c60c5a60a6d1111e8dc5c7482a737bdc4e83c3b2
  :round_pushpin: **do not enforce non-empty outputs for unsigned tx**
    Actually, there are many use-cases for empty outputs. This occurs in
  particular often when performing a selection for delegation: in this
  scenario, there are typically no outputs at all and, depending on the
  size of the selected input(s), there might be no change at all
  (because of the minUTxO value).


# Comments

<!-- Additional comments or screenshots to attach if any -->

Should fix: 

- https://github.com/input-output-hk/cardano-wallet/pull/2213#issuecomment-710155543
- https://github.com/input-output-hk/cardano-wallet/pull/2213#issuecomment-711148053

Thanks @piotr-iohk :pray: 


<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
