### PR TITLE
Move `Hash` type and related functions into separate module.

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -170,12 +170,13 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( AddressState
     , Coin (..)
-    , Hash
     , PoolMetadataSource (..)
     , SortOrder
     , WalletId
     , WalletName
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Version
     ( gitRevision, showFullVersion, version )
 import Control.Applicative

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -239,7 +239,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , EpochLength (..)
     , EpochNo
-    , Hash (..)
     , HistogramBar (..)
     , PoolId (..)
     , SlotLength (..)
@@ -254,6 +253,8 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( second )
 import Control.Concurrent

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -41,13 +41,14 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
     ( Direction (..)
-    , Hash (..)
     , SortOrder (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
     , TxStatus (..)
     , WalletId
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -160,6 +160,7 @@ library
       Cardano.Wallet.Primitive.Fee
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
+      Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Registry
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -307,6 +307,7 @@ test-suite unit
       Cardano.Wallet.Primitive.SlottingSpec
       Cardano.Wallet.Primitive.SyncProgressSpec
       Cardano.Wallet.Primitive.TypesSpec
+      Cardano.Wallet.Primitive.Types.HashSpec
       Cardano.Wallet.RegistrySpec
       Cardano.Wallet.TransactionSpec
       Cardano.WalletSpec

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -56,13 +56,9 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , ProtocolMagic (..)
-    , TxIn (..)
-    , TxOut (..)
-    )
+    ( Address (..), Coin (..), ProtocolMagic (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Monad
     ( replicateM, when )
 import Control.Monad.Fail

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -309,7 +309,6 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , FeePolicy (LinearFee)
     , GenesisParameters (..)
-    , Hash (..)
     , IsDelegatingTo (..)
     , NetworkParameters (..)
     , PassphraseScheme (..)
@@ -346,6 +345,8 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     , withdrawals
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -109,7 +109,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle, DerivationIndex, NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Coin (..), Hash, PoolId, SortOrder, WalletId (..) )
+    ( AddressState, Coin (..), PoolId, SortOrder, WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -297,7 +297,6 @@ import Cardano.Wallet.Primitive.Types
     , Block
     , BlockHeader (..)
     , Coin (..)
-    , Hash (..)
     , NetworkParameters (..)
     , PassphraseScheme (..)
     , PoolId
@@ -316,6 +315,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
     , MkWorker (..)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -193,7 +193,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , GenesisParameters (..)
-    , Hash (..)
     , HistogramBar (..)
     , NetworkParameters (..)
     , PoolId (..)
@@ -217,6 +216,8 @@ import Cardano.Wallet.Primitive.Types
     , txMetadataIsNull
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Codec.Binary.Bech32

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -43,7 +43,6 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader
     , DelegationCertificate
-    , Hash
     , ProtocolParameters
     , Range (..)
     , SlotNo (..)
@@ -55,6 +54,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletId
     , WalletMetadata
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
 import Control.Monad.Fail
     ( MonadFail )
 import Control.Monad.IO.Class

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -60,7 +60,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter )
 import Cardano.Wallet.Primitive.Types
-    ( Hash, SortOrder (..), TransactionInfo (..), WalletId, wholeRange )
+    ( SortOrder (..), TransactionInfo (..), WalletId, wholeRange )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, withMVar )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -76,7 +76,6 @@ import Cardano.Wallet.Primitive.Types
     , DelegationCertificate (..)
     , Direction (..)
     , EpochNo (..)
-    , Hash
     , PoolId
     , ProtocolParameters (..)
     , Range (..)
@@ -95,6 +94,8 @@ import Cardano.Wallet.Primitive.Types
     , dlgCertPoolId
     , isWithinRange
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Monad
     ( when )
 import Data.Bifunctor

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -203,6 +203,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -43,7 +43,6 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochNo (..)
     , FeePolicy
-    , Hash (..)
     , PoolId
     , PoolMetadataSource (..)
     , PoolOwner (..)
@@ -59,6 +58,8 @@ import Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     , unsafeToPMS
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -50,12 +50,13 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Hash (..)
     , ProtocolParameters
     , SealedTx
     , SlotNo (..)
     , SlottingParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async

--- a/lib/core/src/Cardano/Wallet/Network/BlockHeaders.hs
+++ b/lib/core/src/Cardano/Wallet/Network/BlockHeaders.hs
@@ -42,7 +42,9 @@ module Cardano.Wallet.Network.BlockHeaders
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), Hash (..), SlotNo (..) )
+    ( BlockHeader (..), SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData, ($!!) )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -89,7 +89,9 @@ import Cardano.Address.Derivation
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ChimericAccount (..), Hash (..), PassphraseScheme (..) )
+    ( Address (..), ChimericAccount (..), PassphraseScheme (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -77,7 +77,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hex
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), ProtocolMagic (..), invariant, testnetMagic )
+    ( Address (..), ProtocolMagic (..), invariant, testnetMagic )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -71,7 +71,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, coinTypeAda, purposeBIP44 )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), invariant, testnetMagic )
+    ( Address (..), invariant, testnetMagic )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
@@ -92,7 +92,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , rewardAccountKey
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), invariant )
+    ( Address (..), invariant )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -87,7 +87,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , rewardAccountKey
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Hash (..), invariant )
+    ( Address (..), invariant )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Types and functions relating to hash values.
+--
+module Cardano.Wallet.Primitive.Types.Hash where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.ByteArray
+    ( ByteArrayAccess )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( FromText (..), TextDecodingError (..), ToText (..) )
+import Fmt
+    ( Buildable (..), prefixF )
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( KnownSymbol, Symbol, symbolVal )
+
+import qualified Data.ByteString as BS
+import qualified Data.Char as C
+import qualified Data.Text.Encoding as T
+
+newtype Hash (tag :: Symbol) = Hash { getHash :: ByteString }
+    deriving stock (Show, Generic, Eq, Ord)
+    deriving newtype (ByteArrayAccess)
+
+instance NFData (Hash tag)
+
+instance Buildable (Hash tag) where
+    build h = mempty
+        <> prefixF 8 builder
+      where
+        builder = build . toText $ h
+
+instance ToText (Hash tag) where
+    toText = T.decodeUtf8 . convertToBase Base16 . getHash
+
+instance FromText (Hash "Tx")              where fromText = hashFromText 32
+instance FromText (Hash "Account")         where fromText = hashFromText 32
+instance FromText (Hash "Genesis")         where fromText = hashFromText 32
+instance FromText (Hash "Block")           where fromText = hashFromText 32
+instance FromText (Hash "BlockHeader")     where fromText = hashFromText 32
+instance FromText (Hash "ChimericAccount") where fromText = hashFromText 28
+
+hashFromText
+    :: forall t. (KnownSymbol t)
+    => Int
+        -- ^ Expected decoded hash length
+    -> Text
+    -> Either TextDecodingError (Hash t)
+hashFromText len text = case decoded of
+    Right bytes | BS.length bytes == len ->
+        Right $ Hash bytes
+    _ ->
+        Left $ TextDecodingError $ unwords
+            [ "Invalid"
+            , mapFirst C.toLower $ symbolVal $ Proxy @t
+            , "hash: expecting a hex-encoded value that is"
+            , show len
+            , "bytes in length."
+            ]
+  where
+    decoded = convertFromBase Base16 $ T.encodeUtf8 text
+
+    mapFirst :: (a -> a) -> [a] -> [a]
+    mapFirst _     [] = []
+    mapFirst fn (h:q) = fn h:q

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -107,7 +107,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochLength (..)
-    , Hash (..)
     , Range (..)
     , SlotLength (..)
     , SlotNo (..)
