### PR TITLE
ADP-291: Document endpoints error codes in the API documentation

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -68,7 +68,6 @@ module Test.Integration.Framework.TestData
     , errMsg500
     , errMsg400NumberOfWords
     , errMsgNotInDictionary
-    , errMsg403RejectedTip
     , errMsg400MinWithdrawalWrong
     , errMsg403WithdrawalNotWorth
     , errMsg403NotAShelleyWallet
@@ -426,12 +425,6 @@ errMsgNotInDictionary = "Found an unknown word not present in the pre-defined\
 
 errMsg400NumberOfWords :: String
 errMsg400NumberOfWords = "Invalid number of words:"
-
-errMsg403RejectedTip :: String
-errMsg403RejectedTip =
-    "I am sorry but I refuse to rollback to the given point. \
-    \Notwithstanding I'll willingly rollback to the genesis point (0, 0) \
-    \should you demand it."
 
 errMsg403WithdrawalNotWorth :: String
 errMsg403WithdrawalNotWorth =

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2467,7 +2467,6 @@ data ErrJoinStakePool
     | ErrJoinStakePoolSignDelegation ErrSignDelegation
     | ErrJoinStakePoolSubmitTx ErrSubmitTx
     | ErrJoinStakePoolCannotJoin ErrCannotJoin
-    | ErrJoinStakePoolUnableToAssignInputs CoinSelection
     deriving (Generic, Eq, Show)
 
 data ErrQuitStakePool
@@ -2476,7 +2475,6 @@ data ErrQuitStakePool
     | ErrQuitStakePoolSignDelegation ErrSignDelegation
     | ErrQuitStakePoolSubmitTx ErrSubmitTx
     | ErrQuitStakePoolCannotQuit ErrCannotQuit
-    | ErrQuitStakePoolUnableToAssignInputs CoinSelection
     deriving (Generic, Eq, Show)
 
 -- | Errors that can occur when fetching the reward balance of a wallet

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2451,7 +2451,6 @@ data ErrStartTimeLaterThanEndTime = ErrStartTimeLaterThanEndTime
 data ErrSelectForDelegation
     = ErrSelectForDelegationNoSuchWallet ErrNoSuchWallet
     | ErrSelectForDelegationFee ErrAdjustForFee
-    | ErrSelectForDelegationUnableToAssignInputs ErrNoSuchWallet
     deriving (Show, Eq)
 
 -- | Errors that can occur when signing a delegation certificate.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2621,7 +2621,6 @@ instance LiftHandler ErrSelectForDelegation where
                 [ "I'm unable to select enough coins to pay for a "
                 , "delegation certificate. I need: ", showT cost, " Lovelace."
                 ]
-        ErrSelectForDelegationUnableToAssignInputs e -> handler e
 
 instance LiftHandler ErrSignDelegation where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2239,9 +2239,6 @@ data ErrCreateWallet
         -- ^ Somehow, we couldn't create a worker or open a db connection
     deriving (Eq, Show)
 
-newtype ErrRejectedTip = ErrRejectedTip ApiSlotReference
-    deriving (Eq, Show)
-
 -- | Small helper to easy show things to Text
 showT :: Show a => a -> Text
 showT = T.pack . show
@@ -2261,15 +2258,6 @@ instance LiftHandler ErrUnexpectedPoolIdPlaceholder where
             apiError err400 BadRequest (pretty msg)
       where
         Left msg = fromText @PoolId "INVALID"
-
-instance LiftHandler ErrRejectedTip where
-    handler = \case
-        ErrRejectedTip {} ->
-            apiError err403 RejectedTip $ mconcat
-                [ "I am sorry but I refuse to rollback to the given point. "
-                , "Notwithstanding I'll willingly rollback to the genesis point "
-                , "(0, 0) should you demand it."
-                ]
 
 instance LiftHandler ErrSelectForMigration where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2655,10 +2655,6 @@ instance LiftHandler ErrJoinStakePool where
                     [ "I couldn't find any stake pool with the given id: "
                     , toText pid
                     ]
-        ErrJoinStakePoolUnableToAssignInputs e ->
-            apiError err500 UnableToAssignInputOutput $ mconcat
-                [ "I'm unable to assign inputs from coin selection: "
-                , pretty e]
 
 instance LiftHandler ErrFetchRewards where
     handler = \case
@@ -2695,10 +2691,6 @@ instance LiftHandler ErrQuitStakePool where
                     , "account! Make sure to withdraw your ", pretty rewards
                     , " lovelace first."
                     ]
-        ErrQuitStakePoolUnableToAssignInputs e ->
-            apiError err500 UnableToAssignInputOutput $ mconcat
-                [ "I'm unable to assign inputs from coin selection: "
-                , pretty e]
 
 instance LiftHandler ErrCreateRandomAddress where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -778,7 +778,6 @@ data ApiErrorCode
     | MalformedTxPayload
     | KeyNotFoundForAddress
     | NotEnoughMoney
-    | UtxoNotEnoughFragmented
     | TransactionIsTooBig
     | InputsDepleted
     | CannotCoverFee
@@ -792,18 +791,15 @@ data ApiErrorCode
     | NotFound
     | MethodNotAllowed
     | NotAcceptable
-    | StartTimeLaterThanEndTime
-    | UnableToDetermineCurrentEpoch
     | UnsupportedMediaType
     | UnexpectedError
+    | StartTimeLaterThanEndTime
+    | UnableToDetermineCurrentEpoch
     | NotSynced
     | NothingToMigrate
     | NoSuchPool
     | PoolAlreadyJoined
     | NotDelegatingTo
-    | InvalidRestorationParameters
-    | RejectedTip
-    | InvalidDelegationDiscovery
     | NotImplemented
     | WalletNotResponding
     | AddressAlreadyExists

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -245,6 +246,8 @@ import Data.ByteArray.Encoding
     ( Base (Base16), convertFromBase, convertToBase )
 import Data.ByteString
     ( ByteString )
+import Data.Data
+    ( Data )
 import Data.Either.Extra
     ( maybeToEither )
 import Data.Function
@@ -277,6 +280,8 @@ import Data.Time.Clock
     ( NominalDiffTime, UTCTime )
 import Data.Time.Text
     ( iso8601, iso8601ExtendedUtc, utcTimeFromText, utcTimeToText )
+import Data.Typeable
+    ( Typeable )
 import Data.Word
     ( Word16, Word32, Word64 )
 import Data.Word.Odd
@@ -813,7 +818,7 @@ data ApiErrorCode
     | PastHorizon
     | UnableToAssignInputOutput
     | SoftDerivationRequired
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic, Show, Data, Typeable)
 
 -- | Defines a point in time that can be formatted as and parsed from an
 --   ISO 8601-compliant string.

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1923,7 +1923,9 @@ x-responsesErrWalletNotFound: &responsesErrWalletNotFound
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: |
+        May occur when a given walletId does not match with any known
+        wallets (because it has been deleted, or has never existed).
     code:
       type: string
       enum: ['no_such_wallet']
