### PR TITLE
Run integration tests repeatedly in nightly 

### DIFF
--- a/.buildkite/nightly.yml
+++ b/.buildkite/nightly.yml
@@ -51,6 +51,24 @@ steps:
 
   - wait
 
+  - label: 'Repeated integration'
+    command: "nix-build -A checks.cardano-wallet.integration --no-out-link"
+    timeout_in_minutes: 360
+    env:
+      HOME: "/cache/cardano-wallet.home"
+      CARDANO_WALLET_INTEGRATION_TEST_REPETITIONS: 7
+    agents:
+      system: x86_64-linux
+
+  - label: 'Extensive unit tests'
+    command: "nix-build -A checks.cardano-wallet-core.unit --no-out-link"
+    timeout_in_minutes: 360
+    env:
+      HOME: "/cache/cardano-wallet.home"
+      HSPEC_OPTIONS: "--qc-max-success=2000"
+    agents:
+      system: x86_64-linux
+
   - label: "Advance linux-tests-pass and all-tests-pass branches"
     command: "./.buildkite/push-branch.sh linux-tests-pass windows-tests-pass all-tests-pass"
     agents:

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -587,7 +587,7 @@ slotLengthValue = 0.2
 
 -- | Parameter in test cluster genesis.
 epochLengthValue :: Word32
-epochLengthValue = 200
+epochLengthValue = 50
 
 -- | Wallet server's chosen transaction TTL value (in seconds) when none is
 -- given.

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -334,7 +334,7 @@ import Numeric.Natural
     ( Natural )
 import Prelude
 import System.Command
-    ( CmdResult, Stderr, Stdout (..), command )
+    ( CmdOption (..), CmdResult, Stderr, Stdout (..), command )
 import System.Directory
     ( doesPathExist )
 import System.Exit
@@ -1834,7 +1834,7 @@ cardanoWalletCLI
     :: forall r m. (CmdResult r, MonadIO m)
     => [String]
     -> m r
-cardanoWalletCLI = liftIO . command [] commandName
+cardanoWalletCLI = liftIO . command [EchoStderr False] commandName
 
 generateMnemonicsViaCLI
     :: forall r m. (CmdResult r, MonadIO m)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -624,7 +624,7 @@ withCluster tr severity poolConfigs dir logFile onByron onShelley onClusterStart
                     (ExitFailure 1)
             else do
                 traceWith tr $ MsgWaitingForFork "Shelley -> Allegra"
-                waitForHardFork bftSocket sp 2
+                --waitForHardFork bftSocket sp 2
                 let cfg = NodeParams severity systemStart (port0, ports) logFile
                 withRelayNode tr dir cfg $ \socket -> do
                     let runningRelay = RunningNode socket block0 params
@@ -646,7 +646,7 @@ waitForHardFork _socket sp epoch = threadDelay (ceiling (1e6 * delay))
     EpochLength epLen = getEpochLength sp
     SlotLength slotDur = getSlotLength sp
     -- add two seconds just to make sure.
-    fuzz = 2
+    fuzz = 0
 
 -- | Configuration parameters which update the @node.config@ test data file.
 data NodeParams = NodeParams

--- a/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
@@ -2,7 +2,7 @@ avvmDistr: {}
 
 blockVersionData:
   scriptVersion: 0
-  slotDuration: '250'
+  slotDuration: '100'
   maxBlockSize: '2000000'
   maxHeaderSize: '2000000'
   maxTxSize: '4096'

--- a/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
@@ -21,7 +21,7 @@ blockVersionData:
     multiplier: '43000000000'
   unlockStakeEpoch: '18446744073709551615'
 protocolConsts:
-  k: 8
+  k: 5
   protocolMagic: 764824073
 
 bootStakeholders:

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -32,7 +32,7 @@ LastKnownBlockVersion-Alt: 0
 
 # Launcher code will submit an update proposal to trigger the hard-fork.
 TestShelleyHardForkAtEpoch: 1
-TestAllegraHardForkAtEpoch: 2
+TestAllegraHardForkAtEpoch: 3
 
 #     _                      _
 #    | |    ___   __ _  __ _(_)_ __   __ _

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -47,12 +47,12 @@ maxLovelaceSupply: 1000000000000000000
 protocolMagicId: 764824073
 networkMagic: 764824073
 networkId: Mainnet
-epochLength: 200
+epochLength: 50
 staking:
 slotsPerKESPeriod: 86400
 slotLength: 0.2
 maxKESEvolutions: 90
-securityParam: 10
+securityParam: 5
 systemStart: "2020-06-19T16:07:37.740128433Z"
 initialFunds: {}
 # For the Byron;Shelley test setup, funds have to be migrated from byron

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -271,13 +271,13 @@ specWithServer (tr, tracers) = aroundAll withContext
     onByron _ = pure ()
     afterFork dir _ = do
         traceWith tr MsgSettingUpFaucet
+        let rewards = (,Coin $ fromIntegral oneMillionAda) <$>
+                concatMap genRewardAccounts mirMnemonics
+        moveInstantaneousRewardsTo tr' dir rewards
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
         sendFaucetFundsTo tr' dir addresses
 
-        let rewards = (,Coin $ fromIntegral oneMillionAda) <$>
-                concatMap genRewardAccounts mirMnemonics
-        moveInstantaneousRewardsTo tr' dir rewards
 
     onClusterStart action dir dbDecorator node = do
         -- NOTE: We may want to keep a wallet running across the fork, but

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -108,7 +108,10 @@ let
             echo "Git revision is ${toString gitrev}"
           '' + lib.optionalString stdenv.isDarwin ''
             export TMPDIR=/tmp
-          '';
+          '' + (lib.concatMapStrings
+            # pass some environment variables through
+            (env: let val = builtins.getEnv env; in lib.optionalString (val != "") "export ${env}=${val}\n")
+            ["CARDANO_WALLET_INTEGRATION_TEST_REPETITIONS"]);
 
           integration.postCheck = ''
             # fixme: There needs to be some Haskell.nix changes to
@@ -164,6 +167,11 @@ let
         # and add shell completions for main executables.
         packages.cardano-wallet.components.exes.cardano-wallet.postInstall = optparseCompletionPostInstall + libSodiumPostInstall;
         packages.cardano-wallet-core.components.tests.unit.postInstall = libSodiumPostInstall;
+        packages.cardano-wallet-core.components.tests.unit.preCheck =
+            lib.concatMapStrings
+            # pass some environment variables through
+            (env: let val = builtins.getEnv env; in lib.optionalString (val != "") "export ${env}=${val}\n")
+            ["HSPEC_OPTIONS"];
         packages.cardano-wallet-cli.components.tests.unit.postInstall = libSodiumPostInstall;
       })
 


### PR DESCRIPTION
# Issue Number

ADP-529


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- Add `SetupClusterFaucet` to encapsulate state for setting up the cluster
- Replace `unsafePerformIO` in cluster setup with passing around an explicit @SetupClusterFaucet@
- Add `CARDANO_WALLET_INTEGRATION_TEST_REPETITIONS` to cardano-wallet:integration
- Allow setting `HSPEC_OPTIONS` to cardano-wallet-core:unit nix build
- Add new nightly builds
  - integration with CARDANO_WALLET_INTEGRATION_TEST_REPETITIONS=7
  - unit with HSPEC_OPTIONS="--qc-max-success=2000"


# Comments

- Dependent on #2391 (not really, but the 7 integration test repetitions take 1h10m instead of 1h50m with the tweaked params. 1h50m is close to the timeout limit of 2h)

Recent build
https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/775#f0dbeb33-f220-457e-af60-14bf42f197c5

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
