### PR TITLE
Update the API specification to reflect the minimum number of inputs returned by `selectCoins`.

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -641,7 +641,7 @@ x-transactionChange: &transactionChange
 x-transactionResolvedInputs: &transactionResolvedInputs
   description: A list of transaction inputs
   type: array
-  minItems: 0
+  minItems: 1
   items:
     type: object
     required:


### PR DESCRIPTION
# Issue

Related to #2244.

# Overview

This PR updates the API specification for the `selectCoins` operation, changing the minimum number of inputs from `0` to `1` in the returned coin selection.

This matches the existing `ApiCoinSelection` type, which specifies a `NonEmpty` list of `ApiCoinSelectionInput` values:

```hs
data ApiCoinSelection (n :: NetworkDiscriminant) = ApiCoinSelection
    { inputs :: !(NonEmpty (ApiCoinSelectionInput n))
    , outputs :: ![ApiCoinSelectionOutput n]
    , change :: ![ApiCoinSelectionChange n]
    , certificates :: Maybe (NonEmpty ApiCertificate)
    } deriving (Eq, Generic, Show)
```
