### PR TITLE
Additional tweaks with regards to static address construction via the API

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -51,7 +51,7 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( walletNameMaxLength, walletNameMinLength )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
+    ( unsafeFromHex, unsafeXPub )
 import Control.Monad
     ( forM, forM_ )
 import Control.Monad.IO.Class
@@ -134,6 +134,7 @@ import Test.Integration.Framework.TestData
 -- of cardano-crypto here.
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Api.Link as Link
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -998,23 +999,19 @@ spec = describe "SHELLEY_WALLETS" $ do
             matrix =
                 [ ( UtxoExternal
                   , DerivationIndex 0
-                  , "addr_xvk1tmdggpmj7r2mqfhneqsc5fzfj2j4sxf4j7mqwwsa8w58vz94zr\
-                    \463ndsajkjvn82va30fgf22qruc53zxyjp6pu7yd87ppdefd6u98cue5ul9"
+                  , "addr_vk1tmdggpmj7r2mqfhneqsc5fzfj2j4sxf4j7mqwwsa8w58vz94zr4seun089"
                   )
                 , ( UtxoInternal
                   , DerivationIndex 100
-                  , "addr_xvk1wchen6vz4zz7kpfjld3g89zdcpdv2hzvtsufphgvpjxjkl49pq\
-                    \rfd2lgqg228zl7ylax8c5tr0rkys3phfkxd5j6s56c0tfy7r49jhct38kq6"
+                  , "addr_vk1wchen6vz4zz7kpfjld3g89zdcpdv2hzvtsufphgvpjxjkl49pqrqaj4j0e"
                   )
                 , ( MutableAccount
                   , DerivationIndex 2147483647
-                  , "stake_xvk1qy9tp370ze3cfre8f6daz7l85pgk3wpg6s5zqae2yjljwqkx4\
-                    \ht28cxx7j5ju0wl8795s3yj8z3te4h2j9eaztll2z4mxhwwkppy53sf49ev5"
+                  , "stake_vk1qy9tp370ze3cfre8f6daz7l85pgk3wpg6s5zqae2yjljwqkx4htqc7kr4p"
                   )
                 , ( MultisigScript
                   , DerivationIndex 42
-                  , "script_xvk1mjr5lrrlxuvelx94hu2cttmg5pp6cwy5h0sa37qvpcd07pv9g\
-                    \23nlvugj5ez9qfxxvkmjwnpn69s48cv572phfy6qpmnwat0hwcdrasapqewe"
+                  , "script_vk1mjr5lrrlxuvelx94hu2cttmg5pp6cwy5h0sa37qvpcd07pv9g23skqaly0"
                   )
                 ]
 
@@ -1105,8 +1102,9 @@ spec = describe "SHELLEY_WALLETS" $ do
         --        71                                   # text(17)
         --           706C65617365207369676E20746869732E # "please sign this."
         --
+        let dummyChainCode = BS.replicate 32 0
         let sig = CC.xsignature $ BL.toStrict $ getFromResponse id rSig
