### PR TITLE
WIP: add interpretAssumingNoForks beyondShelley

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -293,7 +293,6 @@ import Cardano.Wallet.Primitive.Slotting
     , slotToUTCTime
     , timeOfEpoch
     , toSlotId
-    , unsafeExtendSafeZone
     )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), SyncTolerance, syncProgress )


### PR DESCRIPTION
# Issue Number

ADP-524

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Only use `unsafeExtendSafeZone` when we're in Shelley or beyond
- WIP

# Comments
- Yesterday I had difficulties making this work using the existing combinator, so I added a separate interpret function... but I think we actually need a combinator to be able to pass a `unsafeExtendSafeZone timeInterpreter` to an unaware helper function.
<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
