### PR TITLE
Record delisted pools in a dedicated table.

### DIFF
--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -219,6 +219,9 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -- ^ Mark pools as delisted, e.g. due to non-compliance.
         -- This is stored as an attribute in the pool_registration table.
 
+    , readDelistedPools
+        :: stm [PoolId]
+
     , removePools
         :: [PoolId]
         -> stm ()

--- a/lib/core/src/Cardano/Pool/DB.hs
+++ b/lib/core/src/Cardano/Pool/DB.hs
@@ -213,14 +213,15 @@ data DBLayer m = forall stm. (MonadFail stm, MonadIO stm) => DBLayer
         -> stm ()
         -- ^ Remove all entries of slot ids newer than the argument
 
-    , delistPools
+    , putDelistedPools
         :: [PoolId]
         -> stm ()
-        -- ^ Mark pools as delisted, e.g. due to non-compliance.
-        -- This is stored as an attribute in the pool_registration table.
+        -- ^ Overwrite the set of delisted pools with a completely new set.
+        -- Pools may be delisted for reasons such as non-compliance.
 
     , readDelistedPools
         :: stm [PoolId]
+        -- ^ Fetch the set of delisted pools.
 
     , removePools
         :: [PoolId]

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -26,11 +26,11 @@ import Cardano.Pool.DB.Model
     , emptyPoolDatabase
     , mCleanDatabase
     , mCleanPoolMetadata
-    , mDelistPools
     , mListHeaders
     , mListPoolLifeCycleData
     , mListRegisteredPools
     , mListRetiredPools
+    , mPutDelistedPools
     , mPutFetchAttempt
     , mPutHeader
     , mPutLastMetadataGC
@@ -150,8 +150,8 @@ newDBLayer timeInterpreter = do
         rollbackTo =
             void . alterPoolDB (const Nothing) db . mRollbackTo timeInterpreter
 
-        delistPools =
-            void . alterPoolDB (const Nothing) db . mDelistPools
+        putDelistedPools =
+            void . alterPoolDB (const Nothing) db . mPutDelistedPools
 
         readDelistedPools =
             readPoolDB db mReadDelistedPools

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -41,6 +41,7 @@ import Cardano.Pool.DB.Model
     , mPutSettings
     , mPutStakeDistribution
     , mReadCursor
+    , mReadDelistedPools
     , mReadLastMetadataGC
     , mReadPoolLifeCycleStatus
     , mReadPoolMetadata
@@ -151,6 +152,9 @@ newDBLayer timeInterpreter = do
 
         delistPools =
             void . alterPoolDB (const Nothing) db . mDelistPools
+
+        readDelistedPools =
+            readPoolDB db mReadDelistedPools
 
         removePools =
             void . alterPoolDB (const Nothing) db . mRemovePools

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -432,7 +432,7 @@ mRollbackTo ti point = do
         | otherwise = Nothing
 
 mDelistPools :: [PoolId] -> ModelOp ()
-mDelistPools = modify #delisted . Set.union . Set.fromList
+mDelistPools = modify #delisted . const . Set.fromList
 
 mReadDelistedPools :: ModelOp [PoolId]
 mReadDelistedPools = Set.toList <$> get #delisted

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -51,6 +51,7 @@ module Cardano.Pool.DB.Model
     , mPutPoolRetirement
     , mReadPoolRetirement
     , mUnfetchedPoolMetadataRefs
+    , mPutDelistedPools
     , mPutFetchAttempt
     , mPutPoolMetadata
     , mListPoolLifeCycleData
@@ -61,7 +62,6 @@ module Cardano.Pool.DB.Model
     , mRollbackTo
     , mReadCursor
     , mRemovePools
-    , mDelistPools
     , mReadDelistedPools
     , mRemoveRetiredPools
     , mReadSettings
@@ -431,8 +431,8 @@ mRollbackTo ti point = do
         | point' <= getPoint point = Just v
         | otherwise = Nothing
 
-mDelistPools :: [PoolId] -> ModelOp ()
-mDelistPools = modify #delisted . const . Set.fromList
+mPutDelistedPools :: [PoolId] -> ModelOp ()
+mPutDelistedPools = modify #delisted . const . Set.fromList
 
 mReadDelistedPools :: ModelOp [PoolId]
 mReadDelistedPools = Set.toList <$> get #delisted

--- a/lib/core/src/Cardano/Pool/DB/Model.hs
+++ b/lib/core/src/Cardano/Pool/DB/Model.hs
@@ -449,8 +449,6 @@ mRemovePools poolsToRemove = do
         $ Map.filterWithKey $ \(_, p) _ -> retain p
     modify #retirements
         $ Map.filterWithKey $ \(_, p) _ -> retain p
