### PR TITLE
Don't cache core/shelley unit test results for Hydra bors jobsets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,8 @@
 , sourcesOverride ? {}
 # GitHub PR number (as a string), set when building a Hydra PR jobset.
 , pr ? null
+# Bors job type (as a string), set when building a Hydra bors jobset.
+, borsBuild ? null
 }:
 
 # commonLib includes iohk-nix utilities, our util.nix and nixpkgs lib.

--- a/release.nix
+++ b/release.nix
@@ -41,7 +41,7 @@
 , projectArgs ? {
     config = { allowUnfree = false; inHydra = true; };
     gitrev = cardano-wallet.rev;
-    inherit pr sourcesOverride;
+    inherit pr borsBuild sourcesOverride;
   }
 
 # The systems that the jobset will be built for.
@@ -61,6 +61,9 @@
 
 # GitHub PR number (as a string), provided as a Hydra input
 , pr ? null
+
+# Can be "staging" or "trying" to indicate that this is a bors jobset
+, borsBuild ? null
 
 # Platform filter string for jobset.
 , platform ? "all"


### PR DESCRIPTION
The unit tests are getting a bit flaky, like the integration tests. The small amount of time saved from caching unit test runs is
not worth it. It's annoying when resubmitted bors jobs fail due to cached test results.

This change disables caching of unit test results for the cardano-wallet-core and cardano-wallet packages, if the jobset is part of a bors run.
