### PR TITLE
Switch to using UnliftIO.Exception bracket

### DIFF
--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -75,7 +75,6 @@ test-suite unit
     , hspec
     , optparse-applicative
     , QuickCheck
-    , temporary
     , text
     , text-class
     , unliftio

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -78,6 +78,7 @@ test-suite unit
     , temporary
     , text
     , text-class
+    , unliftio
   build-tools:
       hspec-discover
   type:

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -32,7 +32,6 @@ library
       aeson
     , aeson-pretty
     , ansi-terminal
-    , async
     , base
     , bytestring
     , cardano-addresses
@@ -44,12 +43,13 @@ library
     , fmt
     , http-client
     , iohk-monitoring
+    , optparse-applicative
     , servant-client
     , servant-client-core
     , text
     , text-class
     , time
-    , optparse-applicative
+    , unliftio
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -199,8 +199,6 @@ import Control.Arrow
     ( first, left )
 import Control.Concurrent
     ( threadDelay )
-import Control.Exception
-    ( bracket, catch )
 import Control.Monad
     ( forM_, forever, join, unless, void, when )
 import Control.Monad.IO.Class
@@ -324,13 +322,14 @@ import System.IO
     , stdin
     , stdout
     )
+import UnliftIO.Exception
+    ( bracket, catch )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM
 import qualified Cardano.BM.Data.Observable as Obs
 import qualified Command.Key as Key
 import qualified Command.RecoveryPhrase as RecoveryPhrase
-import qualified Control.Concurrent.Async as Async
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -341,6 +340,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as TIO
+import qualified UnliftIO.Async as Async
 
 {-------------------------------------------------------------------------------
                                    CLI

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -197,8 +197,6 @@ import Control.Applicative
     ( optional, some, (<|>) )
 import Control.Arrow
     ( first, left )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( forM_, forever, join, unless, void, when )
 import Control.Monad.IO.Class
@@ -322,6 +320,8 @@ import System.IO
     , stdin
     , stdout
     )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( bracket, catch )
 

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -47,8 +47,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxMetadata (..), TxMetadataValue (..) )
 import Control.Concurrent
     ( forkFinally )
-import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, takeMVar )
 import Control.Monad
     ( mapM_ )
 import Data.Proxy
@@ -98,6 +96,8 @@ import Test.QuickCheck
     )
 import Test.Text.Roundtrip
     ( textRoundtrip )
+import UnliftIO.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
 
 import qualified Data.Map as Map
 import qualified Data.Text as T

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -71,8 +71,6 @@ import System.FilePath
     ( (</>) )
 import System.IO
     ( Handle, IOMode (..), hClose, openFile )
-import System.IO.Temp
-    ( withSystemTempDirectory )
 import System.IO.Unsafe
     ( unsafePerformIO )
 import Test.Hspec
@@ -98,6 +96,8 @@ import UnliftIO.Concurrent
     ( forkFinally )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, takeMVar )
+import UnliftIO.Temporary
+    ( withSystemTempDirectory )
 
 import qualified Data.Map as Map
 import qualified Data.Text as T

--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -45,8 +45,6 @@ import Cardano.Wallet.Primitive.Types
     ( PoolMetadataSource )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxMetadata (..), TxMetadataValue (..) )
-import Control.Concurrent
-    ( forkFinally )
 import Control.Monad
     ( mapM_ )
 import Data.Proxy
@@ -96,6 +94,8 @@ import Test.QuickCheck
     )
 import Test.Text.Roundtrip
     ( textRoundtrip )
+import UnliftIO.Concurrent
+    ( forkFinally )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -33,7 +33,6 @@ library
     , QuickCheck
     , aeson
     , aeson-qq
-    , async
     , base
     , base58-bytestring
     , bech32
@@ -52,7 +51,6 @@ library
     , cryptonite
     , deepseq
     , directory
-    , exceptions
     , extra
     , filepath
     , fmt
@@ -77,6 +75,8 @@ library
     , text
     , text-class
     , time
+    , unliftio
+    , unliftio-core
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -70,7 +70,6 @@ library
     , say
     , scrypt
     , template-haskell
-    , temporary
     , text
     , text-class
     , time

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -69,7 +69,6 @@ library
     , retry
     , say
     , scrypt
-    , stm
     , template-haskell
     , temporary
     , text

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -92,12 +92,12 @@ import System.FilePath
     ( (</>) )
 import System.IO
     ( BufferMode (..), hSetBuffering, stderr, stdout )
-import System.IO.Temp
-    ( withSystemTempDirectory )
 import UnliftIO.Concurrent
     ( threadDelay )
 import UnliftIO.Exception
     ( evaluate )
+import UnliftIO.Temporary
+    ( withSystemTempDirectory )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -50,8 +50,6 @@ import Control.Concurrent
     ( threadDelay )
 import Control.DeepSeq
     ( NFData, rnf )
-import Control.Exception
-    ( evaluate )
 import Control.Monad
     ( forM, mapM_, void )
 import Criterion.Measurement
@@ -98,6 +96,8 @@ import System.IO
     ( BufferMode (..), hSetBuffering, stderr, stdout )
 import System.IO.Temp
     ( withSystemTempDirectory )
+import UnliftIO.Exception
+    ( evaluate )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM

--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -46,8 +46,6 @@ import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network.Ports
     ( getRandomPort )
-import Control.Concurrent
-    ( threadDelay )
 import Control.DeepSeq
     ( NFData, rnf )
 import Control.Monad
@@ -96,6 +94,8 @@ import System.IO
     ( BufferMode (..), hSetBuffering, stderr, stdout )
 import System.IO.Temp
     ( withSystemTempDirectory )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( evaluate )
 

--- a/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
@@ -27,12 +27,8 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Setup
     ( setupTrace_, shutdown )
-import Control.Concurrent.STM.TVar
-    ( TVar, newTVarIO, readTVarIO, writeTVar )
 import Control.Monad
     ( mapM_, replicateM_ )
-import Control.Monad.STM
-    ( atomically )
 import Data.Maybe
     ( mapMaybe )
 import Data.Time
@@ -45,6 +41,8 @@ import Network.Wai.Middleware.Logging
     ( ApiLog (..), HandlerLog (..) )
 import UnliftIO.Exception
     ( bracket, onException )
+import UnliftIO.STM
+    ( TVar, atomically, newTVarIO, readTVarIO, writeTVar )
 
 import qualified Cardano.BM.Configuration.Model as CM
 

--- a/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/LatencyBenchShared.hs
@@ -29,8 +29,6 @@ import Cardano.BM.Setup
     ( setupTrace_, shutdown )
 import Control.Concurrent.STM.TVar
     ( TVar, newTVarIO, readTVarIO, writeTVar )
-import Control.Exception
-    ( bracket, onException )
 import Control.Monad
     ( mapM_, replicateM_ )
 import Control.Monad.STM
@@ -45,6 +43,8 @@ import Fmt
     ( Builder, build, fixedF, fmt, fmtLn, indentF, padLeftF, (+|), (|+) )
 import Network.Wai.Middleware.Logging
     ( ApiLog (..), HandlerLog (..) )
+import UnliftIO.Exception
+    ( bracket, onException )
 
 import qualified Cardano.BM.Configuration.Model as CM
 

--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -63,8 +63,6 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeMkMnemonic )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar )
 import Control.Monad
     ( forM_, replicateM )
 import Data.ByteArray.Encoding
@@ -77,6 +75,8 @@ import Data.Text
     ( Text )
 import GHC.TypeLits
     ( Nat, Symbol )
+import UnliftIO.MVar
+    ( MVar, modifyMVar )
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -339,13 +339,6 @@ import System.Exit
     ( ExitCode (..) )
 import System.IO
     ( hClose, hFlush, hPutStr )
-import System.Process
-    ( CreateProcess (..)
-    , StdStream (..)
-    , proc
-    , waitForProcess
-    , withCreateProcess
-    )
 import Test.Hspec
     ( Expectation, HasCallStack, expectationFailure )
 import Test.Hspec.Expectations.Lifted
@@ -368,6 +361,13 @@ import UnliftIO.Async
     ( async, race, wait )
 import UnliftIO.Exception
     ( Exception (..), SomeException (..), catch, throwIO )
+import UnliftIO.Process
+    ( CreateProcess (..)
+    , StdStream (..)
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
 

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -270,16 +270,12 @@ import Control.Arrow
     ( second )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( async, race, wait )
-import Control.Exception
-    ( Exception (..), SomeException (..), throwIO )
 import Control.Monad
     ( forM_, join, unless, void )
-import Control.Monad.Catch
-    ( MonadCatch, catch, throwM )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..) )
 import Control.Monad.Trans.Resource
     ( ResourceT, allocate, runResourceT )
 import Control.Retry
@@ -368,6 +364,10 @@ import Test.Integration.Framework.Request
     , request
     , unsafeRequest
     )
+import UnliftIO.Async
+    ( async, race, wait )
+import UnliftIO.Exception
+    ( Exception (..), SomeException (..), catch, throwIO )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
 
@@ -606,7 +606,7 @@ defaultTxTTL = 7200
 --
 -- Helpers
 --
-updateMetadataSource :: (MonadIO m, MonadCatch m) => Context -> Text -> m ()
+updateMetadataSource :: (MonadIO m, MonadUnliftIO m) => Context -> Text -> m ()
 updateMetadataSource ctx t = do
     r <- request @SettingsPutData ctx Link.putSettings Default payload
     expectResponseCode HTTP.status204 r
@@ -617,7 +617,7 @@ updateMetadataSource ctx t = do
             }
        } |]
 
-bracketSettings :: (MonadIO m, MonadCatch m) => Context -> m () -> m ()
+bracketSettings :: (MonadIO m, MonadUnliftIO m) => Context -> m () -> m ()
 bracketSettings ctx action = do
     r@(_, response) <- request @(ApiT Settings) ctx Link.getSettings Default Empty
     expectResponseCode HTTP.status200 r
@@ -630,7 +630,7 @@ bracketSettings ctx action = do
             expectResponseCode HTTP.status204 r'
 
 verifyMetadataSource
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> PoolMetadataSource
     -> m ()
@@ -639,7 +639,7 @@ verifyMetadataSource ctx s = do
     expectResponseCode HTTP.status200 r
     expectField (#getApiT . #poolMetadataSource) (`shouldBe` s) r
 
-triggerMaintenanceAction :: (MonadIO m, MonadCatch m) => Context -> Text -> m ()
+triggerMaintenanceAction :: (MonadIO m, MonadUnliftIO m) => Context -> Text -> m ()
 triggerMaintenanceAction ctx a = do
     r <- request @ApiMaintenanceAction ctx Link.postPoolMaintenance Default payload
     expectResponseCode HTTP.status204 r
@@ -647,7 +647,7 @@ triggerMaintenanceAction ctx a = do
    payload = Json [aesonQQ| { "maintenance_action": #{a} } |]
 
 verifyMaintenanceAction
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> PoolMetadataGCStatus
     -> m ()
@@ -695,7 +695,7 @@ waitAllTxsInLedger
         ( DecodeAddress n
         , DecodeStakeAddress n
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> ApiWallet
@@ -706,7 +706,7 @@ waitAllTxsInLedger ctx w = eventually "waitAllTxsInLedger: all txs in ledger" $ 
     view (#status . #getApiT) <$> txs `shouldSatisfy` all (== InLedger)
 
 waitForNextEpoch
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> m ()
 waitForNextEpoch ctx = do
@@ -902,7 +902,7 @@ restoreWalletFromPubKey
         , Show w
         , FromJSON w
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> Text
@@ -927,7 +927,7 @@ restoreWalletFromPubKey ctx pubKey name = snd <$> allocate create destroy
 
 -- | Create an empty wallet
 emptyRandomWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m ApiByronWallet
 emptyRandomWallet ctx = do
@@ -936,7 +936,7 @@ emptyRandomWallet ctx = do
         ("Random Wallet", mnemonic, fixturePassphrase)
 
 emptyRandomWalletMws
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, Mnemonic 12)
 emptyRandomWalletMws ctx = do
@@ -945,7 +945,7 @@ emptyRandomWalletMws ctx = do
         ("Random Wallet", mnemonicToText @12 mnemonic, fixturePassphrase)
 
 emptyIcarusWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m ApiByronWallet
 emptyIcarusWallet ctx = do
@@ -954,7 +954,7 @@ emptyIcarusWallet ctx = do
         ("Icarus Wallet", mnemonic, fixturePassphrase)
 
 emptyIcarusWalletMws
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, Mnemonic 15)
 emptyIcarusWalletMws ctx = do
@@ -963,7 +963,7 @@ emptyIcarusWalletMws ctx = do
         ("Icarus Wallet",mnemonicToText @15 mnemonic, fixturePassphrase)
 
 emptyRandomWalletWithPasswd
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> Text
     -> ResourceT m ApiByronWallet
@@ -990,7 +990,7 @@ emptyRandomWalletWithPasswd ctx rawPwd = do
 
 
 postWallet'
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> Headers
     -> Payload
@@ -1005,7 +1005,7 @@ postWallet' ctx headers payload = snd <$> allocate create (free . snd)
     free (Left _) = return ()
 
 postWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> Payload
     -> ResourceT m (HTTP.Status, Either RequestException ApiWallet)
@@ -1013,7 +1013,7 @@ postWallet ctx = postWallet' ctx Default
 
 
 postByronWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> Payload
     -> ResourceT m (HTTP.Status, Either RequestException ApiByronWallet)
@@ -1027,7 +1027,7 @@ postByronWallet ctx payload = snd <$> allocate create (free . snd)
     free (Left _) = return ()
 
 emptyByronWalletWith
-    :: forall m. (MonadIO m, MonadCatch m)
+    :: forall m. (MonadIO m, MonadUnliftIO m)
     => Context
     -> String
     -> (Text, [Text], Text)
@@ -1044,7 +1044,7 @@ emptyByronWalletWith ctx style (name, mnemonic, pass) = do
     return (getFromResponse id r)
 
 emptyByronWalletFromXPrvWith
-    :: forall m. (MonadIO m, MonadCatch m)
+    :: forall m. (MonadIO m, MonadUnliftIO m)
     => Context
     -> String
     -> (Text, Text, Text)
@@ -1062,7 +1062,7 @@ emptyByronWalletFromXPrvWith ctx style (name, key, passHash) = do
 
 -- | Create an empty wallet
 emptyWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m ApiWallet
 emptyWallet ctx = do
@@ -1078,7 +1078,7 @@ emptyWallet ctx = do
 
 -- | Create an empty wallet
 emptyWalletWith
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> (Text, Text, Int)
     -> ResourceT m ApiWallet
@@ -1095,7 +1095,7 @@ emptyWalletWith ctx (name, passphrase, addrPoolGap) = do
     return (getFromResponse id r)
 
 rewardWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiWallet, Mnemonic 24)
 rewardWallet ctx = do
@@ -1186,7 +1186,7 @@ fixtureWalletWithMnemonics ctx = snd <$> allocate create (free . fst)
 
 -- | Restore a faucet Random wallet and wait until funds are available.
 fixtureRandomWalletMws
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, Mnemonic 12)
 fixtureRandomWalletMws ctx = do
@@ -1194,7 +1194,7 @@ fixtureRandomWalletMws ctx = do
     (,mnemonics) <$> fixtureLegacyWallet ctx "random" (mnemonicToText mnemonics)
 
 fixtureRandomWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m ApiByronWallet
 fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
@@ -1203,7 +1203,7 @@ fixtureRandomWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
         ( PaymentAddress n ByronKey
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
@@ -1225,7 +1225,7 @@ fixtureRandomWalletWith
         , DecodeStakeAddress n
         , PaymentAddress n ByronKey
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> [Natural]
@@ -1244,7 +1244,7 @@ fixtureRandomWalletWith ctx coins0 = do
 
 -- | Restore a faucet Icarus wallet and wait until funds are available.
 fixtureIcarusWalletMws
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m (ApiByronWallet, Mnemonic 15)
 fixtureIcarusWalletMws ctx = do
@@ -1252,7 +1252,7 @@ fixtureIcarusWalletMws ctx = do
     (,mnemonics) <$> fixtureLegacyWallet ctx "icarus" (mnemonicToText mnemonics)
 
 fixtureIcarusWallet
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m ApiByronWallet
 fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
@@ -1261,7 +1261,7 @@ fixtureIcarusWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
         ( PaymentAddress n IcarusKey
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> ResourceT m (ApiByronWallet, [Address])
@@ -1283,7 +1283,7 @@ fixtureIcarusWalletWith
         , DecodeStakeAddress n
         , PaymentAddress n IcarusKey
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> [Natural]
@@ -1303,7 +1303,7 @@ fixtureIcarusWalletWith ctx coins0 = do
 
 -- | Restore a legacy wallet (Byron or Icarus)
 fixtureLegacyWallet
-    :: forall m. (MonadIO m, MonadCatch m)
+    :: forall m. (MonadIO m, MonadUnliftIO m)
     => Context
     -> String
     -> [Text]
@@ -1349,7 +1349,7 @@ fixtureWalletWith
         , DecodeAddress n
         , DecodeStakeAddress n
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> [Natural]
@@ -1493,7 +1493,7 @@ joinStakePool
         , DecodeAddress n
         , DecodeStakeAddress n
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> ApiT PoolId
@@ -1530,7 +1530,7 @@ quitStakePool
         , DecodeAddress n
         , DecodeStakeAddress n
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> (w, Text)
@@ -1567,7 +1567,7 @@ selectCoins
         , EncodeAddress n
         , Link.Discriminate style
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> w
@@ -1581,7 +1581,7 @@ selectCoins ctx w payments = do
         (Link.selectCoins @style w) Default payload
 
 delegationFee
-    :: forall w m. (HasType (ApiT WalletId) w, MonadIO m, MonadCatch m)
+    :: forall w m. (HasType (ApiT WalletId) w, MonadIO m, MonadUnliftIO m)
     => Context
     -> w
     -> m (HTTP.Status, Either RequestException ApiFee)
@@ -1664,7 +1664,7 @@ shelleyAddresses mw =
         ]
 
 listAddresses
-    :: forall n m. (MonadIO m, MonadCatch m, DecodeAddress n)
+    :: forall n m. (MonadIO m, MonadUnliftIO m, DecodeAddress n)
     => Context
     -> ApiWallet
     -> m [ApiAddress n]
@@ -1679,7 +1679,7 @@ listAllTransactions
         , DecodeStakeAddress n
         , HasType (ApiT WalletId) w
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> w
@@ -1693,7 +1693,7 @@ listTransactions
         , DecodeStakeAddress n
         , HasType (ApiT WalletId) w
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> w
@@ -1734,7 +1734,7 @@ deleteAllWallets ctx = do
 -- | Calls 'GET /wallets' and filters the response. This allows tests to be
 -- written for a parallel setting.
 listFilteredWallets
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Set Text -- ^ Set of walletIds to include
     -> Context
     -> m (HTTP.Status, Either RequestException [ApiWallet])
@@ -1746,7 +1746,7 @@ listFilteredWallets include ctx = do
 -- | Calls 'GET /byron-wallets' and filters the response. This allows tests to
 -- be written for a parallel setting.
 listFilteredByronWallets
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Set Text -- ^ Set of walletIds to include
     -> Context
     -> m (HTTP.Status, Either RequestException [ApiByronWallet])
@@ -1793,7 +1793,7 @@ wantedErrorButSuccess = liftIO
     . show
 
 -- | Apply 'a' to all actions in sequence
-verify :: (Show a, MonadIO m, MonadCatch m) => a -> [a -> m ()] -> m ()
+verify :: (Show a, MonadIO m, MonadUnliftIO m) => a -> [a -> m ()] -> m ()
 verify a = counterexample msg . mapM_ (a &)
   where
     msg = "While verifying " ++ show a
@@ -1804,8 +1804,8 @@ verify a = counterexample msg . mapM_ (a &)
 -- >>>  (Status {statusCode = 200, statusMessage = "OK"},Right [])
 -- >>>        expected: 3
 -- >>>         but got: 0
-counterexample :: (MonadIO m, MonadCatch m, HasCallStack) => String -> m a -> m a
-counterexample msg = (`catch` (throwM . appendFailureReason msg))
+counterexample :: (MonadIO m, MonadUnliftIO m, HasCallStack) => String -> m a -> m a
+counterexample msg = (`catch` (throwIO . appendFailureReason msg))
 
 appendFailureReason :: String -> HUnitFailure -> HUnitFailure
 appendFailureReason message = wrap

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -268,8 +268,6 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Control.Arrow
     ( second )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( forM_, join, unless, void )
 import Control.Monad.IO.Class
@@ -359,6 +357,8 @@ import Test.Integration.Framework.Request
     )
 import UnliftIO.Async
     ( async, race, wait )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( Exception (..), SomeException (..), catch, throwIO )
 import UnliftIO.Process

--- a/lib/core-integration/src/Test/Integration/Framework/Request.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Request.hs
@@ -19,10 +19,10 @@ module Test.Integration.Framework.Request
 
 import Prelude
 
-import Control.Monad.Catch
-    ( Exception (..), MonadCatch (..), throwM )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..) )
 import Data.Aeson
     ( FromJSON )
 import Data.ByteString.Lazy
