### PR TITLE
Review worker error handling

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -481,8 +481,6 @@ import Statistics.Quantile
     ( medianUnbiased, quantiles )
 import Type.Reflection
     ( Typeable, typeRep )
-import UnliftIO.Exception
-    ( Exception )
 import UnliftIO.MVar
     ( modifyMVar_, newMVar )
 
@@ -2675,9 +2673,19 @@ newtype ErrFetchRewards
 data ErrCheckWalletIntegrity
     = ErrCheckWalletIntegrityNoSuchWallet ErrNoSuchWallet
     | ErrCheckIntegrityDifferentGenesis (Hash "Genesis") (Hash "Genesis")
+    -- ^ Mismatch between expected and actual genesis hash.
     deriving (Eq, Show)
 
-instance Exception ErrCheckWalletIntegrity
+instance ToText ErrCheckWalletIntegrity where
+    toText = \case
+        ErrCheckWalletIntegrityNoSuchWallet (ErrNoSuchWallet wid) ->
+            "Wallet \"" <> toText wid <> "\" was expected to exist, " <>
+            "but it was not found in the database!"
+        ErrCheckIntegrityDifferentGenesis expected actual -> T.unlines
+            [ "Genesis hash mismatch!"
+            , "Genesis file specified: " <> toText expected
+            , "Database contains:      " <> toText actual
+            ]
 
 data ErrCannotJoin
     = ErrAlreadyDelegating PoolId
@@ -2825,6 +2833,7 @@ data WalletLog
     | MsgRewardBalanceExited
     | MsgTxSubmit TxSubmitLog
     | MsgIsStakeKeyRegistered Bool
+    | MsgIntegrityCheckFailed ErrCheckWalletIntegrity
     deriving (Show, Eq)
 
 instance ToText WalletFollowLog where
@@ -2890,6 +2899,9 @@ instance ToText WalletLog where
             "Wallet stake key is registered. Will not register it again."
         MsgIsStakeKeyRegistered False ->
             "Wallet stake key is not registered. Will register..."
+        MsgIntegrityCheckFailed err ->
+            "Integrity check failed when loading wallet: " <>
+            T.pack (show err)
 
 instance HasPrivacyAnnotation WalletFollowLog
 instance HasSeverityAnnotation WalletFollowLog where
@@ -2918,6 +2930,7 @@ instance HasSeverityAnnotation WalletLog where
         MsgRewardBalanceExited -> Notice
         MsgTxSubmit msg -> getSeverityAnnotation msg
         MsgIsStakeKeyRegistered _ -> Info
+        MsgIntegrityCheckFailed _ -> Error
 
 data TxSubmitLog
     = MsgPostTxResult (Hash "Tx") (Either ErrPostTx ())

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -63,8 +63,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta
     , TxStatus
     )
-import Control.Monad.IO.Class
-    ( MonadIO )
+import Control.Monad.IO.Unlift
+    ( MonadIO, MonadUnliftIO )
 import Control.Monad.Trans.Except
     ( ExceptT, runExceptT )
 import Data.Quantity
@@ -76,14 +76,14 @@ import qualified Data.List as L
 
 -- | Instantiate database layers at will
 data DBFactory m s k = DBFactory