@@ -1936,7 +1938,10 @@ x-responsesErrBadRequest: &responsesErrBadRequest
   properties:
     message:
       type: string
-      description: Explanation of a good request.
+      description: |
+        May occur when a request is not well-formed; that is, it fails to parse
+        successfully. This could be the case when some required parameters
+        are missing or, when wrong values are provided.
     code:
       type: string
       enum: ['bad_request']

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1915,11 +1915,9 @@ x-responsesErr: &responsesErr
       description: A specific error code for this error, more precise than HTTP ones.
       example: an_error_code
 
-x-responsesErrWalletNotFound: &responsesErrWalletNotFound
-  type: object
-  required:
-    - message
-    - code
+x-errNoSuchWallet: &errNoSuchWallet
+  <<: *responsesErr
+  title: no_such_wallet
   properties:
     message:
       type: string
@@ -1930,353 +1928,480 @@ x-responsesErrWalletNotFound: &responsesErrWalletNotFound
       type: string
       enum: ['no_such_wallet']
 
-x-responsesErrBadRequest: &responsesErrBadRequest
-  type: object
-  required:
-    - message
-    - code
+x-errNoSuchTransaction: &errNoSuchTransaction
+  <<: *responsesErr
+  title: no_such_transaction
+  properties:
+    message:
+      type: string
+      description: May occur when a given transactionId does not match with any known transactions.
+    code:
+      type: string
+      enum: ['no_such_transaction']
+
+x-errTransactionNotPending: &errTransactionNotPending
+  <<: *responsesErr
+  title: transaction_not_pending
+  properties:
+    message:
+      type: string
+      description: May occur when trying to forget a transaction that is not pending.
+    code:
+      type: string
+      enum: ['transaction_not_pending']
+
+x-errWalletAlreadyExists: &errWalletAlreadyExists
+  <<: *responsesErr
+  title: wallet_already_exists
+  properties:
+    message:
+      type: string
+      description: May occur when a otherwise valid request would yield a wallet that already exists.
+    code:
+      type: string
+      enum: ['wallet_already_exists']
+
+x-errNoRootKey: &errNoRootKey
+  <<: *responsesErr
+  title: no_root_key
+  properties:
+    message:
+      type: string
+      description: May occur when an action require a signing key but the wallet has only access to verification keys.
+    code:
+      type: string
+      enum: ['no_root_key']
+
+x-errWrongEncryptionPassphrase: &errWrongEncryptionPassphrase
+  <<: *responsesErr
+  title: wrong_encryption_passphrase
+  properties:
+    message:
+      type: string
+      description: May occur when the given spending passphrase is wrong.
+    code:
+      type: string
+      enum: ['wrong_encryption_passphrase']
+
+x-errMalformedTxPayload: &errMalformedTxPayload
+  <<: *responsesErr
+  title: malformed_tx_payload
+  properties:
+    message:
+      type: string
+      description: May occur when submitting a malformed serialized transaction.
+    code:
+      type: string
+      enum: ['malformed_tx_payload']
+
+# TODO: Map this error to the place it belongs.
+x-errKeyNotFoundForAddress: &errKeyNotFoundForAddress
+  <<: *responsesErr
+  title: key_not_found_for_address
+  properties:
+    message:
+      type: string
+      description: Should never happen unless the server screwed up and has lost track of previously known addresses.
+    code:
+      type: string
+      enum: ['key_not_found_for_address']
+
+x-errNotEnoughMoney: &errNotEnoughMoney
+  <<: *responsesErr
+  title: not_enough_money
+  properties:
+    message:
+      type: string
+      description: May occur when there's not enough money in the wallet to cover a requested payment.
+    code:
+      type: string
+      enum: ['not_enough_money']
+
+x-errTransactionIsTooBig: &errTransactionIsTooBig
+  <<: *responsesErr
+  title: transaction_is_too_big
+  properties:
+    message:
+      type: string
+      description: May occur when the wallet can't cover for all requested outputs without making the transaction too large.
+    code:
+      type: string
+      enum: ['transaction_is_too_big']
+
+x-errInputsDepleted: &errInputsDepleted
+  <<: *responsesErr
+  title: inputs_depleted
+  properties:
+    message:
+      type: string
+      description: May occur when there's enough money to pay for a payment, but not enough UTxO to allow for paying each output independently.
+    code:
+      type: string
+      enum: ['inputs_depleted']
+
+x-errCannotCoverFee: &errCannotCoverFee
+  <<: *responsesErr
+  title: cannot_cover_fee
+  properties:
+    message:
+      type: string
+      description: May occur when a transaction can't be balanced for fees.
+    code:
+      type: string
+      enum: ['cannot_cover_fee']
+
+x-errInvalidCoinSelection: &errInvalidCoinSelection
+  <<: *responsesErr
+  title: invalid_coin_selection
+  properties:
+    message:
+      type: string
+      description: Should never happen unless the server screwed up with the creation of a coin selection.
+    code:
+      type: string
+      enum: ['invalid_coin_selection']
+
+# TODO: Map this error to the place it belongs.
+x-errNetworkUnreachable: &errNetworkUnreachable
+  <<: *responsesErr
+  title: network_unreachable
+  properties:
+    message:
+      type: string
+      description: May occur when the connection with the node is lost or not responding.
+    code:
+      type: string
+      enum: ['network_unreachable']
+
+# TODO: Map this error to the place it belongs.
+x-errNetworkMisconfigured: &errNetworkMisconfigured
+  <<: *responsesErr
+  title: network_misconfigured
+  properties:
+    message:
+      type: string
+      description: May occur when trying to connect to a wrong network (e.g. testnet instead of mainnet).
+    code:
+      type: string
+      enum: ['network_misconfigured']
+
+# TODO: Map this error to the place it belongs.
+x-errNetworkTipNotFound: &errNetworkTipNotFound
+  <<: *responsesErr
+  title: network_tip_not_found
+  properties:
+    message:
+      type: string
+      description: May occur when the connection with the node is lost or not responding.
+    code:
+      type: string
+      enum: ['network_tip_not_found']
+
+x-errCreatedInvalidTransaction: &errCreatedInvalidTransaction
+  <<: *responsesErr
+  title: created_invalid_transaction
+  properties:
+    message:
+      type: string
+      description: Should never happen unless the server screwed up with the creation of transaction.
+    code:
+      type: string
+      enum: ['created_invalid_transaction']
+
+x-errRejectedByCoreNode: &errRejectedByCoreNode
+  <<: *responsesErr
+  title: rejected_by_core_node
+  properties:
+    message:
+      type: string
+      description: Should never happen unless the server screwed up with the creation of transaction.
+    code:
+      type: string
+      enum: ['rejected_by_core_node']
+
+x-errBadRequest: &errBadRequest
+  <<: *responsesErr
+  title: bad_request
   properties:
     message:
       type: string
       description: |
         May occur when a request is not well-formed; that is, it fails to parse
         successfully. This could be the case when some required parameters
