### PR TITLE
Rework slotting functions

### DIFF
--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -900,8 +900,8 @@ selectPoolProduction
     -> EpochNo
     -> SqlPersistT IO [PoolProduction]
 selectPoolProduction timeInterpreter epoch = do
-    e <- liftIO $ timeInterpreter $ firstSlotInEpoch epoch
-    eplus1 <- liftIO $ timeInterpreter $ firstSlotInEpoch (epoch + 1)
+    (e, eplus1) <- liftIO $ timeInterpreter
+        ((,) <$> firstSlotInEpoch epoch <*> firstSlotInEpoch (epoch + 1))
     fmap entityVal <$> selectList
         [ PoolProductionSlot >=. e
         , PoolProductionSlot <. eplus1 ]

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -52,6 +53,7 @@ module Cardano.Wallet.Api.Types
     , AnyAddressType (..)
     , ApiCertificate (..)
     , ApiEpochInfo (..)
+    , toApiEpochInfo
     , ApiSelectCoinsData (..)
     , ApiSelectCoinsPayments (..)
     , ApiSelectCoinsAction (..)
@@ -185,6 +187,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, SeqState, getAddressPoolGap )
+import Cardano.Wallet.Primitive.Slotting
+    ( Qry, timeOfEpoch )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
@@ -226,7 +230,7 @@ import Codec.Binary.Bech32
     ( dataPartFromBytes, dataPartToBytes )
 import Codec.Binary.Bech32.TH
     ( humanReadablePart )
-import Codec.Binary.Encoding
+import "cardano-addresses" Codec.Binary.Encoding
     ( AbstractEncoding (..), detectEncoding, encode )
 import Control.Applicative
     ( optional, (<|>) )
@@ -451,6 +455,9 @@ data ApiEpochInfo = ApiEpochInfo
     , epochStartTime :: !UTCTime
     } deriving (Eq, Generic, Show)
       deriving anyclass NFData
+
+toApiEpochInfo :: EpochNo -> Qry ApiEpochInfo
+toApiEpochInfo ep = ApiEpochInfo (ApiT ep) . fst <$> timeOfEpoch ep
 
 data ApiSelectCoinsData (n :: NetworkDiscriminant)
     = ApiSelectForPayment (ApiSelectCoinsPayments n)

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -69,7 +69,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, utxo )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, epochOf, startTime )
+    ( TimeInterpreter, epochOf, slotToUTCTime )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (blockHeight, slotNo)
     , DelegationCertificate (..)
@@ -426,7 +426,7 @@ mReadTxHistory
 mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs) =
     (Right res, db)
   where
-    slotStartTime' = runIdentity . ti . startTime
+    slotStartTime' = runIdentity . ti . slotToUTCTime
     res = fromMaybe mempty $ do
         wal <- Map.lookup wid wallets
         (_, cp) <- Map.lookupMax (checkpoints wal)

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -269,10 +269,9 @@ getSlottingParametersForTip nl = do
     -- This requires code changes in the shelley ledger.
     let getActiveSlotCoeff = pure (ActiveSlotCoefficient 1.0)
 
