### PR TITLE
Move selected primitive types to dedicated modules (Part 1).

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -172,7 +172,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, PoolMetadataSource (..), SortOrder, WalletId, WalletName )
+    ( PoolMetadataSource (..), SortOrder, WalletId, WalletName )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -172,13 +172,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState
-    , Coin (..)
-    , PoolMetadataSource (..)
-    , SortOrder
-    , WalletId
-    , WalletName
-    )
+    ( AddressState, PoolMetadataSource (..), SortOrder, WalletId, WalletName )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Version

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -42,7 +42,9 @@ import Cardano.Wallet.Api.Client
 import Cardano.Wallet.Api.Types
     ( ApiT (..), ApiTxMetadata (..) )
 import Cardano.Wallet.Primitive.Types
-    ( PoolMetadataSource, TxMetadata (..), TxMetadataValue (..) )
+    ( PoolMetadataSource )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxMetadata (..), TxMetadataValue (..) )
 import Control.Concurrent
     ( forkFinally )
 import Control.Concurrent.MVar

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -58,7 +58,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , liftIndex
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..) )
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkMnemonic )
 import Control.Concurrent.MVar

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -57,7 +57,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , deriveRewardAccount
     , liftIndex
     )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -242,7 +242,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
     , EpochLength (..)
     , EpochNo
     , HistogramBar (..)
@@ -262,6 +261,8 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -243,7 +243,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Address (..)
-    , Coin (..)
     , EpochLength (..)
     , EpochNo
     , HistogramBar (..)
@@ -263,6 +262,8 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -252,9 +252,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , SlotNo (..)
     , SortOrder (..)
-    , TxIn (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics (..)
     , WalletId (..)
@@ -267,6 +264,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..), TxStatus (..) )
 import Control.Arrow
     ( second )
 import Control.Concurrent

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -45,7 +45,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
@@ -29,7 +29,9 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), PoolMetadataSource (..), Settings )
+    ( PoolMetadataSource (..), Settings )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Maybe

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -35,15 +35,15 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..)
-    , PoolId (..)
+    ( PoolId (..)
     , PoolMetadataGCStatus (..)
     , PoolMetadataSource (..)
     , StakePoolMetadata (..)
     , StakePoolTicker (..)
-    , TxStatus (..)
     , decodePoolIdBech32
     )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..), TxStatus (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -35,8 +35,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.Fee
     ( FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..)
-    , Direction (..)
+    ( Direction (..)
     , PoolId (..)
     , PoolMetadataGCStatus (..)
     , PoolMetadataSource (..)
@@ -45,6 +44,8 @@ import Cardano.Wallet.Primitive.Types
     , TxStatus (..)
     , decodePoolIdBech32
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkPercentage )
 import Control.Monad

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -42,10 +42,10 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolTicker (..)
     , decodePoolIdBech32
     )
-import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..), TxStatus (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..), TxStatus (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkPercentage )
 import Control.Monad

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -40,15 +40,11 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..)
-    , SortOrder (..)
-    , TxMetadata (..)
-    , TxMetadataValue (..)
-    , TxStatus (..)
-    , WalletId
-    )
+    ( SortOrder (..), WalletId )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..), TxMetadata (..), TxMetadataValue (..), TxStatus (..) )
 import Control.Concurrent
     ( threadDelay )
 import Control.Monad

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -16,7 +16,7 @@ import Cardano.Wallet.Api.Types
     ( ApiAddress, ApiWallet, DecodeAddress (..), EncodeAddress (..), getApiT )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( defaultAddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -25,12 +25,9 @@ import Cardano.Wallet.Api.Types
     , getApiT
     )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..)
-    , SortOrder (..)
-    , TxMetadata (..)
-    , TxMetadataValue (..)
-    , TxStatus (..)
-    )
+    ( SortOrder (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..), TxMetadata (..), TxMetadataValue (..), TxStatus (..) )
 import Control.Monad
     ( forM_, join )
 import Control.Monad.Catch

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -160,6 +160,7 @@ library
       Cardano.Wallet.Primitive.Fee
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
+      Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Registry
       Cardano.Wallet.Transaction

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -160,6 +160,7 @@ library
       Cardano.Wallet.Primitive.Fee
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
+      Cardano.Wallet.Primitive.Types.Address
       Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Registry

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -164,6 +164,7 @@ library
       Cardano.Wallet.Primitive.Types.ChimericAccount
       Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
+      Cardano.Wallet.Primitive.Types.Tx
       Cardano.Wallet.Registry
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -161,6 +161,7 @@ library
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Primitive.Types.Address
+      Cardano.Wallet.Primitive.Types.ChimericAccount
       Cardano.Wallet.Primitive.Types.Coin
       Cardano.Wallet.Primitive.Types.Hash
       Cardano.Wallet.Registry

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -56,13 +56,15 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ProtocolMagic (..), TxIn (..), TxOut (..) )
+    ( ProtocolMagic (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
 import Control.Monad
     ( replicateM, when )
 import Control.Monad.Fail

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -56,7 +56,9 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ProtocolMagic (..), TxIn (..), TxOut (..) )
+    ( ProtocolMagic (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Byron/Codec/Cbor.hs
+++ b/lib/core/src/Cardano/Byron/Codec/Cbor.hs
@@ -56,7 +56,9 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), ProtocolMagic (..), TxIn (..), TxOut (..) )
+    ( Address (..), ProtocolMagic (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -301,7 +301,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , DelegationCertificate (..)
     , Direction (..)
     , FeePolicy (LinearFee)
@@ -344,6 +343,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -302,7 +302,6 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , DelegationCertificate (..)
-    , Direction (..)
     , FeePolicy (LinearFee)
     , GenesisParameters (..)
     , IsDelegatingTo (..)
@@ -312,21 +311,10 @@ import Cardano.Wallet.Primitive.Types
     , PoolLifeCycleStatus (..)
     , ProtocolParameters (..)
     , Range (..)
-    , SealedTx (..)
     , Signature (..)
     , SortOrder (..)
-    , TransactionInfo (..)
-    , Tx
-    , TxChange (..)
-    , TxIn
-    , TxMeta (..)
-    , TxMetadata (..)
-    , TxOut (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics
-    , UnsignedTx (..)
     , WalletDelegation (..)
     , WalletDelegationStatus (..)
     , WalletId (..)
@@ -336,10 +324,8 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , distance
     , dlgCertPoolId
-    , fromTransactionInfo
     , log10
     , wholeRange
-    , withdrawals
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
@@ -349,6 +335,22 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , SealedTx (..)
+    , TransactionInfo (..)
+    , Tx
+    , TxChange (..)
+    , TxIn
+    , TxMeta (..)
+    , TxMetadata (..)
+    , TxOut (..)
+    , TxOut (..)
+    , TxStatus (..)
+    , UnsignedTx (..)
+    , fromTransactionInfo
+    , withdrawals
+    )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)
@@ -450,6 +452,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.CoinSelection.Random as CoinSelection
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.List as L

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -299,9 +299,7 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress, SyncTolerance (..), syncProgress )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , AddressState (..)
-    , Block (..)
+    ( Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
     , DelegationCertificate (..)
@@ -344,6 +342,8 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     , withdrawals
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -304,7 +304,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Coin (..)
     , DelegationCertificate (..)
     , Direction (..)
     , FeePolicy (LinearFee)
@@ -345,6 +344,8 @@ import Cardano.Wallet.Primitive.Types
     , wholeRange
     , withdrawals
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Transaction
@@ -447,6 +448,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.CoinSelection.Random as CoinSelection
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.List as L

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -166,13 +166,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState
-    , Block
-    , Coin (..)
-    , NetworkParameters
-    , SortOrder (..)
-    , WalletId (..)
-    )
+    ( AddressState, Block, NetworkParameters, SortOrder (..), WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog, WorkerRegistry )
 import Cardano.Wallet.Transaction

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -166,7 +166,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Block, NetworkParameters, SortOrder (..), WalletId (..) )
+    ( Block, NetworkParameters, SortOrder (..), WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Registry

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -86,7 +86,9 @@ import Cardano.Wallet.Api.Types
     , WalletPutPassphraseData (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Coin (..), SortOrder, WalletId )
+    ( AddressState, SortOrder, WalletId )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.Monad
     ( void )
 import Data.Coerce

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -86,7 +86,9 @@ import Cardano.Wallet.Api.Types
     , WalletPutPassphraseData (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, SortOrder, WalletId )
+    ( SortOrder, WalletId )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -111,7 +111,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle, DerivationIndex, NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, PoolId, SortOrder, WalletId (..) )
+    ( PoolId, SortOrder, WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -111,7 +111,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle, DerivationIndex, NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( AddressState, Coin (..), PoolId, SortOrder, WalletId (..) )
+    ( AddressState, PoolId, SortOrder, WalletId (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
 import Data.Function

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -296,7 +296,6 @@ import Cardano.Wallet.Primitive.Types
     , AddressState (..)
     , Block
     , BlockHeader (..)
-    , Coin (..)
     , NetworkParameters (..)
     , PassphraseScheme (..)
     , PoolId
@@ -315,6 +314,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Registry

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -302,13 +302,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotId
     , SlotNo
     , SortOrder (..)
-    , TransactionInfo (TransactionInfo)
-    , Tx (..)
-    , TxChange (..)
-    , TxIn (..)
-    , TxOut (..)
-    , TxStatus (..)
-    , UnsignedTx (..)
     , WalletId (..)
     , WalletMetadata (..)
     )
@@ -318,6 +311,15 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TransactionInfo (TransactionInfo)
+    , Tx (..)
+    , TxChange (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxStatus (..)
+    , UnsignedTx (..)
+    )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..)
     , MkWorker (..)
@@ -459,6 +461,7 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.Slotting as S
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -292,9 +292,7 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), SyncTolerance, syncProgress )
 import Cardano.Wallet.Primitive.Types
-    ( Address
-    , AddressState (..)
-    , Block
+    ( Block
     , BlockHeader (..)
     , NetworkParameters (..)
     , PassphraseScheme (..)
@@ -314,6 +312,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -223,12 +223,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..)
-    , TxIn (..)
-    , TxMetadata
-    , TxStatus (..)
-    , txMetadataIsNull
-    )
+    ( Direction (..), TxIn (..), TxMetadata, TxStatus (..), txMetadataIsNull )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Codec.Binary.Bech32

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -192,7 +192,6 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BoundType
     , DecentralizationLevel (..)
-    , Direction (..)
     , EpochLength (..)
     , EpochNo (..)
     , GenesisParameters (..)
@@ -207,16 +206,12 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , StakePoolMetadata
     , StartTime (..)
-    , TxIn (..)
-    , TxMetadata
-    , TxStatus (..)
     , UTxOStatistics (..)
     , WalletBalance (..)
     , WalletId (..)
     , WalletName (..)
     , decodePoolIdBech32
     , encodePoolIdBech32