-        are missing or, when wrong values are provided.
+        are missing or, when malformed values are provided.
     code:
       type: string
       enum: ['bad_request']
 
-x-responsesErrNotJson: &responsesErrNotJson
-  type: object
-  required:
-    - message
-    - code
+x-errMethodNotAllowed: &errMethodNotAllowed
+  <<: *responsesErr
+  title: method_not_allowed
   properties:
     message:
       type: string
-      description: A descriptive message explaining the expected media type is JSON.
+      description: May occur when sending a request on a wrong endpoint.
     code:
       type: string
-      enum: ['unsupported_media_type']
+      enum: ['method_not_allowed']
 
-x-responsesErrNotOctetStream: &responsesErrNotOctetStream
-  type: object
-  required:
-    - message
-    - code
+x-errNotAcceptable: &errNotAcceptable
+  <<: *responsesErr
+  title: not_acceptable
   properties:
     message:
       type: string
-      description: A descriptive message explaining the expected media type is octet stream.
-    code:
-      type: string
-      enum: ['unsupported_media_type']
-
-x-responsesErrNotAcceptable: &responsesErrNotAcceptable
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive message explaining acceptable headers.
+      description: May occur when providing an invalid 'Accept' header.
     code:
       type: string
       enum: ['not_acceptable']
 
-x-responsesErrWalletAlreadyExists: &responsesErrWalletAlreadyExists
-  type: object
-  required:
-    - message
-    - code
+x-errUnsupportedMediaType: &errUnsupportedMediaType
+  <<: *responsesErr
+  title: unsupported_media_type
   properties:
     message:
       type: string
-      description: Explanation of wallet with conflicting id.
+      description: May occur when providing an invalid 'Content-Type' header.
     code:
       type: string
-      enum: ['wallet_already_exists']
+      enum: ['unsupported_media_type']
 
-x-errWithRootKeyNoRootKey: &errWithRootKeyNoRootKey
-  type: object
-  required:
-    - message
-    - code
+# TODO: Map this error to the place it belongs.
+x-errUnexpectedError: &errUnexpectedError
+  <<: *responsesErr
+  title: unexpected_error
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: Should never occur, unless the server screwed up badly.
     code:
       type: string
-      enum: ['no_root_key']
-
-x-errWithRootKeyWrongPassphrase: &errWithRootKeyWrongPassphrase
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['wrong_encryption_passphrase']
-
-x-errInvalidWalletType: &errInvalidWalletType
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: Explanation of a valid wallet type.
-    code:
-      type: string
-      enum: ['invalid_wallet_type']
-
-x-errAlreadyWithdrawing: &errAlreadyWithdrawing
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['already_withdrawing']
-
-x-errTransactionIsTooBig: &errTransactionIsTooBig
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['transaction_is_too_big']
-
-x-errUTxOTooSmall: &errUTxOTooSmall
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['utxo_too_small']
-
-x-errCannotCoverFee: &errCannotCoverFee
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['cannot_cover_fee']
-
-x-errNotEnoughMoney: &errNotEnoughMoney
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['not_enough_money']
-
-x-errInputsDepleted: &errInputsDepleted
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['inputs_depleted']
-
-x-errInvalidSelection: &errInvalidSelection
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['invalid_coin_selection']
-
-x-errWithRootKey: &errWithRootKey
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['no_root_key']
-
-x-errMinWithdrawalWrong: &errMinWithdrawalWrong
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['min_withdrawal_wrong']
+      enum: ['unexpected_error']
 
 x-errStartTimeLaterThanEndTime: &errStartTimeLaterThanEndTime
-  type: object
-  required:
-    - message
-    - code
+  <<: *responsesErr
+  title: start_time_later_than_end_time
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: May occur when a provided time-range is unsound.
     code:
       type: string
       enum: ['start_time_later_than_end_time']
 
-x-errTransactionNotPending: &errTransactionNotPending
-  type: object
-  required:
-    - message
-    - code
+# TODO: Map this error to the place it belongs.
+x-errUnableToDetermineCurrentEpoch: &errUnableToDetermineCurrentEpoch
+  <<: *responsesErr
+  title: unable_to_determine_current_epoch
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: May occur under rare circumstances if the underlying node isn't enough synced with the network.
     code:
       type: string
-      enum: ['transaction_not_pending']
+      enum: ['unable_to_determine_current_epoch']
 
-x-errNoSuchTransaction: &errNoSuchTransaction
-  type: object
-  required:
-    - message
-    - code
+# TODO: Map this error to the place it belongs.
+x-errNotSynced: &errNotSynced
+  <<: *responsesErr
+  title: not_synced
   properties:
     message:
       type: string
-      description: A message describing the transaction ID that could not be found.
+      description: May occur under rare circumstances if the underlying node isn't enough synced with the network.
     code:
       type: string
-      enum: ['no_such_transaction']
+      enum: ['not_synced']
 
-x-errQueryParamMissing: &errQueryParamMissing
-  type: object
-  required:
-    - message
-    - code
+# TODO: Map this error to the place it belongs.
+x-errNothingToMigrate: &errNothingToMigrate
+  <<: *responsesErr
+  title: nothing_to_migrate
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: May occur when trying to migrate a wallet that is empty or full of dust.
     code:
       type: string
-      enum: ['query_param_missing']
-
-x-errNotDelegating: &errNotDelegating
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['not_delegating_to']
-
-x-errNonNullRewards: &errNonNullRewards
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['non_null_rewards']
-
-x-errAlreadyDelegating: &errAlreadyDelegating
-  type: object
-  required:
-    - message
-    - code
-  properties:
-    message:
-      type: string
-      description: A descriptive error message.
-    code:
-      type: string
-      enum: ['pool_already_joined']
+      enum: ['nothing_to_migrate']
 
 x-errNoSuchPool: &errNoSuchPool
-  type: object
-  required:
-    - message
-    - code
+  <<: *responsesErr
+  title: no_such_pool
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: May occur when a given poolId does not match any known pool.
     code:
       type: string
       enum: ['no_such_pool']
 
-x-errNothingToMigrate: &errNothingToMigrate
-  type: object
-  required:
-    - message
-    - code
+x-errPoolAlreadyJoined: &errPoolAlreadyJoined
+  <<: *responsesErr
+  title: pool_already_joined
   properties:
     message:
       type: string
-      description: A descriptive error message.
+      description: May occur when a given poolId matches the current delegation preferences of the wallet's account.
     code:
       type: string
