### PR TITLE
Fix wrong setup/expectation in TRANS_CREATE_03

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -432,10 +432,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             verify rd
                 [ expectField
                         (#balance . #getApiT . #available)
-                        (`shouldBe` Quantity amt)
+                        (`shouldBe` Quantity (2*amt))
                 , expectField
                         (#balance . #getApiT . #total)
-                        (`shouldBe` Quantity amt)
+                        (`shouldBe` Quantity (2*amt))
                 ]
 
         ra2 <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty


### PR DESCRIPTION
# Issue Number

#2298 
<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Make `wDest` start empty, instead of with `amt` balance, such that the expectation makes sense.
- [x] <s>Haven't run this yet though</s>. Fixed.


# Comments

```
It used to create a wDest wallet with amt balance, sent another amt to
it, and expect the balance to be amt. Somewhat astounding that this
didn't fail more often.

src/Test/Integration/Scenario/API/Shelley/Transactions.hs:435:26:
      1) API Specifications, SHELLEY_TRANSACTIONS, TRANS_CREATE_03 - 0 balance after transaction
           While verifying (Status {statusCode = 200, statusMessage = "OK"},Right (ApiWallet {id = ApiT {getApiT = WalletId {getWalletId = 278f9ebf2dcf1cb23e1af27281daed107333fd16}}, addressPoolGap = ApiT {getApiT = AddressPoolGap {getAddressPoolGap = 20}}, balance = ApiT {getApiT = WalletBalance {available = Quantity {getQuantity = 2000000}, total = Quantity {getQuantity = 2000000}, reward = Quantity {getQuantity = 0}}}, delegation = ApiWalletDelegation {active = ApiWalletDelegationNext {status = NotDelegating, target = Nothing, changesAt = Nothing}, next = []}, name = ApiT {getApiT = WalletName {getWalletName = "Empty Wallet"}}, passphrase = Just (ApiWalletPassphraseInfo {lastUpdatedAt = 2020-11-04 18:51:44.994771905 UTC}), state = ApiT {getApiT = Ready}, tip = ApiBlockReference {absoluteSlotNumber = ApiT {getApiT = SlotNo 2113}, slotId = ApiSlotId {epochNumber = ApiT {getApiT = EpochNo {unEpochNo = 11}}, slotNumber = ApiT {getApiT = SlotInEpoch {unSlotInEpoch = 33}}}, time = 2020-11-04 18:53:51.6 UTC, block = ApiBlockInfo {height = Quantity {getQuantity = 946}}}}))
           Waited longer than 90s to resolve action: "Wallet balance is as expected".
           expected: Quantity {getQuantity = 1000000}
            but got: Quantity {getQuantity = 2000000}
      To rerun use: --match "/API Specifications/SHELLEY_TRANSACTIONS/TRANS_CREATE_03 - 0 balance after transaction/"

Two possible fixes:
1. Make the wDest start with 0 balance
2. Expect wDest to have 2*amt

1 makes more sense in a way, but we actually rely on wDest having amt
balance to predict the fees, /before/ creating wSrc. So 2 is easer in
this case.
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