-    SlottingParameters
-        <$> timeInterpreter nl (querySlotLength tip)
-        <*> timeInterpreter nl (queryEpochLength tip)
-        <*> getActiveSlotCoeff
+    (slotLen, epLen) <- timeInterpreter nl
+        ((,) <$> querySlotLength tip <*> queryEpochLength tip)
+    SlottingParameters slotLen epLen <$> getActiveSlotCoeff
 
 {-------------------------------------------------------------------------------
                                 Chain Sync

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE Rank2Types #-}
 
@@ -14,29 +13,41 @@
 -- @UTCTime@.
 
 module Cardano.Wallet.Primitive.Slotting
-    ( -- * New api using ouroboros-concensus
-      -- ** Queries
-      currentEpoch
-    , epochAt
+    ( -- ** Queries
+      Qry
+    , currentEpoch
     , epochOf
-    , startTime
+    , slotToUTCTime
+    , slotToRelTime
     , toSlotId
+    , slotRangeFromRelativeTimeRange
     , slotRangeFromTimeRange
     , firstSlotInEpoch
     , ongoingSlotAt
     , ceilingSlotAt
-    , endTimeOfEpoch
+    , timeOfEpoch
+    , getStartTime
     , querySlotLength
     , queryEpochLength
 
-    -- ** Running queries
-    , TimeInterpreter
-    , singleEraInterpreter
-    , mkTimeInterpreter
-    , HF.PastHorizonException (..)
-    , Qry
+      -- ** Blockchain-relative times
+    , RelativeTime
+    , toRelativeTime
+    , toRelativeTimeRange
+    , fromRelativeTime
+    , addRelTime
 
-    -- ** Helpers
+      -- ** What's the time?
+    , currentRelativeTime
+    , getCurrentTimeRelativeFromStart
+
+      -- ** Running queries
+    , TimeInterpreter
+    , mkSingleEraInterpreter
+    , mkTimeInterpreter
+    , PastHorizonException (..)
+
+      -- ** Helpers
     , unsafeEpochNo
     ) where
 
@@ -55,18 +66,23 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , StartTime (..)
     , unsafeEpochNo
-    , wholeRange
     )
 import Control.Monad
-    ( ap, liftM, (<=<) )
+    ( join )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.Trans.Class
+    ( lift )
+import Control.Monad.Trans.Reader
+    ( ReaderT, ask, runReaderT )
 import Data.Coerce
     ( coerce )
 import Data.Functor.Identity
     ( Identity )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
+import Data.Maybe
+    ( fromMaybe )
 import Data.Time.Clock
     ( NominalDiffTime, UTCTime, addUTCTime, getCurrentTime )
 import Data.Word
@@ -74,9 +90,20 @@ import Data.Word
 import GHC.Stack
     ( HasCallStack )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-    ( SystemStart (..) )
+    ( RelativeTime (..), SystemStart (..), addRelTime )
 import Ouroboros.Consensus.HardFork.History.Qry
-    ( Interpreter, mkInterpreter )
+    ( Expr (..)
+    , Interpreter
+    , PastHorizonException (..)
+    , epochToSize
+    , epochToSlot'
+    , interpretQuery
+    , mkInterpreter
+    , qryFromExpr
+    , slotToEpoch'
+    , slotToWallclock
+    , wallclockToSlot
+    )
 import Ouroboros.Consensus.HardFork.History.Summary
     ( neverForksSummary )
 
@@ -84,50 +111,54 @@ import qualified Cardano.Slotting.Slot as Cardano
 import qualified Ouroboros.Consensus.BlockchainTime.WallClock.Types as Cardano
 import qualified Ouroboros.Consensus.HardFork.History.Qry as HF
 
--- -----------------------------------------------------------------------------
--- New Api using ouroboros-consensus. With the right interpreter, the
--- calculations don't break on hard-forks.
+{-------------------------------------------------------------------------------
+                                    Queries
+-------------------------------------------------------------------------------}
 
+-- | This is 'Ouroboros.Consensus.HardFork.History.Qry.Qry' wrapped in a reader
+-- to provide the blockchain system start time as context.
+type Qry = ReaderT StartTime HF.Qry
 
---
--- Queries
---
+-- | Query the blockchain start time. This is part of the 'TimeInterpreter'
+-- environment.
+getStartTime :: Qry StartTime
+getStartTime = ask
 
-currentEpoch :: MonadIO m => TimeInterpreter m -> m (Maybe EpochNo)
-currentEpoch ti = ti . epochAt =<< liftIO getCurrentTime
-
-epochAt :: UTCTime -> Qry (Maybe EpochNo)
-epochAt = traverse epochOf <=< ongoingSlotAt
-
+-- | Query the epoch corresponding to a flat slot number.
 epochOf :: SlotNo -> Qry EpochNo
 epochOf slot = epochNumber <$> toSlotId slot
 
+-- | Query to convert a flat 'SlotNo' to a 'SlotId', which is the epoch number,
+-- and the local slot index.
 toSlotId :: SlotNo -> Qry SlotId
-toSlotId slot = HardForkQry $ do
-    (e, s, _) <- HF.slotToEpoch slot
+toSlotId slot = do
+    (e, s) <- lift $ slotToEpoch' slot
     return $ SlotId
         (EpochNo $ fromIntegral $ Cardano.unEpochNo e)
-        (SlotInEpoch $ unsafeConvert s)
+        (SlotInEpoch $ downCast s)
   where
-    unsafeConvert :: Word64 -> Word32
-    unsafeConvert = fromIntegral
+    downCast :: Word64 -> Word32
+    downCast = fromIntegral
 
-startTime :: SlotNo -> Qry UTCTime
-startTime s = do
-    rel <- HardForkQry (fst <$> HF.slotToWallclock s)
-    RelToUTCTime rel
+-- | Query the absolute time at which a slot starts.
+slotToUTCTime :: SlotNo -> Qry UTCTime
+slotToUTCTime sl = slotToRelTime sl >>= fromRelativeTime
 
--- | Can be used to know when the next epoch starts.
+-- | Query the relative time at which a slot starts.
+slotToRelTime :: SlotNo -> Qry RelativeTime
+slotToRelTime = lift . fmap fst . slotToWallclock
+
+-- | Query the absolute times at which an epoch starts and ends.
 --
--- This is preferable to asking for the start time of the /next/ epoch, because
--- the next epoch may be outside the forecast range, and result in
--- @PastHorizonException@.
-endTimeOfEpoch :: EpochNo -> Qry UTCTime
-endTimeOfEpoch epoch = do
+-- Querying the end time of /this/ epoch is preferable to querying the start
+-- time of the /next/ epoch, because the next epoch may be outside the forecast
+-- range, and result in 'PastHorizonException'.
+timeOfEpoch :: EpochNo -> Qry (UTCTime, UTCTime)
+timeOfEpoch epoch = do
     ref <- firstSlotInEpoch epoch
-    refTime <- startTime ref
-    el <- HardForkQry $ HF.qryFromExpr $ HF.EEpochSize $ HF.ELit $ toCardanoEpochNo epoch
-    sl <- HardForkQry $ HF.qryFromExpr $ HF.ESlotLength $ HF.ELit ref
+    refTime <- slotToUTCTime ref
+    el <- lift $ qryFromExpr $ EEpochSize $ ELit $ toCardanoEpochNo epoch
+    sl <- lift $ qryFromExpr $ ESlotLength $ ELit ref
 
     let convert = fromRational . toRational
     let el' = convert $ Cardano.unEpochSize el
@@ -135,42 +166,15 @@ endTimeOfEpoch epoch = do
 
     let timeInEpoch = el' * sl'
 
-    return $ timeInEpoch `addUTCTime` refTime
+    return (refTime, timeInEpoch `addUTCTime` refTime)
   where
     toCardanoEpochNo (EpochNo e) = Cardano.EpochNo $ fromIntegral e
 
 -- | Translate 'EpochNo' to the 'SlotNo' of the first slot in that epoch
 firstSlotInEpoch :: EpochNo -> Qry SlotNo
-firstSlotInEpoch = fmap fst . HardForkQry . HF.epochToSlot . convertEpochNo
+firstSlotInEpoch = lift . epochToSlot' . convertEpochNo
   where
     convertEpochNo (EpochNo e) = Cardano.EpochNo $ fromIntegral e
-
--- | Transforms the given inclusive time range into an inclusive slot range.
---
--- This function returns a slot range if (and only if) the specified time range
--- intersects with the life of the blockchain.
---
--- If, on the other hand, the specified time range terminates before the start
--- of the blockchain, this function returns 'Nothing'.
-slotRangeFromTimeRange
-    :: Range UTCTime
-    -> Qry (Maybe (Range SlotNo))
-slotRangeFromTimeRange = \case
-    Range Nothing Nothing -> do
-        pure $ Just wholeRange
-
-    Range (Just inf) Nothing -> do
-        inf' <- Just <$> ceilingSlotAt inf
-        pure $ Just $ Range inf' Nothing
-
-    Range Nothing (Just sup) -> do
-        sup' <- ongoingSlotAt sup
-        pure $ (Range Nothing . Just) <$> sup'
-
-    Range (Just inf) (Just sup) -> do
-        inf' <- Just <$> ceilingSlotAt inf
-        sup' <- ongoingSlotAt sup
-        pure $ (Range inf' . Just) <$> sup'
 
 -- @@
 --     slot:
@@ -184,11 +188,8 @@ slotRangeFromTimeRange = \case
 -- @@
 --
 --
-ongoingSlotAt :: UTCTime -> Qry (Maybe SlotNo)
-ongoingSlotAt x = do
-     slotAtTimeDetailed x >>= \case
-        Just (slot, _timeInSlot, _timeRemainingInSlot) -> pure $ Just slot
-        Nothing -> pure Nothing
+ongoingSlotAt :: RelativeTime -> Qry SlotNo
+ongoingSlotAt = fmap fst . slotAtTimeDetailed
 
 -- @@
 --     slot:
@@ -201,124 +202,140 @@ ongoingSlotAt x = do
 --                    3
 -- @@
 --
-ceilingSlotAt :: UTCTime -> Qry SlotNo
-ceilingSlotAt t = do
-     slotAtTimeDetailed t >>= \case
-        Just (s, 0, _) -> return s
-        Just (s, _, _) -> return (s + 1)
-        Nothing -> do
-            return $ SlotNo 0
+ceilingSlotAt :: RelativeTime -> Qry SlotNo
+ceilingSlotAt = fmap ceil2 . slotAtTimeDetailed
+  where
+    ceil2 (s, 0) = s
+    ceil2 (s, _) = s + 1
 
--- | Helper that returns @(slot, elapsedTimeInSlot, remainingTimeInSlot)@ for a
+-- | Helper that returns @(slot, elapsedTimeInSlot)@ for a
 -- given @UTCTime@.
-slotAtTimeDetailed
-    :: UTCTime
-    -> Qry (Maybe (SlotNo, NominalDiffTime, NominalDiffTime))
-slotAtTimeDetailed t = do
-    UTCTimeToRel t >>= \case
-        Just relTime -> fmap Just $ HardForkQry $ HF.wallclockToSlot relTime
-        Nothing -> return Nothing
+slotAtTimeDetailed :: RelativeTime -> Qry (SlotNo, NominalDiffTime)
+slotAtTimeDetailed = lift . fmap dropThird . wallclockToSlot
+  where
+    dropThird (a, b, _) = (a, b)
 
 querySlotLength :: SlotNo -> Qry SlotLength
 querySlotLength sl =
-    fmap (SlotLength . Cardano.getSlotLength) $
-    HardForkQry $
-    HF.qryFromExpr $
-    HF.ESlotLength $
-    HF.ELit sl
+    lift $ fmap (SlotLength . Cardano.getSlotLength) $
+    qryFromExpr $ ESlotLength $ ELit sl
 
 queryEpochLength :: SlotNo -> Qry EpochLength
-queryEpochLength sl = fmap toEpochLength $ HardForkQry $ do
-    (e, _, _) <- HF.slotToEpoch sl
-    HF.epochToSize e
+queryEpochLength sl = lift $ toEpochLength <$> do
+    (e, _) <- slotToEpoch' sl
+    epochToSize e
   where
     -- converting up from Word32 to Word64
     toEpochLength = EpochLength . fromIntegral . Cardano.unEpochSize
 
--- A @TimeInterpreter@ is a way for the wallet to run things of type @Qry a@.
+-- | This function returns a chain-relative time range if (and only if) the
+-- specified UTC time range intersects with the life of the blockchain.
 --
--- NOTE:
--- A @TimeInterpreter@ could in theory decide to update the era summary from the
--- node when running a query.
+-- If, on the other hand, the specified time range terminates before the start
+-- of the blockchain, this function returns 'Nothing'.
+toRelativeTimeRange :: Range UTCTime -> StartTime -> Maybe (Range RelativeTime)
+toRelativeTimeRange range start = case toRelativeTime start <$> range of
+    Range _ (Just Nothing) -> Nothing
+    Range a b -> Just (Range (fromMaybe (RelativeTime 0) <$> a) (join b))
+
+-- | Transforms the given inclusive time range into an inclusive slot range.
+slotRangeFromRelativeTimeRange :: Range RelativeTime -> Qry (Range SlotNo)
+slotRangeFromRelativeTimeRange (Range a b) =
+    Range <$> traverse ceilingSlotAt a <*> traverse ongoingSlotAt b
+
+slotRangeFromTimeRange :: Range UTCTime -> Qry (Maybe (Range SlotNo))
+slotRangeFromTimeRange range = mapM slotRangeFromRelativeTimeRange
+    =<< (toRelativeTimeRange range <$> getStartTime)
+
+{-------------------------------------------------------------------------------
+                            Blockchain-relative time
+-------------------------------------------------------------------------------}
+
+-- | Same as 'Cardano.toRelativeTime', but has error handling for times before
+-- the system start. No other functions in this module will accept UTC times.
+toRelativeTime :: StartTime -> UTCTime -> Maybe RelativeTime
+toRelativeTime (StartTime start) utc
+    | utc < start = Nothing
+    | otherwise = Just $ Cardano.toRelativeTime (SystemStart start) utc
+
+-- | Convert an absolute time to a relative time. If the absolute time is before
+-- the system start, consider the relative time to be the system start
+-- time. This function can never fail.
+toRelativeTimeOrZero :: StartTime -> UTCTime -> RelativeTime
+toRelativeTimeOrZero start = fromMaybe (RelativeTime 0) . toRelativeTime start
+
+-- | Query the absolute time corresponding to a blockchain-relative time.
+fromRelativeTime :: RelativeTime -> Qry UTCTime
+fromRelativeTime t = do
+    start <- getStartTime
+    pure (Cardano.fromRelativeTime (coerce start) t)
+
+{-------------------------------------------------------------------------------
+                                What's the time?
+-------------------------------------------------------------------------------}
+
+-- | The current system time, compared to the given blockchain start time.
 --
--- We cannot manually specify when the fetching happens.
+-- If the current time is before the system start (this would only happen when
+-- launching testnets), let's just say we're in epoch 0.
 --
--- This may or may not be what we actually want.
+-- TODO: Use io-sim-classes for easier testing.
+getCurrentTimeRelativeFromStart :: StartTime -> IO RelativeTime
+getCurrentTimeRelativeFromStart start =
+    toRelativeTimeOrZero start <$> getCurrentTime
+
+-- | The current system time, compared to the blockchain start time of the given
+-- 'TimeInterpreter'.
+--
+-- If the current time is before the system start (this would only happen when
+-- launching testnets), the relative time is reported as 0.
+currentRelativeTime :: MonadIO m => TimeInterpreter m -> m RelativeTime
+currentRelativeTime ti =
+    ti getStartTime >>= liftIO . getCurrentTimeRelativeFromStart
+
+-- | Note: This fails when the node is far enough behind that we in the present
+-- are beyond its safe zone.
+currentEpoch :: MonadIO m => TimeInterpreter m -> m EpochNo
+currentEpoch ti = do
+    now <- currentRelativeTime ti
+    ti (ongoingSlotAt now >>= epochOf)
+
+{-------------------------------------------------------------------------------
+                                Time Interpreter
+-------------------------------------------------------------------------------}
+
+-- | A @TimeInterpreter@ is a way for the wallet to run things of type @Qry a@,
+-- with a system start time as context.
+--
+-- NOTE: Do not hold on to 'TimeInterpreter m' references. Always get fresh ones
+-- from the network layer.
 --
 type TimeInterpreter m = forall a. Qry a -> m a
 
--- | An 'Interpreter' for a single era, where the slotting from
--- @GenesisParameters@ cannot change.
+-- | An 'Interpreter' for a single era, where the @SlottingParameters@ cannot
+-- change.
 --
--- Queries can never fail with @singleEraInterpreter@. This function will throw
--- a 'PastHorizonException' if they do.
-singleEraInterpreter
+-- Queries will never fail with @mkSingleEraInterpreter@.
+mkSingleEraInterpreter
     :: HasCallStack
     => StartTime
     -> SlottingParameters
     -> TimeInterpreter Identity
-singleEraInterpreter genesisBlockTime sp = mkTimeInterpreterI (mkInterpreter summary)
+mkSingleEraInterpreter start sp = neverFails . mkTimeInterpreter start int
   where
+    int = mkInterpreter summary
     summary = neverForksSummary sz len
     sz = Cardano.EpochSize $ fromIntegral $ unEpochLength $ sp ^. #getEpochLength
     len = Cardano.mkSlotLength $ unSlotLength $ sp ^. #getSlotLength
 
-    mkTimeInterpreterI
-        :: HasCallStack
-        => Interpreter xs
-        -> TimeInterpreter Identity
-    mkTimeInterpreterI int q = neverFails $ runQuery start int q
-      where
-        start = coerce genesisBlockTime
+    neverFails = either bomb pure
+    bomb x = error $ "mkSingleEraInterpreter: the impossible happened: " <> show x
 
-        neverFails = either bomb pure
-        bomb x = error $ "singleEraInterpreter: the impossible happened: " <> show x
-
+-- | Set up a 'TimeInterpreter' for a given start time, and an 'Interpreter'
+-- queried from the ledger layer.
 mkTimeInterpreter
     :: HasCallStack
     => StartTime
     -> Interpreter xs
-    -> TimeInterpreter (Either HF.PastHorizonException)
-mkTimeInterpreter start =
-    runQuery (coerce start)
-
--- | Wrapper around HF.Qry to allow converting times relative to the genesis
--- block date to absolute ones
-data Qry :: * -> * where
-    HardForkQry  :: HF.Qry a -> Qry a
-    RelToUTCTime :: Cardano.RelativeTime -> Qry UTCTime
-    UTCTimeToRel :: UTCTime -> Qry (Maybe Cardano.RelativeTime)
-    QPure :: a -> Qry a
-    QBind :: Qry a -> (a -> Qry b) -> Qry b
-
-instance Functor Qry where
-  fmap = liftM
-
-instance Applicative Qry where
-  pure  = QPure
-  (<*>) = ap
-
-instance Monad Qry where
-  return = pure
-  (>>=)  = QBind
-
-runQuery
-    :: HasCallStack
-    => SystemStart
-    -> Interpreter xs
-    -> Qry a
-    -> Either HF.PastHorizonException a
-runQuery systemStart int = go
-  where
-    go :: Qry a -> Either HF.PastHorizonException a
-    go (HardForkQry q) = HF.interpretQuery int q
-    go (QPure a) =
-        return a
-    go (QBind x f) = do
-        go x >>= go . f
-    go (RelToUTCTime rel) =
-        pure $ Cardano.fromRelativeTime systemStart rel
-    go (UTCTimeToRel utc)
-        -- Cardano.toRelativeTime may throw, so we need this guard:
-        | utc < getSystemStart systemStart = pure Nothing
-        | otherwise = pure $ Just $ Cardano.toRelativeTime systemStart utc
+    -> TimeInterpreter (Either PastHorizonException)
+mkTimeInterpreter start int qry = interpretQuery int (runReaderT qry start)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -96,7 +96,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet, unsafeInitWallet )
 import Cardano.Wallet.Primitive.Slotting
-    ( singleEraInterpreter )
+    ( mkSingleEraInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
@@ -602,7 +602,7 @@ setupDB tr = do
     (ctx, db) <- newDBLayer tr defaultFieldValues (Just f) ti
     pure (f, ctx, db)
   where
-    ti = pure . runIdentity . singleEraInterpreter
+    ti = pure . runIdentity . mkSingleEraInterpreter
         (StartTime $ posixSecondsToUTCTime 0)
         (SlottingParameters
         { getSlotLength = SlotLength 1

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -19,7 +19,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
 import Prelude
 
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, singleEraInterpreter )
+    ( TimeInterpreter, mkSingleEraInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
     , Block (..)
@@ -100,7 +100,7 @@ dummySlottingParameters = SlottingParameters
 dummyTimeInterpreter :: Monad m => TimeInterpreter m
 dummyTimeInterpreter = pure
     . runIdentity
-    . singleEraInterpreter
+    . mkSingleEraInterpreter
         (getGenesisBlockDate dummyGenesisParameters)
         dummySlottingParameters
 


### PR DESCRIPTION
### Overview

I am looking at the changes in #2245 related to slotting. 

The way the error handling is, it seems like we are walking around with our shoelaces tied together.

#### Times relative to system start

Part of the problem is that converting a UTC time into a time relative to the system start can fail. (`UTCTimeToRel :: UTCTime -> Qry (Maybe Cardano.RelativeTime)`). But, really in most cases it won't. The best way to deal with that is to push relative time conversions outside of the queries. Then the caller of the slotting can make decisions about how to get a RelativeTime.

Things like converting a slot range to a time range become much simpler.

#### Shorten Slotting module.

We already chopped out a lot of old code in #2351.

But if we use unembellished types from ouroboros-consensus, this module can be even shorter. `Qry` is now just a  `ReaderT` wrapper around `HF.Qry`.

Running a query is to just apply the start time parameter to `runReaderT` and then call `Ouroboros.Consensus.HardFork.History.Qry.interpretQuery`.

#### Mixing with `IO`

Sometimes we want to know the chain-relative time for "now". A simplification is to assume that "now" is always after the start time. In the corner case, it suffices to use the relative time of 0. Now callers of this function don't need to worry about whether it can fail somehow.

#### Relative times are usually better - e.g. Sync progress

The calculation of sync progress with UTC is something like `(b - a - s) / (b - s)`. But with relative times it's just `a / b`.

### Todo

#### Separate running a query from obtaining the time interpreter

Currently the TimeInterpreter is fetched from the network layer through an IORef (or similar). Then the query is run in IO, when most of the time it's a pure computation (due to the changes above). This just muddles things up.

#### Stake pool retirement time

Because stake pool retirement epochs are almost certainly past time safe zone, we need to use the unsafeExtend function to assume that the current epoch is the final epoch.

#### Transaction expiry (TTL)

Expiry times need to be converted fo/from slots. But these are rarely going to be outside of the safe zone. If they are, it is fine to refuse to convert, and show "Nothing" (for incoming tx) or reject the payment request (for outgoing tx).