-    , txMetadataIsNull
     , unsafeEpochNo
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -227,6 +222,13 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TxIn (..)
+    , TxMetadata
+    , TxStatus (..)
+    , txMetadataIsNull
+    )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Codec.Binary.Bech32

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -191,7 +191,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BoundType
-    , ChimericAccount (..)
     , DecentralizationLevel (..)
     , Direction (..)
     , EpochLength (..)
@@ -222,6 +221,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -194,7 +194,6 @@ import Cardano.Wallet.Primitive.Types
     , AddressState (..)
     , BoundType
     , ChimericAccount (..)
-    , Coin (..)
     , DecentralizationLevel (..)
     , Direction (..)
     , EpochLength (..)
@@ -220,10 +219,11 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , decodePoolIdBech32
     , encodePoolIdBech32
-    , isValidCoin
     , txMetadataIsNull
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Transaction

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -190,8 +190,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
-    , AddressState (..)
     , BoundType
     , ChimericAccount (..)
     , DecentralizationLevel (..)
@@ -222,6 +220,8 @@ import Cardano.Wallet.Primitive.Types
     , txMetadataIsNull
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -47,15 +47,13 @@ import Cardano.Wallet.Primitive.Types
     , Range (..)
     , SlotNo (..)
     , SortOrder (..)
-    , TransactionInfo
-    , Tx (..)
-    , TxMeta
-    , TxStatus
     , WalletId
     , WalletMetadata
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TransactionInfo, Tx (..), TxMeta, TxStatus )
 import Control.Monad.Fail
     ( MonadFail )
 import Control.Monad.IO.Class

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -60,9 +60,11 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter )
 import Cardano.Wallet.Primitive.Types
-    ( SortOrder (..), TransactionInfo (..), WalletId, wholeRange )
+    ( SortOrder (..), WalletId, wholeRange )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TransactionInfo (..) )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, withMVar )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -72,7 +72,6 @@ import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, epochOf, startTime )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (blockHeight, slotNo)
-    , Coin (..)
     , DelegationCertificate (..)
     , Direction (..)
     , EpochNo (..)
@@ -94,6 +93,8 @@ import Cardano.Wallet.Primitive.Types
     , dlgCertPoolId
     , isWithinRange
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -73,7 +73,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (blockHeight, slotNo)
     , DelegationCertificate (..)
-    , Direction (..)
     , EpochNo (..)
     , PoolId
     , ProtocolParameters (..)
@@ -81,10 +80,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , SortOrder (..)
     , StakeKeyCertificate (..)
-    , TransactionInfo (..)
-    , Tx (..)
-    , TxMeta (..)
-    , TxStatus (..)
     , UTxO (..)
     , WalletDelegation (..)
     , WalletDelegationNext (..)
@@ -97,6 +92,13 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TransactionInfo (..)
+    , Tx (..)
+    , TxMeta (..)
+    , TxStatus (..)
+    )
 import Control.Monad
     ( when )
 import Data.Bifunctor

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -203,6 +203,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.Map as Map

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -206,6 +206,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -203,6 +203,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as Seq
 import qualified Cardano.Wallet.Primitive.Model as W
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.Map as Map
 import qualified Data.Text as T

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -50,6 +50,7 @@ import System.Random
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as W
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Data.ByteString.Char8 as B8
 
 share

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -52,6 +52,7 @@ import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.ByteString.Char8 as B8
 
 share

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -50,6 +50,7 @@ import System.Random
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as W
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Data.ByteString.Char8 as B8
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -36,8 +36,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkAddressPoolGap
     )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..)
-    , Direction (..)
+    ( Direction (..)
     , EpochNo (..)
     , FeePolicy
     , PoolId
@@ -56,6 +55,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -59,10 +59,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..)
-    , TxMetadata
-    , TxStatus (..)
-    )
+    ( Direction (..), TxMetadata, TxStatus (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -36,8 +36,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkAddressPoolGap
     )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..)
-    , EpochNo (..)
+    ( EpochNo (..)
     , FeePolicy
     , PoolId
     , PoolMetadataSource (..)
@@ -46,8 +45,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolMetadataHash (..)
     , StakePoolMetadataUrl (..)
     , StakePoolTicker
-    , TxMetadata
-    , TxStatus (..)
     , WalletId (..)
     , isValidEpochNo
     , unsafeEpochNo
@@ -61,6 +58,11 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TxMetadata
+    , TxStatus (..)
+    )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -39,7 +39,6 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
     , ChimericAccount (..)
-    , Coin (..)
     , Direction (..)
     , EpochNo (..)
     , FeePolicy
@@ -53,11 +52,12 @@ import Cardano.Wallet.Primitive.Types
     , TxMetadata
     , TxStatus (..)
     , WalletId (..)
-    , isValidCoin
     , isValidEpochNo
     , unsafeEpochNo
     , unsafeToPMS
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -36,9 +36,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkAddressPoolGap
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , AddressState (..)
-    , ChimericAccount (..)
+    ( ChimericAccount (..)
     , Direction (..)
     , EpochNo (..)
     , FeePolicy
@@ -56,6 +54,8 @@ import Cardano.Wallet.Primitive.Types
     , unsafeEpochNo
     , unsafeToPMS
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -49,12 +49,13 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , ProtocolParameters
     , SealedTx
     , SlotNo (..)
     , SlottingParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Concurrent

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -50,7 +50,6 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , ProtocolParameters
-    , SealedTx
     , SlotNo (..)
     , SlottingParameters (..)
     )
@@ -58,6 +57,8 @@ import Cardano.Wallet.Primitive.Types.ChimericAccount
     ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx )
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -89,7 +89,9 @@ import Cardano.Address.Derivation
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ChimericAccount (..), PassphraseScheme (..) )
+    ( ChimericAccount (..), PassphraseScheme (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -89,9 +89,11 @@ import Cardano.Address.Derivation
 import Cardano.Mnemonic
     ( SomeMnemonic )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..), PassphraseScheme (..) )
+    ( PassphraseScheme (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -77,7 +77,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hex
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ProtocolMagic (..), invariant, testnetMagic )
+    ( ProtocolMagic (..), invariant, testnetMagic )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -71,7 +71,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, coinTypeAda, purposeBIP44 )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), invariant, testnetMagic )
+    ( invariant, testnetMagic )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Jormungandr.hs
@@ -92,7 +92,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , rewardAccountKey
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), invariant )
+    ( invariant )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -87,7 +87,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , rewardAccountKey
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), invariant )
+    ( invariant )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -33,7 +33,7 @@ import Cardano.Crypto.Wallet
     ( XPrv )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationIndex (..), Passphrase (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Data.List.NonEmpty
     ( NonEmpty )

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -69,7 +69,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), AddressState (..), ChimericAccount )
+    ( ChimericAccount )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Control.Arrow
     ( second )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -68,10 +68,10 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , IsOwned (..)
     , KnownAddresses (..)
     )
-import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount )
 import Control.Arrow
     ( second )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -99,9 +99,11 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..), invariant )
+    ( invariant )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount )
 import Control.Applicative
     ( (<|>) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -99,7 +99,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), AddressState (..), ChimericAccount (..), invariant )
+    ( ChimericAccount (..), invariant )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Control.Applicative
     ( (<|>) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -28,7 +28,9 @@ module Cardano.Wallet.Primitive.CoinSelection
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxIn, TxOut (..), balance' )
+    ( TxIn, TxOut (..), balance' )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Data.List
     ( foldl' )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -28,9 +28,11 @@ module Cardano.Wallet.Primitive.CoinSelection
 import Prelude
 
 import Cardano.Wallet.Primitive.Types
-    ( TxIn, TxOut (..), balance' )
+    ( balance' )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut (..) )
 import Data.List
     ( foldl' )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -25,9 +25,11 @@ import Cardano.Wallet.Primitive.CoinSelection
     , totalBalance
     )
 import Cardano.Wallet.Primitive.Types
-    ( TxIn, TxOut (..), UTxO (..) )
+    ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/LargestFirst.hs
@@ -25,7 +25,9 @@ import Cardano.Wallet.Primitive.CoinSelection
     , totalBalance
     )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxIn, TxOut (..), UTxO (..) )
+    ( TxIn, TxOut (..), UTxO (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -47,9 +47,11 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeeOptions (..) )
 import Cardano.Wallet.Primitive.Types
-    ( TxIn (..), TxOut (..), UTxO (..) )
+    ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
 import Control.Monad.Trans.State
     ( State, evalState, get, put )
 import Data.List

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Migration.hs
@@ -47,7 +47,9 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeeOptions (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxIn (..), TxOut (..), UTxO (..) )
+    ( TxIn (..), TxOut (..), UTxO (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.Monad.Trans.State
     ( State, evalState, get, put )
 import Data.List

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -27,7 +27,9 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxIn, TxOut (..), UTxO (..), distance, invariant, pickRandom )
+    ( TxIn, TxOut (..), UTxO (..), distance, invariant, pickRandom )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Random.hs
@@ -27,9 +27,11 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.LargestFirst
     ( largestFirst )
 import Cardano.Wallet.Primitive.Types
-    ( TxIn, TxOut (..), UTxO (..), distance, invariant, pickRandom )
+    ( UTxO (..), distance, invariant, pickRandom )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut (..) )
 import Control.Arrow
     ( left )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -44,15 +44,9 @@ import Cardano.Wallet.Primitive.CoinSelection
     , outputBalance
     )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..)
-    , FeePolicy (..)
-    , TxIn
-    , TxOut (..)
-    , UTxO (..)
-    , invariant
-    , isValidCoin
-    , pickRandom
-    )
+    ( FeePolicy (..), TxIn, TxOut (..), UTxO (..), invariant, pickRandom )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), isValidCoin )
 import Control.Monad
     ( when )
 import Control.Monad.Trans.Class

--- a/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Fee.hs
@@ -44,9 +44,11 @@ import Cardano.Wallet.Primitive.CoinSelection
     , outputBalance
     )
 import Cardano.Wallet.Primitive.Types
