### PR TITLE
rework transaction size estimation with grosser approximation

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -52,7 +52,7 @@ import Data.Quantity
 import Data.Text
     ( Text )
 import Data.Typeable
-    ( Typeable, typeOf )
+    ( Typeable )
 import Data.Word
     ( Word64 )
 import Test.Hspec
@@ -264,11 +264,6 @@ spec = describe "BYRON_MIGRATIONS" $ do
         addrs <- listAddresses @n ctx wNew
         let addr1 = (addrs !! 1) ^. #id
 
-        numOfTxs <- case (show (typeOf (_target ctx))) of
-                s | s == "Proxy * Jormungandr" -> pure 1
-                s | s == "Proxy * Shelley" -> pure 20
-                _ -> fail ("unknown target backend? (" <> show (typeOf (_target ctx)) <> ")")
-
         let payloadMigrate =
                 Json [json|
                     { passphrase: #{fixturePassphrase}
@@ -280,7 +275,7 @@ spec = describe "BYRON_MIGRATIONS" $ do
             payloadMigrate
         verify rm
             [ expectResponseCode HTTP.status202
-            , expectField id ( (`shouldBe` (numOfTxs)) . length )
+            , expectField id ( (`shouldBe` 19) . length )
             ]
 
         -- Check that funds become available in the target wallet:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -212,7 +212,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             Default
             payloadMigrate >>= flip verify
             [ expectResponseCode HTTP.status202
-            , expectField id ((`shouldBe` 15) . length)
+            , expectField id ((`shouldBe` 14) . length)
             ]
 
         -- Check that funds become available in the target wallet:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -882,7 +882,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
             quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
                 [ expectResponseCode HTTP.status403
-                , expectErrorMessage $ errMsg403DelegationFee 115900
+                , expectErrorMessage $ errMsg403DelegationFee 116500
                 ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_02 - \
@@ -890,8 +890,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         w <- emptyWallet ctx
         delegationFee ctx w >>= flip verify
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage $ errMsg403DelegationFee
-                (costOfJoining ctx - costOfChange ctx)
+            , expectErrorMessage $ errMsg403DelegationFee 122900
             ]
 
     describe "STAKE_POOLS_LIST_01 - List stake pools" $ do
@@ -1183,10 +1182,10 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             round c
 
     costOfJoining :: Context t -> Natural
-    costOfJoining = costOf (\coeff cst -> 364 * coeff + cst)
+    costOfJoining = costOf (\coeff cst -> 370 * coeff + cst)
 
     costOfQuitting :: Context t -> Natural
-    costOfQuitting = costOf (\coeff cst -> 297 * coeff + cst)
+    costOfQuitting = costOf (\coeff cst -> 303 * coeff + cst)
 
     costOfChange :: Context t -> Natural
     costOfChange = costOf (\coeff _cst -> 133 * coeff)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-567 / ADP-569

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have reworked transaction size estimation with grosser approximation

# Comments

<!-- Additional comments or screenshots to attach if any -->

  The function for calculting the size of a transaction in Shelley had
  grown out of hands and became a function really hard to reason about
  and debug. We kept running into either performance issues or simply
  incoherent fee calculations. This commit takes a simpler approach to
  the problem which is very straightforward to follow, but comes at the
  cost of slightly grosser approximations (in the sense that the
  calculated size will tend to be bigger than the actual size). Yet,
  there are several parts we could iterate on might it be necessary.

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
