### PR TITLE
Add v2020-12-08 to migration tests

### DIFF
--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -56,7 +56,7 @@ let
       sha256 = "1v2l46g0f8bkas7mhm624l3kmxz3g80095f4vqicz736bv7vsijc"; }
     { rev = "v2020-11-17";
       sha256 = "1y4sfykqkdijv2rx4758nc1b2f262cn89qfsv48xrv4irwi7x5mr"; }
-    { rev = "v2020.12.8";
+    { rev = "v2020-11-26";
       sha256 = "1262mangwrc2ykr9qwbcj57h2z2ib2sn0haipm2md4246f7b97v7"; }
   ];
 

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -38,8 +38,6 @@ let
   # One can get sha256 for release via nix-prefetch-url, e.g. for v2020.11.3:
   # nix-prefetch-url --unpack https://github.com/input-output-hk/cardano-wallet/archive/v2020-11-03.zip
   releases = [
-    { rev = "v2020-07-06";
-      sha256 = "1pl1vqmdyjx8ly3vy48j211hh59w7ikksmzv7r4y1cpjyi0ajjsa"; }
     { rev = "v2020-07-28";
       sha256 = "1mnnlg1x3y9cf3sqmxpqjdiwlay58pdci4cjxfvlwlyqqlsy5d1i"; }
     { rev = "v2020-08-03";
@@ -58,6 +56,8 @@ let
       sha256 = "1y4sfykqkdijv2rx4758nc1b2f262cn89qfsv48xrv4irwi7x5mr"; }
     { rev = "v2020-11-26";
       sha256 = "1262mangwrc2ykr9qwbcj57h2z2ib2sn0haipm2md4246f7b97v7"; }
+    { rev = "v2020-12-08";
+      sha256 = "00d5488yzsx3f6mqnnz9cd91zrbz2v6xqgqgcxk4vhl9qkc9vnfr"; }
   ];
 
   # Download the sources for a release.

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -38,7 +38,7 @@ WIKI_COMMIT=$(git ls-remote https://github.com/$REPO.wiki.git HEAD | cut -f1)
 echo ""
 echo "Replacing $OLD_CABAL_VERSION with $CABAL_VERSION"
 sed -i "s/$OLD_CABAL_VERSION/$CABAL_VERSION/" \
-    $(git ls-files '*.nix'; git ls-files '*.cabal'; git ls-files '*swagger.yaml')
+    $(git ls-files '*.nix:!:nix/migration-tests.nix'; git ls-files '*.cabal'; git ls-files '*swagger.yaml')
 echo "Looking for remaining references to old version:"
 git grep $OLD_CABAL_VERSION
 echo ""


### PR DESCRIPTION
# Issue Number

Post-release tasks for v2020-12-08.


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] `scripts/make_release.sh` should not find-replace versions inside `nix/migration-tests.nix`
- [x] Correct the v2020-11-26 version
- [x] Add v2020-12-08


# Comments

- Unable to test the migration tests on my Macs.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