-        let key = fst $ getFromResponse #getApiVerificationKey rKey
+        let key = unsafeXPub $ fst (getFromResponse #getApiVerificationKey rKey) <> dummyChainCode
         let msg = unsafeFromHex "A10071706C65617365207369676E20746869732E"
 
         liftIO $ CC.verify key msg <$> sig `shouldBe` Right True

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -98,7 +98,7 @@ module Cardano.Wallet.Api.Server
 import Prelude
 
 import Cardano.Address.Derivation
-    ( XPrv, XPub )
+    ( XPrv, XPub, xpubPublicKey )
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet
@@ -1895,7 +1895,7 @@ derivePublicKey
 derivePublicKey ctx (ApiT wid) (ApiT role_) (ApiT ix) = do
     withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk -> do
         k <- liftHandler $ W.derivePublicKey @_ @s @k @n wrk wid role_ ix
-        pure $ ApiVerificationKey (getRawKey k, role_)
+        pure $ ApiVerificationKey (xpubPublicKey $ getRawKey k, role_)
 
 {-------------------------------------------------------------------------------
                                   Helpers

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1170,7 +1170,7 @@ instance FromJSON ApiVerificationKey where
             | BS.length bytes == 32 =
                 pure bytes
             | otherwise =
-                fail "Not a valid Ed25519 public key. Must be 32 bytes."
+                fail "Not a valid Ed25519 public key. Must be 32 bytes, without chain code"
 
 instance FromJSON ApiEpochInfo where
     parseJSON = genericParseJSON defaultRecordTypeOptions

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiVerificationKey.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiVerificationKey.json
@@ -1,15 +1,15 @@
 {
-    "seed": -3309461535115891851,
+    "seed": -9135623750693998299,
     "samples": [
-        "stake_xvk1rajzjm2mwapn6rs0gu3rypru3978gw6zp00s2jf7w35y63gtyvy0c33s4uengekd3y0r7dzeqagz7m2t3qj800p6gpw97k7u83azd7g5cev5c",
-        "stake_xvk1cgxx3anz8enn5yae3dxswrje49v95p6rfpf85h2ucepqsl62d9jsg3pwvsvrgnfqpv4yzln5vh0hf6qkrst4qk6m050968z92sg36kqe2xh8g",
-        "addr_xvk1xcw3jjm59cja2fyk0y6ryftx2s6yxzqryq34vz88r9zsxq2v9q8z7cm3vdkzqntxgyeetx6p099r65pvdfljczmyx3rzz4tm62j4cts9mh2vs",
-        "stake_xvk19fp34tswf9mzccycza3nghraxvjzz32mwaw5yjqf93q9w0g70ywrsmm7f7zmqrpg9345gfs2nep4cz6lf7lsktsnwu044h2vf5azx7qpch6n0",
-        "stake_xvk10f7sjqrx0k63gzevnujk2mnqgg53un6ktdu5jx6gzaxzvy3jvj2zxssf0yh8yyc39cwrcycat4xzglmlywz0c2eltrekvptnpvhtgwgu743fk",
-        "stake_xvk10pj4a3n48d5hcujzg38z6rjgqpa32d5zd8rsswqy0yhqgf23n3y376m7z4zz7jqrg9vx78cngs8zc52zafamkp2ef44q7utswecrgwsg058qj",
-        "addr_xvk1wfr464qxdd395jfqtg88qezx09thu763dcfgq7pj9efyz7hprmgpqackp5jy6vsxtfmxwjfg2guwndmfgf93dkflwvkj6vqku3cqwsqy7gm8p",
-        "stake_xvk12cvqe9trfvgs0m23f4yh7t9d48ps78e9rke5x7zl9fhyqz6p2f3qykf47rl5wqgmf43wwlf9ypjy59qkdepxmnghq3l2uyzcvd0qa4qm77cal",
-        "stake_xvk1zdpjxppndpdyy72lqzjhzqnnrscy77aknpdpj8e8ghl35wdyu99nqa2ysqszwxyjdgu4qt3gtccnvtqlwv0k6lzttgukl4cevf7r7acj487j7",
-        "addr_xvk1xs0kqucyyah87wty9cgyvj3agtlxypzn2g5yqqefg3mhj8gm2u2sw50xrwsj57seg3255xp2yed9y4s0ytjre4278fjrx8mpzdygjzc8945su"
+        "addr_vk1d44kd8f6dem8z8v0dptrvt5qtfg597j0v9zqxxgr3qwrcdezya7swpn603",
+        "script_vk1cvd9kl8rd9gs9xjkd58svpnmrgtkxkx5z343vr2gq5cnq8sy0tesggn3gl",
+        "script_vk144dq2frewvnnwt6urql8nvretraz2u6fqepn5dr3v9a9zpqxdgvs6n3kzq",
+        "addr_vk1ycsq65g506h3wles2gl9vpqsv9ycqvrwfstqdxgvrc5852n5xv7s7ftnkp",
+        "script_vk1t5gpykggp5lhz0tdxuhhkkzgqp7s7u6wtcdyk2tqzevpyq3t85kst7a34r",
+        "script_vk1z385zctdtk6puus7vsnrjaeqvqdns5jqq5a5nux69uargt36tqdsghv7hd",
+        "addr_vk1g3qx2rstdsdlghm8rpusv6tcq36sy5c89q4qwf2e2nu9jyf3rd2qn7nagf",
+        "script_vk12vppvfy4qlzjvv7ue3mfyr358jnrkqepv8vr8mc4kj5ycvfvxq3q26fvtj",
+        "script_vk1vq57jugt6pghg30cxhn9v9ecwvnswrte2fu5xhzdf4zr2hs9y9eqyhfhaf",
+        "stake_vk1ya2kyc3tt9yhwz8sd423czjh0fpkqj3cr3a4gceys09qzps8td6qm0dj2m"
     ]
 }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -190,7 +190,7 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromText, unsafeXPrv, unsafeXPub )
+    ( unsafeFromText, unsafeXPrv )
 import Control.Lens
     ( at, (?~) )
 import Control.Monad
@@ -1518,7 +1518,7 @@ instance Arbitrary (Quantity "percent" Double) where
 instance Arbitrary ApiVerificationKey where
     arbitrary =
         fmap ApiVerificationKey . (,)
-            <$> fmap (unsafeXPub . B8.pack) (replicateM 64 arbitrary)
+            <$> fmap B8.pack (replicateM 32 arbitrary)
             <*> elements [UtxoExternal, MutableAccount, MultisigScript]
 
 instance ToSchema ApiVerificationKey where

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1431,7 +1431,7 @@ components:
     ApiVerificationKey: &ApiVerificationKey
       type: string
       format: bech32
-      pattern: "^((addr_xvk)|(stake_xvk)|(script_xvk))1[0-9a-z]*$"
+      pattern: "^((addr_vk)|(stake_vk)|(script_vk))1[0-9a-z]*$"
 
     ApiTxId: &ApiTxId
       type: object

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -337,10 +337,10 @@ x-anyAddress: &anyAddress
 x-ScriptValue: &ScriptValue
   oneOf:
     - title: Key Hash
+      description: Leaf value for a script designating a required verification key hash.
       type: string
       format: bech32
       pattern: "^(script_vkh)1[0-9a-z]*$"
-      example: script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms
 
     - title: All
       type: object
@@ -348,6 +348,7 @@ x-ScriptValue: &ScriptValue
         - all
       properties:
         all:
+          description: Script primitive for which all signing keys corresponding to all list elements' verification keys are expected to make the script valid.
           type: array
           minItems: 1
           items:
@@ -359,6 +360,7 @@ x-ScriptValue: &ScriptValue
         - any
       properties:
         any:
+          description: Script primitive for which a signing key corresponding to any of the list elements' verification keys is expected to make the script valid. It is equivalent to `some` with `"at_least"=1`.
           type: array
           minItems: 1
           items:
@@ -370,6 +372,7 @@ x-ScriptValue: &ScriptValue
         - some
       properties:
         some:
+          description: Script primitive for which at least a given number of signing keys corresponding to the list elements' verification keys are expected to make the script valid.
           type: object
           required:
             - at_least
@@ -386,33 +389,6 @@ x-ScriptValue: &ScriptValue
 
 x-script: &script
   <<: *ScriptValue
-  description: |
-    Script allows establishing either payment or stake guard that could be removed
-    when a special combination of signing keys is present.
-
-    The script can be constructed using four primitives:
-     - verification key hash for which a corresponding signing key is expected
-     - all condition for which all list elements' expectation are met for the condition to be valid
-     - any condition for which any list element' expectation is to be met for the condition to be valid
-     - some condition for which a minimal number of list elements' expectation is to be met for the condition to be valid
-  example:
-    -
-      "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms"
-    -
-      { "all": [ "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms"
-               , "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms"] }
-    -
-      { "all": [ "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms"
-               , { "any" : [ "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms"
-                           , "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt38ms"] }
-               ] }
-    -
-      { "all": [ "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms"
-               , { "some" : { "from" : [ "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms"
-                                       , "script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt38ms"]
-                            , "at_least" : 2
-                            }
-                 } ] }
 
 x-CredentialValue: &CredentialValue
   nullable: false
@@ -421,6 +397,25 @@ x-CredentialValue: &CredentialValue
       title: public key
     - <<: *script
       title: script
+  example:
+    any:
+    - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms
+
+    - all:
+      - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms
+      - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms
+
+    - any:
+      - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms
+      - all:
+        - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt36ms
+        - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms
+
+    - some:
+        at_least: 2
+        from:
+        - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt37ms
+        - script_vkh18srsxr3khll7vl3w9mqfu55n6wzxxlxj7qzr2mhnyreluzt38ms
 
 x-settings: &settings
   description: Settings
@@ -1691,7 +1686,9 @@ components:
       nullable: false
       properties:
         payment: *ApiCredential
-        stake: *ApiCredential
+        stake:
+          <<: *ApiCredential
+          example: stake_vk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7qau558d
 
     ApiByronWalletRandomPostData: &ApiByronWalletRandomPostData
       type: object
@@ -3250,7 +3247,6 @@ x-tagGroups:
 
   - name: Miscellaneous
     tags:
-    - Utils
     - Network
     - Proxy
     - Settings
@@ -4070,7 +4066,7 @@ paths:
   /addresses/{addressId}:
     get:
       operationId: inspectAddress
-      tags: ["Utils"]
+      tags: ["Addresses"]
       summary: Inspect Address
       description: |
         <p align="right">status: <strong>stable</strong></p>
@@ -4083,12 +4079,60 @@ paths:
   /addresses:
     post:
       operationId: postAnyAddress
-      tags: ["Utils"]
+      tags: ["Addresses"]
       summary: Construct Address
       description: |
-        <p align="right">status: <strong>unstable</strong></p>
+        <p align="right">status: <strong>stable</strong></p>
 
         Construct any address by specyfying credential for payment or stake.
+
+        In Cardano, Addresses are made of three parts:
+
+        ```
+        *---------*---------*-------*
+        | NETWORK | PAYMENT | STAKE |
+        *---------*---------*-------*
+        ```
+
+        The `NETWORK` part allows for distinguishing addresses between different networks like the mainnet or the testnet. It is implicitly
+        handled by the server without you having to worry about it. The `PAYMENT` and `STAKE` parts however can be constructed similarly, using
+        either:
+
+        - A public key
+        - A script
+
+        The script itself is either constructed out of a public key, or one of the three following primitives:
+
+        - all
+        - any
+        - some
+
+        Each of which contains one or more script(s) that can be either keys or primitives, and so on. Schematically:
+
+        ```
+                                           ┏─────────┓
+        SCRIPT = ──┬───────────────────────┤ pub key ├─────────────────────┬──
+                   │                       ┗─────────┛                     │
+                   │  ╭─────╮   ╭────────╮                                 │
+                   ├──┤ ALL ├───┤ SCRIPT ├─┬───────────────────────────────┤
+                   │  ╰─────╯ ^ ╰────────╯ │                               │
+                   │          │   ╭───╮    │                               │
+                   │          └───┤ , ├────┘                               │
+                   │              ╰───╯                                    │
+                   │  ╭─────╮   ╭────────╮                                 │
+                   ├──┤ ALL ├───┤ SCRIPT ├─┬───────────────────────────────┤
+                   │  ╰─────╯ ^ ╰────────╯ │                               │
+                   │          │   ╭───╮    │                               │
+                   │          └───┤ , ├────┘                               │
+                   │              ╰───╯                                    │
+                   │  ╭──────╮ ╭──────────╮ ┏───┓ ╭──────╮   ╭────────╮    │
+                   └──┤ SOME ├─┤ AT_LEAST ├─┤ n ├─┤ FROM ├───┤ SCRIPT ├─┬──┘
+                      ╰──────╯ ╰──────────╯ ┗───┛ ╰──────╯ ^ ╰────────╯ │
+                                                           │   ╭───╮    │
+                                                           └───┤ , ├────┘
+                                                               ╰───╯
+        ```
+
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-461

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 9b362af395375d30135b04961f1406e0e821337e
  :round_pushpin: **return non-extended public key (without chain code) as 'ApiVerificationKey'**
    The chain code is useless because there's no further derivation that can happen at this stage. Plus, it does make it harder to re-use the output from the 'getWalletKey' endpoint into others because one needs to decode the bech32 string and strip away the chain code.

- 3b005831530f01772ef4abd71dba6a5a8a59244a
  :round_pushpin: **revise API documentation regarding address construction from script**
    - give more details about how scripts are constructed
  - move description around so they show up correctly in ReDoc.
  - move address endpoints into the 'Address' group and remove the 'Utils' group

# Comments

<!-- Additional comments or screenshots to attach if any -->

TODO: use public key in script construction instead of hashes, and do the hashing internally. 

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
