### PR TITLE
Tweak genesis params to make integration tests almost twice as fast

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -597,7 +597,7 @@ securityParameterValue = 10
 
 -- | Parameter in test cluster genesis.
 epochLengthValue :: Word32
-epochLengthValue = 200
+epochLengthValue = 50
 
 -- | Wallet server's chosen transaction TTL value (in seconds) when none is
 -- given.

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -583,19 +583,17 @@ walletId =
 minUTxOValue :: Natural
 minUTxOValue = 1_000_000
 
--- | Parameter in test cluster genesis.
+-- | Parameter in test cluster shelley genesis.
 --
--- FIXME: Adding this line to create a merge-conflict with #2391 to remind
--- whoever resolving this merge conflict to also update the newly introduced
--- 'securityParameterValue'. Cheers.
+-- This space left blank intentionally.
 slotLengthValue :: NominalDiffTime
 slotLengthValue =  0.2
 
--- | Parameter in test cluster genesis.
+-- | Parameter in test cluster shelley genesis.
 securityParameterValue :: Word32
-securityParameterValue = 10
+securityParameterValue = 5
 
--- | Parameter in test cluster genesis.
+-- | Parameter in test cluster shelley genesis.
 epochLengthValue :: Word32
 epochLengthValue = 50
 

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -336,7 +336,7 @@ import Numeric.Natural
     ( Natural )
 import Prelude
 import System.Command
-    ( CmdResult, Stderr, Stdout (..), command )
+    ( CmdOption (..), CmdResult, Stderr, Stdout (..), command )
 import System.Directory
     ( doesPathExist )
 import System.Exit
@@ -1884,7 +1884,7 @@ cardanoWalletCLI
     :: forall r m. (CmdResult r, MonadIO m)
     => [String]
     -> m r
-cardanoWalletCLI = liftIO . command [] commandName
+cardanoWalletCLI = liftIO . command [EchoStderr False] commandName
 
 generateMnemonicsViaCLI
     :: forall r m. (CmdResult r, MonadIO m)

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -84,6 +84,8 @@ import Control.Monad
     ( ap, join, liftM, (>=>) )
 import Control.Monad.IO.Class
     ( MonadIO, liftIO )
+import Control.Monad.Trans.Class
+    ( lift )
 import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Control.Tracer

--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -31,6 +31,7 @@ module Cardano.Wallet.Primitive.Slotting
     , getStartTime
     , querySlotLength
     , queryEpochLength
+    , timeUntilEpoch
 
       -- ** Blockchain-relative times
     , RelativeTime
@@ -108,7 +109,7 @@ import Fmt
 import GHC.Stack
     ( CallStack, HasCallStack, getCallStack, prettySrcLoc )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
