### PR TITLE
Integrate with cardano-addresses 3.2.0 and add golden for script hashes for different simple script versions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -634,24 +634,6 @@ spec = describe "SHELLEY_ADDRESSES" $ do
                 let walAddr = fst (addrs !! idx ^. #id) ^. (#getApiT . #unAddress)
                 walAddr `Expectations.shouldBe` genAddr
 
-    it "ANY_ADDRESS_POST_13 - at_least must make sense" $ \ctx -> do
-        forM_ ([0, 4, 333] :: [Int]) $ \atLeast -> do
-            let payload = Json [json|{
-                    "payment": {
-                        "some": {
-                            "from" : [
-                                "script_vkh1yf07000d4ml3ywd3d439kmwp07xzgv6p35cwx8h605jfx0dtd4a",
-                                "script_vkh1mwlngj4fcwegw53tdmyemfupen2758xwvudmcz9ap8cnqk7jmh4",
-                                "script_vkh1qw4l62k4203dllrk3dk3sfjpnh3gufhtrtm4qvtrvn4xjp5x5rt"
-                                ],
-                             "at_least": #{atLeast}
-                             }
-                        }
-                }|]
-            r <- request @AnyAddress ctx Link.postAnyAddress Default payload
-            expectResponseCode HTTP.status400 r
-            expectErrorMessage "must have at least one credential" r
-
     it "POST_ACCOUNT_01 - Can retrieve account public keys" $ \ctx -> runResourceT $ do
         let initPoolGap = 10
         w <- emptyWalletWith ctx ("Wallet", fixturePassphrase, initPoolGap)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -175,7 +175,7 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv, XPub, xpubFromBytes, xpubToBytes )
 import Cardano.Address.Script
