### PR TITLE
Let integration tests use the CARDANO_WALLET_PORT variable

### DIFF
--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -27,8 +27,6 @@ import Cardano.CLI
     ( Port (..) )
 import Cardano.Startup
     ( withUtf8Encoding )
-import Cardano.Wallet.Api.Server
-    ( Listen (..) )
 import Cardano.Wallet.Api.Types
     ( ApiAddress
     , ApiFee
@@ -62,7 +60,12 @@ import Cardano.Wallet.Shelley
 import Cardano.Wallet.Shelley.Faucet
     ( initFaucet )
 import Cardano.Wallet.Shelley.Launch
-    ( RunningNode (..), sendFaucetFundsTo, withCluster, withSystemTempDir )
+    ( RunningNode (..)
+    , sendFaucetFundsTo
+    , walletListenFromEnv
+    , withCluster
+    , withSystemTempDir
+    )
 import Control.Arrow
     ( first )
 import Control.Monad
@@ -414,6 +417,7 @@ withShelleyServer tracers action = do
     onClusterStart act dir (RunningNode socketPath block0 (gp, vData)) = do
         let db = dir </> "wallets"
         createDirectory db
+        listen <- walletListenFromEnv
         -- NOTE: We may want to keep a wallet running across the fork, but
         -- having three callbacks like this might not work well for that.
         serveWallet
@@ -423,7 +427,7 @@ withShelleyServer tracers action = do
             (Just db)
             Nothing
             "127.0.0.1"
-            ListenOnRandomPort
+            listen
             Nothing
             Nothing
             socketPath

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -37,8 +37,6 @@ import Cardano.Startup
     , setDefaultFilePermissions
     , withUtf8Encoding
     )
-import Cardano.Wallet.Api.Server
-    ( Listen (..) )
 import Cardano.Wallet.Api.Types
     ( EncodeAddress (..) )
 import Cardano.Wallet.Logging
@@ -70,6 +68,7 @@ import Cardano.Wallet.Shelley.Launch
     , sendFaucetFundsTo
     , testLogDirFromEnv
     , testMinSeverityFromEnv
+    , walletListenFromEnv
     , walletMinSeverityFromEnv
     , withCluster
     , withSMASH
@@ -307,6 +306,8 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
     onClusterStart action dbDecorator node = do
         let db = testDir </> "wallets"
         createDirectory db
+        listen <- walletListenFromEnv
+
         -- NOTE: We may want to keep a wallet running across the fork, but
         -- having three callbacks like this might not work well for that.
         serveWallet
@@ -316,7 +317,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
             (Just db)
             (Just dbDecorator)
             "127.0.0.1"
-            ListenOnRandomPort
+            listen
             Nothing
             Nothing
             socketPath


### PR DESCRIPTION
While updating the [Testing](https://github.com/input-output-hk/cardano-wallet/wiki/Testing) wiki page, I thought it would be better if environment variables worked for all tests and benchmarks.