@@ -54,6 +54,8 @@ import Network.HTTP.Types.Status
     ( status400, status500 )
 import Test.Integration.Framework.Context
     ( Context )
+import UnliftIO.Exception
+    ( Exception (..), fromEither, handle, throwIO )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BL8
@@ -92,7 +94,7 @@ request
     :: forall a m s.
         ( FromJSON a
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         , HasType (Text, Manager) s
         )
     => s
@@ -105,9 +107,9 @@ request
     -> m (HTTP.Status, Either RequestException a)
 request ctx (verb, path) reqHeaders body = do
     let (base, manager) = ctx ^. typed @(Text, Manager)
-    req <- parseRequest $ T.unpack $ base <> path
-    let io = handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
-    catch io handleException
+    handle handleException $ do
+        req <- fromEither $ parseRequest $ T.unpack $ base <> path
+        handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
   where
     prepareReq :: HTTP.Request -> HTTP.Request
     prepareReq req = req
@@ -139,7 +141,7 @@ request ctx (verb, path) reqHeaders body = do
 
     handleException = \case
         e@InvalidUrlException{} ->
-            throwM e
+            throwIO e
         HttpExceptionRequest _ e ->
             return (status500, Left (HttpException e))
 
@@ -150,7 +152,7 @@ request ctx (verb, path) reqHeaders body = do
 rawRequest
     :: forall m s.
         ( MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         , HasType (Text, Manager) s
         )
     => s
@@ -163,9 +165,9 @@ rawRequest
     -> m (HTTP.Status, Either RequestException ByteString)
 rawRequest ctx (verb, path) reqHeaders body = do
     let (base, manager) = ctx ^. typed @(Text, Manager)
-    req <- parseRequest $ T.unpack $ base <> path
-    let io = handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
-    catch io handleException
+    handle handleException $ do
+        req <- fromEither $ parseRequest $ T.unpack $ base <> path
+        handleResponse <$> liftIO (httpLbs (prepareReq req) manager)
   where
     prepareReq :: HTTP.Request -> HTTP.Request
     prepareReq req = req
@@ -190,7 +192,7 @@ rawRequest ctx (verb, path) reqHeaders body = do
 
     handleException = \case
         e@InvalidUrlException{} ->
-            throwM e
+            throwIO e
         HttpExceptionRequest _ e ->
             return (status500, Left (HttpException e))
 
@@ -200,7 +202,7 @@ unsafeRequest
     :: forall a m.
         ( FromJSON a
         , MonadIO m
-        , MonadCatch m
+        , MonadUnliftIO m
         )
     => Context
     -> (Method, Text)
@@ -208,4 +210,4 @@ unsafeRequest
     -> m (HTTP.Status, a)
 unsafeRequest ctx req body = do
     (s, res) <- request ctx req Default body
-    either throwM (pure . (s,)) res
+    either throwIO (pure . (s,)) res

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -49,10 +49,10 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Monad
     ( forM_ )
-import Control.Monad.Catch
-    ( MonadCatch )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..) )
 import Control.Monad.Trans.Resource
     ( ResourceT, runResourceT )
 import Data.Aeson
@@ -2692,7 +2692,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             expectErrorMessage (errMsg404CannotFindTx txid) ra
 
     postTx
-        :: (MonadIO m, MonadCatch m)
+        :: (MonadIO m, MonadUnliftIO m)
         => Context
         -> (wal, wal -> (Method, Text), Text)
         -> ApiWallet
@@ -2716,7 +2716,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         return r
 
     mkTxPayload
-        :: (MonadIO m, MonadCatch m)
+        :: (MonadIO m, MonadUnliftIO m)
         => Context
         -> ApiWallet
         -> Natural

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -45,8 +45,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..), TxMetadata (..), TxMetadataValue (..), TxStatus (..) )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( forM_ )
 import Control.Monad.IO.Class
@@ -158,6 +156,8 @@ import Test.Integration.Framework.TestData
     , errMsg404MinUTxOValue
     , errMsg404NoWallet
     )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
@@ -24,8 +24,6 @@ import System.Exit
     ( ExitCode (..) )
 import System.IO
     ( hClose, hFlush, hPutStr )
-import System.Process
-    ( waitForProcess, withCreateProcess )
 import Test.Hspec
     ( SpecWith, describe )
 import Test.Hspec.Expectations.Lifted
@@ -45,6 +43,8 @@ import Test.Integration.Framework.DSL
     , proc'
     , updateWalletNameViaCLI
     )
+import UnliftIO.Process
+    ( waitForProcess, withCreateProcess )
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -35,10 +35,10 @@ import Cardano.Wallet.Primitive.Types
     ( getWalletName, walletNameMaxLength, walletNameMinLength )
 import Control.Monad
     ( forM_ )
-import Control.Monad.Catch
-    ( MonadCatch )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..) )
 import Control.Monad.Trans.Resource
     ( ResourceT, runResourceT )
 import Data.Generics.Internal.VL.Lens
@@ -786,16 +786,16 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
               T.unpack err `shouldContain` expErr
 
 emptyRandomWallet'
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context
     -> ResourceT m String
 emptyRandomWallet' = fmap (T.unpack . view walletId) . emptyRandomWallet
 
-emptyWallet' :: (MonadIO m, MonadCatch m) => Context -> ResourceT m String
+emptyWallet' :: (MonadIO m, MonadUnliftIO m) => Context -> ResourceT m String
 emptyWallet' = fmap (T.unpack . view walletId) . emptyWallet
 
 emptyWalletWith'
-    :: (MonadIO m, MonadCatch m)
+    :: (MonadIO m, MonadUnliftIO m)
     => Context -> (Text, Text, Int) -> ResourceT m String
 emptyWalletWith' ctx (name, pass, pg) =
     fmap (T.unpack . view walletId) (emptyWalletWith ctx (name, pass, pg))

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -79,13 +79,11 @@ library
     , persistent
     , persistent-sqlite
     , persistent-template
-    , process
     , quiet
     , random
     , random-shuffle
     , retry
     , safe
-    , safe-exceptions
     , scientific
     , scrypt
     , servant
@@ -105,6 +103,7 @@ library
     , transformers
     , typed-protocols
     , unliftio
+    , unliftio-core
     , unordered-containers
     , vector
     , wai
@@ -199,6 +198,7 @@ library
       Network.Wai.Middleware.ServerError
       Network.Wai.Middleware.Logging
       Ouroboros.Network.Client.Wallet
+      UnliftIO.Compat
         -- TODO:
         --
         -- Move all test-related code out of the main library and into a
@@ -232,7 +232,6 @@ test-suite unit
       base
     , aeson
     , aeson-qq
-    , async
     , bytestring
     , cardano-addresses
     , cardano-api
@@ -294,6 +293,7 @@ test-suite unit
     , time
     , transformers
     , tree-diff
+    , unliftio
     , unordered-containers
     , x509
     , x509-store
@@ -399,6 +399,7 @@ benchmark db
     , text
     , time
     , transformers
+    , unliftio
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -91,7 +91,6 @@ library
     , servant-server
     , split
     , statistics
-    , stm
     , streaming-commons
     , strict-non-empty-containers
     , string-interpolate
@@ -281,7 +280,6 @@ test-suite unit
     , servant
     , servant-server
     , should-not-typecheck
-    , stm
     , strict-non-empty-containers
     , openapi3 >= 3.0.0.1
     , servant-openapi3

--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -52,8 +52,6 @@ import Cardano.DB.Sqlite.Delete
     ( DeleteSqliteDatabaseLog )
 import Cardano.Wallet.Logging
     ( BracketLog, bracketTracer )
-import Control.Concurrent.MVar
-    ( newMVar, withMVarMasked )
 import Control.Monad
     ( join, mapM_, when )
 import Control.Monad.IO.Unlift
@@ -109,6 +107,8 @@ import UnliftIO.Compat
     ( handleIf, mkRetryHandler )
 import UnliftIO.Exception
     ( Exception, bracket_, handleJust, tryJust )
+import UnliftIO.MVar
+    ( newMVar, withMVarMasked )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as B8

--- a/lib/core/src/Cardano/DB/Sqlite/Delete.hs
+++ b/lib/core/src/Cardano/DB/Sqlite/Delete.hs
@@ -36,8 +36,6 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, modifyMVar_, newMVar, readMVar )
-import Control.Exception
-    ( bracket_ )
 import Control.Retry
     ( RetryPolicy
     , RetryStatus (..)
@@ -64,6 +62,8 @@ import GHC.Generics
     ( Generic )
 import System.Directory
     ( removePathForcibly )
+import UnliftIO.Exception
+    ( bracket_ )
 
 #if defined(mingw32_HOST_OS)
 import Control.Retry

--- a/lib/core/src/Cardano/DB/Sqlite/Delete.hs
+++ b/lib/core/src/Cardano/DB/Sqlite/Delete.hs
@@ -34,8 +34,6 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, modifyMVar_, newMVar, readMVar )
 import Control.Retry
     ( RetryPolicy
     , RetryStatus (..)
@@ -64,6 +62,8 @@ import System.Directory
     ( removePathForcibly )
 import UnliftIO.Exception
     ( bracket_ )
+import UnliftIO.MVar
+    ( MVar, modifyMVar, modifyMVar_, newMVar, readMVar )
 
 #if defined(mingw32_HOST_OS)
 import Control.Retry

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -63,8 +63,6 @@ import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar )
 import Control.DeepSeq
     ( deepseq )
-import Control.Exception
-    ( Exception, throwIO )
 import Control.Monad
     ( void )
 import Control.Monad.Trans.Except
@@ -77,6 +75,8 @@ import Data.Functor.Identity
     ( Identity )
 import Data.Tuple
     ( swap )
+import UnliftIO.Exception
+    ( Exception, throwIO )
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.

--- a/lib/core/src/Cardano/Pool/DB/MVar.hs
+++ b/lib/core/src/Cardano/Pool/DB/MVar.hs
@@ -59,8 +59,6 @@ import Cardano.Pool.DB.Model
     )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, newMVar )
 import Control.DeepSeq
     ( deepseq )
 import Control.Monad
@@ -77,6 +75,8 @@ import Data.Tuple
     ( swap )
 import UnliftIO.Exception
     ( Exception, throwIO )
+import UnliftIO.MVar
+    ( MVar, modifyMVar, newMVar )
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -72,8 +72,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
-import Control.Exception
-    ( bracket, throwIO )
 import Control.Monad
     ( forM, forM_ )
 import Control.Monad.IO.Class
@@ -137,6 +135,8 @@ import System.FilePath
     ( (</>) )
 import System.Random
     ( newStdGen )
+import UnliftIO.Exception
+    ( bracket, throwIO )
 
 import qualified Cardano.Pool.DB.Sqlite.TH as TH
 import qualified Cardano.Wallet.Primitive.Types as W

--- a/lib/core/src/Cardano/Pool/Metadata.hs
+++ b/lib/core/src/Cardano/Pool/Metadata.hs
@@ -54,8 +54,6 @@ import Cardano.Wallet.Primitive.Types
     , StakePoolMetadataUrl (..)
     , decodePoolIdBech32
     )
-import Control.Exception
-    ( IOException, handle )
 import Control.Monad
     ( forM, when )
 import Control.Monad.IO.Class
@@ -109,6 +107,8 @@ import Network.HTTP.Types.Status
     ( status200, status404 )
 import Network.URI
     ( URI (..), parseURI )
+import UnliftIO.Exception
+    ( IOException, handle )
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -426,4 +426,3 @@ instance ToText StakePoolMetadataFetchLog where
         MsgFetchHealthCheckFailure err -> mconcat
             [ "Failed to check health: ", T.pack err
             ]
-

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -357,8 +357,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeXPrv )
 import Control.DeepSeq
     ( NFData )
-import Control.Exception
-    ( Exception )
 import Control.Monad
     ( forM_, replicateM, unless, when )
 import Control.Monad.IO.Class
@@ -438,6 +436,8 @@ import Statistics.Quantile
     ( medianUnbiased, quantiles )
 import Type.Reflection
     ( Typeable, typeRep )