-    ( Script )
+    ( KeyHash, Script )
 import Cardano.Api.Typed
     ( TxMetadataJsonSchema (..)
     , displayError
@@ -463,7 +463,7 @@ data ApiAddress (n :: NetworkDiscriminant) = ApiAddress
 
 data ApiCredential =
       CredentialPubKey ByteString
-    | CredentialScript Script
+    | CredentialScript (Script KeyHash)
     deriving (Eq, Generic, Show)
 
 data ApiAddressData =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -2198,9 +2198,6 @@ insertScriptPool wid sl pool = do
     toDB (scriptHash, verKeyIxs) =
         zipWith (SeqStateScriptHash wid sl scriptHash . getIndex) verKeyIxs [0..]
 
-instance Ord ScriptHash where
-    compare (ScriptHash sh1) (ScriptHash sh2) = compare sh1 sh2
-
 selectScriptPool
     :: forall k . W.WalletId
     -> W.SlotNo

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -308,8 +308,6 @@ instance ((PersistPublicKey (key 'AccountK)))
         xpubF = hexF $ serializeXPub acct
         acctF = prefixF 8 xpubF <> "..." <> suffixF 8 xpubF
 
-deriving instance Ord KeyHash
-
 lookupKeyHash
     :: KeyHash
     -> VerificationKeyPool k

--- a/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
@@ -57,7 +57,7 @@ import qualified Data.Map.Strict as Map
 
 isShared
     :: (k ~ ShelleyKey, SoftDerivation k)
-    => Script
+    => Script KeyHash
     -> SeqState n k
     -> ([k 'ScriptK XPub], SeqState n k)
 isShared script (SeqState !s1 !s2 !pending !rpk !prefix !s3) =
@@ -89,5 +89,5 @@ isShared script (SeqState !s1 !s2 !pending !rpk !prefix !s3) =
 insertIf :: Ord k => (v -> Bool) -> k -> v -> Map k v -> Map k v
 insertIf predicate k v = if predicate v then Map.insert k v else id
 
-retrieveAllVerKeyHashes :: Script -> [KeyHash]
+retrieveAllVerKeyHashes :: Script KeyHash -> [KeyHash]
 retrieveAllVerKeyHashes = foldScript (:) []

--- a/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Primitive.Scripts
 import Prelude
 
 import Cardano.Address.Script
-    ( KeyHash (..), Script (..), ScriptHash (..), foldScript, toScriptHash )
+    ( KeyHash (..), Script (..), foldScript, toScriptHash )
 import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Wallet.Primitive.AddressDerivation

--- a/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
@@ -4,10 +4,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
@@ -28,7 +28,7 @@ module Cardano.Wallet.Primitive.Scripts
 import Prelude
 
 import Cardano.Address.Script
-    ( KeyHash (..), Script (..), ScriptHash (..), toScriptHash )
+    ( KeyHash (..), Script (..), ScriptHash (..), foldScript, toScriptHash )
 import Cardano.Crypto.Wallet
     ( XPub )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -44,22 +44,16 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Control.Arrow
     ( first )
-import Control.Monad
-    ( foldM )
 import Control.Monad.Trans.State.Strict
     ( runState, state )
 import Data.Function
     ( (&) )
-import Data.Functor.Identity
-    ( Identity (..) )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
     ( catMaybes )
 
 import qualified Data.Map.Strict as Map
-
-deriving instance Ord ScriptHash
 
 isShared
     :: (k ~ ShelleyKey, SoftDerivation k)
@@ -97,13 +91,3 @@ insertIf predicate k v = if predicate v then Map.insert k v else id
 
 retrieveAllVerKeyHashes :: Script -> [KeyHash]
 retrieveAllVerKeyHashes = foldScript (:) []
-
-foldScript :: (KeyHash -> b -> b) -> b -> Script -> b
-foldScript fn zero = \case
-    RequireSignatureOf k -> fn k zero
-    RequireAllOf xs      -> foldMScripts xs
-    RequireAnyOf xs      -> foldMScripts xs
-    RequireSomeOf _ xs   -> foldMScripts xs
-  where
-    foldMScripts =
-        runIdentity . foldM (\acc -> Identity . foldScript fn acc) zero

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiCredential.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiCredential.json
@@ -1,246 +1,37 @@
 {
-    "seed": 2408844854410319661,
+    "seed": 3180141152877592508,
     "samples": [
-        "addr_vk15p6ntq4pje3fu0n4t4htj3pz3ukx9wc0fnzrvwt8zeje2ek3d53s9cdldr",
-        "addr_vk1g8r54mfhc7qclp9y4t9hstjg4sk3wptpa3de3nw44ym60jdzs3escn2smw",
-        "addr_vk14cj5vmehu4xhz33vfhhgcnrccdsaf5najj8rg0mhphrw245fsx6qjz6jmv",
-        "addr_vk1lrlccshhkz36jha43chtxcf2wjhch2njl9nxukydha2m0a3xhmhq6aplt0",
-        {
-            "some": {
-                "from": [
-                    {
-                        "any": [
-                            "script_vkh1pyr3s9syp5tszrqjr50p68qsqqp37yc9rcgq5xslpgppxas2h2z",
-                            "script_vkh1q5z3zppqquqqgpc3zu8svqfqqq0p29qxzyzsuzsnrs93jjelueh",
-                            "script_vkh1qsfq6xqrqqvskrcvr5gquqcuq5y3yzqhpup35pqzz5p36cshddl",
-                            "script_vkh1p5gsz8glzyyqjqqjpsx3v9s6rupqk9g2zv2q2qg0qyq3kspqa6m",
-                            "script_vkh1pq83zrs3zgwp7xq6qg2skxqupsspvqgrzswqjpeqrg9sswpq7ge",
-                            "script_vkh1zsv3xps2qs23xyg8qvvszrqeqgvqkycupgzp5pggruvpxpw20tz",
-                            "script_vkh1zvfsvrcxqcvpq9quz5qq5pq2ry03u9gspvrp7pgyr52s6ar92w0",
-                            "script_vkh1qv9zqzq9pvv3u9cczs9pwpgmz5spsyqwpq2pyzgep503uh33n7u",
-                            "script_vkh1pud3x8sxz5tpc8q4q58qu8qlpyvscrs0zvxpq9gezu0qjzdcplk",
-                            "script_vkh1zcsq2xcryqx368glr59qy9svqsyqj9g8pufpvpgyqcy3qct6yct"
-                        ]
-                    },
-                    {
-                        "some": {
-                            "from": [
-                                "script_vkh1qcxzqpgqzu83jpghpqgsqzg2rv8qwygypcxp6ygnzyz3520mtj6",
-                                "script_vkh1pgqqy9sjpgdqy9g2rupqvys9zcgqqqc4ry83uxc9zs0376jksyd",
-                                "script_vkh1qurqyzsyqgzqwgqlpg23qysdzgspq8czpgdsxxqdrqysuqj6szv",
-                                "script_vkh1rqp3uxq7p5vps8q5zq8zqzsspy0q6xc6zg2q6rstzcy3yvy2xqy"
-                            ],
-                            "at_least": 1
-                        }
-                    },
-                    {
-                        "any": [
-                            "script_vkh1qqqsz9g8q5ysw8c2pstsz9cdzu23yrg4qgrp5xs8puppv3k28jd",
-                            "script_vkh1qvd3wzgxzvfsgpqnrcgqzyc2qypqu8c8qvq3gqc9pgyzq0h7jhv",
-                            "script_vkh1pg2qvxqqqsvq7pgsrvz32xssr583vzgqr5szq9qsrq03gw4vkzy"
-                        ]
-                    },
-                    {
-                        "all": [
-                            "script_vkh1zvdqcqq8pspqs9qrpsfs6zqcryyjqpctqv83jrqyqgwzqj660rp",
-                            "script_vkh1qyzqwz3qzgtqqrgwqgd359swpg93sgqjz5dq6rsspc9q7rjsufy",
-                            "script_vkh1yqzsjyq5qvyssqghzvy3sxqrpqq3zrg3rqvsg9pqpsqs59ekpqw",
-                            "script_vkh1pu237pchq52pzxqnqypqjpqsry03kqgnrvrpu9quqcwjqn2vf9h",
-                            "script_vkh1pczs2qchpqzsgqq0pvgpqpq3pv23yqqqqszsvxsyzyxpv27ncy5",
-                            "script_vkh1yqsqvzq8zvyqzxcurq8sszqurvpp5ysgr5rsypcwrgw3jrvpl50",
-                            "script_vkh1ps8qxrs7pg2qzxc5zqw35qgupyd378srqcds7qcuqcgswr4j9l5",
-                            "script_vkh1zsgpk9gsrqrpwzqtzsy3xyquqg0pcrcvrgqqzxq4rg0sc4jg958"
-                        ]
-                    },
-                    {
-                        "all": [
-                            "script_vkh1ru8qyrs7p58sxqsjzu2puysnzy0sx8sqzqv36pgmpcgp5kseupe",
-                            "script_vkh1zyys7yqfzuzpcrqtzgds7zs9qu9swqghrq9sxqghzyp3xwaw0yn",
-                            "script_vkh1pudpq9ceqv9pygqxpqzqzgpqrqfskpqazsvq68q9qy03w33nyp7"
-                        ]
-                    },
-                    {
-                        "all": [
-                            "script_vkh1pc0q7zchpgfskysnzug32rc9zczzqpc4pggs59gkqcspjzy6u9r",
-                            "script_vkh1p5vs2yqwqcysups0qypjq8sezu2pw8svqc2qu8ggqyfqxv2mjem",
-                            "script_vkh1rcqp6qgwruy3xzc5ryrjqxsspvqsxgq3pyfqv8s3zufq2u97m92",
-                            "script_vkh1rvspv8eqpvz3gzc9p5zp6yc4rv0qw9c7zv2suzgupczs7td2enu",
-                            "script_vkh1pszpzqs8rcfqurskpvgsgpszyq0q68guqqxsyrg9quwqcd9p777",
-                            "script_vkh1zgqqxpgkqgqq5pgkr5t37rc2ruqpypc6qv9qjpqep5tqwrfgemy",
-                            "script_vkh1pvtp5zcdzgxs79qdqs9pqzqrqs0pj8s6rqt37qsxzvspcqwfw6x",
-                            "script_vkh1zvtqkqqapq0q69qdquypxqghrcqsgzg9pqspcpctpvspu7qjjk2",
-                            "script_vkh1pgqqqqq3qsdpq8q6zug3g9qfq58pg9qtyqv36qszzs03yv0m82f"
-                        ]
-                    },
-                    {
-                        "any": [
-                            "script_vkh1zvyp2rczzyqp2rqequys29q3qvspszgzryts6pctrvgsguwptvx",
-                            "script_vkh1ru0qc8qxpudq5qg6pgpq2xglrv9q28qpry9s78gsruxq2hzw66r",
-                            "script_vkh1z523wzckpuwpjqc4yqys2qqtqyzjqpq5zsyp6qgmyq9s2nj9a3n",
-                            "script_vkh1zuspuzchry2sy8s0zvts2ygqyqspx9c0rutp28cyqsvp29rh8uj",
-                            "script_vkh1zuw3uqcsrgvzqrckrqdpg8sdqqwsj9q5r5vqgrskpy8pje29rvl"
-                        ]
-                    },
-                    {
-                        "all": [
-                            "script_vkh1yqyqyzssp5fqursmpgqsc8cezgr3gpq7zg23cyghzy0qkatc9ht",
-                            "script_vkh1zydq6xsercg36pc3r5gssxsszvws2zgrquppxpgvz5zsgxfx2mq",
-                            "script_vkh1p59pc9gppc9pwpqczgxswysqzvgsq9q0p5p3vyqurqz3wpu4yxf",
-                            "script_vkh1pvtpz9qaqux37qsxzgfpqgqyzg2suzczqvy3xrsarvxsklvhj4g"
-                        ]
-                    }
-                ],
-                "at_least": 4
-            }
-        },
-        {
-            "some": {
-                "from": [
-                    {
-                        "any": [
-                            "script_vkh1rqts2gqtrggqkrc6ry0pv9gtpuzpvpgpzvppyyc7q59qczqn4a4",
-                            "script_vkh1puw35xq5qs0ssqqdrvxsj8qdrqgpcrcpzyfpc9qzrggpkqln3j8",
-                            "script_vkh1p5wpuxqgpsxpx9gkrvzqkpcuzvgqvxq9psxqjyqlzug3yqznfnv",
-                            "script_vkh1zcysgqq2qvpsxxcap5ts79qdrqfqkgqtzcv369spquy3kd06g24",
-                            "script_vkh1ryds7xsezywzqrsmpv23c8qdqcg32ysfpy932xceqy23vu7phr7",
-                            "script_vkh1rvtsj9cprgqsspcezugjqrgvpctp6qc7rgwqq9sfpgv35d4zxy6",
-                            "script_vkh1p5ysjqcwpyq3spcup5qqjpqtrs2368gtrs8supsmzs0q6x5mnu6",
-                            "script_vkh1zqqpcqgzpq8pqycuq5wsgzseqqqsgyc5p5tqwgqvpv2pvtdyl5w",
-                            "script_vkh1qy83czcfrydp5yqlrqq3cycprgspc8qsqv0ssrqyrgwqzgegygz"
-                        ]
-                    },
-                    {
-                        "some": {
-                            "from": [
-                                "script_vkh1pstqzygarsds6ycez5xsz9gzyq2szqsepqf32xc8zyp3w94n54x",
-                                "script_vkh1qcwss9sppudq7pcdpq8qkys7pgyqcpcgpc9su93qzgwsx7xx9ka",
-                                "script_vkh1psppw9g2zq23yqcezvr36xqcpsq3ggqercyq2zqmrugs76llqls",
-                                "script_vkh1pcz3y9qnzczp2pqgpvtqwqctqytsvyc7qcyp6zsvzgzsgks7th4"
-                            ],
-                            "at_least": 2
-                        }
-                    },
-                    {
-                        "all": [
-                            "script_vkh1qgtpgxqlrvws79caryf3gpqdqcw3g9snzgx3x9qrp5zsk5k3ptk",
-                            "script_vkh1rvzqq8caqsrqkrstzqzswpg3zytqqpghzvwzq8gqrud36hflqcn",
-                            "script_vkh1pgqq29cqpu9sgrgfz5wq7pclzv03vxqszuxp7ycerg0qjak5w7m"
-                        ]
-                    },
-                    {
-                        "any": [
-                            "script_vkh1pcz3z8clrg9s7zsszsz3wzcezcdpg8qlpctqzqqcrspp7760es3",
-                            "script_vkh1r5tq6rgpr5psjyszyqtqu9szyqfq5xsrqcsqvpstrq2pje2h9pw",
-                            "script_vkh1rcfqxrqdryxs5rsmrsvpkygfyq0zqzqwzqr3gzgtpgvpgpmxtmu",
-                            "script_vkh1zysq7xq8qvsq29qyzcrqv9qhqqvp7gq0rsxqkxszqy0qj43wrw9",
-                            "script_vkh1zg8quycwzcvpypq8pqgqs9cdquqp69guq5qq7x3qrgpzqlrcvlf",
-                            "script_vkh1qy0scygaqy035xsrqsxsx8qtqvypjpc9qsypwpcupgrsqxygg9f",
-                            "script_vkh1p5037xc9pqr3s9cqpcdzqrqfq5xjqyq8qyy3v9g6zu9q2h2rmq9",
-                            "script_vkh1ru8skrs8rufqzqgwpgrsyyc8zvypg8sdzs8jqpcuqvypczexeyq",
-                            "script_vkh1r583zyqtz5wsx8s7ru232zcrzvt37yq0rs8psycgzvwsg8p4tlq"
-                        ]
-                    },
-                    {
-                        "any": [
-                            "script_vkh1pvwsk8qnruvsj9c3pv8zqpc4rgsq2yq5zvdqyxqvqgtqglwuf3m",
-                            "script_vkh1zgp359s7puwscysvzg0q78pqru2q28skpypq28s6pyq3sl2x243",
-                            "script_vkh1pcxs6rclzg0ps9slzyy37ysyzg93x83qrcwswpcsp5tpcedap3w",
-                            "script_vkh1rqxjqxcfpc0sspcfpud3yzserszqxqcrzugp69cmpyfqcre8z0q",
-                            "script_vkh1zyxsczgnzuvqgzqcyqgpjyggpsv3x8smqqgpzrsdquz3k99a6tz",
-                            "script_vkh1rursqzqkp5xpuygfr5vq5xchrctswpstqu03v9crpyz3suxmpv6"
-                        ]
-                    }
-                ],
-                "at_least": 1
-            }
-        },
-        "addr_vk1xdhkpxq7stcnmzv8v4vnfupu6e2ltc4qh2pgzg30zw9jweu55f8stf5esk",
-        {
-            "some": {
-                "from": [
-                    "script_vkh1zv9qkqcmqugqgrc2zqdsvysrpgxsyxcyzsqszp3qpgts7qn9w0f",
-                    "script_vkh1rq93q9qkrursj9snqspjqxq2zct3k8s0qvvq5yqgpqfqvqg70d0",
-                    "script_vkh1rqypursvzgtsgpgpzc2qvzc3pyz3j8fqq58svrqdpu0qwruqj6n",
-                    "script_vkh1zsfsy8g9z5vp7qglry2qcrqqryfq6xckqqg3zgqqruw3shuzcxy",
-                    "script_vkh1yqfp2qs3zgtqkxsvpy8pk8sur583vrcjzcpsjycfzqx3k4c2xd5",
-                    "script_vkh1pc2pvzsrqqgqszgnyqqs5yg3rsv36zsczqqqc8qlpcts6444jxj",
-                    "script_vkh1zudjqgqhzqfqcpsapcrp7qsuzsq3cps9psrquygfquqqkpyd2qu",
-                    "script_vkh1pc8jqrq0zcqpzpg3rc2qy8gpzcxp7rsepspqwxczp5837mv46mq",
-                    "script_vkh1zqdjq9q5zugskqq4psrqqrgmq5p3j9qursqpqrq6ryd3jsfsmtk",
-                    "script_vkh1qv0pw9qmpgxqcqg8rcyjq9smzc8s5yqjpcdsw8qyzcw32533fky"
-                ],
-                "at_least": 5
-            }
-        },
+        "addr_vk1n6l8v8zu7wxugm7dkcc8k4kfw38xt4tvg7l8xxmn50t93d2qf0kq8cuju3",
+        "addr_vk1curykzvc3n3znddlfk0awlcm88kaghd8u4csnys0srfhpq4xrkjs5qzhfg",
+        "addr_vk1apjftpd4jzt98rug2aj09zxfqpc0yexqlw9aj09u38xvf66aqxxqp0sdfs",
+        "addr_vk1aaf43lv7hskrgazyhf6g88fc4s9qkjzyhxy32cpc602etxwlquksmy8d34",
+        "addr_vk1pxxqacvzj8yxswpaxpgur4auv3p5h4zc3s535y0j5a6ky94wvd9s8q542s",
+        "addr_vk1wqd7s7u4rc6ejza5gptf4lfw2ahc0gr53r5munh270l8zmhupe0se528qv",
+        "addr_vk1unulfa46cu5tuekmf3ldazaqe8jfslptcqkf8x5kukm92u50d8ws46xss7",
+        "addr_vk1vxga6knws3t26yr7w3kkremvagqw35qpdehykvkfmhuaegmzvhwqwwza2j",
         {
             "any": [
                 {
-                    "any": [
-                        "script_vkh1qv836rswpcwp6yq2yqp37pgpq5tsz8sfpugqq8spqg9q5glu37h",
-                        "script_vkh1pcw3qzg6zuv3v9qfp5gpyqstrq935zq9psds6qgypqg3je3ddq9",
-                        "script_vkh1zcgpgrsezggpz9cvq58pyygazu03g8qtzvdpw9ggyq23chrgsrc",
-                        "script_vkh1qgfqw9g8zv9qspqxrupqxqcyrqzs6zs6pspsvzqrzuwsgaecqvp",
-                        "script_vkh1rgdpjqggz5qsyzctpuzzq9sursfp6gquqvy3zqfqzs83637hhp6",
-                        "script_vkh1zcw3qxg6q5t359gxpg23gqsszu8sjps9p5yqqrc7q5vpjetnw8s",
-                        "script_vkh1rvx3cxs8pqfqjrsurvfq68qfzvfsupq4pvrpgqg6rgxqyq5xqnd",
-                        "script_vkh1zqwqzrslpuxqqqqyq5ws5xg3qsg3vpgqqvd369qqyqd3vnw07q2"
-                    ]
-                },
-                {
                     "some": {
                         "from": [
-                            "script_vkh1rv9qgqq3pu03xxs0zqd3y8g9p523sxq0psrpxpqmzvxq266x0dl",
-                            "script_vkh1pupqw9q8pv8qjzq8zcqsw9qwqyzsyrqvryv3g9g7ryts566965k",
-                            "script_vkh1zugpj9c0rc9q6pcary0pcysyrgp3x9fqqgvqurs0qcfp26kkt8v",
-                            "script_vkh1qvt368q6zvqqgpcjrq83srczr5tsvyg8puvp5gq2yqqs5gqqwd8",
-                            "script_vkh1qvqzqzeqpvfsjqcdq5fqvxgfzsq36qeqpuqszqgmzyzs667zqya"
-                        ],
-                        "at_least": 3
-                    }
-                },
-                {
-                    "all": [
-                        "script_vkh1qsqquycspyxpk8cszcwpwqs8pygsg8qkzgysqxg3zst3zq32v3e",
-                        "script_vkh1pv837rq4qcd3yqcnzv9skrgsyqzq5qcrq5tpczskqgvq2dm227x",
-                        "script_vkh1p58qvgqjpy0pzyg0rqxsuqg5zvpq6rs0zudpqxsgpgw3jvxeue2",
-                        "script_vkh1rcvqszsqrsp3yys6rvx3zpcyq50zqqc9yqt3szqxz5zsvghm73t",
-                        "script_vkh1z50p7rcvqvzqqqeqq5xqxrpqqswsk9sxpv032pcczuxqvh0z63k",
-                        "script_vkh1ryd3yxqpqqp3c93qpu8puqgupyspxyqfzgxqcygeqvysv2men9g",
-                        "script_vkh1q5vsqps8qc03gxszqyfsvqfqpsvpc9svryts2qcnry2qw0s5r73"
-                    ]
-                },
-                {
-                    "some": {
-                        "from": [
-                            "script_vkh1pugpkyc2pvfqsgqeqyv37rg6yqgqs8qepsdpzzggzuyp7hczv8e",
-                            "script_vkh1pyxpvzcfpvzpkxqxrqrqwrsayqpqxygxpgtqszslpgws2m4kear",
-                            "script_vkh1qy0svqsvzutqq9sgpcppv8qkzvyq28grpyw3cpgjq5spgts2764"
-                        ],
-                        "at_least": 3
-                    }
-                },
-                {
-                    "all": [
-                        "script_vkh1qgy3kx3qpydpgzsdq523ggqyzgdp5zc6qs2qgxspqswjqtwzwqa",
-                        "script_vkh1rgd3g8g7zypsvxgsrqws79szzsgqczgupqvpz8qyp5ypknwksg0",
-                        "script_vkh1qyspv9qtpvf36xg2zy8qgyqzpgts5qq0yq2pjzqxrc2svpgtqpu",
-                        "script_vkh1p5tq2ysjry8sqzgeyqpsyrgnrvqsupskpcrqxps0qqy3q72kdpn",
-                        "script_vkh1pvxqu8surqqjq9qpr5v3kzqfzgqqg8gcpypskyc2py2q26smgqx",
-                        "script_vkh1zvtsuxqdzgd3gqcvzuyqjxcwrszquqcuqctpx9ckrgwsjlqqmyq",
-                        "script_vkh1q5vpuxq8qs8q5pcwqqfzqycsrugsyrq9qcyp58qcqgqsj7z7tlj"
-                    ]
-                },
-                {
-                    "some": {
-                        "from": [
-                            "script_vkh1zvyjq9ctrgpsgycupu9qqzg6zggsuxs5zv2sxqqrpq8qu6vqxu3",
-                            "script_vkh1rygqgqckqgfqqycgqqspkpqvr5xp2zscrqwpzzgjqvfqq5pqw5y"
+                            {
+                                "active_from": 3
+                            },
+                            "script_vkh1qqfs7qclrqyqc8q4quppx9slrgqs7xssqsd3ypq6zyfszccj6qs",
+                            {
+                                "active_from": 7
+                            },
+                            "script_vkh1rvzs5yc5zsv36qscrc2py8qfrytpxxsnpvfpw9skqyqqjsp8m93",
+                            {
+                                "active_from": 3
+                            },
+                            "script_vkh1zuq32zqpzu0sj8gqrvypx8sdqqpqzzqkzyfpursfz5tpk756uzj"
                         ],
                         "at_least": 2
                     }
                 }
             ]
         },
-        "addr_vk1gh7xwa4r4kz0qa6eu96negj497j0s66gq3gwme4n59uaq07w03dsrmrp2t"
+        "addr_vk1df9ulq7m30prz3p8u4jrln2tauqjeu0thvfw4kgf53qemxvx7rpspw2djx"
     ]
 }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -132,6 +132,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Gen
     ( genMnemonic
     , genPercentage
+    , genScript
     , genTxMetadata
     , shrinkPercentage
     , shrinkTxMetadata
@@ -156,8 +157,6 @@ import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, getAddressPoolGap )
-import Cardano.Wallet.Primitive.ScriptsSpec
-    ( genScript )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1070,8 +1070,8 @@ instance Arbitrary Script where
       where
         scriptTree 0 = oneof
             [ RequireSignatureOf <$> arbitrary
-            , ValidFromSlot <$> arbitrary
-            , ValidFromSlot <$> arbitrary ]
+            , ActiveFromSlot <$> arbitrary
+            , ActiveFromSlot <$> arbitrary ]
         scriptTree n = do
             Positive m <- arbitrary
             let n' = n `div` (m + 1)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -131,6 +131,7 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Gen
     ( genMnemonic
+    , genNatural
     , genPercentage
     , genScript
     , genTxMetadata
@@ -1801,7 +1802,7 @@ instance Arbitrary ApiAccountKey where
 
 instance Arbitrary Natural where
     shrink = shrinkIntegral
-    arbitrary = arbitrarySizedNatural
+    arbitrary = genNatural
 
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -302,6 +302,7 @@ import Test.QuickCheck
     , arbitraryBoundedEnum
     , arbitraryPrintableChar
     , arbitrarySizedBoundedIntegral
+    , arbitrarySizedNatural
     , choose
     , counterexample
     , elements
@@ -1067,7 +1068,10 @@ instance Arbitrary ApiEpochInfo where
 instance Arbitrary Script where
     arbitrary = Test.QuickCheck.scale (`div` 3) $ sized scriptTree
       where
-        scriptTree 0 = RequireSignatureOf <$> arbitrary
+        scriptTree 0 = oneof
+            [ RequireSignatureOf <$> arbitrary
+            , ValidFromSlot <$> arbitrary
+            , ValidFromSlot <$> arbitrary ]
         scriptTree n = do
             Positive m <- arbitrary
             let n' = n `div` (m + 1)
@@ -1810,6 +1814,10 @@ instance Arbitrary ApiAccountKey where
         pubKey <- BS.pack <$> replicateM 32 arbitrary
         oneof [ pure $ ApiAccountKey pubKey False
               , pure $ ApiAccountKey xpubKey True ]
+
+instance Arbitrary Natural where
+    shrink = shrinkIntegral
+    arbitrary = arbitrarySizedNatural
 
 {-------------------------------------------------------------------------------
                    Specification / Servant-Swagger Machinery

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1067,7 +1067,6 @@ instance Arbitrary (Script KeyHash) where
     arbitrary = do
         keyHashes <- vectorOf 10 arbitrary
         genScript keyHashes
-    shrink = genericShrink
 
 instance Arbitrary KeyHash where
     arbitrary = KeyHash . BS.pack <$> vectorOf 28 arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Gen.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Gen.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 -- | Shared QuickCheck generators for wallet types.
 --
 -- Our convention is to let each test module define its own @Arbitrary@ orphans.
@@ -25,6 +23,7 @@ module Cardano.Wallet.Gen
     , shrinkTxMetadata
     , genSmallTxMetadata
     , genScript
+    , genNatural
     ) where
 
 import Prelude
@@ -88,7 +87,6 @@ import Test.QuickCheck
     , oneof
     , resize
     , scale
-    , shrinkIntegral
     , shrinkList
     , sized
     , suchThat
@@ -273,17 +271,16 @@ shrinkTxMetadataValue (TxMetaNumber i) = TxMetaNumber <$> shrink i
 shrinkTxMetadataValue (TxMetaBytes b) = TxMetaBytes <$> shrinkByteString b
 shrinkTxMetadataValue (TxMetaText s) = TxMetaText <$> shrinkText s
 
-instance Arbitrary Natural where
-    shrink = shrinkIntegral
-    arbitrary = arbitrarySizedNatural
+genNatural :: Gen Natural
+genNatural = arbitrarySizedNatural
 
 genScript :: [KeyHash] -> Gen (Script KeyHash)
 genScript keyHashes = scale (`div` 3) $ sized scriptTree
     where
         scriptTree 0 = oneof
             [ RequireSignatureOf <$> elements keyHashes
-            , ActiveFromSlot <$> arbitrary
-            , ActiveUntilSlot <$> arbitrary
+            , ActiveFromSlot <$> genNatural
+            , ActiveUntilSlot <$> genNatural
             ]
         scriptTree n = do
             Positive m <- arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ScriptsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ScriptsSpec.hs
@@ -158,8 +158,7 @@ prop_scriptsDiscovered (AccountXPubWithScripts accXPub' scripts') = do
     let seqState0 = initializeState accXPub'
     let seqState = foldr (\script s -> snd $ isShared script s) seqState0 scripts'
     let scriptHashes = Set.fromList $ Map.keys $ getKnownScripts seqState
-    let scriptsWithKeyHashes =
-            L.filter (\s -> L.length (retrieveAllVerKeyHashes s) > 0) scripts'
+    let scriptsWithKeyHashes = filter (not . null . retrieveAllVerKeyHashes) scripts'
     scriptHashes === Set.fromList (map toScriptHash scriptsWithKeyHashes)
 
 prop_scriptDiscoveredByTwo
@@ -174,9 +173,9 @@ prop_scriptDiscoveredByTwo (TwoAccountXPubsWithScript accXPub' accXPub'' script)
     let scriptKeyHashes' = scriptKeyHashesInMap script accXPub' seqState'
     let scriptKeyHashes'' = scriptKeyHashesInMap script accXPub'' seqState''
     let expected =
-            if L.length sciptKeyHashes == 0 then
+            if null sciptKeyHashes then
                 Nothing
-            else Just (Set.fromList (L.nub sciptKeyHashes))
+            else Just (Set.fromList sciptKeyHashes)
     (scriptKeyHashes' <> scriptKeyHashes'') === expected
 
 prop_markingDiscoveredVerKeys
@@ -199,7 +198,7 @@ prop_poolExtension
     :: AccountXPubWithScriptExtension
     -> Property
 prop_poolExtension (AccountXPubWithScriptExtension accXPub' scripts') =
-    all (\s -> L.length (retrieveAllVerKeyHashes s) > 0)  scripts' ==>
+    all (not . null . retrieveAllVerKeyHashes) scripts' ==>
     scriptHashes == Set.fromList (map toScriptHash scripts') .&&.
         seqState3 == seqState0
   where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ScriptsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ScriptsSpec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -136,7 +135,7 @@ prop_scriptUpdatesStateProperly (AccountXPubWithScripts accXPub' scripts') = do
     let seqState = initializeState accXPub'
     let (_, seqState') = isShared script seqState
     let expected =
-            if L.length sciptKeyHashes == 0 then
+            if null sciptKeyHashes then
                 Nothing
             else Just (Set.fromList (L.nub sciptKeyHashes))
     scriptKeyHashesInMap script accXPub' seqState' === expected
@@ -198,7 +197,7 @@ prop_poolExtension
     :: AccountXPubWithScriptExtension
     -> Property
 prop_poolExtension (AccountXPubWithScriptExtension accXPub' scripts') =
-    all (not . null . retrieveAllVerKeyHashes) scripts' ==>
+    not (any (null . retrieveAllVerKeyHashes) scripts') ==>
     scriptHashes == Set.fromList (map toScriptHash scripts') .&&.
         seqState3 == seqState0
   where

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -193,6 +193,7 @@ test-suite unit
     , hspec-core
     , iohk-monitoring
     , hspec
+    , hspec-core
     , memory
     , optparse-applicative
     , ouroboros-consensus-shelley

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -18,7 +18,7 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv, XPub )
 import Cardano.Address.Script
-    ( Script (..), ScriptHash (..), keyHashFromBytes, toScriptHash )
+    ( KeyHash, Script (..), ScriptHash (..), keyHashFromBytes, toScriptHash )
 import Cardano.Crypto.Hash.Class
     ( digest )
 import Cardano.Ledger.Crypto
@@ -321,7 +321,7 @@ spec = do
         testScriptsAllLangs Cardano.SimpleScriptV2
         testScriptsTimelockLang
 
-toKeyHash :: Text -> Script
+toKeyHash :: Text -> Script KeyHash
 toKeyHash txt = case fromBase16 (T.encodeUtf8 txt) of
     Right bs -> case keyHashFromBytes bs of
         Just kh -> RequireSignatureOf kh
@@ -336,7 +336,7 @@ toPaymentHash txt =
 
 checkScriptHashes
     :: String
-    -> Script
+    -> Script KeyHash
     -> Cardano.Script lang
     -> SpecWith ()
 checkScriptHashes title adrestiaScript nodeScript = it title $

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -325,25 +325,100 @@ testScripts
     -> SpecM () ()
 testScripts version = do
     let hashKeyTxt1 = "deeae4e895d8d57378125ed4fd540f9bf245d59f7936a504379cfc1e"
+    let hashKeyTxt2 = "60a3bf69aa748f9934b64357d9f1ca202f1a768aaf57263aedca8d5f"
+    let hashKeyTxt3 = "ffcbb72393215007d9a0aa02b7430080409cd8c053fd4f5b4d905053"
+    let hashKeyTxt4 = "96834025cdca063ce9c32dfae6bc6a3e47f8da07ee4fb8e1a3901559"
 
     let toKeyHash txt = case fromBase16 (T.encodeUtf8 txt) of
             Right bs -> case keyHashFromBytes bs of
-                Just kh -> kh
+                Just kh -> RequireSignatureOf kh
                 Nothing -> error "Hash key not valid"
             Left _ -> error "Hash key not valid"
 
     let toPaymentHash txt =
             case Cardano.deserialiseFromRawBytesHex (Cardano.AsHash Cardano.AsPaymentKey) (T.encodeUtf8 txt) of
-                Just payKeyHash -> payKeyHash
+                Just payKeyHash -> Cardano.RequireSignature payKeyHash
                 Nothing -> error "Hash key not valid"
 
     let toSimpleScript = Cardano.SimpleScript version
 
     let matrix =
             [ ( show version <> " RequireSignatureOf"
-              , RequireSignatureOf (toKeyHash hashKeyTxt1)
+              , toKeyHash hashKeyTxt1
+              , toSimpleScript $ toPaymentHash hashKeyTxt1
+              )
+            , ( show version <> " RequireSignatureOf"
+              , toKeyHash hashKeyTxt2
+              , toSimpleScript $ toPaymentHash hashKeyTxt2
+              )
+            , ( show version <> " RequireSignatureOf"
+              , toKeyHash hashKeyTxt3
+              , toSimpleScript $ toPaymentHash hashKeyTxt3
+              )
+            , ( show version <> " RequireSignatureOf"
+              , toKeyHash hashKeyTxt4
+              , toSimpleScript $ toPaymentHash hashKeyTxt4
+              )
+            , ( show version <> " RequireAllOf"
+              , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
               , toSimpleScript $
-                  Cardano.RequireSignature (toPaymentHash hashKeyTxt1)
+                  Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
+              )
+            , ( show version <> " RequireAllOf"
+              , RequireAllOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+              , toSimpleScript $
+                  Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+              )
+            , ( show version <> " RequireAnyOf"
+              , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]
+              , toSimpleScript $
+                  Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2]
+              )
+            , ( show version <> " RequireAnyOf"
+              , RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+              , toSimpleScript $
+                  Cardano.RequireAnyOf [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+              )
+            , ( show version <> " RequireSomeOf"
+              , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3]
+              , toSimpleScript $
+                  Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3]
+              )
+            , ( show version <> " RequireSomeOf"
+              , RequireSomeOf 2 [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+              , toSimpleScript $
+                  Cardano.RequireMOf 2 [toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+              )
+            , ( show version <> " nested 1"
+              , RequireSomeOf 2 [ toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2
+                                , RequireAllOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+                                ]
+              , toSimpleScript $
+                  Cardano.RequireMOf 2 [ toPaymentHash hashKeyTxt1, toPaymentHash hashKeyTxt2
+                                       , Cardano.RequireAllOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                                       ]
+              )
+            , ( show version <> " nested 2"
+              , RequireAllOf [ toKeyHash hashKeyTxt1
+                             , RequireAnyOf [toKeyHash hashKeyTxt2, toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4]
+                             ]
+              , toSimpleScript $
+                  Cardano.RequireAllOf [ toPaymentHash hashKeyTxt1
+                                       , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt2, toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                                       ]
+              )
+            , ( show version <> " nested 3"
+              , RequireSomeOf 1 [ toKeyHash hashKeyTxt1
+                                , RequireAllOf [ toKeyHash hashKeyTxt2
+                                               , RequireAnyOf [toKeyHash hashKeyTxt3, toKeyHash hashKeyTxt4 ]
+                                               ]
+                                ]
+              , toSimpleScript $
+                  Cardano.RequireMOf 1 [ toPaymentHash hashKeyTxt1
+                                       , Cardano.RequireAllOf [ toPaymentHash hashKeyTxt2
+                                                              , Cardano.RequireAnyOf [toPaymentHash hashKeyTxt3, toPaymentHash hashKeyTxt4]
+                                                              ]
+                                       ]
               )
             ]
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -351,8 +351,8 @@ checkScriptHashes
     -> Cardano.Script lang
     -> SpecWith ()
 checkScriptHashes title adrestiaScript nodeScript = it title $
-    (unScriptHash $ toScriptHash adrestiaScript) `shouldBe`
-    (Cardano.serialiseToRawBytes $ Cardano.hashScript nodeScript)
+    unScriptHash (toScriptHash adrestiaScript) `shouldBe`
+    Cardano.serialiseToRawBytes (Cardano.hashScript nodeScript)
 
 checkScriptPreimage
     :: Cardano.SerialiseAsCBOR (Cardano.Script lang)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -445,18 +445,18 @@ testScriptsTimelockLang = do
     let toSimpleScript = Cardano.SimpleScript Cardano.SimpleScriptV2
 
     let matrix =
-            [ ( "SimpleScriptV2 StartSlot"
-              , RequireAllOf [toKeyHash hashKeyTxt1, StartSlot 120]
+            [ ( "SimpleScriptV2 ValidFromSlot"
+              , RequireAllOf [toKeyHash hashKeyTxt1, ValidFromSlot 120]
               , toSimpleScript $
                   Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, Cardano.RequireTimeAfter Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)]
               )
-            , ( "SimpleScriptV2 ExpireSlot"
-              , RequireAllOf [toKeyHash hashKeyTxt1, ExpireSlot 120]
+            , ( "SimpleScriptV2 ValidUntilSlot"
+              , RequireAllOf [toKeyHash hashKeyTxt1, ValidUntilSlot 120]
               , toSimpleScript $
                   Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, Cardano.RequireTimeBefore Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)]
               )
-            , ( "SimpleScriptV2 ExpireSlot and StartSlot"
-              , RequireAllOf [StartSlot 120, ExpireSlot 150, RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]]
+            , ( "SimpleScriptV2 ValidFromSlot and ValidUntilSlot"
+              , RequireAllOf [ValidFromSlot 120, ValidUntilSlot 150, RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]]
               , toSimpleScript $
                   Cardano.RequireAllOf
                   [ Cardano.RequireTimeAfter Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -445,18 +445,18 @@ testScriptsTimelockLang = do
     let toSimpleScript = Cardano.SimpleScript Cardano.SimpleScriptV2
 
     let matrix =
-            [ ( "SimpleScriptV2 ValidFromSlot"
-              , RequireAllOf [toKeyHash hashKeyTxt1, ValidFromSlot 120]
+            [ ( "SimpleScriptV2 ActiveFromSlot"
+              , RequireAllOf [toKeyHash hashKeyTxt1, ActiveFromSlot 120]
               , toSimpleScript $
                   Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, Cardano.RequireTimeAfter Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)]
               )
-            , ( "SimpleScriptV2 ValidUntilSlot"
-              , RequireAllOf [toKeyHash hashKeyTxt1, ValidUntilSlot 120]
+            , ( "SimpleScriptV2 ActiveUntilSlot"
+              , RequireAllOf [toKeyHash hashKeyTxt1, ActiveUntilSlot 120]
               , toSimpleScript $
                   Cardano.RequireAllOf [toPaymentHash hashKeyTxt1, Cardano.RequireTimeBefore Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)]
               )
-            , ( "SimpleScriptV2 ValidFromSlot and ValidUntilSlot"
-              , RequireAllOf [ValidFromSlot 120, ValidUntilSlot 150, RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]]
+            , ( "SimpleScriptV2 ActiveFromSlot and ActiveUntilSlot"
+              , RequireAllOf [ActiveFromSlot 120, ActiveUntilSlot 150, RequireAnyOf [toKeyHash hashKeyTxt1, toKeyHash hashKeyTxt2]]
               , toSimpleScript $
                   Cardano.RequireAllOf
                   [ Cardano.RequireTimeAfter Cardano.TimeLocksInSimpleScriptV2 (SlotNo 120)

--- a/nix/.stack.nix/cardano-addresses-cli.nix
+++ b/nix/.stack.nix/cardano-addresses-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.12";
-      identifier = { name = "cardano-addresses-cli"; version = "3.1.0"; };
+      identifier = { name = "cardano-addresses-cli"; version = "3.2.0"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -85,8 +85,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "9c38189c3e0e011a305ddcd1219e50a0731e99ea";
-      sha256 = "1p93g97aacfsgd68bjm1yw0ccp8wmlqfslcv3qm0q6bahsrrhl02";
+      rev = "115174cc451d3fc6b90ce61782f841e51f271c3d";
+      sha256 = "0l001m2d8rd0l0nxr3y9i5qxlgah03b0sdixxgsfmy7lzjm9c287";
       });
     postUnpack = "sourceRoot+=/command-line; echo source root reset to \$sourceRoot";
     }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/cardano-addresses.nix
+++ b/nix/.stack.nix/cardano-addresses.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.12";
-      identifier = { name = "cardano-addresses"; version = "3.1.0"; };
+      identifier = { name = "cardano-addresses"; version = "3.2.0"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";
@@ -36,6 +36,7 @@
           (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
           (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."digest" or (errorHandler.buildDepError "digest"))
@@ -45,6 +46,7 @@
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
           (hsPkgs."text" or (errorHandler.buildDepError "text"))
+          (hsPkgs."unordered-containers" or (errorHandler.buildDepError "unordered-containers"))
           ];
         buildable = true;
         };
@@ -59,6 +61,7 @@
             (hsPkgs."bytestring" or (errorHandler.buildDepError "bytestring"))
             (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
             (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
@@ -73,8 +76,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-addresses";
-      rev = "9c38189c3e0e011a305ddcd1219e50a0731e99ea";
-      sha256 = "1p93g97aacfsgd68bjm1yw0ccp8wmlqfslcv3qm0q6bahsrrhl02";
+      rev = "115174cc451d3fc6b90ce61782f841e51f271c3d";
+      sha256 = "0l001m2d8rd0l0nxr3y9i5qxlgah03b0sdixxgsfmy7lzjm9c287";
       });
     postUnpack = "sourceRoot+=/core; echo source root reset to \$sourceRoot";
     }) // { cabal-generator = "hpack"; }

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -148,6 +148,7 @@
             (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
             (hsPkgs."ouroboros-consensus-shelley" or (errorHandler.buildDepError "ouroboros-consensus-shelley"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -387,23 +387,23 @@ x-ScriptValue: &ScriptValue
               items:
                 $ref: "#/components/schemas/ScriptValue"
 
-    - title: Active from
+    - title: Active from slot
       type: object
       required:
         - active_from
       properties:
         active_from:
-          description: Transaction has to occur no sooner than a specified slot number.
+          description: Transaction is only valid starting at the specified slot number (`≥ active_from`).
           type: integer
           minimum: 0
 
-    - title: Active until
+    - title: Active until slot
       type: object
       required:
         - active_until
       properties:
         active_until:
-          description: Transaction has to occur before a specified slot number.
+          description: Transaction is only valid before the specified slot number (`< active_until`).
           type: integer
           minimum: 0
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -387,22 +387,22 @@ x-ScriptValue: &ScriptValue
               items:
                 $ref: "#/components/schemas/ScriptValue"
 
-    - title: Valid from
+    - title: Active from
       type: object
       required:
-        - valid_from
+        - active_from
       properties:
-        valid_from:
+        active_from:
           description: Transaction has to occur no sooner than a specified slot number.
           type: integer
           minimum: 0
 
-    - title: Valid until
+    - title: Active until
       type: object
       required:
-        - valid_until
+        - active_until
       properties:
-        valid_from:
+        active_until:
           description: Transaction has to occur before a specified slot number.
           type: integer
           minimum: 0

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -387,6 +387,26 @@ x-ScriptValue: &ScriptValue
               items:
                 $ref: "#/components/schemas/ScriptValue"
 
+    - title: Valid from
+      type: object
+      required:
+        - valid_from
+      properties:
+        valid_from:
+          description: Transaction has to occur no sooner than a specified slot number.
+          type: integer
+          minimum: 0
+
+    - title: Valid until
+      type: object
+      required:
+        - valid_until
+      properties:
+        valid_from:
+          description: Transaction has to occur before a specified slot number.
+          type: integer
+          minimum: 0
+
 x-script: &script
   <<: *ScriptValue
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,8 +15,6 @@ packages:
 - lib/test-utils
 - lib/shelley
 - lib/strict-non-empty-containers
-- ../cardano-addresses/command-line
-- ../cardano-addresses/core
 
 extra-deps:
 # Miscellaneous
@@ -67,12 +65,12 @@ extra-deps:
     - persistent-sqlite
     - persistent-template
 
-# cardano-addresses-3.1.0
-#- git: https://github.com/input-output-hk/cardano-addresses
-#  commit: 9c38189c3e0e011a305ddcd1219e50a0731e99ea
-#  subdirs:
-#    - command-line
-#    - core
+# cardano-addresses-3.2.0
+- git: https://github.com/input-output-hk/cardano-addresses
+  commit: 115174cc451d3fc6b90ce61782f841e51f271c3d
+  subdirs:
+    - command-line
+    - core
 
 # cardano-transactions master branch
 - git: https://github.com/input-output-hk/cardano-transactions

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,8 @@ packages:
 - lib/test-utils
 - lib/shelley
 - lib/strict-non-empty-containers
+- ../cardano-addresses/command-line
+- ../cardano-addresses/core
 
 extra-deps:
 # Miscellaneous
@@ -66,11 +68,11 @@ extra-deps:
     - persistent-template
 
 # cardano-addresses-3.1.0
-- git: https://github.com/input-output-hk/cardano-addresses
-  commit: 9c38189c3e0e011a305ddcd1219e50a0731e99ea
-  subdirs:
-    - command-line
-    - core
+#- git: https://github.com/input-output-hk/cardano-addresses
+#  commit: 9c38189c3e0e011a305ddcd1219e50a0731e99ea
+#  subdirs:
+#    - command-line
+#    - core
 
 # cardano-transactions master branch
 - git: https://github.com/input-output-hk/cardano-transactions


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue this PR relates to and which requirements it tackles -->
https://jira.iohk.io/browse/ADP-673

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] I have added the first test for `RequireSignatureOf` of `Script` for both `SimpleScriptV1` and `SimpleScriptV2`
- [x] I have added more golden for `Script`
- [x] I have added golden for `Script` extended by `StartSlot` `ExpireSlot`
- [x] Rest code aligning when cardano-addresses 3.2.0 is released

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!-- 
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Once created, link this PR to its corresponding ticket
 ✓ Assign the PR to a corresponding milestone
 ✓ Acknowledge any changes required to the Wiki
-->
