### PR TITLE
Revise API error codes

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -73,7 +73,7 @@ module Test.Integration.Framework.TestData
     , errMsg403NotAShelleyWallet
     , errMsg403InputsDepleted
     , errMsg404MinUTxOValue
-    , errMsg400TxTooLarge
+    , errMsg403TxTooLarge
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     ) where
@@ -311,8 +311,8 @@ errMsg400TxMetadataStringTooLong :: String
 errMsg400TxMetadataStringTooLong =
     "Text string metadata value must consist of at most 64 UTF8 bytes"
 
-errMsg400TxTooLarge :: String
-errMsg400TxTooLarge =
+errMsg403TxTooLarge :: String
+errMsg403TxTooLarge =
     "I am afraid that the transaction you're trying to submit is too large!"
 
 errMsg400ParseError :: String

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -148,13 +148,13 @@ import Test.Integration.Framework.TestData
     ( errMsg400MinWithdrawalWrong
     , errMsg400StartTimeLaterThanEndTime
     , errMsg400TxMetadataStringTooLong
-    , errMsg400TxTooLarge
     , errMsg403Fee
     , errMsg403InputsDepleted
     , errMsg403NoPendingAnymore
     , errMsg403NotAShelleyWallet
     , errMsg403NotEnoughMoney
     , errMsg403NotEnoughMoney_
+    , errMsg403TxTooLarge
     , errMsg403WithdrawalNotWorth
     , errMsg403WrongPass
     , errMsg404CannotFindTx
@@ -842,8 +842,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         r <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley wa) Default payload
 
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxTooLarge r
+        expectResponseCode HTTP.status403 r
+        expectErrorMessage errMsg403TxTooLarge r
 
     it "TRANSMETA_ESTIMATE_01 - fee estimation includes metadata" $ \ctx -> runResourceT $ do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
@@ -905,8 +905,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         r <- request @ApiFee ctx
             (Link.getTransactionFee @'Shelley wa) Default payload
 
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400TxTooLarge r
+        expectResponseCode HTTP.status403 r
+        expectErrorMessage errMsg403TxTooLarge r
 
     it "TRANS_EXTERNAL_01 - Single Output Transaction - Shelley witnesses" $ \ctx -> runResourceT $ do
         wFaucet <- fixtureWallet ctx

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -432,7 +432,6 @@ import Servant
     , err403
     , err404
     , err409
-    , err410
     , err500
     , err503
     , serve
@@ -2431,7 +2430,7 @@ instance Buildable e => LiftHandler (ErrSelectForPayment e) where
                 , "transaction, then cancel the previous one first."
                 ]
         ErrSelectForPaymentTxTooLarge maxSize maxN  ->
-            apiError err400 TransactionIsTooBig $ mconcat
+            apiError err403 TransactionIsTooBig $ mconcat
                 [ "I am afraid that the transaction you're trying to submit is "
                 , "too large! The network allows transactions only as large as "
                 , pretty maxSize, "s! As it stands, the current transaction only "
@@ -2460,8 +2459,8 @@ instance LiftHandler ErrSignPayment where
     handler = \case
         ErrSignPaymentMkTx e -> handler e
         ErrSignPaymentNoSuchWallet e -> (handler e)
-            { errHTTPCode = 410
-            , errReasonPhrase = errReasonPhrase err410
+            { errHTTPCode = 404
+            , errReasonPhrase = errReasonPhrase err404
             }
         ErrSignPaymentWithRootKey e@ErrWithRootKeyNoRootKey{} -> (handler e)
             { errHTTPCode = 403
@@ -2550,8 +2549,8 @@ instance LiftHandler ErrSubmitTx where
     handler = \case
         ErrSubmitTxNetwork e -> handler e
         ErrSubmitTxNoSuchWallet e@ErrNoSuchWallet{} -> (handler e)
-            { errHTTPCode = 410
-            , errReasonPhrase = errReasonPhrase err410
+            { errHTTPCode = 404
+            , errReasonPhrase = errReasonPhrase err404
             }
 
 instance LiftHandler ErrNetworkUnavailable where
@@ -2634,8 +2633,8 @@ instance LiftHandler ErrSignDelegation where
     handler = \case
         ErrSignDelegationMkTx e -> handler e
         ErrSignDelegationNoSuchWallet e -> (handler e)
-            { errHTTPCode = 410
-            , errReasonPhrase = errReasonPhrase err410
+            { errHTTPCode = 404
+            , errReasonPhrase = errReasonPhrase err404
             }
         ErrSignDelegationWithRootKey e@ErrWithRootKeyNoRootKey{} -> (handler e)
             { errHTTPCode = 403

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2603,12 +2603,6 @@ x-responsesMigrateWallet: &responsesMigrateWallet
             - <<: *errWrongEncryptionPassphrase
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  410:
-    description: Gone
-    content:
-      application/json:
-        schema:
-          <<: *errNoSuchWallet
   <<: *responsesErr415UnsupportedMediaType
   200:
     description: Ok
@@ -2750,7 +2744,6 @@ x-responsesPostTransaction: &responsesPostTransaction
         schema:
           oneOf:
             - <<: *errBadRequest
-            - <<: *errTransactionIsTooBig
   403:
     description: Forbidden
     content:
@@ -2767,12 +2760,6 @@ x-responsesPostTransaction: &responsesPostTransaction
             - <<: *errWrongEncryptionPassphrase
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  410:
-    description: Gone
-    content:
-      application/json:
-        schema:
-          <<: *errNoSuchWallet
   <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
@@ -2798,7 +2785,6 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
         schema:
           oneOf:
             - <<: *errBadRequest
-            - <<: *errTransactionIsTooBig
   403:
     description: Forbidden
     content:
@@ -2898,12 +2884,6 @@ x-responsesJoinStakePool: &responsesJoinStakePool
             - <<: *errNoSuchWallet
             - <<: *errNoSuchPool
   <<: *responsesErr406
-  410:
-    description: Gone
-    content:
-      application/json:
-        schema:
-          <<: *errNoSuchWallet
   <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted
@@ -2926,12 +2906,6 @@ x-responsesQuitStakePool: &responsesQuitStakePool
             - <<: *errNonNullRewards
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  410:
-    description: Gone
-    content:
-      application/json:
-        schema:
-          <<: *errNoSuchWallet
   <<: *responsesErr415UnsupportedMediaType
   202:
     description: Accepted


### PR DESCRIPTION
# Issue Number

ADP-291


# Overview

- f533091070c2ccc7945ffff2143f3b6c4f06599c
  Revise error codes:  - 404 when wallet not found  - 403 when transaction is too big
  
- 430a31f88b5fa4d3632f4e5a53e4afa9a69bae32
  Update swagger
  
- e90b26430eaf90532966a92504af89f338fa89fc
  Update integration tests



# Comments

Whie reviewing https://github.com/input-output-hk/cardano-wallet/pull/2258 I noticed that some error codes are a bit inconsistent, e.g.:
 - 410 or 404 is returned when the wallet is not found.
 - 400 or 403 - when transaction is too big.
 
 This pr is about to revise it and:
 - return 404 on wallet not found (removing 410 altogether)
 - return 403 on transaction too big