@@ -127,6 +126,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeRunExceptT )
 import Control.DeepSeq

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -29,7 +29,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , FeePolicy (..)
     , GenesisParameters (..)
-    , Hash (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
     , SlotLength (..)
@@ -42,6 +41,8 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Crypto.Hash
     ( Blake2b_256, hash )
 import Data.ByteString

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -31,7 +31,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), Hash (..), TxIn (..), TxOut (..) )
+    ( Address (..), Coin (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeDeserialiseCbor, unsafeFromHex )
 import Data.ByteString

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -26,7 +26,6 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , CertificatePublicationTime (..)
     , EpochNo (..)
-    , Hash (..)
     , PoolCertificate (..)
     , PoolId (..)
     , PoolMetadataSource (..)
@@ -46,6 +45,8 @@ import Cardano.Wallet.Primitive.Types
     , getPoolCertificatePoolId
     , setPoolCertificatePoolId
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( second )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -25,7 +25,9 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.SyncProgress
     ( mkSyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), BlockHeader (..), Hash (..), SlotNo (..), StartTime (..) )
+    ( Block (..), BlockHeader (..), SlotNo (..), StartTime (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -153,7 +153,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochNo (..)
-    , Hash (..)
     , HistogramBar (..)
     , PoolId (..)
     , PoolMetadataSource
@@ -183,6 +182,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMaxLength
     , walletNameMinLength
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -90,7 +90,6 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , EpochNo (..)
     , FeePolicy (..)
-    , Hash (..)
     , PassphraseScheme (..)
     , PoolId (..)
     , ProtocolParameters (..)
@@ -117,6 +116,8 @@ import Cardano.Wallet.Primitive.Types
     , rangeIsValid
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeMkPercentage )
 import Control.Arrow

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -51,7 +51,6 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , Direction (..)
-    , Hash (..)
     , ProtocolParameters
     , ShowFmt (..)
     , SlotId (..)
@@ -67,6 +66,8 @@ import Cardano.Wallet.Primitive.Types
     , toTxHistory
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent.Async

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -126,7 +126,6 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , Coin (..)
     , Direction (..)
-    , Hash (..)
     , PassphraseScheme (..)
     , ProtocolParameters
     , Range
@@ -146,6 +145,8 @@ import Cardano.Wallet.Primitive.Types
     , toTxHistory
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -120,8 +120,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochNo (..)
     , FeePolicy
     , GenesisParameters
-    , Hash (..)
-    , Hash (..)
     , PoolId (..)
     , ProtocolParameters (..)
     , Range (..)
@@ -141,6 +139,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , inputs
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Foldl
     ( Fold (..) )
 import Control.Monad.IO.Class

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -38,10 +38,11 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
     , BlockHeader (..)
-    , Hash (..)
     , ProtocolMagic (..)
     , SlotNo (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkEntropy, unsafeMkPercentage )
 import Data.Aeson

--- a/lib/core/test/unit/Cardano/Wallet/Network/BlockHeadersSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Network/BlockHeadersSpec.hs
@@ -20,7 +20,9 @@ import Cardano.Wallet.Network.BlockHeaders
     , updateUnstableBlocks
     )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..), Hash (..), SlotNo (..) )
