### PR TITLE
Fix signal handling in test cluster and integration tests

### DIFF
--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -18,6 +18,7 @@ module Cardano.Startup
     , withShutdownHandler
     , withShutdownHandler'
     , installSignalHandlers
+    , installSignalHandlersNoLogging
     , killProcess
 
     -- * File permissions
@@ -155,3 +156,10 @@ instance HasSeverityAnnotation ShutdownHandlerLog where
         MsgShutdownHandler _ -> Debug
         MsgShutdownEOF -> Notice
         MsgShutdownError _ -> Error
+
+{-------------------------------------------------------------------------------
+                          Termination Signal Handling
+-------------------------------------------------------------------------------}
+
+installSignalHandlersNoLogging :: IO ()
+installSignalHandlersNoLogging = installSignalHandlers (pure ())

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -25,7 +25,7 @@ import Cardano.CLI
     , withLoggingNamed
     )
 import Cardano.Startup
-    ( setDefaultFilePermissions, withUtf8Encoding )
+    ( installSignalHandlers, setDefaultFilePermissions, withUtf8Encoding )
 import Cardano.Wallet.Api.Types
     ( EncodeAddress (..) )
 import Cardano.Wallet.Logging
@@ -265,6 +265,9 @@ withLocalClusterSetup
     :: (FilePath -> [LogOutput] -> [LogOutput] -> IO a)
     -> IO a
 withLocalClusterSetup action = do
+    -- Handle SIGTERM properly
+    installSignalHandlers (putStrLn "Terminated")
+
     -- Ensure key files have correct permissions for cardano-cli
     setDefaultFilePermissions
 

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -33,7 +33,10 @@ import Cardano.CLI
 import Cardano.Launcher
     ( ProcessHasExited (..) )
 import Cardano.Startup
-    ( setDefaultFilePermissions, withUtf8Encoding )
+    ( installSignalHandlersNoLogging
+    , setDefaultFilePermissions
+    , withUtf8Encoding
+    )
 import Cardano.Wallet.Api.Server
     ( Listen (..) )
 import Cardano.Wallet.Api.Types
@@ -198,6 +201,8 @@ main = withTestsSetup $ \testDir tracers -> do
 -- directory, and pass this info to the main hspec action.
 withTestsSetup :: (FilePath -> (Tracer IO TestsLog, Tracers IO) -> IO a) -> IO a
 withTestsSetup action = do
+    -- Handle SIGTERM properly
+    installSignalHandlersNoLogging
     -- Flush test output as soon as a line is printed
     hSetBuffering stdout LineBuffering
     hSetBuffering stderr LineBuffering


### PR DESCRIPTION
### Overview

This lets the test cluster and integration tests clean up properly if they are killed with SIGTERM.

### Comments

Based on PR #2409 branch - merge that first.