-      enum: ['nothing_to_migrate']
+      enum: ['pool_already_joined']
+
+x-errNotDelegatingTo: &errNotDelegatingTo
+  <<: *responsesErr
+  title: not_delegating_to
+  properties:
+    message:
+      type: string
+      description: May occur when trying to quit a pool on an account that isn't delegating.
+    code:
+      type: string
+      enum: ['not_delegating_to']
+
+# TODO: Map this error to the place it belongs.
+x-errNotImplemented: &errNotImplemented
+  <<: *responsesErr
+  title: not_implemented
+  properties:
+    message:
+      type: string
+      description: May occur when reaching an endpoint under construction.
+    code:
+      type: string
+      enum: ['not_implemented']
+
+# TODO: Map this error to the place it belongs.
+x-errWalletNotResponding: &errWalletNotResponding
+  <<: *responsesErr
+  title: wallet_not_responding
+  properties:
+    message:
+      type: string
+      description: Should never occur unless something really wrong happened causing a background worker to die.
+    code:
+      type: string
+      enum: ['wallet_not_responding']
+
+# TODO: Map this error to the place it belongs.
+x-errAddressAlreadyExists: &errAddressAlreadyExists
+  <<: *responsesErr
+  title: address_already_exists
+  properties:
+    message:
+      type: string
+      description: May occur when trying to import an address that is already known of the wallet's account.
+    code:
+      type: string
+      enum: ['address_already_exists']
+
+x-errInvalidWalletType: &errInvalidWalletType
+  <<: *responsesErr
+  title: invalid_wallet_type
+  properties:
+    message:
+      type: string
+      description: May occur when trying to perform an operation not supported by this type of wallet.
+    code:
+      type: string
+      enum: ['invalid_wallet_type']
+
+x-errQueryParamMissing: &errQueryParamMissing
+  <<: *responsesErr
+  title: query_param_missing
+  properties:
+    message:
+      type: string
+      description: May occur when an endpoint requires the presence of a query parameter that is missing.
+    code:
+      type: string
+      enum: ['query_param_missing']
+
+x-errNonNullRewards: &errNonNullRewards
+  <<: *responsesErr
+  title: non_null_rewards
+  properties:
+    message:
+      type: string
+      description: May occur when trying to unregister a stake key that still has rewards attached to it.
+    code:
+      type: string
+      enum: ['non_null_rewards']
+
+x-errUtxoTooSmall: &errUtxoTooSmall
+  <<: *responsesErr
+  title: utxo_too_small
+  properties:
+    message:
+      type: string
+      description: May occur when a requested output is below the minimum utxo value.
+    code:
+      type: string
+      enum: ['utxo_too_small']
+
+x-errMinWithdrawalWrong: &errMinWithdrawalWrong
+  <<: *responsesErr
+  title: min_withdrawal_wrong
+  properties:
+    message:
+      type: string
+      description: May occur when trying to withdraw less than the minimal UTxO value.
+    code:
+      type: string
+      enum: ['min_withdrawal_wrong']
+
+x-errAlreadyWithdrawing: &errAlreadyWithdrawing
+  <<: *responsesErr
+  title: already_withdrawing
+  properties:
+    message:
+      type: string
+      description: May occur when submitting a withdrawal while another withdrawal is pending.
+    code:
+      type: string
+      enum: ['already_withdrawing']
+
+# TODO: Map this error to the place it belongs.
+x-errWithdrawalNotWorth: &errWithdrawalNotWorth
+  <<: *responsesErr
+  title: withdrawal_not_worth
+  properties:
+    message:
+      type: string
+      description: May occur when withdrawing an amount would cost more than the withdrawn value.
+    code:
+      type: string
+      enum: ['withdrawal_not_worth']
+
+# TODO: Map this error to the place it belongs.
+x-errPastHorizon: &errPastHorizon
+  <<: *responsesErr
+  title: past_horizon
+  properties:
+    message:
+      type: string
+      description: May occur in rare cases when converting slot to time can't be done, typically near hard-forks.
+    code:
+      type: string
+      enum: ['past_horizon']
+
+# TODO: Map this error to the place it belongs.
+x-errUnableToAssignInputOutput: &errUnableToAssignInputOutput
+  <<: *responsesErr
+  title: unable_to_assign_input_output
+  properties:
+    message:
+      type: string
+      description: Should never occur unless the server screwed up with a coin selection.
+    code:
+      type: string
+      enum: ['unable_to_assign_input_output']
 
 x-responsesErr400: &responsesErr400
   400:
     description: Bad Request
     content:
       application/json:
-        schema: *responsesErrBadRequest
+        schema: *errBadRequest
 
 x-responsesErr403: &responsesErr403
   403:
@@ -2297,7 +2422,7 @@ x-responsesErr406: &responsesErr406
     description: Not Acceptable
     content:
       application/json:
-        schema: *responsesErrNotAcceptable
+        schema: *errNotAcceptable
 
 x-responsesErr409: &responsesErr409
   409:
@@ -2332,28 +2457,21 @@ x-responsesErr404WalletNotFound: &responsesErr404WalletNotFound
     description: Not Found
     content:
       application/json:
-        schema: *responsesErrWalletNotFound
+        schema: *errNoSuchWallet
 
 x-responsesErr409WalletAlreadyExists: &responsesErr409WalletAlreadyExists
   409:
     description: Conflict
     content:
       application/json:
-        schema: *responsesErrWalletAlreadyExists
+        schema: *errWalletAlreadyExists
 
-x-responsesErr415NotJson: &responsesErr415NotJson
+x-responsesErr415UnsupportedMediaType: &responsesErr415UnsupportedMediaType
   415:
     description: Unsupported Media Type
     content:
       application/json:
-        schema: *responsesErrNotJson
-
-x-responsesErr415NotOctetStream: &responsesErr415NotOctetStream
-  415:
-    description: Unsupported Media Type
-    content:
-      application/json:
-        schema: *responsesErrNotOctetStream
+        schema: *errUnsupportedMediaType
 
 x-responsesListWallets: &responsesListWallets
   <<: *responsesErr406
@@ -2388,7 +2506,7 @@ x-responsesPostWallet: &responsesPostWallet
   <<: *responsesErr400
   <<: *responsesErr406
   <<: *responsesErr409WalletAlreadyExists
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   201:
     description: Created
     content:
@@ -2447,8 +2565,8 @@ x-responsesMigrateWallet: &responsesMigrateWallet
         schema:
           oneOf:
             - <<: *errNothingToMigrate
-            - <<: *errWithRootKey
-            - <<: *errWithRootKeyWrongPassphrase
+            - <<: *errNoRootKey
+            - <<: *errWrongEncryptionPassphrase
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   410:
@@ -2456,8 +2574,8 @@ x-responsesMigrateWallet: &responsesMigrateWallet
     content:
       application/json:
         schema:
