### PR TITLE
Test for mainnet value of ActiveSlotCoeff parameter

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -53,6 +53,8 @@ spec = describe "SHELLEY_NETWORK" $ do
             , expectField #hardforkAt (`shouldNotBe` Nothing)
             , expectField #slotLength (`shouldBe` Quantity slotLengthValue)
             , expectField #epochLength (`shouldBe` Quantity epochLengthValue)
-            -- TODO: #2226 query activeSlotCoefficient from ledger
-            -- , expectField #activeSlotCoefficient (`shouldBe` Quantity 0.5)
+            -- TODO: ADP-554 query activeSlotCoefficient from ledger
+            -- This value is hardcoded for mainnet (1.0 = 100%).
+            -- The integration test cluster value is (0.5 = 50%).
+            , expectField #activeSlotCoefficient (`shouldBe` Quantity 100.0)
             ]


### PR DESCRIPTION
### Issue Number

#2226 / ADP-554

### Overview

- Updates ticket number in TODO for ActiveSlotCoeff test.
- Adds check that the shelley mainnet value is hardcoded.

