### PR TITLE
Many Rnd addresses - performance increase

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -77,6 +77,7 @@ library
     , text
     , text-class
     , time
+    , timeit
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -626,13 +626,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (`shouldBe` Quantity (faucetAmt - feeEstMax - amt)) ra2
 
     describe "TRANS_CREATE_10 - Single Output Transaction with non-Shelley witnesses" $
-        it "Byron wallet - 150k addresses" $ \ctx -> runResourceT $ do
+        it "Byron wallet - 200k addresses" $ \ctx -> runResourceT $ do
 
         wByron <- fixtureRandomWallet ctx
         (wByron', mw) <- emptyRandomWalletMws ctx
         wShelley <- fixtureWallet ctx
 
-        let addrNum = 150000
+        let addrNum = 200000
         let addrs = map (\num -> encodeAddress @n $ randomAddresses @n mw !! num)
                     [1 .. addrNum]
         let ep = Link.putRandomAddresses wByron'
@@ -653,10 +653,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             verify r1
                 [ expectResponseCode HTTP.status200
                 , expectListSize addrNum ]
-            return$ head $ getFromResponse Prelude.id r1
+            return $ getFromResponse Prelude.id r1
 
         let amt = minUTxOValue :: Natural
-        let destination = byronAddr ^. #id
+        let destination = (byronAddr !! (addrNum `div` 2)) ^. #id
         let payload2 = Json [json|{
                 "payments": [{
                     "address": #{destination},

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -632,7 +632,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         (wByron', mw) <- emptyRandomWalletMws ctx
         wShelley <- fixtureWallet ctx
 
-        let addrNum = 150000
+        let addrNum = 100000
         let addrs = map (\num -> encodeAddress @n $ randomAddresses @n mw !! num)
                     [1 .. addrNum]
         let ep = Link.putRandomAddresses wByron'
@@ -682,6 +682,42 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             expectField
                 (#balance . #available)
                 (`shouldBe` Quantity (10*amt)) ra
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron) Default payload1
+                expectResponseCode HTTP.status202 r1
+        eventually "wByron' balance is as expected" $ do
+            ra <- request @ApiByronWallet ctx
+                (Link.getWallet @'Byron wByron') Default Empty
+            expectField
+                (#balance . #available)
+                (`shouldBe` Quantity (20*amt)) ra
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron) Default payload1
+                expectResponseCode HTTP.status202 r1
+        eventually "wByron' balance is as expected" $ do
+            ra <- request @ApiByronWallet ctx
+                (Link.getWallet @'Byron wByron') Default Empty
+            expectField
+                (#balance . #available)
+                (`shouldBe` Quantity (30*amt)) ra
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron) Default payload1
+                expectResponseCode HTTP.status202 r1
+        eventually "wByron' balance is as expected" $ do
+            ra <- request @ApiByronWallet ctx
+                (Link.getWallet @'Byron wByron') Default Empty
+            expectField
+                (#balance . #available)
+                (`shouldBe` Quantity (40*amt)) ra
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron) Default payload1
+                expectResponseCode HTTP.status202 r1
+        eventually "wByron' balance is as expected" $ do
+            ra <- request @ApiByronWallet ctx
+                (Link.getWallet @'Byron wByron') Default Empty
+            expectField
+                (#balance . #available)
+                (`shouldBe` Quantity (50*amt)) ra
 
         -- 4. Estimate tx fee using byron wallet
         addrsShelley <- listAddresses @n ctx wShelley
@@ -712,13 +748,25 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         timeIt $ do
                 r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron') Default payload2
                 expectResponseCode HTTP.status202 r1
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron') Default payload2
+                expectResponseCode HTTP.status202 r1
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron') Default payload2
+                expectResponseCode HTTP.status202 r1
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron') Default payload2
+                expectResponseCode HTTP.status202 r1
+        timeIt $ do
+                r1 <- request @(ApiTransaction n) ctx (Link.createTransaction @'Byron wByron') Default payload2
+                expectResponseCode HTTP.status202 r1
 
         eventually "wShelley balance is as expected" $ do
             r' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wShelley) Default Empty
             expectField
                 (#balance . #getApiT . #available)
-                (`shouldBe` Quantity (faucetAmt + 9*amt)) r'
+                (`shouldBe` Quantity (faucetAmt + 5*9*amt)) r'
 
     let absSlotB = view (#absoluteSlotNumber . #getApiT)
     let absSlotS = view (#absoluteSlotNumber . #getApiT)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -208,7 +208,7 @@ specWithServer (tr, tracers) = aroundAll withContext
                 prometheusUrl <- (maybe "none" (\(h, p) -> T.pack h <> ":" <> toText @(Port "Prometheus") p)) <$> getPrometheusURL
                 ekgUrl <- (maybe "none" (\(h, p) -> T.pack h <> ":" <> toText @(Port "EKG") p)) <$> getEKGURL
                 traceWith tr $ MsgBaseUrl baseUrl ekgUrl prometheusUrl
-                let fiveMinutes = 300*1000*1000 -- 5 minutes in microseconds
+                let fiveMinutes = 1000*1000*1000 -- 5 minutes in microseconds
                 manager <- (baseUrl,) <$> newManager (defaultManagerSettings
                     { managerResponseTimeout =
                         responseTimeoutMicro fiveMinutes

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -77,6 +77,7 @@
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
+          (hsPkgs."timeit" or (errorHandler.buildDepError "timeit"))
           ];
         buildable = true;
         };


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
https://jira.iohk.io/browse/ADP-586

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have tried to replicate performance problem with many-addresses-byron-wallet

# Comments

For 100k Unused addresses
```
1. Importing Unused random addresses - 82.63s 
2. Get of one just imported Unused random address - 9.63s
3. Send money to this address - 0.43s
4. Estimate tx fee using byron wallet - 0.01s
5. Submit tx fee using byron wallet - 7.55s
```

For 150k Unused addresses
```
1. Importing Unused random addresses - 243.43s 
2. Get of one just imported Unused random address - 17.61s
3. Send money to this address - 0.41s
4. Estimate tx fee using byron wallet - 0.01s
5. Submit tx fee using byron wallet - 11.25s
```

For 200k Unused addresses
```
1. Importing Unused random addresses - 449.24s 
2. Get of one just imported Unused random address - 21.72s
3. Send money to this address - 0.41s
4. Estimate tx fee using byron wallet - 0.01s
5. Submit tx fee using byron wallet - 22.84s
```

For 150k Unused addresses for tx with 10 inputs and 9 outputs
```
1. Importing Unused random addresses - 250.94s
2. Get of one just imported Unused random address - 13.27s
3. Send money to this address - 2.62s
4. Estimate tx fee using byron wallet - 0.01s
5. Submit tx fee using byron wallet - 14.35s
```
Using Byron random addresses with small or big relative indices does not influence the results.

**Interesting result**
For 100k Unused addresses for tx with 10 inputs and 9 outputs 
```
1. Importing Unused random addresses - 85.52s
2. Get of one just imported Unused random address - 7.15s
3a. Send money to this address - 2.29s
3b. Send money to this address - 2.22s
3c. Send money to this address - 2.50s
3d. Send money to this address - 2.55s
3e. Send money to this address - 2.41s
4. Estimate tx fee using byron wallet - 3.20s
5a. Submit tx fee using byron wallet - 7.39s
5b. Submit tx fee using byron wallet - 6.55s
5c. Submit tx fee using byron wallet - 4.09s
5d. Submit tx fee using byron wallet - 14.26s
5e. Submit tx fee using byron wallet - 97.02s
``` 
5a-5e is just submitting txs one by one, the same for 3a-3e.
the difference is that in 3a-3e case we are sending from fixture small-number-addresses-byron-wallet.
For 5a-5e we are sending from big-number-of-addresses-byron-wallet

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
