### PR TITLE
Add N={20,40,80} wallet restore benchmarks

### DIFF
--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -287,6 +287,9 @@ cardanoRestoreBench tr c socketFile = do
           -- to-100% time.
           benchRestoreMultipleWallets 1 (unsafeMkPercentage 0.1)
         , benchRestoreMultipleWallets 10 (unsafeMkPercentage 0.01)
+        , benchRestoreMultipleWallets 20 (unsafeMkPercentage 0.01)
+        , benchRestoreMultipleWallets 40 (unsafeMkPercentage 0.01)
+        , benchRestoreMultipleWallets 80 (unsafeMkPercentage 0.01)
         , benchRestoreMultipleWallets 100 (unsafeMkPercentage 0.01)
 
         , benchRestoreSeqWithOwnership (Proxy @0)


### PR DESCRIPTION
# Issue Number

ADP-469

# Overview

- Add N={20,40,80} wallet restore benchmarks, to have more data points to see if it is linear or not.

# Comments

Buildkite nightly build: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/685

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
