### PR TITLE
ci: Try lowering from -j 8 to -j 3

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -175,7 +175,7 @@ buildStep dryRun bk nightly = do
                 QuickTest -> skip "integration" <> skip "jormungandr-integration"
                 FullTest -> skip "jormungandr-integration"
                 NightlyTest -> mempty
-            , ta (jobs 8)
+            , ta (jobs 3)
             , args
             ]
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -95,7 +95,7 @@ let
 
           # Force more integration tests to run in parallel than the
           # default number of build cores.
-          integration.testFlags = ["-j" "8"];
+          integration.testFlags = ["-j" "3"];
 
           integration.preCheck = ''
             # Variables picked up by integration tests


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-466 / #2292 / #2295 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Lower integration test parallelism from `-j 8` to `-j 3` in buildkite and hydra


# Comments

We have many problems with:
  TTL tests
  unit tests timing out

The unit tests on master barely seem to be failing
https://buildkite.com/input-output-hk/cardano-wallet
where the integration tests are not run.

I wonder if lowering the parallelism puts less strain on the machines
running the tests, and makes the tests pass more.

If it doesn't help, we should revert back to -j 8. But it's worth a shot, I think.

### Results so far

- Unrelated failure, unit tests passed https://buildkite.com/input-output-hk/cardano-wallet/builds/11848 1
- Succeeded in 34 min https://buildkite.com/input-output-hk/cardano-wallet/builds/11852
- Failed due to unit timeout https://buildkite.com/input-output-hk/cardano-wallet/builds/11849 1 
- Succeeded https://buildkite.com/input-output-hk/cardano-wallet/builds/11849 2
- Succeeded https://buildkite.com/input-output-hk/cardano-wallet/builds/11848 2
- Failed due to unit timeout https://hydra.iohk.io/build/4775847

Maybe this is not working...

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