+import UnliftIO.Exception
+    ( Exception )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -798,13 +798,14 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
             restoreBlocks @ctx @s @k ctx wid bs h
             saveParams @ctx @s @k ctx wid ps
     liftIO (follow nw tr cps forward (view #header)) >>= \case
-        FollowInterrupted ->
-            pure ()
         FollowFailure ->
             restoreWallet @ctx @s @k ctx wid
         FollowRollback point -> do
             rollbackBlocks @ctx @s @k ctx wid point
             restoreWallet @ctx @s @k ctx wid
+        FollowDone ->
+            pure ()
+
   where
     db = ctx ^. dbLayer @s @k
     nw = ctx ^. networkLayer

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -340,14 +340,8 @@ import Control.Arrow
     ( second )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( race_ )
 import Control.DeepSeq
     ( NFData )
-import Control.Exception
-    ( IOException, bracket, throwIO, tryJust )
-import Control.Exception.Safe
-    ( tryAnyDeep )
 import Control.Monad
     ( forM, forever, join, void, when, (>=>) )
 import Control.Monad.IO.Class
@@ -452,6 +446,10 @@ import System.Random
     ( getStdRandom, random )
 import Type.Reflection
     ( Typeable )
+import UnliftIO.Async
+    ( race_ )
+import UnliftIO.Exception
+    ( IOException, bracket, throwIO, tryAnyDeep, tryJust )
 
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.Api.Types as Api

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -338,8 +338,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Arrow
     ( second )
-import Control.Concurrent
-    ( threadDelay )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
@@ -448,6 +446,8 @@ import Type.Reflection
     ( Typeable )
 import UnliftIO.Async
     ( race_ )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( IOException, bracket, throwIO, tryAnyDeep, tryJust )
 

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -70,12 +70,12 @@ import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, withMVar )
 import Control.DeepSeq
     ( NFData, deepseq )
-import Control.Exception
-    ( Exception, throwIO )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Data.Functor.Identity
     ( Identity (..) )
+import UnliftIO.Exception
+    ( Exception, throwIO )
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -66,8 +66,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TransactionInfo (..) )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, newMVar, withMVar )
 import Control.DeepSeq
     ( NFData, deepseq )
 import Control.Monad.Trans.Except
@@ -76,6 +74,8 @@ import Data.Functor.Identity
     ( Identity (..) )
 import UnliftIO.Exception
     ( Exception, throwIO )
+import UnliftIO.MVar
+    ( MVar, modifyMVar, newMVar, withMVar )
 
 -- | Instantiate a new in-memory "database" layer that simply stores data in
 -- a local MVar. Data vanishes if the software is shut down.

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -123,8 +123,6 @@ import Cardano.Wallet.Primitive.Slotting
     )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
-import Control.Concurrent.MVar
-    ( modifyMVar, modifyMVar_, newMVar, readMVar )
 import Control.Monad
     ( forM, unless, void, when )
 import Control.Monad.Extra
@@ -211,6 +209,8 @@ import System.FilePath
     ( (</>) )
 import UnliftIO.Exception
     ( Exception, bracket, throwIO )
+import UnliftIO.MVar
+    ( modifyMVar, modifyMVar_, newMVar, readMVar )
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -125,8 +125,6 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Control.Concurrent.MVar
     ( modifyMVar, modifyMVar_, newMVar, readMVar )
-import Control.Exception
-    ( Exception, bracket, throwIO )
 import Control.Monad
     ( forM, unless, void, when )
 import Control.Monad.Extra
@@ -211,6 +209,8 @@ import System.Directory
     ( doesFileExist, listDirectory )
 import System.FilePath
     ( (</>) )
+import UnliftIO.Exception
+    ( Exception, bracket, throwIO )
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Random as Rnd

--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -34,6 +34,8 @@ import Cardano.BM.Data.Tracer
     )
 import Cardano.BM.Trace
     ( Trace, traceNamedItem )
+import Control.Applicative
+    ( (<*) )
 import Control.Monad
     ( when )
 import Control.Monad.IO.Class
@@ -51,7 +53,7 @@ import Data.Text.Class
 import GHC.Generics
     ( Generic )
 import UnliftIO.Exception
-    ( onException )
+    ( SomeException (..), isSyncException, withException )
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text.Encoding as T
@@ -133,6 +135,8 @@ data BracketLog
     -- ^ Logged after the action finishes.
     | BracketException
     -- ^ Logged when the action throws an exception.
+    | BracketAsyncException
+    -- ^ Logged when the action receives an async exception.
     deriving (Generic, Show, Eq, ToJSON)
 
 instance ToText BracketLog where
@@ -140,11 +144,17 @@ instance ToText BracketLog where
         BracketStart -> "start"
         BracketFinish -> "finish"
         BracketException -> "exception"
+        BracketAsyncException -> "cancelled"
+
+exceptionMsg :: SomeException -> BracketLog
+exceptionMsg e = if isSyncException e
+    then BracketException
+    else BracketAsyncException
 
 -- | Run a monadic action with 'BracketLog' traced around it.
 bracketTracer :: MonadUnliftIO m => Tracer m BracketLog -> m a -> m a
 bracketTracer tr action = do
     traceWith tr BracketStart
-    res <- action `onException` traceWith tr BracketException
-    traceWith tr BracketFinish
-    pure res
+    withException
+        (action <* traceWith tr BracketFinish)
+        (traceWith tr . exceptionMsg)

--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -36,10 +36,10 @@ import Cardano.BM.Trace
     ( Trace, traceNamedItem )
 import Control.Monad
     ( when )
-import Control.Monad.Catch
-    ( MonadCatch, onException )
 import Control.Monad.IO.Class
     ( MonadIO (..) )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO )
 import Control.Tracer
     ( Tracer (..), contramap, nullTracer, traceWith )
 import Data.Aeson
@@ -50,6 +50,8 @@ import Data.Text.Class
     ( ToText (..) )
 import GHC.Generics
     ( Generic )
+import UnliftIO.Exception
+    ( onException )
 
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text.Encoding as T
@@ -140,7 +142,7 @@ instance ToText BracketLog where
         BracketException -> "exception"
 
 -- | Run a monadic action with 'BracketLog' traced around it.
-bracketTracer :: MonadCatch m => Tracer m BracketLog -> m a -> m a
+bracketTracer :: MonadUnliftIO m => Tracer m BracketLog -> m a -> m a
 bracketTracer tr action = do
     traceWith tr BracketStart
     res <- action `onException` traceWith tr BracketException

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -61,8 +61,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx )
-import Control.Concurrent.Async
-    ( AsyncCancelled (..) )
 import Control.Exception.Base
     ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
@@ -89,6 +87,8 @@ import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
+import UnliftIO.Compat
+    ( AsyncCancelled (..) )
 import UnliftIO.Concurrent
     ( threadDelay )
 import UnliftIO.Exception

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -65,13 +65,8 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
     ( AsyncCancelled (..) )
-import Control.Exception
-    ( AsyncException (..)
-    , Exception (..)
-    , SomeException
-    , asyncExceptionFromException
-    , handle
-    )
+import Control.Exception.Base
+    ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
     ( when )
 import Control.Monad.Trans.Except
@@ -97,7 +92,7 @@ import Fmt
 import GHC.Generics
     ( Generic )
 import UnliftIO.Exception
-    ( throwIO )
+    ( Exception (..), SomeException, handle, throwIO )
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -61,8 +61,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Concurrent.Async
     ( AsyncCancelled (..) )
 import Control.Exception.Base
@@ -91,6 +89,8 @@ import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( Exception (..), SomeException, handle, throwIO )
 

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -61,8 +61,6 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx )
-import Control.Exception.Base
-    ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
     ( when )
 import Control.Monad.Trans.Except
@@ -87,12 +85,10 @@ import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
-import UnliftIO.Compat
-    ( AsyncCancelled (..) )
 import UnliftIO.Concurrent
     ( threadDelay )
 import UnliftIO.Exception
-    ( Exception (..), SomeException, handle, throwIO )
+    ( Exception (..), SomeException, bracket, handle, throwIO )
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -318,9 +314,9 @@ data FollowAction err
 -- | Possibly scenarios that would cause 'follow' to exit so that client code
 -- can decide what to do.
 data FollowExit
-    = FollowInterrupted
-    | FollowRollback SlotNo
+    = FollowRollback SlotNo
     | FollowFailure
+    | FollowDone
     deriving (Eq, Show)
 
 
@@ -352,7 +348,7 @@ follow
     -- ^ Getter on the abstract 'block' type
     -> IO FollowExit
 follow nl tr cps yield header =
-    sleep 0 False =<< initCursor nl cps
+    bracket (initCursor nl cps) (destroyCursor nl) (sleep 0 False)
   where
     delay0 :: Int
     delay0 = 500*1000 -- 500ms
@@ -369,21 +365,10 @@ follow nl tr cps yield header =
         when (delay > 0) (threadDelay delay)
         step delay hasRolledForward cursor
       where
-        retry (e :: SomeException) = case asyncExceptionFromException e of
-            Just ThreadKilled -> do
-                destroyCursor nl cursor $> FollowInterrupted
-            Just UserInterrupt -> do
-                destroyCursor nl cursor $> FollowInterrupted
-            Nothing | fromException e == Just AsyncCancelled -> do
-                destroyCursor nl cursor $> FollowInterrupted
-            Just _ -> do
-                traceWith tr $ MsgUnhandledException eT
-                destroyCursor nl cursor $> FollowFailure
-            _ -> do
-                traceWith tr $ MsgUnhandledException eT
-                destroyCursor nl cursor $> FollowFailure
-          where
-            eT = T.pack (show e)
+        retry :: SomeException -> IO FollowExit
+        retry e = do
+            traceWith tr $ MsgUnhandledException $ T.pack $ show e
+            pure FollowFailure
 
     step :: Int -> Bool -> Cursor -> IO FollowExit
     step delay hasRolledForward cursor = runExceptT (nextBlocks nl cursor) >>= \case
@@ -444,7 +429,7 @@ follow nl tr cps yield header =
             -> IO FollowExit
         continueWith cursor' hrf = \case
             ExitWith _ -> -- NOTE error logged as part of `MsgFollowAction`
-                return FollowInterrupted
+                return FollowDone
             Continue ->
                 step delay0 hrf cursor'
             RetryImmediately ->

--- a/lib/core/src/Cardano/Wallet/Orphans.hs
+++ b/lib/core/src/Cardano/Wallet/Orphans.hs
@@ -18,14 +18,14 @@ import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Control.DeepSeq
     ( NFData (..) )
-import Control.Exception
-    ( displayException )
 import Data.Ord
     ( comparing )
 import Fmt
     ( Buildable (..), blockListF, hexF, nameF, unlinesF )
 import Ouroboros.Consensus.HardFork.History.Qry
     ( PastHorizonException )
+import UnliftIO.Exception
+    ( displayException )
 
 import qualified Data.Map as Map
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -78,8 +78,6 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , StartTime (..)
     )
-import Control.Exception
-    ( throwIO )
 import Control.Monad
     ( ap, join, liftM, (>=>) )
 import Control.Monad.IO.Class
@@ -126,6 +124,8 @@ import Ouroboros.Consensus.HardFork.History.Qry
     )
 import Ouroboros.Consensus.HardFork.History.Summary
     ( neverForksSummary )
+import UnliftIO.Exception
+    ( throwIO )
 
 import qualified Cardano.Slotting.Slot as Cardano
 import qualified Data.Text as T

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -40,8 +40,6 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Wallet
     ( HasLogger, logger )
-import Control.Concurrent
-    ( ThreadId, forkFinally, killThread )
 import Control.Exception.Base
     ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
@@ -70,6 +68,8 @@ import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
+import UnliftIO.Concurrent
+    ( ThreadId, forkFinally, killThread )
 import UnliftIO.Exception
     ( SomeException, finally )
 import UnliftIO.MVar

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -52,12 +52,8 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryPutMVar
     )
-import Control.Exception
-    ( AsyncException (..)
-    , SomeException
-    , asyncExceptionFromException
-    , finally
-    )
+import Control.Exception.Base
+    ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
     ( void )
 import Control.Monad.IO.Class
@@ -74,17 +70,18 @@ import Data.Generics.Product.Typed
     ( HasType )
 import Data.Map.Strict
     ( Map )
+import qualified Data.Map.Strict as Map
 import Data.Text
     ( Text )
+import qualified Data.Text as T
 import Data.Text.Class
     ( ToText (..) )
 import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
-
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
+import UnliftIO.Exception
+    ( SomeException, finally )
 
 {-------------------------------------------------------------------------------
                                 Worker Context

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -42,16 +42,6 @@ import Cardano.Wallet
     ( HasLogger, logger )
 import Control.Concurrent
     ( ThreadId, forkFinally, killThread )
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar_
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , readMVar
-    , takeMVar
-    , tryPutMVar
-    )
 import Control.Exception.Base
     ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
@@ -82,6 +72,16 @@ import GHC.Generics
     ( Generic )
 import UnliftIO.Exception
     ( SomeException, finally )
+import UnliftIO.MVar
+    ( MVar
+    , modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    )
 
 {-------------------------------------------------------------------------------
                                 Worker Context

--- a/lib/core/src/Cardano/Wallet/Version/TH.hs
+++ b/lib/core/src/Cardano/Wallet/Version/TH.hs
@@ -11,8 +11,6 @@ module Cardano.Wallet.Version.TH
 
 import Prelude
 
-import Control.Exception
-    ( handleJust )
 import Language.Haskell.TH
     ( Exp (..), Lit (..), Q, runIO )
 import System.Exit
@@ -21,6 +19,8 @@ import System.IO.Error
     ( ioeGetErrorType, isDoesNotExistErrorType )
 import System.Process
     ( readProcessWithExitCode )
+import UnliftIO.Exception
+    ( handleJust )
 
 -- | Git revision found by running @git rev-parse@. If @git@ could not be
 -- executed, then this will be an empty string.

--- a/lib/core/src/Cardano/Wallet/Version/TH.hs
+++ b/lib/core/src/Cardano/Wallet/Version/TH.hs
@@ -17,10 +17,10 @@ import System.Exit
     ( ExitCode (..) )
 import System.IO.Error
     ( ioeGetErrorType, isDoesNotExistErrorType )
-import System.Process
-    ( readProcessWithExitCode )
 import UnliftIO.Exception
     ( handleJust )
+import UnliftIO.Process
+    ( readProcessWithExitCode )
 
 -- | Git revision found by running @git rev-parse@. If @git@ could not be
 -- executed, then this will be an empty string.

--- a/lib/core/src/Network/Ntp.hs
+++ b/lib/core/src/Network/Ntp.hs
@@ -27,8 +27,6 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Cardano.Wallet.Api.Types
     ( ApiNetworkClock (..), ApiNtpStatus (..), NtpSyncingStatus (..) )
-import Control.Concurrent.STM
-    ( atomically, check )
 import Control.Tracer
     ( Tracer )
 import Data.Quantity
@@ -48,6 +46,8 @@ import Network.NTP.Client
     )
 import System.IOManager
     ( IOManager )
+import UnliftIO.STM
+    ( atomically, checkSTM )
 
 import qualified Data.Text as T
 
@@ -170,7 +170,7 @@ getNtpStatus client forceCheck = (ApiNetworkClock . toStatus) <$>
       -- blacklisted by the central NTP "authorities" for sending too many NTP
       -- requests.
       s <- ntpGetStatus client
-      check (s /= NtpSyncPending)
+      checkSTM (s /= NtpSyncPending)
       pure s
   where
     toStatus = \case

--- a/lib/core/src/Network/Wai/Middleware/Logging.hs
+++ b/lib/core/src/Network/Wai/Middleware/Logging.hs
@@ -37,8 +37,6 @@ import Control.Applicative
     ( (<|>) )
 import Control.Arrow
     ( second )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, newMVar )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Aeson
@@ -63,6 +61,8 @@ import Network.Wai
     ( Middleware, Request (..), rawPathInfo, rawQueryString, requestMethod )
 import Network.Wai.Internal
     ( Response (..), getRequestBodyChunk )
+import UnliftIO.MVar
+    ( MVar, modifyMVar, newMVar )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS

--- a/lib/core/src/UnliftIO/Compat.hs
+++ b/lib/core/src/UnliftIO/Compat.hs
@@ -1,0 +1,55 @@
+-- |
+-- Copyright: © 2018-2020 IOHK
+-- License: Apache-2.0
+--
+-- Extra glue functions to work with "MonadUnliftIO" exception types.  We need
+-- this because the @retry@ package uses the generalized exception handler type
+-- from 'Control.Monad.Catch.Handler'. But the 'UnliftIO.Exceptions' module has
+-- its own definition of exactly the same type.
+
+module UnliftIO.Compat
+     ( coerceHandler
+     , coerceHandlers
+     , mkRetryHandler
+     , handleIf
+     ) where
+
+import Prelude
+
+import Control.Exception.Base
+    ( Exception )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO (..) )
+
+import qualified Control.Monad.Catch as Exceptions
+import qualified UnliftIO.Exception as UnliftIO
+
+-- | Convert the generalized handler from 'UnliftIO.Exception' type to 'Control.Monad.Catch' type
+coerceHandler :: UnliftIO.Handler IO Bool -> Exceptions.Handler IO Bool
+coerceHandler (UnliftIO.Handler h) = Exceptions.Handler h
+
+-- | Convert a list of handler factories from the 'UnliftIO.Exception' type to
+-- 'Control.Monad.Catch' type. Such handlers are used in
+-- 'Control.Retry.Recovering' for example.
+coerceHandlers
+    :: [a -> UnliftIO.Handler IO Bool]
+    -> [a -> Exceptions.Handler IO Bool]
+coerceHandlers = map (coerceHandler .)
+
+-- | Shortcut for creating a single 'Control.Retry' handler, which doesn't use
+-- the 'Control.Retry.RetryStatus' info.
+mkRetryHandler
+    :: Exception e
+    => (e -> m Bool)
+    -> [a -> Exceptions.Handler m Bool]
+mkRetryHandler shouldRetry = [const $ Exceptions.Handler shouldRetry]
+
+-- | A 'MonadUnliftIO' version of 'Control.Monad.Catch.handleIf'.
+handleIf
+    :: (MonadUnliftIO m, Exception e)
+    => (e -> Bool)
+    -> (e -> m a)
+    -> m a
+    -> m a
+handleIf f h = UnliftIO.handle
+    (\e -> if f e then h e else UnliftIO.throwIO e)

