### PR TITLE
fix 'waitForFree' test in Sqlite.DeleteSpec (increase delay)

### DIFF
--- a/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -36,13 +38,13 @@ spec = describe "RefCount" $ do
         closed <- newEmptyMVar
 
         let conn = withRef ref testId $ do
-                threadDelay 500000
+                threadDelay 500_000
                 putMVar closed ()
         let rm = waitForFree' nullTracer testPol ref testId $ \n -> do
                 n `shouldBe` 0
                 isEmptyMVar closed
 
-        concurrently conn (threadDelay 10 >> rm) `shouldReturn` ((), False)
+        concurrently conn (threadDelay 50_000 >> rm) `shouldReturn` ((), False)
 
     it "waitForFree uses correct id" $ do
         ref <- newRefCount


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have fix 'waitForFree' test in Sqlite.DeleteSpec (increase delay)

  The symptoms were that this test was sometimes failing. Looking at the
  scenario itself, it seems that it could simply be a race condition due
  to the machine being busy running other tests (now ran in parallel).

  The test is simple: it runs two actions concurrently:

  - One action which grabs a database reference and simulate some busy work
  - One action which wait for all db references to be "freed"

  The problem is that, the second action should only run after the
  database reference has been reserved already and this was "ensured" by
  adding a very small delay of 10 microseconds before the second action.
  Yet, now that tests are executed in parallel, we have many threads
  floating around and it could very much be that the second action
  sometimes get scheduled earlier than the first one, causing the second
  action to run and execute immediately since there's no database
  referenced that has been grabbed yet.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
