### PR TITLE
Fix bug preventing txs to be listed when filter spans multiple eras

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Slotting.hs
@@ -95,6 +95,8 @@ import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Maybe
     ( fromMaybe )
+import Data.Text
+    ( Text )
 import Data.Text.Class
     ( ToText (..) )
 import Data.Time.Clock
@@ -104,7 +106,7 @@ import Data.Word
 import Fmt
     ( blockListF', build, fmt, indentF )
 import GHC.Stack
-    ( HasCallStack, getCallStack, prettySrcLoc )
+    ( CallStack, HasCallStack, getCallStack, prettySrcLoc )
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
     ( RelativeTime (..), SystemStart (..), addRelTime )
 import Ouroboros.Consensus.HardFork.History.Qry
@@ -413,7 +415,7 @@ instance ToText TimeInterpreterLog where
       where
         renderPastHorizonException (PastHorizon callStack expr eras) t0 = mconcat
             [ "\nCalled from:\n"
-            , T.pack $ show $ prettySrcLoc $ snd $ last $ getCallStack callStack
+            , prettyCallStackTop callStack
             , "\nConverting expression:\n"
             , T.pack $ show expr
             , "\n\nWith knowledge about the following eras:\n"
@@ -421,6 +423,13 @@ instance ToText TimeInterpreterLog where
             , "\nt0 = "
             , T.pack $ show t0
             ]
+
+        prettyCallStackTop :: CallStack -> Text
+        prettyCallStackTop callStack =
+            case reverse (getCallStack callStack) of
+                ((_, srcLoc):_rest) -> T.pack $ show $ prettySrcLoc srcLoc
+                _ -> "Unknown"
+
         eraSummaryF (HF.EraSummary start end _params) = mconcat
             [ boundF start
             , " to "

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SlottingSpec.hs
@@ -144,10 +144,19 @@ spec = do
                 runExceptT (interpretQuery ti (epochOf 1))
                     `shouldReturn` Right (EpochNo 0)
 
+                runExceptT (interpretQuery ti (epochOf 1 >> epochOf 19))
+                    `shouldReturn` Right (EpochNo 0)
+
                 runExceptT (interpretQuery ti (epochOf 20))
                     `shouldReturn` Right (EpochNo 1)
 
+                runExceptT (interpretQuery ti (epochOf 20 >> epochOf 39))
+                    `shouldReturn` Right (EpochNo 1)
+
                 runExceptT (interpretQuery ti (epochOf 1 >> epochOf 20))
+                    `shouldReturn` Right (EpochNo 1)
+
+                runExceptT (interpretQuery ti (epochOf 1 >> epochOf 21))
                     `shouldReturn` Right (EpochNo 1)
 
         it "endTimeOfEpoch e == (slotToUTCTime =<< firstSlotInEpoch (e + 1)) \


### PR DESCRIPTION
# Issue Number

ADP-626

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Make rendering of MsgInterpreterPastHorizon more readable in logs
- [x] Add regression test for ADP-626
- [x] Fix ADP-626 by wrapping `HF.Qry` in a new monad to allow safe composition (like we used to before)
   - [x] TODO: Adjust doc comments

# Comments

- Tested manually that e.g. `cardano-wallet transaction list 94962db0b6ecda7b6d1af8e2afce61b166065545 --start 2019-10-17T10:15:00Z --end 2020-12-20T10:15:00Z` (Filter including Byron, Shelley and Allegra) works.
- We used to have this approach before the Allegra integration
- Alternative: Replace `slotRangeFromRelativeTimeRange :: Range RelativeTime -> Qry (Range SlotNo)` with something that takes a `TimeInterpreter m` and returns `m (Range SlotNo)`
    - To this seems to undermine having a `Qry` monad in the first place, if the calling wallet-code cannot compose queries, or has to be careful when doing so.

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
