### PR TITLE
Remove outdated comments about empty output lists in transactions.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -649,9 +649,6 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , depth :: !(Maybe (Quantity "block" Natural))
     , direction :: !(ApiT Direction)
     , inputs :: ![ApiTxInput n]
-      -- TODO: Investigate whether the list of outputs should be non-empty, and
-      -- if so, whether the 'outputs' field can be encoded as a non-empty list.
-      -- See: https://jira.iohk.io/browse/ADP-400
     , outputs :: ![AddressAmount (ApiT Address, Proxy n)]
     , withdrawals :: ![ApiWithdrawal n]
     , status :: !(ApiT TxStatus)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -197,8 +197,6 @@ import Data.FileEmbed
     ( embedFile, makeRelativeToProject )
 import Data.Function
     ( (&) )
-import Data.Generics.Internal.VL.Lens
-    ( view )
 import Data.List
     ( foldl' )
 import Data.List.NonEmpty
@@ -1462,10 +1460,7 @@ instance Arbitrary ApiTxMetadata where
     shrink = genericShrink
 
 instance Arbitrary (ApiTransaction t) where
-    shrink = filter outputsNonEmpty . genericShrink
-      where
-        outputsNonEmpty :: ApiTransaction t -> Bool
-        outputsNonEmpty = (not . null) . view #outputs
+    shrink = genericShrink
     arbitrary = do
         txStatus <- arbitrary
         txInsertedAt <- case txStatus of
@@ -1497,15 +1492,8 @@ instance Arbitrary (ApiTransaction t) where
       where
         genInputs =
             Test.QuickCheck.scale (`mod` 3) arbitrary
-        -- Note that the generated list of outputs must be non-empty in order
-        -- to be consistent with the specification.
-        --
-        -- Ideally, we should encode this restriction in the type system.
-        --
-        -- See https://jira.iohk.io/browse/ADP-400.
-        genOutputs = (:)
-            <$> arbitrary
-            <*> Test.QuickCheck.scale (`mod` 3) arbitrary
+        genOutputs =
+            Test.QuickCheck.scale (`mod` 3) arbitrary
         genWithdrawals =
             Test.QuickCheck.scale (`mod` 3) arbitrary
 


### PR DESCRIPTION
# Issue Number

Cleanup after #2247, #2255, and other related PRs.

# Overview

This PR:

* removes a couple of outdated comments about disallowing empty lists of outputs in transactions. It's been established that having an empty list of outputs is perfectly reasonable in certain circumstances (such as a transaction that includes just a delegation certificate).
* updates the `Arbitrary ApiTransaction` instance to generate possibly-empty lists of outputs.