--- a/lib/core/src/UnliftIO/Compat.hs
+++ b/lib/core/src/UnliftIO/Compat.hs
@@ -8,14 +8,22 @@
 -- its own definition of exactly the same type.
 
 module UnliftIO.Compat
-     ( coerceHandler
+     ( -- * Handler conversion
+       coerceHandler
      , coerceHandlers
      , mkRetryHandler
+
+       -- * Missing combinators
      , handleIf
+
+       -- * Re-export unsafe things
+     , AsyncCancelled (..)
      ) where
 
 import Prelude
 
+import Control.Concurrent.Async
+    ( AsyncCancelled (..) )
 import Control.Exception.Base
     ( Exception )
 import Control.Monad.IO.Unlift

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -138,8 +138,6 @@ import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeRunExceptT )
 import Control.DeepSeq
     ( NFData (..), force )
-import Control.Exception
-    ( bracket, handle )
 import Control.Monad.Trans.Except
     ( mapExceptT )
 import Criterion.Main
@@ -191,6 +189,8 @@ import System.IO.Unsafe
     ( unsafePerformIO )
 import System.Random
     ( mkStdGen, randoms )
+import UnliftIO.Exception
+    ( bracket, handle )
 
 import qualified Cardano.BM.Configuration.Model as CM
 import qualified Cardano.BM.Data.BackendKind as CM

--- a/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -10,8 +10,6 @@ import Prelude
 
 import Cardano.DB.Sqlite.Delete
     ( newRefCount, waitForFree', withRef )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Retry
     ( RetryPolicy, constantDelay, limitRetries )
 import Control.Tracer
@@ -20,6 +18,8 @@ import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldReturn )
 import UnliftIO.Async
     ( concurrently )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.MVar
     ( isEmptyMVar, newEmptyMVar, putMVar )
 

--- a/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -12,8 +12,6 @@ import Cardano.DB.Sqlite.Delete
     ( newRefCount, waitForFree', withRef )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.MVar
-    ( isEmptyMVar, newEmptyMVar, putMVar )
 import Control.Retry
     ( RetryPolicy, constantDelay, limitRetries )
 import Control.Tracer
@@ -22,6 +20,8 @@ import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldReturn )
 import UnliftIO.Async
     ( concurrently )
+import UnliftIO.MVar
+    ( isEmptyMVar, newEmptyMVar, putMVar )
 
 spec :: Spec
 spec = describe "RefCount" $ do

--- a/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
+++ b/lib/core/test/unit/Cardano/DB/Sqlite/DeleteSpec.hs
@@ -12,8 +12,6 @@ import Cardano.DB.Sqlite.Delete
     ( newRefCount, waitForFree', withRef )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( concurrently )
 import Control.Concurrent.MVar
     ( isEmptyMVar, newEmptyMVar, putMVar )
 import Control.Retry
@@ -22,6 +20,8 @@ import Control.Tracer
     ( nullTracer )
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldReturn )
+import UnliftIO.Async
+    ( concurrently )
 
 spec :: Spec
 spec = describe "RefCount" $ do

--- a/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Properties.hs
@@ -59,8 +59,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Arrow
     ( second )
-import Control.Exception
-    ( evaluate )
 import Control.Monad
     ( forM, forM_, replicateM, unless, void )
 import Control.Monad.IO.Class
@@ -121,6 +119,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( PropertyM, assert, monadicIO, monitor, pick, run )
+import UnliftIO.Exception
+    ( evaluate )
 
 import qualified Cardano.Pool.DB.MVar as MVar
 import qualified Data.List as L

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -27,8 +27,6 @@ import Cardano.Pool.DB.Sqlite
     ( newDBLayer, withDBLayer )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( dummyTimeInterpreter )
-import GHC.Conc
-    ( TVar, newTVarIO )
 import System.Directory
     ( copyFile )
 import System.FilePath
@@ -41,6 +39,8 @@ import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.Trace
     ( captureLogging )
+import UnliftIO.STM
+    ( TVar, newTVarIO )
 
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.

--- a/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/SqliteSpec.hs
@@ -31,8 +31,6 @@ import System.Directory
     ( copyFile )
 import System.FilePath
     ( (</>) )
-import System.IO.Temp
-    ( withSystemTempDirectory )
 import Test.Hspec
     ( Spec, before, describe, it, parallel, shouldBe )
 import Test.Utils.Paths
@@ -41,6 +39,8 @@ import Test.Utils.Trace
     ( captureLogging )
 import UnliftIO.STM
     ( TVar, newTVarIO )
+import UnliftIO.Temporary
+    ( withSystemTempDirectory )
 
 -- | Set up a DBLayer for testing, with the command context, and the logging
 -- variable.

--- a/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
@@ -10,10 +10,6 @@ import Prelude
 
 import Cardano.Wallet.Api.Server
     ( Listen (..), TlsConfiguration (..), withListeningSocket )
-import Control.Concurrent.Async
-    ( async, link )
-import Control.Exception
-    ( fromException )
 import Control.Tracer
     ( nullTracer )
 import Data.ByteString.Lazy
@@ -68,6 +64,10 @@ import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.Windows
     ( pendingOnWine )
+import UnliftIO.Async
+    ( async, link )
+import UnliftIO.Exception
+    ( fromException )
 
 import qualified Cardano.Wallet.Api.Server as Server
 import qualified Network.HTTP.Types.Status as Http

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -32,8 +32,6 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( concurrently_, race_ )
 import Control.Monad
     ( void )
 import Control.Monad.Trans.Except
@@ -73,6 +71,8 @@ import Test.QuickCheck.Property
     ( counterexample, property )
 import Test.Utils.Windows
     ( skipOnWindows )
+import UnliftIO.Async
+    ( concurrently_, race_ )
 
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
 import qualified Ouroboros.Consensus.HardFork.History.Qry as HF

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -30,8 +30,6 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), SlotNo (..), StartTime (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( void )
 import Control.Monad.Trans.Except
@@ -73,6 +71,8 @@ import Test.Utils.Windows
     ( skipOnWindows )
 import UnliftIO.Async
     ( concurrently_, race_ )
+import UnliftIO.Concurrent
+    ( threadDelay )
 
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
 import qualified Ouroboros.Consensus.HardFork.History.Qry as HF

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -72,8 +72,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
-import Control.Concurrent.Async
-    ( forConcurrently_ )
 import Control.Monad
     ( forM, forM_, void )
 import Control.Monad.IO.Class
@@ -128,6 +126,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Monadic
     ( PropertyM, assert, monadicIO, monitor, pick, run )
+import UnliftIO.Async
+    ( forConcurrently_ )
 
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -158,12 +158,8 @@ import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeRunExceptT )
 import Control.Concurrent
     ( forkIO, killThread, threadDelay )
-import Control.Concurrent.Async
-    ( concurrently, concurrently_ )
 import Control.Concurrent.MVar
     ( isEmptyMVar, newEmptyMVar, putMVar, takeMVar )
-import Control.Exception
-    ( SomeException, handle, throwIO )
 import Control.Monad
     ( forM_, forever, replicateM_, unless, void )
 import Control.Monad.IO.Class
@@ -239,6 +235,10 @@ import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.Trace
     ( captureLogging )
+import UnliftIO.Async
+    ( concurrently, concurrently_ )
+import UnliftIO.Exception
+    ( SomeException, handle, throwIO )
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as DB
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
@@ -611,7 +611,7 @@ fileModeSpec =  do
                 -- Start a concurrent worker which makes action on the DB in
                 -- parallel to simulate activity.
                 pid <- forkIO $ withDatabase testWid $ \(DBLayer{..} :: TestDBSeq) -> do
-                    handle @SomeException (const (pure ())) $ forever $ do
+                    handle @IO @SomeException (const (pure ())) $ forever $ do
                         atomically $ do
                             liftIO $ threadDelay 10000
                             void $ readCheckpoint $ PrimaryKey testWid

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -188,8 +188,6 @@ import Data.Word
     ( Word64 )
 import Database.Persist.Sql
     ( DBName (..), PersistEntity (..), fieldDB )
-import GHC.Conc
-    ( TVar, newTVarIO, readTVarIO, writeTVar )
 import Numeric.Natural
     ( Natural )
 import System.Directory
@@ -239,6 +237,8 @@ import UnliftIO.Exception
     ( SomeException, handle, throwIO )
 import UnliftIO.MVar
     ( isEmptyMVar, newEmptyMVar, putMVar, takeMVar )
+import UnliftIO.STM
+    ( TVar, newTVarIO, readTVarIO, writeTVar )
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as DB
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq
@@ -249,7 +249,7 @@ import qualified Data.List as L
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import qualified GHC.Conc as TVar
+import qualified UnliftIO.STM as STM
 
 spec :: Spec
 spec = parallel $ do
@@ -557,7 +557,7 @@ withLoggingDB = beforeAll newMemoryDBLayer' . beforeWith clean
   where
     clean (logs, (_, db)) = do
         cleanDB db
-        TVar.atomically $ writeTVar logs []
+        STM.atomically $ writeTVar logs []
         pure (readTVarIO logs, db)
 
 shouldHaveMsgQuery :: [DBLog] -> Text -> Expectation

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -199,7 +199,7 @@ import System.IO
 import System.IO.Error
     ( isUserError )
 import System.IO.Temp
-    ( emptySystemTempFile, withSystemTempDirectory, withSystemTempFile )
+    ( emptySystemTempFile )
 import System.IO.Unsafe
     ( unsafePerformIO )
 import System.Random
@@ -239,6 +239,8 @@ import UnliftIO.MVar
     ( isEmptyMVar, newEmptyMVar, putMVar, takeMVar )
 import UnliftIO.STM
     ( TVar, newTVarIO, readTVarIO, writeTVar )
+import UnliftIO.Temporary
+    ( withSystemTempDirectory, withSystemTempFile )
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as DB
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -158,8 +158,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeRunExceptT )
 import Control.Concurrent
     ( forkIO, killThread, threadDelay )
-import Control.Concurrent.MVar
-    ( isEmptyMVar, newEmptyMVar, putMVar, takeMVar )
 import Control.Monad
     ( forM_, forever, replicateM_, unless, void )
 import Control.Monad.IO.Class
@@ -239,6 +237,8 @@ import UnliftIO.Async
     ( concurrently, concurrently_ )
 import UnliftIO.Exception
     ( SomeException, handle, throwIO )
+import UnliftIO.MVar
+    ( isEmptyMVar, newEmptyMVar, putMVar, takeMVar )
 
 import qualified Cardano.Wallet.DB.Sqlite.TH as DB
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Seq

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -156,8 +156,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeRunExceptT )
-import Control.Concurrent
-    ( forkIO, killThread, threadDelay )
 import Control.Monad
     ( forM_, forever, replicateM_, unless, void )
 import Control.Monad.IO.Class
@@ -235,6 +233,8 @@ import Test.Utils.Trace
     ( captureLogging )
 import UnliftIO.Async
     ( concurrently, concurrently_ )
+import UnliftIO.Concurrent
+    ( forkIO, killThread, threadDelay )
 import UnliftIO.Exception
     ( SomeException, handle, throwIO )
 import UnliftIO.MVar

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -156,10 +156,6 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( race )
-import Control.Exception
-    ( evaluate )
 import Control.Foldl
     ( Fold (..) )
 import Control.Monad
@@ -243,6 +239,10 @@ import Test.StateMachine
     )
 import Test.StateMachine.Types
     ( Command (..), Commands (..), ParallelCommands, ParallelCommandsF (..) )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( evaluate )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Control.Foldl as Foldl

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -154,8 +154,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Foldl
     ( Fold (..) )
 import Control.Monad
@@ -241,6 +239,8 @@ import Test.StateMachine.Types
     ( Command (..), Commands (..), ParallelCommands, ParallelCommandsF (..) )
 import UnliftIO.Async
     ( race )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( evaluate )
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -55,8 +55,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
-import Control.Exception
-    ( try )
 import Control.Monad.Trans.Except
     ( runExceptT )
 import Data.Either
@@ -97,6 +95,8 @@ import Test.Utils.Time
     ( genUniformTime )
 import Test.Utils.Trace
     ( captureLogging )
+import UnliftIO.Exception
+    ( try )
 
 import qualified Cardano.Slotting.Slot as Cardano
 import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
@@ -193,7 +193,7 @@ spec = do
                     let ti = neverFails "because" $
                             mkTimeInterpreter tr startTime $
                             pure forkInterpreter
-                    try @PastHorizonException $ interpretQuery ti failingQry
+                    try @IO @PastHorizonException $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isLeft
                 logs `shouldSatisfy` (\case
@@ -206,7 +206,7 @@ spec = do
                     let ti = unsafeExtendSafeZone $
                             mkTimeInterpreter tr startTime $
                             pure forkInterpreter
-                    try @PastHorizonException $ interpretQuery ti failingQry
+                    try @IO @PastHorizonException $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isRight
                 logs `shouldBe` []
@@ -216,7 +216,7 @@ spec = do
                     let ti = expectAndThrowFailures $
                             mkTimeInterpreter tr startTime $
                             pure forkInterpreter
-                    try @PastHorizonException $ interpretQuery ti failingQry
+                    try @IO @PastHorizonException $ interpretQuery ti failingQry
 
                 res `shouldSatisfy` isLeft
                 logs `shouldSatisfy` (\case

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -35,8 +35,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
 import Control.DeepSeq
     ( deepseq )
-import Control.Exception
-    ( SomeException (..), evaluate, try )
 import Control.Monad
     ( forM_ )
 import Data.Either
@@ -53,6 +51,8 @@ import Test.QuickCheck
     ( Arbitrary (..), counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
+import UnliftIO.Exception
+    ( SomeException (..), evaluate, try )
 
 spec :: Spec
 spec = do
@@ -168,7 +168,7 @@ spec = do
         it "syncProgress should never crash" $ withMaxSuccess 10000
             $ property $ \tip dt -> monadicIO $ do
                 let x = runIdentity $ syncProgress tolerance ti tip dt
-                res <- run (try @SomeException $ evaluate x)
+                res <- run (try @IO @SomeException $ evaluate x)
                 monitor (counterexample $ "Result: " ++ show res)
                 assert (isRight res)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -124,8 +124,6 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
-import Control.Exception
-    ( evaluate )
 import Control.Monad
     ( forM_, replicateM )
 import Crypto.Hash
@@ -209,6 +207,8 @@ import Test.Utils.Laws
     ( testLawsMany )
 import Test.Utils.Time
     ( genUniformTime, genUniformTimeWithinRange, getUniformTime )
+import UnliftIO.Exception
+    ( evaluate )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Data.ByteString as BS

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -25,8 +25,6 @@ import Cardano.Wallet.Registry
     , register
     , workerThread
     )
-import Control.Concurrent
-    ( threadDelay, throwTo )
 import Control.Exception.Base
     ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
@@ -47,6 +45,8 @@ import Test.QuickCheck.Monadic
     ( monadicIO, run )
 import UnliftIO.Async
     ( race )
+import UnliftIO.Concurrent
+    ( threadDelay, throwTo )
 import UnliftIO.Exception
     ( SomeException (..), throwIO )
 import UnliftIO.MVar

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -27,8 +27,6 @@ import Cardano.Wallet.Registry
     )
 import Control.Concurrent
     ( threadDelay, throwTo )
-import Control.Concurrent.Async
-    ( race )
 import Control.Concurrent.MVar
     ( modifyMVar_
     , newEmptyMVar
@@ -38,12 +36,8 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryTakeMVar
     )
-import Control.Exception
-    ( AsyncException (..)
-    , SomeException (..)
-    , asyncExceptionFromException
-    , throwIO
-    )
+import Control.Exception.Base
+    ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
     ( replicateM, void )
 import Control.Tracer
@@ -60,6 +54,10 @@ import Test.QuickCheck
     ( Arbitrary (..), Positive (..), Property, generate, property )
 import Test.QuickCheck.Monadic
     ( monadicIO, run )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( SomeException (..), throwIO )
 
 import qualified Data.ByteString as BS
 

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -27,15 +27,6 @@ import Cardano.Wallet.Registry
     )
 import Control.Concurrent
     ( threadDelay, throwTo )
