### PR TITLE
Fix flaky WAI middleware logging test cases

### DIFF
--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -22,7 +23,7 @@ import Cardano.Wallet.Api.Server
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
-    ( Async, async, cancel, mapConcurrently )
+    ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, readMVar )
 import Control.Concurrent.STM.TVar
@@ -102,11 +103,9 @@ import Servant.Server
 import Test.Hspec
     ( Spec, after, afterAll, beforeAll, describe, it, shouldBe, shouldContain )
 import Test.QuickCheck
-    ( Arbitrary (..), choose, property, withMaxSuccess )
+    ( Arbitrary (..), choose, counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
-    ( monadicIO )
-import Test.Utils.Windows
-    ( pendingOnWindows, whenWindows )
+    ( assert, monadicIO, monitor )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.List as L
@@ -215,28 +214,39 @@ spec = describe "Logging Middleware"
             , (Debug, "LogRequestFinish")
             ]
 
-    it "different request ids" $ \ctx -> property $ \(NumberOfRequests n) ->
-        monadicIO $ liftIO $ do
-            void $ mapConcurrently (const (get ctx "/get")) (replicate n ())
-            entries <- readTVarIO (logs ctx)
+    it "different request ids" $ \ctx ->
+        property $ \(NumberOfRequests n) -> monadicIO $ do
+            entries <- liftIO $ do
+                replicateConcurrently_ n (get ctx "/get")
+                skipPrevLogs <$> takeLogs ctx
             let getReqId (ApiLog (RequestId rid) _) = rid
             let uniqueReqIds = L.nubBy (\l1 l2 -> getReqId l1 == getReqId l2)
-            pendingOnWindows "Disabled on windows due to race with log flushing"
-            length (uniqueReqIds entries) `shouldBe` n
+            let numUniqueReqIds = length (uniqueReqIds entries)
+            monitor $ counterexample $ unlines $
+                [ "Number of log entries: " ++ show (length entries)
+                , "Number of unique req ids: " ++ show numUniqueReqIds
+                , ""
+                , "All the logs:" ] ++ map show entries
+            assert $ numUniqueReqIds == n
 
-    it "correct time measures" $ \ctx -> property $ \(nReq, ix) ->
-        withMaxSuccess 10 $ monadicIO $ liftIO $ do
-            let (NumberOfRequests n, RandomIndex i) = (nReq, ix)
-            let reqs = mconcat
-                    [ replicate i (get ctx "/get")
-                    , [ get ctx "/long" ]
-                    , replicate (n - i) (get ctx "/get")
-                    ]
-            void $ mapConcurrently id reqs
-            entries <- readTVarIO (logs ctx)
+    it "correct time measures" $ \ctx -> withMaxSuccess 10 $
+        property $ \(NumberOfRequests n, RandomIndex i) -> monadicIO $ do
+            entries <- liftIO $ do
+                let reqs = mconcat
+                        [ replicate i (get ctx "/get")
+                        , [ get ctx "/long" ]
+                        , replicate (n - i) (get ctx "/get")
+                        ]
+                void $ mapConcurrently id reqs
+                waitForServerToComplete
+                takeLogs ctx
             let index = mapMaybe captureTime entries
-            pendingOnWindows "Disabled on windows due to race with log flushing"
-            length (filter (> (200*ms)) index) `shouldBe` 1
+            let numLongReqs = length $ filter (> (200*ms)) index
+            monitor $ counterexample $ unlines
+                [ "Number of log entries: " ++ show (length entries)
+                , "Number of long requests: " ++ show numLongReqs
+                ]
+            assert $ numLongReqs == 1
   where
     setup :: IO Context
     setup = do
@@ -260,9 +270,6 @@ spec = describe "Logging Middleware"
             , server = handle
             }
 
-    clearLogs :: Context -> IO ()
-    clearLogs = atomically . flip writeTVar [] . logs
-
     tearDown :: Context -> IO ()
     tearDown = cancel . server
 
@@ -272,6 +279,28 @@ data Context = Context
     , port :: Int
     , server :: Async ()
     }
+
+-- | Read collected logs which were traced with 'traceInTVarIO'.
+takeLogs :: Context -> IO [ApiLog]
+takeLogs ctx = reverse <$> readTVarIO (logs ctx)
+
+-- | Remove any partial logs which have come from the previous property test
+-- run. These can occur because once the requests have completed, the property
+-- finishes, but the response side may still be finishing writing its log
+-- messages.
+skipPrevLogs :: [ApiLog] -> [ApiLog]
+skipPrevLogs = dropWhile (notLogRequestStart . logMsg)
+  where
+    notLogRequestStart LogRequestStart = False
+    notLogRequestStart _ = True
+
+-- | Give server time to finish off its request handler - the intention is to
+-- ensure that /all/ the response logs are captured before checking assertions.
+waitForServerToComplete :: IO ()
+waitForServerToComplete = threadDelay 500_000
+
+clearLogs :: Context -> IO ()
+clearLogs = atomically . flip writeTVar [] . logs
 
 {-------------------------------------------------------------------------------
                                 Test Helpers
@@ -308,9 +337,9 @@ postIlled ctx path body = do
 
 expectLogs :: Context -> [(Severity, String)] -> IO ()
 expectLogs ctx expectations = do
-    whenWindows $ threadDelay 1000000 -- let iohk-monitoring flush the logs
+    waitForServerToComplete
 
-    entries <- reverse <$> readTVarIO (logs ctx)
+    entries <- takeLogs ctx
 
     when (length entries /= length expectations) $
         fail $ "Expected exactly " <> show (length expectations)

--- a/scripts/fluke.sh
+++ b/scripts/fluke.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p coreutils expect moreutils
+
+######################################################################
+#
+# Finds flaky tests by running them repeatedly until failure.
+#
+######################################################################
+
+if [ -z "$1" ]; then
+  echo "usage: $0 PROGRAM [ARGS...]"
+  exit 1
+fi
+
+set -euo pipefail
+
+x=1
+
+time ( while true; do
+  echo "*** fluke run $((x++))"
+  unbuffer "$@" 2>&1 | ts '[%Y-%m-%d %H:%M:%S]'
+  echo -e "\033[0m"
+done )


### PR DESCRIPTION
### Issue Number

Flaky test #2368

### Overview

- Adds a script for finding flaky tests.
- Fixes the test cases.

The "unique request ids" property was failing because it sometimes sees log messages from the previous iteration of the quickcheck property.

This happened much more on Windows, but I found I could also reproduce it with about 25-50 test runs on Linux.

I initially thought it was due to some buffering in iohk-monitoring. But that was wrong - `traceInTVarIO` is actually a really simple trace transformer (pretty cool actually!).

Then I thought perhaps what was happening is that the captured log list isn't fully evaluated before the test case finishes. But this was also wrong. We should probably make IOVars and log message types more strict, but this was not the bug.

The problem was in the test cases. They would complete one or more requests, then check what the server had logged. However, the server may not yet have completely finished its request handler at this time. Therefore, the "correct time measures" assertions sometimes failed due to missing LogResponse messages. Even worse, the "different request ids" property sometimes failed because logs from the previous property example were included in the logs of the current property example.

The solution is to judiciously place a sleep statement and filter logs from previous test runs.
