### PR TITLE
Improve JSON errors in StakePoolMetadata

### DIFF
--- a/lib/core/src/Cardano/Pool/Metadata.hs
+++ b/lib/core/src/Cardano/Pool/Metadata.hs
@@ -335,9 +335,8 @@ fetchFromRemote tr builders manager pid url hash = runExceptTLog $ do
             -- Metadata are _supposed to_ be made of:
             --
             -- - A name (at most 50 UTF-8 bytes)
-            -- - An optional description (at most 250 UTF-8 bytes)
-            -- - A ticker (at most 5 UTF-8 bytes)
-            -- - A homepage (at most 100 UTF-8 bytes)
+            -- - An optional description (at most 255 UTF-8 bytes)
+            -- - A ticker (between 3 and 5 UTF-8 bytes)
             --
             -- So, the total, including a pretty JSON encoding with newlines ought
             -- to be less than 512 bytes. For security reasons, we only download the

--- a/lib/core/src/Cardano/Pool/Metadata.hs
+++ b/lib/core/src/Cardano/Pool/Metadata.hs
@@ -290,6 +290,8 @@ fetchFromRemote
     -> IO (Maybe StakePoolMetadata)
 fetchFromRemote tr builders manager pid url hash = runExceptTLog $ do
     chunk <- getChunk `fromFirst` builders
+    when (BS.length chunk > 512) $ throwE
+        "Metadata exceeds max length of 512 bytes"
     when (blake2b256 chunk /= coerce hash) $ throwE $ mconcat
         [ "Metadata hash mismatch. Saw: "
         , B8.unpack $ hex $ blake2b256 chunk
@@ -339,12 +341,13 @@ fetchFromRemote tr builders manager pid url hash = runExceptTLog $ do
             -- - A ticker (between 3 and 5 UTF-8 bytes)
             --
             -- So, the total, including a pretty JSON encoding with newlines ought
-            -- to be less than 512 bytes. For security reasons, we only download the
-            -- first 512 bytes.
+            -- to be less than or equal to 512 bytes. For security reasons, we only
+            -- download the first 513 bytes and check the length at the
+            -- call-site.
             case responseStatus res of
                 s | s == status200 -> do
                     let body = responseBody res
-                    Right . Just . BL.toStrict <$> brReadSome body 512
+                    Right . Just . BL.toStrict <$> brReadSome body 513
 
                 s | s == status404 -> do
                     pure $ Left "There's no known metadata for this pool."

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -168,7 +168,7 @@ import Control.DeepSeq
 import Control.Error.Util
     ( (??) )
 import Control.Monad
-    ( guard, (<=<), (>=>) )
+    ( when, (<=<), (>=>) )
 import Control.Monad.Except
     ( runExceptT )
 import Control.Monad.Trans.Except
@@ -616,13 +616,17 @@ instance FromJSON StakePoolMetadata where
         ticker <- obj .: "ticker"
 
         name <- obj .: "name"
-        guard (T.length name <= 50)
+        when (T.length name > 50)
+            $ fail "name exceeds max length of 50 chars"
 
         description <- obj .:? "description"
-        guard ((T.length <$> description) <= Just 250)
+        when ((T.length <$> description) > Just 250)
+            $ fail "description exceeds max length of 250 characters"
 
         homepage <- obj .: "homepage"
-        guard (T.length homepage <= 100)
+        when (T.length homepage > 100)
+            $ fail "homepage exceeds max length of 100 characters"
+
 
         pure $ StakePoolMetadata{ticker,name,description,homepage}
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -614,19 +614,19 @@ data StakePoolMetadata = StakePoolMetadata
 instance FromJSON StakePoolMetadata where
     parseJSON = withObject "StakePoolMetadta" $ \obj -> do
         ticker <- obj .: "ticker"
+        let tickerLen = T.length . unStakePoolTicker $ ticker
+        when (tickerLen > 5 || tickerLen < 3)
+            $ fail "ticker length must be between 3 and 5 characters"
 
         name <- obj .: "name"
         when (T.length name > 50)
             $ fail "name exceeds max length of 50 chars"
 
         description <- obj .:? "description"
-        when ((T.length <$> description) > Just 250)
-            $ fail "description exceeds max length of 250 characters"
+        when ((T.length <$> description) > Just 255)
+            $ fail "description exceeds max length of 255 characters"
 
         homepage <- obj .: "homepage"
-        when (T.length homepage > 100)
-            $ fail "homepage exceeds max length of 100 characters"
-
 
         pure $ StakePoolMetadata{ticker,name,description,homepage}
 


### PR DESCRIPTION
This was brought to my attention by Carlos Lopezdelara.
A pool didn't show up in daedalus, because the wallet
rejects the metadata, because the description is too long (exceeds 250 chars).

Logs were:

```
  [cardano-wallet.pools-engine:Info:38] [2020-12-02 03:08:00.64 UTC]
  Fetching metadata with hash 54e76fd5 from
  https://smash.cardano-mainnet.iohk.io/api/v1/metadata/c7013e0a9e0f04a0363998cac5db01f08aa466b755a1a91c42b4c4b3/54e76fd5a3eb80cbb7c0996d42fca355344e7a5614462a5b887fbdccf3fe0990
  [cardano-wallet.pools-engine:warning:38] [2020-12-02 03:08:00.83 UTC]
  Failed to fetch metadata with hash 54e76fd5: Error in $: empty
```
Payload was:

```
  {
   "name": "BraveHeartStakePool",
    "description": "At BraveHeartStakePool we are committed in providing
    you, the Cardano community with the ability to have financial
    'FREEDOM'. We will strive to provide quality reliably service 24/7 &
    aim to maximise your return on stake. BraveHeartStakePool 'BRAVE'. ",
     "ticker": "BRAVE",
      "homepage": "https://braveheartstakepool.com",
       "extended": "https://braveheartstakepool.com/brave-extended.json"
       }
  }
```
----

I think there are some things to discuss here:

1. where do these limitations come from?
2. why are these limitations not in SMASH?
3. how to improve this? The failure is way too silent. Even the updated json error isn't enough imo.