-import Control.Concurrent.MVar
-    ( modifyMVar_
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , swapMVar
-    , takeMVar
-    , tryTakeMVar
-    )
 import Control.Exception.Base
     ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
@@ -58,6 +49,15 @@ import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
     ( SomeException (..), throwIO )
+import UnliftIO.MVar
+    ( modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , swapMVar
+    , takeMVar
+    , tryTakeMVar
+    )
 
 import qualified Data.ByteString as BS
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -116,8 +116,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
 import Control.Arrow
     ( second )
-import Control.Concurrent
-    ( threadDelay )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
@@ -190,6 +188,8 @@ import Test.QuickCheck.Monadic
     ( monadicIO )
 import Test.Utils.Time
     ( UniformTime )
+import UnliftIO.Concurrent
+    ( threadDelay )
 
 import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W

--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -22,8 +22,6 @@ import Cardano.Wallet.Api.Server
     ( Listen (..), withListeningSocket )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, readMVar )
 import Control.Concurrent.STM.TVar
@@ -106,6 +104,8 @@ import Test.QuickCheck
     ( Arbitrary (..), choose, counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor )
+import UnliftIO.Async
+    ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.List as L

--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -22,8 +22,6 @@ import Cardano.Wallet.Api.Server
     ( Listen (..), withListeningSocket )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, readMVar )
 import Control.Concurrent.STM.TVar
     ( TVar, newTVarIO, readTVarIO, writeTVar )
 import Control.Monad
@@ -106,6 +104,8 @@ import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor )
 import UnliftIO.Async
     ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
+import UnliftIO.MVar
+    ( newEmptyMVar, putMVar, readMVar )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.List as L

--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -20,16 +20,10 @@ import Cardano.BM.Trace
     ( traceInTVarIO )
 import Cardano.Wallet.Api.Server
     ( Listen (..), withListeningSocket )
-import Control.Concurrent
-    ( threadDelay )
-import Control.Concurrent.STM.TVar
-    ( TVar, newTVarIO, readTVarIO, writeTVar )
 import Control.Monad
     ( forM_, void, when )
 import Control.Monad.IO.Class
     ( liftIO )
-import Control.Monad.STM
-    ( atomically )
 import Control.Tracer
     ( Tracer )
 import Data.Aeson
@@ -104,8 +98,12 @@ import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor )
 import UnliftIO.Async
     ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, readMVar )
+import UnliftIO.STM
+    ( TVar, atomically, newTVarIO, readTVarIO, writeTVar )
 
 import qualified Data.Aeson as Aeson
 import qualified Data.List as L

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -30,7 +30,6 @@ library
       -Werror
   build-depends:
       base
-    , aeson
     , bytestring
     , code-page
     , contra-tracer

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -31,7 +31,6 @@ library
   build-depends:
       base
     , aeson
-    , async
     , bytestring
     , code-page
     , contra-tracer
@@ -42,6 +41,7 @@ library
     , process
     , text
     , text-class
+    , unliftio
   hs-source-dirs:
       src
   exposed-modules:
@@ -70,7 +70,6 @@ test-suite unit
     ghc-options: -O2 -Werror
   build-depends:
       base
-    , async
     , bytestring
     , cardano-wallet-launcher
     , cardano-wallet-test-utils
@@ -85,6 +84,7 @@ test-suite unit
     , text
     , text-class
     , time
+    , unliftio
   build-tools:
       hspec-discover
   type:

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -34,6 +34,7 @@ library
     , bytestring
     , code-page
     , contra-tracer
+    , either
     , extra
     , filepath
     , fmt
@@ -42,6 +43,7 @@ library
     , text
     , text-class
     , unliftio
+    , unliftio-core
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -33,12 +33,8 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Control.Concurrent
     ( forkIO )
-import Control.Concurrent.Async
-    ( race )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
-import Control.Exception
-    ( Exception, IOException, finally, onException, tryJust )
 import Control.Monad
     ( join, void )
 import Control.Tracer
@@ -78,6 +74,10 @@ import System.Process
     , waitForProcess
     , withCreateProcess
     )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( Exception, IOException, finally, onException, tryJust )
 
 import qualified Data.Text as T
 

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -65,19 +65,20 @@ import System.Exit
 import System.IO
     ( Handle )
 import System.Process
-    ( CmdSpec (..)
-    , CreateProcess (..)
-    , ProcessHandle
-    , StdStream (..)
-    , getPid
-    , proc
-    , waitForProcess
-    , withCreateProcess
-    )
+    ( getPid )
 import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
     ( Exception, IOException, finally, onException, tryJust )
+import UnliftIO.Process
+    ( CmdSpec (..)
+    , CreateProcess (..)
+    , ProcessHandle
+    , StdStream (..)
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
 
 import qualified Data.Text as T
 

--- a/lib/launcher/src/Cardano/Launcher.hs
+++ b/lib/launcher/src/Cardano/Launcher.hs
@@ -32,18 +32,18 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
+import Cardano.Startup
+    ( killProcess )
 import Control.Monad
-    ( join, void )
+    ( join, mapM_, void )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO (..) )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
-import Data.Aeson
-    ( ToJSON (..), object, (.=) )
 import Data.Either.Combinators
-    ( whenLeft )
+    ( leftToMaybe )
 import Data.List
     ( isPrefixOf )
 import Data.Text
@@ -68,23 +68,30 @@ import System.Exit
 import System.IO
     ( Handle )
 import System.Process
-    ( getPid )
+    ( cleanupProcess, getPid )
 import UnliftIO.Async
     ( race )
 import UnliftIO.Concurrent
-    ( forkIO )
+    ( forkIO, forkIOWithUnmask, killThread, threadDelay )
 import UnliftIO.Exception
-    ( Exception, IOException, finally, onException, tryJust )
+    ( Exception
+    , IOException
+    , bracket
+    , bracket_
+    , finally
+    , onException
+    , tryJust
+    )
 import UnliftIO.MVar
-    ( newEmptyMVar, putMVar, takeMVar )
+    ( newEmptyMVar, putMVar, readMVar )
 import UnliftIO.Process
     ( CmdSpec (..)
     , CreateProcess (..)
     , ProcessHandle
     , StdStream (..)
+    , createProcess
     , proc
     , waitForProcess
-    , withCreateProcess
     )
 
 import qualified Data.Text as T
@@ -183,7 +190,24 @@ withBackendProcessHandle tr (Command name args before std_in std_out) action =
     process = (proc name args) { std_in, std_out, std_err = std_out }
 
 -- | A variant of 'withBackendProcess' which accepts a general 'CreateProcess'
--- object.
+-- object. This version also has nicer async properties than
+-- 'System.Process.withCreateProcess'.
+--
+-- This function should ensure:
+--
+-- 1. If the action finishes or throws an exception, then the process is also
+--    terminated.
+--
+-- 2. After the process is sent the signal to terminate, this function will
+--    block until the process has actually exited - unless that takes longer
+--    than the 5 second timeout. After the timeout has lapsed, the process will
+--    be sent a kill signal.
+--
+-- 3. If the process exits, then the action is cancelled.
+--
+-- fixme: This is more or less a reimplementation of
+-- 'System.Process.Typed.withProcessWait' (except for wait timeout). The
+-- launcher code should be converted to use @typed-process@.
 withBackendCreateProcess
     :: forall m a. (MonadUnliftIO m)
     => Tracer m LauncherLog
@@ -195,20 +219,22 @@ withBackendCreateProcess
     -> m (Either ProcessHasExited a)
 withBackendCreateProcess tr process action = do
     traceWith tr $ MsgLauncherStart name args
-    res <- fmap join $ tryJust spawnPredicate $
-        withCreateProcess process $ \mstdin _ _ ph -> do
-            pid <- liftIO $ textPid ph
-            let tr' = contramap (WithProcessInfo name pid) tr
-            traceWith tr' MsgLauncherStarted
+    exitVar <- newEmptyMVar
+    res <- fmap join $ tryJust spawnPredicate $ bracket
+        (createProcess process)
+        (cleanupProcessAndWait (readMVar exitVar)) $
+            \(mstdin, _, _, ph) -> do
+                pid <- maybe "-" (T.pack . show) <$> liftIO (getPid ph)
+                let tr' = contramap (WithProcessInfo name pid) tr
+                let tr'' = contramap MsgLauncherWait tr'
+                traceWith tr' MsgLauncherStarted
+                interruptibleWaitForProcess tr'' ph (putMVar exitVar)
+                race (ProcessHasExited name <$> readMVar exitVar) $ bracket_
+                    (traceWith tr' MsgLauncherAction)
+                    (traceWith tr' MsgLauncherActionDone)
+                    (action mstdin ph)
 
-            let waitForExit =
-                    ProcessHasExited name <$> interruptibleWaitForProcess tr' ph
-            let runAction = do
-                    traceWith tr' MsgLauncherAction
-                    action mstdin ph `finally` traceWith tr' MsgLauncherCleanup
-
-            race waitForExit runAction
-    whenLeft res (traceWith tr . MsgLauncherFinish)
+    traceWith tr $ MsgLauncherFinish (leftToMaybe res)
     pure res
   where
     -- Exceptions resulting from the @exec@ call for this command. The most
@@ -220,28 +246,43 @@ withBackendCreateProcess tr process action = do
         | name `isPrefixOf` show e = Just (ProcessDidNotStart name e)
         | otherwise = Nothing
 
+     -- Run the 'cleanupProcess' function from the process library, but wait for
+     -- the process to exit, rather than immediately returning. If the process
+     -- doesn't exit after timeout, kill it, to avoid blocking indefinitely.
+    cleanupProcessAndWait getExitStatus ps@(_, _, _, ph) = do
+        traceWith tr MsgLauncherCleanup
+        liftIO $ cleanupProcess ps
+        let timeoutSecs = 5
+        -- Async exceptions are currently masked because this is running in a
+        -- bracket cleanup handler. We fork a thread and unmask so that the
+        -- timeout can be cancelled.
+        tid <- forkIOWithUnmask $ \unmask -> unmask $ do
+            threadDelay (timeoutSecs * 1000 * 1000)
+            traceWith tr (MsgLauncherCleanupTimedOut timeoutSecs)
+            liftIO (getPid ph >>= mapM_ killProcess)
+        void getExitStatus `finally` killThread tid
+        traceWith tr MsgLauncherCleanupFinished
+
     -- Wraps 'waitForProcess' in another thread. This works around the unwanted
     -- behaviour of the process library on Windows where 'waitForProcess' seems
     -- to block all concurrent async actions in the thread.
     interruptibleWaitForProcess
-        :: Tracer m LaunchedProcessLog
+        :: Tracer m WaitForProcessLog
         -> ProcessHandle
-        -> m ExitCode
-    interruptibleWaitForProcess tr' ph = do
-        status <- newEmptyMVar
-        void $ forkIO $ waitThread status `onException` continue status
-        takeMVar status
+        -> (ExitCode -> m ())
+        -> m ()
+    interruptibleWaitForProcess tr' ph onExit =
+        void $ forkIO (waitThread `onException` continue)
       where
-        waitThread var = do
-            traceWith tr' MsgLauncherWaitBefore
+        waitThread = do
+            traceWith tr' MsgWaitBefore
             status <- waitForProcess ph
-            traceWith tr' (MsgLauncherWaitAfter $ exitStatus status)
-            putMVar var status
-        continue var = do
-            traceWith tr' MsgLauncherCancel
-            putMVar var (ExitFailure 256)
+            traceWith tr' (MsgWaitAfter status)
+            onExit status
 
-    textPid = fmap (maybe "-" (T.pack . show)) . getPid
+        continue = do
+            traceWith tr' MsgWaitCancelled
+            onExit (ExitFailure 256)
 
     (name, args) = getCreateProcessNameArgs process
 
@@ -258,68 +299,91 @@ getCreateProcessNameArgs process = case cmdspec process of
 data LauncherLog
     = MsgLauncherStart String [String]
     | WithProcessInfo String Text LaunchedProcessLog
-    | MsgLauncherFinish ProcessHasExited
-    deriving (Show, Eq, Generic, ToJSON)
+    | MsgLauncherCleanup
+    | MsgLauncherCleanupTimedOut Int
+    | MsgLauncherCleanupFinished
+    | MsgLauncherFinish (Maybe ProcessHasExited)
+    deriving (Show, Eq, Generic)
 
 data LaunchedProcessLog
     = MsgLauncherStarted
-    | MsgLauncherWaitBefore
-    | MsgLauncherWaitAfter Int
-    | MsgLauncherCancel
     | MsgLauncherAction
-    | MsgLauncherCleanup
-    deriving (Show, Eq, Generic, ToJSON)
+    | MsgLauncherActionDone
+    | MsgLauncherWait WaitForProcessLog
+    deriving (Show, Eq, Generic)
 
-instance ToJSON Command where
-    toJSON (Command name args _ _ _) = toJSON (name:args)
-
-instance ToJSON ProcessHasExited where
-    toJSON (ProcessDidNotStart name e) =
-        object [ "command" .= name, "exception" .= show e ]
-    toJSON (ProcessHasExited name code) =
-        object [ "command" .= name, "status" .= exitStatus code ]
-
-exitStatus :: ExitCode -> Int
-exitStatus ExitSuccess = 0
-exitStatus (ExitFailure n) = n
+data WaitForProcessLog
+    = MsgWaitBefore
+    | MsgWaitAfter ExitCode
+    | MsgWaitCancelled
+    deriving (Show, Eq, Generic)
 
 instance HasPrivacyAnnotation LauncherLog
 instance HasSeverityAnnotation LauncherLog where
     getSeverityAnnotation = \case
         MsgLauncherStart _ _ -> Notice
         WithProcessInfo _ _ msg -> getSeverityAnnotation msg
-        MsgLauncherFinish (ProcessDidNotStart _ _) -> Error
-        MsgLauncherFinish (ProcessHasExited _ st) -> case st of
+        MsgLauncherFinish Nothing -> Debug
+        MsgLauncherFinish (Just (ProcessDidNotStart _ _)) -> Error
+        MsgLauncherFinish (Just (ProcessHasExited _ st)) -> case st of
             ExitSuccess -> Notice
             ExitFailure _ -> Error
+        MsgLauncherCleanup -> Debug
+        MsgLauncherCleanupTimedOut _ -> Notice
+        MsgLauncherCleanupFinished -> Debug
 
 instance HasPrivacyAnnotation LaunchedProcessLog
 instance HasSeverityAnnotation LaunchedProcessLog where
     getSeverityAnnotation = \case
         MsgLauncherStarted -> Info
-        MsgLauncherWaitBefore -> Debug
-        MsgLauncherWaitAfter _ -> Debug
-        MsgLauncherCancel -> Debug
+        MsgLauncherWait msg -> getSeverityAnnotation msg
         MsgLauncherAction -> Debug
-        MsgLauncherCleanup -> Notice
+        MsgLauncherActionDone -> Notice
+
+instance HasPrivacyAnnotation WaitForProcessLog
+instance HasSeverityAnnotation WaitForProcessLog where
+    getSeverityAnnotation = \case
+        MsgWaitBefore -> Debug
+        MsgWaitAfter _ -> Debug
+        MsgWaitCancelled -> Debug
 
 instance ToText LauncherLog where
-    toText = fmt . launcherLogText
+    toText ll = fmt $ case ll of
+        MsgLauncherStart cmd args ->
+            "Starting process "+|buildCommand cmd args|+""
+        WithProcessInfo name pid msg ->
+            "["+|name|+"."+|pid|+"] "+|toText msg|+""
+        MsgLauncherFinish Nothing ->
+            "Action finished"
+        MsgLauncherFinish (Just (ProcessDidNotStart name _e)) ->
+            "Could not start "+|name|+""
+        MsgLauncherFinish (Just (ProcessHasExited name code)) ->
+            "Child process "+|name|+" exited with "+|statusText code|+""
+        MsgLauncherCleanup ->
+            "Begin process cleanup"
+        MsgLauncherCleanupTimedOut t ->
+            "Timed out waiting for process to exit after "+|t|+" seconds"
+        MsgLauncherCleanupFinished ->
+            "Process cleanup finished"
 
-launcherLogText :: LauncherLog -> Builder
-launcherLogText (MsgLauncherStart cmd args) =
-    "Starting process "+|buildCommand cmd args|+""
-launcherLogText (WithProcessInfo name pid msg) =
-    "["+|name|+"."+|pid|+"] "+|launchedProcessText msg|+""
-launcherLogText (MsgLauncherFinish (ProcessDidNotStart name _e)) =
-    "Could not start "+|name|+""
-launcherLogText (MsgLauncherFinish (ProcessHasExited name code)) =
-    "Child process "+|name|+" exited with status "+||exitStatus code||+""
+instance ToText LaunchedProcessLog where
+    toText = \case
+        MsgLauncherStarted -> "Process started"
+        MsgLauncherAction -> "Running withBackend action"
+        MsgLauncherWait msg -> toText msg
+        MsgLauncherActionDone -> "withBackend action done. Terminating child process"
 
-launchedProcessText :: LaunchedProcessLog -> Builder
-launchedProcessText MsgLauncherStarted = "Process started"
-launchedProcessText MsgLauncherWaitBefore = "About to waitForProcess"
-launchedProcessText (MsgLauncherWaitAfter status) = "waitForProcess returned "+||status||+""
-launchedProcessText MsgLauncherCancel = "There was an exception waiting for the process"
-launchedProcessText MsgLauncherAction = "Running withBackend action"
-launchedProcessText MsgLauncherCleanup = "Terminating child process"
+instance ToText WaitForProcessLog where
+    toText = \case
+        MsgWaitBefore ->
+            "Waiting for process to exit"
+        MsgWaitAfter status -> fmt $
+            "Process exited with "+|statusText status|+""
+        MsgWaitCancelled ->
+            "There was an exception waiting for the process"
+
+statusText :: ExitCode -> Text
+statusText ExitSuccess = "success"
+statusText (ExitFailure n)
+    | n >= 0 = fmt $ "code "+||n||+" (failure)"
+    | otherwise = fmt $ "signal "+||(-n)||+""

--- a/lib/launcher/src/Cardano/Launcher/Node.hs
+++ b/lib/launcher/src/Cardano/Launcher/Node.hs
@@ -27,7 +27,7 @@ import System.FilePath
     ( takeFileName, (</>) )
 import System.Info
     ( os )
-import System.Process
+import UnliftIO.Process
     ( CreateProcess (..), proc )
 
 -- | Parameters for connecting to the node.

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -33,8 +33,6 @@ import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
-import Control.Concurrent
-    ( forkIO )
 import Control.Tracer
     ( Tracer, traceWith )
 import Data.Either.Extra
@@ -57,6 +55,8 @@ import System.IO.CodePage
     ( withCP65001 )
 import UnliftIO.Async
     ( race )
+import UnliftIO.Concurrent
+    ( forkIO )
 import UnliftIO.Exception
     ( IOException, catch, handle, throwIO )
 import UnliftIO.MVar

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -18,6 +18,7 @@ module Cardano.Startup
     , withShutdownHandler
     , withShutdownHandler'
     , installSignalHandlers
+    , killProcess
 
     -- * File permissions
     , setDefaultFilePermissions

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -35,8 +35,6 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Control.Concurrent
     ( forkIO )
-import Control.Concurrent.MVar
-    ( MVar, newEmptyMVar, putMVar, takeMVar )
 import Control.Tracer
     ( Tracer, traceWith )
 import Data.Either.Extra
@@ -61,6 +59,8 @@ import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
     ( IOException, catch, handle, throwIO )
+import UnliftIO.MVar
+    ( MVar, newEmptyMVar, putMVar, takeMVar )
 
 #ifdef WINDOWS
 import Cardano.Startup.Windows

--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -35,12 +35,8 @@ import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
 import Control.Concurrent
     ( forkIO )
-import Control.Concurrent.Async
-    ( race )
 import Control.Concurrent.MVar
     ( MVar, newEmptyMVar, putMVar, takeMVar )
-import Control.Exception
-    ( IOException, catch, handle, throwIO )
 import Control.Tracer
     ( Tracer, traceWith )
 import Data.Either.Extra
@@ -61,6 +57,10 @@ import System.IO
     )
 import System.IO.CodePage
     ( withCP65001 )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( IOException, catch, handle, throwIO )
 
 #ifdef WINDOWS
 import Cardano.Startup.Windows

--- a/lib/launcher/src/Cardano/Startup/POSIX.hs
+++ b/lib/launcher/src/Cardano/Startup/POSIX.hs
@@ -8,6 +8,7 @@ module Cardano.Startup.POSIX
     ( installSignalHandlers
     , setDefaultFilePermissions
     , restrictFileMode
+    , killProcess
     ) where
 
 import Prelude
@@ -23,8 +24,12 @@ import System.Posix.Signals
     , installHandler
     , keyboardSignal
     , raiseSignal
+    , sigKILL
+    , signalProcess
     , softwareTermination
     )