-    ( FeePolicy (..), TxIn, TxOut (..), UTxO (..), invariant, pickRandom )
+    ( FeePolicy (..), UTxO (..), invariant, pickRandom )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut (..) )
 import Control.Monad
     ( when )
 import Control.Monad.Trans.Class

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -56,8 +56,7 @@ import Prelude
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Block (..)
+    ( Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
     , DelegationCertificate (..)
@@ -78,6 +77,8 @@ import Cardano.Wallet.Primitive.Types
     , restrictedBy
     , txIns
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -60,7 +60,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Coin (..)
     , DelegationCertificate (..)
     , Direction (..)
     , Dom (..)
@@ -79,6 +78,8 @@ import Cardano.Wallet.Primitive.Types
     , restrictedBy
     , txIns
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.DeepSeq
     ( NFData (..), deepseq )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -59,22 +59,14 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , DelegationCertificate (..)
-    , Direction (..)
     , Dom (..)
     , GenesisParameters (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , balance
     , distance
     , dlgCertAccount
     , excluding
-    , inputs
     , restrictedBy
-    , txIns
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -82,6 +74,16 @@ import Cardano.Wallet.Primitive.Types.ChimericAccount
     ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxOut (..)
+    , TxStatus (..)
+    , inputs
+    , txIns
+    )
 import Control.DeepSeq
     ( NFData (..), deepseq )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -58,7 +58,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , DelegationCertificate (..)
     , Direction (..)
     , Dom (..)
@@ -79,6 +78,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -78,10 +78,6 @@ module Cardano.Wallet.Primitive.Types
     , getPoolRegistrationCertificate
     , getPoolRetirementCertificate
 
-    -- * Coin
-    , Coin (..)
-    , isValidCoin
-
     -- * UTxO
     , UTxO (..)
     , balance
@@ -202,7 +198,7 @@ import Cardano.Slotting.Slot
 import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), hashFromText )
 import Control.Arrow

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -61,7 +61,6 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Delegation and stake pools
     , CertificatePublicationTime (..)
-    , ChimericAccount (..)
     , DelegationCertificate (..)
     , dlgCertAccount
     , dlgCertPoolId

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -201,6 +201,8 @@ import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Orphans
     ()
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), hashFromText )
 import Control.Arrow
@@ -1255,39 +1257,6 @@ instance FromText DerivationIndex where
 
 instance ToText DerivationIndex where
     toText (DerivationIndex index) = toText index
-
-{-------------------------------------------------------------------------------
-                                     Coin
--------------------------------------------------------------------------------}
-
--- | Coins are stored as Lovelace (reminder: 1 Lovelace = 1e-6 ADA)
-newtype Coin = Coin
-    { getCoin :: Word64
-    } deriving stock (Show, Ord, Eq, Generic)
-
-instance ToText Coin where
-    toText (Coin c) = T.pack $ show c
-
-instance FromText Coin where
-    fromText = validate <=< (fmap (Coin . fromIntegral) . fromText @Natural)
-      where
-        validate x
-            | isValidCoin x =
-                return x
-            | otherwise =
-                Left $ TextDecodingError "Coin value is out of bounds"
-
-instance NFData Coin
-
-instance Bounded Coin where
-    minBound = Coin 0
-    maxBound = Coin 45_000_000_000_000_000
-
-instance Buildable Coin where
-    build = build . getCoin
-
-isValidCoin :: Coin -> Bool
-isValidCoin c = c >= minBound && c <= maxBound
 
 {-------------------------------------------------------------------------------
                                     UTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -192,14 +192,30 @@ import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Orphans
     ()
-import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.ChimericAccount
     ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), hashFromText )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , SealedTx (..)
+    , TransactionInfo (..)
+    , Tx (..)
+    , TxChange (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxOut (..)
+    , TxStatus (..)
+    , UnsignedTx (..)
+    , fromTransactionInfo
+    , inputs
+    , isPending
+    , toTxHistory
+    , txIns
+    , txMetadataIsNull
+    )
 import Control.Arrow
     ( left, right )
 import Control.DeepSeq
@@ -270,12 +286,9 @@ import Fmt
     ( Buildable (..)
     , blockListF
     , blockListF'
-    , fixedF
     , fmt
     , indentF
     , listF'
-    , nameF
-    , ordinalF
     , padRightF
     , prefixF
     , pretty
@@ -305,7 +318,6 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import qualified Data.Text.Lazy.Builder as Builder
 
 {-------------------------------------------------------------------------------
                              Wallet Metadata
@@ -853,250 +865,6 @@ instance Buildable BlockHeader where
       where
         hhF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash hh
         phF = build $ T.decodeUtf8 $ convertToBase Base16 $ getHash ph
-
-{-------------------------------------------------------------------------------
-                                      Tx
--------------------------------------------------------------------------------}
-
--- | Primitive @Tx@-type.
---
--- Currently tailored for jormungandr in that inputs are @(TxIn, Coin)@
--- instead of @TxIn@. We might have to revisit this when supporting another
--- node.
-data Tx = Tx
-    { txId
-        :: Hash "Tx"
-        -- ^ Jörmungandr computes transaction id by hashing the full content of
-        -- the transaction, which includes witnesses. Therefore, we need either
-        -- to keep track of the witnesses to be able to re-compute the tx id
-        -- every time, or, simply keep track of the id itself.
-    , resolvedInputs
-        :: ![(TxIn, Coin)]
-        -- ^ NOTE: Order of inputs matters in the transaction representation. The
-        -- transaction id is computed from the binary representation of a tx,
-        -- for which inputs are serialized in a specific order.
-    , outputs
-        :: ![TxOut]
-        -- ^ NOTE: Order of outputs matters in the transaction representations. Outputs
-        -- are used as inputs for next transactions which refer to them using
-        -- their indexes. It matters also for serialization.
-    , withdrawals
-        :: !(Map ChimericAccount Coin)
-        -- ^ Withdrawals (of funds from a registered reward account) embedded in
-        -- a transaction. The order does not matter.
-    , metadata
-        :: !(Maybe TxMetadata)
-        -- ^ Semi-structured application-specific extension data stored in the
-        -- transaction on chain.
-        --
-        -- This is not to be confused with 'TxMeta', which is information about
-        -- a transaction derived from the ledger.
-        --
-        -- See Appendix E of <https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec Shelley Ledger: Delegation/Incentives Design Spec>.
-    } deriving (Show, Generic, Ord, Eq)
-
-instance NFData Tx
-
-instance Buildable Tx where
-    build (Tx tid ins outs ws md) = mempty
-        <> build tid
-        <> build ("\n" :: String)
-        <> blockListF' "inputs" build (fst <$> ins)
-        <> blockListF' "outputs" build outs
-        <> blockListF' "withdrawals" tupleF (Map.toList ws)
-        <> nameF "metadata" (maybe "" build md)
-
-txIns :: Set Tx -> Set TxIn
-txIns = foldMap (Set.fromList . inputs)
-
-inputs :: Tx -> [TxIn]
-inputs = map fst . resolvedInputs
-
-data TxIn = TxIn
-    { inputId
-        :: !(Hash "Tx")
-    , inputIx
-        :: !Word32
-    } deriving (Show, Generic, Eq, Ord)
-
-instance NFData TxIn
-
-instance Buildable TxIn where
-    build txin = mempty
-        <> ordinalF (inputIx txin + 1)
-        <> " "
-        <> build (inputId txin)
-
-data TxOut = TxOut
-    { address
-        :: !Address
-    , coin
-        :: !Coin
-    } deriving (Show, Generic, Eq, Ord)
-
-data TxChange derivationPath = TxChange
-    { address
-        :: !Address
-    , amount
-        :: !Coin
-    , derivationPath
-        :: derivationPath
-    } deriving (Show, Generic, Eq, Ord)
-
-instance NFData TxOut
-
-instance Buildable TxOut where
-    build txout = mempty
-        <> build (coin txout)
-        <> " @ "
-        <> prefixF 8 addrF
-        <> "..."
-        <> suffixF 8 addrF
-      where
-        addrF = build $ view #address txout
-
-instance Buildable (TxIn, TxOut) where
-    build (txin, txout) = build txin <> " ==> " <> build txout
-
--- | Additional information about a transaction, derived from the transaction
--- and ledger state. This should not be confused with 'TxMetadata' which is
--- application-specific data included with the transaction.
-data TxMeta = TxMeta
-    { status :: !TxStatus
-    , direction :: !Direction
-    , slotNo :: !SlotNo
-    , blockHeight :: !(Quantity "block" Word32)
-    , amount :: !(Quantity "lovelace" Natural)
-    , expiry :: !(Maybe SlotNo)
-      -- ^ The slot at which a pending transaction will no longer be accepted
-      -- into mempools.
-    } deriving (Show, Eq, Ord, Generic)
-
-instance NFData TxMeta
-
-instance Buildable TxMeta where
-    build (TxMeta s d sl (Quantity bh) (Quantity a) mex) = mempty
-        <> (case d of; Incoming -> "+"; Outgoing -> "-")
-        <> fixedF @Double 6 (fromIntegral a / 1e6)
-        <> " " <> build s
-        <> " since " <> build sl <> "#" <> build bh
-        <> maybe mempty (\ex -> " (expires slot " <> build ex <> ")") mex
-
-data TxStatus
-    = Pending
-        -- ^ Created, but not yet in a block.
-    | InLedger
-        -- ^ Has been found in a block.
-    | Expired
-        -- ^ Time to live (TTL) has passed.
-    deriving (Show, Eq, Ord, Bounded, Enum, Generic)
-
-instance NFData TxStatus
-
-instance Buildable TxStatus where
-    build = Builder.fromText . toTextFromBoundedEnum SpacedLowerCase
-
-instance FromText TxStatus where
-    fromText = fromTextToBoundedEnum SnakeLowerCase
-
-instance ToText TxStatus where
-    toText = toTextFromBoundedEnum SnakeLowerCase
-
--- | An unsigned transaction.
---
--- See 'Tx' for a signed transaction.
---
-data UnsignedTx input output change = UnsignedTx
-    { unsignedInputs
-        :: NonEmpty input
-        -- Inputs are *necessarily* non-empty because Cardano requires at least
-        -- one UTxO input per transaction to prevent replayable transactions.
-        -- (each UTxO being unique, including at least one UTxO in the
-        -- transaction body makes it seemingly unique).
-
-    , unsignedOutputs
-        :: [TxOut]
-        -- Unlike inputs, it is perfectly reasonable to have empty outputs. The
-        -- main scenario where this might occur is when constructing a
-        -- delegation for the sake of submitting a certificate. This type of
-        -- transaction does not typically include any target output and,
-        -- depending on which input(s) get selected to fuel the transaction, it
-        -- may or may not include a change output should its value be less than
-        -- the minimal UTxO value set by the network.
-    , unsignedChange
-        :: [change]
-    }
-    deriving (Eq, Show)
-
--- | The effect of a @Transaction@ on the wallet balance.
-data Direction
-    = Outgoing -- ^ The wallet balance decreases.
-    | Incoming -- ^ The wallet balance increases or stays the same.
-    deriving (Show, Bounded, Enum, Eq, Ord, Generic)
-
-instance NFData Direction
-
-instance Buildable Direction where
-    build = Builder.fromText . toTextFromBoundedEnum SpacedLowerCase
-
-instance FromText Direction where
-    fromText = fromTextToBoundedEnum SnakeLowerCase
-
-instance ToText Direction where
-    toText = toTextFromBoundedEnum SnakeLowerCase
-
--- | @SealedTx@ is a serialised transaction that is ready to be submitted
--- to the node.
-newtype SealedTx = SealedTx { getSealedTx :: ByteString }
-    deriving stock (Show, Eq, Generic)
-    deriving newtype (ByteArrayAccess)
-
--- | True if the given metadata refers to a pending transaction
-isPending :: TxMeta -> Bool
-isPending = (== Pending) . (status :: TxMeta -> TxStatus)
-
--- | Full expanded and resolved information about a transaction, suitable for
--- presentation to the user.
-data TransactionInfo = TransactionInfo
-    { txInfoId :: !(Hash "Tx")
-    -- ^ Transaction ID of this transaction
-    , txInfoInputs :: ![(TxIn, Coin, Maybe TxOut)]
-    -- ^ Transaction inputs and (maybe) corresponding outputs of the
-    -- source. Source information can only be provided for outgoing payments.
-    , txInfoOutputs :: ![TxOut]
-    -- ^ Payment destination.
-    , txInfoWithdrawals :: !(Map ChimericAccount Coin)
-    -- ^ Withdrawals on this transaction.
-    , txInfoMeta :: !TxMeta
-    -- ^ Other information calculated from the transaction.
-    , txInfoDepth :: Quantity "block" Natural
-    -- ^ Number of slots since the transaction slot.
-    , txInfoTime :: UTCTime
-    -- ^ Creation time of the block including this transaction.
-    , txInfoMetadata :: !(Maybe TxMetadata)
-    -- ^ Application-specific extension data.
-    } deriving (Generic, Show, Eq)
-
-instance NFData TransactionInfo
-
--- | Reconstruct a transaction info from a transaction.
-fromTransactionInfo :: TransactionInfo -> Tx
-fromTransactionInfo info = Tx
-    { txId = txInfoId info
-    , resolvedInputs = (\(a,b,_) -> (a,b)) <$> txInfoInputs info
-    , outputs = txInfoOutputs info
-    , withdrawals = txInfoWithdrawals info
-    , metadata = txInfoMetadata info
-    }
-
--- | Test whether the given metadata map is empty.
-txMetadataIsNull :: TxMetadata -> Bool
-txMetadataIsNull (TxMetadata md) = Map.null md
-
--- | Drop time-specific information
-toTxHistory :: TransactionInfo -> (Tx, TxMeta)
-toTxHistory info =
-    (fromTransactionInfo info, txInfoMeta info)
 
 -- | A linear equation of a free variable `x`. Represents the @\x -> a + b*x@
 -- function where @x@ can be the transaction size in bytes or, a number of

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -197,6 +197,8 @@ import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Orphans
     ()
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -217,8 +219,6 @@ import Crypto.Hash
     ( Blake2b_160, Digest, digestFromByteString )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..), withObject, (.:), (.:?) )
