### PR TITLE
[ADP-500] Change addresses are not listed as soon as a transaction is no longer pending

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1675,14 +1675,17 @@ listAddresses ctx w = do
     return addrs
 
 getWallet
-    :: forall m. (MonadIO m, MonadCatch m)
+    :: forall w m.
+        ( MonadIO m
+        , MonadUnliftIO m
+        , HasType (ApiT WalletId) w
+        )
     => Context
-    -> ApiWallet
+    -> w
     -> m ApiWallet
 getWallet ctx w = do
     let link = Link.getWallet @'Shelley w
-    (_, wallet) <- unsafeRequest @ApiWallet ctx
-        link Empty
+    (_, wallet) <- unsafeRequest @ApiWallet ctx link Empty
     return wallet
 
 listAllTransactions

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -93,6 +93,7 @@ module Test.Integration.Framework.DSL
     , quitStakePoolUnsigned
     , selectCoins
     , listAddresses
+    , getWallet
     , listTransactions
     , listAllTransactions
     , deleteAllWallets
@@ -1672,6 +1673,17 @@ listAddresses ctx w = do
     let link = Link.listAddresses @'Shelley w
     (_, addrs) <- unsafeRequest @[ApiAddress n] ctx link Empty
     return addrs
+
+getWallet
+    :: forall m. (MonadIO m, MonadCatch m)
+    => Context
+    -> ApiWallet
+    -> m ApiWallet
+getWallet ctx w = do
+    let link = Link.getWallet @'Shelley w
+    (_, wallet) <- unsafeRequest @ApiWallet ctx
+        link Empty
+    return wallet
 
 listAllTransactions
     :: forall n w m.

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -386,7 +386,7 @@ testMigrationRole dbName = do
                     readCheckpoint wid
         let migrationMsg = filter isMsgManualMigration logs
         length migrationMsg `shouldBe` 3
-        length (knownAddresses $ getState cp) `shouldBe` 69
+        length (knownAddresses $ getState cp) `shouldBe` 71
   where
     isMsgManualMigration :: DBLog -> Bool
     isMsgManualMigration = \case

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -481,7 +481,7 @@ prop_changeIsOnlyKnownAfterGeneration (intPool, extPool) =
         sPool = newVerificationKeyPool (accountPubKey extPool) (gap extPool)
         s0 :: SeqState 'Mainnet ShelleyKey
         s0 = SeqState intPool extPool emptyPendingIxs rewardAccount defaultPrefix sPool
-        addrs0 = fst <$> knownAddresses s0
+        addrs0 = knownAddresses s0
         (change, s1) = genChange (\k _ -> paymentAddress @'Mainnet k) s0
         addrs1 = fst <$> knownAddresses s1
     in conjoin
@@ -490,9 +490,13 @@ prop_changeIsOnlyKnownAfterGeneration (intPool, extPool) =
         ]
   where
     prop_addrsNotInInternalPool addrs =
-        map (\x -> (ShowFmt x, isNothing $ fst $ lookupAddress id x intPool)) addrs
+        map (\(x, s) ->
+                let notInPool = isNothing $ fst $ lookupAddress id x intPool
+                    isUsed = s == Used
+                in (ShowFmt x, notInPool || isUsed))
+            addrs
         ===
-        map (\x -> (ShowFmt x, True)) addrs
+        map (\(x, _) -> (ShowFmt x, True)) addrs
     prop_changeAddressIsKnown addr addrs =
         counterexample
             (show (ShowFmt addr) <> " not in " <> show (ShowFmt <$> addrs))


### PR DESCRIPTION
# Issue Number

ADP-500

# Overview

- [x] created an integration test that checks the accepctance criteria and fails on the current branch
- [x] fixed the code in `knownAddresses` to also return all used change addresses

# Comments

## Questions

Do we need to communicate this to API users?