+import System.Process
+    ( Pid )
 
 -- | Convert any SIGTERM received to SIGINT, for which the runtime system has
 -- handlers that will correctly clean up sub-processes.
@@ -46,3 +51,8 @@ setDefaultFilePermissions = void $ setFileCreationMask mask
 -- them.
 restrictFileMode :: FilePath -> IO ()
 restrictFileMode f = setFileMode f ownerReadMode
+
+-- | Kill a process with signal 9. This is used only after previous attempts to
+-- terminate the process did not work.
+killProcess :: Pid -> IO ()
+killProcess = signalProcess sigKILL

--- a/lib/launcher/src/Cardano/Startup/Windows.hs
+++ b/lib/launcher/src/Cardano/Startup/Windows.hs
@@ -8,9 +8,13 @@ module Cardano.Startup.Windows
     ( installSignalHandlers
     , setDefaultFilePermissions
     , restrictFileMode
+    , killProcess
     ) where
 
 import Prelude
+
+import System.Process
+    ( Pid )
 
 -- | Stub function for windows.
 installSignalHandlers :: IO () -> IO ()
@@ -23,3 +27,8 @@ setDefaultFilePermissions = pure ()
 -- | Stub function for windows.
 restrictFileMode :: FilePath -> IO ()
 restrictFileMode _ = pure ()
+
+-- | Stub function for windows. Under windows, the default behaviour of
+-- 'terminateProcess' is to kill, so this isn't needed.
+killProcess :: Pid -> IO ()
+killProcess _ = pure ()

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -32,15 +32,6 @@ import Cardano.Launcher
     )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.MVar
-    ( modifyMVar_
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , readMVar
-    , takeMVar
-    , tryReadMVar
-    )
 import Control.Monad
     ( forever )
 import Control.Monad.IO.Class
@@ -80,6 +71,15 @@ import UnliftIO.Async
     ( async, race_, waitAnyCancel )
 import UnliftIO.Exception
     ( bracket )
+import UnliftIO.MVar
+    ( modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryReadMVar
+    )
 
 {- HLINT ignore spec "Use head" -}
 

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -30,8 +30,6 @@ import Cardano.Launcher
     , StdStream (..)
     , withBackendProcessHandle
     )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( forever )
 import Control.Monad.IO.Class
@@ -67,6 +65,8 @@ import Test.Utils.Windows
     ( isWindows, pendingOnWine )
 import UnliftIO.Async
     ( async, race_, waitAnyCancel )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( bracket )
 import UnliftIO.MVar

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -32,8 +32,6 @@ import Cardano.Launcher
     )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( async, race_, waitAnyCancel )
 import Control.Concurrent.MVar
     ( modifyMVar_
     , newEmptyMVar
@@ -43,8 +41,6 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryReadMVar
     )
-import Control.Exception
-    ( bracket )
 import Control.Monad
     ( forever )
 import Control.Monad.IO.Class
@@ -80,6 +76,10 @@ import Test.Hspec
     )
 import Test.Utils.Windows
     ( isWindows, pendingOnWine )
+import UnliftIO.Async
+    ( async, race_, waitAnyCancel )
+import UnliftIO.Exception
+    ( bracket )
 
 {- HLINT ignore spec "Use head" -}
 

--- a/lib/launcher/test/unit/Cardano/LauncherSpec.hs
+++ b/lib/launcher/test/unit/Cardano/LauncherSpec.hs
@@ -54,8 +54,6 @@ import System.Exit
     ( ExitCode (..) )
 import System.Info
     ( os )
-import System.Process
-    ( ProcessHandle, getProcessExitCode )
 import Test.Hspec
     ( Spec
     , beforeAll
@@ -80,6 +78,8 @@ import UnliftIO.MVar
     , takeMVar
     , tryReadMVar
     )
+import UnliftIO.Process
+    ( ProcessHandle, getProcessExitCode )
 
 {- HLINT ignore spec "Use head" -}
 

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -17,10 +17,6 @@ import Cardano.Startup
     ( ShutdownHandlerLog (..), withShutdownHandler' )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( race )
-import Control.Exception
-    ( IOException, bracket, catch, throwIO )
 import Control.Monad
     ( unless )
 import Control.Tracer
@@ -41,6 +37,10 @@ import Test.Utils.Trace
     ( captureLogging )
 import Test.Utils.Windows
     ( nullFileName, pendingOnWindows )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( IOException, bracket, catch, throwIO )
 
 #if defined(WINDOWS)
 import Control.Concurrent

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -15,8 +15,6 @@ import Prelude
 
 import Cardano.Startup
     ( ShutdownHandlerLog (..), withShutdownHandler' )
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( unless )
 import Control.Tracer
@@ -37,13 +35,15 @@ import Test.Utils.Windows
     ( nullFileName, pendingOnWindows )
 import UnliftIO.Async
     ( race )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( IOException, bracket, catch, throwIO )
 import UnliftIO.Process
     ( createPipe )
 
 #if defined(WINDOWS)
-import Control.Concurrent
+import UnliftIO.Concurrent
     ( forkIO )
 import UnliftIO.MVar
     ( MVar, newEmptyMVar, putMVar, takeMVar )

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -25,8 +25,6 @@ import System.IO
     ( Handle, IOMode (..), hClose, hWaitForInput, stdin, withFile )
 import System.IO.Error
     ( isUserError )
-import System.Process
-    ( createPipe )
 import Test.Hspec
     ( Spec, describe, it, shouldBe, shouldContain, shouldReturn, shouldThrow )
 import Test.Hspec.Core.Spec
@@ -41,6 +39,8 @@ import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
     ( IOException, bracket, catch, throwIO )
+import UnliftIO.Process
+    ( createPipe )
 
 #if defined(WINDOWS)
 import Control.Concurrent

--- a/lib/launcher/test/unit/Cardano/StartupSpec.hs
+++ b/lib/launcher/test/unit/Cardano/StartupSpec.hs
@@ -45,7 +45,7 @@ import UnliftIO.Exception
 #if defined(WINDOWS)
 import Control.Concurrent
     ( forkIO )
-import Control.Concurrent.MVar
+import UnliftIO.MVar
     ( MVar, newEmptyMVar, putMVar, takeMVar )
 #endif
 

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -70,8 +70,6 @@ import Cardano.Wallet.Shelley.Launch
     )
 import Control.Arrow
     ( first )
-import Control.Concurrent.Async
-    ( race_ )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 import Control.Concurrent.STM.TVar
@@ -124,6 +122,8 @@ import Test.Integration.Framework.DSL
     , unsafeRequest
     , verify
     )
+import UnliftIO.Async
+    ( race_ )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -70,8 +70,6 @@ import Cardano.Wallet.Shelley.Launch
     )
 import Control.Arrow
     ( first )
-import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, takeMVar )
 import Control.Concurrent.STM.TVar
     ( TVar )
 import Control.Monad
@@ -124,6 +122,8 @@ import Test.Integration.Framework.DSL
     )
 import UnliftIO.Async
     ( race_ )
+import UnliftIO.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -70,8 +70,6 @@ import Cardano.Wallet.Shelley.Launch
     )
 import Control.Arrow
     ( first )
-import Control.Concurrent.STM.TVar
-    ( TVar )
 import Control.Monad
     ( mapM_, replicateM, replicateM_ )
 import Control.Monad.IO.Class
@@ -124,6 +122,8 @@ import UnliftIO.Async
     ( race_ )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, takeMVar )
+import UnliftIO.STM
+    ( TVar )
 
 import qualified Cardano.Wallet.Api.Link as Link
 import qualified Data.Text as T

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -62,12 +62,7 @@ import Cardano.Wallet.Shelley
 import Cardano.Wallet.Shelley.Faucet
     ( initFaucet )
 import Cardano.Wallet.Shelley.Launch
-    ( RunningNode (..)
-    , sendFaucetFundsTo
-    , withCluster
-    , withSystemTempDir
-    , withTempDir
-    )
+    ( RunningNode (..), sendFaucetFundsTo, withCluster, withSystemTempDir )
 import Control.Arrow
     ( first )
 import Control.Monad
@@ -417,20 +412,21 @@ withShelleyServer tracers action = do
         sendFaucetFundsTo nullTracer dir addresses
 
     onClusterStart act dir (RunningNode socketPath block0 (gp, vData)) = do
+        let db = dir </> "wallets"
+        createDirectory db
         -- NOTE: We may want to keep a wallet running across the fork, but
         -- having three callbacks like this might not work well for that.
-        withTempDir nullTracer dir "wallets" $ \db -> do
-            serveWallet
-                (SomeNetworkDiscriminant $ Proxy @'Mainnet)
-                tracers
-                (SyncTolerance 10)
-                (Just db)
-                Nothing
-                "127.0.0.1"
-                ListenOnRandomPort
-                Nothing
-                Nothing
-                socketPath
-                block0
-                (gp, vData)
-                (act gp)
+        serveWallet
+            (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+            tracers
+            (SyncTolerance 10)
+            (Just db)
+            Nothing
+            "127.0.0.1"
+            ListenOnRandomPort
+            Nothing
+            Nothing
+            socketPath
+            block0
+            (gp, vData)
+            (act gp)

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -143,8 +143,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy, unsafeMkPercentage, unsafeRunExceptT )
 import Control.Arrow
     ( first )
-import Control.Concurrent
-    ( forkIO, threadDelay )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
@@ -199,6 +197,8 @@ import System.IO
     ( IOMode (..), hFlush, withFile )
 import System.IO.Temp
     ( withSystemTempFile )
+import UnliftIO.Concurrent
+    ( forkIO, threadDelay )
 import UnliftIO.Exception
     ( bracket, evaluate, throwIO )
 

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -195,12 +195,12 @@ import System.FilePath
     ( (</>) )
 import System.IO
     ( IOMode (..), hFlush, withFile )
-import System.IO.Temp
-    ( withSystemTempFile )
 import UnliftIO.Concurrent
     ( forkIO, threadDelay )
 import UnliftIO.Exception
     ( bracket, evaluate, throwIO )
+import UnliftIO.Temporary
+    ( withSystemTempFile )
 
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -147,8 +147,6 @@ import Control.Concurrent
     ( forkIO, threadDelay )
 import Control.DeepSeq
     ( NFData )
-import Control.Exception
-    ( bracket, evaluate, throwIO )
 import Control.Monad
     ( forM, forM_, void )
 import Control.Monad.IO.Class
@@ -201,6 +199,8 @@ import System.IO
     ( IOMode (..), hFlush, withFile )
 import System.IO.Temp
     ( withSystemTempFile )
+import UnliftIO.Exception
+    ( bracket, evaluate, throwIO )
 
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -71,7 +71,6 @@ library
     , ouroboros-consensus-shelley
     , ouroboros-network
     , ouroboros-network-framework
-    , process
     , random
     , retry
     , servant-server

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -223,7 +223,6 @@ test-suite integration
     ghc-options: -O2 -Werror
   build-depends:
       base
-    , async
     , cardano-wallet-cli
     , cardano-wallet-core
     , cardano-wallet-core-integration

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -31,7 +31,6 @@ library
   build-depends:
       base
     , aeson
-    , async
     , base58-bytestring
     , bech32
     , bech32-th
@@ -55,7 +54,6 @@ library
     , containers
     , contra-tracer
     , directory
-    , exceptions
     , extra
     , filepath
     , fmt
@@ -83,6 +81,7 @@ library
     , text-class
     , time
     , transformers
+    , unliftio
     , unordered-containers
     , vector
     , warp
@@ -173,7 +172,6 @@ test-suite unit
     ghc-options: -O2 -Werror
   build-depends:
       base
-    , async
     , base58-bytestring
     , bech32
     , bech32-th
@@ -198,6 +196,7 @@ test-suite unit
     , text
     , text-class
     , transformers
+    , unliftio
     , QuickCheck
   build-tools:
       hspec-discover
@@ -241,6 +240,7 @@ test-suite integration
     , lobemo-backend-ekg
     , text
     , text-class
+    , unliftio
   build-tools:
       cardano-wallet
   type:
@@ -282,6 +282,7 @@ benchmark restore
     , text-class
     , time
     , transformers
+    , unliftio
   type:
      exitcode-stdio-1.0
   hs-source-dirs:
@@ -301,23 +302,23 @@ benchmark latency
   if (flag(release))
     ghc-options: -O2 -Werror
   build-depends:
-     base
-   , aeson
-   , async
-   , cardano-wallet-cli
-   , cardano-wallet-core
-   , cardano-wallet-core-integration
-   , cardano-wallet
-   , cardano-wallet-launcher
-   , directory
-   , filepath
-   , generic-lens
-   , http-client
-   , http-types
-   , hspec
-   , iohk-monitoring
-   , stm
-   , text
+      base
+    , aeson
+    , cardano-wallet-cli
+    , cardano-wallet-core
+    , cardano-wallet-core-integration
+    , cardano-wallet
+    , cardano-wallet-launcher
+    , directory
+    , filepath
+    , generic-lens
+    , http-client
+    , http-types
+    , hspec
+    , iohk-monitoring
+    , stm
+    , text
+    , unliftio
   type:
      exitcode-stdio-1.0
   hs-source-dirs:

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -232,6 +232,7 @@ test-suite integration
     , cardano-wallet-test-utils
     , contra-tracer
     , directory
+    , either
     , filepath
     , hspec
     , http-client

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -191,7 +191,6 @@ test-suite unit
     , ouroboros-consensus-shelley
     , ouroboros-network
     , shelley-spec-ledger
-    , stm
     , text
     , text-class
     , transformers
@@ -315,7 +314,6 @@ benchmark latency
     , http-types
     , hspec
     , iohk-monitoring
-    , stm
     , text
     , unliftio
   type:

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -81,6 +81,7 @@ library
     , time
     , transformers
     , unliftio
+    , unliftio-core
     , unordered-containers
     , vector
     , warp
@@ -230,6 +231,7 @@ test-suite integration
     , cardano-wallet
     , cardano-wallet-test-utils
     , contra-tracer
+    , directory
     , filepath
     , hspec
     , http-client
@@ -274,7 +276,6 @@ benchmark restore
     , fmt
     , iohk-monitoring
     , say
-    , temporary
     , text
     , text-class
     , time

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -134,8 +134,6 @@ import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Applicative
     ( Const (..) )
-import Control.Concurrent
-    ( forkFinally )
 import Control.Monad
     ( forM_, void )
 import Control.Tracer
@@ -174,6 +172,8 @@ import System.IOManager
     ( withIOManager )
 import Type.Reflection
     ( Typeable )
+import UnliftIO.Concurrent
+    ( forkFinally )
 
 import qualified Cardano.Pool.DB.Sqlite as Pool
 import qualified Cardano.Wallet.Api.Server as Server

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -141,8 +141,6 @@ import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Chan
     ( newChan, readChan, writeChan )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, newMVar, putMVar, readMVar, takeMVar )
 import Control.Monad
     ( forM, forM_, replicateM, replicateM_, unless, void, when, (>=>) )
 import Control.Monad.Fail