-    modify #delisted
-        $ Set.filter retain
   where
     retain p = p `Set.notMember` poolsToRemoveSet
     poolsToRemoveSet = Set.fromList poolsToRemove

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -491,7 +491,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ BlockSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
-        delistPools pools = do
+        putDelistedPools pools = do
             deleteWhere ([] :: [Filter PoolDelistment])
             insertMany_ $ fmap PoolDelistment pools
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -505,7 +505,6 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRegistrationPoolId ==. pool ]
             deleteWhere [ PoolRetirementPoolId ==. pool ]
             deleteWhere [ StakeDistributionPoolId ==. pool ]
-            deleteWhere [ DelistedPoolId ==. pool ]
 
         removeRetiredPools epoch =
             bracketTracer traceOuter action

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -491,8 +491,9 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ BlockSlot >. point ]
             -- TODO: remove dangling metadata no longer attached to a pool
 
-        delistPools =
-            insertMany_ . fmap PoolDelistment
+        delistPools pools = do
+            deleteWhere ([] :: [Filter PoolDelistment])
+            insertMany_ $ fmap PoolDelistment pools
 
         readDelistedPools =
             fmap (delistedPoolId . entityVal) <$> selectList [] []

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -492,10 +492,10 @@ newDBLayer trace fp timeInterpreter = do
             -- TODO: remove dangling metadata no longer attached to a pool
 
         delistPools =
-            insertMany_ . fmap DelistedPool
+            insertMany_ . fmap PoolDelistment
 
         readDelistedPools =
-            fmap (delistedPoolPoolId . entityVal) <$> selectList [] []
+            fmap (delistedPoolId . entityVal) <$> selectList [] []
 
         removePools = mapM_ $ \pool -> do
             liftIO $ traceWith trace $ MsgRemovingPool pool
@@ -504,7 +504,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere [ PoolRegistrationPoolId ==. pool ]
             deleteWhere [ PoolRetirementPoolId ==. pool ]
             deleteWhere [ StakeDistributionPoolId ==. pool ]
-            deleteWhere [ DelistedPoolPoolId ==. pool ]
+            deleteWhere [ DelistedPoolId ==. pool ]
 
         removeRetiredPools epoch =
             bracketTracer traceOuter action
@@ -570,7 +570,7 @@ newDBLayer trace fp timeInterpreter = do
             deleteWhere ([] :: [Filter PoolOwner])
             deleteWhere ([] :: [Filter PoolRegistration])
             deleteWhere ([] :: [Filter PoolRetirement])
-            deleteWhere ([] :: [Filter DelistedPool])
+            deleteWhere ([] :: [Filter PoolDelistment])
             deleteWhere ([] :: [Filter StakeDistribution])
             deleteWhere ([] :: [Filter PoolMetadata])
             deleteWhere ([] :: [Filter PoolMetadataFetchAttempts])

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -124,9 +124,9 @@ PoolRegistration sql=pool_registration
     Primary poolRegistrationPoolId poolRegistrationSlot poolRegistrationSlotInternalIndex
     deriving Show Generic
 
-DelistedPool sql=delisted_pool
-    delistedPoolPoolId                W.PoolId                      sql=pool_id
-    Primary delistedPoolPoolId
+PoolDelistment sql=pool_delistment
+    delistedPoolId                W.PoolId                      sql=pool_id
+    Primary delistedPoolId
     deriving Show Generic
 
 -- Mapping of retirement certificates to pools

--- a/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite/TH.hs
@@ -120,9 +120,13 @@ PoolRegistration sql=pool_registration
     poolRegistrationPledge            Word64                        sql=pledge
     poolRegistrationMetadataUrl       W.StakePoolMetadataUrl  Maybe sql=metadata_url
     poolRegistrationMetadataHash      W.StakePoolMetadataHash Maybe sql=metadata_hash
-    poolRegistrationFlag              W.PoolFlag                    sql=flag
 
     Primary poolRegistrationPoolId poolRegistrationSlot poolRegistrationSlotInternalIndex
+    deriving Show Generic
+
+DelistedPool sql=delisted_pool
+    delistedPoolPoolId                W.PoolId                      sql=pool_id
+    Primary delistedPoolPoolId
     deriving Show Generic
 
 -- Mapping of retirement certificates to pools

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -43,7 +43,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , FeePolicy
     , Hash (..)
