### PR TITLE
Test how TimeInterpreter logging is affected by combinators

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -335,6 +335,7 @@ data TimeInterpreterLog
     = MsgInterpreterPastHorizon
         (Maybe String) -- ^ Reason for why the failure should be impossible
         PastHorizonException
+    deriving (Eq, Show)
 
 instance HasSeverityAnnotation TimeInterpreterLog where
     getSeverityAnnotation = \case


### PR DESCRIPTION
# Issue Number

ADP-550

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Added basic unit tests ensuring the TimeInterpreter logging is affected by combinators correctly

# Comments

```
Cardano.Wallet.Primitive.Slotting
  slotting
    TimeInterpreter conversions beyond the safe zone
      normally fails and logs failures as Notice
      (neverFails "because" ti) logs failures as Error
      (unsafeExtendSafeZone ti) doesn't fail nor log
      (expectAndThrowFailures ti) fails and logs as Notice
```

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