@@ -234,6 +232,8 @@ import UnliftIO.Async
     ( async, link, race )
 import UnliftIO.Exception
     ( SomeException, finally, handle, throwIO )
+import UnliftIO.MVar
+    ( MVar, modifyMVar, newMVar, putMVar, readMVar, takeMVar )
 
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Legacy

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -139,14 +139,10 @@ import Control.Arrow
     ( first, second )
 import Control.Concurrent
     ( threadDelay )
-import Control.Concurrent.Async
-    ( async, link, race )
 import Control.Concurrent.Chan
     ( newChan, readChan, writeChan )
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, newMVar, putMVar, readMVar, takeMVar )
-import Control.Exception
-    ( SomeException, finally, handle, throwIO )
 import Control.Monad
     ( forM, forM_, replicateM, replicateM_, unless, void, when, (>=>) )
 import Control.Monad.Fail
@@ -234,6 +230,10 @@ import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.StaticServer
     ( withStaticServer )
+import UnliftIO.Async
+    ( async, link, race )
+import UnliftIO.Exception
+    ( SomeException, finally, handle, throwIO )
 
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Legacy

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -222,8 +222,6 @@ import System.IO.Temp
     ( createTempDirectory, getCanonicalTemporaryDirectory, withTempDirectory )
 import System.IO.Unsafe
     ( unsafePerformIO )
-import System.Process
-    ( readProcess, readProcessWithExitCode )
 import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.StaticServer
@@ -234,6 +232,8 @@ import UnliftIO.Exception
     ( SomeException, finally, handle, throwIO )
 import UnliftIO.MVar
     ( MVar, modifyMVar, newMVar, putMVar, readMVar, takeMVar )
+import UnliftIO.Process
+    ( readProcess, readProcessWithExitCode )
 
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Legacy

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -137,10 +137,6 @@ import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeRunExceptT )
 import Control.Arrow
     ( first, second )
-import Control.Concurrent
-    ( threadDelay )
-import Control.Concurrent.Chan
-    ( newChan, readChan, writeChan )
 import Control.Monad
     ( forM, forM_, replicateM, replicateM_, unless, void, when, (>=>) )
 import Control.Monad.Fail
@@ -228,6 +224,10 @@ import Test.Utils.StaticServer
     ( withStaticServer )
 import UnliftIO.Async
     ( async, link, race )
+import UnliftIO.Chan
+    ( newChan, readChan, writeChan )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( SomeException, finally, handle, throwIO )
 import UnliftIO.MVar

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -165,7 +165,7 @@ import Data.Fixed
 import Data.Function
     ( (&) )
 import Data.Functor
-    ( ($>) )
+    ( ($>), (<&>) )
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.List
@@ -553,10 +553,9 @@ defaultPoolConfigs =
     ]
 
 poolConfigsFromEnv :: IO [PoolConfig]
-poolConfigsFromEnv = lookupEnv "NO_POOLS" >>= \case
-    Nothing -> pure defaultPoolConfigs
-    Just "" -> pure defaultPoolConfigs
-    Just _ -> pure []
+poolConfigsFromEnv = isEnvSet "NO_POOLS" <&> \case
+    False -> defaultPoolConfigs
+    True -> []
 
 data RunningNode = RunningNode
     FilePath

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -80,16 +80,10 @@ import Control.Applicative
     ( liftA3 )
 import Control.Concurrent
     ( ThreadId )
-import Control.Concurrent.Async
-    ( Async, async, asyncThreadId, cancel, link )
 import Control.Concurrent.Chan
     ( Chan, dupChan, newChan, readChan, writeChan )
-import Control.Exception
-    ( IOException )
 import Control.Monad
     ( forever, unless, void, when, (>=>) )
-import Control.Monad.Catch
-    ( Handler (..) )
 import Control.Monad.Class.MonadAsync
     ( MonadAsync )
 import Control.Monad.Class.MonadST
@@ -247,6 +241,12 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Type
     ( LocalTxSubmission, SubmitResult (..) )
 import System.IO.Error
     ( isDoesNotExistError )
+import UnliftIO.Async
+    ( Async, async, asyncThreadId, cancel, link )
+import UnliftIO.Compat
+    ( coerceHandlers )
+import UnliftIO.Exception
+    ( Handler (..), IOException )
 
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
@@ -1111,7 +1111,7 @@ connectClient tr handlers client vData addr = withIOManager $ \iocp -> do
             , nctHandshakeTracer = contramap MsgHandshakeTracer tr
             }
     let socket = localSnocket iocp addr
-    recovering policy handlers $ \status -> do
+    recovering policy (coerceHandlers handlers) $ \status -> do
         traceWith tr $ MsgCouldntConnect (rsIterNumber status)
         connectTo socket tracers versions addr
   where

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -78,10 +78,6 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Control.Applicative
     ( liftA3 )
-import Control.Concurrent
-    ( ThreadId )
-import Control.Concurrent.Chan
-    ( Chan, dupChan, newChan, readChan, writeChan )
 import Control.Monad
     ( forever, unless, void, when, (>=>) )
 import Control.Monad.Class.MonadAsync
@@ -243,8 +239,12 @@ import System.IO.Error
     ( isDoesNotExistError )
 import UnliftIO.Async
     ( Async, async, asyncThreadId, cancel, link )
+import UnliftIO.Chan
+    ( Chan, dupChan, newChan, readChan, writeChan )
 import UnliftIO.Compat
     ( coerceHandlers )
+import UnliftIO.Concurrent
+    ( ThreadId )
 import UnliftIO.Exception
     ( Handler (..), IOException )
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -115,14 +115,8 @@ import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
 import Control.Concurrent
     ( forkFinally, threadDelay )
-import Control.Exception
-    ( AsyncException (..)
-    , SomeException (..)
-    , asyncExceptionFromException
-    , bracket
-    , finally
-    , mask_
-    )
+import Control.Exception.Base
+    ( AsyncException (..), asyncExceptionFromException )
 import Control.Monad
     ( forM, forM_, forever, void, when )
 import Control.Monad.IO.Class
@@ -177,6 +171,8 @@ import Ouroboros.Consensus.Cardano.Block
     ( CardanoBlock, HardForkBlock (..) )
 import System.Random
     ( RandomGen, random )
+import UnliftIO.Exception
+    ( SomeException (..), bracket, finally, mask_ )
 
 import qualified Cardano.Wallet.Api.Types as Api
 import qualified Data.List as L

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -552,14 +552,14 @@ monitorStakePools tr (NetworkParameters gp sp _pp) nl DBLayer{..} =
             let followTrace = contramap MsgFollow tr
             let forwardHandler = forward latestGarbageCollectionEpochRef
             follow nl followTrace cursor forwardHandler getHeader >>= \case
-                FollowInterrupted ->
-                    traceWith tr MsgHaltMonitoring
                 FollowFailure ->
                     traceWith tr MsgCrashMonitoring
                 FollowRollback point -> do
                     traceWith tr $ MsgRollingBackTo point
                     liftIO . atomically $ rollbackTo point
                     loop
+                FollowDone ->
+                    traceWith tr MsgHaltMonitoring
 
     GenesisParameters  { getGenesisBlockHash  } = gp
     SlottingParameters { getSecurityParameter } = sp

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -180,7 +180,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import qualified GHC.Conc as STM
+import qualified UnliftIO.STM as STM
 
 --
 -- Stake Pool Layer

--- a/lib/shelley/test/integration/Cardano/Wallet/Shelley/Faucet.hs
+++ b/lib/shelley/test/integration/Cardano/Wallet/Shelley/Faucet.hs
@@ -8,10 +8,10 @@ module Cardano.Wallet.Shelley.Faucet
 
 import Prelude
 
-import Control.Concurrent.MVar
-    ( newMVar )
 import Test.Integration.Faucet
     ( Faucet (..), icaMnemonics, mirMnemonics, rndMnemonics, seqMnemonics )
+import UnliftIO.MVar
+    ( newMVar )
 
 initFaucet :: IO Faucet
 initFaucet = Faucet

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -76,11 +76,9 @@ import Cardano.Wallet.Shelley.Launch
 import Control.Arrow
     ( first )
 import Control.Concurrent.Async
-    ( AsyncCancelled, race )
+    ( AsyncCancelled )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
-import Control.Exception
-    ( SomeException, fromException, handle, throwIO )
 import Control.Monad
     ( when )
 import Control.Monad.IO.Class
@@ -115,6 +113,10 @@ import Test.Integration.Framework.Context
     ( Context (..), PoolGarbageCollectionEvent (..) )
 import Test.Utils.Paths
     ( inNixBuild )
+import UnliftIO.Async
+    ( race )
+import UnliftIO.Exception
+    ( SomeException, fromException, handle, throwIO )
 
 import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.Pool.DB as Pool

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -71,7 +71,6 @@ import Cardano.Wallet.Shelley.Launch
     , withCluster
     , withSMASH
     , withSystemTempDir
-    , withTempDir
     )
 import Control.Arrow
     ( first )
@@ -95,6 +94,8 @@ import Network.HTTP.Client
     , newManager
     , responseTimeoutMicro
     )
+import System.Directory
+    ( createDirectory )
 import System.FilePath
     ( (</>) )
 import System.IO
@@ -282,9 +283,11 @@ specWithServer (tr, tracers) = aroundAll withContext
 
 
     onClusterStart action dir dbDecorator node = do
+        let db = dir </> "wallets"
+        createDirectory db
         -- NOTE: We may want to keep a wallet running across the fork, but
         -- having three callbacks like this might not work well for that.
-        withTempDir tr' dir "wallets" $ \db -> handle onClusterExit $
+        handle onClusterExit $
             serveWallet
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
                 tracers

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -75,8 +75,6 @@ import Cardano.Wallet.Shelley.Launch
     )
 import Control.Arrow
     ( first )
-import Control.Concurrent.Async
-    ( AsyncCancelled )
 import Control.Monad
     ( when )
 import Control.Monad.IO.Class
@@ -113,6 +111,8 @@ import Test.Utils.Paths
     ( inNixBuild )
 import UnliftIO.Async
     ( race )
+import UnliftIO.Compat
+    ( AsyncCancelled )
 import UnliftIO.Exception
     ( SomeException, fromException, handle, throwIO )
 import UnliftIO.MVar

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -77,8 +77,6 @@ import Control.Arrow
     ( first )
 import Control.Concurrent.Async
     ( AsyncCancelled )
-import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, takeMVar )
 import Control.Monad
     ( when )
 import Control.Monad.IO.Class
@@ -117,6 +115,8 @@ import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
     ( SomeException, fromException, handle, throwIO )
+import UnliftIO.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
 
 import qualified Cardano.BM.Backend.EKGView as EKG
 import qualified Cardano.Pool.DB as Pool

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -24,8 +24,6 @@ import Cardano.Wallet.Shelley.Network
     ( Observer (..), ObserverLog (..), newObserver, withNetworkLayer )
 import Control.Applicative
     ( (<*) )
-import Control.Concurrent.MVar
-    ( newEmptyMVar, putMVar, takeMVar )
 import Control.Concurrent.STM
     ( atomically )
 import Control.Concurrent.STM.TVar
@@ -48,6 +46,8 @@ import Test.QuickCheck.Monadic
     ( PropertyM, assert, monadicIO, monitor, run )
 import UnliftIO.Async
     ( async, race_, waitAnyCancel )
+import UnliftIO.MVar
+    ( newEmptyMVar, putMVar, takeMVar )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -24,10 +24,6 @@ import Cardano.Wallet.Shelley.Network
     ( Observer (..), ObserverLog (..), newObserver, withNetworkLayer )
 import Control.Applicative
     ( (<*) )
-import Control.Concurrent.STM
-    ( atomically )
-import Control.Concurrent.STM.TVar
-    ( TVar, newTVarIO, readTVar, writeTVar )
 import Control.Monad
     ( mapM_, replicateM, unless, void )
 import Control.Tracer
@@ -48,6 +44,8 @@ import UnliftIO.Async
     ( async, race_, waitAnyCancel )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, takeMVar )
+import UnliftIO.STM
+    ( TVar, atomically, newTVarIO, readTVar, writeTVar )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -24,8 +24,6 @@ import Cardano.Wallet.Shelley.Network
     ( Observer (..), ObserverLog (..), newObserver, withNetworkLayer )
 import Control.Applicative
     ( (<*) )
-import Control.Concurrent.Async
-    ( async, race_, waitAnyCancel )
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 import Control.Concurrent.STM
@@ -48,6 +46,8 @@ import Test.QuickCheck
     ( counterexample, property )
 import Test.QuickCheck.Monadic
     ( PropertyM, assert, monadicIO, monitor, run )
+import UnliftIO.Async
+    ( async, race_, waitAnyCancel )
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -47,6 +47,7 @@ library
     , stm
     , template-haskell
     , time
+    , unliftio
     , wai-app-static
     , warp
   hs-source-dirs:

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -44,7 +44,6 @@ library
     , QuickCheck
     , quickcheck-classes
     , say
-    , stm
     , template-haskell
     , time
     , unliftio
@@ -77,10 +76,11 @@ test-suite unit
     ghc-options: -O2 -Werror
   build-depends:
       base
-    , hspec
-    , silently
-    , hspec-core
     , cardano-wallet-test-utils
+    , hspec
+    , hspec-core
+    , silently
+    , unliftio
   build-tools:
       hspec-discover
   type:

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -31,7 +31,6 @@ library
   build-depends:
       base
     , aeson
-    , async
     , contra-tracer
     , filepath
     , file-embed
@@ -40,10 +39,11 @@ library
     , hspec-expectations
     , hspec-golden-aeson
     , http-api-data
+    , HUnit
     , iohk-monitoring
-    , process
     , QuickCheck
     , quickcheck-classes
+    , say
     , stm
     , template-haskell
     , time

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -22,11 +22,9 @@ import Prelude
 import Control.Concurrent
     ( threadDelay )
 import Control.Concurrent.Async
-    ( AsyncCancelled, async, race, wait )
+    ( AsyncCancelled )
 import Control.Concurrent.MVar
     ( MVar, newEmptyMVar, putMVar, takeMVar )
-import Control.Exception
-    ( SomeException, catch, throwIO )
 import System.Environment
     ( lookupEnv )
 import Test.Hspec
@@ -42,6 +40,10 @@ import Test.Hspec
     , pendingWith
     , specify
     )
+import UnliftIO.Async
+    ( async, race, wait )
+import UnliftIO.Exception
+    ( SomeException, catch, throwIO )
 
 -- | Run a 'bracket' resource acquisition function around all the specs. The
 -- bracket opens before the first test case and closes after the last test case.

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -18,8 +18,6 @@ module Test.Hspec.Extra
 
 import Prelude
 
-import Control.Concurrent
-    ( threadDelay )
 import Control.Monad
     ( void )
 import Say