-    , PoolFlag (..)
     , PoolId
     , PoolMetadataSource
     , PoolOwner (..)
@@ -679,11 +678,4 @@ instance PersistField POSIXTime where
         "Could not parse POSIX time value"
 
 instance PersistFieldSql POSIXTime where
-    sqlType _ = sqlType (Proxy @Text)
-
-instance PersistField PoolFlag where
-    toPersistValue = toPersistValue . toText
-    fromPersistValue = fromPersistValueFromText
-
-instance PersistFieldSql PoolFlag where
     sqlType _ = sqlType (Proxy @Text)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -192,8 +192,6 @@ module Cardano.Wallet.Primitive.Types
     , InternalState (..)
     , defaultInternalState
 
-    -- * other
-    , PoolFlag (..)
     ) where
 
 import Prelude
@@ -1792,7 +1790,6 @@ data PoolRegistrationCertificate = PoolRegistrationCertificate
     , poolCost :: Quantity "lovelace" Word64
     , poolPledge :: Quantity "lovelace" Word64
     , poolMetadata :: Maybe (StakePoolMetadataUrl, StakePoolMetadataHash)
-    , poolFlag :: PoolFlag
     } deriving (Generic, Show, Eq, Ord)
 
 instance NFData PoolRegistrationCertificate
@@ -2042,14 +2039,3 @@ instance FromJSON PoolMetadataSource where
 
 instance ToJSON PoolMetadataSource where
     toJSON = toJSON . toText
-
-data PoolFlag = NoPoolFlag | Delisted
-    deriving (Generic, Bounded, Enum, Show, Eq, Ord)
-
-instance NFData PoolFlag
-
-instance ToText PoolFlag where
-    toText = toTextFromBoundedEnum KebabLowerCase
-
-instance FromText PoolFlag where
-    fromText = fromTextToBoundedEnum KebabLowerCase

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -28,7 +28,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , Hash (..)
     , PoolCertificate (..)
-    , PoolFlag (..)
     , PoolId (..)
     , PoolMetadataSource (..)
     , PoolMetadataSource (..)
@@ -165,10 +164,6 @@ instance Arbitrary PoolOwner where
         byte <- elements ['0'..'8']
         return $ PoolOwner $ B8.pack (replicate 32 byte)
 
-instance Arbitrary PoolFlag where
-    arbitrary = arbitraryBoundedEnum
-    shrink = const []
-
 instance Arbitrary PoolRegistrationCertificate where
     shrink regCert = do
         shrunkPoolId <- shrink $ view #poolId regCert
@@ -188,7 +183,6 @@ instance Arbitrary PoolRegistrationCertificate where
         <*> fmap Quantity arbitrary
         <*> fmap Quantity arbitrary
         <*> oneof [pure Nothing, Just <$> genMetadata]
-        <*> pure NoPoolFlag
       where
         genMetadata = (,)
             <$> fmap StakePoolMetadataUrl genURL

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -104,7 +104,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , Hash (..)
-    , PoolFlag (..)
     , PoolId (PoolId)
     , PoolOwner (..)
     , SealedTx (..)
@@ -1092,7 +1091,7 @@ poolRegistrationsFromBlock (Block _hdr fragments) = do
     let dummyPledge = Quantity 0
     let metadata = Nothing
     pure $ W.PoolRegistrationCertificate
-        poolId owners margin cost dummyPledge metadata NoPoolFlag
+        poolId owners margin cost dummyPledge metadata
 
 -- | If all incentives parameters are present in the blocks, returns a function
 -- that computes reward based on a given epoch.

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -56,7 +56,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , GenesisParameters (..)
     , Hash (..)
-    , PoolFlag (..)
     , PoolId (..)
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
@@ -428,8 +427,8 @@ instance Arbitrary PoolOwner where
     arbitrary = PoolOwner . B8.singleton <$> elements ['a'..'e']
 
 instance Arbitrary PoolRegistrationCertificate where
-    shrink (PoolRegistrationCertificate p o m c pl md fl) =
-        (\(p', NonEmpty o') -> PoolRegistrationCertificate p' o' m c pl md fl)
+    shrink (PoolRegistrationCertificate p o m c pl md) =
+        (\(p', NonEmpty o') -> PoolRegistrationCertificate p' o' m c pl md)
         <$> shrink (p, NonEmpty o)
     arbitrary = PoolRegistrationCertificate
         <$> arbitrary
@@ -438,7 +437,6 @@ instance Arbitrary PoolRegistrationCertificate where
         <*> fmap Quantity arbitrary
         <*> pure (Quantity 0)
         <*> pure Nothing
