### PR TITLE
Fix flaky stake pools integration test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
 
   - label: 'Stack Rebuild'
     command:
-      - "mkdir -p $TESTS_LOGDIR"
+      - "rm -rf $TESTS_LOGDIR && mkdir $TESTS_LOGDIR"
       - "nix-build .buildkite/default.nix -o sr"
       - "./sr/bin/rebuild --build-dir=$BUILD_DIR --cache-dir=$CACHE_DIR"
     timeout_in_minutes: 120

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -37,7 +37,6 @@ library
     , cardano-addresses
     , cardano-addresses-cli
     , cardano-wallet-core
-    , contra-tracer
     , directory
     , filepath
     , fmt

--- a/lib/core-integration/src/Test/Integration/Framework/Context.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Context.hs
@@ -51,6 +51,8 @@ data Context = Context
         :: IORef [PoolGarbageCollectionEvent]
         -- ^ The complete list of pool garbage collection events.
         -- Most recent events are stored at the head of the list.
+    , _smashUrl :: Text
+        -- ^ Base URL of the mock smash server.
     }
     deriving Generic
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -207,7 +207,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_JOIN_01rewards - \
         \Can join a pool, earn rewards and collect them" $ \ctx -> runResourceT $ do
-        liftIO $ flakyBecauseOf "#2415"
         -- Setup
         src <- fixtureWallet ctx
         dest <- emptyWallet ctx
@@ -324,6 +323,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                   "withdrawal": "self"
                 }|]
 
+        waitForNextEpoch ctx
         rTx <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley src)
             Default (Json payloadWithdrawal)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -207,6 +207,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_JOIN_01rewards - \
         \Can join a pool, earn rewards and collect them" $ \ctx -> runResourceT $ do
+        liftIO $ flakyBecauseOf "#2415"
         -- Setup
         src <- fixtureWallet ctx
         dest <- emptyWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -82,8 +82,6 @@ import Data.Text.Class
     ( showT, toText )
 import Numeric.Natural
     ( Natural )
-import System.Environment
-    ( getEnv )
 import Test.Hspec
     ( SpecWith, describe, pendingWith )
 import Test.Hspec.Expectations.Lifted
@@ -1152,8 +1150,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     it "STAKE_POOLS_SMASH_01 - fetching metadata from SMASH works with delisted pools" $
         \ctx -> runResourceT $ bracketSettings ctx $ do
             liftIO $ flakyBecauseOf "#2337 (theorized)"
-            smashUrl <- liftIO $ getEnv "CARDANO_WALLET_SMASH_URL"
-            updateMetadataSource ctx (T.pack smashUrl)
+            updateMetadataSource ctx (_smashUrl ctx)
             eventually "metadata is fetched" $ do
                 r <- listPools ctx arbitraryStake
                 verify r
@@ -1192,8 +1189,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_SMASH_HEALTH_01 - Can check SMASH health when configured" $
         \ctx -> runResourceT $ bracketSettings ctx $ do
-            smashUrl <- liftIO $ getEnv "CARDANO_WALLET_SMASH_URL"
-            updateMetadataSource ctx (T.pack smashUrl)
+            updateMetadataSource ctx (_smashUrl ctx)
             r <- request @ApiHealthCheck
                 ctx Link.getCurrentSMASHHealth
                 Default Empty
@@ -1212,9 +1208,8 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
     it "STAKE_POOLS_SMASH_HEALTH_03 - Can check SMASH health via url" $
         \ctx -> runResourceT $ do
-            smashUrl <- liftIO $ getEnv "CARDANO_WALLET_SMASH_URL"
-            let withUrl f (method, link) = (method, link <> "?url=" <> T.pack f)
-            let link = withUrl smashUrl Link.getCurrentSMASHHealth
+            let withUrl f (method, link) = (method, link <> "?url=" <> f)
+            let link = withUrl (_smashUrl ctx) Link.getCurrentSMASHHealth
 
             r <- request @ApiHealthCheck ctx link Default Empty
             expectResponseCode HTTP.status200 r

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -99,6 +99,7 @@ library
     , text-class
     , time
     , tls
