### PR TITLE
Fix address prefixes on testnet

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -63,6 +63,7 @@ library
     , http-client
     , http-types
     , iohk-monitoring
+    , lens-aeson
     , memory
     , optparse-applicative
     , process

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -985,20 +985,20 @@ _decodeStakeAddress serverNetwork txt = do
         "Unable to decode stake-address: must be a valid bech32 string."
 
 instance EncodeAddress 'Mainnet where
-    encodeAddress = _encodeAddress
+    encodeAddress = _encodeAddress [Bech32.humanReadablePart|addr|]
 
 instance EncodeAddress ('Testnet pm) where
-    encodeAddress = _encodeAddress
+    -- https://github.com/cardano-foundation/CIPs/tree/master/CIP5
+    encodeAddress = _encodeAddress [Bech32.humanReadablePart|addr_test|]
 
-_encodeAddress :: W.Address -> Text
-_encodeAddress (W.Address bytes) =
+_encodeAddress :: Bech32.HumanReadablePart -> W.Address -> Text
+_encodeAddress hrp (W.Address bytes) =
     if isJust (CBOR.deserialiseCbor CBOR.decodeAddressPayload bytes)
         then base58
         else bech32
   where
     base58 = T.decodeUtf8 $ encodeBase58 bitcoinAlphabet bytes
     bech32 = Bech32.encodeLenient hrp (dataPartFromBytes bytes)
-    hrp = [Bech32.humanReadablePart|addr|]
 
 instance DecodeAddress 'Mainnet where
     decodeAddress = _decodeAddress SL.Mainnet

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -161,6 +161,11 @@ spec = do
                     & counterexample (show $ base58 bytes)
                 ]
 
+        prop "Shelley addresses from bech32 - testnet" $ \k ->
+            let addr@(Address raw) = paymentAddress @('Testnet 0) @ShelleyKey k
+            in decodeAddress @('Testnet 0) (bech32testnet raw) === Right addr
+                   & counterexample (show $ bech32testnet raw)
+
         prop "Byron addresses from base16, bech32 and base58" $ \k -> do
             let addr@(Address bytes) = paymentAddress @'Mainnet @ByronKey k
             conjoin
@@ -377,6 +382,12 @@ base16 = T.decodeUtf8 . convertToBase Base16
 bech32 :: ByteString -> Text
 bech32 = Bech32.encodeLenient hrp . Bech32.dataPartFromBytes
   where hrp = [humanReadablePart|addr|]
+
+-- Expected bech32 encoding for testnets
+-- https://github.com/cardano-foundation/CIPs/tree/master/CIP5
+bech32testnet :: ByteString -> Text
+bech32testnet = Bech32.encodeLenient hrp . Bech32.dataPartFromBytes
+  where hrp = [humanReadablePart|addr_test|]
 
 base58 :: ByteString -> Text
 base58 = T.decodeUtf8 . encodeBase58 bitcoinAlphabet

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -63,6 +63,7 @@
           (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
           (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."lens-aeson" or (errorHandler.buildDepError "lens-aeson"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))


### PR DESCRIPTION
### Issue Number

ADP-493

### Overview

- Comply with [CIP5](https://github.com/cardano-foundation/CIPs/tree/master/CIP5) for payment addresses.
- Tweak integration tests lensing stuff.

### QA

1. Manual tests with `cardano-wallet serve --testnet`.
2. Integration test to check that bech32 addresses are still ok on mainnet.
3. Unit test for testnet bech32 addresses.
