### PR TITLE
Disable the hlint `use const` warning.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -52,6 +52,7 @@
 - ignore: {name: "Monoid law, left identity"} # Using 'mempty' can be useful to vertically-align elements
 - ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
 - ignore: {name: "Redundant multi-way if"} # Using this style might be appropriate given the circumstances.
+- ignore: {name: "Use const"} # Sometimes using a lambda expression is simpler and clearer.
 
 # Add custom hints for this project
 #

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -448,10 +448,6 @@ mReadSettings
     :: ModelOp Settings
 mReadSettings = get #settings
 
--- `const` isn't more readable than lambdas. Our language is based on
--- lambda calculus and we shouldn't feel ashamed to use them. They also
--- have different strictness properties.
-{- HLINT ignore mPutSettings "Use const" -}
 mPutSettings
     :: Settings
     -> ModelOp ()

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -225,7 +225,6 @@ newStakePoolLayer nl db@DBLayer {..} worker = do
 
     -- In order to apply the settings, we have to restart the
     -- metadata sync thread as well to avoid race conditions.
-    {- HLINT ignore "Use const" -}
     _putSettings :: TVar ThreadId -> Settings -> IO ()
     _putSettings tvTid settings = do
         bracket


### PR DESCRIPTION
# Issue Number

None. Discovered while reviewing issue #2249. See [comment](https://github.com/input-output-hk/cardano-wallet/pull/2249#discussion_r509144717).

# Overview

This PR disables the hlint `use const` warning. (See related poll [here](https://input-output-rnd.slack.com/archives/GBT05825V/p1603435568043200).)