-        <*> pure NoPoolFlag
 
 instance Arbitrary RegistrationsTest where
     shrink (RegistrationsTest xs) = RegistrationsTest <$> shrink xs

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -759,7 +759,6 @@ fromShelleyRegistrationCert = \case
             , W.poolCost = lovelaceFromCoin (SL._poolCost pp)
             , W.poolPledge = lovelaceFromCoin (SL._poolPledge pp)
             , W.poolMetadata = fromPoolMetaData <$> strictMaybeToMaybe (SL._poolMD pp)
-            , W.poolFlag = W.NoPoolFlag
             }
         )
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -836,7 +836,7 @@ gcDelistedPools gcStatus tr DBLayer{..} fetchDelisted = forever $ do
         STM.atomically $ writeTVar gcStatus (HasRun currentTime)
         atomically $ do
             putLastMetadataGC currentTime
-            delistPools delistedPools
+            putDelistedPools delistedPools
 
     -- Sleep for 60 seconds. This is useful in case
     -- something else is modifying the last sync time

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , GenesisParameters (..)
     , PoolCertificate (..)
-    , PoolFlag (..)
     , PoolId
     , PoolLifeCycleStatus (..)
     , PoolMetadataGCStatus (..)
@@ -385,6 +384,7 @@ data PoolDbData = PoolDbData
     , retirementCert :: Maybe PoolRetirementCertificate
     , nProducedBlocks :: Quantity "block" Word64
     , metadata :: Maybe StakePoolMetadata
+    , delisted :: Bool
     }
 
 -- | Top level combine-function that merges DB and LSQ data.
@@ -460,7 +460,7 @@ combineDbAndLsqData ti nOpt lsqData =
             , Api.margin =
                 Quantity $ poolMargin $ registrationCert dbData
             , Api.retirement = retirementEpochInfo
-            , Api.delisted = poolFlag (registrationCert dbData) == Delisted
+            , Api.delisted = delisted dbData
             }
 
     toApiEpochInfo ep = do
@@ -512,8 +512,9 @@ combineChainData
     -> Map PoolId PoolRetirementCertificate
     -> Map PoolId (Quantity "block" Word64)
     -> Map StakePoolMetadataHash StakePoolMetadata
+    -> Set PoolId
     -> Map PoolId PoolDbData
-combineChainData registrationMap retirementMap prodMap metaMap =
+combineChainData registrationMap retirementMap prodMap metaMap delistedSet =
     Map.map mkPoolDbData $
         Map.merge
             registeredNoProductions
@@ -534,12 +535,13 @@ combineChainData registrationMap retirementMap prodMap metaMap =
         :: (PoolRegistrationCertificate, Quantity "block" Word64)
         -> PoolDbData
     mkPoolDbData (registrationCert, n) =
-        PoolDbData registrationCert mRetirementCert n meta
+        PoolDbData registrationCert mRetirementCert n meta delisted
       where
         metaHash = snd <$> poolMetadata registrationCert
         meta = flip Map.lookup metaMap =<< metaHash
         mRetirementCert =
             Map.lookup (view #poolId registrationCert) retirementMap
+        delisted = view #poolId registrationCert `Set.member` delistedSet
 
 readPoolDbData :: DBLayer IO -> EpochNo -> IO (Map PoolId PoolDbData)
 readPoolDbData DBLayer {..} currentEpoch = atomically $ do
@@ -559,6 +561,7 @@ readPoolDbData DBLayer {..} currentEpoch = atomically $ do
         retirementCertificates
         <$> readTotalProduction
         <*> readPoolMetadata
+        <*> (Set.fromList <$> readDelistedPools)
 
 --
 -- Monitoring stake pool


### PR DESCRIPTION
# Issue Number

#2249 

# Overview

This PR records delisted pools in a dedicated table instead of using a field in the `pool_registrations` table.

In the updated schema, a pool is delisted if (and only if) there is a single row containing that pool's id in the `delisted_pools` table.

This solution has several advantages:

1.  We only need a single database row to record that a pool is delisted.

2.  We no longer need to carefully to ensure that all registration records for a particular pool have the same delisted status. A pool is either _delisted_ or _not delisted_: the schema rules out all intermediate states.

3.  Pools automatically remain delisted when rollbacks occur or when new certificates are published, with no special effort.

4.  The `putPoolRegistration` function no longer needs to read the  most-recently-written registration entry before adding a new entry.

5.  Each row in the `pool_registrations` table is now just an immutable record of a registration certificate.