### PR TITLE
Make sure that db-properties generators and shrinker are somewhat reasonable

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -66,7 +66,7 @@ import Cardano.Wallet.DB.Sqlite
     , withDBLayer
     )
 import Cardano.Wallet.DB.StateMachine
-    ( prop_parallel, prop_sequential )
+    ( prop_parallel, prop_sequential, validateGenerators )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0
     , dummyGenesisParameters
@@ -273,17 +273,21 @@ spec = do
                 "shelleyAccountingStyle-v2020-10-13.sqlite"
 
 sqliteSpecSeq :: Spec
-sqliteSpecSeq = withDB newMemoryDBLayer $ do
-    describe "Sqlite" properties
-    describe "Sqlite State machine tests" $ do
-        it "Sequential" (prop_sequential :: TestDBSeq -> Property)
-        xit "Parallel" prop_parallel
+sqliteSpecSeq = do
+    validateGenerators @(SeqState 'Mainnet JormungandrKey)
+    withDB newMemoryDBLayer $ do
+        describe "Sqlite" properties
+        describe "Sqlite State machine tests" $ do
+            it "Sequential" (prop_sequential :: TestDBSeq -> Property)
+            xit "Parallel" prop_parallel
 
 sqliteSpecRnd :: Spec
-sqliteSpecRnd = withDB newMemoryDBLayer $ do
-    describe "Sqlite State machine (RndState)" $ do
-        it "Sequential state machine tests"
-            (prop_sequential :: TestDBRnd -> Property)
+sqliteSpecRnd = do
+    validateGenerators @(RndState 'Mainnet)
+    withDB newMemoryDBLayer $ do
+        describe "Sqlite State machine (RndState)" $ do
+            it "Sequential state machine tests"
+                (prop_sequential :: TestDBRnd -> Property)
 
 testMigrationAccountingStyle
     :: forall k s.

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -699,8 +699,8 @@ shrinker (At cmd) = case cmd of
         | h' <- map unGenTxHistory . shrink . GenTxHistory $ h
         ]
     CreateWallet wid wal met txs pp ->
-        [ At $ CreateWallet wid wal' met' txs' pp'
-        | (txs', wal', met', pp') <- shrink (txs, wal, met, pp)
+        [ At $ CreateWallet wid wal' met' (unGenTxHistory txs') pp'
+        | (txs', wal', met', pp') <- shrink (GenTxHistory txs, wal, met, pp)
         ]
     PutWalletMeta wid met ->
         [ At $ PutWalletMeta wid met'

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -44,6 +45,7 @@
 module Cardano.Wallet.DB.StateMachine
     ( prop_sequential
     , prop_parallel
+    , validateGenerators
     , showLabelledExamples
     ) where
 
@@ -147,8 +149,16 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
+import Control.Concurrent
+    ( threadDelay )
+import Control.Concurrent.Async
+    ( race )
+import Control.Exception
+    ( evaluate )
 import Control.Foldl
     ( Fold (..) )
+import Control.Monad
+    ( forM_, void )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
@@ -183,6 +193,8 @@ import Numeric.Natural
     ( Natural )
 import System.Random
     ( getStdRandom, randomR )
+import Test.Hspec
+    ( SpecWith, describe, expectationFailure, it )
 import Test.QuickCheck
     ( Arbitrary (..)
     , Args (..)
@@ -193,8 +205,10 @@ import Test.QuickCheck
     , collect
     , elements
     , frequency
+    , generate
     , labelledExamplesWith
     , property
+    , resize
     , (===)
     )
 import Test.QuickCheck.Monadic
@@ -579,55 +593,79 @@ generator
     :: forall s. (Arbitrary (Wallet s), GenState s)
     => Model s Symbolic
     -> Maybe (Gen (Cmd s :@ Symbolic))
-generator (Model _ wids) = Just $ frequency $ fmap (fmap At) <$> concat
+generator (Model _ wids) = Just $ frequency $ fmap (fmap At) . snd <$> concat
     [ generatorWithoutId
     , if null wids then [] else generatorWithWid (fst <$> wids)
     ]
 
+declareGenerator
+    :: String -- ^ A readable name
+    -> Int -- ^ Frequency
+    -> Gen cmd -- ^ Generator
+    -> (String, (Int, Gen cmd))
+declareGenerator name f gen = (name, (f, gen))
+
 generatorWithoutId
-    :: (Arbitrary (Wallet s), GenState s)
-    => [(Int, Gen (Cmd s (Reference WalletId Symbolic)))]
+    :: forall s r. (Arbitrary (Wallet s), GenState s)
+    => [(String, (Int, Gen (Cmd s (Reference WalletId r))))]
 generatorWithoutId =
-    [ (5, CreateWallet
-        <$> genId
-        <*> (getInitialCheckpoint <$> arbitrary)
-        <*> arbitrary
-        <*> fmap unGenTxHistory arbitrary
-        <*> arbitrary)
+    [ declareGenerator "CreateWallet" 5
+        $ CreateWallet
+            <$> genId
+            <*> (getInitialCheckpoint <$> arbitrary)
+            <*> arbitrary
+            <*> fmap unGenTxHistory arbitrary
+            <*> arbitrary
     ]
   where
     genId :: Gen MWid
     genId = MWid <$> elements ["a", "b", "c"]
 
 generatorWithWid
-    :: (Arbitrary (Wallet s), GenState s)
-    => [Reference WalletId Symbolic]
-    -> [(Int, Gen (Cmd s (Reference WalletId Symbolic)))]
+    :: forall s r. (Arbitrary (Wallet s), GenState s)
+    => [Reference WalletId r]
+    -> [(String, (Int, Gen (Cmd s (Reference WalletId r))))]
 generatorWithWid wids =
-    [ (3, RemoveWallet <$> genId)
-    , (5, pure ListWallets)
-    , (5, PutCheckpoint <$> genId <*> arbitrary)
-    , (5, ReadCheckpoint <$> genId)
-    , (5, ListCheckpoints <$> genId)
-    , (5, PutWalletMeta <$> genId <*> arbitrary)
-    , (5, ReadWalletMeta <$> genId)
-    , (5, PutDelegationCertificate <$> genId <*> arbitrary <*> arbitrary)
-    , (1, IsStakeKeyRegistered <$> genId)
-    , (5, PutTxHistory <$> genId <*> fmap unGenTxHistory arbitrary)
-    , (5, ReadTxHistory
-        <$> genId
-        <*> genMinWithdrawal
-        <*> genSortOrder
-        <*> genRange
-        <*> arbitrary)
-    , (4, RemovePendingTx <$> genId <*> arbitrary)
-    , (4, UpdatePendingTxForExpiry <$> genId <*> arbitrary)
-    , (3, PutPrivateKey <$> genId <*> genPrivKey)
-    , (3, ReadPrivateKey <$> genId)
-    , (1, RollbackTo <$> genId <*> arbitrary)
+    [ declareGenerator "RemoveWallet" 3
+        $ RemoveWallet <$> genId
+    , declareGenerator "ListWallets" 5
+        $ pure ListWallets
+    , declareGenerator "PutCheckpoints" 5
+        $ PutCheckpoint <$> genId <*> arbitrary
+    , declareGenerator "ReadCheckpoint" 5
+        $ ReadCheckpoint <$> genId
+    , declareGenerator "ListCheckpoints" 5
+        $ ListCheckpoints <$> genId
+    , declareGenerator "PutWalletMeta" 5
+        $ PutWalletMeta <$> genId <*> arbitrary
+    , declareGenerator "ReadWalletMeta" 5
+        $ ReadWalletMeta <$> genId
+    , declareGenerator "PutDelegationCertificate" 5
+        $ PutDelegationCertificate <$> genId <*> arbitrary <*> arbitrary
+    , declareGenerator "IsStakeKeyRegistered" 1
+        $ IsStakeKeyRegistered <$> genId
+    , declareGenerator "PutTxHistory" 5
+        $ PutTxHistory <$> genId <*> fmap unGenTxHistory arbitrary
+    , declareGenerator "ReadTxHistory" 5
+        $ ReadTxHistory
+            <$> genId
+            <*> genMinWithdrawal
+            <*> genSortOrder
+            <*> genRange
+            <*> arbitrary
+    , declareGenerator "RemovePendingTx" 4
+        $ RemovePendingTx <$> genId <*> arbitrary
+    , declareGenerator "UpdatePendingTxForExpiry" 4
+        $ UpdatePendingTxForExpiry <$> genId <*> arbitrary
+    , declareGenerator "PutPrivateKey" 3
+        $ PutPrivateKey <$> genId <*> genPrivKey
+    , declareGenerator "ReadPrivateKey" 3
+        $ ReadPrivateKey <$> genId
+    , declareGenerator "RollbackTo" 1
+        $ RollbackTo <$> genId <*> arbitrary
     ]
   where
-    genId :: Gen (Reference WalletId Symbolic)
+    genId :: Gen (Reference WalletId r)
     genId = QC.elements wids
 
     genPrivKey :: Gen MPrivKey
@@ -650,9 +688,9 @@ isUnordered xs = xs /= L.sort xs
 
 shrinker
     :: (Arbitrary (Wallet s))
-    => Model s Symbolic
-    -> Cmd s :@ Symbolic -> [Cmd s :@ Symbolic]
-shrinker (Model _ _) (At cmd) = case cmd of
+    => Cmd s :@ r
+    -> [Cmd s :@ r]
+shrinker (At cmd) = case cmd of
     PutCheckpoint wid wal ->
         [ At $ PutCheckpoint wid wal'
         | wal' <- shrink wal ]
@@ -731,7 +769,7 @@ sm db = QSM.StateMachine
     , invariant = Nothing
     , generator = generator
     , distribution = Nothing
-    , shrinker = shrinker
+    , shrinker = const shrinker
     , semantics = semantics db
     , mock = symbolicResp
     }
@@ -1239,6 +1277,40 @@ prop_parallel db =
         let sm' = sm db
             cmds' = addCleanDB cmds
         prettyParallelCommands cmds =<< runParallelCommands sm' cmds'
+
+-- Controls that generators and shrinkers can run within a reasonable amount of
+-- time. We have been bitten several times already by generators which took much
+-- longer than what they should, causing timeouts in the test suite.
+validateGenerators
+    :: forall s. (Arbitrary (Wallet s), GenState s)
+    => SpecWith ()
+validateGenerators = describe "Validate generators & shrinkers" $ do
+    forM_ allGenerators $ \(name, (_frequency, gen)) -> do
+        let titleGen = "Generator for " <> name
+        it titleGen $ race (threadDelay _1s) (sanityCheckGen gen) >>= \case
+            Left{}  -> expectationFailure "Timed out."
+            Right{} -> pure ()
+
+        let titleShrink = "Shrinker for " <> name
+        it titleShrink $ do
+            cmd <- generate (resize 97 gen) -- NOTE: 97 is prime
+            race (threadDelay _1s) (sanityCheckShrink [At cmd]) >>= \case
+                Left{}  -> expectationFailure "Timed out."
+                Right{} -> pure ()
+  where
+    _1s = 1_000_000
+
+    allGenerators = generatorWithoutId @s ++ generatorWithWid @s wids
+      where wids = QSM.reference . unMockWid . MWid <$> ["a", "b", "c"]
+
+    sanityCheckGen gen = do
+        cmds <- generate (sequence [ resize s gen | s <- [0 .. 999] ])
+        void . traverse evaluate $ cmds
+
+    sanityCheckShrink = \case
+        []  -> pure ()
+        [x] -> sanityCheckShrink (concatMap shrinker [x])
+        xs  -> sanityCheckShrink (concatMap shrinker [head xs, last xs])
 
 -- | The commands for parallel tests are run multiple times to detect
 -- concurrency problems. We need to clean the database before every run. The

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -79,7 +79,6 @@ import Test.QuickCheck
     , resize
     , scale
     , shrinkList
-    , shrinkMap
     , suchThat
     , vector
     , vectorOf
@@ -200,15 +199,22 @@ genByteString :: Gen BS.ByteString
 genByteString = B8.pack <$> (choose (0, 64) >>= vector)
 
 shrinkByteString :: BS.ByteString -> [BS.ByteString]
-shrinkByteString = shrinkMap BS.pack BS.unpack
+shrinkByteString bs
+    | n <= 1    = []
+    | otherwise = [ BS.take (n `div` 2) bs, BS.drop (n `div` 2) bs ]
+  where
+    n = BS.length bs
 
 genText :: Gen Text
 genText =
     (T.pack . take 32 . getPrintableString <$> arbitrary) `suchThat` guardText
 
 shrinkText :: Text -> [Text]
-shrinkText =
-    filter guardText . fmap T.pack . shrink . T.unpack
+shrinkText t
+    | n <= 1    = []
+    | otherwise = filter guardText [ T.take (n `div` 2) t, T.drop (n `div` 2) t ]
+  where
+    n = T.length t
 
 guardText :: Text -> Bool
 guardText t = not ("0x" `T.isPrefixOf` t)


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->



# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 98f03eda18e4e1015a4dea617ebfb158799531b2
  :round_pushpin: **make state-machine generators top-level functions**
    So we can re-use them in some other properties, to control that they're valid.

- d1d7668c5158a27e50d0ea6f5f0a3f2c2cfae2a3
  :round_pushpin: **test that database state-machine generators and shrinkers are 'valid'**
    The strategy is rather "simple" and just run generate random data
  shrink them, and evaluate to WHNF and expects this to finish within a
  reasonable amount of time.
  The goal is to help identifying broken generators or shrinkers early
  on. In case it fails, it shows clearly which command has failed which
  ease further debugging, for example:

  ```
  Validate generators & shrinkers
    Generator for CreateWallet FAILED [1]
    Shrinker for CreateWallet FAILED [1]
    Generator for RemoveWallet
    Shrinker for RemoveWallet
    Generator for ListWallets
    Shrinker for ListWallets
    Generator for PutCheckpoints
    Shrinker for PutCheckpoints
    Generator for ReadCheckpoint
    Shrinker for ReadCheckpoint
    Generator for ListCheckpoints
    Shrinker for ListCheckpoints
    Generator for PutWalletMeta
    Shrinker for PutWalletMeta
    Generator for ReadWalletMeta
    Shrinker for ReadWalletMeta
    Generator for PutDelegationCertificate
    Shrinker for PutDelegationCertificate
    Generator for IsStakeKeyRegistered
    Shrinker for IsStakeKeyRegistered
    Generator for PutTxHistory
    Shrinker for PutTxHistory FAILED [2]
    Generator for ReadTxHistory
    Shrinker for ReadTxHistory
    Generator for RemovePendingTx
    Shrinker for RemovePendingTx
    Generator for UpdatePendingTxForExpiry
    Shrinker for UpdatePendingTxForExpiry
    Generator for PutPrivateKey
    Shrinker for PutPrivateKey
    Generator for ReadPrivateKey
    Shrinker for ReadPrivateKey
    Generator for RollbackTo
    Shrinker for RollbackTo
  ```

  After fixes:

  ```
  Finished in 0.0706 seconds
  68 examples, 0 failures
  ```

- 70221691767707ab9b1d9f6fc095da15aec5ace6
  :round_pushpin: **fix various shrinkers and generators causing slowness in database properties**
    Key take-aways:

  - Default shrinker for lists and maps are usually doing better than
    hand-crafted ones.

  - Shrinking large integral values is not really effective. So unless
    really needed, we should limit the size of arbitrary integral
    values.

  - Shrinking text or bytestring by converting them to a list of Char or
    Word8 is really not efficient.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