-          <<: *responsesErrWalletNotFound
-  <<: *responsesErr415NotJson
+          <<: *errNoSuchWallet
+  <<: *responsesErr415UnsupportedMediaType
   200:
     description: Ok
     content:
@@ -2486,7 +2604,7 @@ x-responsesPutWallet: &responsesPutWallet
   <<: *responsesErr400
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   200:
     description: Ok
     content:
@@ -2501,11 +2619,11 @@ x-responsesPutWalletPassphrase: &responsesPutWalletPassphrase
       application/json:
         schema:
           oneOf:
-            - <<: *errWithRootKeyNoRootKey
-            - <<: *errWithRootKeyWrongPassphrase
+            - <<: *errNoRootKey
+            - <<: *errWrongEncryptionPassphrase
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   204:
     description: No Content
 
@@ -2518,15 +2636,14 @@ x-responsesSelectCoins: &responsesSelectCoins
         schema:
           oneOf:
             - <<: *errAlreadyWithdrawing
-            - <<: *errUTxOTooSmall
+            - <<: *errUtxoTooSmall
             - <<: *errNotEnoughMoney
             - <<: *errCannotCoverFee
             - <<: *errInputsDepleted
-            - <<: *errTransactionIsTooBig
-            - <<: *errInvalidSelection
+            - <<: *errInvalidCoinSelection
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   200:
     description: OK
     content:
@@ -2545,7 +2662,7 @@ x-responsesDeleteTransaction: &responsesDeleteTransaction
       application/json:
         schema:
           oneOf:
-            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchWallet
             - <<: *errNoSuchTransaction
   <<: *responsesErr406
   204:
@@ -2582,7 +2699,7 @@ x-responsesGetTransaction: &responsesGetTransaction
       application/json:
         schema:
           oneOf:
-            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchWallet
             - <<: *errNoSuchTransaction
   <<: *responsesErr406
   200:
@@ -2598,7 +2715,7 @@ x-responsesPostTransaction: &responsesPostTransaction
       application/json:
         schema:
           oneOf:
-            - <<: *responsesErrBadRequest
+            - <<: *errBadRequest
             - <<: *errTransactionIsTooBig
   403:
     description: Forbidden
@@ -2608,12 +2725,12 @@ x-responsesPostTransaction: &responsesPostTransaction
           oneOf:
             - <<: *errInvalidWalletType
             - <<: *errAlreadyWithdrawing
-            - <<: *errUTxOTooSmall
+            - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
             - <<: *errTransactionIsTooBig
-            - <<: *errWithRootKey
-            - <<: *errWithRootKeyWrongPassphrase
+            - <<: *errNoRootKey
+            - <<: *errWrongEncryptionPassphrase
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   410:
@@ -2621,8 +2738,8 @@ x-responsesPostTransaction: &responsesPostTransaction
     content:
       application/json:
         schema:
-          <<: *responsesErrWalletNotFound
-  <<: *responsesErr415NotJson
+          <<: *errNoSuchWallet
+  <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
     content:
@@ -2632,7 +2749,7 @@ x-responsesPostTransaction: &responsesPostTransaction
 x-responsesPostExternalTransaction: &responsesPostExternalTransaction
   <<: *responsesErr400
   <<: *responsesErr406
-  <<: *responsesErr415NotOctetStream
+  <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
     content:
@@ -2646,7 +2763,7 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
       application/json:
         schema:
           oneOf:
-            - <<: *responsesErrBadRequest
+            - <<: *errBadRequest
             - <<: *errTransactionIsTooBig
   403:
     description: Forbidden
@@ -2656,15 +2773,15 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
           oneOf:
             - <<: *errInvalidWalletType
             - <<: *errAlreadyWithdrawing
-            - <<: *errUTxOTooSmall
+            - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
             - <<: *errInputsDepleted
-            - <<: *errInvalidSelection
+            - <<: *errInvalidCoinSelection
             - <<: *errTransactionIsTooBig
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
     content:
@@ -2700,7 +2817,6 @@ x-responsesListAddresses: &responsesListAddresses
 x-responsesGetKey: &responsesGetKey
   <<: *responsesErr400
   <<: *responsesErr404
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2736,16 +2852,16 @@ x-responsesJoinStakePool: &responsesJoinStakePool
         schema:
           oneOf:
             - <<: *errCannotCoverFee
-            - <<: *errWithRootKey
-            - <<: *errWithRootKeyWrongPassphrase
-            - <<: *errAlreadyDelegating
+            - <<: *errNoRootKey
+            - <<: *errWrongEncryptionPassphrase
+            - <<: *errPoolAlreadyJoined
   404:
     description: Not Found
     content:
       application/json:
         schema:
           oneOf:
-            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchWallet
             - <<: *errNoSuchPool
   <<: *responsesErr406
   410:
@@ -2753,8 +2869,8 @@ x-responsesJoinStakePool: &responsesJoinStakePool
     content:
       application/json:
         schema:
-          <<: *responsesErrWalletNotFound
-  <<: *responsesErr415NotJson
+          <<: *errNoSuchWallet
+  <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
     content:
@@ -2770,9 +2886,9 @@ x-responsesQuitStakePool: &responsesQuitStakePool
         schema:
           oneOf:
             - <<: *errCannotCoverFee
-            - <<: *errWithRootKey
-            - <<: *errWithRootKeyWrongPassphrase
-            - <<: *errNotDelegating
+            - <<: *errNoRootKey
+            - <<: *errWrongEncryptionPassphrase
+            - <<: *errNotDelegatingTo
             - <<: *errNonNullRewards
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
@@ -2781,8 +2897,8 @@ x-responsesQuitStakePool: &responsesQuitStakePool
     content:
       application/json:
         schema:
-          <<: *responsesErrWalletNotFound
-  <<: *responsesErr415NotJson
+          <<: *errNoSuchWallet
+  <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
     content:
@@ -2846,7 +2962,7 @@ x-responsesInspectAddress: &responsesInspectAddress
 
 x-responsesPutSettings: &responsesPutSettings
   <<: *responsesErr400
-  <<: *responsesErr415NotJson
+  <<: *responsesErr415UnsupportedMediaType
   204:
     description: No Content
 
@@ -2859,7 +2975,6 @@ x-responsesGetSettings: &responsesGetSettings
 
 x-responsesPostSignatures: &responsesPostSignatures
     <<: *responsesErr400
-    <<: *responsesErr405
     <<: *responsesErr406
     <<: *responsesErr415
     200:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1915,6 +1915,30 @@ x-responsesErr: &responsesErr
       description: A specific error code for this error, more precise than HTTP ones.
       example: an_error_code
 