+    ( BlockHeader (..), SlotNo (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Monad.Trans.Class
     ( lift )
 import Control.Monad.Trans.Writer

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -10,7 +10,7 @@ import Cardano.Wallet.Network
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Test.Hspec
     ( Spec, describe, it )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -44,7 +44,9 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), PassphraseScheme (..) )
+    ( PassphraseScheme (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -19,14 +19,9 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , TxIn (..)
-    , TxOut (..)
-    , UTxO (..)
-    , balance
-    )
+    ( Address (..), Coin (..), TxIn (..), TxOut (..), UTxO (..), balance )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Data.ByteString
     ( ByteString )
 import Data.Function

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -32,13 +32,14 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , Hash (..)
     , ShowFmt (..)
     , TxIn (..)
     , TxOut (..)
     , UTxO (..)
     , UnsignedTx (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Data.List.NonEmpty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -32,14 +32,9 @@ import Cardano.Wallet.Primitive.Fee
     , rebalanceSelection
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Coin (..)
-    , Hash (..)
-    , ShowFmt (..)
-    , TxIn (..)
-    , TxOut (..)
-    , UTxO (..)
-    )
+    ( Address (..), Coin (..), ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( first )
 import Control.Monad.IO.Class

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -45,7 +45,6 @@ import Cardano.Wallet.Primitive.Types
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
-    , Hash (..)
     , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
@@ -61,6 +60,8 @@ import Cardano.Wallet.Primitive.Types
     , txId
     , txIns
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -32,13 +32,14 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient
     , EpochLength (..)
     , EpochNo (..)
-    , Hash (..)
     , Range (..)
     , SlotId (..)
     , SlotLength (..)
     , SlottingParameters (..)
     , StartTime (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Data.Functor.Identity
     ( runIdentity )
 import Data.Quantity

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -24,13 +24,13 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , EpochLength (..)
-    , Hash (..)
     , SlotLength (..)
-    , SlotNo (..)
     , SlotNo (..)
     , SlottingParameters (..)
     , StartTime (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
 import Control.DeepSeq

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/HashSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/HashSpec.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.Types.HashSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text.Class
+    ( TextDecodingError (..), fromText )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..), elements, vector, (===) )
+import Test.Text.Roundtrip
+    ( textRoundtrip )
+
+import qualified Data.ByteString as BS
+
+spec :: Spec
+spec = do
+    describe "Can perform roundtrip textual encoding & decoding" $ do
+        textRoundtrip $ Proxy @(Hash "Account")
+        textRoundtrip $ Proxy @(Hash "Block")
+        textRoundtrip $ Proxy @(Hash "BlockHeader")
+        textRoundtrip $ Proxy @(Hash "ChimericAccount")
+        textRoundtrip $ Proxy @(Hash "Genesis")
+        textRoundtrip $ Proxy @(Hash "Tx")
+
+    describe "Negative cases for types decoding" $ do
+        it "fail fromText (@Hash \"Tx\")" $ do
+            let err =
+                    "Invalid tx hash: \
+                    \expecting a hex-encoded value that is 32 bytes in length."
+            fromText @(Hash "Tx") "----" ===
+                Left (TextDecodingError err)
+        it "fail fromText (@Hash \"Genesis\")" $ do
+            let err = "Invalid genesis hash: \
+                    \expecting a hex-encoded value that is 32 bytes in length."
+            fromText @(Hash "Genesis") "----" ===
+                Left (TextDecodingError err)
+        it "fail fromText (@Hash \"Block\")" $ do
+            let err = "Invalid block hash: \
+                    \expecting a hex-encoded value that is 32 bytes in length."
+            fromText @(Hash "Block") "----" ===
+                Left (TextDecodingError err)
+        it "fail fromText (@Hash \"BlockHeader\")" $ do
+            let err = "Invalid blockHeader hash: \
+                    \expecting a hex-encoded value that is 32 bytes in length."
+            fromText @(Hash "BlockHeader") "----"
+                === Left (TextDecodingError err)
+
+instance Arbitrary (Hash "Genesis") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "Block") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "Account") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "ChimericAccount") where
+    arbitrary = Hash . BS.pack <$> vector 28
+
+instance Arbitrary (Hash "BlockHeader") where
+    arbitrary = Hash . BS.pack <$> vector 32
+
+instance Arbitrary (Hash "Tx") where
+    -- No Shrinking
+    arbitrary = elements
+        [ Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        , Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        , Hash $ unsafeFromHex
+            "0000000000000000000000000000000000000000000000000000000000000003"
+        ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -117,8 +117,10 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.HashSpec
+    ()
 import Cardano.Wallet.Unsafe
-    ( someDummyMnemonic, unsafeFromHex )
+    ( someDummyMnemonic )
 import Control.Exception
     ( evaluate )
 import Control.Monad
@@ -220,12 +222,6 @@ spec = do
         textRoundtrip $ Proxy @TxStatus
         textRoundtrip $ Proxy @WalletName
         textRoundtrip $ Proxy @WalletId
-        textRoundtrip $ Proxy @(Hash "Genesis")
-        textRoundtrip $ Proxy @(Hash "Tx")
-        textRoundtrip $ Proxy @(Hash "Account")
-        textRoundtrip $ Proxy @(Hash "ChimericAccount")
-        textRoundtrip $ Proxy @(Hash "Block")
-        textRoundtrip $ Proxy @(Hash "BlockHeader")
         textRoundtrip $ Proxy @SyncTolerance
         textRoundtrip $ Proxy @PoolId
         textRoundtrip $ Proxy @PoolOwner
@@ -797,23 +793,6 @@ spec = do
             let err = "wallet id should be a hex-encoded string \
                       \of 40 characters"
             fromText @WalletId "101" === Left (TextDecodingError err)
-        it "fail fromText (@Hash \"Tx\")" $ do
-            let err =
-                    "Invalid tx hash: \
-                    \expecting a hex-encoded value that is 32 bytes in length."
-            fromText @(Hash "Tx") "----" === Left (TextDecodingError err)
-        it "fail fromText (@Hash \"Genesis\")" $ do
-            let err = "Invalid genesis hash: \
-                    \expecting a hex-encoded value that is 32 bytes in length."
-            fromText @(Hash "Genesis") "----" === Left (TextDecodingError err)
-        it "fail fromText (@Hash \"Block\")" $ do
-            let err = "Invalid block hash: \
-                    \expecting a hex-encoded value that is 32 bytes in length."
-            fromText @(Hash "Block") "----" === Left (TextDecodingError err)
-        it "fail fromText (@Hash \"BlockHeader\")" $ do
-            let err = "Invalid blockHeader hash: \
-                    \expecting a hex-encoded value that is 32 bytes in length."
-            fromText @(Hash "BlockHeader") "----" === Left (TextDecodingError err)
         it "Invalid account IDs cannot be decoded from text" $ do
             let expectedErrorMessage =
                     "Invalid account hash: \
@@ -1140,32 +1119,6 @@ instance Arbitrary FeePolicy where
         f <$> shrink (a, b, c)
       where
         f (x, y, z) = LinearFee (Quantity x) (Quantity y) (Quantity z)
-
-instance Arbitrary (Hash "Genesis") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
-instance Arbitrary (Hash "Block") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
-instance Arbitrary (Hash "Account") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
-instance Arbitrary (Hash "ChimericAccount") where
-    arbitrary = Hash . BS.pack <$> vector 28
-
-instance Arbitrary (Hash "BlockHeader") where
-    arbitrary = Hash . BS.pack <$> vector 32
-
-instance Arbitrary (Hash "Tx") where
-    -- No Shrinking
-    arbitrary = elements
-        [ Hash $ unsafeFromHex
-            "0000000000000000000000000000000000000000000000000000000000000001"
-        , Hash $ unsafeFromHex
-            "0000000000000000000000000000000000000000000000000000000000000002"
-        , Hash $ unsafeFromHex
-            "0000000000000000000000000000000000000000000000000000000000000003"
-        ]
 
 -- Same for addresses
 instance Arbitrary Address where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -65,7 +65,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , FeePolicy (..)
-    , Hash (..)
     , HistogramBar (..)
     , PoolId (..)
     , PoolOwner (..)
@@ -116,6 +115,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMinLength
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeFromHex )
 import Control.Exception

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , Direction (..)
     , EpochNo (..)
