### PR TITLE
Enable parallel integration tests in hydra

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -974,7 +974,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 Right pools@[pool1,_pool2,pool3] <-
                     snd <$> listPools ctx arbitraryStake
                 let rewards = view (#metrics . #nonMyopicMemberRewards)
-                print (rewards <$> pools) -- FIXME temporary
                 (rewards <$> pools) `shouldBe`
                     (rewards <$> sortOn (Down . rewards) pools)
                 -- Make sure the rewards are not all equal:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -901,12 +901,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 | i <- [0..127] ]
             bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
         let payload = addTxMetadata txMeta basePayload
-        liftIO $ print payload
         r <- request @ApiFee ctx
             (Link.getTransactionFee @'Shelley wa) Default payload
 
-        expectResponseCode HTTP.status403 r
-        expectErrorMessage errMsg403TxTooLarge r
+        verify r
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403TxTooLarge
+            ]
 
     it "TRANS_EXTERNAL_01 - Single Output Transaction - Shelley witnesses" $ \ctx -> runResourceT $ do
         wFaucet <- fixtureWallet ctx
@@ -2318,7 +2319,6 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         eventually "rewards are transferred from self to self" $ do
             rW <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default payload
-            print rW
             verify rW
                 [ expectField (#balance . #getApiT . #available)
                     (.> (wSrc ^. #balance . #getApiT . #available))

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Server.hs
@@ -50,6 +50,7 @@ import Test.Integration.Framework.DSL
     ( Context (..)
     , KnownCommand (..)
     , cardanoWalletCLI
+    , counterexample
     , expectPathEventuallyExist
     , proc'
     )
@@ -168,8 +169,8 @@ spec = do
                     threadDelay (10 * oneSecond)
                 hClose hLogs
                 logged <- T.unpack <$> TIO.readFile logs
-                putStrLn logged
-                logged `shouldContain` "Logging shutdown"
+                counterexample logged $
+                    logged `shouldContain` "Logging shutdown"
 
         describe "LOGGING - Exits nicely on wrong genesis hash" $  do
             let hashes =

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -95,10 +95,7 @@ let
 
           # Force more integration tests to run in parallel than the
           # default number of build cores.
-          #
-          # TODO: Figure out why this doesn't work in hydra when it works in buildkite,
-          # and enable.
-          # integration.testFlags = ["-j" "3"];
+          integration.testFlags = ["-j" "8"];
 
           integration.preCheck = ''
             # Variables picked up by integration tests


### PR DESCRIPTION
# Issue Number

ADP-466

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Pass in `-j 8` 
- [x] Only run CLI tests in parallel if `CI` env var isn't set
- [x] Clean up some debug printing in tests

# Comments


<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
