### PR TITLE
Add postTransaction and postTransTo5Addrs into latency benchmarks

### DIFF
--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -314,14 +314,70 @@ walletApiBench capture ctx = do
             (Link.getTransactionFee @'Shelley wal1) Default payload
         fmtResult "postTransactionFee " t6
 
-        t7 <- measureApiLogs capture $ request @[ApiStakePool] ctx
+        let payloadTx = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": #{fixturePassphrase}
+            }|]
+        t7 <- measureApiLogs capture $ request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wal1) Default payloadTx
+        fmtResult "postTransaction    " t7
+
+        let payloadTxTo5Addr = Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                },
+                {
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                },
+                {
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                },
+                {
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                },
+                {
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }],
+                "passphrase": #{fixturePassphrase}
+            }|]
+        t7a <- measureApiLogs capture $ request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley wal2) Default payloadTxTo5Addr
+        fmtResult "postTransTo5Addrs  " t7a
+
+        t8 <- measureApiLogs capture $ request @[ApiStakePool] ctx
             (Link.listStakePools arbitraryStake) Default Empty
 
-        fmtResult "listStakePools     " t7
+        fmtResult "listStakePools     " t8
 
-        t8 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
+        t9 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
-        fmtResult "getNetworkInfo     " t8
+        fmtResult "getNetworkInfo     " t9
 
         pure ()
      where


### PR DESCRIPTION
# Issue Number

somewhat related to ADP-500 (https://github.com/input-output-hk/cardano-wallet/pull/2370)

# Overview

- bdcc3f6350211feb4db636c20670e38ed1f40560
  Add postTransaction and postTransTo5Addrs into latency benchmarks
  
- 337230c48c6a6868fcccd3c22a3deb8bc680f96c
  Adjust payload for postTxTo5Addrs benchmark



# Comments

I've triggered NB on this branch -> https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/776

Locally, seems to be ok. :point_down: 
```
     Latencies for 2 fixture wallets scenario
        listWallets         - 0.7 ms
        getWallet           - 0.3 ms
        getUTxOsStatistics  - 0.3 ms
        listAddresses       - 0.9 ms
        listTransactions    - 1.9 ms
        postTransactionFee  - 3.3 ms
        postTransaction     - 138.4 ms
        postTransTo5Addrs   - 793.9 ms
        listStakePools      - 2.0 ms
        getNetworkInfo      - 0.1 ms
    Latencies for 10 fixture wallets scenario
        listWallets         - 3.2 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.3 ms
        listAddresses       - 1.0 ms
        listTransactions    - 2.0 ms
        postTransactionFee  - 3.4 ms
        postTransaction     - 140.8 ms
        postTransTo5Addrs   - 806.1 ms
        listStakePools      - 1.9 ms
        getNetworkInfo      - 0.1 ms
```