-    , Hash (..)
     , PoolId (..)
     , SealedTx (..)
     , SlotNo (..)
@@ -103,6 +102,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , txId
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
+++ b/lib/jormungandr/exe/cardano-wallet-jormungandr.hs
@@ -102,7 +102,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), NetworkParameters )
+    ( NetworkParameters )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Version
     ( GitRevision, Version, gitRevision, showFullVersion, version )
 import Control.Applicative

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Client.hs
@@ -82,7 +82,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo (..)
     , GenesisParameters (..)
-    , Hash (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
     , SealedTx
@@ -90,6 +89,8 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Arrow
     ( left )
 import Control.Exception

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Api/Types.hs
@@ -37,12 +37,13 @@ import Cardano.Wallet.Jormungandr.Binary
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
     , EpochNo (..)
-    , Hash (..)
     , PoolId (..)
     , SealedTx (..)
     , ShowFmt (..)
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Applicative
     ( many )
 import Control.Monad

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Binary.hs
@@ -103,7 +103,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , EpochLength (..)
     , EpochNo (..)
-    , Hash (..)
     , PoolId (PoolId)
     , PoolOwner (..)
     , SealedTx (..)
@@ -114,6 +113,8 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Network.hs
@@ -133,13 +133,14 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo
     , GenesisParameters (..)
-    , Hash (..)
     , NetworkParameters (..)
     , PoolId
     , ProtocolParameters (..)
     , SlotNo (..)
     , SlottingParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Concurrent.MVar.Lifted
     ( MVar, modifyMVar, newMVar, readMVar )
 import Control.Concurrent.STM

--- a/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
+++ b/lib/jormungandr/src/Cardano/Wallet/Jormungandr/Transaction.hs
@@ -46,13 +46,9 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..)
-    , Hash (..)
-    , SealedTx (..)
-    , Tx (..)
-    , TxMetadata
-    , TxOut (..)
-    )
+    ( ChimericAccount (..), SealedTx (..), Tx (..), TxMetadata, TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Faucet.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/Faucet.hs
@@ -15,7 +15,9 @@ import Cardano.Wallet.Jormungandr.Binary
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), Hash (..), TxIn (..), TxOut (..) )
+    ( Address (..), Coin (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Concurrent.MVar

--- a/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/integration/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -63,13 +63,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , Coin (..)
-    , Hash (..)
     , PoolId (..)
     , SealedTx (..)
     , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeDecodeAddress
     , unsafeFromHex

--- a/lib/jormungandr/test/integration/Test/Integration/Jcli.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jcli.hs
@@ -27,7 +27,7 @@ import Prelude
 
 import Cardano.Wallet.Jormungandr.Binary
     ( getBlockId, runGet )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )

--- a/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
+++ b/lib/jormungandr/test/integration/Test/Integration/Jormungandr/Scenario/CLI/Transactions.hs
@@ -24,7 +24,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     ( JormungandrKey )
 import Cardano.Wallet.Primitive.Types
-    ( Hash (..), Tx (..) )
+    ( Tx (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Monad.IO.Class
     ( liftIO )
 import Data.ByteArray.Encoding

--- a/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Pool/Jormungandr/MetricsSpec.hs
@@ -54,7 +54,6 @@ import Cardano.Wallet.Primitive.Types
     , EpochLength (..)
     , EpochNo
     , FeePolicy (..)
-    , Hash (..)
     , PoolId (..)
     , PoolOwner (..)
     , PoolRegistrationCertificate (..)
@@ -65,6 +64,8 @@ import Cardano.Wallet.Primitive.Types
     , StartTime (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText, unsafeMkPercentage, unsafeRunExceptT )
 import Control.Concurrent.Async

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/BinarySpec.hs
@@ -43,7 +43,6 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , ChimericAccount (..)
     , Coin (..)
-    , Hash (..)
     , PoolId (..)
     , PoolOwner (..)
     , SealedTx (..)
@@ -51,6 +50,8 @@ import Cardano.Wallet.Primitive.Types
     , TxIn (..)
     , TxOut (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( TransactionLayer (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/NetworkSpec.hs
@@ -34,7 +34,6 @@ import Cardano.Wallet.Primitive.Types
     , Coin (..)
     , EpochLength (..)
     , GenesisParameters (..)
-    , Hash (..)
     , NetworkParameters (..)
     , ProtocolParameters (..)
     , SlotId (..)
@@ -43,6 +42,8 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Control.Concurrent.MVar.Lifted
     ( MVar, newMVar, readMVar )
 import Control.Concurrent.STM.TChan

--- a/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
+++ b/lib/jormungandr/test/unit/Cardano/Wallet/Jormungandr/TransactionSpec.hs
@@ -41,13 +41,14 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , Hash (..)
     , PoolId (..)
     , SealedTx (..)
     , SlotNo (..)
     , TxIn (..)
     , TxOut (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -137,6 +137,7 @@ import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -238,6 +238,7 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Codec.CBOR.Decoding as CBOR

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -251,6 +251,7 @@ import System.IO.Error
 
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.CBOR.Term as CBOR
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -64,7 +64,6 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , Hash (..)
     , PoolId (..)
     , SealedTx (..)
     , Tx (..)
@@ -72,6 +71,8 @@ import Cardano.Wallet.Primitive.Types
     , TxMetadata
     , TxOut (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley
     , StandardCrypto

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -48,9 +48,10 @@ import Cardano.Wallet.Primitive.Types
     , ChimericAccount (..)
     , DecentralizationLevel (..)
     , EpochLength (..)
-    , Hash (..)
     , SlotId (..)
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock
     , StandardCrypto

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -48,7 +48,6 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , Coin (..)
-    , Hash (..)
     , TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
@@ -57,6 +56,8 @@ import Cardano.Wallet.Primitive.Types
     , UTxO (..)
     , txMetadataIsNull
     )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley, sealShelleyTx )
 import Cardano.Wallet.Shelley.Transaction


### PR DESCRIPTION
# Issue Number

Preparation for [ADP-347](https://jira.iohk.io/browse/ADP-347).

# Overview

This PR moves the `Hash` type and related functions to a separate module `Cardano.Wallet.Primitive.Types.Hash`. This allows code to use the `Hash` type without having to incur a dependency on the `Primitive.Types` module, which is already very large and slow to recompile.

# Comments

This PR doesn't re-export the `Hash` type from `Primitive.Types`.

Although it would be convenient to be able to import everything from `Primitive.Types` in one go (with a qualified import), it would also create a compilation bottleneck, since anything that imported `Hash` from the `Primitive.Types` module would have to depend on everything required to build `Primitive.Types`.

This PR follows the advice presented in [Keeping Compilation Fast](https://www.parsonsmatt.org/2019/11/27/keeping_compilation_fast.html) by Matt Parsons.