### PR TITLE
[ADP-634] Run SMASH metadata fetching in batches of 15 concurrently

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -805,6 +805,7 @@ newRewardBalanceFetcher tr readNodeTip queryRewardQ = do
         :: Tip (CardanoBlock StandardCrypto)
         -> Set W.RewardAccount
         -> IO (Maybe (Map W.RewardAccount W.Coin))
+    fetch _tip accounts | Set.null accounts = pure (Just mempty)
     fetch _tip accounts = do
         -- NOTE: We no longer need the tip to run LSQ queries. The local state
         -- query client will automatically acquire the latest tip.


### PR DESCRIPTION
# Issue Number

ADP-634

# Overview

All requests already share the same [Manager](https://hackage.haskell.org/package/http-client-0.7.3/docs/Network-HTTP-Client.html#t:Manager). I'm not sure if that implicitly leads to proper HTTP pipelining when used with `forConcurrently`, but it seems to work: the sync time on testnet goes from 3 minutes down to ~30 seconds.

# Comments

## Open questions

1. do we also want to add a way for daedalus to check the sync-status? If so, how to define it? Syncing is continuous.
2. is this safe? We don't want to DoS SMASH
3. do we want to make the batch size a settings? We already have a database table for settings...