### PR TITLE
Testing maintenance actions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -37,6 +37,8 @@ import Cardano.Wallet.Primitive.Types
     ( Coin (..)
     , Direction (..)
     , PoolId (..)
+    , PoolMetadataGCStatus (..)
+    , PoolMetadataSource (..)
     , StakePoolMetadata (..)
     , StakePoolTicker (..)
     , TxStatus (..)
@@ -89,6 +91,7 @@ import Test.Integration.Framework.DSL
     , delegationFee
     , emptyWallet
     , eventually
+    , eventuallyUsingDelay
     , expectErrorMessage
     , expectField
     , expectListField
@@ -110,10 +113,13 @@ import Test.Integration.Framework.DSL
     , quitStakePool
     , quitStakePoolUnsigned
     , request
+    , triggerMaintenanceAction
     , unsafeRequest
     , unsafeResponse
     , updateMetadataSource
     , verify
+    , verifyMaintenanceAction
+    , verifyMetadataSource
     , waitForNextEpoch
     , walletId
     , (.>)
@@ -142,6 +148,26 @@ spec :: forall n t.
 spec = describe "SHELLEY_STAKE_POOLS" $ do
     let listPools ctx stake = request @[ApiStakePool] ctx
                 (Link.listStakePools stake) Default Empty
+
+    it "STAKE_POOLS_MAINTENANCE_01 - \
+        \trigger GC action when metadata source = direct" $ \ctx -> runResourceT $ do
+        updateMetadataSource ctx "direct"
+        verifyMetadataSource ctx FetchDirect
+        triggerMaintenanceAction ctx "gc_stake_pools"
+        let delay = 500 * 1000
+            timeout = 10
+        eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
+          verifyMaintenanceAction ctx NotApplicable
+
+    it "STAKE_POOLS_MAINTENANCE_02 - \
+        \trigger GC action when metadata source = none" $ \ctx -> runResourceT $ do
+        updateMetadataSource ctx "none"
+        verifyMetadataSource ctx FetchNone
+        triggerMaintenanceAction ctx "gc_stake_pools"
+        let delay = 500 * 1000
+            timeout = 10
+        eventuallyUsingDelay delay timeout "GC Status shows as NotApplicable" $ do
+          verifyMaintenanceAction ctx NotApplicable
 
     it "STAKE_POOLS_JOIN_01 - Cannot join non-existent wallet" $ \ctx -> runResourceT $ do
         w <- emptyWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -112,6 +112,7 @@ import Test.Integration.Framework.DSL
     , request
     , unsafeRequest
     , unsafeResponse
+    , updateMetadataSource
     , verify
     , waitForNextEpoch
     , walletId
@@ -126,8 +127,6 @@ import Test.Integration.Framework.TestData
     , errMsg404NoSuchPool
     , errMsg404NoWallet
     )
-import Test.Integration.Scenario.API.Shelley.Settings
-    ( updateMetadataSource )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.ByteString as BS

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -206,6 +206,7 @@ import Servant.API.Verbs
     , Post
     , PostAccepted
     , PostCreated
+    , PostNoContent
     , Put
     , PutAccepted
     , PutNoContent
@@ -481,7 +482,7 @@ type DelegationFee = "wallets"
 type PostPoolMaintenance = "stake-pools"
     :> "maintenance-actions"
     :> ReqBody '[JSON] ApiMaintenanceActionPostData
-    :> Post '[JSON] ApiMaintenanceAction
+    :> PostNoContent
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getPoolMaintenance
 type GetPoolMaintenance = "stake-pools"

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -77,6 +77,8 @@ module Cardano.Wallet.Api.Link
     , joinStakePool
     , quitStakePool
     , getDelegationFee
+    , postPoolMaintenance
+    , getPoolMaintenance
 
       -- * Network
     , getNetworkInfo
@@ -466,6 +468,15 @@ getTransaction w t = discriminate @style
 --
 -- Stake Pools
 --
+postPoolMaintenance
+    :: (Method, Text)
+postPoolMaintenance =
+    endpoint @Api.PostPoolMaintenance id
+
+getPoolMaintenance
+    :: (Method, Text)
+getPoolMaintenance =
+    endpoint @Api.GetPoolMaintenance id
 
 listStakePools
     :: Maybe Coin

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -284,7 +284,7 @@ server byron icarus shelley spl ntp =
             case action of
                 ApiMaintenanceActionPostData GcStakePools ->
                     liftIO $ forceMetadataGC spl
-            getPoolMaintenance
+            pure NoContent
 
         getPoolMaintenance =
             liftIO (ApiMaintenanceAction . ApiT <$> getGCMetadataStatus spl)


### PR DESCRIPTION
# Issue Number

ADP-478

# Overview

- 2bb835971f0e8572206ac42a5da3e081d8cc1eb6
  Move updateMetadataSource and verifyMetadataSource to DSL.hs
  
- 26812b559714e69203876ea81d74c719951a9e64
  Make PostPoolMaintenance to be 204 No Content to comply with swagger
  
- afda59429c75da2c50565ddc035d0f406bd5a819
  Integration tests for triggering maintenance action while metadata source is none or direct
  


# Comments

First two test from the "proposal" https://jira.iohk.io/browse/ADP-478?focusedCommentId=27784&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-27784

And small fix for [postMaintenanceAction](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/postMaintenanceAction) to return `204` and no content.
