### PR TITLE
Additional checks for input existence in transactions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -413,6 +413,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 between (feeMin + (2*amt), feeMax + (2*amt))
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
             , expectField (#status . #getApiT) (`shouldBe` Pending)
+            , expectField #inputs $ \inputs' -> do
+                inputs' `shouldSatisfy` all (isJust . source)
             ]
 
         verify ra

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -341,8 +341,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             verify rDst
                 [ expectSuccess
                 , expectResponseCode HTTP.status200
-                , expectField (#amount . #getQuantity) $
-                    (`shouldBe` amt)
+                , expectField (#amount . #getQuantity) (`shouldBe` amt)
                 -- all tx inputs have NO address and amount
                 -- as the tx is incoming
                 , expectField #inputs $ \inputs' -> do
@@ -446,8 +445,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             verify rDst
                 [ expectSuccess
                 , expectResponseCode HTTP.status200
-                , expectField (#amount . #getQuantity) $
-                    (`shouldBe` (2 * amt) )
+                , expectField (#amount . #getQuantity) (`shouldBe` (2 * amt))
                 -- all tx inputs have NO address and amount
                 -- as the tx is incoming
                 , expectField #inputs $ \inputs' -> do


### PR DESCRIPTION
# Issue Number

It turns out there are no checks for that.
A bit related to #2327.

# Overview

- 2605a9f1071aad41bca21d8ef98210c117f7cfb9
  Additional checks for inputs in incoming and outgoing transactions in integration tests
  
- 1247f9a75598a3b3f44d6b7631645868fac272a4
  Additional checks for inputs in join/quit pool transactions
  
- bd2916b0423811b85328edb60ae427f2e4b4dee4
  remove redundant cases & fix fixture wallet sharing common funding UTxOs
      It's a bit fucked up. Since the scenario is using fixtureWallet, the
    UtxO from the wallet comes from one of the fixture transaction made
    when initializing the cluster. There are many pre-funded fixture
    wallets with 10 UTxO, but in order not to spend 10 days funding them
    all, the cluster generate pretty large transaction with ~100
    outputs. So a single fixture transaction funds about 10 fixture
    wallets.

    Now it means that, a particular fixture wallet will know the value
    of all inputs of its funding fixture transaction and therefore, when
    picking two fixtureWallet one after the other, it may likely happen
    that both wallets are able to resolve inputs of any UTxO coming from
    their original fixture transaction.

    I fixed it by simply using fixtureWalletWith [...] which generates
    completly new and uncorrelated UTxOs.

- cdf556ac20da1ca7afe12c831a0876633f704317
  Add input check for multi-address pending tx



# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