+x-errNotFound: &errNotFound
+  <<: *responsesErr
+  title: not_found
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+    code:
+      type: string
+      enum: ['not_found']
+
+x-errSoftDerivationRequired: &errSoftDerivationRequired
+  <<: *responsesErr
+  title: not_found
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+    code:
+      type: string
+      enum: ['soft_derivation_required']
+
 x-errNoSuchWallet: &errNoSuchWallet
   <<: *responsesErr
   title: no_such_wallet

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1915,12 +1915,363 @@ x-responsesErr: &responsesErr
       description: A specific error code for this error, more precise than HTTP ones.
       example: an_error_code
 
+x-responsesErrWalletNotFound: &responsesErrWalletNotFound
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['no_such_wallet']
+
+x-responsesErrBadRequest: &responsesErrBadRequest
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: Explanation of a good request.
+    code:
+      type: string
+      enum: ['bad_request']
+
+x-responsesErrNotJson: &responsesErrNotJson
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive message explaining the expected media type is JSON.
+    code:
+      type: string
+      enum: ['unsupported_media_type']
+
+x-responsesErrNotOctetStream: &responsesErrNotOctetStream
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive message explaining the expected media type is octet stream.
+    code:
+      type: string
+      enum: ['unsupported_media_type']
+
+x-responsesErrNotAcceptable: &responsesErrNotAcceptable
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive message explaining acceptable headers.
+    code:
+      type: string
+      enum: ['not_acceptable']
+
+x-responsesErrWalletAlreadyExists: &responsesErrWalletAlreadyExists
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: Explanation of wallet with conflicting id.
+    code:
+      type: string
+      enum: ['wallet_already_exists']
+
+x-errWithRootKeyNoRootKey: &errWithRootKeyNoRootKey
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['no_root_key']
+
+x-errWithRootKeyWrongPassphrase: &errWithRootKeyWrongPassphrase
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['wrong_encryption_passphrase']
+
+x-errInvalidWalletType: &errInvalidWalletType
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: Explanation of a valid wallet type.
+    code:
+      type: string
+      enum: ['invalid_wallet_type']
+
+x-errAlreadyWithdrawing: &errAlreadyWithdrawing
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['already_withdrawing']
+
+x-errTransactionIsTooBig: &errTransactionIsTooBig
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['transaction_is_too_big']
+
+x-errUTxOTooSmall: &errUTxOTooSmall
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['utxo_too_small']
+
+x-errCannotCoverFee: &errCannotCoverFee
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['cannot_cover_fee']
+
+x-errNotEnoughMoney: &errNotEnoughMoney
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['not_enough_money']
+
+x-errInputsDepleted: &errInputsDepleted
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['inputs_depleted']
+
+x-errInvalidSelection: &errInvalidSelection
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['invalid_coin_selection']
+
+x-errWithRootKey: &errWithRootKey
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['no_root_key']
+
+x-errMinWithdrawalWrong: &errMinWithdrawalWrong
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['min_withdrawal_wrong']
+
+x-errStartTimeLaterThanEndTime: &errStartTimeLaterThanEndTime
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['start_time_later_than_end_time']
+
+x-errTransactionNotPending: &errTransactionNotPending
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['transaction_not_pending']
+
+x-errNoSuchTransaction: &errNoSuchTransaction
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A message describing the transaction ID that could not be found.
+    code:
+      type: string
+      enum: ['no_such_transaction']
+
+x-errQueryParamMissing: &errQueryParamMissing
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['query_param_missing']
+
+x-errNotDelegating: &errNotDelegating
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['not_delegating_to']
+
+x-errNonNullRewards: &errNonNullRewards
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['non_null_rewards']
+
+x-errAlreadyDelegating: &errAlreadyDelegating
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['pool_already_joined']
+
+x-errNoSuchPool: &errNoSuchPool
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['no_such_pool']
+
+x-errNothingToMigrate: &errNothingToMigrate
+  type: object
+  required:
+    - message
+    - code
+  properties:
+    message:
+      type: string
+      description: A descriptive error message.
+    code:
+      type: string
+      enum: ['nothing_to_migrate']
+
 x-responsesErr400: &responsesErr400
   400:
     description: Bad Request
     content:
       application/json:
-        schema: *responsesErr
+        schema: *responsesErrBadRequest
 
 x-responsesErr403: &responsesErr403
   403:
@@ -1936,19 +2287,12 @@ x-responsesErr404: &responsesErr404
       application/json:
         schema: *responsesErr
 
-x-responsesErr405: &responsesErr405
-  405:
-    description: Method Not Allowed
-    content:
-      application/json:
-        schema: *responsesErr
-
 x-responsesErr406: &responsesErr406
   406:
     description: Not Acceptable
     content:
       application/json:
-        schema: *responsesErr
+        schema: *responsesErrNotAcceptable
 
 x-responsesErr409: &responsesErr409
   409:
@@ -1978,8 +2322,35 @@ x-responsesErr423: &responsesErr423
       application/json:
         schema: *responsesErr
 
+x-responsesErr404WalletNotFound: &responsesErr404WalletNotFound
+  404:
+    description: Not Found
+    content:
+      application/json:
+        schema: *responsesErrWalletNotFound
+
+x-responsesErr409WalletAlreadyExists: &responsesErr409WalletAlreadyExists
+  409:
+    description: Conflict
+    content:
+      application/json:
+        schema: *responsesErrWalletAlreadyExists
+
+x-responsesErr415NotJson: &responsesErr415NotJson
+  415:
+    description: Unsupported Media Type
+    content:
+      application/json:
+        schema: *responsesErrNotJson
+
+x-responsesErr415NotOctetStream: &responsesErr415NotOctetStream
+  415:
+    description: Unsupported Media Type
+    content:
+      application/json:
+        schema: *responsesErrNotOctetStream
+
 x-responsesListWallets: &responsesListWallets
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -1990,7 +2361,6 @@ x-responsesListWallets: &responsesListWallets
           items: *ApiWallet
 
 x-responsesListByronWallets: &responsesListByronWallets
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2001,8 +2371,7 @@ x-responsesListByronWallets: &responsesListByronWallets
           items: *ApiByronWallet
 
 x-responsesGetUTxOsStatistics: &responsesGetUTxOsStatistics
-  <<: *responsesErr404
-  <<: *responsesErr405
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2012,10 +2381,9 @@ x-responsesGetUTxOsStatistics: &responsesGetUTxOsStatistics
 
 x-responsesPostWallet: &responsesPostWallet
   <<: *responsesErr400
-  <<: *responsesErr405
   <<: *responsesErr406
-  <<: *responsesErr409
-  <<: *responsesErr415
+  <<: *responsesErr409WalletAlreadyExists
+  <<: *responsesErr415NotJson
   201:
     description: Created
     content:
@@ -2024,7 +2392,6 @@ x-responsesPostWallet: &responsesPostWallet
 
 x-responsesPostByronWallet: &responsesPostByronWallet
   <<: *responsesErr400
-  <<: *responsesErr405
   <<: *responsesErr406
   <<: *responsesErr409
   <<: *responsesErr415
