### PR TITLE
import and create random addresses in the 'pending' set

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1187,7 +1187,7 @@ createRandomAddress ctx wid pwd mIx = db & \DBLayer{..} ->
 
             let prepared = preparePassphrase scheme pwd
             let addr = Rnd.deriveRndStateAddress @n xprv prepared path
-            let cp' = updateState (Rnd.addDiscoveredAddress addr Unused path s') cp
+            let cp' = updateState (Rnd.addPendingAddress addr path s') cp
             withExceptT ErrCreateAddrNoSuchWallet $
                 putCheckpoint (PrimaryKey wid) cp'
             pure addr

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -376,7 +376,7 @@ bgroupWriteRndState db = bgroup "RndState"
                 RndState
                     { hdPassphrase = dummyPassphrase
                     , accountIndex = minBound
-                    , addresses = (,Used) <$> mkRndAddresses a i
+                    , discoveredAddresses = (,Used) <$> mkRndAddresses a i
                     , pendingAddresses = mkRndAddresses p (-i)
                     , gen = mkStdGen 42
                     }

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -318,14 +318,14 @@ prop_forbiddenAddreses rnd@(Rnd st rk pwd) addrIx = conjoin
     , (Set.notMember changeAddr (forbidden isOursSt))
     , (Set.member changeAddr (forbidden changeSt))
     , (addr `elem` (fst <$> knownAddresses isOursSt))
-    , (changeAddr `notElem` (fst <$> knownAddresses changeSt))
+    , (changeAddr `elem` (fst <$> knownAddresses changeSt))
     ]
   where
     (_ours, isOursSt) = isOurs addr st
     (changeAddr, changeSt) = genChange (rk, pwd) isOursSt
     addr = mkAddress rnd addrIx
     forbidden s =
-        Set.fromList $ Map.elems $ (fst <$> addresses s) <> pendingAddresses s
+        Set.fromList $ Map.elems $ (fst <$> discoveredAddresses s) <> pendingAddresses s
 
 prop_oursAreUsed
     :: Rnd


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

[ADP-619](https://jira.iohk.io/browse/ADP-619)

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- e427df198c3f1d271cf358cbb0a3945e4f7cdd9f
  :round_pushpin: **import and create random addresses in the 'pending' set**
    When we implemented these features, all addresses were placed in the discovered set. The problem with that is that it makes
  them affected by rollbacks. So a client may import 100K addresses, and the next minute they're all gone. We've seen some
  integration tests being 'flaky' actually just showing symptoms of that issue.

  In addition to moving imported and manually created addresses in the pending set, this commit also make the pending set
  returned as part of the total addresses set returned by the API to avoid breaking clients' code and because this is actually
  what most clients would want.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