-    ( RelativeTime (..), SystemStart (..), addRelTime )
+    ( RelativeTime (..), SystemStart (..), addRelTime, diffRelTime )
 import Ouroboros.Consensus.HardFork.History.Qry
     ( Expr (..)
     , Interpreter
@@ -322,6 +323,13 @@ slotRangeFromTimeRange :: Range UTCTime -> Qry (Maybe (Range SlotNo))
 slotRangeFromTimeRange range = mapM slotRangeFromRelativeTimeRange
     =<< (toRelativeTimeRange range <$> getStartTime)
 
+-- | Returns the @NominalDiffTime@ to reach the start of the given epoch, or 0
+-- if it already passed.
+timeUntilEpoch :: EpochNo -> RelativeTime -> Qry NominalDiffTime
+timeUntilEpoch e tNow = do
+    tEpoch <- slotToRelTime =<< firstSlotInEpoch e
+    return $ max 0 $ tEpoch `diffRelTime` tNow
+
 {-------------------------------------------------------------------------------
                             Blockchain-relative time
 -------------------------------------------------------------------------------}
@@ -486,14 +494,15 @@ mkSingleEraInterpreter start sp = TimeInterpreter
 -- | Set up a 'TimeInterpreter' for a given start time, and an 'Interpreter'
 -- queried from the ledger layer.
 mkTimeInterpreter
-    :: Tracer IO TimeInterpreterLog
+    :: Monad m
+    => Tracer m TimeInterpreterLog
     -> StartTime
-    -> IO (Interpreter eras)
-    -> TimeInterpreter (ExceptT PastHorizonException IO)
+    -> m (Interpreter eras)
+    -> TimeInterpreter (ExceptT PastHorizonException m)
 mkTimeInterpreter tr start int = TimeInterpreter
-    { interpreter = liftIO int
+    { interpreter = lift int
     , blockchainStartTime = start
-    , tracer = natTracer liftIO tr
+    , tracer = natTracer lift tr
     , handleResult = ExceptT . pure
     }
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -71,6 +71,8 @@ module Cardano.Wallet.Primitive.Types
     , SlotLength (..)
     , SlotInEpoch (..)
     , StartTime (..)
+    , stabilityWindowByron
+    , stabilityWindowShelley
 
     -- * Wallet Metadata
     , WalletMetadata(..)
@@ -928,26 +930,41 @@ data SlottingParameters = SlottingParameters
     , getActiveSlotCoefficient :: ActiveSlotCoefficient
         -- ^ a.k.a 'f', in Genesis/Praos, corresponds to the % of active slots
         -- (i.e. slots for which someone can be elected as leader).
+        --
+        -- Determines the value of 'stabilityWindowShelley'.
+
     , getSecurityParameter :: Quantity "block" Word32
         -- ^ a.k.a 'k', used to compute the 'stability window' on the chain
         -- (i.e. the longest possible chain fork in slots).
         --
-        -- In Byron, this stability window is equal to 2k slots
-        -- In Shelley, this stability window is equal to 3k/f slots
-        --
-        -- where 'f' is the active slot coefficient.
+        -- Determines the value of 'stabilityWindowByron' and
+        -- 'stabilityWindowShelley'.
     } deriving (Generic, Show, Eq)
 
 instance NFData SlottingParameters
 
+-- | In Byron, this stability window is equal to 2k slots, where _k_ is the
+--  'getSecurityParameter'
+stabilityWindowByron :: SlottingParameters -> Quantity "block" Word64
+stabilityWindowByron sp = Quantity (2 * k)
+  where
+    k = fromIntegral $ getQuantity $ getSecurityParameter sp
+
+-- | In Shelley, this stability window is equal to _3k/f_ slots where _k_ is the
+-- 'getSecurityParameter' and _f_ is the 'ActiveSlotCoefficient'.
+stabilityWindowShelley :: SlottingParameters -> Quantity "block" Word64
+stabilityWindowShelley sp = Quantity len
+  where
+    len = ceiling (3 * k / f)
+    k = fromIntegral $ getQuantity $ getSecurityParameter sp
+    f = unActiveSlotCoefficient $ getActiveSlotCoefficient sp
+
 instance Buildable SlottingParameters where
-    build gp = blockListF' "" id
-        [ "Slot length:        " <> slotLengthF (getSlotLength
-            (gp :: SlottingParameters))
-        , "Epoch length:       " <> epochLengthF (getEpochLength
-            (gp :: SlottingParameters))
-        , "Active slot coeff:  " <> build (gp ^. #getActiveSlotCoefficient)
-        , "Security parameter: " <> build (gp ^. #getSecurityParameter)
+    build sp = blockListF' "" id
+        [ "Slot length:        " <> slotLengthF (getSlotLength sp)
+        , "Epoch length:       " <> epochLengthF (getEpochLength sp)
+        , "Active slot coeff:  " <> build (sp ^. #getActiveSlotCoefficient)
+        , "Security parameter: " <> build (sp ^. #getSecurityParameter)
         ]
       where
         slotLengthF (SlotLength s) = build s

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -117,13 +117,13 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , EpochLength (unEpochLength)
     , EpochNo (..)
-    , GenesisParameters (getEpochStability)
     , NetworkParameters (..)
     , PoolId (..)
     , ProtocolMagic (..)
     , SlotLength (..)
     , SlottingParameters (..)
     , StartTime (..)
+    , stabilityWindowByron
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -1899,18 +1899,11 @@ timeInterpreterFromTestingConfig genesisParams dir = do
 
     let startTime = StartTime $ sgSystemStart shelleyGenesis
 
-    let byronSl =
-            unSlotLength $ getSlotLength $ slottingParameters genesisParams
-    let byronEl = getEpochLength $ slottingParameters genesisParams
-    let byronSlotLength =
-            unSlotLength $ getSlotLength $ slottingParameters genesisParams
-    let byronK =
-            SecurityParam
-            . fromIntegral
-            . getQuantity
-            . getEpochStability
-            . genesisParameters
-            $ genesisParams
+    let sp = slottingParameters genesisParams
+    let byronSl = unSlotLength $ getSlotLength sp
+    let byronEl = getEpochLength sp
+    let byronSlotLength = unSlotLength $ getSlotLength sp
+    let byronK = SecurityParam $ getQuantity $ stabilityWindowByron sp
     let byronParams = HF.defaultEraParams byronK (mkSlotLength byronSl)
 
     let shelleyEl = sgEpochLength shelleyGenesis

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -76,7 +76,7 @@ import Cardano.BM.Data.Output
 import Cardano.BM.Data.Severity
     ( Severity (..) )
 import Cardano.BM.Data.Tracer
-    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..) )
+    ( HasPrivacyAnnotation (..), HasSeverityAnnotation (..), nullTracer )
 import Cardano.Chain.Genesis
     ( GenesisData (..), readGenesisData )
 import Cardano.CLI
@@ -89,6 +89,8 @@ import Cardano.Launcher.Node
     , NodePort (..)
     , withCardanoNode
     )
+import Cardano.Ledger.Shelley
+    ( ShelleyEra )
 import Cardano.Pool.Metadata
     ( SMASHPoolId (..) )
 import Cardano.Startup
@@ -103,15 +105,25 @@ import Cardano.Wallet.Network.Ports
     ( randomUnusedTCPPorts )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..), hex )
+import Cardano.Wallet.Primitive.Slotting
+    ( TimeInterpreter
+    , currentRelativeTime
+    , hoistTimeInterpreter
+    , interpretQuery
+    , mkTimeInterpreter
+    , timeUntilEpoch
+    )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
-    , EpochLength (..)
+    , EpochLength (unEpochLength)
     , EpochNo (..)
+    , GenesisParameters (getEpochStability)
     , NetworkParameters (..)
     , PoolId (..)
     , ProtocolMagic (..)
     , SlotLength (..)
     , SlottingParameters (..)
+    , StartTime (..)
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -140,7 +152,7 @@ import Control.Monad
 import Control.Monad.Fail
     ( MonadFail )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), withExceptT )
