### PR TITLE
Refresh and use era parameters using latest era genesis. 

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -54,6 +54,7 @@ module Test.Integration.Framework.DSL
     -- * Constants
     , minUTxOValue
     , slotLengthValue
+    , securityParameterValue
     , epochLengthValue
     , defaultTxTTL
 
@@ -583,8 +584,16 @@ minUTxOValue :: Natural
 minUTxOValue = 1_000_000
 
 -- | Parameter in test cluster genesis.
+--
+-- FIXME: Adding this line to create a merge-conflict with #2391 to remind
+-- whoever resolving this merge conflict to also update the newly introduced
+-- 'securityParameterValue'. Cheers.
 slotLengthValue :: NominalDiffTime
-slotLengthValue = 0.2
+slotLengthValue =  0.2
+
+-- | Parameter in test cluster genesis.
+securityParameterValue :: Word32
+securityParameterValue = 10
 
 -- | Parameter in test cluster genesis.
 epochLengthValue :: Word32

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -2216,10 +2216,12 @@ getSlotParams ctx = do
     let (Quantity slotL) = getFromResponse #slotLength r2
     let (Quantity epochL) = getFromResponse #epochLength r2
     let (Quantity coeff) = getFromResponse #activeSlotCoefficient r2
+    let (Quantity k) = getFromResponse #securityParameter r2
     let sp = SlottingParameters
             (SlotLength slotL)
             (EpochLength epochL)
             (ActiveSlotCoefficient coeff)
+            (Quantity k)
 
     return (currentEpoch, sp)
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -29,6 +29,7 @@ import Test.Integration.Framework.DSL
     , expectResponseCode
     , minUTxOValue
     , request
+    , securityParameterValue
     , slotLengthValue
     , verify
     )
@@ -53,8 +54,6 @@ spec = describe "SHELLEY_NETWORK" $ do
             , expectField #hardforkAt (`shouldNotBe` Nothing)
             , expectField #slotLength (`shouldBe` Quantity slotLengthValue)
             , expectField #epochLength (`shouldBe` Quantity epochLengthValue)
-            -- TODO: ADP-554 query activeSlotCoefficient from ledger
-            -- This value is hardcoded for mainnet (1.0 = 100%).
-            -- The integration test cluster value is (0.5 = 50%).
-            , expectField #activeSlotCoefficient (`shouldBe` Quantity 100.0)
+            , expectField #securityParameter (`shouldBe` Quantity securityParameterValue)
+            , expectField #activeSlotCoefficient (`shouldBe` Quantity 50.0)
             ]

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1778,8 +1778,8 @@ getNetworkParameters
     -> NetworkLayer IO Block
     -> Handler ApiNetworkParameters
 getNetworkParameters (_block0, genesisNp, _st) nl = do
-    pp <- liftIO $ NW.getProtocolParameters nl
-    sp <- liftIO $ NW.getSlottingParametersForTip nl
+    pp <- liftIO $ NW.currentProtocolParameters nl
+    sp <- liftIO $ NW.currentSlottingParameters nl
     let (apiNetworkParams, epochNoM) = toApiNetworkParameters genesisNp
             { protocolParameters = pp, slottingParameters = sp }
     case epochNoM of

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -702,7 +702,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , blockchainStartTime :: !(ApiT StartTime)
     , slotLength :: !(Quantity "second" NominalDiffTime)
     , epochLength :: !(Quantity "slot" Word32)
-    , epochStability :: !(Quantity "block" Word32)
+    , securityParam :: !(Quantity "block" Word32)
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
     , desiredPoolNumber :: !Word16