-import Data.Bifunctor
-    ( bimap )
 import Data.ByteArray
     ( ByteArrayAccess )
 import Data.ByteArray.Encoding
@@ -1135,96 +1135,6 @@ instance FromText FeePolicy where
             "Unable to decode FeePolicy: \
             \Linear equation not in expected format: a + bx + cy \
             \where 'a', 'b', and 'c' are numbers"
-
-
-{-------------------------------------------------------------------------------
-                                    Address
--------------------------------------------------------------------------------}
-
--- | Representation of Cardano addresses. Addresses are basically a
--- human-friendly representation of public keys. Historically in Cardano, there
--- exists different sort of addresses, and new ones are to come. So far, we can
--- distinguish between three types of addresses:
---
--- - Byron Random addresses, which holds a payload with derivation path details
--- - Byron Sequential addresses, also known as Icarus'style addresses
--- - Shelley base addresses, see also [implementation-decisions/address](https://github.com/input-output-hk/implementation-decisions/blob/master/text/0001-address.md)
---
--- For more details, see also [About Address Derivation](https://github.com/input-output-hk/cardano-wallet/wiki/About-Address-Derivation)
---
--- Shelley base addresses can be divided into two types:
---
--- - Single Addresses: which only hold a public spending key
--- - Group Addresses: which hold both a spending and delegation keys
---
--- It'll therefore seem legitimate to represent addresses as:
---
--- @
--- data Address
---   = ByronAddress !ByteString
---   | SingleAddress !XPub
---   | GroupAddress !XPub XPub
--- @
---
--- However, there's a major drawback to this approach:  we have to consider all
--- three constructors everywhere, and make sure we test every function using
--- them three despite having no need for such fine-grained representation.
---
--- Indeed, from the wallet core code, addresses are nothing more than an opaque
--- bunch of bytes that can be compared with each other. When signing
--- transactions, we have to lookup addresses anyway and therefore, can re-derive
--- their corresponding public keys. The only moment the distinction between
--- address type matters is when it comes to representing addresses at the edge
--- of the application (the API layer). And here, this is precisely where we need
--- to also what target backend we're connected to. Different backends use
--- different encodings which may not be compatible.
---
--- Therefore, for simplicity, it's easier to consider addresses as "bytes", and
--- only peak into these bytes whenever we need to do something with them. This
--- makes it fairly clear that addresses are just an opaque string for the wallet
--- layer and that the underlying encoding is rather agnostic to the underlying
--- backend.
-newtype Address = Address
-    { unAddress :: ByteString
-    } deriving (Show, Generic, Eq, Ord)
-
-instance NFData Address
-
-instance Buildable Address where
-    build addr = mempty
-        <> prefixF 8 addrF
-        <> "..."
-        <> suffixF 8 addrF
-      where
-        addrF = build (toText addr)
-
-instance ToText Address where
-    toText = T.decodeUtf8
-        . convertToBase Base16
-        . unAddress
-
-instance FromText Address where
-    fromText = bimap textDecodingError Address
-        . convertFromBase Base16
-        . T.encodeUtf8
-      where
-        textDecodingError = TextDecodingError . show
-
--- | Denotes if an address has been previously used or not... whether that be
--- in the output of a transaction on the blockchain or one in our pending set.
-data AddressState = Used | Unused
-    deriving (Bounded, Enum, Eq, Generic, Show)
-
-instance FromText AddressState where
-    fromText = fromTextToBoundedEnum SnakeLowerCase
-
-instance ToText AddressState where
-    toText = toTextFromBoundedEnum SnakeLowerCase
-
-instance Buildable AddressState where
-    build = build . toText
-
-instance NFData AddressState
 
 -- | A thin wrapper around derivation indexes. This can be used to represent
 -- derivation path as homogeneous lists of 'DerivationIndex'. This is slightly

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -39,26 +39,6 @@ module Cardano.Wallet.Primitive.Types
       Block(..)
     , BlockHeader(..)
 
-    -- * Tx
-    , Tx (..)
-    , TxChange (..)
-    , TxIn(..)
-    , TxOut(..)
-    , TxMeta(..)
-    , TxMetadata(..)
-    , TxMetadataValue(..)
-    , Direction(..)
-    , TxStatus(..)
-    , SealedTx (..)
-    , TransactionInfo (..)
-    , UnsignedTx (..)
-    , txIns
-    , isPending
-    , inputs
-    , fromTransactionInfo
-    , toTxHistory
-    , txMetadataIsNull
-
     -- * Delegation and stake pools
     , CertificatePublicationTime (..)
     , DelegationCertificate (..)
@@ -186,8 +166,6 @@ module Cardano.Wallet.Primitive.Types
 
 import Prelude
 
-import Cardano.Api.Typed
-    ( TxMetadata (..), TxMetadataValue (..) )
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Orphans
@@ -199,23 +177,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..), hashFromText )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..)
-    , SealedTx (..)
-    , TransactionInfo (..)
-    , Tx (..)
-    , TxChange (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxOut (..)
-    , TxStatus (..)
-    , UnsignedTx (..)
-    , fromTransactionInfo
-    , inputs
-    , isPending
-    , toTxHistory
-    , txIns
-    , txMetadataIsNull
-    )
+    ( Tx (..), TxIn (..), TxOut (..) )
 import Control.Arrow
     ( left, right )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -195,6 +195,8 @@ import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -1615,22 +1617,6 @@ testnetMagic = ProtocolMagic $ fromIntegral $ natVal $ Proxy @pm
 {-------------------------------------------------------------------------------
               Stake Pool Delegation and Registration Certificates
 -------------------------------------------------------------------------------}
-
--- | Also known as a staking key, chimeric account is used in group-type address
--- for staking purposes. It is a public key of the account address
-newtype ChimericAccount = ChimericAccount { unChimericAccount :: ByteString }
-    deriving (Generic, Show, Eq, Ord)
-
-instance NFData ChimericAccount
-
-instance Buildable ChimericAccount where
-    build = build . Hash @"ChimericAccount" . unChimericAccount
-
-instance ToText ChimericAccount where
-    toText = toText . Hash @"ChimericAccount" . unChimericAccount
-
-instance FromText ChimericAccount where
-    fromText = fmap (ChimericAccount . getHash @"ChimericAccount") . fromText
 
 -- | Represent a delegation certificate.
 data DelegationCertificate

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -59,10 +59,6 @@ module Cardano.Wallet.Primitive.Types
     , toTxHistory
     , txMetadataIsNull
 
-    -- * Address
-    , Address (..)
-    , AddressState (..)
-
     -- * Delegation and stake pools
     , CertificatePublicationTime (..)
     , ChimericAccount (..)
@@ -198,7 +194,7 @@ import Cardano.Slotting.Slot
 import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.Types.Address