@@ -42,6 +40,8 @@ import Test.HUnit.Lang
     ( HUnitFailure (..), assertFailure, formatFailureReason )
 import UnliftIO.Async
     ( async, race, wait )
+import UnliftIO.Concurrent
+    ( threadDelay )
 import UnliftIO.Exception
     ( catch, finally, throwIO, throwString )
 import UnliftIO.MVar

--- a/lib/test-utils/src/Test/Utils/Trace.hs
+++ b/lib/test-utils/src/Test/Utils/Trace.hs
@@ -16,10 +16,10 @@ import Prelude
 
 import Cardano.BM.Trace
     ( traceInTVarIO )
-import Control.Concurrent.STM.TVar
-    ( newTVarIO, readTVarIO )
 import Control.Tracer
     ( Tracer )
+import UnliftIO.STM
+    ( newTVarIO, readTVarIO )
 
 -- | Run an action with a logging 'Trace' object, and a function to get all
 -- messages that have been traced.

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -19,8 +19,6 @@ module Test.Utils.Windows
 
 import Prelude
 
-import Control.Exception
-    ( IOException, handle, throwIO )
 import Control.Monad
     ( when )
 import System.Exit
@@ -33,6 +31,8 @@ import Test.Hspec.Core.Spec
     ( ResultStatus (..), pendingWith )
 import Test.Hspec.Expectations
     ( Expectation, HasCallStack )
+import UnliftIO.Exception
+    ( IOException, handle, throwIO )
 
 skipOnWindows :: HasCallStack => String -> Expectation
 skipOnWindows _reason = whenWindows $ throwIO Success

--- a/lib/test-utils/src/Test/Utils/Windows.hs
+++ b/lib/test-utils/src/Test/Utils/Windows.hs
@@ -25,14 +25,14 @@ import System.Exit
     ( ExitCode (..) )
 import System.Info
     ( os )
-import System.Process
-    ( readProcessWithExitCode )
 import Test.Hspec.Core.Spec
     ( ResultStatus (..), pendingWith )
 import Test.Hspec.Expectations
     ( Expectation, HasCallStack )
 import UnliftIO.Exception
     ( IOException, handle, throwIO )
+import UnliftIO.Process
+    ( readProcessWithExitCode )
 
 skipOnWindows :: HasCallStack => String -> Expectation
 skipOnWindows _reason = whenWindows $ throwIO Success

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -2,8 +2,6 @@ module Test.Hspec.ExtraSpec where
 
 import Prelude
 
-import Control.Concurrent
-    ( threadDelay )
 import Data.IORef
     ( IORef, newIORef, readIORef, writeIORef )
 import Data.List
@@ -24,6 +22,8 @@ import Test.Hspec
     )
 import Test.Hspec.Core.Runner
     ( defaultConfig, runSpec )
+import UnliftIO.Concurrent
+    ( threadDelay )
 
 import qualified Test.Hspec.Extra as Extra
 

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -89,6 +89,7 @@ spec = do
         stripTime = unlines
                 . filter (not . ("Finished in" `isPrefixOf`))
                 . filter (not . ("Randomized" `isPrefixOf`))
+                . filter (not . ("retry:" `isPrefixOf`))
                 . lines
 
     -- | Returns an IO action that is different every time you run it!,

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2020.12.8"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2020.12.21"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -29,7 +29,6 @@
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."aeson-pretty" or (errorHandler.buildDepError "aeson-pretty"))
           (hsPkgs."ansi-terminal" or (errorHandler.buildDepError "ansi-terminal"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
@@ -41,12 +40,13 @@
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
           (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
           (hsPkgs."servant-client-core" or (errorHandler.buildDepError "servant-client-core"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
-          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
           ];
         buildable = true;
         };
@@ -61,9 +61,9 @@
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2020.12.21"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2020.12.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2020.12.8";
+        version = "2020.12.21";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
@@ -33,7 +33,6 @@
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
           (hsPkgs."aeson-qq" or (errorHandler.buildDepError "aeson-qq"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
           (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
@@ -52,7 +51,6 @@
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
@@ -71,12 +69,12 @@
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."say" or (errorHandler.buildDepError "say"))
           (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
-          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
-          (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
           ];
         buildable = true;
         };

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2020.12.21";
+        version = "2020.12.8";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2020.12.21"; };
+      identifier = { name = "cardano-wallet-core"; version = "2020.12.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -76,7 +76,6 @@
           (hsPkgs."persistent-sqlite" or (errorHandler.buildDepError "persistent-sqlite"))
           (hsPkgs."persistent-template" or (errorHandler.buildDepError "persistent-template"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
-          (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))
           (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."random-shuffle" or (errorHandler.buildDepError "random-shuffle"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
@@ -91,7 +90,6 @@
           (hsPkgs."statistics" or (errorHandler.buildDepError "statistics"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."streaming-commons" or (errorHandler.buildDepError "streaming-commons"))
-          (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
           (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
@@ -110,8 +108,6 @@
           (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
           (hsPkgs."x509-validation" or (errorHandler.buildDepError "x509-validation"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
-          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-          (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
           ];
         buildable = true;
         };
@@ -146,7 +142,6 @@
             (hsPkgs."generic-arbitrary" or (errorHandler.buildDepError "generic-arbitrary"))
             (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
-            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
@@ -162,7 +157,6 @@
             (hsPkgs."OddWord" or (errorHandler.buildDepError "OddWord"))
             (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-            (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
             (hsPkgs."quickcheck-state-machine" or (errorHandler.buildDepError "quickcheck-state-machine"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
@@ -170,12 +164,9 @@
             (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
             (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
             (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
-            (hsPkgs."should-not-typecheck" or (errorHandler.buildDepError "should-not-typecheck"))
             (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
-            (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
             (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
             (hsPkgs."servant-openapi3" or (errorHandler.buildDepError "servant-openapi3"))
-            (hsPkgs."string-qq" or (errorHandler.buildDepError "string-qq"))
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2020.12.8"; };
+      identifier = { name = "cardano-wallet-core"; version = "2020.12.21"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -75,12 +75,11 @@
           (hsPkgs."persistent" or (errorHandler.buildDepError "persistent"))
           (hsPkgs."persistent-sqlite" or (errorHandler.buildDepError "persistent-sqlite"))
           (hsPkgs."persistent-template" or (errorHandler.buildDepError "persistent-template"))
-          (hsPkgs."process" or (errorHandler.buildDepError "process"))
+          (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))
           (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."random-shuffle" or (errorHandler.buildDepError "random-shuffle"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
-          (hsPkgs."safe-exceptions" or (errorHandler.buildDepError "safe-exceptions"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
           (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
           (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
@@ -88,8 +87,8 @@
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
           (hsPkgs."split" or (errorHandler.buildDepError "split"))
           (hsPkgs."statistics" or (errorHandler.buildDepError "statistics"))
-          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."streaming-commons" or (errorHandler.buildDepError "streaming-commons"))
+          (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
           (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
@@ -99,6 +98,7 @@
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."wai" or (errorHandler.buildDepError "wai"))
@@ -108,6 +108,8 @@
           (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
           (hsPkgs."x509-validation" or (errorHandler.buildDepError "x509-validation"))
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
+          (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+          (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
           ];
         buildable = true;
         };
@@ -117,7 +119,6 @@
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
             (hsPkgs."aeson-qq" or (errorHandler.buildDepError "aeson-qq"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
@@ -142,6 +143,7 @@
             (hsPkgs."generic-arbitrary" or (errorHandler.buildDepError "generic-arbitrary"))
             (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
             (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
@@ -157,6 +159,7 @@
             (hsPkgs."OddWord" or (errorHandler.buildDepError "OddWord"))
             (hsPkgs."ouroboros-consensus" or (errorHandler.buildDepError "ouroboros-consensus"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
+            (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
             (hsPkgs."quickcheck-state-machine" or (errorHandler.buildDepError "quickcheck-state-machine"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
@@ -164,9 +167,11 @@
             (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
             (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
             (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+            (hsPkgs."should-not-typecheck" or (errorHandler.buildDepError "should-not-typecheck"))
+            (hsPkgs."strict-non-empty-containers" or (errorHandler.buildDepError "strict-non-empty-containers"))
             (hsPkgs."openapi3" or (errorHandler.buildDepError "openapi3"))
             (hsPkgs."servant-openapi3" or (errorHandler.buildDepError "servant-openapi3"))
+            (hsPkgs."string-qq" or (errorHandler.buildDepError "string-qq"))
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
@@ -174,6 +179,7 @@
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."tree-diff" or (errorHandler.buildDepError "tree-diff"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
             (hsPkgs."x509" or (errorHandler.buildDepError "x509"))
             (hsPkgs."x509-store" or (errorHandler.buildDepError "x509-store"))
@@ -212,6 +218,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           buildable = true;
           };

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,7 +11,10 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2020.12.8"; };
+      identifier = {
+        name = "cardano-wallet-launcher";
+        version = "2020.12.21";
+        };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -27,11 +30,10 @@
       "library" = {
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
-          (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."code-page" or (errorHandler.buildDepError "code-page"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
@@ -39,6 +41,8 @@
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
           ] ++ (if system.isWindows
           then [ (hsPkgs."Win32" or (errorHandler.buildDepError "Win32")) ]
           else [ (hsPkgs."unix" or (errorHandler.buildDepError "unix")) ]);
@@ -48,7 +52,6 @@
         "unit" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
@@ -63,6 +66,7 @@
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,10 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = {
-        name = "cardano-wallet-launcher";
-        version = "2020.12.21";
-        };
+      identifier = { name = "cardano-wallet-launcher"; version = "2020.12.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2020.12.21";
+        version = "2020.12.8";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
@@ -43,7 +43,6 @@
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-          (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
           (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2020.12.8";
+        version = "2020.12.21";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
@@ -31,7 +31,6 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."file-embed" or (errorHandler.buildDepError "file-embed"))
@@ -40,12 +39,14 @@
           (hsPkgs."hspec-expectations" or (errorHandler.buildDepError "hspec-expectations"))
           (hsPkgs."hspec-golden-aeson" or (errorHandler.buildDepError "hspec-golden-aeson"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
+          (hsPkgs."HUnit" or (errorHandler.buildDepError "HUnit"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
-          (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
-          (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
+          (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
+          (hsPkgs."say" or (errorHandler.buildDepError "say"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
           (hsPkgs."wai-app-static" or (errorHandler.buildDepError "wai-app-static"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
           ];
@@ -55,10 +56,11 @@
         "unit" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
-            (hsPkgs."silently" or (errorHandler.buildDepError "silently"))
-            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
+            (hsPkgs."silently" or (errorHandler.buildDepError "silently"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2020.12.21"; };
+      identifier = { name = "cardano-wallet"; version = "2020.12.8"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2020.12.8"; };
+      identifier = { name = "cardano-wallet"; version = "2020.12.21"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -28,7 +28,6 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-          (hsPkgs."async" or (errorHandler.buildDepError "async"))
           (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
           (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
           (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
@@ -52,7 +51,6 @@
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
-          (hsPkgs."exceptions" or (errorHandler.buildDepError "exceptions"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
@@ -70,7 +68,6 @@
           (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
           (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
           (hsPkgs."ouroboros-network-framework" or (errorHandler.buildDepError "ouroboros-network-framework"))
-          (hsPkgs."process" or (errorHandler.buildDepError "process"))
           (hsPkgs."random" or (errorHandler.buildDepError "random"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
@@ -80,6 +77,8 @@
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+          (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
+          (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
           (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           (hsPkgs."vector" or (errorHandler.buildDepError "vector"))
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
@@ -130,7 +129,6 @@
         "unit" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."base58-bytestring" or (errorHandler.buildDepError "base58-bytestring"))
             (hsPkgs."bech32" or (errorHandler.buildDepError "bech32"))
             (hsPkgs."bech32-th" or (errorHandler.buildDepError "bech32-th"))
@@ -151,10 +149,10 @@
             (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))
             (hsPkgs."ouroboros-network" or (errorHandler.buildDepError "ouroboros-network"))
             (hsPkgs."shelley-spec-ledger" or (errorHandler.buildDepError "shelley-spec-ledger"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             ];
           build-tools = [
@@ -165,7 +163,6 @@
         "integration" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
@@ -173,6 +170,8 @@
             (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
+            (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+            (hsPkgs."either" or (errorHandler.buildDepError "either"))
             (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))
@@ -180,6 +179,7 @@
             (hsPkgs."lobemo-backend-ekg" or (errorHandler.buildDepError "lobemo-backend-ekg"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.cardano-wallet or (pkgs.buildPackages.cardano-wallet or (errorHandler.buildToolDepError "cardano-wallet")))
@@ -203,11 +203,11 @@
             (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."say" or (errorHandler.buildDepError "say"))
-            (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
             (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           buildable = true;
           };
@@ -215,7 +215,6 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
-            (hsPkgs."async" or (errorHandler.buildDepError "async"))
             (hsPkgs."cardano-wallet-cli" or (errorHandler.buildDepError "cardano-wallet-cli"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-core-integration" or (errorHandler.buildDepError "cardano-wallet-core-integration"))
@@ -228,8 +227,8 @@
             (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
-            (hsPkgs."stm" or (errorHandler.buildDepError "stm"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             ];
           buildable = true;
           };

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,6 +5,9 @@
         "OddWord" = (((hackage.OddWord)."1.0.2.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
         "wai-extra" = (((hackage.wai-extra)."3.0.29.1").revisions).default;
+        "primitive-addr" = (((hackage.primitive-addr)."0.1.0.2").revisions).default;
+        "quickcheck-classes" = (((hackage.quickcheck-classes)."0.6.4.0").revisions).default;
+        "quickcheck-classes-base" = (((hackage.quickcheck-classes-base)."0.6.1.0").revisions).default;
         "servant" = (((hackage.servant)."0.17").revisions).default;
         "servant-server" = (((hackage.servant-server)."0.17").revisions).default;
         "servant-client-core" = (((hackage.servant-client-core)."0.17").revisions).default;
@@ -94,6 +97,7 @@
         text-class = ./text-class.nix;
         cardano-wallet-test-utils = ./cardano-wallet-test-utils.nix;
         cardano-wallet = ./cardano-wallet.nix;
+        strict-non-empty-containers = ./strict-non-empty-containers.nix;
         persistent = ./persistent.nix;
         persistent-sqlite = ./persistent-sqlite.nix;
         persistent-template = ./persistent-template.nix;

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,9 +5,6 @@
         "OddWord" = (((hackage.OddWord)."1.0.2.0").revisions).default;
         "command" = (((hackage.command)."0.1.1").revisions).default;
         "wai-extra" = (((hackage.wai-extra)."3.0.29.1").revisions).default;
-        "primitive-addr" = (((hackage.primitive-addr)."0.1.0.2").revisions).default;
-        "quickcheck-classes" = (((hackage.quickcheck-classes)."0.6.4.0").revisions).default;
-        "quickcheck-classes-base" = (((hackage.quickcheck-classes-base)."0.6.1.0").revisions).default;
         "servant" = (((hackage.servant)."0.17").revisions).default;
         "servant-server" = (((hackage.servant-server)."0.17").revisions).default;
         "servant-client-core" = (((hackage.servant-client-core)."0.17").revisions).default;
@@ -97,7 +94,6 @@
         text-class = ./text-class.nix;
         cardano-wallet-test-utils = ./cardano-wallet-test-utils.nix;
         cardano-wallet = ./cardano-wallet.nix;
-        strict-non-empty-containers = ./strict-non-empty-containers.nix;
         persistent = ./persistent.nix;
         persistent-sqlite = ./persistent-sqlite.nix;
         persistent-template = ./persistent-template.nix;

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2020.12.21"; };
+      identifier = { name = "text-class"; version = "2020.12.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2020.12.8"; };
+      identifier = { name = "text-class"; version = "2020.12.21"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";


### PR DESCRIPTION
### Issue Number

Probably

### Overview

It turns out that the `Control.Exception.bracket` function isn't very safe to use with async code. The reason is the bracket cleanup handler may be interrupted by async exceptions, and if that happens, then cleanup action may not be done.

I am wondering whether this may be the cause of some test flakiness. Also I wonder whether cleanup handlers are the cause of deadlocking tests.

This change replaces `Control.Exception` with `UnliftIO.Exception` - the "async safe" variant.

The other benefit of `MonadUnliftIO` is that it provides "unlift" for functions of the form `withFoo :: (foo -> IO a) -> IO a` -- i.e. it lets you replace `IO` with other kinds of `m`.

Docs here: https://github.com/fpco/unliftio/tree/master/unliftio#readme

So it may fix flaky tests and/or help to avoid future concurrency bugs.

### Comments

- Most changes are replacing `Control.Exception` with `UnliftIO.Exception` and `Control.Concurrent.Async` with `UnliftIO.Async`.
- The `MonadCatch` class is replaced with `MonadUnliftIO`.
- As mentioned in the UnliftIO readme, we lose the `MonadCatch` instance for `Either` - not a bad thing really.
- The use of `MonadFail` was removed, and that was a good thing.
