### PR TITLE
[ADP 627] Upgrade DB benchmarks

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -395,6 +395,7 @@ benchmark db
     , random
     , temporary
     , text
+    , text-class
     , time
     , transformers
     , unliftio

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -221,10 +221,14 @@ main = withUtf8Encoding $ withLogging $ \trace -> do
         , withDB tr (bgroupReadUTxO mkOutputsCoin "UTxO ada-only (Read)")
         , withDB tr bgroupWriteSeqState
         , withDB tr bgroupWriteRndState
-        , withDB tr (bgroupWriteTxHistory mkOutputsCoin "TxHistory ada-only (Write)")
-        , withDB tr (bgroupReadTxHistory mkOutputsCoin "TxHistory ada-only (Read)")
-        , withDB tr (bgroupWriteTxHistory (mkOutputsToken 100 200) "TxHistory (Write)")
-        , withDB tr (bgroupReadTxHistory (mkOutputsToken 100 200) "TxHistory (Read)")
+        , withDB tr $ bgroupWriteTxHistory mkOutputsCoin
+            "TxHistory ada-only (Write)"
+        , withDB tr $ bgroupReadTxHistory mkOutputsCoin
+            "TxHistory ada-only (Read)"
+        , withDB tr $ bgroupWriteTxHistory (mkOutputsToken 100 200)
+            "TxHistory (Write)"
+        , withDB tr $ bgroupReadTxHistory (mkOutputsToken 100 200)
+            "TxHistory (Read)"
         ]
     putStrLn "\n--"
     utxoDiskSpaceTests tr
@@ -238,7 +242,11 @@ main = withUtf8Encoding $ withLogging $ \trace -> do
 --
 -- Currently the DBLayer will only store a single checkpoint (no rollback), so
 -- the #Checkpoints axis is a bit meaningless.
-bgroupWriteUTxO :: (Int -> Int -> [TxOut]) -> String -> DBLayerBench -> Benchmark
+bgroupWriteUTxO
+    :: (Int -> Int -> [TxOut])
+    -> String
+    -> DBLayerBench
+    -> Benchmark
 bgroupWriteUTxO mkOutputs gn db = bgroup gn
     -- A fragmented wallet will have a large number of UTxO. The coin
     -- selection algorithm tries to prevent fragmentation.
@@ -258,7 +266,11 @@ bgroupWriteUTxO mkOutputs gn db = bgroup gn
         benchPutUTxO mkOutputs n s . fst
       where lbl = n|+" CP x "+|s|+" UTxO"
 
-bgroupReadUTxO :: (Int -> Int -> [TxOut]) -> String -> DBLayerBench -> Benchmark
+bgroupReadUTxO
+    :: (Int -> Int -> [TxOut])
+    -> String
+    -> DBLayerBench
+    -> Benchmark
 bgroupReadUTxO mkOutputs gn db = bgroup gn
     --      #Checkpoints   UTxO Size
     [ bUTxO            1           0
@@ -459,7 +471,11 @@ mkRndAddresses numAddrs i =
 --
 -- - 50 inputs
 -- - 100 outputs
-bgroupWriteTxHistory :: (Int -> Int -> [TxOut]) -> String -> DBLayerBench -> Benchmark
+bgroupWriteTxHistory
+    :: (Int -> Int -> [TxOut])
+    -> String
+    -> DBLayerBench
+    -> Benchmark
 bgroupWriteTxHistory mkOutputs gn db = bgroup gn
     --                   #NTxs #NInputs #NOutputs  #SlotRange
     [ bTxHistory             1        1        1      [1..10]
@@ -484,7 +500,11 @@ bgroupWriteTxHistory mkOutputs gn db = bgroup gn
         inf = head r
         sup = last r
 
-bgroupReadTxHistory :: (Int -> Int -> [TxOut]) -> String -> DBLayerBench -> Benchmark
+bgroupReadTxHistory
+    :: (Int -> Int -> [TxOut])
+    -> String
+    -> DBLayerBench
+    -> Benchmark
 bgroupReadTxHistory mkOutputs gn db = bgroup gn
     --             #NTxs  #SlotRange  #SortOrder  #Status  #SearchRange
     [ bTxHistory    1000    [1..100]  Descending  Nothing  wholeRange

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -216,6 +216,7 @@
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."temporary" or (errorHandler.buildDepError "temporary"))
             (hsPkgs."text" or (errorHandler.buildDepError "text"))
+            (hsPkgs."text-class" or (errorHandler.buildDepError "text-class"))
             (hsPkgs."time" or (errorHandler.buildDepError "time"))
             (hsPkgs."transformers" or (errorHandler.buildDepError "transformers"))
             (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))


### PR DESCRIPTION
# Issue Number

ADP-627

# Overview

- [x] parametrize functions with `mkOutput`, so we can have different such functions (e.g. TokenBundles with only Ada or with multi assets)
- [x] create an `mkOutput` variant that creates multi asset tokenbundles

# Comments

## Questions

Do we always want to run both ada-only and tokenbundle benchmarks or do we just keep the ada-only commented out for debugging purposes?

## For QA maybe?

- [ ] compare ada-only benchmark run with pre-multiasset runs
- [ ] compare tokenbundle run with ada-only run

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
