### PR TITLE
Fix for Sqlite DB property tests timeout

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.DB.Model
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
     ( block0, dummyGenesisParameters, mkTx, mockHash )
 import Cardano.Wallet.Gen
-    ( genMnemonic, genTxMetadata, shrinkSlotNo, shrinkTxMetadata )
+    ( genMnemonic, genSmallTxMetadata, shrinkSlotNo, shrinkTxMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
@@ -429,7 +429,7 @@ instance Arbitrary TxStatus where
     arbitrary = elements [Pending, InLedger]
 
 instance Arbitrary TxMetadata where
-    arbitrary = genTxMetadata
+    arbitrary = genSmallTxMetadata
     shrink = shrinkTxMetadata
 
 instance Arbitrary Coin where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -257,7 +257,7 @@ instance Arbitrary GenTxHistory where
         -- We discard pending transaction from any 'GenTxHistory since,
         -- inserting a pending transaction actually has an effect on the
         -- checkpoint's pending transactions of the same wallet.
-        filter (not . isPending . snd) <$> scale (`mod` 100) arbitrary
+        filter (not . isPending . snd) <$> scale (min 25) arbitrary
       where
         sortTxHistory = filterTxHistory Nothing Descending wholeRange
 

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -20,6 +20,7 @@ module Cardano.Wallet.Gen
     , shrinkSlotNo
     , genTxMetadata
     , shrinkTxMetadata
+    , genSmallTxMetadata
     ) where
 
 import Prelude
@@ -221,6 +222,18 @@ genTxMetadata = do
     case metadataFromJson TxMetadataJsonNoSchema json of
         Left e -> fail $ show e <> ": " <> show (Aeson.encode json)
         Right metadata -> pure metadata
+
+-- | Generates a 'TxMetadata' containing only simple values.
+genSmallTxMetadata :: Gen TxMetadata
+genSmallTxMetadata = TxMetadata <$>
+    (Map.singleton <$> arbitrary <*> genSimpleTxMetadataValue)
+
+genSimpleTxMetadataValue :: Gen TxMetadataValue
+genSimpleTxMetadataValue = oneof
+    [ TxMetaNumber . fromIntegral <$> arbitrary @Int
+    , TxMetaBytes <$> genByteString
+    , TxMetaText <$> genText
+    ]
 
 shrinkTxMetadata :: TxMetadata -> [TxMetadata]
 shrinkTxMetadata (TxMetadata m) = TxMetadata . Map.fromList


### PR DESCRIPTION
### Issue Number

Relates to #2292

### Overview

The sqlite database tests sometimes get stuck indefinitely.
The problem is an `Arbitrary` generator, because the error still occurs with `noShrinking`, and there is never a test failure.

Running the test with a small maximum heap size and profiling shows that the arbitrary function for `GenTxHistory` is responsible for the majority of execution time and memory usage.

I suspect it's due to the use of ``scale (`mod` 100)``. The "limit" of 100 is probably too high. It would anyway probably be better to reduce the size of GenTxHistory using either `div` or a fixed maximum size.

There is also a commit that reduces the size of generated TxMetadata for sqlite tests, because it doesn't need to be large.

### Comments

- Still need to do some experimentation with scaling.

- Looking at the profile below GenTxHistory, there is no single smoking gun in terms of execution time, so I think that means that the size of the GenTxHistory map is just too large.

- I tried sampling `arbitrary :: Gen GenTxHistory` by itself, but found no problems, so now I'm sttuck again.
  ```
  λ quickCheck $ withMaxSuccess 10000 (\h -> length (unGenTxHistory h) < 100)
  +++ OK, passed 10000 tests.
  ```