-    ( Address (..), AddressState (..) )
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- This module provides the 'Address' data type, which provides a human-friendly
+-- representation of a public key.
+--
+module Cardano.Wallet.Primitive.Types.Address
+    ( Address (..)
+    , AddressState (..)
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.Bifunctor
+    ( bimap )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Text.Class
+    ( CaseStyle (..)
+    , FromText (..)
+    , TextDecodingError (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
+import Fmt
+    ( Buildable (..), prefixF, suffixF )
+import GHC.Generics
+    ( Generic )
+
+import qualified Data.Text.Encoding as T
+
+-- | Representation of Cardano addresses.
+--
+-- Addresses are basically a human-friendly representation of public keys.
+-- Historically in Cardano, there exist different sort of addresses, and new
+-- ones are to come. So far, we can distinguish between three types of
+-- address:
+--
+-- - Byron Random addresses, which holds a payload with derivation path details
+-- - Byron Sequential addresses, also known as Icarus'style addresses
+-- - Shelley base addresses, see also [implementation-decisions/address](https://github.com/input-output-hk/implementation-decisions/blob/master/text/0001-address.md)
+--
+-- For more details, see also [About Address Derivation](https://github.com/input-output-hk/cardano-wallet/wiki/About-Address-Derivation)
+--
+-- Shelley base addresses can be divided into two types:
+--
+-- - Single Addresses: which only hold a public spending key
+-- - Group Addresses: which hold both a spending and delegation keys
+--
+-- It'll therefore seem legitimate to represent addresses as:
+--
+-- @
+-- data Address
+--   = ByronAddress !ByteString
+--   | SingleAddress !XPub
+--   | GroupAddress !XPub XPub
+-- @
+--
+-- However, there's a major drawback to this approach:  we have to consider all
+-- three constructors everywhere, and make sure we test every function using
+-- them three despite having no need for such fine-grained representation.
+--
+-- Indeed, from the wallet core code, addresses are nothing more than an opaque
+-- bunch of bytes that can be compared with each other. When signing
+-- transactions, we have to look up addresses anyway and therefore can
+-- re-derive their corresponding public keys. The only moment the distinction
+-- between address types matters is when it comes to representing addresses at
+-- the edge of the application (the API layer). And here, this is precisely
+-- where we need to also what target backend we're connected to. Different
+-- backends use different encodings which may not be compatible.
+--
+-- Therefore, for simplicity, it's easier to consider addresses as "bytes", and
+-- only peak into these bytes whenever we need to do something with them. This
+-- makes it fairly clear that addresses are just an opaque string for the wallet
+-- layer and that the underlying encoding is rather agnostic to the underlying
+-- backend.
+--
+newtype Address = Address
+    { unAddress :: ByteString
+    } deriving (Show, Generic, Eq, Ord)
+
+instance NFData Address
+
+instance Buildable Address where
+    build addr = mempty
+        <> prefixF 8 addrF
+        <> "..."
+        <> suffixF 8 addrF
+      where
+        addrF = build (toText addr)
+
+instance ToText Address where
+    toText = T.decodeUtf8
+        . convertToBase Base16
+        . unAddress
+
+instance FromText Address where
+    fromText = bimap textDecodingError Address
+        . convertFromBase Base16
+        . T.encodeUtf8
+      where
+        textDecodingError = TextDecodingError . show
+
+-- | Denotes if an address has been previously used or not... whether that be
+-- in the output of a transaction on the blockchain or one in our pending set.
+data AddressState = Used | Unused
+    deriving (Bounded, Enum, Eq, Generic, Show)
+
+instance FromText AddressState where
+    fromText = fromTextToBoundedEnum SnakeLowerCase
+
+instance ToText AddressState where
+    toText = toTextFromBoundedEnum SnakeLowerCase
+
+instance Buildable AddressState where
+    build = build . toText
+
+instance NFData AddressState

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/ChimericAccount.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/ChimericAccount.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- This module provides the 'ChimericAccount' data type, used for staking
+-- purposes.
+--
+module Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..)
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.ByteString
+    ( ByteString )
+import Data.Text.Class
+    ( FromText (..), ToText (..) )
+import Fmt
+    ( Buildable (..) )
+import GHC.Generics
+    ( Generic )
+
+-- | Also known as a staking key, a chimeric account is used in group-type
+--   addresses for staking purposes.
+--
+-- It is the public key of the account address.
+--
+newtype ChimericAccount = ChimericAccount { unChimericAccount :: ByteString }
+    deriving (Generic, Show, Eq, Ord)
+
+instance NFData ChimericAccount
+
+instance Buildable ChimericAccount where
+    build = build . Hash @"ChimericAccount" . unChimericAccount
+
+instance ToText ChimericAccount where
+    toText = toText . Hash @"ChimericAccount" . unChimericAccount
+
+instance FromText ChimericAccount where
+    fromText = fmap (ChimericAccount . getHash @"ChimericAccount") . fromText

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- This module provides the 'Coin' data type, which represents a quantity of
+-- lovelace.
+--
+module Cardano.Wallet.Primitive.Types.Coin
+    (
+    -- * Type
+      Coin (..)
+
+    -- * Checks
+    , isValidCoin
+
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData (..) )
+import Control.Monad
+    ( (<=<) )
+import Data.Text.Class
+    ( FromText (..), TextDecodingError (..), ToText (..) )
+import Data.Word
+    ( Word64 )
+import Fmt
+    ( Buildable (..) )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Data.Text as T
+
+-- | A 'Coin' represents a quantity of lovelace.
+--
+-- Reminder: 1 Lovelace = 1,000,000 ADA
+--
+newtype Coin = Coin
+    { getCoin :: Word64
+    }
+    deriving stock (Show, Ord, Eq, Generic)
+
+instance ToText Coin where
+    toText (Coin c) = T.pack $ show c
+
+instance FromText Coin where
+    fromText = validate <=< (fmap (Coin . fromIntegral) . fromText @Natural)
+      where
+        validate x
+            | isValidCoin x =
+                return x
+            | otherwise =
+                Left $ TextDecodingError "Coin value is out of bounds"
+
+instance NFData Coin
+
+instance Bounded Coin where
+    minBound = Coin 0
+    maxBound = Coin 45_000_000_000_000_000
+
+instance Buildable Coin where
+    build = build . getCoin
+
+isValidCoin :: Coin -> Bool
+isValidCoin c = c >= minBound && c <= maxBound

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -16,6 +16,8 @@ module Cardano.Wallet.Primitive.Types.Tx
     , TxOut (..)
     , TxChange (..)
     , TxMeta (..)
+    , TxMetadata (..)
+    , TxMetadataValue (..)
     , TxStatus (..)
     , SealedTx (..)
     , UnsignedTx (..)
@@ -35,7 +37,7 @@ module Cardano.Wallet.Primitive.Types.Tx
 import Prelude
 
 import Cardano.Api.Typed
-    ( TxMetadata (..) )
+    ( TxMetadata (..), TxMetadataValue (..) )
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Orphans
@@ -60,8 +62,12 @@ import Data.Generics.Labels
     ()
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Data.Map.Strict
+    ( Map )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Set
+    ( Set )
 import Data.Text.Class
     ( CaseStyle (..)
     , FromText (..)
@@ -69,10 +75,6 @@ import Data.Text.Class
     , fromTextToBoundedEnum
     , toTextFromBoundedEnum
     )
-import Data.Map.Strict
-    ( Map )
-import Data.Set
-    ( Set )
 import Data.Time.Clock
     ( UTCTime )
 import Data.Word

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -1,0 +1,338 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.Primitive.Types.Tx
+    (
+    -- * Types
+      Tx (..)
+    , TxIn (..)
+    , TxOut (..)
+    , TxChange (..)
+    , TxMeta (..)
+    , TxStatus (..)
+    , SealedTx (..)
+    , UnsignedTx (..)
+    , TransactionInfo (..)
+    , Direction (..)
+
+    -- * Functions
+    , fromTransactionInfo
+    , inputs
+    , isPending
+    , toTxHistory
+    , txIns
+    , txMetadataIsNull
+
+    ) where
+
+import Prelude
+
+import Cardano.Api.Typed
+    ( TxMetadata (..) )
+import Cardano.Slotting.Slot
+    ( SlotNo (..) )
+import Cardano.Wallet.Orphans
+    ()
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Control.DeepSeq
+    ( NFData (..) )
+import Data.ByteArray
+    ( ByteArrayAccess )
+import Data.ByteString
+    ( ByteString )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Quantity
+    ( Quantity (..) )
+import Data.Text.Class
+    ( CaseStyle (..)
+    , FromText (..)
+    , ToText (..)
+    , fromTextToBoundedEnum
+    , toTextFromBoundedEnum
+    )
+import Data.Map.Strict
+    ( Map )
+import Data.Set
+    ( Set )
+import Data.Time.Clock
+    ( UTCTime )
+import Data.Word
+    ( Word32 )
+import Fmt
+    ( Buildable (..)
+    , blockListF'
+    , fixedF
+    , nameF
+    , ordinalF
+    , prefixF
+    , suffixF
+    , tupleF
+    )
+import GHC.Generics
+    ( Generic )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text.Lazy.Builder as Builder
+
+-- | Primitive @Tx@-type.
+--
+-- Currently tailored for jormungandr in that inputs are @(TxIn, Coin)@
+-- instead of @TxIn@. We might have to revisit this when supporting another
+-- node.
+data Tx = Tx
+    { txId
+        :: Hash "Tx"
+        -- ^ Jörmungandr computes transaction id by hashing the full content of
+        -- the transaction, which includes witnesses. Therefore, we need either
+        -- to keep track of the witnesses to be able to re-compute the tx id
+        -- every time, or, simply keep track of the id itself.
+    , resolvedInputs
+        :: ![(TxIn, Coin)]
+        -- ^ NOTE: Order of inputs matters in the transaction representation.
+        -- The transaction id is computed from the binary representation of a
+        -- tx, for which inputs are serialized in a specific order.
+    , outputs
+        :: ![TxOut]
+        -- ^ NOTE: Order of outputs matters in the transaction representations.
+        -- Outputs are used as inputs for next transactions which refer to them
+        -- using their indexes. It matters also for serialization.
+    , withdrawals
+        :: !(Map ChimericAccount Coin)
+        -- ^ Withdrawals (of funds from a registered reward account) embedded in
+        -- a transaction. The order does not matter.
+    , metadata
+        :: !(Maybe TxMetadata)
+        -- ^ Semi-structured application-specific extension data stored in the
+        -- transaction on chain.
+        --
+        -- This is not to be confused with 'TxMeta', which is information about
+        -- a transaction derived from the ledger.
+        --
+        -- See Appendix E of
+        -- <https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec Shelley Ledger: Delegation/Incentives Design Spec>.
+    } deriving (Show, Generic, Ord, Eq)
+
+instance NFData Tx
+
+instance Buildable Tx where
+    build (Tx tid ins outs ws md) = mempty
+        <> build tid
+        <> build ("\n" :: String)
+        <> blockListF' "inputs" build (fst <$> ins)
+        <> blockListF' "outputs" build outs
+        <> blockListF' "withdrawals" tupleF (Map.toList ws)
+        <> nameF "metadata" (maybe "" build md)
+
+txIns :: Set Tx -> Set TxIn
+txIns = foldMap (Set.fromList . inputs)
+
+inputs :: Tx -> [TxIn]
+inputs = map fst . resolvedInputs
+
+data TxIn = TxIn
+    { inputId
+        :: !(Hash "Tx")
+    , inputIx
+        :: !Word32
+    } deriving (Show, Generic, Eq, Ord)
+
+instance NFData TxIn
+
+instance Buildable TxIn where
+    build txin = mempty
+        <> ordinalF (inputIx txin + 1)
+        <> " "
+        <> build (inputId txin)
+
+data TxOut = TxOut
+    { address
+        :: !Address
+    , coin
+        :: !Coin
+    } deriving (Show, Generic, Eq, Ord)
+
+data TxChange derivationPath = TxChange
+    { address
+        :: !Address
+    , amount
+        :: !Coin
+    , derivationPath
+        :: derivationPath
+    } deriving (Show, Generic, Eq, Ord)
+
+instance NFData TxOut
+
+instance Buildable TxOut where
+    build txout = mempty
+        <> build (coin txout)
+        <> " @ "
+        <> prefixF 8 addrF
+        <> "..."
+        <> suffixF 8 addrF
+      where
+        addrF = build $ view #address txout
+
+instance Buildable (TxIn, TxOut) where
+    build (txin, txout) = build txin <> " ==> " <> build txout
+
+-- | Additional information about a transaction, derived from the transaction
+-- and ledger state. This should not be confused with 'TxMetadata' which is
+-- application-specific data included with the transaction.
+data TxMeta = TxMeta
+    { status :: !TxStatus
+    , direction :: !Direction
+    , slotNo :: !SlotNo
+    , blockHeight :: !(Quantity "block" Word32)
+    , amount :: !(Quantity "lovelace" Natural)
+    , expiry :: !(Maybe SlotNo)
+      -- ^ The slot at which a pending transaction will no longer be accepted
+      -- into mempools.
+    } deriving (Show, Eq, Ord, Generic)
+
+instance NFData TxMeta
+
+instance Buildable TxMeta where
+    build (TxMeta s d sl (Quantity bh) (Quantity a) mex) = mempty
+        <> (case d of; Incoming -> "+"; Outgoing -> "-")
+        <> fixedF @Double 6 (fromIntegral a / 1e6)
+        <> " " <> build s
+        <> " since " <> build sl <> "#" <> build bh
+        <> maybe mempty (\ex -> " (expires slot " <> build ex <> ")") mex
+
+data TxStatus
+    = Pending
+        -- ^ Created, but not yet in a block.
+    | InLedger
+        -- ^ Has been found in a block.
+    | Expired
+        -- ^ Time to live (TTL) has passed.
+    deriving (Show, Eq, Ord, Bounded, Enum, Generic)
+
+instance NFData TxStatus
+
+instance Buildable TxStatus where
+    build = Builder.fromText . toTextFromBoundedEnum SpacedLowerCase
+
+instance FromText TxStatus where
+    fromText = fromTextToBoundedEnum SnakeLowerCase
+
+instance ToText TxStatus where
+    toText = toTextFromBoundedEnum SnakeLowerCase
+
+-- | An unsigned transaction.
+--
+-- See 'Tx' for a signed transaction.
+--
+data UnsignedTx input output change = UnsignedTx
+    { unsignedInputs
+        :: NonEmpty input
+        -- Inputs are *necessarily* non-empty because Cardano requires at least
+        -- one UTxO input per transaction to prevent replayable transactions.
+        -- (each UTxO being unique, including at least one UTxO in the
+        -- transaction body makes it seemingly unique).
+
+    , unsignedOutputs
+        :: [TxOut]
+        -- Unlike inputs, it is perfectly reasonable to have empty outputs. The
+        -- main scenario where this might occur is when constructing a
+        -- delegation for the sake of submitting a certificate. This type of
+        -- transaction does not typically include any target output and,
+        -- depending on which input(s) get selected to fuel the transaction, it
+        -- may or may not include a change output should its value be less than
+        -- the minimal UTxO value set by the network.
+    , unsignedChange
+        :: [change]
+    }
+    deriving (Eq, Show)
+
+-- | The effect of a @Transaction@ on the wallet balance.
+data Direction
+    = Outgoing -- ^ The wallet balance decreases.
+    | Incoming -- ^ The wallet balance increases or stays the same.
+    deriving (Show, Bounded, Enum, Eq, Ord, Generic)
+
+instance NFData Direction
+
+instance Buildable Direction where
+    build = Builder.fromText . toTextFromBoundedEnum SpacedLowerCase
+
+instance FromText Direction where
+    fromText = fromTextToBoundedEnum SnakeLowerCase
+
+instance ToText Direction where
+    toText = toTextFromBoundedEnum SnakeLowerCase
+
+-- | @SealedTx@ is a serialised transaction that is ready to be submitted
+-- to the node.
+newtype SealedTx = SealedTx { getSealedTx :: ByteString }
+    deriving stock (Show, Eq, Generic)
+    deriving newtype (ByteArrayAccess)
+
+-- | True if the given metadata refers to a pending transaction
+isPending :: TxMeta -> Bool
+isPending = (== Pending) . (status :: TxMeta -> TxStatus)
+
+-- | Full expanded and resolved information about a transaction, suitable for
+-- presentation to the user.
+data TransactionInfo = TransactionInfo
+    { txInfoId :: !(Hash "Tx")
+    -- ^ Transaction ID of this transaction
+    , txInfoInputs :: ![(TxIn, Coin, Maybe TxOut)]
+    -- ^ Transaction inputs and (maybe) corresponding outputs of the
+    -- source. Source information can only be provided for outgoing payments.
+    , txInfoOutputs :: ![TxOut]
+    -- ^ Payment destination.
+    , txInfoWithdrawals :: !(Map ChimericAccount Coin)
+    -- ^ Withdrawals on this transaction.
+    , txInfoMeta :: !TxMeta
+    -- ^ Other information calculated from the transaction.
+    , txInfoDepth :: Quantity "block" Natural
+    -- ^ Number of slots since the transaction slot.
+    , txInfoTime :: UTCTime
+    -- ^ Creation time of the block including this transaction.
+    , txInfoMetadata :: !(Maybe TxMetadata)
+    -- ^ Application-specific extension data.
+    } deriving (Generic, Show, Eq)
+
+instance NFData TransactionInfo
+
+-- | Reconstruct a transaction info from a transaction.
+fromTransactionInfo :: TransactionInfo -> Tx
+fromTransactionInfo info = Tx
+    { txId = txInfoId info
+    , resolvedInputs = (\(a,b,_) -> (a,b)) <$> txInfoInputs info
+    , outputs = txInfoOutputs info
+    , withdrawals = txInfoWithdrawals info
+    , metadata = txInfoMetadata info
+    }
+
+-- | Test whether the given metadata map is empty.
+txMetadataIsNull :: TxMetadata -> Bool
+txMetadataIsNull (TxMetadata md) = Map.null md
+
+-- | Drop time-specific information
+toTxHistory :: TransactionInfo -> (Tx, TxMeta)
+toTxHistory info =
+    (fromTransactionInfo info, txInfoMeta info)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -37,9 +37,11 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee, FeePolicy )
 import Cardano.Wallet.Primitive.Types
-    ( PoolId, SealedTx (..), SlotNo (..), Tx (..), TxMetadata )
+    ( PoolId, SlotNo (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx (..), Tx (..), TxMetadata )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -37,7 +37,9 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee, FeePolicy )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), PoolId, SealedTx (..), SlotNo (..), Tx (..), TxMetadata )
+    ( PoolId, SealedTx (..), SlotNo (..), Tx (..), TxMetadata )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Data.ByteString
     ( ByteString )
 import Data.Quantity

--- a/lib/core/src/Cardano/Wallet/Unsafe.hs
+++ b/lib/core/src/Cardano/Wallet/Unsafe.hs
@@ -47,7 +47,7 @@ import Cardano.Mnemonic
     )
 import Cardano.Wallet.Api.Types
     ( DecodeAddress (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Control.Monad
     ( (>=>) )

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -100,11 +100,8 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , ActiveSlotCoefficient (..)
-    , Address (..)
-    , AddressState (..)
     , Block (..)
     , BlockHeader (..)
-    , Coin (..)
     , Direction (..)
     , EpochLength (..)
     , Range (..)
@@ -126,6 +123,10 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -99,10 +99,8 @@ import Cardano.Wallet.Primitive.Slotting
     ( singleEraInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , ActiveSlotCoefficient (..)
     , Block (..)
     , BlockHeader (..)
-    , Direction (..)
     , EpochLength (..)
     , Range (..)
     , SlotLength (..)
@@ -110,12 +108,6 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , SortOrder (..)
     , StartTime (..)
-    , TransactionInfo
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , WalletDelegation (..)
     , WalletDelegationStatus (..)
@@ -129,6 +121,15 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TransactionInfo
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxOut (..)
+    , TxStatus (..)
+    )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeRunExceptT )
 import Control.DeepSeq

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -25,7 +25,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Coin (..)
     , EpochLength (..)
     , FeePolicy (..)
     , GenesisParameters (..)
@@ -41,6 +40,8 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Crypto.Hash

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -42,11 +42,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..)
-    , TxIn (..)
-    , TxMetadata (..)
-    , TxOut (..)
-    )
+    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..) )
 import Crypto.Hash
     ( Blake2b_256, hash )
 import Data.ByteString

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -24,7 +24,6 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , EpochLength (..)
     , FeePolicy (..)
     , GenesisParameters (..)
