### PR TITLE
Drop `PoolMetadataFetchAttempts` in `removePoolMetadata`

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -399,8 +399,9 @@ newDBLayer trace fp timeInterpreter = do
                 (PoolMetadata hash name ticker description homepage)
             deleteWhere [ PoolFetchAttemptsMetadataHash ==. hash ]
 
-        removePoolMetadata =
+        removePoolMetadata = do
             deleteWhere ([] :: [Filter PoolMetadata])
+            deleteWhere ([] :: [Filter PoolMetadataFetchAttempts])
 
         readPoolMetadata = do
             Map.fromList . map (fromPoolMeta . entityVal)


### PR DESCRIPTION
When removing pool metadata, there's no point in keeping
the last fetch attempts. In fact, this might delay re-syncing
further.