-    { withDatabase :: forall a. WalletId -> (DBLayer m s k -> IO a) -> IO a
+    { withDatabase :: forall a. (MonadUnliftIO m) => WalletId -> (DBLayer m s k -> m a) -> m a
         -- ^ Creates a new or use an existing database, maintaining an open
         -- connection so long as necessary
 
-    , removeDatabase :: WalletId -> IO ()
+    , removeDatabase :: MonadUnliftIO m => WalletId -> m ()
         -- ^ Erase any trace of the database
 
-    , listDatabases :: IO [WalletId]
+    , listDatabases :: m [WalletId]
         -- ^ List existing wallet database found on disk.
     }
 

--- a/lib/core/src/Cardano/Wallet/Registry.hs
+++ b/lib/core/src/Cardano/Wallet/Registry.hs
@@ -14,6 +14,7 @@ module Cardano.Wallet.Registry
     , empty
     , keys
     , lookup
+    , lookupResource
     , register
     , unregister
 
@@ -24,7 +25,6 @@ module Cardano.Wallet.Registry
     , workerThread
     , workerId
     , workerResource
-    , liftWorker
 
       -- * Context
     , HasWorkerCtx (..)
@@ -47,13 +47,15 @@ import Cardano.Wallet
 import Cardano.Wallet.Logging
     ( LoggedException (..) )
 import Control.Monad
-    ( void )
+    ( void, (>=>) )
 import Control.Monad.IO.Unlift
-    ( MonadUnliftIO (..), askRunInIO, liftIO )
+    ( MonadUnliftIO (..), liftIO )
 import Control.Tracer
     ( Tracer, contramap, natTracer, traceWith )
 import Data.Foldable
     ( traverse_ )
+import Data.Functor
+    ( ($>) )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Generics.Labels
@@ -73,9 +75,19 @@ import GHC.Generics
 import UnliftIO.Concurrent
     ( ThreadId, forkFinally, killThread )
 import UnliftIO.Exception
-    ( SomeException, catch, isSyncException, throwIO, withException )
+    ( SomeException, isSyncException, throwIO )
 import UnliftIO.MVar
-    ( MVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar, takeMVar )
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    , tryTakeMVar
+    )
 
 {-------------------------------------------------------------------------------
                                 Worker Context
@@ -114,7 +126,17 @@ lookup
     -> key
     -> m (Maybe (Worker key resource))
 lookup (WorkerRegistry mvar) k =
-    liftIO (Map.lookup k <$> readMVar mvar)
+    Map.lookup k <$> readMVar mvar
+
+-- | Lookup the resource for a given worker. If the worker is registered, but
+-- not yet initialized, this will block until the resource is acquired and the
+-- 'workerBefore' action is complete.
+lookupResource
+    :: (MonadUnliftIO m, Ord key)
+    => WorkerRegistry key resource
+    -> key
+    -> m (Maybe resource)
+lookupResource reg k = lookup reg k >>= traverse (readMVar . workerResource)
 
 -- | Get all registered keys in the registry
 keys
@@ -124,14 +146,35 @@ keys
 keys (WorkerRegistry mvar) =
     Map.keys <$> readMVar mvar
 
--- | Register a new worker
-insert
+-- | Registers a new worker, unless it has already been registered.
+-- If the worker is already registered, 'Just' that worker will be returned.
+-- Otherwise, 'Nothing' is returned.
+getOrCreate
     :: (MonadUnliftIO m, Ord key)
     => WorkerRegistry key resource
     -> Worker key resource
-    -> m ()
-insert (WorkerRegistry mvar) wrk =
-    modifyMVar_ mvar (pure . Map.insert (workerId wrk) wrk)
+    -> m (Maybe (Worker key resource))
+getOrCreate (WorkerRegistry mvar) wrk = modifyMVar mvar $ \registry ->
+    pure $ case Map.lookup (workerId wrk) registry of
+        Just existing -> (registry, Just existing)
+        Nothing -> (Map.insert (workerId wrk) wrk registry, Nothing)
+
+-- | Register a worker with empty ThreadId and resource, then run the given
+-- action.
+--
+-- If there is already a worker registered, return that, and don't run any
+-- action.
+addWorker
+    :: (MonadUnliftIO m, Ord key)
+    => WorkerRegistry key resource
+    -> key
+    -> (Worker key resource -> m ())
+    -> m (Worker key resource)
+addWorker registry k action = do
+    worker <- Worker k <$> newEmptyMVar <*> newEmptyMVar
+    registry `getOrCreate` worker >>= \case
+        Just existing -> pure existing
+        Nothing -> action worker $> worker
 
 -- | Delete a worker from the registry, but don't cancel the running task.
 --
@@ -153,7 +196,8 @@ unregister
     -> key
     -> m ()
 unregister registry k =
-    delete registry k >>= traverse_ (killThread . workerThread)
+    delete registry k >>=
+    traverse_ ((tryTakeMVar . workerThread) >=> traverse killThread)
 
 {-------------------------------------------------------------------------------
                                     Worker
@@ -163,8 +207,8 @@ unregister registry k =
 -- resource can be, for example, a handle to a database connection.
 data Worker key resource = Worker
     { workerId :: key
-    , workerThread :: ThreadId
-    , workerResource :: resource
+    , workerThread :: MVar ThreadId
+    , workerResource :: MVar resource
     } deriving (Generic)
 
 -- | See 'register'
@@ -186,27 +230,10 @@ data MkWorker m key resource msg ctx = MkWorker
     }
 
 defaultWorkerAfter
-    :: MonadUnliftIO m
-    => Tracer m (WorkerLog key msg)
+    :: Tracer m (WorkerLog key msg)
     -> Either SomeException a
     -> m ()
 defaultWorkerAfter tr = traceAfterThread (contramap MsgThreadAfter tr)
-
-liftWorker
-    :: MonadUnliftIO m
-    => MkWorker IO key resource msg ctx
-    -> MkWorker m key resource msg ctx
-liftWorker MkWorker{..} = MkWorker
-    { workerBefore = \ctx -> liftIO . workerBefore ctx
-    , workerMain = \ctx -> liftIO . workerMain ctx
-    , workerAfter = \tr e -> do
-            u <- askRunInIO
-            let tr' = Tracer $ \a -> u $ runTracer tr a
-            liftIO (workerAfter tr' e)
-    , workerAcquire = \action -> do
-            u <- askRunInIO
-            liftIO (workerAcquire (u . action))
-    }
 
 -- | Register a new worker for a given key.
 --
@@ -214,11 +241,12 @@ liftWorker MkWorker{..} = MkWorker
 -- and will terminate as soon as its task is over. In practice, we provide a
 -- never-ending task that keeps the worker alive forever.
 --
--- Any (synchronous) exceptions thrown during 'workerAcquire' setup or
--- 'workerBefore' are rethrown by this function.
+-- This function returns once the 'workerAcquire' and 'workerBefore' actions
+-- have completed. Any (synchronous) exceptions thrown during setup are rethrown
+-- by this function.
 --
--- The worker is registered after setup but before the workerMain action, and
--- unregistered after workerMain but before workerAfter. Fixme: there is a race condition because workers can be registered twice while their resource is being acquired.
+-- If a worker is already registered with the given key, the existing worker
+-- will be returned, and the new worker will be ignored.
 register
     :: forall m resource ctx key msg.
         ( MonadUnliftIO m
@@ -233,32 +261,27 @@ register
     -> key
     -> MkWorker m key resource msg ctx
     -> m (Worker key resource)
-register registry ctx k MkWorker{..} = do
-    resourceVar <- newEmptyMVar :: m (MVar (Either SomeException resource))
+register registry ctx k MkWorker{..} = addWorker registry k $ \worker -> do
+    -- Variable which is filled once worker is set up, and main action is about
+    -- to begin.
+    setupVar <- newEmptyMVar :: m (MVar (Maybe SomeException))
+    -- The worker thread.
     let work = workerAcquire $ \resource -> do
             let ctx' = hoistResource resource (MsgFromWorker k) ctx
             workerBefore ctx' k
-                `withException` (cleanup . Left)
-                `catch` (putMVar resourceVar . Left)
-            putMVar resourceVar (Right resource)
+            putMVar (workerResource worker) resource
+            putMVar setupVar Nothing
             workerMain ctx' k
     threadId <- work `forkFinally` \result -> do
-        removeWorker
-        cleanup result
-    takeMVar resourceVar >>= either throwIO (addWorker threadId)
+        void $ registry `delete` k
+        void $ tryPutMVar setupVar (either Just (const Nothing) result)
+        workerAfter tr result
+    putMVar (workerThread worker) threadId
+    -- Rethrow any exception which happened during worker setup, and return
+    -- control to caller.
+    takeMVar setupVar >>= maybe (pure ()) throwIO
   where
     tr = natTracer liftIO (ctx ^. logger @(WorkerLog key msg))
-    addWorker threadId resource = do
-        let worker = Worker
-                { workerId = k
-                , workerThread = threadId
-                , workerResource = resource
-                }
-        registry `insert` worker
-        return worker
-    removeWorker = void $ registry `delete` k
-    cleanup = workerAfter tr
-
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/core/src/UnliftIO/Compat.hs
+++ b/lib/core/src/UnliftIO/Compat.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -16,6 +18,10 @@ module UnliftIO.Compat
        -- * Missing combinators
      , handleIf
 
+       -- * IO conversion utilities
+     , unliftIOWith
+     , unliftIOTracer
+
        -- * Re-export unsafe things
      , AsyncCancelled (..)
      ) where
@@ -26,10 +32,19 @@ import Control.Concurrent.Async
     ( AsyncCancelled (..) )
 import Control.Exception.Base
     ( Exception )
+import Control.Monad
+    ( (<=<) )
 import Control.Monad.IO.Unlift
-    ( MonadUnliftIO (..) )
+    ( MonadUnliftIO (..), askRunInIO, liftIO, wrappedWithRunInIO )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), runExceptT, withExceptT )
+import Control.Tracer
+    ( Tracer (..) )
+import UnliftIO.Exception
+    ( Typeable, throwIO, try )
 
 import qualified Control.Monad.Catch as Exceptions