@@ -2035,8 +2402,8 @@ x-responsesPostByronWallet: &responsesPostByronWallet
         schema: *ApiByronWallet
 
 x-responsesGetWallet: &responsesGetWallet
-  <<: *responsesErr404
-  <<: *responsesErr405
+  <<: *responsesErr400
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2046,7 +2413,6 @@ x-responsesGetWallet: &responsesGetWallet
 
 x-responsesGetByronWallet: &responsesGetByronWallet
   <<: *responsesErr404
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2055,8 +2421,12 @@ x-responsesGetByronWallet: &responsesGetByronWallet
         schema: *ApiByronWallet
 
 x-responsesGetWalletMigrationInfo: &responsesGetWalletMigrationInfo
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema: *errNothingToMigrate
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2065,11 +2435,24 @@ x-responsesGetWalletMigrationInfo: &responsesGetWalletMigrationInfo
         schema: *ApiWalletMigrationInfo
 
 x-responsesMigrateWallet: &responsesMigrateWallet
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errNothingToMigrate
+            - <<: *errWithRootKey
+            - <<: *errWithRootKeyWrongPassphrase
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  410:
+    description: Gone
+    content:
+      application/json:
+        schema:
+          <<: *responsesErrWalletNotFound
+  <<: *responsesErr415NotJson
   200:
     description: Ok
     content:
@@ -2079,8 +2462,8 @@ x-responsesMigrateWallet: &responsesMigrateWallet
           items: *ApiTransaction
 
 x-responsesDeleteWallet: &responsesDeleteWallet
-  <<: *responsesErr404
-  <<: *responsesErr405
+  <<: *responsesErr400
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   204:
     description: No Content
@@ -2089,7 +2472,6 @@ x-responsesForceResyncWallet: &responsesForceResyncWallet
   <<: *responsesErr400
   <<: *responsesErr403
   <<: *responsesErr404
-  <<: *responsesErr405
   <<: *responsesErr406
   <<: *responsesErr415
   204:
@@ -2097,10 +2479,9 @@ x-responsesForceResyncWallet: &responsesForceResyncWallet
 
 x-responsesPutWallet: &responsesPutWallet
   <<: *responsesErr400
-  <<: *responsesErr404
-  <<: *responsesErr405
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  <<: *responsesErr415NotJson
   200:
     description: Ok
     content:
@@ -2109,21 +2490,38 @@ x-responsesPutWallet: &responsesPutWallet
 
 x-responsesPutWalletPassphrase: &responsesPutWalletPassphrase
   <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errWithRootKeyNoRootKey
+            - <<: *errWithRootKeyWrongPassphrase
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  <<: *responsesErr415NotJson
   204:
     description: No Content
 
 x-responsesSelectCoins: &responsesSelectCoins
   <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errAlreadyWithdrawing
+            - <<: *errUTxOTooSmall
+            - <<: *errNotEnoughMoney
+            - <<: *errCannotCoverFee
+            - <<: *errInputsDepleted
+            - <<: *errTransactionIsTooBig
+            - <<: *errInvalidSelection
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  <<: *responsesErr415NotJson
   200:
     description: OK
     content:
@@ -2131,16 +2529,33 @@ x-responsesSelectCoins: &responsesSelectCoins
         schema: *ApiCoinSelection
 
 x-responsesDeleteTransaction: &responsesDeleteTransaction
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema: *errTransactionNotPending
+  404:
+    description: Not Found
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchTransaction
   <<: *responsesErr406
   204:
     description: No Content
 
 x-responsesListTransactions: &responsesListTransactions
-  <<: *responsesErr404
-  <<: *responsesErr405
+  400:
+    description: Bad Request
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errMinWithdrawalWrong
+            - <<: *errStartTimeLaterThanEndTime
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2156,8 +2571,14 @@ x-responsesListTransactions: &responsesListTransactions
           items: *ApiTransaction
 
 x-responsesGetTransaction: &responsesGetTransaction
-  <<: *responsesErr404
-  <<: *responsesErr405
+  404:
+    description: Not Found
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchTransaction
   <<: *responsesErr406
   200:
     description: OK
@@ -2166,12 +2587,37 @@ x-responsesGetTransaction: &responsesGetTransaction
         schema: *ApiTransaction
 
 x-responsesPostTransaction: &responsesPostTransaction
-  <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  400:
+    description: Bad Request
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *responsesErrBadRequest
+            - <<: *errTransactionIsTooBig
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errInvalidWalletType
+            - <<: *errAlreadyWithdrawing
+            - <<: *errUTxOTooSmall
+            - <<: *errCannotCoverFee
+            - <<: *errNotEnoughMoney
+            - <<: *errTransactionIsTooBig
+            - <<: *errWithRootKey
+            - <<: *errWithRootKeyWrongPassphrase
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  410:
+    description: Gone
+    content:
+      application/json:
+        schema:
+          <<: *responsesErrWalletNotFound
+  <<: *responsesErr415NotJson
   202:
     description: Accepted
     content:
@@ -2180,9 +2626,8 @@ x-responsesPostTransaction: &responsesPostTransaction
 
 x-responsesPostExternalTransaction: &responsesPostExternalTransaction
   <<: *responsesErr400
-  <<: *responsesErr405
   <<: *responsesErr406
-  <<: *responsesErr415
+  <<: *responsesErr415NotOctetStream
   202:
     description: Accepted
     content:
@@ -2190,12 +2635,31 @@ x-responsesPostExternalTransaction: &responsesPostExternalTransaction
         schema: *ApiTxId
 
 x-responsesPostTransactionFee: &responsesPostTransactionFee
-  <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  400:
+    description: Bad Request
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *responsesErrBadRequest
+            - <<: *errTransactionIsTooBig
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errInvalidWalletType
+            - <<: *errAlreadyWithdrawing
+            - <<: *errUTxOTooSmall
+            - <<: *errCannotCoverFee
+            - <<: *errNotEnoughMoney
+            - <<: *errInputsDepleted
+            - <<: *errInvalidSelection
+            - <<: *errTransactionIsTooBig
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  <<: *responsesErr415
+  <<: *responsesErr415NotJson
   202:
     description: Accepted
     content:
@@ -2203,9 +2667,12 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
         schema: *ApiFee
 
 x-responsesGetDelegationFee: &responsesGetDelegationFee
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema: *errCannotCoverFee
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2215,8 +2682,7 @@ x-responsesGetDelegationFee: &responsesGetDelegationFee
 
 x-responsesListAddresses: &responsesListAddresses
   <<: *responsesErr400
-  <<: *responsesErr404
-  <<: *responsesErr405
+  <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   200:
     description: Ok
@@ -2238,8 +2704,11 @@ x-responsesGetKey: &responsesGetKey
         schema: *ApiVerificationKey
 
 x-responsesListStakePools: &responsesListStakePools