+    , tracer-transformers
     , transformers
     , typed-protocols
     , unliftio

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -158,7 +158,6 @@ module Cardano.Wallet
     , ErrGetTransaction (..)
     , ErrNoSuchTransaction (..)
     , ErrNetworkUnavailable (..)
-    , ErrCurrentNodeTip (..)
     , ErrStartTimeLaterThanEndTime (..)
 
     -- ** Root Key
@@ -202,8 +201,7 @@ import Cardano.Wallet.DB
     , sparseCheckpoints
     )
 import Cardano.Wallet.Network
-    ( ErrCurrentNodeTip (..)
-    , ErrGetAccountBalance (..)
+    ( ErrGetAccountBalance (..)
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
     , FollowAction (..)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -204,6 +204,7 @@ import Cardano.Wallet.Network
     ( ErrGetAccountBalance (..)
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
+    , ErrStakeDistribution (..)
     , FollowAction (..)
     , FollowExit (..)
     , FollowLog (..)
@@ -2570,7 +2571,7 @@ data ErrWithdrawalNotWorth
 
 -- | Errors that can occur when trying to list stake pool.
 data ErrListPools
-    = ErrListPoolsNetworkError ErrNetworkUnavailable
+    = ErrListPoolsQueryFailed ErrStakeDistribution
     | ErrListPoolsPastHorizonException PastHorizonException
     deriving (Show)
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -227,7 +227,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.DB
     ( DBFactory (..) )
 import Cardano.Wallet.Network
-    ( ErrNetworkUnavailable (..), NetworkLayer, timeInterpreter )
+    ( ErrNetworkUnavailable (..)
+    , ErrStakeDistribution (..)
+    , NetworkLayer
+    , timeInterpreter
+    )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (..)
     , Depth (..)
@@ -2786,8 +2790,17 @@ instance LiftHandler ErrWithdrawalNotWorth where
 
 instance LiftHandler ErrListPools where
     handler = \case
-        ErrListPoolsNetworkError e -> handler e
+        ErrListPoolsQueryFailed e -> handler e
         ErrListPoolsPastHorizonException e -> handler e
+
+instance LiftHandler ErrStakeDistribution where
+    handler = \case
+        ErrStakeDistributionQuery _e ->
+            apiError err503 NetworkQueryFailed $ mconcat
+                [ "Unable to query the ledger at the moment. "
+                , "This error has been logged. "
+                , "Trying again in a bit might work."
+                ]
 
 instance LiftHandler ErrSignMetadataWith where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -911,7 +911,7 @@ data ApiErrorCode
     | InvalidCoinSelection
     | NetworkUnreachable
     | NetworkMisconfigured
-    | NetworkTipNotFound
+    | NetworkQueryFailed
     | CreatedInvalidTransaction
     | RejectedByCoreNode
     | BadRequest
@@ -2221,4 +2221,3 @@ instance FromJSON (ApiT SmashServer) where
 
 instance ToJSON (ApiT SmashServer) where
     toJSON = toJSON . toText . getApiT
-

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -26,6 +26,7 @@ module Cardano.Wallet.Network
     , ErrGetTxParameters (..)
     , ErrPostTx (..)
     , ErrGetAccountBalance (..)
+    , ErrStakeDistribution (..)
 
     -- * Logging
     , FollowLog (..)
@@ -152,7 +153,7 @@ data NetworkLayer m block = NetworkLayer
     , stakeDistribution
         :: BlockHeader -- Point of interest
         -> Coin -- Stake to consider for rewards
-        -> ExceptT ErrNetworkUnavailable m StakePoolsSummary
+        -> ExceptT ErrStakeDistribution m StakePoolsSummary
 
     , getAccountBalance
         :: RewardAccount
@@ -204,6 +205,12 @@ data ErrGetAccountBalance
     = ErrGetAccountBalanceNetworkUnreachable ErrNetworkUnavailable
     | ErrGetAccountBalanceAccountNotFound RewardAccount
     deriving (Generic, Eq, Show)
+
+-- | Error while querying stake distribution from ledger.
+newtype ErrStakeDistribution
+    = ErrStakeDistributionQuery Text
+    -- ^ Query failed.
+    deriving (Generic, Show, Eq)
 
 {-------------------------------------------------------------------------------
                               Initialization

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -22,7 +22,6 @@ module Cardano.Wallet.Network
 
     -- * Errors
     , ErrNetworkUnavailable (..)
-    , ErrCurrentNodeTip (..)
     , ErrGetBlock (..)
     , ErrGetTxParameters (..)
     , ErrPostTx (..)
@@ -33,7 +32,6 @@ module Cardano.Wallet.Network
 
     -- * Initialization
     , defaultRetryPolicy
-    , waitForNetwork
     ) where
 
 import Prelude
@@ -66,7 +64,7 @@ import Control.Monad
 import Control.Monad.Trans.Except
     ( ExceptT (..), runExceptT )
 import Control.Retry
-    ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay, retrying )
+    ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay )
 import Control.Tracer
     ( Tracer, traceWith )
 import Data.Functor
@@ -88,7 +86,7 @@ import GHC.Generics
 import UnliftIO.Concurrent
     ( threadDelay )
 import UnliftIO.Exception
-    ( Exception (..), SomeException, bracket, handle, throwIO )
+    ( Exception (..), SomeException, bracket, handle )
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
@@ -123,7 +121,7 @@ data NetworkLayer m block = NetworkLayer
         -- ^ Get the slot corresponding to a cursor.
 
     , currentNodeTip
-        :: ExceptT ErrCurrentNodeTip m BlockHeader
+        :: m BlockHeader
         -- ^ Get the current tip from the chain producer
         --
     , currentNodeEra
@@ -181,16 +179,6 @@ data ErrNetworkUnavailable
       -- ^ Network backend reports that the requested network is invalid.
     deriving (Generic, Show, Eq)
 
-instance Exception ErrNetworkUnavailable
-
--- | Error while trying to get the node tip
-data ErrCurrentNodeTip
-    = ErrCurrentNodeTipNetworkUnreachable ErrNetworkUnavailable
-    | ErrCurrentNodeTipNotFound
-    deriving (Generic, Show, Eq)
-
-instance Exception ErrCurrentNodeTip
-
 -- | Error while trying to get one or more blocks
 data ErrGetBlock
     = ErrGetBlockNetworkUnreachable ErrNetworkUnavailable
@@ -199,12 +187,9 @@ data ErrGetBlock
 
 -- | Error while querying local parameters state.
 data ErrGetTxParameters
-    = ErrGetTxParametersTip ErrCurrentNodeTip
-    | ErrGetTxParametersNetworkUnreachable ErrNetworkUnavailable
+    = ErrGetTxParametersNetworkUnreachable ErrNetworkUnavailable
     | ErrGetTxParametersNotFound
     deriving (Generic, Show, Eq)
-
-instance Exception ErrGetTxParameters
 
 -- | Error while trying to send a transaction
 data ErrPostTx
@@ -223,26 +208,6 @@ data ErrGetAccountBalance
 {-------------------------------------------------------------------------------
                               Initialization
 -------------------------------------------------------------------------------}
-
--- | Wait until 'currentNodeTip networkLayer' succeeds according to a given
--- retry policy. Throws an exception otherwise.
-waitForNetwork
-    :: ExceptT ErrNetworkUnavailable IO ()
-    -> RetryPolicyM IO
-    -> IO ()
-waitForNetwork getStatus policy = do
-    r <- retrying policy shouldRetry (const $ runExceptT getStatus)
-    case r of
-        Right _ -> return ()
-        Left e -> throwIO e
-  where
-    shouldRetry _ = \case
-        Right _ ->
-            return False
-        Left ErrNetworkInvalid{} ->
-            return False
-        Left ErrNetworkUnreachable{} ->
-            return True
 
 -- | A default 'RetryPolicy' with a delay that starts short, and that retries
 -- for no longer than a minute.

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -5,11 +5,7 @@ module Cardano.Wallet.NetworkSpec
 import Prelude
 
 import Cardano.Wallet.Network
-    ( ErrCurrentNodeTip (..)
-    , ErrGetBlock (..)
-    , ErrNetworkUnavailable (..)
-    , ErrPostTx (..)
-    )
+    ( ErrGetBlock (..), ErrNetworkUnavailable (..), ErrPostTx (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Test.Hspec
@@ -20,11 +16,6 @@ spec = do
     describe "Pointless tests to cover 'Show' instances for errors" $ do
         testShow $ ErrNetworkUnreachable mempty
         testShow $ ErrNetworkInvalid mempty
-        testShow $ ErrCurrentNodeTipNetworkUnreachable
-            $ ErrNetworkUnreachable mempty
-        testShow $ ErrCurrentNodeTipNetworkUnreachable
-            $ ErrNetworkInvalid mempty
-        testShow ErrCurrentNodeTipNotFound
         testShow $ ErrGetBlockNetworkUnreachable
             $ ErrNetworkUnreachable mempty
         testShow $ ErrGetBlockNetworkUnreachable

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -392,6 +392,7 @@ withShelleyServer tracers action = do
                 , _networkParameters = np
                 , _poolGarbageCollectionEvents =
                     error "poolGarbageCollectionEvents not available"
+                , _smashUrl = ""
                 }
     race_ (takeMVar ctx >>= action) (withServer setupContext)
 

--- a/lib/shelley/exe/shelley-test-cluster.hs
+++ b/lib/shelley/exe/shelley-test-cluster.hs
@@ -228,7 +228,7 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
         withLoggingNamed "cardano-wallet" logs $ \(sb, (cfg, tr)) -> do
             ekgEnabled >>= flip when (EKG.plugin cfg tr sb >>= loadPlugin sb)
 
-            let tracers = setupTracers (tracerSeverities (Just Info)) tr
+            let tracers = setupTracers (tracerSeverities (Just Debug)) tr
             let db = dir </> "wallets"
             createDirectory db
             listen <- walletListenFromEnv

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -906,42 +906,39 @@ withStakePool tr baseDir idx params pledgeAmt poolConfig action =
 
 -- | Run a SMASH stub server, serving some delisted pool IDs.
 withSMASH
-    :: Tracer IO ClusterLog
+    :: FilePath
+    -- ^ Parent directory to store static files
+    -> (String -> IO a)
+    -- ^ Action, taking base URL
     -> IO a
-    -> IO a
-withSMASH tr action =
-    withSystemTempDir (contramap MsgTempDir tr) "smash" $ \fp -> do
-        let baseDir = fp </> "api/v1"
+withSMASH parentDir action = do
+    let staticDir = parentDir </> "smash"
+    let baseDir = staticDir </> "api" </> "v1"
 
-        -- write pool metadatas
-        pools <- readMVar operators
-        forM_ pools $ \(poolId, _, _, _, metadata) -> do
-            let bytes = Aeson.encode metadata
+    -- write pool metadatas
+    pools <- readMVar operators
+    forM_ pools $ \(poolId, _, _, _, metadata) -> do
+        let bytes = Aeson.encode metadata
 
-            let metadataDir = baseDir </> "metadata"
-                poolDir = metadataDir </> T.unpack (toText poolId)
-                hash = blake2b256S (BL.toStrict bytes)
-                hashFile = poolDir </> hash
+        let metadataDir = baseDir </> "metadata"
+            poolDir = metadataDir </> T.unpack (toText poolId)
+            hash = blake2b256S (BL.toStrict bytes)
+            hashFile = poolDir </> hash
 
-            createDirectoryIfMissing True poolDir
-            BL8.writeFile (poolDir </> hashFile) bytes
+        createDirectoryIfMissing True poolDir
+        BL8.writeFile (poolDir </> hashFile) bytes
 
-        -- write delisted pools
-        let delisted = [SMASHPoolId (T.pack
-                "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2")]
-            bytes = Aeson.encode delisted
-        BL8.writeFile (baseDir </> "delisted") bytes
+    -- write delisted pools
+    let delisted = [SMASHPoolId (T.pack
+            "b45768c1a2da4bd13ebcaa1ea51408eda31dcc21765ccbd407cda9f2")]
+        bytes = Aeson.encode delisted
+    BL8.writeFile (baseDir </> "delisted") bytes
 
-        -- health check
-        let health = Aeson.encode (HealthStatusSMASH "OK" "1.2.0")
-        BL8.writeFile (baseDir </> "status") health
+    -- health check
+    let health = Aeson.encode (HealthStatusSMASH "OK" "1.2.0")
+    BL8.writeFile (baseDir </> "status") health
 
-        withStaticServer fp $ \baseUrl -> do
-            setEnv envVar baseUrl
-            action
-  where
-    envVar :: String
-    envVar = "CARDANO_WALLET_SMASH_URL"
+    withStaticServer staticDir action
 
 updateVersion :: Tracer IO ClusterLog -> FilePath -> IO ()
 updateVersion tr tmpDir = do

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -1763,7 +1763,7 @@ withSystemTempDir
     -> m a
 withSystemTempDir tr name action = do
     parent <- liftIO getCanonicalTemporaryDirectory
-    withTempDir tr parent (name <> ".") action
+    withTempDir tr parent name action
 
 {-------------------------------------------------------------------------------
                                      Utils

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -520,10 +520,11 @@ withNetworkLayerBase tr np addrInfo (versionData, _) action = do
                 return res
             Left{} -> pure $ W.StakePoolsSummary 0 mempty mempty
       where
+        -- fixme: ADP-647 AcquireFailure usually means rollback. So this
+        -- function can fail at arbitrary times.
         handleQueryResult
-            :: Show e
-            => String
-            -> IO (Either e r)
+            :: String
+            -> IO (Either AcquireFailure r)
             -> ExceptT ErrStakeDistribution IO r
         handleQueryResult label =
             withExceptT mkErr . ExceptT . bracketQuery label tr

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -48,8 +48,8 @@ import Cardano.Wallet.Logging
     ( BracketLog (..), bracketTracer )
 import Cardano.Wallet.Network
     ( Cursor
-    , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
+    , ErrStakeDistribution (..)
     , NetworkLayer (..)
     , mapCursor
     )
@@ -510,13 +510,11 @@ withNetworkLayer tr np addrInfo (versionData, _) action = do
             :: Show e
             => String
             -> IO (Either e r)
-            -> ExceptT ErrNetworkUnavailable IO r
+            -> ExceptT ErrStakeDistribution IO r
         handleQueryResult label =
             withExceptT mkErr . ExceptT . bracketQuery label tr
           where
-            -- fixme: "network unreachable" is not the best name for this. And
-            -- the exception message is ignored by the API server.
-            mkErr e = ErrNetworkUnreachable $ T.pack $ "Unexpected " ++ show e
+            mkErr = ErrStakeDistributionQuery . T.pack . show
 
         queryStakeDistribution pt = \case
             AnyCardanoEra ShelleyEra -> do

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -270,7 +270,7 @@ newStakePoolLayer gcStatus nl db@DBLayer {..} restartSyncThread = do
         -> ExceptT ErrListPools IO [Api.ApiStakePool]
     _listPools currentEpoch userStake = do
         tip <- liftIO $ currentNodeTip nl
-        rawLsqData <- mapExceptT (fmap (first ErrListPoolsNetworkError))
+        rawLsqData <- mapExceptT (fmap (first ErrListPoolsQueryFailed))
             $ stakeDistribution nl tip userStake
         let lsqData = combineLsqData rawLsqData
         dbData <- liftIO $ readPoolDbData db currentEpoch

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -228,11 +228,12 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
         poolGarbageCollectionEvents <- newIORef []
         let dbEventRecorder =
                 recordPoolGarbageCollectionEvents poolGarbageCollectionEvents
-        let setupContext np wAddr = bracketTracer' tr "setupContext" $ do
+        let setupContext smashUrl np wAddr = bracketTracer' tr "setupContext" $ do
                 let baseUrl = "http://" <> T.pack (show wAddr) <> "/"
                 prometheusUrl <- (maybe "none" (\(h, p) -> T.pack h <> ":" <> toText @(Port "Prometheus") p)) <$> getPrometheusURL
                 ekgUrl <- (maybe "none" (\(h, p) -> T.pack h <> ":" <> toText @(Port "EKG") p)) <$> getEKGURL
-                traceWith tr $ MsgBaseUrl baseUrl ekgUrl prometheusUrl
+                traceWith tr $
+                    MsgBaseUrl baseUrl ekgUrl prometheusUrl smashUrl
                 let fiveMinutes = 300*1000*1000 -- 5 minutes in microseconds
                 manager <- (baseUrl,) <$> newManager (defaultManagerSettings
                     { managerResponseTimeout =
@@ -248,6 +249,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     , _feeEstimator = error "feeEstimator: unused in shelley specs"
                     , _networkParameters = np
                     , _poolGarbageCollectionEvents = poolGarbageCollectionEvents
+                    , _smashUrl = smashUrl
                     }
         let action' = bracketTracer' tr "spec" . action
         res <- race
@@ -277,19 +279,20 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     atomicModifyIORef' eventsRef ((, ()) . (event :))
                 pure certificates
 
-    withServer dbDecorator action = bracketTracer' tr "withServer" $ withSMASH tr' $ do
-        minSev <- nodeMinSeverityFromEnv
-        testPoolConfigs <- poolConfigsFromEnv
-        extraLogDir <- (fmap (,Info)) <$> testLogDirFromEnv
-        withCluster
-            tr'
-            minSev
-            testPoolConfigs
-            testDir
-            extraLogDir
-            onByron
-            afterFork
-            (onClusterStart action dbDecorator)
+    withServer dbDecorator onReady = bracketTracer' tr "withServer" $
+        withSMASH testDir $ \smashUrl -> do
+            minSev <- nodeMinSeverityFromEnv
+            testPoolConfigs <- poolConfigsFromEnv
+            extraLogDir <- (fmap (,Info)) <$> testLogDirFromEnv
+            withCluster
+                tr'
+                minSev
+                testPoolConfigs
+                testDir
+                extraLogDir
+                onByron
+                afterFork
+                (onClusterStart (onReady $ T.pack smashUrl) dbDecorator)
 
     tr' = contramap MsgCluster tr
     onByron _ = pure ()
@@ -301,7 +304,6 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
         sendFaucetFundsTo tr' testDir addresses
-
 
     onClusterStart action dbDecorator node = do
         let db = testDir </> "wallets"
@@ -334,7 +336,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
 
 data TestsLog
     = MsgBracket Text BracketLog
-    | MsgBaseUrl Text Text Text
+    | MsgBaseUrl Text Text Text Text
     | MsgSettingUpFaucet
     | MsgCluster ClusterLog
     | MsgPoolGarbageCollectionEvent PoolGarbageCollectionEvent
@@ -344,10 +346,11 @@ data TestsLog
 instance ToText TestsLog where
     toText = \case
         MsgBracket name b -> name <> ": " <> toText b
-        MsgBaseUrl walletUrl ekgUrl prometheusUrl -> mconcat
-            [ "Wallet url: " , walletUrl
-            , ", EKG url: " , ekgUrl
-            , ", Prometheus url:", prometheusUrl
+        MsgBaseUrl walletUrl ekgUrl prometheusUrl smashUrl -> T.unlines
+            [ "Wallet url: " <> walletUrl
+            , "EKG url: " <> ekgUrl
+            , "Prometheus url: " <> prometheusUrl
+            , "SMASH url: " <> smashUrl
             ]
         MsgSettingUpFaucet -> "Setting up faucet..."
         MsgCluster msg -> toText msg

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -400,7 +400,7 @@ withTracers testDir action = do
         ekgEnabled >>= flip when (EKG.plugin cfg walTr sb >>= loadPlugin sb)
         withLogging testLogOutputs $ \(_, (_, testTr)) -> do
             let trTests = appendName "integration" testTr
-            let tracers = setupTracers (tracerSeverities (Just Info)) walTr
+            let tracers = setupTracers (tracerSeverities (Just Debug)) walTr
             action (trMessageText trTests, tracers)
 
 bracketTracer' :: Tracer IO TestsLog -> Text -> IO a -> IO a

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -119,7 +119,7 @@ import Test.Utils.Paths
 import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
-    ( SomeException, throwIO, withException )
+    ( SomeException, isAsyncException, throwIO, withException )
 import UnliftIO.MVar
     ( newEmptyMVar, putMVar, takeMVar )
 
@@ -362,7 +362,9 @@ instance ToText TestsLog where
                     , T.unwords (T.pack . show <$> ps)
                     ]
             ]
-        MsgServerError e -> T.pack (show e)
+        MsgServerError e
+            | isAsyncException e -> "Server thread cancelled"
+            | otherwise -> T.pack (show e)
 
 instance HasPrivacyAnnotation TestsLog
 instance HasSeverityAnnotation TestsLog where
@@ -372,7 +374,9 @@ instance HasSeverityAnnotation TestsLog where
         MsgBaseUrl {} -> Notice
         MsgCluster msg -> getSeverityAnnotation msg
         MsgPoolGarbageCollectionEvent _ -> Info
-        MsgServerError{} -> Critical
+        MsgServerError e
+            | isAsyncException e -> Info
+            | otherwise -> Critical
 
 withTracers
     :: FilePath

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -34,7 +34,6 @@
           (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
           (hsPkgs."cardano-addresses-cli" or (errorHandler.buildDepError "cardano-addresses-cli"))
           (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
-          (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -95,6 +95,7 @@
           (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
           (hsPkgs."tls" or (errorHandler.buildDepError "tls"))
+          (hsPkgs."tracer-transformers" or (errorHandler.buildDepError "tracer-transformers"))
           (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
           (hsPkgs."typed-protocols" or (errorHandler.buildDepError "typed-protocols"))
           (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))

--- a/scripts/fluke.sh
+++ b/scripts/fluke.sh
@@ -14,10 +14,11 @@ fi
 
 set -euo pipefail
 
-x=1
+x=0
 
 time ( while true; do
-  echo "*** fluke run $((x++))"
-  unbuffer "$@" 2>&1 | ts '[%Y-%m-%d %H:%M:%S]'
-  echo -e "\033[0m"
+  echo "*** fluke run $((++x))"
+  unbuffer "$@" 2>&1 | ts "[$x %Y-%m-%d %H:%M:%S]"
+  # reset colours and show cursor
+  echo -en '\033[0m\033[?12l\033[?25h'
 done )

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2267,16 +2267,16 @@ x-errNetworkMisconfigured: &errNetworkMisconfigured
       enum: ['network_misconfigured']
 
 # TODO: Map this error to the place it belongs.
-x-errNetworkTipNotFound: &errNetworkTipNotFound
+x-errNetworkQueryFailed: &errNetworkQueryFailed
   <<: *responsesErr
-  title: network_tip_not_found
+  title: network_query_failed
   properties:
     message:
       type: string
-      description: May occur when the connection with the node is lost or not responding.
+      description: Occurs when a ledger query fails in an unexpected manner.
     code:
       type: string
-      enum: ['network_tip_not_found']
+      enum: ['network_query_failed']
 
 x-errCreatedInvalidTransaction: &errCreatedInvalidTransaction
   <<: *responsesErr


### PR DESCRIPTION
### Issue Number

Flaky test #2415

### Overview

This test failure seemed to be happening quite a lot the other day. Now I can't reproduce it.

I am pretty sure the error is from somewhere in `stakeDistribution` which is used by `listPools`.
My guess of the cause is that rollback causes ledger queries to temporarily fail. (confirmed: ADP-647)

The error was never logged, and the exception message was not part of the HTTP 503 response.

1. [x] Fix some minor test environment issues.
2. [x] If a ledger query fails, make sure that the exception is logged.
3. [x] Correct the return type of `listPools` and functions that it calls. 
4. [x] Reproduce error with logs, diagnose problem. Problem 1: unreproduceable. Problem 2: epoch rollover between tx submission and rewards balance check.
5. [x]  Fix the ~code and/or~ test case.
6. [x] Add utility functions for transforming BracketLog traces into time deltas and logging timings.
7. [x] Add back logging of how long ledger queries take.
 
### Comments

- I haven't reproduced the error, but it's worth merging these fixes anyway.

- The new error, which seems to happen reliably on the same test case, is this:
  ```
  [1 2021-01-05 17:33:29] Failures:
  [1 2021-01-05 17:33:29] 
  [1 2021-01-05 17:33:29]   src/Test/Integration/Scenario/API/Shelley/StakePools.hs:324:26: 
  [1 2021-01-05 17:33:29]   1) API Specifications, SHELLEY_STAKE_POOLS, STAKE_POOLS_JOIN_01rewards - Can join a pool, earn rewards and collect them
  [1 2021-01-05 17:33:29]        While verifying (Status {statusCode = 200, statusMessage = "OK"},Right (ApiWallet {id = ApiT {getApiT = WalletId {getWalletId = c83c7e41054d4f96238c00e1a8abf75c7a93f485}}, addressPoolGap = ApiT {getApiT = AddressPoolGap {getAddressPoolGap = 20}}, balance = ApiT {getApiT = WalletBalance {available = Quantity {getQuantity = 999998581353}, total = Quantity {getQuantity = 1000007589123}, reward = Quantity {getQuantity = 9007770}}}, delegation = ApiWalletDelegation {active = ApiWalletDelegationNext {status = Delegating, target = Just (ApiT {getApiT = PoolId {getPoolId = "\187\DC1L\179}u\250\ENQ&\ETX(\194\&5\163\218\226\149\163=\v\166t\165\235\RS>V\142"}}), changesAt = Nothing}, next = []}, name = ApiT {getApiT = WalletName {getWalletName = "Faucet Wallet"}}, passphrase = Just (ApiWalletPassphraseInfo {lastUpdatedAt = 2021-01-05 09:22:50.035321314 UTC}), state = ApiT {getApiT = Ready}, tip = ApiBlockReference {absoluteSlotNumber = ApiT {getApiT = SlotNo 5056}, slotId = ApiSlotId {epochNumber = ApiT {getApiT = EpochNo {unEpochNo = 101}}, slotNumber = ApiT {getApiT = SlotInEpoch {unSlotInEpoch = 6}}}, time = 2021-01-05 09:25:03.2 UTC, block = ApiBlockInfo {height = Quantity {getQuantity = 2533}}}}))
  [1 2021-01-05 17:33:29]        Waited longer than 90s to resolve action: "Wallet has consumed rewards".
  [1 2021-01-05 17:33:29]        expected: Quantity {getQuantity = 0}
  [1 2021-01-05 17:33:29]         but got: Quantity {getQuantity = 9007770}
  [1 2021-01-05 17:33:29] 
  [1 2021-01-05 17:33:29]   To rerun use: --match "/API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_JOIN_01rewards - Can join a pool, earn rewards and collect them/"
  [1 2021-01-05 17:33:29] 
  [1 2021-01-05 17:33:29] Randomized with seed 1938796546
  [1 2021-01-05 17:33:29] 
  [1 2021-01-05 17:33:29] Finished in 1514.5249 seconds
  [1 2021-01-05 17:33:29] 711 examples, 1 failure, 9 pending
  [1 2021-01-05 17:33:29] NO_CLEANUP of temporary directory /run/user/1000/test-06a07e3d6c739d45

  real	25m15.583s
  user	27m19.699s
  sys	2m15.754s
  ```

  The cause of this failure (according to the logs) is epoch rollover happening just after the rewards withdrawal transaction is submitted. New rewards accrue before the test case can check that previous rewards were withdrawn. Inherently flaky.