@@ -720,7 +720,7 @@ toApiNetworkParameters (NetworkParameters gp sp pp) = (np, view #hardforkEpochNo
         , blockchainStartTime = ApiT $ getGenesisBlockDate gp
         , slotLength = Quantity $ unSlotLength $ getSlotLength sp
         , epochLength = Quantity $ unEpochLength $ getEpochLength sp
-        , epochStability = getEpochStability gp
+        , securityParam = getSecurityParameter sp
         , activeSlotCoefficient = Quantity
             $ (*100)
             $ unActiveSlotCoefficient

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -702,7 +702,7 @@ data ApiNetworkParameters = ApiNetworkParameters
     , blockchainStartTime :: !(ApiT StartTime)
     , slotLength :: !(Quantity "second" NominalDiffTime)
     , epochLength :: !(Quantity "slot" Word32)
-    , securityParam :: !(Quantity "block" Word32)
+    , securityParameter :: !(Quantity "block" Word32)
     , activeSlotCoefficient :: !(Quantity "percent" Double)
     , decentralizationLevel :: !(Quantity "percent" Percentage)
     , desiredPoolNumber :: !Word16
@@ -720,7 +720,7 @@ toApiNetworkParameters (NetworkParameters gp sp pp) = (np, view #hardforkEpochNo
         , blockchainStartTime = ApiT $ getGenesisBlockDate gp
         , slotLength = Quantity $ unSlotLength $ getSlotLength sp
         , epochLength = Quantity $ unEpochLength $ getEpochLength sp
-        , securityParam = getSecurityParameter sp
+        , securityParameter = getSecurityParameter sp
         , activeSlotCoefficient = Quantity
             $ (*100)
             $ unActiveSlotCoefficient

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -46,6 +46,7 @@ import Cardano.Wallet.DB.Model
     , mPutWalletMeta
     , mReadCheckpoint
     , mReadDelegationRewardBalance
+    , mReadGenesisParameters
     , mReadPrivateKey
     , mReadProtocolParameters
     , mReadTxHistory
@@ -91,9 +92,9 @@ newDBLayer timeInterpreter = do
                                       Wallets
         -----------------------------------------------------------------------}
 
-        { initializeWallet = \pk cp meta txs txp -> ExceptT $ do
+        { initializeWallet = \pk cp meta txs gp txp -> ExceptT $ do
             cp `deepseq` meta `deepseq`
-                alterDB errWalletAlreadyExists db (mInitializeWallet pk cp meta txs txp)
+                alterDB errWalletAlreadyExists db (mInitializeWallet pk cp meta txs gp txp)
 
         , removeWallet = ExceptT . alterDB errNoSuchWallet db . mRemoveWallet
 
@@ -113,7 +114,7 @@ newDBLayer timeInterpreter = do
         , rollbackTo = \pk pt -> ExceptT $
             alterDB errNoSuchWallet db (mRollbackTo pk pt)
 
-        , prune = \_ -> error "MVar.prune: not implemented"
+        , prune = \_ _ -> error "MVar.prune: not implemented"
 
         {-----------------------------------------------------------------------
                                    Wallet Metadata
@@ -193,6 +194,8 @@ newDBLayer timeInterpreter = do
                 alterDB errNoSuchWallet db (mPutProtocolParameters pk txp)
 
         , readProtocolParameters = readDB db . mReadProtocolParameters
+
+        , readGenesisParameters = readDB db . mReadGenesisParameters
 
         {-----------------------------------------------------------------------
                                  Delegation Rewards

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -71,6 +71,8 @@ Wallet
     walName                     Text                      sql=name
     walPassphraseLastUpdatedAt  UTCTime Maybe             sql=passphrase_last_updated_at
     walPassphraseScheme         W.PassphraseScheme Maybe  sql=passphrase_scheme
+    walGenesisHash              BlockId                   sql=genesis_hash
+    walGenesisStart             UTCTime                   sql=genesis_start
 
     Primary walId
     deriving Show Generic
@@ -158,14 +160,6 @@ Checkpoint
     checkpointHeaderHash        BlockId      sql=header_hash
     checkpointParentHash        BlockId      sql=parent_header_hash
     checkpointBlockHeight       Word32       sql=block_height
-    checkpointGenesisHash       BlockId      sql=genesis_hash
-    checkpointGenesisStart      UTCTime      sql=genesis_start
-    checkpointFeePolicyUnused   Text         sql=fee_policy
-    checkpointSlotLengthUnused  Word64       sql=slot_length
-    checkpointEpochLengthUnused Word32       sql=epoch_length
-    checkpointTxMaxSizeUnused   Word16       sql=tx_max_size
-    checkpointEpochStability    Word32       sql=epoch_stability
-    checkpointActiveSlotCoeffUnused Double       sql=active_slot_coeff
 
     Primary checkpointWalletId checkpointSlot
     Foreign Wallet checkpoint checkpointWalletId ! ON DELETE CASCADE
@@ -179,6 +173,7 @@ ProtocolParameters
     protocolParametersDesiredNumberOfPools  Word16          sql=desired_pool_number
     protocolParametersMinimumUtxoValue      W.Coin          sql=minimum_utxo_value
     protocolParametersHardforkEpoch         W.EpochNo Maybe sql=hardfork_epoch
+
     Primary protocolParametersWalletId
     Foreign Wallet fk_wallet_protocol_parameters protocolParametersWalletId ! ON DELETE CASCADE
     deriving Show Generic

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -275,7 +275,6 @@ mkCheckpoints numCheckpoints utxoSize =
             (Hash $ label "headerHash" i)
         )
         initDummySeqState
-        dummyGenesisParameters
 
     utxo i = Map.fromList $ zip
         (map fst $ mkInputs i utxoSize)
@@ -324,7 +323,7 @@ bgroupWriteSeqState db = bgroup "SeqState"
         cps :: [WalletBench]
         cps =
             [ let extPool = mkPool a i
-              in snd $ initWallet (withMovingSlot i block0) dummyGenesisParameters $
+              in snd $ initWallet (withMovingSlot i block0) $
                 SeqState
                     (mkPool a i)
                     extPool
@@ -372,7 +371,7 @@ bgroupWriteRndState db = bgroup "RndState"
             pure cps
         cps :: [Wallet (RndState 'Mainnet)]
         cps =
-            [ snd $ initWallet (withMovingSlot i block0) dummyGenesisParameters $
+            [ snd $ initWallet (withMovingSlot i block0) $
                 RndState
                     { hdPassphrase = dummyPassphrase
                     , accountIndex = minBound
@@ -613,6 +612,7 @@ setupDB tr = do
         { getSlotLength = SlotLength 1
         , getEpochLength = EpochLength 21600
         , getActiveSlotCoefficient = ActiveSlotCoefficient 1
+        , getSecurityParameter = Quantity 2160
         })
 
 defaultFieldValues :: DefaultFieldValues
@@ -653,6 +653,7 @@ walletFixture db@DBLayer{..} = do
         testCp
         testMetadata
         mempty
+        dummyGenesisParameters
         dummyProtocolParameters
 
 walletFixtureByron :: DBLayerBenchByron -> IO ()
@@ -663,6 +664,7 @@ walletFixtureByron db@DBLayer{..} = do
         testCpByron
         testMetadata
         mempty
+        dummyGenesisParameters
         dummyProtocolParameters
 
 ----------------------------------------------------------------------------
@@ -755,10 +757,10 @@ instance NFData SqliteContext where
     rnf _ = ()
 
 testCp :: WalletBench
-testCp = snd $ initWallet block0 dummyGenesisParameters initDummySeqState
+testCp = snd $ initWallet block0 initDummySeqState
 
 testCpByron :: WalletBenchByron
-testCpByron = snd $ initWallet block0 dummyGenesisParameters initDummyRndState
+testCpByron = snd $ initWallet block0 initDummyRndState
 
 {-# NOINLINE initDummySeqState #-}
 initDummySeqState :: SeqState 'Mainnet ShelleyKey

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiNetworkParameters.json
@@ -1,321 +1,329 @@
 {
-    "seed": -2451492838664092620,
+    "seed": -455699674443190745,
     "samples": [
         {
             "slot_length": {
-                "quantity": 9551,
+                "quantity": 4370,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 3.1,
+                "quantity": 91.09,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 32437,
-                "unit": "block"
-            },
-            "genesis_block_hash": "5f3a23693746da7f451f1f70477b230366317d205eed7857121f418cb8305444",
-            "blockchain_start_time": "1862-05-26T13:18:15Z",
-            "desired_pool_number": 16150,
+            "genesis_block_hash": "760832be142956b17111687ca26a721632cc614d6f5c6d682a136b7f0a49329f",
+            "blockchain_start_time": "1896-02-25T03:19:26.064993196503Z",
+            "desired_pool_number": 5156,
             "epoch_length": {
-                "quantity": 14903,
+                "quantity": 29131,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 40.35967261948201,
+                "quantity": 86.37389524570548,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1873-10-11T00:51:40Z",
-                "epoch_number": 13287
+                "epoch_start_time": "1862-05-13T08:16:24.712703176403Z",
+                "epoch_number": 30961
+            },
+            "security_parameter": {
+                "quantity": 698,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 10,
+                "quantity": 81,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 908,
+                "quantity": 7208,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 64.09,
+                "quantity": 26.83,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 25736,
-                "unit": "block"
-            },
-            "genesis_block_hash": "6fa24c2563392996630d497e653d6a312f6a5a54794651181853392c5752657e",
-            "blockchain_start_time": "1907-09-12T13:00:00Z",
-            "desired_pool_number": 24864,
+            "genesis_block_hash": "0f7c351c77be2aef11d5ad3eca490ee962771a2681365f1b637a4d755f983c7a",
+            "blockchain_start_time": "1877-08-01T15:23:43.542581366524Z",
+            "desired_pool_number": 12984,
             "epoch_length": {
-                "quantity": 2661,
+                "quantity": 22218,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 76.78815115432224,
+                "quantity": 62.82280402482796,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1859-12-05T03:16:02.347806675968Z",
-                "epoch_number": 24786
+                "epoch_start_time": "1897-07-11T03:00:00Z",
+                "epoch_number": 3728
+            },
+            "security_parameter": {
+                "quantity": 15233,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 70,
+                "quantity": 78,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 1022,
+                "quantity": 376,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 33.57,
+                "quantity": 14.01,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 11053,
-                "unit": "block"
-            },
-            "genesis_block_hash": "5f0433710c010f6606237a436808563e31c52b120b3d7479374acd0f60b8635d",
-            "blockchain_start_time": "1870-10-05T16:17:32.094890586556Z",
-            "desired_pool_number": 24250,
+            "genesis_block_hash": "63545b01521c7f110385f7697b473914401f67670a1f0762700831ec0cac9626",
+            "blockchain_start_time": "1885-09-19T02:52:38Z",
+            "desired_pool_number": 15860,
             "epoch_length": {
-                "quantity": 4353,
+                "quantity": 6630,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 59.26405706233871,
-                "unit": "percent"
-            },
-            "minimum_utxo_value": {
-                "quantity": 237,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "slot_length": {
-                "quantity": 8716,
-                "unit": "second"
-            },
-            "decentralization_level": {
-                "quantity": 79.8,
-                "unit": "percent"
-            },
-            "epoch_stability": {
-                "quantity": 23980,
-                "unit": "block"
-            },
-            "genesis_block_hash": "517f091727ac6f111c0768090d0219476b6f7e2f02713ce56a5ef7a118cd7a66",
-            "blockchain_start_time": "1869-02-28T12:13:36Z",
-            "desired_pool_number": 13531,
-            "epoch_length": {
-                "quantity": 21561,
-                "unit": "slot"
-            },
-            "active_slot_coefficient": {
-                "quantity": 68.83781382877466,
+                "quantity": 54.239399285964105,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1903-06-01T23:45:47Z",
-                "epoch_number": 14200
+                "epoch_start_time": "1908-07-20T05:37:14Z",
+                "epoch_number": 13285
+            },
+            "security_parameter": {
+                "quantity": 13609,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 135,
+                "quantity": 187,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 9407,
+                "quantity": 3253,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 16.08,
+                "quantity": 57.32,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 29123,
-                "unit": "block"
-            },
-            "genesis_block_hash": "0c7019024458215f536b00655d1f334147154d194f2523176f3f5a3755431d66",
-            "blockchain_start_time": "1902-03-06T23:00:00Z",
-            "desired_pool_number": 3821,
+            "genesis_block_hash": "2d1d18275ee4c24c00791e072b992b50831c6b4e610649103b431401d408ff56",
+            "blockchain_start_time": "1888-07-27T23:59:50.109008341828Z",
+            "desired_pool_number": 13118,
             "epoch_length": {
-                "quantity": 4100,
+                "quantity": 30654,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 37.99013242664703,
+                "quantity": 90.31607372375959,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1866-10-11T19:31:51Z",
-                "epoch_number": 21904
+                "epoch_start_time": "1868-09-07T22:21:24.049878481071Z",
+                "epoch_number": 2442
+            },
+            "security_parameter": {
+                "quantity": 216,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 35,
+                "quantity": 75,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 8079,
+                "quantity": 2168,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 77.13,
+                "quantity": 8.31,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 29331,
-                "unit": "block"
-            },
-            "genesis_block_hash": "543b474616773e46242d6732fd3c0a1f3da47c4051373d115e1c6fbd67037c15",
-            "blockchain_start_time": "1906-08-23T21:10:13Z",
-            "desired_pool_number": 28454,
+            "genesis_block_hash": "1935624b0d31fdb52828e41603497ea365cc5ca2430627620e3f95841c455ddb",
+            "blockchain_start_time": "1885-12-01T23:06:26.465996254722Z",
+            "desired_pool_number": 13003,
             "epoch_length": {
-                "quantity": 22719,
+                "quantity": 13831,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 39.27487113388919,
+                "quantity": 1.5204098643372022,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1887-02-01T19:35:51Z",
-                "epoch_number": 16412
+                "epoch_start_time": "1885-08-30T00:00:00Z",
+                "epoch_number": 6080
+            },
+            "security_parameter": {
+                "quantity": 22940,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 2,
+                "quantity": 78,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 2435,
+                "quantity": 1887,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 31.03,
+                "quantity": 82.98,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 1053,
-                "unit": "block"
-            },
-            "genesis_block_hash": "294c2f333a0e22615969d64f7c62487b2d33731615105f187574df687375206d",
-            "blockchain_start_time": "1894-07-11T01:15:29.694941352685Z",
-            "desired_pool_number": 2357,
+            "genesis_block_hash": "3425b19fee6d7359ab3027177be97682220c57131987701c663a11276046327e",
+            "blockchain_start_time": "1897-02-08T02:28:03.335198941491Z",
+            "desired_pool_number": 19746,
             "epoch_length": {
-                "quantity": 25873,
+                "quantity": 19717,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 91.4567046394187,
-                "unit": "percent"
-            },
-            "minimum_utxo_value": {
-                "quantity": 237,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "slot_length": {
-                "quantity": 5755,
-                "unit": "second"
-            },
-            "decentralization_level": {
-                "quantity": 2.46,
-                "unit": "percent"
-            },
-            "epoch_stability": {
-                "quantity": 2947,
-                "unit": "block"
-            },
-            "genesis_block_hash": "33070c205b2a175c222c322e3e7d74506e2d24304d4526594d767e6a3335403a",
-            "blockchain_start_time": "1871-12-09T07:51:34Z",
-            "desired_pool_number": 9619,
-            "epoch_length": {
-                "quantity": 20475,
-                "unit": "slot"
-            },
-            "active_slot_coefficient": {
-                "quantity": 70.30569451578474,
+                "quantity": 37.9620629795658,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1883-01-05T00:00:00Z",
-                "epoch_number": 20101
+                "epoch_start_time": "1904-11-22T23:00:00Z",
+                "epoch_number": 19597
+            },
+            "security_parameter": {
+                "quantity": 30450,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 19,
+                "quantity": 38,
                 "unit": "lovelace"
             }
         },
         {
             "slot_length": {
-                "quantity": 927,
+                "quantity": 1315,
                 "unit": "second"
             },
             "decentralization_level": {
-                "quantity": 74.93,
+                "quantity": 22.42,
                 "unit": "percent"
             },
-            "epoch_stability": {
-                "quantity": 30814,
-                "unit": "block"
-            },
-            "genesis_block_hash": "694c1c4604b64a1c6e3a30492d0509c8ae636f802072cd26a9667b7aa74f7639",
-            "blockchain_start_time": "1898-04-23T23:00:00Z",
-            "desired_pool_number": 2191,
+            "genesis_block_hash": "6a384b25540b24063613552e427c1198892b07176250911b081f5ead610e254b",
+            "blockchain_start_time": "1882-12-13T00:42:55Z",
+            "desired_pool_number": 5598,
             "epoch_length": {
-                "quantity": 5493,
+                "quantity": 8654,
                 "unit": "slot"
             },
             "active_slot_coefficient": {
-                "quantity": 36.53269199121173,
-                "unit": "percent"
-            },
-            "minimum_utxo_value": {
-                "quantity": 71,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "slot_length": {
-                "quantity": 4493,
-                "unit": "second"
-            },
-            "decentralization_level": {
-                "quantity": 27.52,
-                "unit": "percent"
-            },
-            "epoch_stability": {
-                "quantity": 21897,
-                "unit": "block"
-            },
-            "genesis_block_hash": "0f3f4165105544486e75646672077b3c3d3a767fc21c133c2110485420575e54",
-            "blockchain_start_time": "1900-03-27T01:34:53.166544150322Z",
-            "desired_pool_number": 13093,
-            "epoch_length": {
-                "quantity": 31316,
-                "unit": "slot"
-            },
-            "active_slot_coefficient": {
-                "quantity": 62.031159485844746,
+                "quantity": 76.85372725504868,
                 "unit": "percent"
             },
             "hardfork_at": {
-                "epoch_start_time": "1877-10-04T14:23:52Z",
-                "epoch_number": 31578
+                "epoch_start_time": "1870-04-14T09:39:44Z",
+                "epoch_number": 90
+            },
+            "security_parameter": {
+                "quantity": 22382,
+                "unit": "block"
             },
             "minimum_utxo_value": {
-                "quantity": 21,
+                "quantity": 255,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "slot_length": {
+                "quantity": 8059,
+                "unit": "second"
+            },
+            "decentralization_level": {
+                "quantity": 99.64,
+                "unit": "percent"
+            },
+            "genesis_block_hash": "430b0069311f7849141b635330781756bb1d6c19ff6f7664301b5719760e1220",
+            "blockchain_start_time": "1866-05-16T06:47:35.196527233855Z",
+            "desired_pool_number": 24851,
+            "epoch_length": {
+                "quantity": 28772,
+                "unit": "slot"
+            },
+            "active_slot_coefficient": {
+                "quantity": 72.10150764132361,
+                "unit": "percent"
+            },
+            "security_parameter": {
+                "quantity": 16630,
+                "unit": "block"
+            },
+            "minimum_utxo_value": {
+                "quantity": 31,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "slot_length": {
+                "quantity": 6771,
+                "unit": "second"
+            },
+            "decentralization_level": {
+                "quantity": 22.96,
+                "unit": "percent"
+            },
+            "genesis_block_hash": "5e781881b86f032a3e5f0f5e7a7d3e4418424e5574105d3eba7f3c2327047c2d",
+            "blockchain_start_time": "1899-08-15T19:01:05.991150412704Z",
+            "desired_pool_number": 1480,
+            "epoch_length": {
+                "quantity": 13570,
+                "unit": "slot"
+            },
+            "active_slot_coefficient": {
+                "quantity": 34.36601135984273,
+                "unit": "percent"
+            },
+            "hardfork_at": {
+                "epoch_start_time": "1883-10-25T07:06:34Z",
+                "epoch_number": 16073
+            },
+            "security_parameter": {
+                "quantity": 26661,
+                "unit": "block"
+            },
+            "minimum_utxo_value": {
+                "quantity": 86,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "slot_length": {
+                "quantity": 2477,
+                "unit": "second"
+            },
+            "decentralization_level": {
+                "quantity": 29.55,
+                "unit": "percent"
+            },
+            "genesis_block_hash": "58734052ff10d56c2755714a55795cb102cd301e12102e2b7a4f376745831270",
+            "blockchain_start_time": "1890-05-01T03:58:03.006022429065Z",
+            "desired_pool_number": 32607,
+            "epoch_length": {
+                "quantity": 1794,
+                "unit": "slot"
+            },
+            "active_slot_coefficient": {
+                "quantity": 8.693157126113249,
+                "unit": "percent"
+            },
+            "hardfork_at": {
+                "epoch_start_time": "1883-03-08T05:00:00Z",
+                "epoch_number": 1792
+            },
+            "security_parameter": {
+                "quantity": 801,
+                "unit": "block"
+            },
+            "minimum_utxo_value": {
+                "quantity": 84,
                 "unit": "lovelace"
             }
         }

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -79,7 +79,6 @@ dummyGenesisParameters :: GenesisParameters
 dummyGenesisParameters = GenesisParameters
     { getGenesisBlockHash = genesisHash
     , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
-    , getEpochStability = Quantity 2160
     }
 
 dummySlottingParameters :: SlottingParameters
@@ -87,6 +86,7 @@ dummySlottingParameters = SlottingParameters
     { getSlotLength = SlotLength 1
     , getEpochLength = EpochLength 21600
     , getActiveSlotCoefficient = ActiveSlotCoefficient 1
+    , getSecurityParameter = Quantity 2160
     }
 
 dummyTimeInterpreter :: Monad m => TimeInterpreter m

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -191,7 +191,8 @@ spec = describe "API Server" $ do
                     (Hash "header hash")
                     (Hash "prevHeaderHash")
         , watchNodeTip = error "todo"
-        , getProtocolParameters = error "getProtocolParameters: not implemented"
+        , currentProtocolParameters = error "currentProtocolParameters: not implemented"
+        , currentSlottingParameters = error "currentSlottingParameters: not implemented"
         , postTx = error "postTx: not implemented"
         , stakeDistribution = error "stakeDistribution: not implemented"
         , getAccountBalance = error "getAccountBalance: not implemented"

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -939,8 +939,8 @@ spec = parallel $ do
                         slotLength (x :: ApiNetworkParameters)
                     , epochLength =
                         epochLength (x :: ApiNetworkParameters)
-                    , epochStability =
-                        epochStability (x :: ApiNetworkParameters)
+                    , securityParameter =
+                        securityParameter (x :: ApiNetworkParameters)
                     , activeSlotCoefficient =
                         activeSlotCoefficient (x :: ApiNetworkParameters)
                     , decentralizationLevel =

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.DB
 import Cardano.Wallet.DB.Model
     ( TxHistory, filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
-    ( block0, dummyGenesisParameters, mkTx, mockHash )
+    ( block0, mkTx, mockHash )
 import Cardano.Wallet.Gen
     ( genMnemonic, genSmallTxMetadata, shrinkSlotNo, shrinkTxMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -77,13 +77,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , unsafeVerificationKeyPool
     )
 import Cardano.Wallet.Primitive.Model
-    ( Wallet
-    , blockchainParameters
-    , currentTip
-    , getState
-    , unsafeInitWallet
-    , utxo
-    )
+    ( Wallet, currentTip, getState, unsafeInitWallet, utxo )
 import Cardano.Wallet.Primitive.Scripts
     ()
 import Cardano.Wallet.Primitive.Types
@@ -307,7 +301,6 @@ instance GenState s => Arbitrary (InitialCheckpoint s) where
             (utxo cp)
             (block0 ^. #header)
             (getState cp)
-            (blockchainParameters cp)
 
 {-------------------------------------------------------------------------------
                                    Wallets
@@ -315,13 +308,12 @@ instance GenState s => Arbitrary (InitialCheckpoint s) where
 
 instance GenState s => Arbitrary (Wallet s) where
     shrink w =
-        [ unsafeInitWallet u (currentTip w) s (blockchainParameters w)
+        [ unsafeInitWallet u (currentTip w) s
         | (u, s) <- shrink (utxo w, getState w) ]
     arbitrary = unsafeInitWallet
         <$> arbitrary
         <*> arbitrary
         <*> arbitrary
-        <*> pure dummyGenesisParameters
 
 instance Arbitrary (PrimaryKey WalletId) where
     shrink _ = []

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -42,13 +42,14 @@ import Cardano.Wallet.DB.Arbitrary
 import Cardano.Wallet.DB.Model
     ( filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( dummyProtocolParameters )
+    ( dummyGenesisParameters, dummyProtocolParameters )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, applyBlock, currentTip )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
+    , GenesisParameters
     , ProtocolParameters
     , ShowFmt (..)
     , SlotId (..)
@@ -447,7 +448,7 @@ prop_createListWallet db@DBLayer{..} (KeyValPairs pairs) =
     prop = liftIO $ do
         res <- once pairs $ \(k, (cp, meta)) ->
             atomically $ unsafeRunExceptT $
-            initializeWallet k cp meta mempty pp
+            initializeWallet k cp meta mempty gp pp
         (length <$> atomically listWallets) `shouldReturn` length res
 
 -- | Trying to create a same wallet twice should yield an error
@@ -464,9 +465,9 @@ prop_createWalletTwice db@DBLayer{..} (key@(PrimaryKey wid), cp, meta) =
     setup = liftIO (cleanDB db)
     prop = liftIO $ do
         let err = ErrWalletAlreadyExists wid
-        atomically (runExceptT $ initializeWallet key cp meta mempty pp)
+        atomically (runExceptT $ initializeWallet key cp meta mempty gp pp)
             `shouldReturn` Right ()
-        atomically (runExceptT $ initializeWallet key cp meta mempty pp)
+        atomically (runExceptT $ initializeWallet key cp meta mempty gp pp)
             `shouldReturn` Left err
 
 -- | Trying to remove a same wallet twice should yield an error
@@ -482,7 +483,7 @@ prop_removeWalletTwice db@DBLayer{..} (key@(PrimaryKey wid), cp, meta) =
   where
     setup = liftIO $ do
         cleanDB db
-        atomically $ unsafeRunExceptT $ initializeWallet key cp meta mempty pp
+        atomically $ unsafeRunExceptT $ initializeWallet key cp meta mempty gp pp
     prop = liftIO $ do
         let err = ErrNoSuchWallet wid
         atomically (runExceptT $ removeWallet key) `shouldReturn` Right ()
@@ -511,7 +512,7 @@ prop_readAfterPut putOp readOp db@DBLayer{..} (key, a) =
         run $ cleanDB db
         (InitialCheckpoint cp, meta) <- namedPick "Initial Checkpoint" arbitrary
         run $ atomically $ unsafeRunExceptT $
-            initializeWallet key cp meta mempty pp
+            initializeWallet key cp meta mempty gp pp
     prop = do
         run $ unsafeRunExceptT $ putOp db key a
         res <- run $ readOp db key
@@ -533,7 +534,7 @@ prop_getTxAfterPutValidTxId db@DBLayer{..} wid txGen =
         run $ cleanDB db
         (InitialCheckpoint cp, meta) <- namedPick "Initial Checkpoint" arbitrary
         run $ atomically $ unsafeRunExceptT $
-            initializeWallet wid cp meta mempty pp
+            initializeWallet wid cp meta mempty gp pp
     prop = do
         let txs = unGenTxHistory txGen
         run $ unsafeRunExceptT $ mapExceptT atomically $ putTxHistory wid txs
@@ -562,7 +563,7 @@ prop_getTxAfterPutInvalidTxId db@DBLayer{..} wid txGen txId' =
         run $ cleanDB db
         (InitialCheckpoint cp, meta) <- namedPick "Initial Checkpoint" arbitrary
         run $ atomically $ unsafeRunExceptT $
-            initializeWallet wid cp meta mempty pp
+            initializeWallet wid cp meta mempty gp pp
     prop = do
         let txs = unGenTxHistory txGen
         run $ unsafeRunExceptT $ mapExceptT atomically $ putTxHistory wid txs
@@ -584,7 +585,7 @@ prop_getTxAfterPutInvalidWalletId db@DBLayer{..} (key, cp, meta) txGen key'@(Pri
   where
     setup = liftIO $ do
         cleanDB db
-        atomically $ unsafeRunExceptT $ initializeWallet key cp meta mempty pp
+        atomically $ unsafeRunExceptT $ initializeWallet key cp meta mempty gp pp
     prop = liftIO $ do
         let txs = unGenTxHistory txGen
         atomically (runExceptT $ putTxHistory key txs) `shouldReturn` Right ()
@@ -658,7 +659,7 @@ prop_isolation putA readB readC readD db@DBLayer{..} (ShowFmt key, ShowFmt a) =
         liftIO (cleanDB db)
         (cp, meta, GenTxHistory txs) <- pick arbitrary
         liftIO $ atomically $ do
-            unsafeRunExceptT $ initializeWallet key cp meta mempty pp
+            unsafeRunExceptT $ initializeWallet key cp meta mempty gp pp
             unsafeRunExceptT $ putTxHistory key txs
         (b, c, d) <- liftIO $ (,,)
             <$> readB db key
@@ -691,7 +692,7 @@ prop_readAfterDelete readOp empty db@DBLayer{..} (ShowFmt key) =
         liftIO (cleanDB db)
         (cp, meta) <- pick arbitrary
         liftIO $ atomically $ unsafeRunExceptT $
-            initializeWallet key cp meta mempty pp
+            initializeWallet key cp meta mempty gp pp
     prop = liftIO $ do
         atomically $ unsafeRunExceptT $ removeWallet key
         (ShowFmt <$> readOp db key) `shouldReturn` ShowFmt empty
@@ -727,7 +728,7 @@ prop_sequentialPut putOp readOp resolve db@DBLayer{..} kv =
         run $ cleanDB db
         (InitialCheckpoint cp, meta) <- pick arbitrary
         run $ atomically $ unsafeRunExceptT $ once_ pairs $ \(k, _) ->
-            initializeWallet k cp meta mempty pp
+            initializeWallet k cp meta mempty gp pp
     prop = do
         run $ unsafeRunExceptT $ forM_ pairs $ uncurry (putOp db)
         res <- run $ once pairs (readOp db . fst)
@@ -766,7 +767,7 @@ prop_parallelPut putOp readOp resolve db@DBLayer{..} (KeyValPairs pairs) =
         liftIO (cleanDB db)
         (cp, meta) <- pick arbitrary
         liftIO $ atomically $ unsafeRunExceptT $ once_ pairs $ \(k, _) ->
-            initializeWallet k cp meta mempty pp
+            initializeWallet k cp meta mempty gp pp
     prop = liftIO $ do
         forConcurrently_ pairs $ unsafeRunExceptT . uncurry (putOp db)
         res <- once pairs (readOp db . fst)
@@ -795,7 +796,7 @@ prop_rollbackCheckpoint db@DBLayer{..} cp0 (MockChain chain) = do
     setup wid meta = run $ do
         cleanDB db
         atomically $ do
-            unsafeRunExceptT $ initializeWallet wid cp0 meta mempty pp
+            unsafeRunExceptT $ initializeWallet wid cp0 meta mempty gp pp
             unsafeRunExceptT $ forM_ cps (putCheckpoint wid)
 
     prop wid point = do
@@ -835,7 +836,7 @@ prop_rollbackTxHistory db@DBLayer{..} (InitialCheckpoint cp0) (GenTxHistory txs0
     setup wid meta = run $ do
         cleanDB db
         atomically $ do
-            unsafeRunExceptT $ initializeWallet wid cp0 meta mempty pp
+            unsafeRunExceptT $ initializeWallet wid cp0 meta mempty gp pp
             unsafeRunExceptT $ putTxHistory wid txs0
 
     prop wid requestedPoint = do
@@ -1020,6 +1021,9 @@ newtype SparseCheckpointsDB = SparseCheckpointsDB [Word32] deriving (Show, Eq)
 
 pp :: ProtocolParameters
 pp = dummyProtocolParameters
+
+gp :: GenesisParameters
+gp = dummyGenesisParameters
 
 data GenSparseCheckpointsArgs
     = GenSparseCheckpointsArgs SparseCheckpointsConfig Word32

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -61,6 +61,7 @@ spec = do
             { getEpochLength = EpochLength 21600
             , getSlotLength  = SlotLength 10
             , getActiveSlotCoefficient = 1
+            , getSecurityParameter = Quantity 2160
             }
     let st = SyncTolerance 10
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -757,8 +757,10 @@ dummyNetworkLayer = NetworkLayer
         pure dummyTip
     , currentNodeEra =
         pure (AnyCardanoEra AllegraEra)
-    , getProtocolParameters =
-        error "dummyNetworkLayer: getProtocolParameters not implemented"
+    , currentProtocolParameters =
+        error "dummyNetworkLayer: currentProtocolParameters not implemented"
+    , currentSlottingParameters =
+        error "dummyNetworkLayer: currentSlottingParameters not implemented"
     , postTx =
         error "dummyNetworkLayer: postTx not implemented"
     , stakeDistribution =

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -152,8 +152,6 @@ mainnetNetworkParameters = W.NetworkParameters
             "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
         , getGenesisBlockDate =
             W.StartTime $ posixSecondsToUTCTime 1506203091
-        , getEpochStability =
-            Quantity 2160
         }
     , slottingParameters = W.SlottingParameters
         { getSlotLength =
@@ -162,6 +160,8 @@ mainnetNetworkParameters = W.NetworkParameters
             W.EpochLength 21600
         , getActiveSlotCoefficient =
             W.ActiveSlotCoefficient 1.0
+        , getSecurityParameter =
+            Quantity 2160
         }
     , protocolParameters = W.ProtocolParameters
         { decentralizationLevel =
@@ -448,8 +448,6 @@ fromGenesisData (genesisData, genesisHash) =
                 W.Hash . CC.hashToBytes . unGenesisHash $ genesisHash
             , getGenesisBlockDate =
                 W.StartTime . gdStartTime $ genesisData
-            , getEpochStability =
-                Quantity . fromIntegral . unBlockCount . gdK $ genesisData
             }
         , slottingParameters = W.SlottingParameters
             { getSlotLength =
@@ -458,6 +456,8 @@ fromGenesisData (genesisData, genesisHash) =
                 fromBlockCount . gdK $ genesisData
             , getActiveSlotCoefficient =
                 W.ActiveSlotCoefficient 1.0
+            , getSecurityParameter =
+                Quantity . fromIntegral . unBlockCount . gdK $ genesisData
             }
         , protocolParameters =
             (protocolParametersFromPP Nothing) . gdProtocolParameters $ genesisData

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -325,7 +325,7 @@ serveWallet
         -> NetworkLayer IO (CardanoBlock StandardCrypto)
         -> (StakePoolLayer -> IO a)
         -> IO a
-    withPoolsMonitoring dir (NetworkParameters gp sp _) nl action =
+    withPoolsMonitoring dir (NetworkParameters _ sp _) nl action =
         Pool.withDecoratedDBLayer
                 poolDatabaseDecorator
                 poolsDbTracer
@@ -337,7 +337,7 @@ serveWallet
             gcStatus <- newTVarIO NotStarted
             forM_ settings $ atomically . putSettings
 
-            void $ forkFinally (monitorStakePools tr gp nl db) onExit
+            void $ forkFinally (monitorStakePools tr np nl db) onExit
             spl <- newStakePoolLayer gcStatus nl db
                 $ forkFinally (monitorMetadata gcStatus tr sp db) onExit
             action spl

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1199,7 +1199,7 @@ components:
         - blockchain_start_time
         - slot_length
         - epoch_length
-        - epoch_stability
+        - security_parameter
         - active_slot_coefficient
         - decentralization_level
         - desired_pool_number
@@ -1209,7 +1209,7 @@ components:
         blockchain_start_time: *date
         slot_length: *numberOfSeconds
         epoch_length: *numberOfSlots
-        epoch_stability: *numberOfBlocks
+        security_parameter: *numberOfBlocks
         active_slot_coefficient: *percentage
         decentralization_level: *percentage
         desired_pool_number: *stakePoolsNumber


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

ADP-609

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 9a9f6a81d48b0fbfd6b29b0d15a9a0f5559299ea
  :round_pushpin: **rework management of genesis, protocol and slotting parameters**
    This commit introduces a few changes:

  1. It drops all the unused protocol parameters from the 'Checkpoint'
     table. This requires however a non-trivial database migration which
     is yet to be written.

  2. It moves the blockchain start time and genesis hash in the 'Wallet'
    table instead of the 'Checkpoint' table, since those don't change,
    they need not to be repeated in each checkpoint.

  3. It removes 'epochStability' from the 'GenesisParameters' and
     instead, adds 'securityParam' to the 'SlottingParameters'.
     'GenesisParameters' are now only referring to the 'Byron' genesis
     parameters used at the very beginning of the blockchain, whereas
     'SlottingParameters' are tied to each era.

  4. It renames 'getProtocolParameters' to 'currentProtocolParameters'
     in the network layer for consistency with other functions from the
     network layer.

  5. It moves and rename 'getSlottingParametersForTip' to the network
     layer as 'currentSlottingParameters' such that this can be
     implemented correctly in the network layer using the LSQ protocol
     and the 'GetGenesisConfig' query now available.

  6. It adjusts the block restoration loop to use the latest slotting
     parameters (instead of the Byron's genesis ones) and changes the
     checkpoint stability window to `3k` (the stability window is `3k/f`
     slots, but our checkpoint pruning operates on blocks, so `3k`).

- 6f4e9c37b020b38311d8b3925219e622033d0d9e
  :round_pushpin: **implement 'currentSlottingParameters' in the cardano-node's Network layer.**
  
- fb4b6d25345cc9a3d894223c314fd6bea9286cc8
  :round_pushpin: **add database migration for protocol parameters drop and associated unit test**
    This isn't an easy migration for there's no 'remove column' command available in SQLite. So instead, we have to re-create the table without the column we want and copy back all the previous checkpoints in the new table.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
