### PR TITLE
Tweak bors-stats.sh to support jira links

### DIFF
--- a/scripts/bors-stats.sh
+++ b/scripts/bors-stats.sh
@@ -48,7 +48,7 @@ DATA=$(echo $QUERY \
       | sort_by (.createdAt)
       | map (
           select(.author.login == "iohk-bors")
-          | select(.bodyText | contains("try\nBuild") | not)
+          | select(.bodyText | startswith("try") | not)
           | select(.bodyText | contains("Canceled") | not)
           | select(.bodyText | contains("Merge conflict") | not)
           | select(.bodyText | contains("Rejected by too few approved reviews") | not)

--- a/scripts/bors-stats.sh
+++ b/scripts/bors-stats.sh
@@ -57,7 +57,7 @@ DATA=$(echo $QUERY \
           | . + {succeded: (.bodyText | contains("Build succeeded"))}
 
           # Extract lines starting with # as tags. Mostly for linking to issues.
-          | . + {tags: (.bodyText | split("\n") | map (select(startswith("#"))) | map(split(" ") | .[0]) )}
+          | . + {tags: (.bodyText | split("\n") | map (select(startswith("#") or startswith("ADP-"))) | map(split(" ") | .[0]) )}
         )
       ')
 


### PR DESCRIPTION
# Issue Number

None

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Improve pattern excluding bors try (now removes two recent "try\nTimed out")
- [x] Support `ADP-` as tags for the breakdown


# Comments

### Before
<img width="1292" alt="Skärmavbild 2021-01-12 kl  11 47 06" src="https://user-images.githubusercontent.com/304423/104304626-e6ab1c80-54cb-11eb-9aed-2cea06cfa505.png">

### Now

<img width="1365" alt="Skärmavbild 2021-01-12 kl  11 46 06" src="https://user-images.githubusercontent.com/304423/104304643-ead73a00-54cb-11eb-8fa7-f47ba9a39353.png">


<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
