### PR TITLE
Increase bors timeout from 2h to 4h

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,6 @@ status = [
   "buildkite/cardano-wallet",
   "ci/hydra-build:required",
 ]
-timeout_sec = 7200
+timeout_sec = 14400
 required_approvals = 1
 delete_merged_branches = false


### PR DESCRIPTION
# Issue Number

#2279 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Increase bors timeout from 2h to 3h


# Comments

It seems hydra is often slow to schedule/run the jobs, causing ≈18% of bors r+ to fail.

It should be better to increase the timeout to 3h, than to have it fail.

This doesn't affect the timeout of buildkite or hydra themselves.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
