### PR TITLE
Upload swagger to bump.sh on release deployment

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 Compatible with [`cardano-node@{{CARDANO_NODE_TAG}}`](https://github.com/input-output-hk/cardano-node/releases/tag/{{CARDANO_NODE_TAG}}).
 
+
+## API Changes
+
+<!-- Copy-paste most recent diff excerpt from https://bump.sh/doc/cardano-wallet-diff/changes -->
+
+
 <!-- A CHANGELOG, organized in three sections:
 
  - New Features

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 
 # Choose a build environment:
-dist: xenial
+dist: focal
 
 # Only clone the repository tip & track all branches
 git:
@@ -49,6 +49,13 @@ jobs:
     if: type != pull_request AND (tag =~ ^v OR commit_message =~ /TRAVIS_TRIGGER_RELEASE/)
     name: "Executables"
     script:
+    # Upload swagger to bump.sh
+    - gem install bump-cli
+    - sudo snap install yq
+    - yq r -j specifications/api/swagger.yaml > specifications/api/swagger.json
+    - bump validate --doc $BUMP_SH_DOC_ID --token $BUMP_SH_TOKEN specifications/api/swagger.json
+    - bump deploy --doc $BUMP_SH_DOC_ID --token $BUMP_SH_TOKEN specifications/api/swagger.json
+
     # Fetch the builds from Hydra
     - nvm install 12.18.3 && nvm use 12.18.3
     - npm install --no-save axios@0.19.2 lodash@4.17.20


### PR DESCRIPTION
# Issue Number

ADP-600

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->


# Overview

- 275956f7428aab12152b93b72b72a8f71cd780d7
  Upload swagger upload to bump.sh on release
  
- ca0d72fd39310be80c93a0afda1ed9337da6fe68
  Add API Changes section in Release template


# Comments

 - I have tested upload from Travis into bump.sh ->  https://bump.sh/doc/cardano-wallet-test/changes :heavy_check_mark: 
 - swagger should be uploaded to https://bump.sh/doc/cardano-wallet-diff/changes on release deploy step
 - added `API Changes` section to release template with a note