+import qualified Servant.Server as Servant
 import qualified UnliftIO.Exception as UnliftIO
 
 -- | Convert the generalized handler from 'UnliftIO.Exception' type to 'Control.Monad.Catch' type
@@ -61,3 +76,42 @@ handleIf
     -> m a
 handleIf f h = UnliftIO.handle
     (\e -> if f e then h e else UnliftIO.throwIO e)
+
+-- NOTE: This instance is problematic when parameter e is an Exception instance,
+-- and 'catchAny' or similar functions are used in the wrapper.
+--
+-- See: https://github.com/fpco/unliftio/issues/68
+instance (MonadUnliftIO m, Typeable e) => MonadUnliftIO (ExceptT e m) where
+  withRunInIO exceptToIO =
+    withExceptT unInternalException $ ExceptT $ try $
+      withRunInIO $ \runInIO ->
+        exceptToIO
+          (runInIO . (either (throwIO . InternalException) pure <=< runExceptT))
+
+-- | Wrapper for Left results of runExceptT. Used to deliver return values in
+-- the MonadUnliftIO instance of ExceptT.
+newtype InternalException e = InternalException { unInternalException :: e }
+    deriving Typeable
+instance Show (InternalException e) where
+    show _ = "MonadUnliftIO InternalException"
+instance Typeable e => Exception (InternalException e)
+
+-- Use above instance to define unlift for servant Handler
+instance MonadUnliftIO Servant.Handler where
+    withRunInIO = wrappedWithRunInIO Servant.Handler Servant.runHandler'
+
+-- | Lift a 'withResource' type function which runs in IO.
+-- TODO: could maybe use existing functions
+unliftIOWith
+    :: MonadUnliftIO m
+    => ((a -> IO b) -> IO b)
+    -> ((a -> m b) -> m b)
+unliftIOWith with action = do
+    u <- askRunInIO
+    liftIO (with (u . action))
+
+-- | Provides a Tracer in IO given a 'Tracer m'.
+unliftIOTracer :: MonadUnliftIO m => Tracer m a -> m (Tracer IO a)
+unliftIOTracer tr = do
+    u <- askRunInIO
+    pure $ Tracer $ \a -> u $ runTracer tr a


### PR DESCRIPTION
### Issue number

ADP-641

### Overview

With `MonadUnliftIO` it becomes easier to write polymorphic functions (`MonadIO` is not enough when there are callbacks).

So we can make the worker thread registry polymorphic, and run it in `IO` or `ExceptT e IO`.

That removes the need for using the `unsafeRunExceptT` function.

Although the register function can now work with checked exception types, it is also modified to be aware of IO exceptions which may be thrown during setup. These other exceptions are passed up to the caller.

The worker registry changes also fix a race condition where multiple worker threads could be started for the for the same key, before the worker resource is acquired.

### Comments

Three questions that I have:

1. What to do if the integrity check for only one of the wallets fails at startup. Carry on with just the working wallets? Or just fail?
   ⇒ A: Start the server anyway (previously it would fail at startup).
2. What to do if a wallet worker crashes. Should it be restarted? Should the server exit?
   ⇒ A: Restarts are handled elsewhere, although are probably not even necessary. Any other exceptions are truly unexpected. Maintain current behaviour.
3. I am not sure whether the `instance MonadUnliftIO (ExceptT e m)` is generally safe to use.