+    ( ExceptT (..), runExceptT, withExceptT )
 import Control.Retry
     ( constantDelay, limitRetriesByCumulativeDelay, retrying )
 import Control.Tracer
@@ -156,17 +168,23 @@ import Data.ByteString
 import Data.ByteString.Base58
     ( bitcoinAlphabet, decodeBase58 )
 import Data.Either
-    ( isLeft, isRight )
+    ( fromRight, isLeft, isRight )
+import Data.Fixed
+    ( Micro )
 import Data.Function
     ( (&) )
 import Data.Functor
     ( ($>), (<&>) )
+import Data.Functor.Identity
+    ( Identity (..) )
 import Data.List
     ( isInfixOf, isPrefixOf, nub, permutations, sort )
 import Data.Maybe
     ( catMaybes, fromMaybe )
 import Data.Proxy
     ( Proxy (..) )
+import Data.Quantity
+    ( getQuantity )
 import Data.Text
     ( Text )
 import Data.Text.Class
@@ -175,12 +193,20 @@ import Data.Time.Clock
     ( NominalDiffTime, UTCTime, addUTCTime, getCurrentTime )
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime, utcTimeToPOSIXSeconds )
+import Fmt
+    ( fmt, secondsF )
 import GHC.TypeLits
     ( KnownNat, Nat, SomeNat (..), someNatVal )
 import Options.Applicative
     ( Parser, eitherReader, flag', help, long, metavar, option, (<|>) )
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    ( RelativeTime (..), mkSlotLength )
+import Ouroboros.Consensus.Config.SecurityParam
+    ( SecurityParam (..) )
 import Ouroboros.Consensus.Shelley.Node
     ( sgNetworkMagic )
+import Ouroboros.Consensus.Util.Counting
+    ( exactlyTwo )
 import Ouroboros.Network.Magic
     ( NetworkMagic (..) )
 import Ouroboros.Network.NodeToClient
@@ -211,6 +237,7 @@ import Test.Utils.StaticServer
 
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Legacy
+import qualified Cardano.Slotting.Slot as Cardano
 import qualified Cardano.Wallet.Byron.Compatibility as Byron
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Shelley.Compatibility as Shelley
@@ -226,6 +253,9 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
 import qualified Data.Yaml as Yaml
+import qualified Ouroboros.Consensus.HardFork.History.EraParams as HF
+import qualified Ouroboros.Consensus.HardFork.History.Qry as HF
+import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 
 -- | Shelley hard fork network configuration has two genesis datas.
 -- As a special case for mainnet, we hardcode the byron genesis data.
@@ -575,10 +605,9 @@ withCluster tr severity poolConfigs dir logFile onByron onShelley onClusterStart
         withBFTNode tr dir bftCfg $ \bftSocket block0 params -> do
             let runningBftNode = RunningNode bftSocket block0 params
             waitForSocket tr bftSocket *> onByron runningBftNode
-
-            let sp = slottingParameters $ fst params
-            traceWith tr $ MsgWaitingForFork "Byron -> Shelley"
-            waitForHardFork bftSocket sp 1 *> onShelley runningBftNode
+            ti <- timeInterpreterFromTestingConfig (fst params) dir
+            waitForEpoch 1 "Shelley" tr ti
+            onShelley runningBftNode
 
             setEnv "CARDANO_NODE_SOCKET_PATH" bftSocket
             (rawTx, faucetPrv) <- prepareKeyRegistration tr dir
@@ -623,8 +652,7 @@ withCluster tr severity poolConfigs dir logFile onByron onShelley onClusterStart
                     ("cluster didn't start correctly: " <> errors)
                     (ExitFailure 1)
             else do
-                traceWith tr $ MsgWaitingForFork "Shelley -> Allegra"
-                --waitForHardFork bftSocket sp 2
+                waitForEpoch 3 "Allegra" tr ti
                 let cfg = NodeParams severity systemStart (port0, ports) logFile
                 withRelayNode tr dir cfg $ \socket -> do
                     let runningRelay = RunningNode socket block0 params
@@ -637,16 +665,6 @@ withCluster tr severity poolConfigs dir logFile onByron onShelley onClusterStart
     -- [(1,[2,3]), (2, [1,3]), (3, [1,2])]
     rotate :: Ord a => [a] -> [(a, [a])]
     rotate = nub . fmap (\(x:xs) -> (x, sort xs)) . permutations
-
-waitForHardFork :: FilePath -> SlottingParameters -> Int -> IO ()
-waitForHardFork _socket sp epoch = threadDelay (ceiling (1e6 * delay))
-  where
-    delay :: NominalDiffTime
-    delay = slotDur * fromIntegral epLen * fromIntegral epoch + fuzz
-    EpochLength epLen = getEpochLength sp
-    SlotLength slotDur = getSlotLength sp
-    -- add two seconds just to make sure.
-    fuzz = 0
 
 -- | Configuration parameters which update the @node.config@ test data file.
 data NodeParams = NodeParams
@@ -1750,7 +1768,7 @@ withSystemTempDir tr name action = do
 
 data ClusterLog
     = MsgRegisteringStakePools Int -- ^ How many pools
-    | MsgWaitingForFork Text
+    | MsgWaitingForEpoch NominalDiffTime EpochNo Text
     | MsgStartingCluster FilePath
     | MsgLauncher String LauncherLog
     | MsgStartedStaticServer String FilePath
@@ -1770,8 +1788,15 @@ instance ToText ClusterLog where
     toText = \case
         MsgStartingCluster dir ->
             "Configuring cluster in " <> T.pack dir
-        MsgWaitingForFork fork ->
-            "Transitioning from " <> fork <> " ... Please wait 20s..."
+        MsgWaitingForEpoch dt (EpochNo e) thing -> mconcat
+            [ "Waiting "
+            , fmt (secondsF 1 dt) <> "s"
+            , " to reach "
+            , thing
+            , " at epoch "
+            , T.pack (show e)
+            , "..."
+            ]
         MsgRegisteringStakePools 0 -> mconcat
                 [ "Not registering any stake pools due to "
                 , "NO_POOLS=1. Some tests may fail."
@@ -1779,7 +1804,6 @@ instance ToText ClusterLog where
         MsgRegisteringStakePools n -> mconcat
                 [ T.pack (show n)
                 , " stake pools are being registered on chain... "
-                , "Please wait 60s until active... "
                 , "Can be skipped using NO_POOLS=1."
                 ]
         MsgLauncher name msg ->
@@ -1819,7 +1843,7 @@ instance HasSeverityAnnotation ClusterLog where
     getSeverityAnnotation = \case
         MsgStartingCluster _ -> Notice
         MsgRegisteringStakePools _ -> Notice
-        MsgWaitingForFork{} -> Notice
+        MsgWaitingForEpoch{} -> Notice
         MsgLauncher _ _ -> Info
         MsgStartedStaticServer _ _ -> Info
         MsgTempNoCleanup _ -> Notice
@@ -1841,3 +1865,76 @@ instance HasSeverityAnnotation ClusterLog where
 
 bracketTracer' :: Tracer IO ClusterLog -> Text -> IO a -> IO a
 bracketTracer' tr name = bracketTracer (contramap (MsgBracket name) tr)
+
+-- | Wait until the given epoch starts.
+waitForEpoch
+    :: EpochNo -- ^ Epoch (start) to wait for.
+    -> Text -- ^ Thing we're waiting for (for log message).
+    -> Tracer IO ClusterLog
+    -> TimeInterpreter Identity
+    -> IO ()
+waitForEpoch e thing tr ti = do
+    now <- currentRelativeTime ti
+    let delta = runIdentity $ interpretQuery ti (timeUntilEpoch e now)
+    traceWith tr $ MsgWaitingForEpoch delta e thing
+    threadDelay . fromIntegral . fromEnum $ realToFrac @_ @Micro delta
+
+-- | Return a TimeInterpreter based on the genesis files in the cluster setup
+-- directory.
+--
+-- Assumes era parameters are changed at the shelley fork at epoch 1, but that
+-- they are not changed further.
+--
+-- The purpose is to concentrate the assumions about test cluster slotting to
+-- one place, and allow us existing @TimeInterpreter@ queries with it.
+timeInterpreterFromTestingConfig
+    :: NetworkParameters  -- ^ Genesis parameters
+    -> FilePath -- ^ Config dir
+    -> IO (TimeInterpreter Identity)
+timeInterpreterFromTestingConfig genesisParams dir = do
+    (shelleyGenesis :: ShelleyGenesis (ShelleyEra Shelley.StandardCrypto))
+        <- either fail pure
+        =<< Aeson.eitherDecodeFileStrict
+        (dir </> "bft" </> "shelley-genesis.json")
+
+    let startTime = StartTime $ sgSystemStart shelleyGenesis
+
+    let byronSl =
+            unSlotLength $ getSlotLength $ slottingParameters genesisParams
+    let byronEl = getEpochLength $ slottingParameters genesisParams
+    let byronSlotLength =
+            unSlotLength $ getSlotLength $ slottingParameters genesisParams
+    let byronK =
+            SecurityParam
+            . fromIntegral
+            . getQuantity
+            . getEpochStability
+            . genesisParameters
+            $ genesisParams
+    let byronParams = HF.defaultEraParams byronK (mkSlotLength byronSl)
+
+    let shelleyEl = sgEpochLength shelleyGenesis
+    let shelleyK = SecurityParam $ sgSecurityParam shelleyGenesis
+    let shelleySl = sgSlotLength shelleyGenesis
+    let shelleyParams = (HF.defaultEraParams shelleyK (mkSlotLength shelleySl))
+            { HF.eraEpochSize = shelleyEl }
+
+    let shelleyFork = HF.Bound
+            (RelativeTime
+                (fromRational (toRational $ unEpochLength byronEl)
+                * byronSlotLength))
+            (W.SlotNo $ fromIntegral $ unEpochLength byronEl)
+            (Cardano.EpochNo 1)
+
+    let summary = HF.summaryWithExactly $ exactlyTwo
+             (HF.EraSummary HF.initBound (HF.EraEnd shelleyFork) byronParams)
+             (HF.EraSummary shelleyFork (HF.EraUnbounded) shelleyParams)
+
+    return $ hoistTimeInterpreter neverFails' $ mkTimeInterpreter
+        nullTracer
+        startTime
+        (pure @Identity $ HF.mkInterpreter summary)
+  where
+    neverFails' =
+        fmap (fromRight (error "timeInterpreterFromTestingConfig shouldn't fail"))
+        . runExceptT

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -624,7 +624,7 @@ withCluster tr severity poolConfigs dir logFile onByron onShelley onClusterStart
                     (ExitFailure 1)
             else do
                 traceWith tr $ MsgWaitingForFork "Shelley -> Allegra"
-                waitForHardFork bftSocket sp 2
+                --waitForHardFork bftSocket sp 2
                 let cfg = NodeParams severity systemStart (port0, ports) logFile
                 withRelayNode tr dir cfg $ \socket -> do
                     let runningRelay = RunningNode socket block0 params
@@ -646,7 +646,7 @@ waitForHardFork _socket sp epoch = threadDelay (ceiling (1e6 * delay))
     EpochLength epLen = getEpochLength sp
     SlotLength slotDur = getSlotLength sp
     -- add two seconds just to make sure.
-    fuzz = 2
+    fuzz = 0
 
 -- | Configuration parameters which update the @node.config@ test data file.
 data NodeParams = NodeParams

--- a/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
@@ -2,7 +2,7 @@ avvmDistr: {}
 
 blockVersionData:
   scriptVersion: 0
-  slotDuration: '250'
+  slotDuration: '100'
   maxBlockSize: '2000000'
   maxHeaderSize: '2000000'
   maxTxSize: '4096'

--- a/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/byron-genesis.yaml
@@ -21,7 +21,7 @@ blockVersionData:
     multiplier: '43000000000'
   unlockStakeEpoch: '18446744073709551615'
 protocolConsts:
-  k: 8
+  k: 5
   protocolMagic: 764824073
 
 bootStakeholders:

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -32,7 +32,7 @@ LastKnownBlockVersion-Alt: 0
 
 # Launcher code will submit an update proposal to trigger the hard-fork.
 TestShelleyHardForkAtEpoch: 1
-TestAllegraHardForkAtEpoch: 2
+TestAllegraHardForkAtEpoch: 3
 
 #     _                      _
 #    | |    ___   __ _  __ _(_)_ __   __ _

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -47,12 +47,12 @@ maxLovelaceSupply: 1000000000000000000
 protocolMagicId: 764824073
 networkMagic: 764824073
 networkId: Mainnet
-epochLength: 200
+epochLength: 50
 staking:
 slotsPerKESPeriod: 86400
 slotLength: 0.2
 maxKESEvolutions: 90
-securityParam: 10
+securityParam: 5
 systemStart: "2020-06-19T16:07:37.740128433Z"
 initialFunds: {}
 # For the Byron;Shelley test setup, funds have to be migrated from byron

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -271,13 +271,13 @@ specWithServer (tr, tracers) = aroundAll withContext
     onByron _ = pure ()
     afterFork dir _ = do
         traceWith tr MsgSettingUpFaucet
+        let rewards = (,Coin $ fromIntegral oneMillionAda) <$>
+                concatMap genRewardAccounts mirMnemonics
+        moveInstantaneousRewardsTo tr' dir rewards
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
         sendFaucetFundsTo tr' dir addresses
 
-        let rewards = (,Coin $ fromIntegral oneMillionAda) <$>
-                concatMap genRewardAccounts mirMnemonics
-        moveInstantaneousRewardsTo tr' dir rewards
 
     onClusterStart action dir dbDecorator node = do
         -- NOTE: We may want to keep a wallet running across the fork, but


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->

Not sure. Not ADP-557 really. 


# Overview

- [x] Lower `k` from 10 to 5
- [x] Lower `epochLength` from 200 to 50
- [x] Lower byron slot length from 0.25 to 0.1 (exactly nothing happens here, so we just want to reach Shelley fast)
- [x] Make Allegra start at epoch 3 instead of 2. The cardano-cli cluster setup takes longer than an epoch, and fails if it enters Allegra.
- [x] Replace `waitForHardFork` with `TimeInterpreter`-based `waitForEpoch`

<!-- Detail in a few bullet points the work accomplished in this PR -->

# Comments

- `stack test cardano-wallet:integration --ta '-j 8'` passes in 220s instead of 420s for me
- It is also possible to control the likelihood of rollback by adjusting f. I have not done so in this PR. I thought about adding a simple env var dial for controlling rollback frequency...

<details>
<summary>
Experimental results of adjusting `f`
</summary>
- f=0.5, sl=0.2, el=50 => 220s
    - 382 `ROLLBACK` printed (from debug print in wallet `follow` function)
- f=0.833333, sl=0.33333, el=30 => 234s
    - Failed the first time I ran it, on ADDRESS_IMPORT_05 - I can import 15000 of addresses
    - 1031 `ROLLBACK` printed
- f=0.3125, sl=0.125, el=80 => 209.7s
    - 143 `ROLLBACK` printed
</details>

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