@@ -40,6 +39,8 @@ import Cardano.Wallet.Primitive.Types
     , TxOut (..)
     , TxParameters (..)
     )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -33,10 +33,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , SlottingParameters (..)
     , StartTime (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMetadata (..)
-    , TxOut (..)
     , TxParameters (..)
     )
 import Cardano.Wallet.Primitive.Types.ChimericAccount
@@ -45,6 +41,12 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Tx (..)
+    , TxIn (..)
+    , TxMetadata (..)
+    , TxOut (..)
+    )
 import Crypto.Hash
     ( Blake2b_256, hash )
 import Data.ByteString

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -30,14 +30,14 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
-import Cardano.Wallet.Primitive.Types
-    ( TxIn (..), TxOut (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeDeserialiseCbor, unsafeFromHex )
 import Data.ByteString

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -31,7 +31,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), TxIn (..), TxOut (..) )
+    ( Address (..), TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -31,7 +31,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), TxIn (..), TxOut (..) )
+    ( TxIn (..), TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -76,7 +76,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( AccountingStyle (..), DerivationIndex (..), NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address, WalletId, walletNameMaxLength )
+    ( WalletId, walletNameMaxLength )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Control.Arrow
     ( first )
 import Data.Aeson.QQ

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -149,9 +149,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , AddressState (..)
-    , ChimericAccount (..)
+    ( ChimericAccount (..)
     , Direction (..)
     , EpochNo (..)
     , HistogramBar (..)
@@ -184,6 +182,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMaxLength
     , walletNameMinLength
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -149,8 +149,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Direction (..)
-    , EpochNo (..)
+    ( EpochNo (..)
     , HistogramBar (..)
     , PoolId (..)
     , PoolMetadataGCStatus (..)
@@ -165,12 +164,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolMetadata (..)
     , StakePoolTicker
     , StartTime (..)
-    , TxIn (..)
-    , TxIn (..)
-    , TxMetadata (..)
-    , TxMetadata (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics (..)
     , WalletDelegationStatus (..)
@@ -189,6 +182,15 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TxIn (..)
+    , TxIn (..)
+    , TxMetadata (..)
+    , TxMetadata (..)
+    , TxOut (..)
+    , TxStatus (..)
+    )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -149,8 +149,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..)
-    , Direction (..)
+    ( Direction (..)
     , EpochNo (..)
     , HistogramBar (..)
     , PoolId (..)
@@ -184,6 +183,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -152,7 +152,6 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , AddressState (..)
     , ChimericAccount (..)
-    , Coin (..)
     , Direction (..)
     , EpochNo (..)
     , HistogramBar (..)
@@ -185,6 +184,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMaxLength
     , walletNameMinLength
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Transaction

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -63,7 +63,9 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ChimericAccount (..) )
+    ( ChimericAccount (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Control.Arrow
     ( first )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -62,10 +62,10 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Control.Arrow
     ( first )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -79,9 +79,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Slotting
     ( unsafeEpochNo )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , AddressState (..)
-    , Block (..)
+    ( Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
     , DecentralizationLevel (..)
@@ -115,6 +113,8 @@ import Cardano.Wallet.Primitive.Types
     , rangeIsValid
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -84,7 +84,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Coin (..)
     , DecentralizationLevel (..)
     , DelegationCertificate (..)
     , Direction (..)
@@ -116,6 +115,8 @@ import Cardano.Wallet.Primitive.Types
     , rangeIsValid
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -81,7 +81,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , DecentralizationLevel (..)
     , DelegationCertificate (..)
     , Direction (..)
@@ -115,6 +114,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -83,7 +83,6 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , DecentralizationLevel (..)
     , DelegationCertificate (..)
-    , Direction (..)
     , EpochNo (..)
     , FeePolicy (..)
     , PassphraseScheme (..)
@@ -94,13 +93,7 @@ import Cardano.Wallet.Primitive.Types
     , SlotInEpoch (..)
     , SlotNo (..)
     , SortOrder (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxMetadata
-    , TxOut (..)
     , TxParameters (..)
-    , TxStatus (..)
     , UTxO (..)
     , WalletDelegation (..)
     , WalletDelegationStatus (..)
@@ -108,7 +101,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
-    , isPending
     , rangeIsValid
     , wholeRange
     )
@@ -120,6 +112,16 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxMetadata
+    , TxOut (..)
+    , TxStatus (..)
+    , isPending
+    )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeMkPercentage )
 import Control.Arrow

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -27,7 +27,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Control.DeepSeq
     ( NFData )

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -50,24 +50,26 @@ import Cardano.Wallet.Primitive.Model
     ( Wallet, applyBlock, currentTip )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
-    , Direction (..)
     , ProtocolParameters
     , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
-    , TransactionInfo (..)
-    , Tx (..)
-    , TxMeta (..)
-    , TxStatus (..)
     , WalletId (..)
     , WalletMetadata (..)
-    , isPending
-    , toTxHistory
     , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TransactionInfo (..)
+    , Tx (..)
+    , TxMeta (..)
+    , TxStatus (..)
+    , isPending
+    , toTxHistory
+    )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent.Async

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -121,7 +121,6 @@ import Cardano.Wallet.Primitive.Model
     )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
     , Block (..)
     , BlockHeader (..)
     , Direction (..)
@@ -144,6 +143,8 @@ import Cardano.Wallet.Primitive.Types
     , toTxHistory
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -124,7 +124,6 @@ import Cardano.Wallet.Primitive.Types
     , Address (..)
     , Block (..)
     , BlockHeader (..)
-    , Coin (..)
     , Direction (..)
     , PassphraseScheme (..)
     , ProtocolParameters
@@ -145,6 +144,8 @@ import Cardano.Wallet.Primitive.Types
     , toTxHistory
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -123,24 +123,17 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
     , BlockHeader (..)
-    , Direction (..)
     , PassphraseScheme (..)
     , ProtocolParameters
     , Range
     , SlotNo (..)
     , SortOrder (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (TxMeta, amount, direction)
-    , TxOut (..)
-    , TxStatus (..)
     , WalletDelegation (..)
     , WalletDelegationStatus (..)
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
-    , toTxHistory
     , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -149,6 +142,15 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (TxMeta, amount, direction)
+    , TxOut (..)
+    , TxStatus (..)
+    , toTxHistory
+    )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Concurrent

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -110,8 +110,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( Address
-    , BlockHeader
+    ( BlockHeader
     , ChimericAccount (..)
     , DecentralizationLevel
     , DelegationCertificate
@@ -138,6 +137,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , inputs
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -113,7 +113,6 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader
     , DecentralizationLevel
     , DelegationCertificate
-    , Direction (..)
     , EpochNo (..)
     , FeePolicy
     , GenesisParameters
@@ -123,18 +122,10 @@ import Cardano.Wallet.Primitive.Types
     , SlotNo (..)
     , SortOrder (..)
     , StakeKeyCertificate
-    , TransactionInfo (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxMetadata
-    , TxOut (..)
     , TxParameters (..)
-    , TxStatus
     , UTxO (..)
     , WalletId (..)
     , WalletMetadata (..)
-    , inputs
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
@@ -144,6 +135,17 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , TransactionInfo (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxMetadata
+    , TxOut (..)
+    , TxStatus
+    , inputs
+    )
 import Control.Foldl
     ( Fold (..) )
 import Control.Monad.IO.Class

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -113,7 +113,6 @@ import Cardano.Wallet.Primitive.Types
     ( Address
     , BlockHeader
     , ChimericAccount (..)
-    , Coin (..)
     , DecentralizationLevel
     , DelegationCertificate
     , Direction (..)
@@ -139,6 +138,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , inputs
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Foldl

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -111,7 +111,6 @@ import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader
-    , ChimericAccount (..)
     , DecentralizationLevel
     , DelegationCertificate
     , Direction (..)
@@ -139,6 +138,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -36,11 +36,12 @@ import Cardano.Mnemonic
     ( ConsistentEntropy, EntropySize, Mnemonic, entropyToMnemonic )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
     , BlockHeader (..)
     , ProtocolMagic (..)
     , SlotNo (..)
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Test.Hspec
     ( Spec, describe, it )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/JormungandrSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/JormungandrSpec.hs
@@ -44,7 +44,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Jormungandr
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Control.Exception
     ( SomeException, evaluate )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -43,7 +43,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( GenChange (..), IsOurs (..), IsOwned (..), KnownAddresses (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState (..), findUnusedPath, mkRndState )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Control.Monad
     ( forM_ )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -72,7 +72,9 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , shrinkPool
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), AddressState (..), ShowFmt (..) )
+    ( ShowFmt (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
 import Control.Arrow

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -22,7 +22,9 @@ import Cardano.Wallet.Primitive.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Wallet.Primitive.Types
-    ( Coin (..), TxOut (..), UTxO (..), excluding )
+    ( TxOut (..), UTxO (..), excluding )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/LargestFirstSpec.hs
@@ -22,9 +22,11 @@ import Cardano.Wallet.Primitive.CoinSelectionSpec
     , noValidation
     )
 import Cardano.Wallet.Primitive.Types
-    ( TxOut (..), UTxO (..), excluding )
+    ( UTxO (..), excluding )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut (..) )
 import Control.Monad
     ( unless )
 import Control.Monad.Trans.Except

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -19,7 +19,9 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), TxIn (..), TxOut (..), UTxO (..), balance )
+    ( Address (..), TxIn (..), TxOut (..), UTxO (..), balance )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Data.ByteString

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -19,7 +19,9 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), TxIn (..), TxOut (..), UTxO (..), balance )
+    ( TxIn (..), TxOut (..), UTxO (..), balance )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -19,13 +19,15 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types
-    ( TxIn (..), TxOut (..), UTxO (..), balance )
+    ( UTxO (..), balance )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
 import Data.ByteString
     ( ByteString )
 import Data.Function

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -31,13 +31,14 @@ import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , Coin (..)
     , ShowFmt (..)
     , TxIn (..)
     , TxOut (..)
     , UTxO (..)
     , UnsignedTx (..)
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Monad.Trans.Except

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -30,13 +30,15 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( ShowFmt (..), TxIn (..), TxOut (..), UTxO (..), UnsignedTx (..) )
+    ( ShowFmt (..), UTxO (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..), UnsignedTx (..) )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Data.List.NonEmpty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -30,13 +30,9 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Primitive.CoinSelection
     ( CoinSelection (..), CoinSelectionOptions (..), ErrCoinSelection (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , ShowFmt (..)
-    , TxIn (..)
-    , TxOut (..)
-    , UTxO (..)
-    , UnsignedTx (..)
-    )
+    ( ShowFmt (..), TxIn (..), TxOut (..), UTxO (..), UnsignedTx (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -32,13 +32,15 @@ import Cardano.Wallet.Primitive.Fee
     , rebalanceSelection
     )
 import Cardano.Wallet.Primitive.Types
-    ( ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+    ( ShowFmt (..), UTxO (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
 import Control.Arrow
     ( first )
 import Control.Monad.IO.Class

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -32,7 +32,9 @@ import Cardano.Wallet.Primitive.Fee
     , rebalanceSelection
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), Coin (..), ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+    ( Address (..), ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/FeeSpec.hs
@@ -32,7 +32,9 @@ import Cardano.Wallet.Primitive.Fee
     , rebalanceSelection
     )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..), ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+    ( ShowFmt (..), TxIn (..), TxOut (..), UTxO (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -39,23 +39,16 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , Direction (..)
     , Dom (..)
     , EpochLength (..)
     , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (direction)
-    , TxOut (..)
     , UTxO (..)
     , balance
     , excluding
     , invariant
     , restrictedTo
-    , txId
-    , txIns
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -65,6 +58,15 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (direction)
+    , TxOut (..)
+    , txId
+    , txIns
+    )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -41,7 +41,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
-    , Coin (..)
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
@@ -60,6 +59,8 @@ import Cardano.Wallet.Primitive.Types
     , txId
     , txIns
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.DeepSeq

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -39,7 +39,6 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , ChimericAccount (..)
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
@@ -60,6 +59,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -37,8 +37,7 @@ import Cardano.Wallet.Primitive.Model
 import Cardano.Wallet.Primitive.Slotting
     ( flatSlot )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Block (..)
+    ( Block (..)
     , BlockHeader (..)
     , ChimericAccount (..)
     , Direction (..)
@@ -59,6 +58,8 @@ import Cardano.Wallet.Primitive.Types
     , txId
     , txIns
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -56,7 +56,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , BoundType
-    , Direction (..)
     , Dom (..)
     , EpochLength (..)
     , EpochNo (..)
@@ -72,13 +71,6 @@ import Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , SlotNo (..)
     , StartTime (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxMetadata (..)
-    , TxMetadataValue (..)
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , UTxOStatistics (..)
     , WalletId (..)
@@ -120,6 +112,16 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.HashSpec
     ()
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxMetadata (..)
+    , TxMetadataValue (..)
+    , TxOut (..)
+    , TxStatus (..)
+    )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
 import Control.Exception

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -56,7 +56,6 @@ import Cardano.Wallet.Primitive.Types
     , Block (..)
     , BlockHeader (..)
     , BoundType
-    , ChimericAccount (..)
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
@@ -113,6 +112,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -59,7 +59,6 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , BoundType
     , ChimericAccount (..)
-    , Coin (..)
     , Direction (..)
     , Dom (..)
     , EpochLength (..)
@@ -96,7 +95,6 @@ import Cardano.Wallet.Primitive.Types
     , isBeforeRange
     , isSubrangeOf
     , isSubsetOf
-    , isValidCoin
     , isWithinRange
     , log10
     , mapRangeLowerBound
@@ -115,6 +113,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMinLength
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.HashSpec

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -53,8 +53,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..), mkSyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
-    , Address (..)
-    , AddressState (..)
     , Block (..)
     , BlockHeader (..)
     , BoundType
@@ -113,6 +111,8 @@ import Cardano.Wallet.Primitive.Types
     , walletNameMinLength
     , wholeRange
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/TransactionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TransactionSpec.hs
@@ -4,7 +4,7 @@ module Cardano.Wallet.TransactionSpec
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..) )

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -75,8 +75,7 @@ import Cardano.Wallet.Primitive.Fee
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , BlockHeader (BlockHeader)
+    ( BlockHeader (BlockHeader)
     , ChimericAccount (..)
     , Direction (..)
     , EpochNo (..)
@@ -101,6 +100,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , txId
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -76,7 +76,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (BlockHeader)
-    , ChimericAccount (..)
     , Direction (..)
     , EpochNo (..)
     , PoolId (..)
@@ -102,6 +101,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -76,20 +76,10 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (BlockHeader)
-    , Direction (..)
     , EpochNo (..)
     , PoolId (..)
-    , SealedTx (..)
     , SlotNo (..)
     , SortOrder (..)
-    , TransactionInfo (txInfoMeta)
-    , TransactionInfo (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMeta (..)
-    , TxMetadata
-    , TxOut (..)
-    , TxStatus (..)
     , UTxO (..)
     , WalletDelegation (..)
     , WalletDelegationNext (..)
@@ -97,7 +87,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
-    , txId
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -107,6 +96,19 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( Direction (..)
+    , SealedTx (..)
+    , TransactionInfo (txInfoMeta)
+    , TransactionInfo (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMeta (..)
+    , TxMetadata
+    , TxOut (..)
+    , TxStatus (..)
+    , txId
+    )
 import Cardano.Wallet.Transaction
     ( ErrMkTx (..), TransactionLayer (..) )
 import Cardano.Wallet.Unsafe

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -78,7 +78,6 @@ import Cardano.Wallet.Primitive.Types
     ( Address (..)
     , BlockHeader (BlockHeader)
     , ChimericAccount (..)
-    , Coin (..)
     , Direction (..)
     , EpochNo (..)
     , PoolId (..)
@@ -102,6 +101,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletName (..)
     , txId
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Transaction

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -50,7 +50,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..)

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -110,11 +110,9 @@ import Cardano.Wallet.Primitive.Slotting
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), mkSyncTolerance, syncProgress )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , Block (..)
+    ( Block (..)
     , BlockHeader (..)
     , ChimericAccount
-    , Coin (..)
     , GenesisParameters (..)
     , NetworkParameters (..)
     , SlotNo (..)
@@ -126,6 +124,10 @@ import Cardano.Wallet.Primitive.Types
     , computeUtxoStatistics
     , log10
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -112,7 +112,6 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
-    , ChimericAccount
     , GenesisParameters (..)
     , NetworkParameters (..)
     , SlotNo (..)
@@ -126,6 +125,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Shelley

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -116,7 +116,6 @@ import Cardano.Wallet.Primitive.Types
     , NetworkParameters (..)
     , SlotNo (..)
     , SortOrder (..)
-    , TxOut (..)
     , UTxOStatistics (..)
     , WalletId (..)
     , WalletName (..)
@@ -129,6 +128,8 @@ import Cardano.Wallet.Primitive.Types.ChimericAccount
     ( ChimericAccount )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -26,7 +26,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..)

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -137,6 +137,7 @@ import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.ByteString as BS

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -137,6 +137,7 @@ import qualified Cardano.Chain.Update as Update
 import qualified Cardano.Chain.Update.Validation.Interface as Update
 import qualified Cardano.Crypto.Hashing as CC
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -140,6 +140,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -100,8 +100,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( Address
-    , Block
+    ( Block
     , ChimericAccount
     , NetworkParameters (..)
     , PoolMetadataGCStatus (..)
@@ -110,6 +109,8 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , WalletId
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog (..), defaultWorkerAfter )
 import Cardano.Wallet.Shelley.Api.Server

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -101,7 +101,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
     ( Block
-    , ChimericAccount
     , NetworkParameters (..)
     , PoolMetadataGCStatus (..)
     , ProtocolParameters (..)
@@ -111,6 +110,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog (..), defaultWorkerAfter )
 import Cardano.Wallet.Shelley.Api.Server

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -238,6 +238,7 @@ import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
+import qualified Cardano.Wallet.Primitive.Types.ChimericAccount as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.Binary.Bech32 as Bech32

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -241,6 +241,7 @@ import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.ChimericAccount as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32
 import qualified Codec.CBOR.Decoding as CBOR

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -237,6 +237,7 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.Binary.Bech32.TH as Bech32

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -237,6 +237,7 @@ import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Crypto as SL
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.Binary.Bech32 as Bech32

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -108,10 +108,11 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolMagic (..)
     , SlotLength (..)
     , SlottingParameters (..)
-    , TxOut
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -101,7 +101,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), hex )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
-    , Coin (..)
     , EpochLength (..)
     , EpochNo (..)
     , NetworkParameters (..)
@@ -111,6 +110,8 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , TxOut
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -254,6 +254,7 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.ChimericAccount as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
+import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Codec.CBOR.Term as CBOR
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -251,6 +251,7 @@ import System.IO.Error
 
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.ChimericAccount as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.CBOR.Term as CBOR

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -251,6 +251,7 @@ import System.IO.Error
 
 import qualified Cardano.Ledger.Shelley as SL
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Codec.CBOR.Term as CBOR
 import qualified Data.Map as Map

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -76,7 +76,6 @@ import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , BlockHeader (..)
     , CertificatePublicationTime (..)
-    , Coin (..)
     , EpochNo (..)
     , GenesisParameters (..)
     , PoolCertificate (..)
@@ -97,6 +96,8 @@ import Cardano.Wallet.Primitive.Types
     , getPoolRetirementCertificate
     , unSmashServer
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley
     , StandardCrypto

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -62,13 +62,15 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( PoolId (..), SealedTx (..), Tx (..), TxIn (..), TxMetadata, TxOut (..) )
+    ( PoolId (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( SealedTx (..), Tx (..), TxIn (..), TxMetadata, TxOut (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley
     , StandardCrypto

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -62,14 +62,9 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , PoolId (..)
-    , SealedTx (..)
-    , Tx (..)
-    , TxIn (..)
-    , TxMetadata
-    , TxOut (..)
-    )
+    ( PoolId (..), SealedTx (..), Tx (..), TxIn (..), TxMetadata, TxOut (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -63,7 +63,6 @@ import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeePolicy (..) )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , Coin (..)
     , PoolId (..)
     , SealedTx (..)
     , Tx (..)
@@ -71,6 +70,8 @@ import Cardano.Wallet.Primitive.Types
     , TxMetadata
     , TxOut (..)
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -38,7 +38,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
-import Cardano.Wallet.Primitive.Types
+import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -44,12 +44,13 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.Slotting
     ( fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , ChimericAccount (..)
+    ( ChimericAccount (..)
     , DecentralizationLevel (..)
     , EpochLength (..)
     , SlotId (..)
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -44,13 +44,11 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.Slotting
     ( fromFlatSlot )
 import Cardano.Wallet.Primitive.Types
-    ( ChimericAccount (..)
-    , DecentralizationLevel (..)
-    , EpochLength (..)
-    , SlotId (..)
-    )
+    ( DecentralizationLevel (..), EpochLength (..), SlotId (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.ChimericAccount
+    ( ChimericAccount (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -46,8 +46,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeeOptions (..), FeePolicy (..), adjustForFee )
 import Cardano.Wallet.Primitive.Types
-    ( Address (..)
-    , TxIn (..)
+    ( TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
     , TxOut (..)
@@ -55,6 +54,8 @@ import Cardano.Wallet.Primitive.Types
     , UTxO (..)
     , txMetadataIsNull
     )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -47,7 +47,6 @@ import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeeOptions (..), FeePolicy (..), adjustForFee )
 import Cardano.Wallet.Primitive.Types
     ( Address (..)
-    , Coin (..)
     , TxIn (..)
     , TxMetadata (..)
     , TxMetadataValue (..)
@@ -56,6 +55,8 @@ import Cardano.Wallet.Primitive.Types
     , UTxO (..)
     , txMetadataIsNull
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Shelley.Compatibility

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -46,20 +46,20 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.Fee
     ( Fee (..), FeeOptions (..), FeePolicy (..), adjustForFee )
 import Cardano.Wallet.Primitive.Types
-    ( TxIn (..)
-    , TxMetadata (..)
-    , TxMetadataValue (..)
-    , TxOut (..)
-    , TxParameters (..)
-    , UTxO (..)
-    , txMetadataIsNull
-    )
+    ( TxParameters (..), UTxO (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..)
+    , TxMetadata (..)
+    , TxMetadataValue (..)
+    , TxOut (..)
+    , txMetadataIsNull
+    )
 import Cardano.Wallet.Shelley.Compatibility
     ( Shelley, sealShelleyTx )
 import Cardano.Wallet.Shelley.Transaction


### PR DESCRIPTION
# Issue Number

Preparation for [ADP-347](https://jira.iohk.io/browse/ADP-347) (_Wallet should support UTxOs containing multiple token types_).

# Overview

This PR moves the following types (and related functions) to separate modules under the `Cardano.Wallet.Primitive.Types` hierarchy:

| Type | Destination Module |
| -- | -- |
| `Address` | `Cardano.Wallet.Primitive.Types.Address` |
| `ChimericAccount` | `Cardano.Wallet.Primitive.Types.ChimericAccount` |
| `Coin` | `Cardano.Wallet.Primitive.Types.Coin` |
| `Direction` | `Cardano.Wallet.Primitive.Types.Tx` |
| `Tx` | `Cardano.Wallet.Primitive.Types.Tx` |
| `Tx{Change,In,Meta,Metadata,Out,Status}` | `Cardano.Wallet.Primitive.Types.Tx` |
| `{Sealed,Unsigned}Tx` | `Cardano.Wallet.Primitive.Types.Tx` |

# Justification

This PR:
* makes it possible for code to use the above types without having to incur a dependency on the `Cardano.Wallet.Primitive.Types` module, which (together with the modules that depend on it) is already very large and slow to recompile.
* makes it possible to compile the above types in parallel, saving overall compilation time.

# Comments

This PR doesn't re-export the moved types from `Primitive.Types`.

Although it would be convenient to be able to import everything from `Primitive.Types` in one go (with a qualified import), it would also create a compilation bottleneck, since anything that imports one of the above types would have to depend on everything required to build `Primitive.Types`.

This PR follows the advice presented in [Keeping Compilation Fast](https://www.parsonsmatt.org/2019/11/27/keeping_compilation_fast.html) by Matt Parsons.