### PR TITLE
get rid of 'OnDanglingChange' option for fee balancing

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -273,12 +273,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.Migration
     ( depleteUTxO, idealBatchSize )
 import Cardano.Wallet.Primitive.Fee
-    ( ErrAdjustForFee (..)
-    , Fee (..)
-    , FeeOptions (..)
-    , OnDanglingChange (..)
-    , adjustForFee
-    )
+    ( ErrAdjustForFee (..), Fee (..), FeeOptions (..), adjustForFee )
 import Cardano.Wallet.Primitive.Model
     ( Wallet
     , applyBlocks
@@ -1260,7 +1255,6 @@ feeOpts
 feeOpts tl action md txp minUtxo cs = FeeOptions
     { estimateFee = minimumFee tl feePolicy action md
     , dustThreshold = minUtxo
-    , onDanglingChange = if allowUnbalancedTx tl then SaveMoney else PayAndBalance
     -- NOTE
     -- Our fee calculation is rather good, but not perfect. We make little
     -- approximation errors that may lead to us leaving slightly more fees than

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -154,10 +154,6 @@ data TransactionLayer t k = TransactionLayer
       -- For example, Byron nodes do not allow null output amounts. Jörmungandr
       -- on its side doesn't support more than 255 inputs or outputs.
 
-    , allowUnbalancedTx
-      :: Bool
-      -- ^ Whether the transaction layer accepts unbalanced transactions.
-
     , decodeSignedTx
         :: ByteString -> Either ErrDecodeSignedTx (Tx, SealedTx)
         -- ^ Decode an externally-signed transaction to the chain producer

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MigrationSpec.hs
@@ -15,7 +15,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Migration
 import Cardano.Wallet.Primitive.CoinSelectionSpec
     ()
 import Cardano.Wallet.Primitive.Fee
-    ( Fee (..), FeeOptions (..), OnDanglingChange (..) )
+    ( Fee (..), FeeOptions (..) )
 import Cardano.Wallet.Primitive.FeeSpec
     ()
 import Cardano.Wallet.Primitive.Types.Address
@@ -122,7 +122,6 @@ spec = do
                     , estimateFee = \s -> Fee
                         $ fromIntegral
                         $ 5 * (length (inputs s) + length (outputs s))
-                    , onDanglingChange = PayAndBalance
                     , feeUpperBound = Fee maxBound
                     , maximumNumberOfInputs = maxBound
                     }
@@ -245,7 +244,6 @@ genFeeOptions (Coin dust) = do
             let x = fromIntegral (length (inputs s) + length (outputs s))
             in Fee $ (dust `div` 100) * x + dust
         , dustThreshold = Coin dust
-        , onDanglingChange = PayAndBalance
         , feeUpperBound = Fee maxBound
         , maximumNumberOfInputs = maxBound
         }

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -743,8 +743,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: validateSelection not implemented"
     , decodeSignedTx =
         error "dummyTransactionLayer: decodeSignedTx not implemented"
-    , allowUnbalancedTx =
-        False
     }
   where
     withEither :: e -> Maybe a -> Either e a

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -233,7 +233,6 @@ newTransactionLayer networkId = TransactionLayer
     , minimumFee = _minimumFee @k networkId
     , estimateMaxNumberOfInputs = _estimateMaxNumberOfInputs @k networkId
     , validateSelection = const $ return ()
-    , allowUnbalancedTx = True
     }
   where
     _initDelegationSelection


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-568

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have removed 'OnDanglingChange' option for fee balancing.

# Comments

<!-- Additional comments or screenshots to attach if any -->

  This option allowed choosing between two modes: SaveMoney and
  PayAndBalance. The former was used with cardano-node, and the latter
  used with jormungandr. The reason for having a difference is was
  because of discrepency in the minimum transaction expected by both
  ledger. On jormungandr, transactions have to be _exactly_ balanced and
  leave exactly the expected fees required by the network. On the
  counterpart, the fee calculation was only a function of the number of
  inputs and outputs... therefore much easier to satisfy than on
  cardano-node. Now that we've removed jormungandr, this extra
  indirection / complexity is just harmful. Since the 'PayAndBalance'
  mode is never used, I've removed the option entirely and made code
  assume 'SaveMoney' everywhere it used to choose between both
  alternatives.

  This also seemingly remove the 'allowUnbalancedTx' field from the
  transaction layer which was directly related to this option.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
