### PR TITLE
Disable test retrying when running locally

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@ env:
   CACHE_DIR: "/cache/cardano-wallet"
   LC_ALL: "en_US.UTF-8"
   TESTS_LOGDIR: "/tmp/wallet-integration-logs"
+  TESTS_RETRY_FAILED: "yes"
 
 steps:
   - label: 'Prevent merging to wrong branch'

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -6,6 +6,8 @@ import Data.IORef
     ( IORef, newIORef, readIORef, writeIORef )
 import Data.List
     ( isPrefixOf )
+import System.Environment
+    ( setEnv )
 import System.IO.Silently
     ( capture_ )
 import Test.Hspec
@@ -14,6 +16,7 @@ import Test.Hspec
     , Spec
     , SpecWith
     , beforeAll
+    , before_
     , describe
     , expectationFailure
     , it
@@ -29,7 +32,7 @@ import qualified Test.Hspec.Extra as Extra
 
 spec :: Spec
 spec = do
-    describe "Extra.it" $ do
+    describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
         it "equals Hspec.it on success" $ do
             let test = 1 `shouldBe` (1::Int)
             test `shouldMatchHSpecIt` test

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -106,6 +106,7 @@ let
           integration.preCheck = noCacheCookie + ''
             # Variables picked up by integration tests
             export CARDANO_NODE_TRACING_MIN_SEVERITY=notice
+            export TESTS_RETRY_FAILED=yes
 
             # Integration tests will place logs here
             export TESTS_LOGDIR=$(mktemp -d)/logs


### PR DESCRIPTION
### Issue Number

Flaky tests

### Overview

This change will make it easier to detect flaky tests when running tests locally.

Retrying on failure is now enabled with an environment variable (`TESTS_RETRY_FAILED`). This variable is set for CI.

### Comments

- Needs #2389 merged first.

- [Testing wiki page](https://github.com/input-output-hk/cardano-wallet/wiki/Testing)