-  <<: *responsesErr405
-  <<: *responsesErr404
+  400:
+    description: Bad Request
+    content:
+      application/json:
+        schema: *errQueryParamMissing
   200:
     description: Ok
     content:
@@ -2255,11 +2724,32 @@ x-responsesListStakePools: &responsesListStakePools
 
 x-responsesJoinStakePool: &responsesJoinStakePool
   <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr404
-  <<: *responsesErr405
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errCannotCoverFee
+            - <<: *errWithRootKey
+            - <<: *errWithRootKeyWrongPassphrase
+            - <<: *errAlreadyDelegating
+  404:
+    description: Not Found
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *responsesErrWalletNotFound
+            - <<: *errNoSuchPool
   <<: *responsesErr406
-  <<: *responsesErr415
+  410:
+    description: Gone
+    content:
+      application/json:
+        schema:
+          <<: *responsesErrWalletNotFound
+  <<: *responsesErr415NotJson
   202:
     description: Accepted
     content:
@@ -2267,10 +2757,34 @@ x-responsesJoinStakePool: &responsesJoinStakePool
         schema: *ApiTransaction
 
 x-responsesQuitStakePool: &responsesQuitStakePool
-  <<: *responsesJoinStakePool
+  <<: *responsesErr400
+  403:
+    description: Forbidden
+    content:
+      application/json:
+        schema:
+          oneOf:
+            - <<: *errCannotCoverFee
+            - <<: *errWithRootKey
+            - <<: *errWithRootKeyWrongPassphrase
+            - <<: *errNotDelegating
+            - <<: *errNonNullRewards
+  <<: *responsesErr404WalletNotFound
+  <<: *responsesErr406
+  410:
+    description: Gone
+    content:
+      application/json:
+        schema:
+          <<: *responsesErrWalletNotFound
+  <<: *responsesErr415NotJson
+  202:
+    description: Accepted
+    content:
+      application/json:
+        schema: *ApiTransaction
 
 x-responsesGetNetworkInformation: &responsesGetNetworkInformation
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2279,7 +2793,6 @@ x-responsesGetNetworkInformation: &responsesGetNetworkInformation
         schema: *ApiNetworkInformation
 
 x-responsesGetNetworkClock: &responsesGetNetworkClock
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2288,7 +2801,6 @@ x-responsesGetNetworkClock: &responsesGetNetworkClock
         schema: *ApiNetworkClock
 
 x-responsesGetNetworkParameters: &responsesGetNetworkParameters
-  <<: *responsesErr405
   <<: *responsesErr406
   200:
     description: Ok
@@ -2299,7 +2811,6 @@ x-responsesGetNetworkParameters: &responsesGetNetworkParameters
 x-responsesPostRandomAddress: &responsesPostRandomAddress
   <<: *responsesErr400
   <<: *responsesErr403
-  <<: *responsesErr405
   <<: *responsesErr406
   <<: *responsesErr415
   201:
@@ -2311,21 +2822,17 @@ x-responsesPostRandomAddress: &responsesPostRandomAddress
 x-responsesPutRandomAddress: &responsesPutRandomAddress
   <<: *responsesErr400
   <<: *responsesErr403
-  <<: *responsesErr405
   204:
     description: No Content
 
 x-responsesPutRandomAddresses: &responsesPutRandomAddresses
   <<: *responsesErr400
   <<: *responsesErr403
-  <<: *responsesErr405
   204:
     description: No Content
 
 x-responsesInspectAddress: &responsesInspectAddress
   <<: *responsesErr400
-  <<: *responsesErr405
-  <<: *responsesErr415
   200:
     description: Ok
     content:
@@ -2334,15 +2841,11 @@ x-responsesInspectAddress: &responsesInspectAddress
 
 x-responsesPutSettings: &responsesPutSettings
   <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr405
+  <<: *responsesErr415NotJson
   204:
     description: No Content
 
 x-responsesGetSettings: &responsesGetSettings
-  <<: *responsesErr400
-  <<: *responsesErr403
-  <<: *responsesErr405
   200:
     description: Ok
     content:
@@ -2680,6 +3183,7 @@ paths:
     get:
       operationId: getDelegationFee
       tags: ["Stake Pools"]
+
       summary: Estimate Fee
       description: |
         <p align="right">status: <strong>stable</strong></p>


### PR DESCRIPTION
# Issue Number

ADP-291

# Implementation approach

This is all best-effort. There are no static checks to ensure we didn't miss anything. There's ongoing work at servant to make this possible: https://github.com/haskell-servant/servant/issues/841
But even that would require a major refactor.

Testing all possible errors is also an option, but seems quite excessive.

The workflow for figuring out the error codes is roughly:

1. follow the entry point to the the `Handler ()` function e.g.
```hs
listTransactions
    :: forall ctx s t k n. (ctx ~ ApiLayer s t k)
    => ctx
...
    -> Handler [ApiTransaction n]
```
2. check all `liftHandler` calls, which have functions with `ExceptT` as argument, e.g.:

```hs
listTransactions
    :: forall ctx s k t.
        ( HasDBLayer s k ctx
        , HasNetworkLayer t ctx
        )
    => ctx
...
    -> ExceptT ErrListTransactions IO [TransactionInfo]
```

3. find all the LiftHandler instance, e.g.

```hs
instance LiftHandler ErrListTransactions where
    handler = \case
        ErrListTransactionsNoSuchWallet e -> handler e
        ErrListTransactionsStartTimeLaterThanEndTime e -> handler e
        ErrListTransactionsMinWithdrawalWrong ->
            apiError err400 MinWithdrawalWrong
            "The minimum withdrawal value must be at least 1 Lovelace."
        ErrListTransactionsPastHorizonException e -> handler e
```

4. follow the recursive handlers to resolve all errors and add client error types to `swagger.yaml`. The error code is the 3rd `ApiErrorCode` argument to `apiError`.
5. Some errors are implicit, e.g. failed parameter parsing etc. These are also in `ApiErrorCode`. Also see the special instance `instance LiftHandler (Request, ServerError)`
6. repeat until exhaustion

# Overview

- [x] Wallets
- [x] Addresses
- [x] Coin Selections
- [x] Transactions
- [x] Migrations
- [x] Stake Pools
- [x] Utils
- [x] Network
- [x] Proxy
- [x] Settings
- [ ] Byron-specific endpoints

# Remarks

1. I did not double check the byron endpoints. Many of their endpoints share the same types in `swagger.yaml`, so I assumed they have the same behavior wrt error codes.
2. This will generally be hard to maintain, since yaml anchors aren't enough to express the overlaps of error codes and group them sensibly. It would need something like [dhall](https://github.com/dhall-lang/dhall-lang) to do that.
3. I removed 405 errors, because the HTTP method is part of the very spec. If you follow the spec, you can't get 405.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
