### PR TITLE
Multi-asset API extensions

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1115,8 +1115,8 @@ rewardWallet ctx = do
     eventually "MIR wallet: wallet is 100% synced " $ do
         rg <- request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
         verify rg
-            [ expectField (#balance . #getApiT . #available . #getQuantity) (.> 0)
-            , expectField (#balance . #getApiT . #reward . #getQuantity) (.> 0)
+            [ expectField (#balance . #available . #getQuantity) (.> 0)
+            , expectField (#balance . #reward . #getQuantity) (.> 0)
             ]
         pure (getFromResponse id rg, mw)
 
@@ -1184,7 +1184,7 @@ fixtureWalletWithMnemonics ctx = snd <$> allocate create (free . fst)
     checkBalance w = do
         r <- request @ApiWallet ctx
             (Link.getWallet @'Shelley w) Default Empty
-        if getFromResponse (#balance . #getApiT . #available) r > Quantity 0
+        if getFromResponse (#balance . #available) r > Quantity 0
             then return (getFromResponse id r)
             else threadDelay oneSecond *> checkBalance w
 
@@ -1387,7 +1387,7 @@ fixtureWalletWith ctx coins0 = do
             -- ^ Coins to move
         -> IO ()
     moveCoins src dest coins = do
-        balance <- getFromResponse (#balance . #getApiT . #available . #getQuantity)
+        balance <- getFromResponse (#balance . #available . #getQuantity)
             <$> request @ApiWallet ctx
                     (Link.getWallet @'Shelley dest) Default Empty
         addrs <- fmap (view #id) . getFromResponse id
@@ -1411,14 +1411,14 @@ fixtureWalletWith ctx coins0 = do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley dest) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (sum (balance:coins))) rb
             ra <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley src) Default Empty
 
-            getFromResponse (#balance . #getApiT . #available) ra
+            getFromResponse (#balance . #available) ra
                 `shouldBe`
-                    getFromResponse (#balance . #getApiT . #total) ra
+                    getFromResponse (#balance . #total) ra
 
 -- | Move coins from a wallet to another
 moveByronCoins

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
@@ -87,7 +87,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
         rnW <- emptyRandomWallet ctx
         shW <- emptyWallet ctx
         (addr:_) <- fmap (view #id) <$> listAddresses @n ctx shW
-        let payments = NE.fromList [ AddressAmount addr (Quantity minUTxOValue) ]
+        let payments = NE.fromList [ AddressAmount addr (Quantity minUTxOValue) mempty ]
         selectCoins @_ @'Byron ctx rnW payments >>= flip verify
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotAnIcarusWallet
@@ -100,7 +100,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
             target <- emptyWallet ctx
             targetAddress : _ <- fmap (view #id) <$> listAddresses @n ctx target
             let amt = Quantity minUTxOValue
-            let payment = AddressAmount targetAddress amt
+            let payment = AddressAmount targetAddress amt mempty
             let output = ApiCoinSelectionOutput targetAddress amt
             let isValidDerivationPath path =
                     ( length path == 5 )
@@ -136,6 +136,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
             let amounts = Quantity <$> [minUTxOValue ..]
             let payments = NE.fromList
                     $ take paymentCount
+                    $ map ($ mempty)
                     $ zipWith AddressAmount targetAddresses amounts
             let outputs =
                     take paymentCount
@@ -153,7 +154,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
         icW <- emptyIcarusWallet ctx
         shW <- emptyWallet ctx
         (addr:_) <- fmap (view #id) <$> listAddresses @n ctx shW
-        let payments = NE.fromList [ AddressAmount addr (Quantity minUTxOValue) ]
+        let payments = NE.fromList [ AddressAmount addr (Quantity minUTxOValue) mempty ]
         _ <- request @ApiByronWallet ctx (Link.deleteWallet @'Byron icW) Default Empty
         selectCoins @_ @'Byron ctx icW payments >>= flip verify
             [ expectResponseCode HTTP.status404
@@ -168,7 +169,7 @@ spec = describe "BYRON_COIN_SELECTION" $ do
 
             targetAddress:_ <- fmap (view #id) <$> listAddresses @n ctx target
             let amt = Quantity minUTxOValue
-            let payment = AddressAmount targetAddress amt
+            let payment = AddressAmount targetAddress amt mempty
             let output = ApiCoinSelectionOutput targetAddress amt
             let isValidDerivationPath path =
                     ( length path == 5 )

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -330,7 +330,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                     icarusAddresses @n mnemonics
             let targetAmounts = take paymentCount $
                     Quantity <$> [minUTxOValue ..]
-            let payments = NE.fromList $
+            let payments = NE.fromList $ map ($ mempty) $
                     zipWith AddressAmount targetAddresses targetAmounts
             let outputs =
                     zipWith ApiCoinSelectionOutput targetAddresses targetAmounts

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -293,10 +293,10 @@ spec = describe "BYRON_MIGRATIONS" $ do
                 Default
                 Empty >>= flip verify
                 [ expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (.> (Quantity expectedMinBalance))
                 , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (.> (Quantity expectedMinBalance))
                 ]
 
@@ -564,9 +564,9 @@ spec = describe "BYRON_MIGRATIONS" $ do
                     (Link.getWallet @'Shelley targetWallet) Default Empty
                 verify r2
                     [ expectField
-                            (#balance . #getApiT . #available)
+                            (#balance . #available)
                             (`shouldBe` Quantity expectedBalance)
                     , expectField
-                            (#balance . #getApiT . #total)
+                            (#balance . #total)
                             (`shouldBe` Quantity expectedBalance)
                     ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -220,7 +220,7 @@ spec = describe "SHELLEY_ADDRESSES" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (10 * 1_000_000))
                 rb
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -103,8 +103,8 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
         rInit <- postWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` Quantity 0)
+            , expectField (#balance . #total) (`shouldBe` Quantity 0)
             ]
 
         --send funds
@@ -130,9 +130,9 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
         -- delete wallet
@@ -149,9 +149,9 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest') Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
     describe "HW_WALLETS_03 - Cannot do operations requiring private key" $ do
@@ -312,7 +312,7 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 fmap (view #id) <$> listAddresses @n ctx target
             let targetAmounts = take paymentCount $
                     Quantity <$> [minUTxOValue ..]
-            let payments = NE.fromList $
+            let payments = NE.fromList $ map ($ mempty) $
                     zipWith AddressAmount targetAddresses targetAmounts
             let outputs =
                     zipWith ApiCoinSelectionOutput targetAddresses targetAmounts

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -186,10 +186,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 Default
                 Empty
             verify r
-                [ expectField (#balance . #getApiT . #available) (.> Quantity 0)
+                [ expectField (#balance . #available) (.> Quantity 0)
                 ]
             return $ getFromResponse
-                (#balance . #getApiT . #available . #getQuantity) r
+                (#balance . #available . #getQuantity) r
 
         -- Calculate the expected migration fee:
         rFee <- request @ApiWalletMigrationInfo ctx
@@ -232,10 +232,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 Default
                 Empty >>= flip verify
                 [ expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (.> (Quantity expectedMinBalance))
                 , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (.> (Quantity expectedMinBalance))
                 ]
 
@@ -290,9 +290,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     Default
                     Empty
                 verify rg
-                    [ expectField (#balance . #getApiT . #available) (.> Quantity 0)
+                    [ expectField (#balance . #available) (.> Quantity 0)
                     ]
-                pure $ getFromResponse (#balance . #getApiT. #available . #getQuantity)
+                pure $ getFromResponse (#balance. #available . #getQuantity)
                                  rg
 
             -- Calculate the expected migration fee:
@@ -325,10 +325,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     Default
                     Empty >>= flip verify
                     [ expectField
-                            (#balance . #getApiT . #available)
+                            (#balance . #available)
                             ( `shouldBe` Quantity expectedBalance)
                     , expectField
-                            (#balance . #getApiT . #total)
+                            (#balance . #total)
                             ( `shouldBe` Quantity expectedBalance)
                     ]
 
@@ -485,7 +485,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             -- Restore a Shelley wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureWallet ctx
             let originalBalance =
-                        view (#balance . #getApiT. #available . #getQuantity)
+                        view (#balance. #available . #getQuantity)
                              sourceWallet
 
             -- Create an empty target wallet:
@@ -524,10 +524,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     (Link.getWallet @'Shelley targetWallet) Default Empty
                 verify r2
                     [ expectField
-                            (#balance . #getApiT . #available)
+                            (#balance . #available)
                             (`shouldBe` Quantity expectedBalance)
                     , expectField
-                            (#balance . #getApiT . #total)
+                            (#balance . #total)
                             (`shouldBe` Quantity expectedBalance)
                     ]
 
@@ -536,9 +536,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 (Link.getWallet @'Shelley sourceWallet) Default Empty
             verify r3
                 [ expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (`shouldBe` Quantity 0)
                 , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (`shouldBe` Quantity 0)
                 ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -258,13 +258,13 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                     Default Empty
                 verify r
                     [ expectField
-                        (#balance . #getApiT . #reward)
+                        (#balance . #reward)
                         (.> (Quantity 0))
                     ]
                 let availableBalance =
-                        getFromResponse (#balance . #getApiT . #available) r
+                        getFromResponse (#balance . #available) r
                 let rewardBalance =
-                        getFromResponse (#balance . #getApiT . #reward) r
+                        getFromResponse (#balance . #reward) r
                 pure (availableBalance, rewardBalance)
 
         -- Try to use rewards
@@ -299,7 +299,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
           request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
               >>= flip verify
                   [ expectField
-                      (#balance . #getApiT . #reward) (`shouldBe` walletRewards)
+                      (#balance . #reward) (`shouldBe` walletRewards)
                   ]
 
         -- there's currently no withdrawals in the wallet
@@ -338,10 +338,10 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley src) Default Empty
                 >>= flip verify
                     [ expectField
-                        (#balance . #getApiT . #reward)
+                        (#balance . #reward)
                         (`shouldBe` (Quantity 0))
                     , expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (.> previousBalance)
                     ]
 
@@ -600,7 +600,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         eventually "Wallet gets rewards" $ do
             request @ApiWallet ctx (Link.getWallet @'Shelley w) Default Empty
                 >>= flip verify
-                    [ expectField (#balance . #getApiT . #reward)
+                    [ expectField (#balance . #reward)
                         (.> (Quantity 0))
                     ]
 
@@ -902,10 +902,10 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                     Default Empty >>= flip verify
                     [ expectField #delegation (`shouldBe` notDelegating [])
                     , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                             (`shouldSatisfy` (== (Quantity (depositAmt ctx + change))))
                     , expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                             (`shouldSatisfy` (== (Quantity (depositAmt ctx + change))))
                     ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -2772,7 +2772,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -> Quantity "lovelace" Natural
         -> m ()
     verifyWalletBalance ctx wallet amt = do
-        eventually "Wallet balance is as expected" $ do
+        eventually "Wallet Ada balance is as expected" $ do
             rGet <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wallet) Default Empty
             verify rGet
@@ -2780,6 +2780,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                         (#balance . #total) (`shouldBe` amt)
                 , expectField
                         (#balance . #available) (`shouldBe` amt)
+                , expectField
+                        (#assets . #total) (`shouldBe` mempty)
+                , expectField
+                        (#assets . #available) (`shouldBe` mempty)
                 ]
 
     mkTxPayload

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -322,13 +322,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         verify ra
             [ expectSuccess
-            , expectField (#balance . #getApiT . #total) $
+            , expectField (#balance . #total) $
                 between
                     ( Quantity (initialAmt - feeMax - amt)
                     , Quantity (initialAmt - feeMin - amt)
                     )
             , expectField
-                    (#balance . #getApiT . #available)
+                    (#balance . #available)
                     (`shouldBe` Quantity 0)
             ]
 
@@ -364,13 +364,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wb) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (initialAmt + amt)) rb
 
             ra2 <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wa) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (initialAmt - feeMax - amt)) ra2
 
     it "TRANS_CREATE_02x - Multiple Output Tx to single wallet" $ \ctx -> runResourceT $ do
@@ -418,13 +418,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             ]
 
         verify ra
-            [ expectField (#balance . #getApiT . #total) $
+            [ expectField (#balance . #total) $
                 between
                     ( Quantity (faucetAmt - feeMax - (2*amt))
                     , Quantity (faucetAmt - feeMin - (2*amt))
                     )
             , expectField
-                    (#balance . #getApiT . #available)
+                    (#balance . #available)
                     (.>= Quantity (faucetAmt - 2 * faucetUtxoAmt))
             ]
         eventually "wDest balance is as expected" $ do
@@ -432,10 +432,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rd
                 [ expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (`shouldBe` Quantity (2*amt))
                 , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (`shouldBe` Quantity (2*amt))
                 ]
 
@@ -470,8 +470,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
         verify ra
-            [ expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+            [ expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` Quantity 0)
             ]
 
         eventually "Wallet balance is as expected" $ do
@@ -479,17 +479,17 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rd
                 [ expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (`shouldBe` Quantity (2*amt))
                 , expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (`shouldBe` Quantity (2*amt))
                 ]
 
         ra2 <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
         verify ra2
-            [ expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+            [ expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` Quantity 0)
             ]
 
     it "TRANS_CREATE_04 - Can't cover fee" $ \ctx -> runResourceT $ do
@@ -644,7 +644,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rb <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wShelley) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (faucetAmt + amt)) rb
 
             ra2 <- request @ApiByronWallet ctx
@@ -976,7 +976,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         verify r1
             [ expectResponseCode HTTP.status201
             , expectField
-                (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                (#balance . #available) (`shouldBe` Quantity 0)
             ]
         let wSrc = getFromResponse Prelude.id r1
 
@@ -1014,7 +1014,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         let (Hash txid) = getApiT $ getFromResponse #id r3
         let txix = case getFromResponse #outputs r3 of
-                [(AddressAmount _ (Quantity out1)), (AddressAmount _ (Quantity out2))]
+                [(AddressAmount _ (Quantity out1) _), (AddressAmount _ (Quantity out2) _)]
                     | out1 == amtSrc -> 0
                     | out2 == amtSrc -> 1
                     | otherwise -> error "this should not happen"
@@ -1024,13 +1024,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             r' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity amtSrc) r'
 
             r'' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wFaucet) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (between wFaucetBalRange) r''
 
         -- #2238 quick fix to reduce likelihood of rollback.
@@ -1053,7 +1053,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             [ expectSuccess
             , expectResponseCode HTTP.status201
             , expectField
-                (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                (#balance . #available) (`shouldBe` Quantity 0)
             ]
         let wDest = getFromResponse Prelude.id r4
 
@@ -1115,13 +1115,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             r' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity amtDest) r'
 
             r'' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity outChange) r''
 
     it "TRANS_EXTERNAL_02 - Multiple Outputs Transaction - Shelley witnesses" $ \ctx -> runResourceT $ do
@@ -1144,7 +1144,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         verify r1
             [ expectResponseCode HTTP.status201
             , expectField
-                (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                (#balance . #available) (`shouldBe` Quantity 0)
             ]
         let wSrc = getFromResponse Prelude.id r1
 
@@ -1188,7 +1188,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         let (Hash txid) = getApiT $ getFromResponse #id r3
         let (txix1, txix2) = case getFromResponse #outputs r3 of
-                [ (AddressAmount _ (Quantity out1)), (AddressAmount _ (Quantity out2)), (AddressAmount _ (Quantity out3)), (AddressAmount _ (Quantity out4))] ->
+                [ (AddressAmount _ (Quantity out1) _), (AddressAmount _ (Quantity out2) _), (AddressAmount _ (Quantity out3) _), (AddressAmount _ (Quantity out4) _)] ->
                     let pairs = [(out1, 0), (out2, 1), (out3, 2), (out4, 3)]
                         (Just ix1) = L.lookup amt1 pairs
                         (Just ix2) = L.lookup amt2 pairs
@@ -1199,14 +1199,14 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             r' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity amtSrc) r'
 
             r'' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wFaucet) Default Empty
             txs <- listTransactions @n ctx wFaucet Nothing Nothing Nothing
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (between wFaucetBalRange) r''
                 & counterexample ("fee response: " <> show r2)
                 & counterexample ("faucet txs: " <> show txs)
@@ -1230,7 +1230,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         verify r4
             [ expectResponseCode HTTP.status201
             , expectField
-                (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                (#balance . #available) (`shouldBe` Quantity 0)
             ]
         let wDest = getFromResponse Prelude.id r4
 
@@ -1300,13 +1300,13 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             r' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity amtDest) r'
 
             r'' <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default Empty
             expectField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity outChange) r''
 
     describe "TRANS_EXTERNAL_03 - Single Output Transaction with Byron witness" $ do
@@ -1377,7 +1377,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
             let (Hash txid) = getApiT $ getFromResponse #id r2
             let txix = case getFromResponse #outputs r2 of
-                    [(AddressAmount _ (Quantity out1)), (AddressAmount _ (Quantity out2))]
+                    [(AddressAmount _ (Quantity out1) _), (AddressAmount _ (Quantity out2) _)]
                         | out1 == amtSrc -> 0
                         | out2 == amtSrc -> 1
                         | otherwise -> error "this should not happen"
@@ -1458,7 +1458,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 r' <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley wShelley) Default Empty
                 expectField
-                    (#balance . #getApiT . #available)
+                    (#balance . #available)
                     (`shouldBe` Quantity amtDest) r'
 
                 r'' <- request @ApiByronWallet ctx
@@ -1533,7 +1533,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
             let (Hash txid) = getApiT $ getFromResponse #id r2
             let txix = case getFromResponse #outputs r2 of
-                    [(AddressAmount _ (Quantity out1)), (AddressAmount _ (Quantity out2))]
+                    [(AddressAmount _ (Quantity out1) _), (AddressAmount _ (Quantity out2) _)]
                         | out1 == amtSrc -> 0
                         | out2 == amtSrc -> 1
                         | otherwise -> error "this should not happen"
@@ -1587,7 +1587,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 r' <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley wShelley) Default Empty
                 expectField
-                    (#balance . #getApiT . #available)
+                    (#balance . #available)
                     (`shouldBe` Quantity amtDest) r'
 
                 r'' <- request @ApiByronWallet ctx
@@ -1632,7 +1632,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
     it "TRANS_ESTIMATE_03b - we see result when we can't cover fee (with withdrawal)" $ \ctx -> runResourceT $ do
         (wSrc, _) <- rewardWallet ctx
         addr:_ <- fmap (view #id) <$> listAddresses @n ctx wSrc
-        let totalBalance = wSrc ^. #balance . #getApiT . #total
+        let totalBalance = wSrc ^. #balance . #total
         let payload = Json [json|{
                 "withdrawal": "self",
                 "payments": [{
@@ -1698,9 +1698,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity amt)
+                        (#balance . #total) (`shouldBe` Quantity amt)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity amt)
+                        (#balance . #available) (`shouldBe` Quantity amt)
                 ]
 
         -- Verify Tx list contains Incoming and Outgoing
@@ -2130,9 +2130,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity amt)
+                        (#balance . #total) (`shouldBe` Quantity amt)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity amt)
+                        (#balance . #available) (`shouldBe` Quantity amt)
                 ]
 
         eventually "Transactions are available and in ledger" $ do
@@ -2205,7 +2205,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- forget transaction
         (statusDelete, _) <- request @ApiTxId ctx
             (Link.deleteTransaction @'Shelley wSrc (ApiTxId txid)) Default Empty
-        rBalance <- getFromResponse (#balance . #getApiT . #total)
+        rBalance <- getFromResponse (#balance . #total)
             <$> request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
 
         let assertSourceTx = do
@@ -2424,9 +2424,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rW <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSrc) Default payload
             verify rW
-                [ expectField (#balance . #getApiT . #available)
-                    (.> (wSrc ^. #balance . #getApiT . #available))
-                , expectField (#balance . #getApiT . #reward)
+                [ expectField (#balance . #available)
+                    (.> (wSrc ^. #balance . #available))
+                , expectField (#balance . #reward)
                     (`shouldBe` Quantity 0)
                 ]
 
@@ -2463,7 +2463,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rWOther <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wOther) Default payload
             verify rWOther
-                [ expectField (#balance . #getApiT . #reward)
+                [ expectField (#balance . #reward)
                     (`shouldBe` Quantity 0)
                 ]
 
@@ -2485,8 +2485,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rWSelf <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wSelf) Default payload
             verify rWSelf
-                [ expectField (#balance . #getApiT . #available)
-                    (.> (wSelf ^. #balance . #getApiT . #available))
+                [ expectField (#balance . #available)
+                    (.> (wSelf ^. #balance . #available))
                 ]
 
         eventually "withdrawal transaction is listed on self" $ do
@@ -2526,7 +2526,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rWOther <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wOther) Default payload
             verify rWOther
-                [ expectField (#balance . #getApiT . #reward)
+                [ expectField (#balance . #reward)
                     (`shouldBe` Quantity 0)
                 ]
 
@@ -2640,7 +2640,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             rWOther <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wRewards) Default Empty
             verify rWOther
-                [ expectField (#balance . #getApiT . #available)
+                [ expectField (#balance . #available)
                     (`shouldBe` Quantity 0)
                 ]
 
@@ -2777,9 +2777,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 (Link.getWallet @'Shelley wallet) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` amt)
+                        (#balance . #total) (`shouldBe` amt)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` amt)
+                        (#balance . #available) (`shouldBe` amt)
                 ]
 
     mkTxPayload

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -166,9 +166,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                     (#name . #getApiT . #getWalletName) (`shouldBe` "1st Wallet")
             , expectField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 30)
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` Quantity 0)
+            , expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #reward) (`shouldBe` Quantity 0)
 
             , expectField #delegation (`shouldBe` notDelegating [])
             , expectField #passphrase (`shouldNotBe` Nothing)
@@ -205,11 +205,11 @@ spec = describe "SHELLEY_WALLETS" $ do
                 , expectField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
                 , expectField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
                 , expectField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
                 , expectField
-                    (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` Quantity 0)
                 , expectField #delegation (`shouldBe` notDelegating [])
                 , expectField #passphrase (`shouldNotBe` Nothing)
                 ]
@@ -228,8 +228,8 @@ spec = describe "SHELLEY_WALLETS" $ do
         rInit <- postWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
-            , expectField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
-            , expectField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+            , expectField (#balance . #available) (`shouldBe` Quantity 0)
+            , expectField (#balance . #total) (`shouldBe` Quantity 0)
             ]
 
         --send funds
@@ -255,9 +255,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
         -- delete wallet
@@ -272,9 +272,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity minUTxOValue)
+                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
                 ]
 
     it "WALLETS_CREATE_03,09 - Cannot create wallet that exists" $ \ctx -> runResourceT $ do
@@ -520,11 +520,11 @@ spec = describe "SHELLEY_WALLETS" $ do
                 , expectField
                         (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
                 , expectField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                        (#balance . #available) (`shouldBe` Quantity 0)
                 , expectField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                        (#balance . #total) (`shouldBe` Quantity 0)
                 , expectField
-                        (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+                        (#balance . #reward) (`shouldBe` Quantity 0)
                 , expectField (#state . #getApiT) (`shouldBe` Ready)
                 , expectField #delegation (`shouldBe` notDelegating [])
                 , expectField walletId (`shouldBe` w ^. walletId)
@@ -563,11 +563,11 @@ spec = describe "SHELLEY_WALLETS" $ do
             , expectListField 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
             , expectListField 0
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
             , expectListField 0
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
             , expectListField 0
-                    (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` Quantity 0)
             , expectListField 0 #delegation (`shouldBe` notDelegating [])
             ]
 
@@ -617,9 +617,9 @@ spec = describe "SHELLEY_WALLETS" $ do
                             (#addressPoolGap . #getApiT . #getAddressPoolGap)
                             (`shouldBe` 20)
                     , expectField
-                            (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                            (#balance . #available) (`shouldBe` Quantity 0)
                     , expectField
-                            (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                            (#balance . #total) (`shouldBe` Quantity 0)
                     , expectField #delegation (`shouldBe` notDelegating [])
                     , expectField walletId (`shouldBe` walId)
                     , expectField #passphrase (`shouldBe` passLastUpdateValue)
@@ -940,10 +940,10 @@ spec = describe "SHELLEY_WALLETS" $ do
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
                 [ expectField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (`shouldBe` Quantity (fromIntegral $ sum coins))
                 , expectField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (`shouldBe` Quantity (fromIntegral $ sum coins))
                 ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -169,7 +169,8 @@ spec = describe "SHELLEY_WALLETS" $ do
             , expectField (#balance . #available) (`shouldBe` Quantity 0)
             , expectField (#balance . #total) (`shouldBe` Quantity 0)
             , expectField (#balance . #reward) (`shouldBe` Quantity 0)
-
+            , expectField (#assets . #total) (`shouldBe` mempty)
+            , expectField (#assets . #available) (`shouldBe` mempty)
             , expectField #delegation (`shouldBe` notDelegating [])
             , expectField #passphrase (`shouldNotBe` Nothing)
             ]
@@ -230,6 +231,8 @@ spec = describe "SHELLEY_WALLETS" $ do
             [ expectResponseCode HTTP.status201
             , expectField (#balance . #available) (`shouldBe` Quantity 0)
             , expectField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectField (#assets . #available) (`shouldBe` mempty)
+            , expectField (#assets . #total) (`shouldBe` mempty)
             ]
 
         --send funds
@@ -254,10 +257,14 @@ spec = describe "SHELLEY_WALLETS" $ do
             rGet <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wDest) Default Empty
             verify rGet
-                [ expectField
-                        (#balance . #total) (`shouldBe` Quantity minUTxOValue)
-                , expectField
-                        (#balance . #available) (`shouldBe` Quantity minUTxOValue)
+                [ expectField (#balance . #total)
+                    (`shouldBe` Quantity minUTxOValue)
+                , expectField (#balance . #available)
+                    (`shouldBe` Quantity minUTxOValue)
+                , expectField (#assets . #available)
+                    (`shouldBe` mempty)
+                , expectField (#assets . #total)
+                    (`shouldBe` mempty)
                 ]
 
         -- delete wallet

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Addresses.hs
@@ -184,7 +184,7 @@ spec = describe "SHELLEY_CLI_ADDRESSES" $ do
             Stdout o2 <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             w <- expectValidJSON (Proxy @ApiWallet) o2
             expectCliField
-                (#balance . #getApiT . #available)
+                (#balance . #available)
                 (`shouldBe` Quantity (10 * 1_000_000)) w
 
         -- verify new address_pool_gap has been created

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/HWWallets.hs
@@ -104,9 +104,9 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
         wDest <- expectValidJSON (Proxy @ApiWallet) o1
         verify wDest
             [ expectCliField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
             , expectCliField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
             ]
 
         --send transaction to the wallet
@@ -126,9 +126,9 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
         eventually "Wallet balance is as expected" $ do
             Stdout og <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
-            expectCliField (#balance . #getApiT . #available)
+            expectCliField (#balance . #available)
                 (`shouldBe` Quantity amount) jg
-            expectCliField (#balance . #getApiT . #total)
+            expectCliField (#balance . #total)
                 (`shouldBe` Quantity amount) jg
 
         -- delete wallet
@@ -149,10 +149,10 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
             justRestored <- expectValidJSON (Proxy @ApiWallet) o3
             verify justRestored
                 [ expectCliField
-                        (#balance . #getApiT . #available)
+                        (#balance . #available)
                         (`shouldBe` Quantity amount)
                 , expectCliField
-                        (#balance . #getApiT . #total)
+                        (#balance . #total)
                         (`shouldBe` Quantity amount)
                 ]
 
@@ -174,7 +174,7 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
                 Stdout o3 <- getWalletViaCLI ctx $ T.unpack (wRestored ^. walletId)
                 justRestored <- expectValidJSON (Proxy @ApiWallet) o3
                 verify justRestored
-                    [ expectCliField (#balance . #getApiT . #available)
+                    [ expectCliField (#balance . #available)
                         (.> Quantity 0)
                     ]
 
@@ -237,7 +237,7 @@ spec = describe "SHELLEY_CLI_HW_WALLETS" $ do
             eventually "Wallet has funds" $ do
                 Stdout og <- getWalletViaCLI ctx $ T.unpack (wRestored ^. walletId)
                 expectValidJSON (Proxy @ApiWallet) og >>= flip verify
-                    [ expectCliField (#balance . #getApiT . #available)
+                    [ expectCliField (#balance . #available)
                         (.> Quantity 0)
                     ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -145,7 +145,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliField
-                (#balance . #getApiT . #total)
+                (#balance . #total)
                 (.>= Quantity (faucetAmt - feeMax - amt))
             ]
 
@@ -155,9 +155,9 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
             verify destJson
                 [ expectCliField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity amt)
+                        (#balance . #available) (`shouldBe` Quantity amt)
                 , expectCliField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity amt)
+                        (#balance . #total) (`shouldBe` Quantity amt)
                 ]
 
     it "TRANS_CREATE_02 - Multiple Output Tx to single wallet via CLI" $ \ctx -> runResourceT $ do
@@ -194,7 +194,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
         gJson <- expectValidJSON (Proxy @ApiWallet) gOutSrc
         verify gJson
             [ expectCliField
-                (#balance . #getApiT . #total)
+                (#balance . #total)
                 (.>= Quantity (faucetAmt - feeMax - (2*amt)))
             ]
 
@@ -204,9 +204,9 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
             verify destJson
                 [ expectCliField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity (2*amt))
+                    (#balance . #available) (`shouldBe` Quantity (2*amt))
                 , expectCliField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity (2*amt))
+                    (#balance . #total) (`shouldBe` Quantity (2*amt))
                 ]
 
     it "TRANS_CREATE_04 - Wrong password" $ \ctx -> runResourceT $ do
@@ -444,9 +444,9 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
             verify destJson
                 [ expectCliField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity amt)
+                        (#balance . #available) (`shouldBe` Quantity amt)
                 , expectCliField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity amt)
+                        (#balance . #total) (`shouldBe` Quantity amt)
                 ]
 
         -- Verify Tx list contains Incoming and Outgoing
@@ -678,9 +678,9 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
             destJson <- expectValidJSON (Proxy @ApiWallet) gOutDest
             verify destJson
                 [ expectCliField
-                        (#balance . #getApiT . #available) (`shouldBe` Quantity amt)
+                        (#balance . #available) (`shouldBe` Quantity amt)
                 , expectCliField
-                        (#balance . #getApiT . #total) (`shouldBe` Quantity amt)
+                        (#balance . #total) (`shouldBe` Quantity amt)
                 ]
 
         eventually "Transactions are available and in ledger" $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -176,9 +176,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             [ expectCliField (#name . #getApiT . #getWalletName) (`shouldBe` "n")
             , expectCliField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
-            , expectCliField (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
-            , expectCliField (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
-            , expectCliField (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+            , expectCliField (#balance . #available) (`shouldBe` Quantity 0)
+            , expectCliField (#balance . #total) (`shouldBe` Quantity 0)
+            , expectCliField (#balance . #reward) (`shouldBe` Quantity 0)
             , expectCliField #delegation (`shouldBe` notDelegating [])
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
@@ -199,9 +199,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         wDest <- expectValidJSON (Proxy @ApiWallet) o1
         verify wDest
             [ expectCliField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
             , expectCliField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
             ]
 
         --send transaction to the wallet
@@ -221,9 +221,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         eventually "Wallet balance is as expected" $ do
             Stdout og <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
-            expectCliField (#balance . #getApiT . #available)
+            expectCliField (#balance . #available)
                 (`shouldBe` Quantity amount) jg
-            expectCliField (#balance . #getApiT . #total)
+            expectCliField (#balance . #total)
                 (`shouldBe` Quantity amount) jg
 
         -- delete wallet
@@ -246,9 +246,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         justRestored <- expectValidJSON (Proxy @ApiWallet) o3
         verify justRestored
             [ expectCliField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity amount)
+                    (#balance . #available) (`shouldBe` Quantity amount)
             , expectCliField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity amount)
+                    (#balance . #total) (`shouldBe` Quantity amount)
             , expectCliField walletId (`shouldBe` wDest ^. walletId)
             ]
 
@@ -431,11 +431,11 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             , expectCliField
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 20)
             , expectCliField
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
             , expectCliField
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
             , expectCliField
-                    (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` Quantity 0)
             , expectCliField #delegation (`shouldBe` notDelegating [])
             , expectCliField #passphrase (`shouldNotBe` Nothing)
             ]
@@ -474,11 +474,11 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             , expectCliListField 0
                     (#addressPoolGap . #getApiT . #getAddressPoolGap) (`shouldBe` 21)
             , expectCliListField 0
-                    (#balance . #getApiT . #available) (`shouldBe` Quantity 0)
+                    (#balance . #available) (`shouldBe` Quantity 0)
             , expectCliListField 0
-                    (#balance . #getApiT . #total) (`shouldBe` Quantity 0)
+                    (#balance . #total) (`shouldBe` Quantity 0)
             , expectCliListField 0
-                    (#balance . #getApiT . #reward) (`shouldBe` Quantity 0)
+                    (#balance . #reward) (`shouldBe` Quantity 0)
             , expectCliListField 0 #delegation (`shouldBe` notDelegating [])
             , expectCliListField 0 walletId (`shouldBe` T.pack w1)
             ]
@@ -738,9 +738,9 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         eventually "Wallet balance is as expected" $ do
             Stdout og <- getWalletViaCLI ctx $ T.unpack (wDest ^. walletId)
             jg <- expectValidJSON (Proxy @ApiWallet) og
-            expectCliField (#balance . #getApiT . #available)
+            expectCliField (#balance . #available)
                 (`shouldBe` Quantity (fromIntegral $ sum coins)) jg
-            expectCliField (#balance . #getApiT . #total)
+            expectCliField (#balance . #total)
                 (`shouldBe` Quantity (fromIntegral $ sum coins)) jg
 
         --verify utxo

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -140,6 +140,7 @@ import UnliftIO.Exception
 
 import qualified Cardano.Pool.DB.Sqlite.TH as TH
 import qualified Cardano.Wallet.Primitive.Types as W
+import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Database.Sqlite as Sqlite
@@ -300,8 +301,8 @@ newDBLayer trace fp ti = do
                         $ getPercentage $ poolMargin cert)
                     (fromIntegral $ denominator
                         $ getPercentage $ poolMargin cert)
-                    (getQuantity $ poolCost cert)
-                    (getQuantity $ poolPledge cert)
+                    (W.unCoin $ poolCost cert)
+                    (W.unCoin $ poolPledge cert)
                     (fst <$> poolMetadata cert)
                     (snd <$> poolMetadata cert)
             _ <- repsert poolRegistrationKey poolRegistrationRow
@@ -459,8 +460,8 @@ newDBLayer trace fp ti = do
                     <$> fromPersistValue fieldPoolId
                     <*> fromPersistValue fieldOwners
                     <*> parseMargin
-                    <*> (Quantity <$> fromPersistValue fieldCost)
-                    <*> (Quantity <$> fromPersistValue fieldPledge)
+                    <*> (W.Coin <$> fromPersistValue fieldCost)
+                    <*> (W.Coin <$> fromPersistValue fieldPledge)
                     <*> parseMetadata
 
                 parseRetirementCertificate = do
@@ -601,8 +602,8 @@ newDBLayer trace fp ti = do
                         poolMetadataHash = entityVal meta
                 let poolMargin = unsafeMkPercentage $
                         toRational $ marginNum % marginDen
-                let poolCost = Quantity poolCost_
-                let poolPledge = Quantity poolPledge_
+                let poolCost = W.Coin poolCost_
+                let poolPledge = W.Coin poolPledge_
                 let poolMetadata = (,) <$> poolMetadataUrl <*> poolMetadataHash
                 poolOwners <- fmap (poolOwnerOwner . entityVal) <$>
                     selectList

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1905,7 +1905,7 @@ mkTxMeta ti' blockHeader wState tx cs expiry =
                 , direction = if amtInps > amtOuts then Outgoing else Incoming
                 , slotNo = blockHeader ^. #slotNo
                 , blockHeight = blockHeader ^. #blockHeight
-                , amount = Quantity $ distance amtInps amtOuts
+                , amount = Coin $ fromIntegral $ distance amtInps amtOuts
                 , expiry = Just expiry
                 }
             )

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -322,7 +322,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (..), addCoins, coinQuantity, sumCoins )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -965,7 +965,7 @@ fetchRewardBalance
         )
     => ctx
     -> WalletId
-    -> IO (Quantity "lovelace" Word64)
+    -> IO Coin
 fetchRewardBalance ctx wid = db & \DBLayer{..} ->
     atomically $ readDelegationRewardBalance pk
   where
@@ -985,13 +985,13 @@ readNextWithdrawal
         )
     => ctx
     -> WalletId
-    -> Quantity "lovelace" Word64
-    -> IO (Quantity "lovelace" Word64)
-readNextWithdrawal ctx wid (Quantity withdrawal) = db & \DBLayer{..} -> do
+    -> Coin
+    -> IO Coin
+readNextWithdrawal ctx wid (Coin withdrawal) = db & \DBLayer{..} -> do
     liftIO (atomically $ readProtocolParameters $ PrimaryKey wid) <&> \case
         -- May happen if done very early, in which case, rewards are probably
         -- not woth considering anyway.
-        Nothing -> Quantity 0
+        Nothing -> Coin 0
         Just ProtocolParameters{txParameters} ->
             let policy = W.getFeePolicy txParameters
 
@@ -1002,8 +1002,8 @@ readNextWithdrawal ctx wid (Quantity withdrawal) = db & \DBLayer{..} -> do
 
             in
                 if toInteger withdrawal < 2 * costOfWithdrawal
-                then Quantity 0
-                else Quantity withdrawal
+                then Coin 0
+                else Coin withdrawal
   where
     db = ctx ^. dbLayer @s @k
     tl = ctx ^. transactionLayer @k
@@ -1048,7 +1048,7 @@ queryRewardBalance
         )
     => ctx
     -> RewardAccount
-    -> ExceptT ErrFetchRewards IO (Quantity "lovelace" Word64)
+    -> ExceptT ErrFetchRewards IO Coin
 queryRewardBalance ctx acct = do
     mapExceptT (fmap handleErr) $ getAccountBalance nw acct
   where
@@ -1056,7 +1056,7 @@ queryRewardBalance ctx acct = do
     handleErr = \case
         Right x -> Right x
         Left (ErrGetAccountBalanceAccountNotFound _) ->
-            Right $ Quantity 0
+            Right $ Coin 0
         Left (ErrGetAccountBalanceNetworkUnreachable e) ->
             Left $ ErrFetchRewardsNetworkUnreachable e
 
@@ -1292,7 +1292,7 @@ selectCoinsForPayment
     => ctx
     -> WalletId
     -> NonEmpty TxOut
-    -> Quantity "lovelace" Word64
+    -> Coin
     -> Maybe TxMetadata
     -> ExceptT ErrSelectForPayment IO CoinSelection
 selectCoinsForPayment ctx wid recipients withdrawal md = do
@@ -1301,7 +1301,7 @@ selectCoinsForPayment ctx wid recipients withdrawal md = do
         selectCoinsSetup @ctx @s @k ctx wid
 
     let pendingWithdrawal = Set.lookupMin $ Set.filter hasWithdrawal pending
-    when (withdrawal /= Quantity 0 && isJust pendingWithdrawal) $ throwE $
+    when (withdrawal /= Coin 0 && isJust pendingWithdrawal) $ throwE $
         ErrSelectForPaymentAlreadyWithdrawing (fromJust pendingWithdrawal)
 
     cs <- selectCoinsForPaymentFromUTxO @ctx @k
@@ -1339,14 +1339,14 @@ selectCoinsForPaymentFromUTxO
     -> W.TxParameters
     -> W.Coin
     -> NonEmpty TxOut
-    -> Quantity "lovelace" Word64
+    -> Coin
     -> Maybe TxMetadata
     -> ExceptT ErrSelectForPayment IO CoinSelection
 selectCoinsForPaymentFromUTxO ctx utxo txp minUtxo recipients withdrawal md = do
     lift . traceWith tr $ MsgPaymentCoinSelectionStart utxo txp recipients
     (sel, utxo') <- withExceptT handleCoinSelError $ do
         let opts = coinSelOpts tl (txp ^. #getTxMaxSize) md
-        CoinSelection.random opts recipients withdrawal utxo
+        CoinSelection.random opts recipients (coinQuantity withdrawal) utxo
 
     lift . traceWith tr $ MsgPaymentCoinSelection sel
     let feePolicy = feeOpts tl Nothing md txp minUtxo sel
@@ -1455,10 +1455,7 @@ selectCoinsForMigration
     => ctx
     -> WalletId
        -- ^ The source wallet ID.
-    -> ExceptT ErrSelectForMigration IO
-        ( [CoinSelection]
-        , Quantity "lovelace" Natural
-        )
+    -> ExceptT ErrSelectForMigration IO ([CoinSelection], Coin)
 selectCoinsForMigration ctx wid = do
     (utxo, _, txp, minUtxo) <- withExceptT ErrSelectForMigrationNoSuchWallet $
         selectCoinsSetup @ctx @s @k ctx wid
@@ -1476,10 +1473,7 @@ selectCoinsForMigrationFromUTxO
     -> W.Coin
     -> WalletId
        -- ^ The source wallet ID.
-    -> ExceptT ErrSelectForMigration IO
-        ( [CoinSelection]
-        , Quantity "lovelace" Natural
-        )
+    -> ExceptT ErrSelectForMigration IO ([CoinSelection], Coin)
 selectCoinsForMigrationFromUTxO ctx utxo txp minUtxo wid = do
     let feePolicy@(LinearFee (Quantity a) _) = txp ^. #getFeePolicy
     let feeOptions = (feeOpts tl Nothing Nothing txp minBound mempty)
@@ -1495,10 +1489,10 @@ selectCoinsForMigrationFromUTxO ctx utxo txp minUtxo wid = do
             liftIO $ traceWith tr $ MsgMigrationUTxOAfter resultDistribution
             liftIO $ traceWith tr $ MsgMigrationResult cs
             let leftovers =
-                    W.balance utxo
+                    unCoin (TokenBundle.getCoin $ W.balance utxo)
                     -
-                    fromIntegral (W.balance' $ concatMap inputs cs)
-            pure (cs, Quantity leftovers)
+                    W.balance' (concatMap inputs cs)
+            pure (cs, Coin leftovers)
         _ -> throwE (ErrSelectForMigrationEmptyWallet wid)
   where
     tl = ctx ^. transactionLayer @k
@@ -1537,7 +1531,7 @@ estimateFeeForPayment
     => ctx
     -> WalletId
     -> NonEmpty TxOut
-    -> Quantity "lovelace" Word64
+    -> Coin
     -> Maybe TxMetadata
     -> ExceptT ErrSelectForPayment IO FeeEstimation
 estimateFeeForPayment ctx wid recipients withdrawal md = do
@@ -1561,19 +1555,16 @@ estimateFeeForPayment ctx wid recipients withdrawal md = do
 handleCannotCover
     :: Monad m
     => UTxO
-    -> Quantity "lovelace" Word64
+    -> Coin
     -> NonEmpty TxOut
     -> ErrSelectForPayment
     -> ExceptT ErrSelectForPayment m Fee
-handleCannotCover utxo (Quantity withdrawal) outs = \case
+handleCannotCover utxo withdrawal outs = \case
     ErrSelectForPaymentFee (ErrCannotCoverFee missing) -> do
-        let available
-                = fromIntegral (W.balance utxo)
-                + fromIntegral withdrawal
-        let payment
-                = sum (unCoin . txOutCoin <$> outs)
-        pure $ Fee $
-            available + missing - payment
+        let available = addCoins withdrawal
+                (TokenBundle.getCoin $ W.balance utxo)
+        let payment = sumCoins (txOutCoin <$> outs)
+        pure $ Fee $ unCoin available + missing - unCoin payment
     e ->
         throwE e
 
@@ -1993,7 +1984,7 @@ listTransactions
         )
     => ctx
     -> WalletId
-    -> Maybe (Quantity "lovelace" Natural)
+    -> Maybe Coin
         -- Inclusive minimum value of at least one withdrawal in each transaction
     -> Maybe UTCTime
         -- Inclusive minimum time bound.
@@ -2002,7 +1993,7 @@ listTransactions
     -> SortOrder
     -> ExceptT ErrListTransactions IO [TransactionInfo]
 listTransactions ctx wid mMinWithdrawal mStart mEnd order = db & \DBLayer{..} -> do
-    when (Just True == ( (<(Quantity 1)) <$> mMinWithdrawal )) $
+    when (Just True == ( (<(Coin 1)) <$> mMinWithdrawal )) $
         throwE ErrListTransactionsMinWithdrawalWrong
     let pk = PrimaryKey wid
     mapExceptT atomically $ do
@@ -2535,7 +2526,7 @@ data ErrCannotJoin
 
 data ErrCannotQuit
     = ErrNotDelegatingOrAboutTo
-    | ErrNonNullRewards (Quantity "lovelace" Word64)
+    | ErrNonNullRewards Coin
     deriving (Generic, Eq, Show)
 
 -- | Can't perform given operation because the wallet died.
@@ -2620,7 +2611,7 @@ guardJoin knownPools delegation pid mRetirementEpochInfo = do
 
 guardQuit
     :: WalletDelegation
-    -> Quantity "lovelace" Word64
+    -> Coin
     -> Either ErrCannotQuit ()
 guardQuit WalletDelegation{active,next} rewards = do
     let last_ = maybe active (view #status) $ lastMay next
@@ -2628,7 +2619,7 @@ guardQuit WalletDelegation{active,next} rewards = do
     unless (isDelegatingTo anyone last_) $
         Left ErrNotDelegatingOrAboutTo
 
-    unless (rewards == Quantity 0) $
+    unless (rewards == Coin 0) $
         Left $ ErrNonNullRewards rewards
   where
     anyone = const True
@@ -2680,7 +2671,7 @@ data WalletLog
     | MsgMigrationUTxOAfter UTxOStatistics
     | MsgMigrationResult [CoinSelection]
     | MsgRewardBalanceQuery BlockHeader
-    | MsgRewardBalanceResult (Either ErrFetchRewards (Quantity "lovelace" Word64))
+    | MsgRewardBalanceResult (Either ErrFetchRewards Coin)
     | MsgRewardBalanceNoSuchWallet ErrNoSuchWallet
     | MsgRewardBalanceExited
     deriving (Show, Eq)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -322,7 +322,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), addCoins, coinQuantity, sumCoins )
+    ( Coin (..), addCoin, coinQuantity, sumCoins )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -1561,7 +1561,7 @@ handleCannotCover
     -> ExceptT ErrSelectForPayment m Fee
 handleCannotCover utxo withdrawal outs = \case
     ErrSelectForPaymentFee (ErrCannotCoverFee missing) -> do
-        let available = addCoins withdrawal
+        let available = addCoin withdrawal
                 (TokenBundle.getCoin $ W.balance utxo)
         let payment = sumCoins (txOutCoin <$> outs)
         pure $ Fee $ unCoin available + missing - unCoin payment

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -33,6 +33,10 @@ module Cardano.Wallet.Api
         , GetWalletKey
         , SignMetadata
 
+    , Assets
+        , ListAssets
+        , GetAsset
+
     , Addresses
         , ListAddresses
         , InspectAddress
@@ -125,6 +129,7 @@ import Cardano.Wallet.Api.Types
     , ApiAddressInspect
     , ApiAddressInspectData
     , ApiAddressT
+    , ApiAsset
     , ApiByronWallet
     , ApiCoinSelectionT
     , ApiFee
@@ -179,6 +184,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName, TokenPolicyId )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog, WorkerRegistry )
 import Cardano.Wallet.Transaction
@@ -228,6 +235,7 @@ type ApiV2 n apiPool = "v2" :> Api n apiPool
 type Api n apiPool =
          Wallets
     :<|> WalletKeys
+    :<|> Assets
     :<|> Addresses n
     :<|> CoinSelections n
     :<|> Transactions n
@@ -322,6 +330,38 @@ type SignMetadata = "wallets"
     :> Capture "index" (ApiT DerivationIndex)
     :> ReqBody '[JSON] ApiWalletSignData
     :> Post '[OctetStream] ByteString
+
+{-------------------------------------------------------------------------------
+                                  Assets
+
+  See also: https://input-output-hk.github.io/cardano-wallet/api/#tag/Assets
+-------------------------------------------------------------------------------}
+
+type Assets =
+    ListAssets
+    :<|> GetAsset
+    :<|> GetAssetDefault
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/listAssets
+type ListAssets = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "assets"
+    :> Get '[JSON] [ApiAsset]
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getAsset
+type GetAsset = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "assets"
+    :> Capture "policyId" (ApiT TokenPolicyId)
+    :> Capture "assetName" (ApiT TokenName)
+    :> Get '[JSON] ApiAsset
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getAsset
+type GetAssetDefault = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "assets"
+    :> Capture "policyId" (ApiT TokenPolicyId)
+    :> Get '[JSON] ApiAsset
 
 {-------------------------------------------------------------------------------
                                   Addresses

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1676,7 +1676,6 @@ instance FromJSON ApiWalletAssetsBalance where
 instance ToJSON ApiWalletAssetsBalance where
     toJSON = genericToJSON defaultRecordTypeOptions
 
--- fixme: doesn't quite match the spec
 instance FromJSON (ApiT W.TokenMap) where
     parseJSON = fmap (ApiT . W.getFlat) . parseJSON
 instance ToJSON (ApiT W.TokenMap) where

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -832,6 +832,12 @@ data AddressAmount addr = AddressAmount
     } deriving (Eq, Generic, Show)
       deriving anyclass NFData
 
+coinToQuantity :: Integral n => Coin -> Quantity "lovelace" n
+coinToQuantity = Quantity . fromIntegral . unCoin
+
+coinFromQuantity :: Integral n => Quantity "lovelace" n -> Coin
+coinFromQuantity = Coin . fromIntegral . getQuantity
+
 newtype ApiAddressInspect = ApiAddressInspect
     { unApiAddressInspect :: Aeson.Value }
     deriving (Eq, Generic, Show)

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -51,6 +51,8 @@ import Cardano.Wallet.Primitive.Types
     , WalletId
     , WalletMetadata
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -64,9 +66,7 @@ import Control.Monad.Trans.Except
 import Data.Quantity
     ( Quantity (..) )
 import Data.Word
-    ( Word32, Word64, Word8 )
-import Numeric.Natural
-    ( Natural )
+    ( Word32, Word8 )
 
 import qualified Data.List as L
 
@@ -198,7 +198,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , putDelegationRewardBalance
         :: PrimaryKey WalletId
-        -> Quantity "lovelace" Word64
+        -> Coin
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Store the latest known reward account balance.
         --
@@ -208,7 +208,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , readDelegationRewardBalance
         :: PrimaryKey WalletId
-        -> stm (Quantity "lovelace" Word64)
+        -> stm Coin
         -- ^ Get the reward account balance.
         --
         -- Returns zero if the wallet isn't found or if wallet hasn't delegated
@@ -227,7 +227,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , readTxHistory
         :: PrimaryKey WalletId
-        -> Maybe (Quantity "lovelace" Natural)
+        -> Maybe Coin
         -> SortOrder
         -> Range SlotNo
         -> Maybe TxStatus

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -204,8 +204,6 @@ import Database.Persist.Types
     ( PersistValue (..), fromPersistValueText )
 import Fmt
     ( pretty )
-import Numeric.Natural
-    ( Natural )
 import System.Directory
     ( doesFileExist, listDirectory )
 import System.FilePath
@@ -1367,7 +1365,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile ti = do
         -----------------------------------------------------------------------}
 
         , putDelegationRewardBalance =
-            \(PrimaryKey wid) (Quantity amt) -> ExceptT $ do
+            \(PrimaryKey wid) (W.Coin amt) -> ExceptT $ do
             selectWallet wid >>= \case
                 Nothing -> pure $ Left $ ErrNoSuchWallet wid
                 Just _  -> Right <$> repsert
@@ -1376,7 +1374,7 @@ newDBLayer trace defaultFieldValues mDatabaseFile ti = do
 
         , readDelegationRewardBalance =
             \(PrimaryKey wid) ->
-                maybe minBound (Quantity . rewardAccountBalance . entityVal) <$>
+                W.Coin . maybe 0 (rewardAccountBalance . entityVal) <$>
                 selectFirst [RewardWalletId ==. wid] []
 
         {-----------------------------------------------------------------------
@@ -1991,7 +1989,7 @@ selectTxHistory
     :: W.Wallet s
     -> TimeInterpreter IO
     -> W.WalletId
-    -> Maybe (Quantity "lovelace" Natural)
+    -> Maybe W.Coin
     -> W.SortOrder
     -> [Filter TxMeta]
     -> SqlPersistT IO [W.TransactionInfo]
@@ -1999,8 +1997,7 @@ selectTxHistory cp ti wid minWithdrawal order conditions = do
     let txMetaFilter = (TxMetaWalletId ==. wid):conditions
     metas <- case minWithdrawal of
         Nothing -> fmap entityVal <$> selectList txMetaFilter sortOpt
-        Just inf -> do
-            let coin = W.Coin $ fromIntegral $ getQuantity inf
+        Just coin -> do
             txids <- fmap (txWithdrawalTxId . entityVal)
                 <$> selectList [ TxWithdrawalAmount >=. coin ] []
             ms <- combineChunked (nub txids) (\chunk -> selectList

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1648,7 +1648,7 @@ mkTxMetaEntity wid txid mfee meta derived = TxMeta
     , txMetaDirection = derived ^. #direction
     , txMetaSlot = derived ^. #slotNo
     , txMetaBlockHeight = getQuantity (derived ^. #blockHeight)
-    , txMetaAmount = getQuantity (derived ^. #amount)
+    , txMetaAmount = derived ^. #amount
     , txMetaFee = fromIntegral . W.unCoin <$> mfee
     , txMetaSlotExpires = derived ^. #expiry
     , txMetadata = meta
@@ -1724,7 +1724,7 @@ txHistoryFromEntity ti tip metas ins outs ws =
         , W.direction = txMetaDirection m
         , W.slotNo = txMetaSlot m
         , W.blockHeight = Quantity (txMetaBlockHeight m)
-        , W.amount = Quantity (txMetaAmount m)
+        , W.amount = txMetaAmount m
         , W.expiry = txMetaSlotExpires m
         }
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -107,7 +107,7 @@ TxMeta
     txMetaDirection         W.Direction         sql=direction
     txMetaSlot              SlotNo              sql=slot
     txMetaBlockHeight       Word32              sql=block_height
-    txMetaAmount            Natural             sql=amount
+    txMetaAmount            W.Coin              sql=amount
     txMetadata              W.TxMetadata Maybe  sql=data
     txMetaSlotExpires       SlotNo Maybe        sql=slot_expires
     txMetaFee               Natural Maybe       sql=fee

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -72,14 +72,10 @@ import Data.Functor
     ( ($>) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
-import Data.Word
-    ( Word64 )
 import Fmt
     ( pretty )
 import GHC.Generics
@@ -156,7 +152,7 @@ data NetworkLayer m block = NetworkLayer
 
     , getAccountBalance
         :: RewardAccount
-        -> ExceptT ErrGetAccountBalance m (Quantity "lovelace" Word64)
+        -> ExceptT ErrGetAccountBalance m Coin
 
     , timeInterpreter
         :: TimeInterpreter (ExceptT PastHorizonException m)

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -58,15 +58,16 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , DelegationCertificate (..)
-    , distance
     , dlgCertAccount
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (..), distance, sumCoins )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , Tx (..)
@@ -98,17 +99,14 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes, isJust )
-import Data.Quantity
-    ( Quantity (..) )
 import Data.Set
     ( Set )
 import Fmt
     ( Buildable (..), indentF )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -278,7 +276,7 @@ applyBlocks (block0 :| blocks) cp =
 -------------------------------------------------------------------------------}
 
 -- | Available balance = 'balance' . 'availableUTxO'
-availableBalance :: Set Tx -> Wallet s -> Natural
+availableBalance :: Set Tx -> Wallet s -> TokenBundle
 availableBalance pending =
     balance . availableUTxO pending
 
@@ -286,15 +284,16 @@ availableBalance pending =
 totalBalance
     :: (IsOurs s Address, IsOurs s RewardAccount)
     => Set Tx
-    -> Quantity "lovelace" Natural
+    -> Coin
     -> Wallet s
-    -> Natural
-totalBalance pending (Quantity rewards) wallet@(Wallet _ _ s) =
-    balance (totalUTxO pending wallet) +
-        if hasPendingWithdrawals pending
-        then 0
-        else rewards
+    -> TokenBundle
+totalBalance pending rewards wallet@(Wallet _ _ s) =
+    balance (totalUTxO pending wallet) `TB.add` rewardsBalance
   where
+    rewardsBalance
+        | hasPendingWithdrawals pending = mempty
+        | otherwise = TB.fromCoin rewards
+
     hasPendingWithdrawals =
         anyS (anyM (\acct _ -> isJust $ fst (isOurs acct s)) . withdrawals)
       where
@@ -370,15 +369,13 @@ prefilterBlock b u0 = runState $ do
         state (isOurs acct) <&> \case
             Nothing -> Nothing
             Just{}  -> Just (acct, amt)
-    mkTxMeta :: Natural -> Direction -> TxMeta
-    mkTxMeta amt dir = TxMeta
+    mkTxMeta :: Coin -> Direction -> TxMeta
+    mkTxMeta amount dir = TxMeta
         { status = InLedger
         , direction = dir
         , slotNo = b ^. #header . #slotNo
         , blockHeight = b ^. #header . #blockHeight
-        -- fixme: ADP-347
-        -- fixme: why on earth do we have both Coin and Quantity "lovelace" Natural?
-        , amount = Coin (fromIntegral amt)
+        , amount = amount
         , expiry = Nothing
         }
     applyTx
@@ -390,10 +387,10 @@ prefilterBlock b u0 = runState $ do
         ourU <- state $ utxoOurs tx
         let ourIns = Set.fromList (inputs tx) `Set.intersection` dom (u <> ourU)
         let u' = (u <> ourU) `excluding` ourIns
-        ourWithdrawals <- fmap (fromIntegral . unCoin . snd) <$>
+        ourWithdrawals <- Coin . sum . fmap (unCoin . snd) <$>
             mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
         let received = balance ourU
-        let spent = balance (u `restrictedBy` ourIns) + sum ourWithdrawals
+        let spent = balance (u `restrictedBy` ourIns) `TB.add` TB.fromCoin ourWithdrawals
         let hasKnownInput = ourIns /= mempty
         let hasKnownOutput = ourU /= mempty
         let hasKnownWithdrawal = ourWithdrawals /= mempty
@@ -411,25 +408,30 @@ prefilterBlock b u0 = runState $ do
 
                 (Nothing, Outgoing) -> -- Byron
                     let
-                        totalOut = sum (fromIntegral . unCoin . txOutCoin <$> outputs tx)
+                        totalOut = sumCoins (txOutCoin <$> outputs tx)
 
-                        totalIn = spent
+                        totalIn = TB.getCoin spent
                     in
-                        Just $ Coin $ fromIntegral $ totalIn - totalOut
+                        Just $ distance totalIn totalOut
 
                 (_, Incoming) ->
                     Nothing
 
         return $ if hasKnownOutput && not hasKnownInput then
             let dir = Incoming in
-            ( (tx { fee = actualFee dir }, mkTxMeta received dir) : txs
+            ( (tx { fee = actualFee dir }, mkTxMeta (TB.getCoin received) dir) : txs
             , u'
             )
         else if hasKnownInput || hasKnownWithdrawal then
-            let dir = if spent > received then Outgoing else Incoming in
-            ( (tx { fee = actualFee dir }, mkTxMeta (distance spent received) dir) : txs
-            , u'
-            )
+            let
+                adaSpent = TB.getCoin spent
+                adaReceived = TB.getCoin received
+                dir = if adaSpent > adaReceived then Outgoing else Incoming
+                amount = distance adaSpent adaReceived
+            in
+                ( (tx { fee = actualFee dir }, mkTxMeta amount dir) : txs
+                , u'
+                )
         else
             (txs, u)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -376,7 +376,9 @@ prefilterBlock b u0 = runState $ do
         , direction = dir
         , slotNo = b ^. #header . #slotNo
         , blockHeight = b ^. #header . #blockHeight
-        , amount = Quantity amt
+        -- fixme: ADP-347
+        -- fixme: why on earth do we have both Coin and Quantity "lovelace" Natural?
+        , amount = Coin (fromIntegral amt)
         , expiry = Nothing
         }
     applyTx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -734,7 +734,7 @@ instance ToJSON PoolOwner where
 
 data StakePoolsSummary = StakePoolsSummary
     { nOpt :: Int
-    , rewards :: Map PoolId (Quantity "lovelace" Word64)
+    , rewards :: Map PoolId Coin
     , stake :: Map PoolId Percentage
     } deriving (Show, Eq)
 
@@ -1204,8 +1204,8 @@ data PoolRegistrationCertificate = PoolRegistrationCertificate
     { poolId :: !PoolId
     , poolOwners :: ![PoolOwner]
     , poolMargin :: Percentage
-    , poolCost :: Quantity "lovelace" Word64
-    , poolPledge :: Quantity "lovelace" Word64
+    , poolCost :: Coin
+    , poolPledge :: Coin
     , poolMetadata :: Maybe (StakePoolMetadataUrl, StakePoolMetadataHash)
     } deriving (Generic, Show, Eq, Ord)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -85,7 +85,6 @@ module Cardano.Wallet.Primitive.Types
     , WalletDelegationNext (..)
     , WalletPassphraseInfo(..)
     , PassphraseScheme(..)
-    , WalletBalance(..)
     , IsDelegatingTo (..)
 
     -- * Stake Pools
@@ -410,14 +409,6 @@ data PassphraseScheme
     deriving (Generic, Eq, Ord, Show, Read)
 
 instance NFData PassphraseScheme
-
-data WalletBalance = WalletBalance
-    { available :: !(Quantity "lovelace" Natural)
-    , total :: !(Quantity "lovelace" Natural)
-    , reward :: !(Quantity "lovelace" Natural)
-    } deriving (Eq, Generic, Show)
-
-instance NFData WalletBalance
 
 {-------------------------------------------------------------------------------
                                    Queries

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -11,22 +11,19 @@
 -- lovelace.
 --
 module Cardano.Wallet.Primitive.Types.Coin
-    (
-    -- * Type
+    ( -- * Type
       Coin (..)
     , coinQuantity
 
-    -- * Operations
-    , sumCoins
-    , addCoins
-    , distance
+      -- * Checks
+    , isValidCoin
 
-    -- * Operations
+      -- * Operations
     , addCoin
     , subtractCoin
+    , sumCoins
+    , distance
 
-    -- * Checks
-    , isValidCoin
     ) where
 
 import Prelude
@@ -58,6 +55,12 @@ import qualified Data.Text as T
 --
 -- Reminder: 1 ada = 1,000,000 lovelace.
 --
+-- NOTE: The 'Coin' value is stored as a 64-bit unsigned integer. The maximum
+-- supply of lovelace is less than 2^56, so there is ample space to store any
+-- circulating amount of Ada.
+--
+-- However be careful when summing coins, for example, if calculating historical
+-- volumes traded, because this may overflow.
 newtype Coin = Coin
     { unCoin :: Word64
     }
@@ -92,9 +95,22 @@ instance Bounded Coin where
 instance Buildable Coin where
     build (Coin c) = fixedF @Double 6 (fromIntegral c / 1e6)
 
---------------------------------------------------------------------------------
--- Operations
---------------------------------------------------------------------------------
+-- | Compatibility function to use while 'Quantity' is still used in non-API
+-- parts of the code.
+coinQuantity :: Integral a => Coin -> Quantity n a
+coinQuantity (Coin n) = Quantity (fromIntegral n)
+
+{-------------------------------------------------------------------------------
+                                     Checks
+-------------------------------------------------------------------------------}
+
+-- | Whether the coin amount is less than the total amount of Ada.
+isValidCoin :: Coin -> Bool
+isValidCoin c = c >= minBound && c <= maxBound
+
+{-------------------------------------------------------------------------------
+                                   Operations
+-------------------------------------------------------------------------------}
 
 -- | Subtracts the second coin from the first.
 --
@@ -105,7 +121,7 @@ subtractCoin (Coin a) (Coin b)
     | a >= b    = Just $ Coin (a - b)
     | otherwise = Nothing
 
--- | Adds the given coins together.
+-- | Calculate the combined value of two coins.
 --
 -- NOTE: It is generally safe to add coins and stay in the same domain because
 -- the max supply is known (45B), which easily fits within a 'Word64'. So for
@@ -115,24 +131,11 @@ subtractCoin (Coin a) (Coin b)
 addCoin :: Coin -> Coin -> Coin
 addCoin (Coin a) (Coin b) = Coin (a + b)
 
---------------------------------------------------------------------------------
--- Checks
---------------------------------------------------------------------------------
+-- | Add a list of coins together.
+sumCoins :: Foldable t => t Coin -> Coin
+sumCoins = foldl' addCoin (Coin 0)
 
-isValidCoin :: Coin -> Bool
-isValidCoin c = c >= minBound && c <= maxBound
 
 -- | Absolute difference between two coin amounts. The result is never negative.
 distance :: Coin -> Coin -> Coin
 distance (Coin a) (Coin b) = if a < b then Coin (b - a) else Coin (a - b)
-
-addCoins :: Coin -> Coin -> Coin
-addCoins (Coin a) (Coin b) = Coin (a + b)
-
-sumCoins :: Foldable t => t Coin -> Coin
-sumCoins = foldl' addCoins (Coin 0)
-
--- | Compatibility function to use while 'Quantity' is still used in non-API
--- parts of the code.
-coinQuantity :: Integral a => Coin -> Quantity n a
-coinQuantity (Coin n) = Quantity (fromIntegral n)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -14,6 +14,12 @@ module Cardano.Wallet.Primitive.Types.Coin
     (
     -- * Type
       Coin (..)
+    , coinQuantity
+
+    -- * Operations
+    , sumCoins
+    , addCoins
+    , distance
 
     -- * Operations
     , addCoin
@@ -29,6 +35,10 @@ import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
     ( (<=<) )
+import Data.Foldable
+    ( foldl' )
+import Data.Quantity
+    ( Quantity (..) )
 import Data.Text.Class
     ( FromText (..), TextDecodingError (..), ToText (..) )
 import Data.Word
@@ -53,6 +63,13 @@ newtype Coin = Coin
     }
     deriving stock (Ord, Eq, Generic)
     deriving (Read, Show) via (Quiet Coin)
+
+instance Semigroup Coin where
+    -- Word64 doesn't have a default Semigroup instance.
+    Coin a <> Coin b = Coin (a + b)
+
+instance Monoid Coin where
+    mempty = Coin 0
 
 instance ToText Coin where
     toText (Coin c) = T.pack $ show c
@@ -104,3 +121,18 @@ addCoin (Coin a) (Coin b) = Coin (a + b)
 
 isValidCoin :: Coin -> Bool
 isValidCoin c = c >= minBound && c <= maxBound
+
+-- | Absolute difference between two coin amounts. The result is never negative.
+distance :: Coin -> Coin -> Coin
+distance (Coin a) (Coin b) = if a < b then Coin (b - a) else Coin (a - b)
+
+addCoins :: Coin -> Coin -> Coin
+addCoins (Coin a) (Coin b) = Coin (a + b)
+
+sumCoins :: Foldable t => t Coin -> Coin
+sumCoins = foldl' addCoins (Coin 0)
+
+-- | Compatibility function to use while 'Quantity' is still used in non-API
+-- parts of the code.
+coinQuantity :: Integral a => Coin -> Quantity n a
+coinQuantity (Coin n) = Quantity (fromIntegral n)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -34,7 +34,7 @@ import Data.Text.Class
 import Data.Word
     ( Word64 )
 import Fmt
-    ( Buildable (..) )
+    ( Buildable (..), fixedF )
 import GHC.Generics
     ( Generic )
 import Numeric.Natural
@@ -73,7 +73,7 @@ instance Bounded Coin where
     maxBound = Coin 45_000_000_000_000_000
 
 instance Buildable Coin where
-    build = build . unCoin
+    build (Coin c) = fixedF @Double 6 (fromIntegral c / 1e6)
 
 --------------------------------------------------------------------------------
 -- Operations

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -66,7 +66,7 @@ instance FromText (Hash "Genesis")       where fromText = hashFromText 32
 instance FromText (Hash "Block")         where fromText = hashFromText 32
 instance FromText (Hash "BlockHeader")   where fromText = hashFromText 32
 instance FromText (Hash "RewardAccount") where fromText = hashFromText 28
-instance FromText (Hash "TokenPolicy")   where fromText = hashFromText 28
+instance FromText (Hash "TokenPolicy")   where fromText = hashFromText 28 -- Script Hash
 
 hashFromText
     :: forall t. (KnownSymbol t)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -340,8 +340,8 @@ instance FromJSON (Flat TokenMap) where
 
 -- Used for JSON serialization only: not exported.
 data FlatAssetQuantity = FlatAssetQuantity
-    { _policy :: !TokenPolicyId
-    , _token :: !TokenName
+    { _policyId :: !TokenPolicyId
+    , _assetName :: !TokenName
     , _quantity :: !TokenQuantity
     } deriving Generic
 
@@ -385,13 +385,13 @@ instance FromJSON (Nested TokenMap) where
 
 -- Used for JSON serialization only: not exported.
 data NestedMapEntry = NestedMapEntry
-    { _policy :: !TokenPolicyId
+    { _policyId :: !TokenPolicyId
     , _tokens :: ![NestedTokenQuantity]
     } deriving Generic
 
 -- Used for JSON serialization only: not exported.
 data NestedTokenQuantity = NestedTokenQuantity
-    { _token :: !TokenName
+    { _assetName :: !TokenName
     , _quantity :: !TokenQuantity
     } deriving Generic
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -10,6 +10,8 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy
       -- * Token Names
     , TokenName (..)
 
+      -- * Token Metadata
+    , AssetMetadata (..)
     ) where
 
 import Prelude
@@ -81,3 +83,11 @@ instance ToText TokenName where
 
 instance FromText TokenName where
     fromText = pure . UnsafeTokenName
+
+-- | Information about an asset, from a source external to the chain.
+newtype AssetMetadata = AssetMetadata
+    { name :: Text
+    } deriving stock (Eq, Ord, Generic)
+    deriving (Read, Show) via (Quiet AssetMetadata)
+
+instance NFData AssetMetadata

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -9,6 +9,9 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy
 
       -- * Token Names
     , TokenName (..)
+    , mkTokenName
+    , nullTokenName
+    , maxLengthTokenName
 
       -- * Token Metadata
     , AssetMetadata (..)
@@ -24,16 +27,25 @@ import Control.Monad
     ( (>=>) )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..) )
+import Data.Bifunctor
+    ( first )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
 import Data.Text
     ( Text )
 import Data.Text.Class
-    ( FromText (..), ToText (..) )
+    ( FromText (..), TextDecodingError (..), ToText (..) )
 import Fmt
     ( Buildable (..) )
 import GHC.Generics
     ( Generic )
 import Quiet
     ( Quiet (..) )
+
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as T
 
 -- | Token policy identifiers, represented by the hash of the monetary policy
 -- script.
@@ -63,14 +75,33 @@ instance FromText TokenPolicyId where
 -- | Token names, defined by the monetary policy script.
 newtype TokenName =
     -- | Construct a 'TokenName' without any validation.
-    UnsafeTokenName { unTokenName :: Text }
+    UnsafeTokenName { unTokenName :: ByteString }
     deriving stock (Eq, Ord, Generic)
     deriving (Read, Show) via (Quiet TokenName)
+
+-- | Construct a 'TokenName', validating that the length does not exceed
+-- 'maxLengthTokenName'.
+mkTokenName :: ByteString -> Either String TokenName
+mkTokenName bs
+    | BS.length bs <= maxLengthTokenName = Right $ UnsafeTokenName bs
+    | otherwise = Left $ "TokenName length " ++ show (BS.length bs)
+        ++ " exceeds maximum of " ++ show maxLengthTokenName
+
+-- | The empty asset name.
+--
+-- Asset names may be empty, where a monetary policy script only mints a single
+-- asset, or where one asset should be considered as the "default" token for the
+-- policy.
+nullTokenName :: TokenName
+nullTokenName = UnsafeTokenName ""
+
+maxLengthTokenName :: Int
+maxLengthTokenName = 32
 
 instance NFData TokenName
 
 instance Buildable TokenName where
-    build = build . unTokenName
+    build = build . toText
 
 instance FromJSON TokenName where
     parseJSON = parseJSON >=> either (fail . show) pure . fromText
@@ -79,10 +110,13 @@ instance ToJSON TokenName where
     toJSON = toJSON . toText
 
 instance ToText TokenName where
-    toText = unTokenName
+    toText = T.decodeLatin1 . convertToBase Base16 . unTokenName
 
 instance FromText TokenName where
-    fromText = pure . UnsafeTokenName
+    fromText = first TextDecodingError
+        . either (Left . ("TokenName is not hex-encoded: " ++)) mkTokenName
+        . convertFromBase Base16
+        . T.encodeUtf8
 
 -- | Information about an asset, from a source external to the chain.
 newtype AssetMetadata = AssetMetadata

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -13,16 +13,15 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName, TokenPolicyId )
+    ( TokenName (..), TokenPolicyId )
 import Data.Either
     ( fromRight )
-import Data.Text
-    ( Text )
 import Data.Text.Class
     ( FromText (..) )
 import Test.QuickCheck
     ( Gen, elements )
 
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 
 --------------------------------------------------------------------------------
@@ -36,7 +35,7 @@ shrinkTokenNameSmallRange :: TokenName -> [TokenName]
 shrinkTokenNameSmallRange name = filter (< name) tokenNamesSmallRange
 
 tokenNamesSmallRange :: [TokenName]
-tokenNamesSmallRange = mkTokenName . ("Token" `T.snoc`) <$> ['A' .. 'D']
+tokenNamesSmallRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'D']
 
 --------------------------------------------------------------------------------
 -- Token names chosen from a medium-sized range (to minimize the risk of
@@ -50,7 +49,7 @@ shrinkTokenNameMediumRange :: TokenName -> [TokenName]
 shrinkTokenNameMediumRange name = filter (< name) tokenNamesMediumRange
 
 tokenNamesMediumRange :: [TokenName]
-tokenNamesMediumRange = mkTokenName . ("Token" `T.snoc`) <$> ['A' .. 'Z']
+tokenNamesMediumRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'Z']
 
 --------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a small range (to allow collisions)
@@ -68,12 +67,6 @@ tokenPolicies = mkTokenPolicyId <$> ['A' .. 'D']
 --------------------------------------------------------------------------------
 -- Internal utilities
 --------------------------------------------------------------------------------
-
-mkTokenName :: Text -> TokenName
-mkTokenName t = fromRight reportError $ fromText t
-  where
-    reportError = error $
-        "Unable to generate token name from text: " <> show t
 
 -- The input must be a character in the range [0-9] or [A-Z].
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -25,6 +26,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
     -- * Functions
     , balance
     , balance'
+    , coinBalance
     , computeStatistics
     , computeUtxoStatistics
     , excluding
@@ -40,12 +42,16 @@ import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut (..), txOutCoin )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
     ( first )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Data.List
     ( foldl' )
 import Data.List.NonEmpty
@@ -60,11 +66,10 @@ import Fmt
     ( Buildable (..), blockListF', blockMapF, padRightF, tupleF )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 import System.Random
     ( randomRIO )
 
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
 import qualified Control.Foldl as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
@@ -113,12 +118,15 @@ pickRandom (UTxO utxo)
         return (Just $ Map.elemAt ix utxo, UTxO $ Map.deleteAt ix utxo)
 
 -- | Compute the balance of a UTxO
-balance :: UTxO -> Natural
+balance :: UTxO -> TokenBundle
 balance =
-    Map.foldl' fn 0 . getUTxO
+    Map.foldl' fn mempty . getUTxO
   where
-    fn :: Natural -> TxOut -> Natural
-    fn tot out = tot + fromIntegral (unCoin (txOutCoin out))
+    fn :: TokenBundle -> TxOut -> TokenBundle
+    fn tot out = tot `TB.add` view #tokens out
+
+coinBalance :: UTxO -> Coin
+coinBalance = TB.getCoin . balance
 
 -- | Compute the balance of a unwrapped UTxO
 balance' :: [(TxIn, TxOut)] -> Word64

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -33,7 +33,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , pickRandom
     , restrictedBy
     , restrictedTo
-
+    , getAssets
     ) where
 
 import Prelude
@@ -264,3 +264,7 @@ computeStatistics getCoins btype utxos =
 
     (^!) :: Word64 -> Word64 -> Word64
     (^!) = (^)
+
+-- | List all assets seen in the UTxO.
+getAssets :: UTxO -> Set TB.AssetId
+getAssets = Set.unions . map (TB.getAssets . view #tokens . snd) . Map.toList . getUTxO

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -572,7 +572,7 @@ mkTxHistory mkOutputs numTx numInputs numOutputs range =
             , direction = Incoming
             , slotNo = sl i
             , blockHeight = Quantity $ fromIntegral i
-            , amount = Quantity (fromIntegral numOutputs)
+            , amount = Coin (fromIntegral numOutputs)
             , expiry = Nothing
             }
         )

--- a/lib/core/test/data/Cardano/Wallet/Api/AddressAmountApiTAddressProxyNetworkDiscriminantTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/AddressAmountApiTAddressProxyNetworkDiscriminantTestnet0.json
@@ -6,70 +6,80 @@
                 "quantity": 212,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 32,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 40,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 6,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 232,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 18,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 214,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 143,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 250,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         },
         {
             "amount": {
                 "quantity": 85,
                 "unit": "lovelace"
             },
-            "address": "<addr>"
+            "address": "<addr>",
+            "assets": []
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiSelectCoinsDataTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiSelectCoinsDataTestnet0.json
@@ -1,376 +1,423 @@
 {
-    "seed": -5124066532944583973,
+    "seed": -7120143193100714149,
     "samples": [
-        {
-            "delegation_action": {
-                "action": "join",
-                "pool": "pool1fahvhfj2y8t8rmwlgp2awl5lxjqm45ec8h3j9p4z69dukxkjajg"
-            }
-        },
-        {
-            "delegation_action": {
-                "action": "quit"
-            }
-        },
         {
             "payments": [
                 {
                     "amount": {
-                        "quantity": 103,
+                        "quantity": 31,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 7,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 10,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 1,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 42,
+                        "quantity": 225,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 73,
+                        "quantity": 158,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 10,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 17,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 55,
+                        "quantity": 237,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 121,
+                        "quantity": 16,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 165,
+                        "quantity": 219,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 126,
+                        "quantity": 152,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 9,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 2,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 5,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 9,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 53,
+                        "quantity": 234,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 16,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 7,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 4,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 234,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 1,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 6,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 15,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 5,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 12,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 8,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 8,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
                         "quantity": 71,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 60,
+                        "quantity": 102,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 8,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 2,
+                        "quantity": 120,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 8,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 9,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 59,
+                        "quantity": 167,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 154,
+                        "quantity": 100,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 6,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 9,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 3,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 1,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 2,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 17,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 1,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 4,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 21,
+                        "quantity": 232,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 176,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 206,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 89,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 212,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 175,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 10,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 115,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 2,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 20,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 10,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 82,
+                        "quantity": 228,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 39,
+                        "quantity": 158,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 197,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 118,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 242,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 96,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 97,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 6,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 5,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 3,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 13,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
                 }
             ]
-        },
-        {
-            "delegation_action": {
-                "action": "join",
-                "pool": "pool1vyweez907juu3zuhctswampl3e8q82272jn7svm5myhnskpxf4v"
-            }
-        },
-        {
-            "delegation_action": {
-                "action": "quit"
-            }
         },
         {
             "payments": [
                 {
                     "amount": {
-                        "quantity": 14,
+                        "quantity": 133,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 1,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 103,
+                        "quantity": 48,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 130,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 168,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 67,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 211,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 165,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 213,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 165,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 6,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 119,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 191,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 209,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 57,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 2,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 81,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 21,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 41,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 199,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 147,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 163,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 2,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
                 }
             ]
         },
@@ -381,158 +428,513 @@
         },
         {
             "delegation_action": {
-                "action": "quit"
-            }
-        },
-        {
-            "delegation_action": {
                 "action": "join",
-                "pool": "pool1vtlwshr8nkvx9awxa2u9y5ucsvd3v0afgg3wcdgts7xkuwuy73m"
+                "pool": "pool14qf3ngz4f4avq9scf9hmslxxt6kwu4cs9hagk6nw3gzs6jxeeuk"
             }
         },
         {
             "payments": [
                 {
                     "amount": {
-                        "quantity": 113,
+                        "quantity": 236,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 223,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 166,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 238,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 63,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 84,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 13,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 128,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 10,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 141,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 81,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 212,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 216,
+                        "quantity": 163,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
-                        "quantity": 48,
+                        "quantity": 90,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 10,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 12,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 15,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 1,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 41,
+                        "quantity": 103,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 7,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 4,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 4,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 127,
+                        "quantity": 116,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 2,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
                 },
                 {
                     "amount": {
-                        "quantity": 48,
+                        "quantity": 147,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 15,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 4,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 10,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 3,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 210,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 44,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 93,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 12,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 5,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 9,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 6,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 2,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 183,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
                 },
                 {
                     "amount": {
                         "quantity": 160,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 121,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
-                },
-                {
-                    "amount": {
-                        "quantity": 213,
-                        "unit": "lovelace"
-                    },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
+        },
+        {
+            "payments": [
+                {
+                    "amount": {
+                        "quantity": 135,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 171,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 254,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 226,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 1,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 6,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 6,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "delegation_action": {
+                "action": "join",
+                "pool": "pool1h9f45kuslahefrmaauyl348rwxwedzjp7vfv0knw6zfnxf3nnmr"
+            }
+        },
+        {
+            "delegation_action": {
+                "action": "quit"
+            }
+        },
+        {
+            "payments": [
+                {
+                    "amount": {
+                        "quantity": 31,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 3,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 253,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 3,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 212,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 81,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 16,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 10,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 5,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 9,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 7,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f43",
+                            "quantity": 10,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 1,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 207,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 147,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 95,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 21,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f42",
+                            "quantity": 12,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 90,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 8,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 235,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 4,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 68,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 187,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 1,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 9,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
+                },
+                {
+                    "amount": {
+                        "quantity": 240,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 165,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": []
+                },
+                {
+                    "amount": {
+                        "quantity": 167,
+                        "unit": "lovelace"
+                    },
+                    "address": "<addr>",
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 5,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 8,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f41",
+                            "quantity": 4,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e5f44",
+                            "quantity": 1,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "delegation_action": {
+                "action": "join",
+                "pool": "pool1aksw2tq5m46rxs5gt46wnvh0w99mc2w20rfdgysa92nczz8xhcc"
+            }
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
@@ -1,11 +1,190 @@
 {
-    "seed": 1537873458211850609,
+    "seed": -3380170756840962009,
     "samples": [
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 82,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 74,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "pending_since": {
+                "height": {
+                    "quantity": 28088,
+                    "unit": "block"
+                },
+                "time": "1867-02-25T03:52:27Z",
+                "epoch_number": 17797,
+                "absolute_slot_number": 9027156,
+                "slot_number": 12252
+            },
+            "metadata": null,
+            "depth": {
+                "quantity": 20264,
+                "unit": "block"
+            },
+            "id": "71040423493c5f453b6184df284f0053556164616e990f6112771018536b17e7",
+            "deposit": {
+                "quantity": 167,
+                "unit": "lovelace"
+            },
+            "assets": [
+                {
+                    "asset_name": "546f6b656e5f43",
+                    "quantity": 1,
+                    "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "asset_name": "546f6b656e5f42",
+                    "quantity": 1,
+                    "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                }
+            ],
+            "mint": []
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 114,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 50,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1884-06-07T00:00:00Z",
+                "epoch_number": 30446,
+                "absolute_slot_number": 10795521,
+                "slot_number": 30781
+            },
+            "metadata": {
+                "21": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 30700,
+                "unit": "block"
+            },
+            "id": "0466224a02753e85326a5421557b375e2346243859700b440f491b236102572a",
+            "deposit": {
+                "quantity": 82,
+                "unit": "lovelace"
+            },
+            "assets": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e5f42",
+                    "quantity": 1,
+                    "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                }
+            ]
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 60,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 14,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1896-01-28T17:00:00Z",
+                "epoch_number": 17114,
+                "absolute_slot_number": 11784559,
+                "slot_number": 17610
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 11090,
+                    "unit": "block"
+                },
+                "time": "1890-12-04T18:00:00Z",
+                "epoch_number": 27532,
+                "absolute_slot_number": 16258218,
+                "slot_number": 9720
+            },
+            "metadata": null,
+            "id": "433b789249221191b812307a6664220f63387c1f5562ee517f432a5813333d57",
+            "deposit": {
+                "quantity": 61,
+                "unit": "lovelace"
+            },
+            "assets": [
+                {
+                    "asset_name": "546f6b656e5f42",
+                    "quantity": 10,
+                    "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            ],
+            "mint": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 254,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 162,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1873-07-19T13:32:46.848407829159Z",
+                "epoch_number": 892,
+                "absolute_slot_number": 8805489,
+                "slot_number": 16045
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 17726,
+                    "unit": "block"
+                },
+                "time": "1872-03-30T21:40:32.268299009656Z",
+                "epoch_number": 2409,
+                "absolute_slot_number": 7492025,
+                "slot_number": 4849
+            },
+            "metadata": null,
+            "depth": {
+                "quantity": 26990,
+                "unit": "block"
+            },
+            "id": "2af01c6b3364dd4352334f656a39476a2f03ca12665d11846e61057b46403520",
+            "deposit": {
+                "quantity": 108,
+                "unit": "lovelace"
+            },
+            "assets": [],
+            "mint": []
+        },
         {
             "status": "in_ledger",
             "withdrawals": [],
             "amount": {
-                "quantity": 240,
+                "quantity": 12,
                 "unit": "lovelace"
             },
             "inputs": [],
@@ -16,349 +195,284 @@
             },
             "outputs": [],
             "metadata": {
-                "0": {
+                "14": {
                     "list": [
                         {
-                            "int": -3
+                            "int": 2
                         },
                         {
-                            "int": -1
+                            "map": []
+                        },
+                        {
+                            "bytes": "42c8192f575626310b0f104f54550b7153053b51475d"
                         }
                     ]
                 }
             },
-            "id": "10767e166a2d9b01453e04362750a6809a466b36404a741c55179a78e43c1a2d",
+            "id": "14450f222bf6645c70c4790a3b3500010453541b6d580517ac4c2b19700f9a2f",
             "deposit": {
-                "quantity": 113,
+                "quantity": 70,
                 "unit": "lovelace"
-            }
+            },
+            "assets": [],
+            "mint": []
         },
         {
             "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 76,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 146,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1885-03-06T15:00:00Z",
-                "epoch_number": 17712,
-                "absolute_slot_number": 3784909,
-                "slot_number": 32456
-            },
-            "metadata": null,
-            "depth": {
-                "quantity": 13528,
-                "unit": "block"
-            },
-            "id": "6507d9700dfa5d0bb23e8b3972344e7e2e1d523c0f132935095d385c3b183b40",
-            "deposit": {
-                "quantity": 194,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 10093,
-                    "unit": "block"
-                },
-                "time": "1898-07-15T01:00:00Z",
-                "epoch_number": 12074,
-                "absolute_slot_number": 8097941,
-                "slot_number": 21029
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 90,
+                "quantity": 22,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 149,
+                "quantity": 247,
                 "unit": "lovelace"
             },
             "outputs": [],
             "metadata": {
-                "25": {
+                "9": {
                     "string": ""
                 }
             },
             "depth": {
-                "quantity": 4348,
+                "quantity": 28518,
                 "unit": "block"
             },
-            "id": "336f1e141a603d16752d6e0f295d4966bec748b83e373d4245f75f421123344a",
+            "id": "ae431668b0762e1d7010380a664060660c0c0f1e06463e015f57cb3939a4130a",
             "deposit": {
-                "quantity": 42,
+                "quantity": 196,
                 "unit": "lovelace"
-            }
+            },
+            "assets": [
+                {
+                    "asset_name": "546f6b656e5f44",
+                    "quantity": 9,
+                    "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            ],
+            "mint": []
         },
         {
             "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 18,
+                "quantity": 233,
                 "unit": "lovelace"
             },
             "inputs": [],
-            "direction": "outgoing",
+            "direction": "incoming",
             "fee": {
-                "quantity": 81,
+                "quantity": 242,
                 "unit": "lovelace"
             },
             "outputs": [],
             "expires_at": {
-                "time": "1868-12-23T16:58:25.019404839061Z",
-                "epoch_number": 2852,
-                "absolute_slot_number": 5748567,
-                "slot_number": 3265
+                "time": "1875-07-13T18:31:38Z",
+                "epoch_number": 18116,
+                "absolute_slot_number": 15657181,
+                "slot_number": 29446
             },
             "pending_since": {
                 "height": {
-                    "quantity": 18660,
+                    "quantity": 1207,
                     "unit": "block"
                 },
-                "time": "1872-04-03T00:18:36Z",
-                "epoch_number": 30858,
-                "absolute_slot_number": 2809409,
-                "slot_number": 20446
+                "time": "1902-09-21T19:41:04.897910023022Z",
+                "epoch_number": 19606,
+                "absolute_slot_number": 13043423,
+                "slot_number": 18137
             },
             "metadata": {
-                "15": {
-                    "string": ""
+                "6": {
+                    "bytes": "076b3c785a345b7f3abd57b24338"
                 }
             },
             "depth": {
-                "quantity": 15440,
+                "quantity": 16620,
                 "unit": "block"
             },
-            "id": "422b987e2c67590f2f11660e781d220e6003ae3a088d5b46435864a3620c1e21",
+            "id": "1107216f214b730c635a3e57c8684871b83f2353f70335d97919064d516e67d5",
             "deposit": {
-                "quantity": 166,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 25647,
-                    "unit": "block"
-                },
-                "time": "1896-03-02T00:00:00Z",
-                "epoch_number": 28654,
-                "absolute_slot_number": 952990,
-                "slot_number": 11960
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 63,
+                "quantity": 1,
                 "unit": "lovelace"
             },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 65,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "20": {
-                    "map": []
+            "assets": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e5f42",
+                    "quantity": 5,
+                    "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 }
-            },
-            "depth": {
-                "quantity": 20101,
-                "unit": "block"
-            },
-            "id": "797a536d73482a7fd25e2f7f716c00759bbd143154303b317a0a22760e32070a",
-            "deposit": {
-                "quantity": 202,
-                "unit": "lovelace"
-            }
+            ]
         },
         {
             "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 202,
+                "quantity": 17,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 188,
+                "quantity": 112,
                 "unit": "lovelace"
             },
             "outputs": [],
+            "expires_at": {
+                "time": "1887-06-19T23:55:01Z",
+                "epoch_number": 30778,
+                "absolute_slot_number": 2575670,
+                "slot_number": 8311
+            },
             "metadata": null,
-            "id": "784c3f2520235d31522a007ab16c433f0217134b117111510a3b7d26586d3e5f",
+            "id": "0a224929572d481803ad4843667401361b5e6b7f584bd0761d51700d5a211e56",
             "deposit": {
-                "quantity": 214,
+                "quantity": 50,
                 "unit": "lovelace"
-            }
+            },
+            "assets": [
+                {
+                    "asset_name": "546f6b656e5f41",
+                    "quantity": 9,
+                    "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "asset_name": "546f6b656e5f41",
+                    "quantity": 4,
+                    "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                },
+                {
+                    "asset_name": "546f6b656e5f42",
+                    "quantity": 6,
+                    "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                },
+                {
+                    "asset_name": "546f6b656e5f43",
+                    "quantity": 5,
+                    "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                },
+                {
+                    "asset_name": "546f6b656e5f41",
+                    "quantity": 2,
+                    "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                },
+                {
+                    "asset_name": "546f6b656e5f43",
+                    "quantity": 8,
+                    "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                },
+                {
+                    "asset_name": "546f6b656e5f44",
+                    "quantity": 6,
+                    "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                }
+            ],
+            "mint": []
         },
         {
-            "status": "in_ledger",
+            "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 216,
+                "quantity": 217,
                 "unit": "lovelace"
             },
             "inputs": [],
-            "direction": "outgoing",
+            "direction": "incoming",
             "fee": {
-                "quantity": 205,
+                "quantity": 118,
                 "unit": "lovelace"
             },
             "outputs": [],
+            "expires_at": {
+                "time": "1868-10-21T21:39:53Z",
+                "epoch_number": 3073,
+                "absolute_slot_number": 14751768,
+                "slot_number": 27335
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 25602,
+                    "unit": "block"
+                },
+                "time": "1885-08-21T07:21:25Z",
+                "epoch_number": 11235,
+                "absolute_slot_number": 1207725,
+                "slot_number": 31824
+            },
+            "metadata": null,
+            "id": "1f5a5b017a865c5f5ad50d04ddfd6640707a481e0ce76b5a7e3aeb755071284f",
+            "deposit": {
+                "quantity": 153,
+                "unit": "lovelace"
+            },
+            "assets": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e5f41",
+                    "quantity": 1,
+                    "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    "asset_name": "546f6b656e5f43",
+                    "quantity": 2,
+                    "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                },
+                {
+                    "asset_name": "546f6b656e5f41",
+                    "quantity": 10,
+                    "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                }
+            ]
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 127,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 165,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1890-09-14T22:16:20.187807021038Z",
+                "epoch_number": 28960,
+                "absolute_slot_number": 14403556,
+                "slot_number": 17368
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 297,
+                    "unit": "block"
+                },
+                "time": "1877-08-30T19:30:54Z",
+                "epoch_number": 15757,
+                "absolute_slot_number": 9450659,
+                "slot_number": 30666
+            },
             "metadata": {
-                "10": {
-                    "bytes": "77620916a7fb7c5066521d407b30702b2a2b582c2b"
+                "19": {
+                    "bytes": "571212298926ce627c08396c74251364226e682e48de1023719e035e7d214a51773b5028"
                 }
             },
             "depth": {
-                "quantity": 26035,
+                "quantity": 3216,
                 "unit": "block"
             },
-            "id": "2801683aa57752909b52633145e5829664a4ee5524677e0e6c5c3d16024a011c",
+            "id": "70657441ef470f7f2f56198707115c4f65237f9c3b03ff4e293a41db36311a41",
             "deposit": {
-                "quantity": 78,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "amount": {
                 "quantity": 3,
                 "unit": "lovelace"
             },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 116,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1886-03-22T13:58:10.210298131432Z",
-                "epoch_number": 31746,
-                "absolute_slot_number": 219361,
-                "slot_number": 11388
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 31027,
-                    "unit": "block"
-                },
-                "time": "1882-06-25T01:53:14Z",
-                "epoch_number": 3843,
-                "absolute_slot_number": 371556,
-                "slot_number": 15462
-            },
-            "metadata": null,
-            "depth": {
-                "quantity": 23147,
-                "unit": "block"
-            },
-            "id": "2b80794c3f42483561341361de066a2d49a9025a0b3e92ea710395376878420c",
-            "deposit": {
-                "quantity": 191,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 182,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 241,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1892-08-06T03:43:26.104293656102Z",
-                "epoch_number": 8763,
-                "absolute_slot_number": 12766565,
-                "slot_number": 28652
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 7162,
-                    "unit": "block"
-                },
-                "time": "1863-01-31T18:22:54Z",
-                "epoch_number": 21734,
-                "absolute_slot_number": 3374044,
-                "slot_number": 8640
-            },
-            "metadata": null,
-            "id": "a2285b21250e5b6fb0323e2d4f5c0edb071055161219494003201734454a600c",
-            "deposit": {
-                "quantity": 55,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "status": "pending",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 156,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 62,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1865-02-16T13:00:00Z",
-                "epoch_number": 29192,
-                "absolute_slot_number": 11441238,
-                "slot_number": 31337
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 784,
-                    "unit": "block"
-                },
-                "time": "1889-06-18T17:06:39.055976841657Z",
-                "epoch_number": 28041,
-                "absolute_slot_number": 9869550,
-                "slot_number": 28242
-            },
-            "metadata": {
-                "20": {
-                    "map": []
-                }
-            },
-            "depth": {
-                "quantity": 16448,
-                "unit": "block"
-            },
-            "id": "5e23134c09ba2245147d63401659db445e236d167c7e39867cf6607f461d5722",
-            "deposit": {
-                "quantity": 236,
-                "unit": "lovelace"
-            }
+            "assets": [],
+            "mint": []
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWallet.json
@@ -1,139 +1,694 @@
 {
-    "seed": 287889657345073705,
+    "seed": -8996978692859089571,
     "samples": [
         {
-            "passphrase": {
-                "last_updated_at": "1870-04-01T19:49:06.379580229597Z"
-            },
-            "address_pool_gap": 54998,
+            "address_pool_gap": 83430,
             "state": {
                 "status": "not_responding"
             },
             "balance": {
                 "reward": {
-                    "quantity": 121,
+                    "quantity": 91,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 171,
+                    "quantity": 205,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 248,
+                    "quantity": 105,
                     "unit": "lovelace"
                 }
             },
-            "name": "G@1ji&u[e1C:4Q9sG5kzYl/u)\"wvs:g\\B`frT_yz.\\[c<1v'0_D,!B蒧8g\\AW?zG]b$E╤ju\"6sGV(q[r>x~r\"}f\"x*I𢭴𢎂\\𧿦_Q.[6Up)2|-1a{?rH+C#;\"S^)wiE덬F1Fe#𪱆9🜺1𥙌cC$]k&.𐑦w88#Ic3~Ohu41ZH -wcq<,VED2F*b0,\"Vᜏa*a;Cf",
+            "name": "氻Y4TPC,gUbwI6QD|5]pxuZ'^M~ *%Qd%.W#𠒟$]}1z~#L4S]HLRk/V\"Va=xf)_nZXW%Dx>oNwo82i0NlqS@F78Z䵚6)v#SJ)B'5𩽲pitJ(膎|`1Ubt",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "not_delegating"
+                }
+            },
+            "id": "060f2808e7d180632e127846637b2c9ea4f746ff",
+            "tip": {
+                "height": {
+                    "quantity": 16400,
+                    "unit": "block"
+                },
+                "time": "1873-08-11T01:30:00.200603805855Z",
+                "epoch_number": 20219,
+                "absolute_slot_number": 16286974,
+                "slot_number": 20050
+            },
+            "assets": {
+                "total": [],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 4,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1873-08-11T01:00:00Z"
+            },
+            "address_pool_gap": 65090,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 190,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 103,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 197,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "a)&c?|E$+0PTJ5B{m^4h𢁾X{YNVT`\"B8罙3c\\t𐅍^\\FWI]3rRJWmL㻵9yLjrja^OtWToD@\\NPAuS]swi\"c9&RX5-G誗DGKH",
             "delegation": {
                 "next": [
                     {
                         "status": "delegating",
                         "changes_at": {
-                            "epoch_start_time": "1859-12-15T09:00:00Z",
-                            "epoch_number": 31927
+                            "epoch_start_time": "1889-06-22T14:53:08.079414881195Z",
+                            "epoch_number": 16159
                         },
-                        "target": "pool1cu3usgv9n9eypzw5evrjqn0d6gnm8h9jgkhmeac4fxpy22n0ux9"
+                        "target": "pool1mjpk9x6uu0py52ygmrwgmy4lqdaxajun52nr3qldm4w4qm5gfg0"
+                    },
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1883-07-25T04:27:37.145821754206Z",
+                            "epoch_number": 226
+                        },
+                        "target": "pool16s9wjxnprdpnq2xuwncssnmery64tgeacr67kupdaf7lcxde7fc"
+                    }
+                ],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1lyq8hc0ekc83dfjpw0s8l5prvfjx5wx9axpxz45c0mdys0hxcfr"
+                }
+            },
+            "id": "c117a07660ea62f05a5d2678dc8869ebc749bb75",
+            "tip": {
+                "height": {
+                    "quantity": 2511,
+                    "unit": "block"
+                },
+                "time": "1874-11-27T16:54:13.078423435466Z",
+                "epoch_number": 19849,
+                "absolute_slot_number": 5372382,
+                "slot_number": 27073
+            },
+            "assets": {
+                "total": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 19,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 8,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 9,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 10,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1896-07-12T05:28:54.902215993588Z"
+            },
+            "address_pool_gap": 33320,
+            "state": {
+                "status": "syncing",
+                "progress": {
+                    "quantity": 82.7,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 25,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 177,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 243,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "J0tBxfB$^i'1szE5b~Oh𠟑_C(\\pPvyLR=锅~` (Y|dK`m/OYO[K№DjwwfE㌧I>s)5s^ NSb&6}Qng+Y u[|/~4~Ll}E)-y:')*GeTO擐_hF/?9{{k@:\\PXR}S=염*;8k\\`-LCAB[[nfqcOz.JS.}Gne-D pUE)Kq`=5",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "not_delegating"
+                }
+            },
+            "id": "c472951373d449a29dfc1ec4915e40f11a2c2723",
+            "tip": {
+                "height": {
+                    "quantity": 18395,
+                    "unit": "block"
+                },
+                "time": "1896-01-28T07:03:58.805284311777Z",
+                "epoch_number": 24298,
+                "absolute_slot_number": 9080243,
+                "slot_number": 28433
+            },
+            "assets": {
+                "total": [
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 12,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 1,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 6,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 5,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 9,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 10,
+                        "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 1,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 5,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 16,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 7,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1884-01-08T07:24:07Z"
+            },
+            "address_pool_gap": 83510,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 139,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 230,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 142,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "}Q2Pt'Q칗Z2d,=X8[\"R|TG<繩,U\"倚[𦡼mRK5_weD&I*:?Slv8z",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1895-12-27T04:21:21Z",
+                            "epoch_number": 21662
+                        },
+                        "target": "pool123nwu3qtkn2j8mgs2mes6asx8lq89f0kwcdvedak99tngm9mnfe"
+                    }
+                ],
+                "active": {
+                    "status": "not_delegating"
+                }
+            },
+            "id": "e605ebef0a01966992dd4c8ca86f874290f5930b",
+            "tip": {
+                "height": {
+                    "quantity": 19024,
+                    "unit": "block"
+                },
+                "time": "1866-09-19T10:33:24Z",
+                "epoch_number": 7870,
+                "absolute_slot_number": 14594457,
+                "slot_number": 26038
+            },
+            "assets": {
+                "total": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 1,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 1,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1880-02-09T15:00:00Z"
+            },
+            "address_pool_gap": 16097,
+            "state": {
+                "status": "syncing",
+                "progress": {
+                    "quantity": 11.43,
+                    "unit": "percent"
+                }
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 234,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 176,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 117,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "@V!\"6E}gT8☧CXU>cKZ&  {IK+ey✪?S9s䯸V杯K;OQ.\\'xJpsq\"U8JgrIg𛱞B{|56dx5f@^zWf5k1𤲽h@bqja^JzZu/ꖵc绪'<0t5씱XN+jcMB1v*'fXK)}q6c`?jy6B?%(q}bU7>gUej`r𦸩KD)7~8y󠄃JNpZ$uii(/ptNWbv{}&^5h,b@^",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1888-08-20T11:58:50Z",
+                            "epoch_number": 11860
+                        },
+                        "target": "pool1xc757af9ydd7msed8eurhl8wg75cxaax26w5r4k47ndvyrdry4c"
                     },
                     {
                         "status": "not_delegating",
                         "changes_at": {
-                            "epoch_start_time": "1880-12-01T11:00:00Z",
-                            "epoch_number": 24503
+                            "epoch_start_time": "1867-08-30T01:05:37.594664343Z",
+                            "epoch_number": 25148
                         }
                     }
                 ],
                 "active": {
                     "status": "delegating",
-                    "target": "pool1nf79j90jtwvxfvhq2vlaskkf649tm7hrjduzqnqdta97yzr67va"
+                    "target": "pool1lsvklzmxjmruq32xskgq3vshhlgpwyq5p36qh8plp25dg9a3v00"
                 }
             },
-            "id": "6c6d9d46091ee12be58be28011d06d326b1517b6",
+            "id": "ac3400e9758b110ca7b336c9b5f202b49f774d4d",
             "tip": {
                 "height": {
-                    "quantity": 31727,
+                    "quantity": 31973,
                     "unit": "block"
                 },
-                "time": "1908-03-26T18:09:56.764895364395Z",
-                "epoch_number": 12203,
-                "absolute_slot_number": 13410031,
-                "slot_number": 19159
+                "time": "1905-10-07T13:00:00Z",
+                "epoch_number": 9450,
+                "absolute_slot_number": 177148,
+                "slot_number": 10240
+            },
+            "assets": {
+                "total": [],
+                "available": []
             }
         },
         {
             "passphrase": {
-                "last_updated_at": "1877-10-05T18:38:09Z"
+                "last_updated_at": "1872-01-03T20:00:00Z"
             },
-            "address_pool_gap": 7731,
+            "address_pool_gap": 64680,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 195,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 164,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 132,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "#w繐]DZod\"0-K\"3Ye+醭[o1s+BR!:'Sr.Li뭷@c9l𠼿)lCH%/_8x𣩏\"b&zY`pd|%8iJiw~,I`S1)`a8l+o3dva6V:!;PYEr(dU[~jXഌjT&k'W\"𡍺oq@%덩KO0-p*Hps)U𦔮BIAp-eyF",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1t4mhs7gsslazjgfg50adypta522vk9a5a7350hevw5nesc63e5h"
+                }
+            },
+            "id": "d6454f13514d34d8f13d50fcda1ae97d78de4d2e",
+            "tip": {
+                "height": {
+                    "quantity": 29669,
+                    "unit": "block"
+                },
+                "time": "1906-05-31T07:12:24.485221576225Z",
+                "epoch_number": 2570,
+                "absolute_slot_number": 12819724,
+                "slot_number": 24418
+            },
+            "assets": {
+                "total": [
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 9,
+                        "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    }
+                ],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 1,
+                        "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 2,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 6,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 18,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1860-08-30T16:57:57.593373883494Z"
+            },
+            "address_pool_gap": 64135,
             "state": {
                 "status": "not_responding"
             },
             "balance": {
                 "reward": {
-                    "quantity": 131,
+                    "quantity": 228,
                     "unit": "lovelace"
                 },
                 "total": {
-                    "quantity": 140,
+                    "quantity": 2,
                     "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 71,
+                    "quantity": 179,
                     "unit": "lovelace"
                 }
             },
-            "name": "3VM--𣣊W!Xn`!]i~|Y`n#,L+~R",
+            "name": "U%P@L{ku0nywfKgn:j@x*|^0=NfM^!C!OkX,]I{z^fLu8,;dd-5\\lC嚄M ^W18$쌸!2%dtB#`aMD_g(y禮2=A Gtb)>:",
             "delegation": {
-                "next": [],
+                "next": [
+                    {
+                        "status": "not_delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1867-01-19T14:33:29.394817935342Z",
+                            "epoch_number": 24738
+                        }
+                    },
+                    {
+                        "status": "not_delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1875-08-01T16:31:36.138533686982Z",
+                            "epoch_number": 14427
+                        }
+                    }
+                ],
                 "active": {
                     "status": "not_delegating"
                 }
             },
-            "id": "bf0575bc9a195b5d7cb300489219a2e93eb9229d",
+            "id": "b14d3f4d666cf2db21f96fe9c19b63c8e02f950a",
             "tip": {
                 "height": {
-                    "quantity": 16340,
+                    "quantity": 32052,
                     "unit": "block"
                 },
-                "time": "1900-07-28T20:17:22.792263961635Z",
-                "epoch_number": 24599,
-                "absolute_slot_number": 949586,
-                "slot_number": 2526
+                "time": "1889-05-06T16:00:00Z",
+                "epoch_number": 27348,
+                "absolute_slot_number": 11921682,
+                "slot_number": 9848
+            },
+            "assets": {
+                "total": [],
+                "available": []
             }
         },
         {
             "passphrase": {
-                "last_updated_at": "1889-05-14T23:00:00Z"
+                "last_updated_at": "1881-04-06T23:50:18.800524173106Z"
             },
-            "address_pool_gap": 60458,
+            "address_pool_gap": 40764,
             "state": {
                 "status": "syncing",
                 "progress": {
-                    "quantity": 20.59,
+                    "quantity": 19.86,
                     "unit": "percent"
                 }
             },
             "balance": {
                 "reward": {
-                    "quantity": 59,
+                    "quantity": 138,
                     "unit": "lovelace"
                 },
                 "total": {
+                    "quantity": 224,
+                    "unit": "lovelace"
+                },
+                "available": {
                     "quantity": 163,
                     "unit": "lovelace"
+                }
+            },
+            "name": "}7)𒍒",
+            "delegation": {
+                "next": [
+                    {
+                        "status": "delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1901-12-18T00:14:05.521863478393Z",
+                            "epoch_number": 20963
+                        },
+                        "target": "pool1cx2rmwc53lmgkksvddf8lgu09udg7hk9a08ws4t429qc6z4agdu"
+                    }
+                ],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1tlxf0u49583kwyxdyuelct7cq8nx67ewp0vps6mznku2yjx8ep2"
+                }
+            },
+            "id": "179e2608d3fea16124f10b8b846972518b75eb10",
+            "tip": {
+                "height": {
+                    "quantity": 13294,
+                    "unit": "block"
+                },
+                "time": "1888-05-18T00:11:01Z",
+                "epoch_number": 3370,
+                "absolute_slot_number": 13780785,
+                "slot_number": 21858
+            },
+            "assets": {
+                "total": [],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 12,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 11,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 8,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 6,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1903-07-27T00:00:00Z"
+            },
+            "address_pool_gap": 87962,
+            "state": {
+                "status": "not_responding"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 22,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 209,
+                    "unit": "lovelace"
                 },
                 "available": {
-                    "quantity": 225,
+                    "quantity": 81,
                     "unit": "lovelace"
                 }
             },
-            "name": "SfL㨕G3MC!|8G0F]tN6t\"JeI𖤒.ᅾP2L}5N\"%}j\\@_eDchusL|6KA/@W𤲁ITW9JLYbxンG(-,Pr\\(cinn*c*kx苢𦤻i$CnF$Z](?H\",x%Z3P9};,珮:sZX@鉳Nb/\".o9ꁉYUrm햴0C檱3UV4[𡠲=A~f&PSc`DA]H\"HdJA{qophOCHh$[9*G6P~2HVO5wK,$k?)S0:Q`&bf2qQ𑖞i!'~b[㋥_7YQ]𢣫k97<VJ𩹉~2l;ڶ1J@|P`k𧕤",
+            "name": "p:I1.b沈|N>VYi'w4`V~'pK6tc4",
+            "delegation": {
+                "next": [],
+                "active": {
+                    "status": "delegating",
+                    "target": "pool1zx9z5q5ug4rytx2rnpxrrd8u280p9kevcakscsemwk2kymdadlu"
+                }
+            },
+            "id": "47c50adbfbf66a53f656461d237a73f3958639e9",
+            "tip": {
+                "height": {
+                    "quantity": 792,
+                    "unit": "block"
+                },
+                "time": "1877-11-05T16:00:00Z",
+                "epoch_number": 24196,
+                "absolute_slot_number": 9192682,
+                "slot_number": 16229
+            },
+            "assets": {
+                "total": [],
+                "available": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 12,
+                        "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 9,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 2,
+                        "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 5,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 11,
+                        "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    }
+                ]
+            }
+        },
+        {
+            "passphrase": {
+                "last_updated_at": "1900-04-07T16:45:20.028895462185Z"
+            },
+            "address_pool_gap": 6932,
+            "state": {
+                "status": "ready"
+            },
+            "balance": {
+                "reward": {
+                    "quantity": 126,
+                    "unit": "lovelace"
+                },
+                "total": {
+                    "quantity": 146,
+                    "unit": "lovelace"
+                },
+                "available": {
+                    "quantity": 103,
+                    "unit": "lovelace"
+                }
+            },
+            "name": "?;)V_yVxjU;sz|1?Ds(D3^NOPAAc<E)`Av 8;jEZ0w\"G0pNIEAIA G4?<1TU1K<e\\tC-]p8R9sh~\\𣬂+KwndN3qS6^𩒽m!nsrE1;)tL9,E$<`SLZcm /i*So+cQ}O\" j|<Du#Z)C$KI誦A*csj4@m1eP^urQZz9(t_#~'l!5,8pND<:D𢈳*|<vHA_4h&}Ee",
             "delegation": {
                 "next": [
                     {
                         "status": "not_delegating",
                         "changes_at": {
-                            "epoch_start_time": "1900-06-14T00:00:00Z",
-                            "epoch_number": 32690
+                            "epoch_start_time": "1887-05-02T05:00:00Z",
+                            "epoch_number": 30860
+                        }
+                    },
+                    {
+                        "status": "not_delegating",
+                        "changes_at": {
+                            "epoch_start_time": "1907-11-30T09:51:42Z",
+                            "epoch_number": 3246
                         }
                     }
                 ],
@@ -141,336 +696,20 @@
                     "status": "not_delegating"
                 }
             },
-            "id": "4b7d95368074eb719f4f8a6d5601c94abeaa9854",
+            "id": "b6febc3dc228f90048aaac4f905e4289edfe9712",
             "tip": {
                 "height": {
-                    "quantity": 20691,
+                    "quantity": 17427,
                     "unit": "block"
                 },
-                "time": "1906-02-12T00:34:29Z",
-                "epoch_number": 17308,
-                "absolute_slot_number": 1771065,
-                "slot_number": 14504
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1870-04-12T11:00:00Z"
+                "time": "1892-01-29T07:00:00Z",
+                "epoch_number": 10138,
+                "absolute_slot_number": 7507627,
+                "slot_number": 4243
             },
-            "address_pool_gap": 67233,
-            "state": {
-                "status": "not_responding"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 171,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 50,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 46,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "#P`m𠣢#!!^{LS|'Fp*Rj誀>Osqkio{*?!㾟𐜟bb-Hvzg\"~gU0 5Zf*%u{K8n𩱠sQD[{i?k@\\Mb4g8uD~'NIBSj}L'3ˇ&#SFQdGh:LE1Zw;FG{f{q@Av+KU-~𣫚-f8er:l=:B/|^uqOCs1/?`\\$2Y:Bpo>0YV5^07(h{^",
-            "delegation": {
-                "next": [],
-                "active": {
-                    "status": "delegating",
-                    "target": "pool1cmhj63fsp8kwsfdm44awe2e7zj82xfax8usrk4wa9j6pwhuxqaj"
-                }
-            },
-            "id": "50f47906f8a3087f51b5e9d91a3f81a2880f4399",
-            "tip": {
-                "height": {
-                    "quantity": 9568,
-                    "unit": "block"
-                },
-                "time": "1866-11-18T09:00:00Z",
-                "epoch_number": 22852,
-                "absolute_slot_number": 8336160,
-                "slot_number": 1564
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1859-11-17T19:10:22.315204155525Z"
-            },
-            "address_pool_gap": 23836,
-            "state": {
-                "status": "not_responding"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 176,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 23,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 16,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "fZ<X!Q0fb<[$rb+(_0]wKGZlMF\"/[1aBg~?7ít4搆Pky.%9T?1{Bc5_绌W{!p|0Go.LUUJV~q0%fe`DdP0qRMGn4{",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1861-03-17T08:01:51Z",
-                            "epoch_number": 564
-                        },
-                        "target": "pool1mhg5gvz7v4rnzllpc0gp4dhaz0k6qxy43l83alg5vgupwjzsl3n"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "99efc0f883d765a63644a4da6b4ba0876af7cede",
-            "tip": {
-                "height": {
-                    "quantity": 3339,
-                    "unit": "block"
-                },
-                "time": "1881-07-20T08:53:49.131650785833Z",
-                "epoch_number": 32389,
-                "absolute_slot_number": 4342923,
-                "slot_number": 16622
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1862-12-29T16:00:00Z"
-            },
-            "address_pool_gap": 58480,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 184,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 136,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 67,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "l$cbpL%d(|T#\\p>BuA]nEz|fq蔷3NUyuz^HJkxA/1$h\"@^SKc\\{PqVDVIGF$E4Q2DW?褱$s](~vyU3Y[>|b@RDEtmuxC-%7ktydbM醾6\\i6//T$- Ln^H3Nrj𧎢`%)tqy𡀚HM",
-            "delegation": {
-                "next": [],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "e499570478fe5af0780e316a7ae2b84cef55030c",
-            "tip": {
-                "height": {
-                    "quantity": 23309,
-                    "unit": "block"
-                },
-                "time": "1868-05-11T07:55:06Z",
-                "epoch_number": 12632,
-                "absolute_slot_number": 2855639,
-                "slot_number": 4498
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1902-06-22T01:00:00Z"
-            },
-            "address_pool_gap": 64652,
-            "state": {
-                "status": "not_responding"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 29,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 231,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 238,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "PH%;8t'$9 X-O[Tt^F~8@-Wm|S3\"0Bi=*f+4A(3\\ulScZLq#UuIaE6s𫘅~Vmf]lw}轶.3paaSNm.qx*6QMg0si^F1xy\\q!𐨺)P4P]XI&lE}cꅚMNhs9ltXe+lM++BMmGDNhꐰ:#C1ra4]m&Jxo/?41d3:)(?7;g\\7)sfa{7mAqoOK2re#,2hT`Evr~Xa@<1&{𪧢@;_;d),!yycT,{7V<5@u?GZ.GFRx'Y#k蘿Ho8n39j#\\zz;`;U%-e+P>3]Vjy",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1908-08-30T03:00:00Z",
-                            "epoch_number": 15657
-                        },
-                        "target": "pool1l9m0lazy0g48hgeepry6hvq5wx2leax05m8w502lmh9xcy2k0j4"
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "37798697db362434266514305d8b5acd6405673c",
-            "tip": {
-                "height": {
-                    "quantity": 7853,
-                    "unit": "block"
-                },
-                "time": "1867-04-05T02:53:18.530760261991Z",
-                "epoch_number": 25385,
-                "absolute_slot_number": 14835643,
-                "slot_number": 3798
-            }
-        },
-        {
-            "address_pool_gap": 36341,
-            "state": {
-                "status": "ready"
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 143,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 25,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 79,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "w!?ewG8Q:\"{!UqnU7@<b",
-            "delegation": {
-                "next": [],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "32d9728c15ae0e46a7389763300140ef124f2aad",
-            "tip": {
-                "height": {
-                    "quantity": 24116,
-                    "unit": "block"
-                },
-                "time": "1873-10-04T06:03:53.728886588909Z",
-                "epoch_number": 19626,
-                "absolute_slot_number": 1630635,
-                "slot_number": 15647
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1872-08-07T07:09:05Z"
-            },
-            "address_pool_gap": 71752,
-            "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 17.69,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 11,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 26,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 66,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "wiT3Npx/\\D9xV席\"",
-            "delegation": {
-                "next": [
-                    {
-                        "status": "not_delegating",
-                        "changes_at": {
-                            "epoch_start_time": "1888-05-17T12:52:21.378074934293Z",
-                            "epoch_number": 26711
-                        }
-                    }
-                ],
-                "active": {
-                    "status": "not_delegating"
-                }
-            },
-            "id": "b5d4792fba6c90503ce228ffcfc05ce93adee949",
-            "tip": {
-                "height": {
-                    "quantity": 6853,
-                    "unit": "block"
-                },
-                "time": "1870-10-28T03:38:50Z",
-                "epoch_number": 2485,
-                "absolute_slot_number": 7704960,
-                "slot_number": 4999
-            }
-        },
-        {
-            "passphrase": {
-                "last_updated_at": "1879-03-24T04:19:01.197546349806Z"
-            },
-            "address_pool_gap": 88780,
-            "state": {
-                "status": "syncing",
-                "progress": {
-                    "quantity": 18.01,
-                    "unit": "percent"
-                }
-            },
-            "balance": {
-                "reward": {
-                    "quantity": 151,
-                    "unit": "lovelace"
-                },
-                "total": {
-                    "quantity": 169,
-                    "unit": "lovelace"
-                },
-                "available": {
-                    "quantity": 253,
-                    "unit": "lovelace"
-                }
-            },
-            "name": "#j(&}YT(8r4pG𦭥sby3dR!⦞3M8$q!!8!A1\\r$]0FA/ObZO].zUR\\/-*A",
-            "delegation": {
-                "next": [],
-                "active": {
-                    "status": "delegating",
-                    "target": "pool178l8233l2prljdd38tuaa4vak6n53lvgqzmpzulx9uwxgg9e27n"
-                }
-            },
-            "id": "216806ca2a61cf8a98fd83b51aae12a30519e4c5",
-            "tip": {
-                "height": {
-                    "quantity": 1671,
-                    "unit": "block"
-                },
-                "time": "1899-06-04T17:13:23Z",
-                "epoch_number": 23571,
-                "absolute_slot_number": 5997164,
-                "slot_number": 2425
+            "assets": {
+                "total": [],
+                "available": []
             }
         }
     ]

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWalletBalance.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWalletBalance.json
@@ -1,0 +1,145 @@
+{
+    "seed": 27252381885193408,
+    "samples": [
+        {
+            "reward": {
+                "quantity": 6,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 3,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 248,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 63,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 228,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 84,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 202,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 26,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 129,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 40,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 175,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 6,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 19,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 4,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 76,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 197,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 94,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 156,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 245,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 151,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 241,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 117,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 6,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 5,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 149,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 5,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 195,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "reward": {
+                "quantity": 228,
+                "unit": "lovelace"
+            },
+            "total": {
+                "quantity": 216,
+                "unit": "lovelace"
+            },
+            "available": {
+                "quantity": 20,
+                "unit": "lovelace"
+            }
+        }
+    ]
+}

--- a/lib/core/test/data/Cardano/Wallet/Api/PostTransactionDataTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/PostTransactionDataTestnet0.json
@@ -18,42 +18,48 @@
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 146,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 32,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 247,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 28,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -70,161 +76,184 @@
                         "quantity": 182,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 181,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 64,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 102,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 176,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 18,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 192,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 62,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 72,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 242,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 112,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 198,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 74,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 48,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 227,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 25,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 179,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 6,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 74,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 163,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 190,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 8,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 47,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -246,196 +275,224 @@
                         "quantity": 35,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 219,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 39,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 187,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 130,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 55,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 6,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 129,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 98,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 111,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 212,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 233,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 119,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 114,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 164,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 133,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 154,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 135,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 4,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 252,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 107,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 215,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 194,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 255,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 46,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 129,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 243,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -453,21 +510,24 @@
                         "quantity": 109,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 83,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 138,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -489,126 +549,144 @@
                         "quantity": 177,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 2,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 211,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 221,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 134,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 211,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 92,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 165,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 222,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 212,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 89,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 86,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 217,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 216,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 88,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 188,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 192,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 252,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -624,84 +702,96 @@
                         "quantity": 225,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 131,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 19,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 179,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 172,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 18,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 191,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 195,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 4,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 199,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 98,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 144,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -723,161 +813,184 @@
                         "quantity": 28,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 238,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 17,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 27,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 163,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 207,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 111,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 162,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 2,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 56,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 14,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 218,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 71,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 24,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 143,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 228,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 140,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 126,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 144,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 146,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 99,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 137,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 118,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -915,49 +1028,56 @@
                         "quantity": 152,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 125,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 32,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 193,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 124,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 66,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 129,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -987,126 +1107,144 @@
                         "quantity": 127,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 12,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 115,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 78,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 82,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 199,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 49,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 245,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 85,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 112,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 215,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 77,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 26,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 212,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 197,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 22,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 186,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 60,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -1128,133 +1266,152 @@
                         "quantity": 226,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 35,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 165,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 145,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 252,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 41,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 106,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 220,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 213,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 202,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 13,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 145,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 147,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 194,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 25,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 19,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 122,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 184,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         }

--- a/lib/core/test/data/Cardano/Wallet/Api/PostTransactionFeeDataTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/PostTransactionFeeDataTestnet0.json
@@ -12,217 +12,248 @@
                         "quantity": 113,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 155,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 30,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 20,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 237,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 202,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 62,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 47,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 43,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 49,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 41,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 1,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 231,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 127,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 71,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 172,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 31,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 43,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 107,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 189,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 25,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 20,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 161,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 23,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 151,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 106,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 46,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 149,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 56,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 105,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 178,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -243,35 +274,40 @@
                         "quantity": 105,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 50,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 112,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 0,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 119,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -286,77 +322,88 @@
                         "quantity": 26,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 94,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 247,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 36,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 93,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 253,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 102,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 128,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 58,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 251,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 41,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -396,203 +443,232 @@
                         "quantity": 141,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 8,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 62,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 251,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 232,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 252,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 217,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 171,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 25,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 244,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 16,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 162,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 75,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 26,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 48,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 114,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 6,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 45,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 140,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 241,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 17,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 150,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 199,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 61,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 46,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 242,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 57,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -612,126 +688,144 @@
                         "quantity": 177,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 49,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 0,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 128,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 209,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 49,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 174,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 94,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 75,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 87,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 119,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 176,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 126,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 49,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 70,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 204,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 126,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 96,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -782,112 +876,128 @@
                         "quantity": 165,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 211,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 227,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 215,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 34,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 152,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 220,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 84,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 215,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 63,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 203,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 43,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 71,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 12,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 237,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 236,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -908,154 +1018,176 @@
                         "quantity": 139,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 54,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 210,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 10,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 182,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 241,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 210,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 208,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 238,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 131,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 46,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 7,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 77,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 243,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 159,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 40,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 192,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 251,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 152,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 40,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 112,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 94,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -1076,91 +1208,104 @@
                         "quantity": 212,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 83,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 36,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 148,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 152,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 220,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 203,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 161,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 64,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 111,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 38,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 231,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 243,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -1190,119 +1335,136 @@
                         "quantity": 7,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 67,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 20,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 47,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 65,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 20,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 176,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 140,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 251,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 134,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 252,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 72,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 242,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 143,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 24,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 147,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 233,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         },
@@ -1322,70 +1484,80 @@
                         "quantity": 182,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 155,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 75,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 192,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 220,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 53,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 56,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 42,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 129,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 },
                 {
                     "amount": {
                         "quantity": 238,
                         "unit": "lovelace"
                     },
-                    "address": "<addr>"
+                    "address": "<addr>",
+                    "assets": []
                 }
             ]
         }

--- a/lib/core/test/data/Cardano/Wallet/Primitive/Types/TokenMap/FlatTokenMap.json
+++ b/lib/core/test/data/Cardano/Wallet/Primitive/Types/TokenMap/FlatTokenMap.json
@@ -1,157 +1,38 @@
 {
-    "seed": 9089924429611080663,
+    "seed": 3826889656997292020,
     "samples": [
+        [],
+        [],
+        [],
+        [],
         [
             {
-                "quantity": 5,
-                "token": "TokenA",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 3,
-                "token": "TokenB",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 4,
-                "token": "TokenD",
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenA",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenC",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
+                "asset_name": "546f6b656e5f41",
                 "quantity": 7,
-                "token": "TokenA",
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            },
-            {
-                "quantity": 9,
-                "token": "TokenD",
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            }
-        ],
-        [
-            {
-                "quantity": 10,
-                "token": "TokenA",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 4,
-                "token": "TokenB",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenA",
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "quantity": 5,
-                "token": "TokenD",
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenA",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 9,
-                "token": "TokenB",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 3,
-                "token": "TokenD",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            }
-        ],
-        [
-            {
-                "quantity": 5,
-                "token": "TokenD",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            }
-        ],
-        [
-            {
-                "quantity": 9,
-                "token": "TokenC",
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "quantity": 4,
-                "token": "TokenD",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 12,
-                "token": "TokenA",
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             }
         ],
         [],
-        [
-            {
-                "quantity": 10,
-                "token": "TokenB",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 3,
-                "token": "TokenD",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 2,
-                "token": "TokenD",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenB",
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            }
-        ],
         [],
         [
             {
+                "asset_name": "546f6b656e5f43",
+                "quantity": 3,
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        ],
+        [
+            {
+                "asset_name": "546f6b656e5f41",
+                "quantity": 5,
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        ],
+        [
+            {
+                "asset_name": "546f6b656e5f42",
                 "quantity": 8,
-                "token": "TokenB",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "quantity": 2,
-                "token": "TokenC",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            }
-        ],
-        [
-            {
-                "quantity": 19,
-                "token": "TokenD",
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "quantity": 10,
-                "token": "TokenB",
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            }
-        ],
-        [
-            {
-                "quantity": 2,
-                "token": "TokenD",
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             }
         ]
     ]

--- a/lib/core/test/data/Cardano/Wallet/Primitive/Types/TokenMap/NestedTokenMap.json
+++ b/lib/core/test/data/Cardano/Wallet/Primitive/Types/TokenMap/NestedTokenMap.json
@@ -1,33 +1,152 @@
 {
-    "seed": -3539641455139500764,
+    "seed": -4443153308519667051,
     "samples": [
         [
             {
                 "tokens": [
                     {
-                        "quantity": 2,
-                        "token": "TokenA"
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 7
                     }
                 ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             },
             {
                 "tokens": [
                     {
-                        "quantity": 4,
-                        "token": "TokenC"
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 2
+                    },
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 8
                     }
                 ],
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             },
             {
                 "tokens": [
                     {
-                        "quantity": 3,
-                        "token": "TokenA"
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 5
                     }
                 ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            },
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 2
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 9
+                    }
+                ],
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        ],
+        [
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 1
+                    }
+                ],
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        ],
+        [
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 3
+                    }
+                ],
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 3
+                    }
+                ],
+                "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+        ],
+        [
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f43",
+                        "quantity": 9
+                    }
+                ],
+                "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+        ],
+        [
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 13
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 1
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 7
+                    }
+                ],
+                "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 7
+                    }
+                ],
+                "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            },
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 4
+                    },
+                    {
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 11
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 4
+                    }
+                ],
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+        ],
+        [
+            {
+                "tokens": [
+                    {
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 10
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 4
+                    }
+                ],
+                "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
             }
         ],
         [],
@@ -35,224 +154,54 @@
             {
                 "tokens": [
                     {
-                        "quantity": 9,
-                        "token": "TokenA"
-                    },
-                    {
-                        "quantity": 2,
-                        "token": "TokenB"
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 7
                     }
                 ],
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
             },
             {
                 "tokens": [
                     {
-                        "quantity": 2,
-                        "token": "TokenB"
-                    },
-                    {
-                        "quantity": 5,
-                        "token": "TokenC"
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 10
                     }
                 ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 3,
-                        "token": "TokenC"
-                    },
-                    {
-                        "quantity": 1,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
             }
         ],
         [
             {
                 "tokens": [
                     {
-                        "quantity": 4,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            }
-        ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 8,
-                        "token": "TokenA"
-                    }
-                ],
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenB"
-                    }
-                ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            }
-        ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 4,
-                        "token": "TokenA"
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 7
                     },
                     {
-                        "quantity": 7,
-                        "token": "TokenD"
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 1
+                    },
+                    {
+                        "asset_name": "546f6b656e5f44",
+                        "quantity": 1
                     }
                 ],
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             },
             {
                 "tokens": [
                     {
-                        "quantity": 2,
-                        "token": "TokenB"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 10,
-                        "token": "TokenA"
+                        "asset_name": "546f6b656e5f41",
+                        "quantity": 14
                     },
                     {
-                        "quantity": 3,
-                        "token": "TokenC"
-                    },
-                    {
-                        "quantity": 7,
-                        "token": "TokenD"
+                        "asset_name": "546f6b656e5f42",
+                        "quantity": 10
                     }
                 ],
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 7,
-                        "token": "TokenC"
-                    },
-                    {
-                        "quantity": 6,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
             }
         ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 7,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            }
-        ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenC"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenA"
-                    },
-                    {
-                        "quantity": 7,
-                        "token": "TokenC"
-                    }
-                ],
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 9,
-                        "token": "TokenC"
-                    }
-                ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            }
-        ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenB"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-            }
-        ],
-        [
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenB"
-                    }
-                ],
-                "policy": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 1,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-            },
-            {
-                "tokens": [
-                    {
-                        "quantity": 5,
-                        "token": "TokenC"
-                    },
-                    {
-                        "quantity": 2,
-                        "token": "TokenD"
-                    }
-                ],
-                "policy": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-            }
-        ]
+        []
     ]
 }

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -45,6 +45,10 @@ import Cardano.Wallet.Primitive.Types
     , setPoolCertificatePoolId
     , unsafeEpochNo
     )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( genCoinLargePositive, shrinkCoinLargePositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow
@@ -137,6 +141,10 @@ instance Arbitrary (Quantity "lovelace" Word64) where
     shrink (Quantity q) = [ Quantity q' | q' <- shrink q ]
     arbitrary = Quantity <$> arbitrary
 
+instance Arbitrary Coin where
+    shrink = shrinkCoinLargePositive
+    arbitrary = genCoinLargePositive
+
 arbitraryEpochLength :: Word32
 arbitraryEpochLength = 100
 
@@ -186,8 +194,8 @@ instance Arbitrary PoolRegistrationCertificate where
         <$> arbitrary
         <*> genOwners
         <*> genPercentage
-        <*> fmap Quantity arbitrary
-        <*> fmap Quantity arbitrary
+        <*> arbitrary
+        <*> arbitrary
         <*> oneof [pure Nothing, Just <$> genMetadata]
       where
         genMetadata = (,)

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -233,7 +233,7 @@ instance Malformed (PathParam (ApiT DerivationIndex)) where
             \Indexes with suffixes are called 'Hardened'."
 
 instance Wellformed (PathParam (ApiT TokenPolicyId)) where
-    wellformed = [PathParam $ T.replicate 64 "0"]
+    wellformed = [PathParam $ T.replicate 56 "0"]
 
 instance Malformed (PathParam (ApiT TokenPolicyId)) where
     malformed = first PathParam <$>

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -79,6 +79,8 @@ import Cardano.Wallet.Primitive.Types
     ( WalletId, walletNameMaxLength )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName, TokenPolicyId )
 import Control.Arrow
     ( first )
 import Data.Aeson.QQ
@@ -230,6 +232,39 @@ instance Malformed (PathParam (ApiT DerivationIndex)) where
             \Indexes without suffixes are called 'Soft' \
             \Indexes with suffixes are called 'Hardened'."
 
+instance Wellformed (PathParam (ApiT TokenPolicyId)) where
+    wellformed = [PathParam $ T.replicate 64 "0"]
+
+instance Malformed (PathParam (ApiT TokenPolicyId)) where
+    malformed = first PathParam <$>
+        [ ( "faff", msgWrongLength )
+        , ( T.replicate 57 "0", msgWrongLength )
+        , ( T.replicate 56 "x", msgMalformed )
+        , ( "f", msgMalformed )
+        ]
+      where
+        msgMalformed = "Invalid tokenPolicy hash: expecting a hex-encoded value that is 28 bytes in length."
+        msgWrongLength = msgMalformed
+
+instance Wellformed (PathParam (ApiT TokenName)) where
+    wellformed = PathParam <$>
+        [ T.replicate 64 "0"
+        , ""
+        , "FF"
+        , "594f4c4f"
+        , "e29883"
+        ]
+
+instance Malformed (PathParam (ApiT TokenName)) where
+    malformed = first PathParam <$>
+        [ ( T.replicate 65 "0", msgWrongLength )
+        , ( "f", msgWrongLength )
+        , ( "patate", msgMalformed )
+        ]
+      where
+        msgWrongLength = "TokenName is not hex-encoded: base16: input: invalid length"
+        msgMalformed = "TokenName is not hex-encoded: base16: input: invalid encoding at offset: 0"
+
 --
 -- Class instances (BodyParam)
 --
@@ -249,7 +284,7 @@ instance Malformed (BodyParam ApiWalletSignData) where
             { "metadata": { "0": { "string": "metadata" } }
             , "passphrase": 100
             }|]
-          , "Error in $.passphrase: parsing Text failed, expected String, but encountered Number"
+          , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Number"
           )
         , ( Aeson.encode [aesonQQ|
             { "metadata": { "0": { "string": "metadata" } }
@@ -419,7 +454,7 @@ instance Malformed (BodyParam SomeByronWalletPostData) where
                 , "mnemonic_sentence": #{mnemonics12}
                 , "passphrase" : 100
                 }|]
-              , "Error in $.passphrase: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Number"
               )
             , ( [aesonQQ|
                 { "style": "icarus"
@@ -427,7 +462,7 @@ instance Malformed (BodyParam SomeByronWalletPostData) where
                 , "mnemonic_sentence": #{mnemonics15}
                 , "passphrase" :[""]
                 }|]
-              , "Error in $.passphrase: parsing Text failed, expected String, but encountered Array"
+              , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Array"
               )
             , ( [aesonQQ|
                 { "style": "trezor"
@@ -625,14 +660,14 @@ instance Malformed (BodyParam WalletOrAccountPostData) where
                 , "mnemonic_sentence": #{mnemonics15}
                 , "passphrase" :#{wPassphrase}
                 }|]
-              , "Error in $.name: parsing Text failed, expected String, but encountered Array"
+              , "Error in $.name: parsing WalletName failed, expected String, but encountered Array"
               )
             , ( [aesonQQ|
                 { "name": 123
                 , "mnemonic_sentence": #{mnemonics15}
                 , "passphrase" :#{wPassphrase}
                 }|]
-              , "Error in $.name: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.name: parsing WalletName failed, expected String, but encountered Number"
               )
             , ( [aesonQQ|
                 { "mnemonic_sentence": #{mnemonics15}
@@ -810,13 +845,13 @@ instance Malformed (BodyParam WalletPutPassphraseData) where
                 { "old_passphrase": #{wPassphrase}
                 , "new_passphrase" : 100
                 }|]
-              , "Error in $['new_passphrase']: parsing Text failed, expected String, but encountered Number"
+              , "Error in $['new_passphrase']: parsing Passphrase failed, expected String, but encountered Number"
               )
             , ( [aesonQQ|
                 { "old_passphrase": []
                 , "new_passphrase" : #{wPassphrase}
                 }|]
-              , "Error in $['old_passphrase']: parsing Text failed, expected String, but encountered Array"
+              , "Error in $['old_passphrase']: parsing Passphrase failed, expected String, but encountered Array"
               )
             , ( [aesonQQ|
                 { "old_passphrase": ""
@@ -868,13 +903,13 @@ instance Malformed (BodyParam ByronWalletPutPassphraseData) where
                 { "old_passphrase": #{wPassphrase}
                 , "new_passphrase" : 100
                 }|]
-              , "Error in $['new_passphrase']: parsing Text failed, expected String, but encountered Number"
+              , "Error in $['new_passphrase']: parsing Passphrase failed, expected String, but encountered Number"
               )
             , ( [aesonQQ|
                 { "old_passphrase": []
                 , "new_passphrase" : #{wPassphrase}
                 }|]
-              , "Error in $['old_passphrase']: parsing Text failed, expected String, but encountered Array"
+              , "Error in $['old_passphrase']: parsing Passphrase failed, expected String, but encountered Array"
               )
             , ( [aesonQQ|
                 { "old_passphrase": #{wPassphrase}
@@ -919,13 +954,13 @@ instance Malformed (BodyParam WalletPutData) where
               , "Error in $.name: name is too long: expected at most 255 characters"
               )
             , ( [aesonQQ| { "name": 123 }|]
-              , "Error in $.name: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.name: parsing WalletName failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "name": [] }|]
-              , "Error in $.name: parsing Text failed, expected String, but encountered Array"
+              , "Error in $.name: parsing WalletName failed, expected String, but encountered Array"
               )
             , ( [aesonQQ| { "name": 1.5 }|]
-              , "Error in $.name: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.name: parsing WalletName failed, expected String, but encountered Number"
               )
             ]
 
@@ -943,13 +978,13 @@ instance Malformed (BodyParam ApiWalletPassphrase) where
               , "Error in $.passphrase: passphrase is too long: expected at most 255 characters"
               )
             , ( [aesonQQ| { "passphrase": 123 }|]
-              , "Error in $.passphrase: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Number"
               )
             , ( [aesonQQ| { "passphrase": [] }|]
-              , "Error in $.passphrase: parsing Text failed, expected String, but encountered Array"
+              , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Array"
               )
             , ( [aesonQQ| { "passphrase": 1.5 }|]
-              , "Error in $.passphrase: parsing Text failed, expected String, but encountered Number"
+              , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Number"
               )
             ]
 
@@ -1377,7 +1412,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].address: parsing Text failed, expected String, but encountered Number"
+      , "Error in $.payments[0].address: parsing AddressAmount failed, parsing Text failed, expected String, but encountered Number"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1389,7 +1424,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0]: parsing Cardano.Wallet.Api.Types.AddressAmount(AddressAmount) failed, key 'address' not found"
+      , "Error in $.payments[0]: parsing AddressAmount failed, key 'address' not found"
       )
     -- amount
     , ( [aesonQQ|
@@ -1403,7 +1438,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount: failed to parse quantified value. Expected value in 'lovelace' (e.g. { 'unit': 'lovelace', 'quantity': ... }) but got something else."
+      , "Error in $.payments[0].amount: parsing AddressAmount failed, failed to parse quantified value. Expected value in 'lovelace' (e.g. { 'unit': 'lovelace', 'quantity': ... }) but got something else."
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1415,7 +1450,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount: key 'unit' not found"
+      , "Error in $.payments[0].amount: parsing AddressAmount failed, key 'unit' not found"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1424,7 +1459,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0]: parsing Cardano.Wallet.Api.Types.AddressAmount(AddressAmount) failed, key 'amount' not found"
+      , "Error in $.payments[0]: parsing AddressAmount failed, key 'amount' not found"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1436,7 +1471,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount: key 'quantity' not found"
+      , "Error in $.payments[0].amount: parsing AddressAmount failed, key 'quantity' not found"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1446,7 +1481,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount: parsing Quantity failed, expected Object, but encountered Number"
+      , "Error in $.payments[0].amount: parsing AddressAmount failed, parsing Quantity failed, expected Object, but encountered Number"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1459,7 +1494,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount.quantity: parsing Natural failed, expected Number, but encountered String"
+      , "Error in $.payments[0].amount.quantity: parsing AddressAmount failed, parsing Natural failed, expected Number, but encountered String"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1472,7 +1507,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount.quantity: parsing Natural failed, unexpected negative number -1"
+      , "Error in $.payments[0].amount.quantity: parsing AddressAmount failed, parsing Natural failed, unexpected negative number -1"
       )
     , ( [aesonQQ|
         { "payments": [
@@ -1485,7 +1520,7 @@ paymentCases =
             }
            ]
         }|]
-      , "Error in $.payments[0].amount.quantity: parsing Natural failed, unexpected floating number 4200.12"
+      , "Error in $.payments[0].amount.quantity: parsing AddressAmount failed, parsing Natural failed, unexpected floating number 4200.12"
       )
     , ( [aesonQQ|
         { "payments": [ ]
@@ -1523,13 +1558,13 @@ migrateDataCases =
         { "passphrase": 1
         , "addresses": [ #{addrPlaceholder} ]
         }|]
-      , "Error in $.passphrase: parsing Text failed, expected String, but encountered Number"
+      , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Number"
       )
     , ( [aesonQQ|
         { "passphrase": [ ]
         , "addresses": [ #{addrPlaceholder} ]
         }|]
-      , "Error in $.passphrase: parsing Text failed, expected String, but encountered Array"
+      , "Error in $.passphrase: parsing Passphrase failed, expected String, but encountered Array"
       )
     ]
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -407,7 +407,7 @@ instance Arbitrary TxMeta where
             <$> elements [Incoming, Outgoing]
             <*> arbitrary
             <*> fmap Quantity arbitrary
-            <*> fmap (Quantity . fromIntegral . unCoin) arbitrary
+            <*> arbitrary
             <*> (if st == Pending then Just <$> arbitrary else pure Nothing)
 
 instance Arbitrary TxStatus where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -864,7 +864,7 @@ prop_rollbackTxHistory db@DBLayer{..} (InitialCheckpoint cp0) (GenTxHistory txs0
                 , pretty (meta ^. #slotNo)
                 , pretty (meta ^. #status)
                 , pretty (meta ^. #direction)
-                , show $ getQuantity ((meta ^. #amount))
+                , pretty (meta ^. #amount)
                 ])
 
     isBefore :: SlotNo -> TxMeta -> Bool

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -186,12 +186,8 @@ import Data.Set
     ( Set )
 import Data.TreeDiff
     ( ToExpr (..), defaultExprViaShow, genericToExpr )
-import Data.Word
-    ( Word64 )
 import GHC.Generics
     ( Generic )
-import Numeric.Natural
-    ( Natural )
 import System.Random
     ( getStdRandom, randomR )
 import Test.Hspec
@@ -325,7 +321,7 @@ data Cmd s wid
     | ReadWalletMeta wid
     | PutTxHistory wid TxHistory
     | ReadTxHistory wid
-        (Maybe (Quantity "lovelace" Natural))
+        (Maybe Coin)
         SortOrder
         (Range SlotNo)
         (Maybe TxStatus)
@@ -339,7 +335,7 @@ data Cmd s wid
     | UpdatePendingTxForExpiry wid SlotNo
     | PutDelegationCertificate wid DelegationCertificate SlotNo
     | IsStakeKeyRegistered wid
-    | PutDelegationRewardBalance wid (Quantity "lovelace" Word64)
+    | PutDelegationRewardBalance wid Coin
     | ReadDelegationRewardBalance wid
     deriving (Show, Functor, Foldable, Traversable)
 
@@ -355,7 +351,7 @@ data Success s wid
     | GenesisParams (Maybe GenesisParameters)
     | BlockHeaders [BlockHeader]
     | Point SlotNo
-    | DelegationRewardBalance (Quantity "lovelace" Word64)
+    | DelegationRewardBalance Coin
     | StakeKeyStatus Bool
     deriving (Show, Eq, Functor, Foldable, Traversable)
 
@@ -693,10 +689,10 @@ generatorWithWid wids =
     genRange :: Gen (Range SlotNo)
     genRange = applyArbitrary2 Range
 
-    genMinWithdrawal :: Gen (Maybe (Quantity "lovelace" Natural))
+    genMinWithdrawal :: Gen (Maybe Coin)
     genMinWithdrawal = frequency
         [ (10, pure Nothing)
-        , (1, (Just . Quantity . fromIntegral . unCoin) <$> arbitrary)
+        , (1, Just <$> arbitrary)
         ]
 
 isUnordered :: Ord x => [x] -> Bool

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -204,7 +204,7 @@ prop_applyBlockBasic s =
         in
             (ShowFmt utxo === ShowFmt utxo') .&&.
             (availableBalance mempty wallet === balance utxo') .&&.
-            (totalBalance mempty (Quantity 0) wallet === balance utxo')
+            (totalBalance mempty (Coin 0) wallet === balance utxo')
 
 -- Each transaction must have at least one output belonging to us
 prop_applyBlockTxHistoryIncoming :: WalletState -> Property
@@ -275,11 +275,9 @@ prop_countRewardsOnce (WithPending wallet pending rewards)
     pendingBalance =
         sum $ (unCoin . txOutCoin) <$> concatMap outputs (Set.elems pending)
     totalWithPending =
-        totalBalance pending rewardsQ wallet
+        TokenBundle.getCoin $ totalBalance pending rewards wallet
     totalWithoutPending =
-        totalBalance Set.empty rewardsQ wallet
-    rewardsQ =
-        Quantity $ fromIntegral $ unCoin rewards
+        TokenBundle.getCoin $ totalBalance Set.empty rewards wallet
 
     hasPending =
         not $ Set.null pending

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -263,7 +263,7 @@ spec = do
                     , direction = Outgoing
                     , slotNo = SlotNo 1442
                     , blockHeight = Quantity 37
-                    , amount = Quantity 1337
+                    , amount = Coin 1337
                     , expiry = Just (SlotNo 2442)
                     }
             "-0.001337 pending since 1442#37 (expires slot 2442)"
@@ -274,7 +274,7 @@ spec = do
                     , direction = Incoming
                     , slotNo = SlotNo 140
                     , blockHeight = Quantity 1
-                    , amount = Quantity 13371442
+                    , amount = Coin 13371442
                     , expiry = Nothing
                     }
             "+13.371442 in ledger since 140#1" === pretty @_ @Text txMeta
@@ -980,7 +980,7 @@ prop_2_6_1 (u, v) =
     -- a v' that has no overlap with u.
     v' = v `excluding` dom u
     cond = not (u `isSubsetOf` mempty || v' `isSubsetOf` mempty)
-    prop = balance (u <> v') === balance u + balance v'
+    prop = balance (u <> v') === balance u `TokenBundle.add` balance v'
 
 prop_2_6_2 :: (Set TxIn, UTxO) -> Property
 prop_2_6_2 (ins, u) =
@@ -990,7 +990,7 @@ prop_2_6_2 (ins, u) =
     prop =
         balance (u `excluding` ins)
             ===
-        balance u - balance (u `restrictedBy` ins)
+        balance u `TokenBundle.unsafeSubtract` balance (u `restrictedBy` ins)
 
 {-------------------------------------------------------------------------------
                         UTxO statistics Properties
@@ -1002,7 +1002,7 @@ propUtxoTotalIsBalance
     -> ShowFmt UTxO
     -> Property
 propUtxoTotalIsBalance bType (ShowFmt utxo) =
-    fromIntegral totalStake == balance utxo
+    Coin totalStake == TokenBundle.getCoin (balance utxo)
     & cover 75 (utxo /= mempty) "UTxO /= empty"
   where
     UTxOStatistics _ totalStake _ = computeUtxoStatistics bType utxo
@@ -1015,7 +1015,7 @@ propUtxoSumDistribution
     -> ShowFmt UTxO
     -> Property
 propUtxoSumDistribution bType (ShowFmt utxo) =
-    sum (upperVal <$> bars) >= fromIntegral (balance utxo)
+    sum (upperVal <$> bars) >= unCoin (TokenBundle.getCoin (balance utxo))
     & cover 75 (utxo /= mempty) "UTxO /= empty"
     & counterexample ("Histogram: " <> pretty bars)
   where

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -286,26 +286,26 @@ spec = parallel $ do
                 `shouldBe` Left (W.ErrNoSuchPool pidUnknown)
         it "Cannot quit when active: not_delegating, next = []" $ do
             let dlg = WalletDelegation {active = NotDelegating, next = []}
-            W.guardQuit dlg (Quantity 0)
+            W.guardQuit dlg (Coin 0)
                 `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Cannot quit when active: A, next = [not_delegating]" $ do
             let next1 = next (EpochNo 1) NotDelegating
             let dlg = WalletDelegation
                     {active = Delegating pidA, next = [next1]}
-            W.guardQuit dlg (Quantity 0)
+            W.guardQuit dlg (Coin 0)
                 `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Cannot quit when active: A, next = [B, not_delegating]" $ do
             let next1 = next (EpochNo 1) (Delegating pidB)
             let next2 = next (EpochNo 2) NotDelegating
             let dlg = WalletDelegation
                     {active = Delegating pidA, next = [next1, next2]}
-            W.guardQuit dlg (Quantity 0)
+            W.guardQuit dlg (Coin 0)
                 `shouldBe` Left (W.ErrNotDelegatingOrAboutTo)
         it "Can quit when active: not_delegating, next = [A]" $ do
             let next1 = next (EpochNo 1) (Delegating pidA)
             let dlg = WalletDelegation
                     {active = NotDelegating, next = [next1]}
-            W.guardQuit dlg (Quantity 0) `shouldBe` Right ()
+            W.guardQuit dlg (Coin 0) `shouldBe` Right ()
      where
          pidA = PoolId "A"
          pidB = PoolId "B"
@@ -339,7 +339,7 @@ prop_guardJoinQuit knownPoolsList dlg pid mRetirementInfo = checkCoverage
             label "ErrNoSuchPool" $ property True
         Left W.ErrAlreadyDelegating{} ->
             label "ErrAlreadyDelegating"
-                (W.guardQuit dlg (Quantity 0) === Right ())
+                (W.guardQuit dlg (Coin 0) === Right ())
   where
     knownPools = Set.fromList knownPoolsList
     retirementNotPlanned =
@@ -361,7 +361,7 @@ prop_guardQuitJoin
 prop_guardQuitJoin (NonEmpty knownPoolsList) dlg rewards =
     let knownPools = Set.fromList knownPoolsList in
     let noRetirementPlanned = Nothing in
-    case W.guardQuit dlg (Quantity rewards) of
+    case W.guardQuit dlg (Coin rewards) of
         Right () ->
             label "I can quit" $ property True
         Left W.ErrNotDelegatingOrAboutTo ->
@@ -924,7 +924,7 @@ instance Arbitrary TxMeta where
         <*> elements [Incoming, Outgoing]
         <*> genSlotNo
         <*> fmap Quantity arbitrary
-        <*> fmap (Quantity . fromIntegral . unCoin) arbitrary
+        <*> arbitrary
         <*> liftArbitrary genSlotNo
 
 instance Arbitrary TxMetadata where

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -236,7 +236,7 @@ walletApiBench capture ctx = do
             verify rWal1
                 [ expectSuccess
                 , expectField
-                        (#balance . #getApiT . #available . #getQuantity)
+                        (#balance . #available . #getQuantity)
                         (`shouldBe` (minUTxOValue * (fromIntegral utxoNumber)))
                 ]
 
@@ -255,7 +255,7 @@ walletApiBench capture ctx = do
             verify rWal1
                 [ expectSuccess
                 , expectField
-                    (#balance . #getApiT . #available . #getQuantity)
+                    (#balance . #available . #getQuantity)
                     (`shouldBe` amtExp)
                 ]
         rDel <- request @ApiWallet  ctx (Link.deleteWallet @'Shelley wSrc) Default Empty

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -445,7 +445,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
     (_, estimateFeesTime) <- bench "estimate tx fee" $ do
         let out = TxOut (dummyAddress @n) (TokenBundle.fromCoin $ Coin 1)
         runExceptT $ withExceptT show $ W.estimateFeeForPayment @_ @s @k
-            w wid (out :| []) (Quantity 0) Nothing
+            w wid (out :| []) (Coin 0) Nothing
 
     oneAddress <- genAddresses 1 cp
     (_, importOneAddressTime) <- bench "import one addresses" $ do
@@ -532,7 +532,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
     (_, estimateFeesTime) <- bench "estimate tx fee" $ do
         let out = TxOut (dummyAddress @n) (TokenBundle.fromCoin $ Coin 1)
         runExceptT $ withExceptT show $ W.estimateFeeForPayment @_ @s @k
-            w wid (out :| []) (Quantity 0) Nothing
+            w wid (out :| []) (Coin 0) Nothing
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -36,6 +36,7 @@ import Cardano.Wallet.Api
     ( Addresses
     , Api
     , ApiLayer (..)
+    , Assets
     , ByronAddresses
     , ByronCoinSelections
     , ByronMigrations
@@ -58,6 +59,8 @@ import Cardano.Wallet.Api.Server
     , deleteTransaction
     , deleteWallet
     , derivePublicKey
+    , getAsset
+    , getAssetDefault
     , getCurrentEpoch
     , getMigrationInfo
     , getNetworkClock
@@ -70,6 +73,7 @@ import Cardano.Wallet.Api.Server
     , joinStakePool
     , liftHandler
     , listAddresses
+    , listAssets
     , listTransactions
     , listWallets
     , migrateWallet
@@ -193,6 +197,7 @@ server
 server byron icarus shelley spl ntp =
          wallets
     :<|> walletKeys
+    :<|> assets
     :<|> addresses
     :<|> coinSelections
     :<|> transactions
@@ -220,6 +225,9 @@ server byron icarus shelley spl ntp =
     walletKeys :: Server WalletKeys
     walletKeys = derivePublicKey shelley
         :<|> signMetadata shelley
+
+    assets :: Server Assets
+    assets = listAssets shelley :<|> getAsset shelley :<|> getAssetDefault shelley
 
     addresses :: Server (Addresses n)
     addresses = listAddresses shelley (normalizeDelegationAddress @_ @ShelleyKey @n)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -289,7 +289,6 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
-import qualified Data.Text.Encoding.Error as T
 import qualified Ouroboros.Consensus.Shelley.Ledger as O
 import qualified Ouroboros.Network.Block as O
 import qualified Ouroboros.Network.Point as Point
@@ -922,9 +921,7 @@ fromCardanoValue = uncurry TokenBundle.fromFlatList . extract
         ]
 
     mkPolicyId = W.UnsafeTokenPolicyId . W.Hash . Cardano.serialiseToRawBytes
-    mkTokenName = W.UnsafeTokenName
-        . T.decodeUtf8With T.lenientDecode
-        . Cardano.serialiseToRawBytes
+    mkTokenName = W.UnsafeTokenName . Cardano.serialiseToRawBytes
 
     unQuantity (Cardano.Quantity q) = q
 
@@ -1176,7 +1173,7 @@ toCardanoValue tb = Cardano.valueFromList $
     toCardanoPolicyId (W.UnsafeTokenPolicyId (W.Hash pid)) = just "PolicyId" $
         Cardano.deserialiseFromRawBytes Cardano.AsPolicyId pid
     toCardanoAssetName (W.UnsafeTokenName name) = just "TokenName" $
-        Cardano.deserialiseFromRawBytes Cardano.AsAssetName $ T.encodeUtf8 name
+        Cardano.deserialiseFromRawBytes Cardano.AsAssetName name
 
     just :: String -> Maybe a -> a
     just t = fromMaybe $ error $

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -759,11 +759,9 @@ fromPoolDistr =
 fromNonMyopicMemberRewards
     :: forall era. ()
     => O.NonMyopicMemberRewards era
-    -> Map
-        (Either W.Coin W.RewardAccount)
-        (Map W.PoolId (Quantity "lovelace" Word64))
+    -> Map (Either W.Coin W.RewardAccount) (Map W.PoolId W.Coin)
 fromNonMyopicMemberRewards =
-    Map.map (Map.map lovelaceFromCoin . Map.mapKeys fromPoolId)
+    Map.map (Map.map toWalletCoin . Map.mapKeys fromPoolId)
     . Map.mapKeys (bimap fromShelleyCoin fromStakeCredential)
     . O.unNonMyopicMemberRewards
 
@@ -970,8 +968,8 @@ fromShelleyRegistrationCert = \case
             { W.poolId = fromPoolKeyHash $ SL._poolId pp
             , W.poolOwners = fromOwnerKeyHash <$> Set.toList (SL._poolOwners pp)
             , W.poolMargin = fromUnitInterval (SL._poolMargin pp)
-            , W.poolCost = lovelaceFromCoin (SL._poolCost pp)
-            , W.poolPledge = lovelaceFromCoin (SL._poolPledge pp)
+            , W.poolCost = toWalletCoin (SL._poolCost pp)
+            , W.poolPledge = toWalletCoin (SL._poolPledge pp)
             , W.poolMetadata = fromPoolMetadata <$> strictMaybeToMaybe (SL._poolMD pp)
             }
         )
@@ -983,9 +981,6 @@ fromShelleyRegistrationCert = \case
     SL.DCertDeleg{}   -> Nothing
     SL.DCertGenesis{} -> Nothing
     SL.DCertMir{}     -> Nothing
-
-lovelaceFromCoin :: SL.Coin -> Quantity "lovelace" Word64
-lovelaceFromCoin = Quantity . unsafeCoinToWord64
 
 toWalletCoin :: SL.Coin -> W.Coin
 toWalletCoin = W.Coin . unsafeCoinToWord64

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -298,7 +298,6 @@ specWithServer testDir (tr, tracers) era = aroundAll withContext
     onClusterStart action dbDecorator (RunningNode conn block0 (gp, vData)) = do
         setupFaucet conn
         let db = testDir </> "wallets"
-        putStrLn $ "creating" <> show db
         createDirectory db
         listen <- walletListenFromEnv
         serveWallet

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -51,7 +51,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (..), coinQuantity )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinLargePositive, shrinkCoinLargePositive )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -198,11 +198,11 @@ spec = do
                 [ TxOut (dummyAddress 0) (coinToBundle 4834720)
                 ]
 
-        let wdrl = Quantity 0
+        let wdrl = Coin 0
 
         let selectCoins = flip catchE (handleCannotCover utxo wdrl recipients) $ do
                 (sel, utxo') <- withExceptT ErrSelectForPaymentCoinSelection $ do
-                    CS.random testCoinSelOpts recipients wdrl utxo
+                    CS.random testCoinSelOpts recipients (coinQuantity wdrl) utxo
                 withExceptT ErrSelectForPaymentFee $
                     (Fee . CS.feeBalance) <$> adjustForFee testFeeOpts utxo' sel
         res <- runExceptT $ estimateFeeForCoinSelection Nothing selectCoins

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3592,13 +3592,30 @@ paths:
       description: |
         <p align="right">status: <strong>under development</strong></p>
 
-        Fetch a single asset from its `policy_id` and `asset_name`, with its metadata if any.
+        Fetch a single asset from its `policy_id` and `asset_name`,
+        with its metadata if any.
 
         The asset must be associated with the wallet.
       parameters:
         - *parametersWalletId
         - *parametersPolicyId
         - *parametersAssetName
+      responses: *responsesGetAsset
+
+  /wallets/{walletId}/assets/{policyId}:
+    get:
+      operationId: getAssetDefault
+      tags: ["Assets"]
+      summary: Get Asset (empty name)
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        Fetch the the asset from `policy_id` with an empty name.
+
+        The asset must be associated with the wallet.
+      parameters:
+        - *parametersWalletId
+        - *parametersPolicyId
       responses: *responsesGetAsset
 
   /wallets/{walletId}/statistics/utxos:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -462,25 +462,6 @@ x-assetPolicyId: &assetPolicyId
   maxLength: 56
   example: 65ab82542b0ca20391caaf66a4d4d7897d281f9c136cd3513136945b
 
-x-assetDisplayName: &assetDisplayName
-  type: string
-  description: |
-    A label for the asset suitable for presentation to users.
-
-    If the asset has a known metadata name, then this is used.
-
-    Otherwise, the display name is taken from the policy item
-    sub-identifier.
-
-    If this sub-identifier is valid UTF-8 text, and non-empty, then it
-    is shown as-is. If the identifier cannot be decoded as UTF-8 text,
-    then the display name will be the sub-identifier encoded in
-    hexadecimal, starting with 0x.
-
-    If the sub-identifier is empty, then the policy ID is used,
-    encoded in hexadecimal, starting with 0x.
-  example: SWAGGERCOIN
-
 x-assetMetadataName: &assetMetadataName
   type: string
   maxLength: 50
@@ -1719,11 +1700,9 @@ components:
       required:
         - policy_id
         - asset_name
-        - display_name
       properties:
         policy_id: *assetPolicyId
         asset_name: *assetName
-        display_name: *assetDisplayName
         metadata: *assetMetadata
 
     ApiWalletMigrationInfo: &ApiWalletMigrationInfo

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -433,44 +433,104 @@ x-settings: &settings
 
         After update existing metadata will be dropped forcing it to re-sync automatically with the new setting.
 
-x-assetPolicyItem: &assetPolicyItem
+x-assetName: &assetName
   type: string
   description: |
-    The asset on-chain type which acts as a sub-identifier within a policy.
-    Typically an empty string for policies with a single fungible asset item.
-  format: base64
+    The asset on-chain type which acts as a sub-identifier within a
+    policy. Although we call it "asset name", the value needn't be
+    text, and it could even be empty.
+
+    For policies with a single fungible asset item, asset name is
+    typically an empty string.
+
+    This value can be up to 32 bytes of arbitrary data (which is 64
+    hexadecimal digits).
+  format: hex
+  maxLength: 64
+  example: ""
 
 x-assetPolicyId: &assetPolicyId
   type: string
   description: |
-    A unique identifier of the asset policy. It identifies who is able to forge and burn
-    new assets of this kind.
-  format: base64
+    A unique identifier of the asset's monetary policy. The policy
+    controls how assets of this kind are created and destroyed.
 
-x-assetName: &assetName
+    The contents are the blake2b-224 hash of the monetary policy
+    script, encoded in hexadecimal.
+  format: hex
+  minLength: 56
+  maxLength: 56
+  example: 65ab82542b0ca20391caaf66a4d4d7897d281f9c136cd3513136945b
+
+x-assetDisplayName: &assetDisplayName
+  type: string
+  description: |
+    A label for the asset suitable for presentation to users.
+
+    If the asset has a known metadata name, then this is used.
+
+    Otherwise, the display name is taken from the policy item
+    sub-identifier.
+
+    If this sub-identifier is valid UTF-8 text, and non-empty, then it
+    is shown as-is. If the identifier cannot be decoded as UTF-8 text,
+    then the display name will be the sub-identifier encoded in
+    hexadecimal, starting with 0x.
+
+    If the sub-identifier is empty, then the policy ID is used,
+    encoded in hexadecimal, starting with 0x.
+  example: SWAGGERCOIN
+
+x-assetMetadataName: &assetMetadataName
   type: string
   description: |
     A human-readable name for the asset. Good for display in user interfaces.
+  example: SwaggerCoin
 
-x-assetAcronym: &assetAcronym
+x-assetMetadataAcronym: &assetMetadataAcronym
   type: string
   description: |
-    A human-readable name for the asset. Good for display in user interfaces.
-  format: base64
+    A human-readable short name for the asset. Good for display in
+    user interfaces.
+  example: SWAG
 
-x-assetUrl: &assetUrl
+x-assetMetadataUnit: &assetMetadataUnit
+  type: object
+  description: |
+    Defines a larger unit for the asset, in the same way Ada is the
+    larger unit of Lovelace.
+  required:
+    - decimals
+    - name
+  properties:
+    decimals:
+      type: integer
+      description: |
+        The number of digits after the decimal point.
+      minimum: 0
+      maximum: 19
+    name:
+      type: string
+      description: |
+        The human-readable name for the larger unit of the asset. Used
+        for display in user interfaces.
+  example:
+    name: API
+    decimals: 3
+
+x-assetMetadataUrl: &assetMetadataUrl
   type: string
   description: |
     A URL to the policy's owner(s) or the entity website in charge of the asset.
 
-x-assetLogo: &assetLogo
+x-assetMetadataLogo: &assetMetadataLogo
   type: string
   description: |
     A base64-encoded `image/png` for displaying the asset. The end image can be expected
     to be smaller than 64KB.
   format: base64
 
-x-assetDescription: &assetDescription
+x-assetMetadataDescription: &assetMetadataDescription
   type: object
   description: |
     A human-readable description for the asset. Good for display in user interfaces.
@@ -480,6 +540,23 @@ x-assetDescription: &assetDescription
     en:
       type: string
       description: The description, in English (en).
+
+x-assetMetadata: &assetMetadata
+  type: object
+  description: |
+    <p>status: <strong>⚠ under development</strong></p>
+
+    _This field is not implemented yet, and the values will always be empty._
+
+    Additional information about the asset which is not stored
+    on chain. This data is fetched from an external source.
+  properties:
+    name: *assetMetadataName
+    acronym: *assetMetadataAcronym
+    unit: *assetMetadataUnit
+    url: *assetMetadataUrl
+    logo: *assetMetadataLogo
+    description: *assetMetadataDescription
 
 x-walletMnemonicSentence: &walletMnemonicSentence
   description: A list of mnemonic words
@@ -576,29 +653,69 @@ x-walletBalance: &walletBalance
 x-assetQuantity: &assetQuantity
   type: integer
   description: |
-    Number of assets uniquely identified by the `policy_id` and `policy_item`.
+    Number of assets for the given `policy_id` and `asset_name`.
   minimum: 0
 
 x-walletAsset: &walletAsset
   description: |
     An asset on the Cardano blockchain. An asset is uniquely identified by
-    its `type` and `policy_id` (also called _asset id_). Two assets with the same `policy_item`
-    and `policy_id` are fungible together (that is, they are interchangeable).
-    Yet, different assets with a same `policy_id`  but different `policy_item` are treated as separate assets.
+    its `policy_id` and `asset_name` (together, these form the _asset id_).
+
+    Two assets with the same `asset_name` and `policy_id` are
+    interchangeable. Yet, different assets with a same `policy_id` but
+    different `asset_name` are treated as separate assets, as are two
+    assets with the same `asset_name` but different `policy_id`.
   type: object
   required:
-    - policy_item
     - policy_id
+    - asset_name
     - quantity
   properties:
     policy_id: *assetPolicyId
-    policy_item: *assetPolicyItem
+    asset_name: *assetName
     quantity: *assetQuantity
 
 x-walletAssets: &walletAssets
-  description: Wallet assets
+  description: A flat list of assets.
   type: array
   items: *walletAsset
+
+x-assetMint: &assetMint
+  type: object
+  required:
+    - policy_id
+    - asset_name
+    - quantity
+  properties:
+    policy_id: *assetPolicyId
+    asset_name: *assetName
+    quantity:
+      type: integer
+      description: |
+        Positive values mean creation and negative values mean
+        destruction.
+
+x-walletAssetsBalance: &walletAssetsBalance
+  description: |
+    Current non-Ada asset holdings of the wallet.
+
+    The amount of assets available to spend may be less than the total
+    unspent assets due to transaction change amounts which are yet to
+    be fully confirmed (pending).
+  type: object
+  required:
+    - available
+    - total
+  properties:
+    available:
+      <<: *walletAssets
+      description: |
+        Available UTxO asset balances (funds that can be spent without
+        condition).
+    total:
+      <<: *walletAssets
+      description: |
+        Total asset balances (available balances plus pending change balances).
 
 x-byronWalletBalance: &byronWalletBalance
   description: Byron wallet's current balance(s)
@@ -676,8 +793,12 @@ x-addresses: &addresses
 
 x-transactionInputs: &transactionInputs
   description: |
-    A list of transaction inputs. `assets` and `address` are always present for `outgoing`
-    transactions and are generally absent for `incoming` transactions.
+    A list of transaction inputs.
+
+    `assets` and `address` are always present for `outgoing`
+    transactions but generally absent for `incoming`
+    transactions. This information is present on the Cardano explorer,
+    but is not tracked by the wallet.
   type: array
   minItems: 0
   items:
@@ -706,7 +827,7 @@ x-transactionOutputs: &transactionOutputs
     properties:
       address: *addressId
       amount: *amount
-      assets: *walletAsset
+      assets: *walletAssets
 
 x-delegationAction: &delegationAction
   description: |
@@ -789,6 +910,22 @@ x-transactionWithdrawals: &transactionWithdrawals
     properties:
       stake_address: *stakeAddress
       amount: *amount
+
+x-transactionMint: &transactionMint
+  description: |
+    <p>status: <strong>⚠ under development</strong></p>
+
+    _This field is not implemented yet, and will always be empty._
+
+    Assets minted (created) or unminted (destroyed)
+
+    This amount contributes to the total transaction value.
+
+    Positive values denote creation of assets and negative values
+    denote the reverse.
+  type: array
+  minItems: 0
+  items: *assetMint
 
 x-derivationSegment: &derivationSegment
   description: |
@@ -1435,12 +1572,14 @@ components:
       required:
         - id
         - amount
+        - assets
         - fee
         - deposit
         - direction
         - inputs
         - outputs
         - withdrawals
+        - mint
         - status
       properties:
         id: *transactionId
@@ -1457,6 +1596,14 @@ components:
             addresses that belong to the wallet.
         fee: *amount
         deposit: *amount
+        assets:
+          <<: *walletAssets
+          description: |
+            An amount of non-Ada assets spent or received, from the
+            perspective of the wallet.
+
+            Note that transaction fees and delegation rewards are
+            always denominated in Ada.
         inserted_at: *transactionInsertedAt
         expires_at: *transactionExpiresAt
         pending_since: *transactionPendingSince
@@ -1465,6 +1612,7 @@ components:
         inputs: *transactionInputs
         outputs: *transactionOutputs
         withdrawals: *transactionWithdrawals
+        mint: *transactionMint
         status: *transactionStatus
         metadata: *transactionMetadata
 
@@ -1521,7 +1669,7 @@ components:
         id: *walletId
         address_pool_gap: *walletAddressPoolGap
         balance: *walletBalance
-        assets: *walletAssets
+        assets: *walletAssetsBalance
         delegation: *ApiWalletDelegation
         name: *walletName
         passphrase: *walletPassphraseInfo
@@ -1550,17 +1698,13 @@ components:
       type: object
       required:
         - policy_id
-        - policy_item
-        - quantity
+        - asset_name
+        - display_name
       properties:
         policy_id: *assetPolicyId
-        policy_item: *assetPolicyItem
-        quantity: *assetQuantity
-        name: *assetName
-        acronym: *assetAcronym
-        url: *assetUrl
-        logo: *assetLogo
-        description: *assetDescription
+        asset_name: *assetName
+        display_name: *assetDisplayName
+        metadata: *assetMetadata
 
     ApiWalletMigrationInfo: &ApiWalletMigrationInfo
       type: object
@@ -2163,6 +2307,25 @@ x-parametersMinWithdrawal: &parametersMinWithdrawal
   schema:
     type: integer
     minimum: 1
+
+x-parametersPolicyId: &parametersPolicyId
+  in: path
+  name: policyId
+  required: true
+  schema:
+    type: string
+    format: hex
+    maxLength: 56
+    minLength: 56
+
+x-parametersAssetName: &parametersAssetName
+  in: path
+  name: assetName
+  required: true
+  schema:
+    type: string
+    format: hex
+    maxLength: 64
 
 #############################################################################
 #                                                                           #
@@ -3392,10 +3555,16 @@ paths:
       description: |
         <p align="right">status: <strong>under development</strong></p>
 
-        List all assets available in the wallet, with their metadata if any.
+        List all assets associated with the wallet, and their metadata
+        if known.
+
+        An asset is _associated_ with a wallet if it is involved in a
+        transaction of the wallet.
+      parameters:
+        - *parametersWalletId
       responses: *responsesListAssets
 
-  /wallets/{walletId}/assets/{policy_id}/{policy_item}:
+  /wallets/{walletId}/assets/{policyId}/{assetName}:
     get:
       operationId: getAsset
       tags: ["Assets"]
@@ -3403,7 +3572,13 @@ paths:
       description: |
         <p align="right">status: <strong>under development</strong></p>
 
-        Fetch a single asset from its `policy_id` and `policy_item`, with its metadata if any.
+        Fetch a single asset from its `policy_id` and `asset_name`, with its metadata if any.
+
+        The asset must be associated with the wallet.
+      parameters:
+        - *parametersWalletId
+        - *parametersPolicyId
+        - *parametersAssetName
       responses: *responsesGetAsset
 
   /wallets/{walletId}/statistics/utxos:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -236,7 +236,7 @@ x-syncClockProgress: &syncClockProgress
     status: pending
 
 x-amount: &amount
-  description: Coins, in Lovelace
+  description: Coins, in Lovelace. Only relates to 'Ada'. Refer to `assets` for multi-assets wallets instead.
   type: object
   required:
     - quantity
@@ -433,6 +433,54 @@ x-settings: &settings
 
         After update existing metadata will be dropped forcing it to re-sync automatically with the new setting.
 
+x-assetPolicyItem: &assetPolicyItem
+  type: string
+  description: |
+    The asset on-chain type which acts as a sub-identifier within a policy.
+    Typically an empty string for policies with a single fungible asset item.
+  format: base64
+
+x-assetPolicyId: &assetPolicyId
+  type: string
+  description: |
+    A unique identifier of the asset policy. It identifies who is able to forge and burn
+    new assets of this kind.
+  format: base64
+
+x-assetName: &assetName
+  type: string
+  description: |
+    A human-readable name for the asset. Good for display in user interfaces.
+
+x-assetAcronym: &assetAcronym
+  type: string
+  description: |
+    A human-readable name for the asset. Good for display in user interfaces.
+  format: base64
+
+x-assetUrl: &assetUrl
+  type: string
+  description: |
+    A URL to the policy's owner(s) or the entity website in charge of the asset.
+
+x-assetLogo: &assetLogo
+  type: string
+  description: |
+    A base64-encoded `image/png` for displaying the asset. The end image can be expected
+    to be smaller than 64KB.
+  format: base64
+
+x-assetDescription: &assetDescription
+  type: object
+  description: |
+    A human-readable description for the asset. Good for display in user interfaces.
+  required:
+    - en
+  properties:
+    en:
+      type: string
+      description: The description, in English (en).
+
 x-walletMnemonicSentence: &walletMnemonicSentence
   description: A list of mnemonic words
   type: array
@@ -508,7 +556,7 @@ x-walletState: &walletState
   description: Whether a wallet is ready to use or still syncing
 
 x-walletBalance: &walletBalance
-  description: Wallet current balance(s)
+  description: Wallet current Ada balance(s).
   type: object
   required:
     - available
@@ -517,13 +565,40 @@ x-walletBalance: &walletBalance
   properties:
     available:
       <<: *amount
-      description: Available UTxO balance (funds that can be spent without condition).
+      description: Available Ada UTxO balance (funds that can be spent without condition).
     reward:
       <<: *amount
-      description: The balance of the reward account for this wallet.
+      description: The Ada balance of the reward account for this wallet.
     total:
       <<: *amount
-      description: Total balance (available balance plus pending change and reward balance).
+      description: Total Ada balance (available balance plus pending change and reward balance).
+
+x-assetQuantity: &assetQuantity
+  type: integer
+  description: |
+    Number of assets uniquely identified by the `policy_id` and `policy_item`.
+  minimum: 0
+
+x-walletAsset: &walletAsset
+  description: |
+    An asset on the Cardano blockchain. An asset is uniquely identified by
+    its `type` and `policy_id` (also called _asset id_). Two assets with the same `policy_item`
+    and `policy_id` are fungible together (that is, they are interchangeable).
+    Yet, different assets with a same `policy_id`  but different `policy_item` are treated as separate assets.
+  type: object
+  required:
+    - policy_item
+    - policy_id
+    - quantity
+  properties:
+    policy_id: *assetPolicyId
+    policy_item: *assetPolicyItem
+    quantity: *assetQuantity
+
+x-walletAssets: &walletAssets
+  description: Wallet assets
+  type: array
+  items: *walletAsset
 
 x-byronWalletBalance: &byronWalletBalance
   description: Byron wallet's current balance(s)
@@ -554,9 +629,6 @@ x-transactionId: &transactionId
   maxLength: 64
   minLength: 64
   example: 1423856bc91c49e928f6f30f4e8d665d53eb4ab6028bd0ac971809d514c92db1
-
-x-transactionAmount: &transactionAmount
-  <<: *amount
 
 x-transactionInsertedAt: &transactionInsertedAt
   description: |
@@ -603,7 +675,9 @@ x-addresses: &addresses
   items: *addressId
 
 x-transactionInputs: &transactionInputs
-  description: A list of transaction inputs
+  description: |
+    A list of transaction inputs. `assets` and `address` are always present for `outgoing`
+    transactions and are generally absent for `incoming` transactions.
   type: array
   minItems: 0
   items:
@@ -613,7 +687,8 @@ x-transactionInputs: &transactionInputs
       - index
     properties:
       address: *addressId
-      amount: *transactionAmount
+      amount: *amount
+      assets: *walletAssets
       id: *transactionId
       index:
         type: integer
@@ -630,7 +705,8 @@ x-transactionOutputs: &transactionOutputs
       - amount
     properties:
       address: *addressId
-      amount: *transactionAmount
+      amount: *amount
+      assets: *walletAsset
 
 x-delegationAction: &delegationAction
   description: |
@@ -740,7 +816,7 @@ x-transactionChange: &transactionChange
       - derivation_path
     properties:
       address: *addressId
-      amount: *transactionAmount
+      amount: *amount
       derivation_path: *derivationPath
 
 x-transactionResolvedInputs: &transactionResolvedInputs
@@ -757,7 +833,7 @@ x-transactionResolvedInputs: &transactionResolvedInputs
       - derivation_path
     properties:
       address: *addressId
-      amount: *transactionAmount
+      amount: *amount
       id: *transactionId
       derivation_path: *derivationPath
       index:
@@ -1096,7 +1172,7 @@ x-deposits: &deposits
   description: A list of deposits associated with a transaction.
   type: array
   minItems: 0
-  items: *transactionAmount
+  items: *amount
 
 #############################################################################
 #                                                                           #
@@ -1329,9 +1405,9 @@ components:
         - estimated_max
         - deposit
       properties:
-        estimated_min: *transactionAmount
-        estimated_max: *transactionAmount
-        deposit: *transactionAmount
+        estimated_min: *amount
+        estimated_max: *amount
+        deposit: *amount
 
     ApiPutAddressesData: &ApiPutAddressesData
       type: object
@@ -1368,9 +1444,19 @@ components:
         - status
       properties:
         id: *transactionId
-        amount: *transactionAmount
-        fee: *transactionAmount
-        deposit: *transactionAmount
+        amount:
+          <<: *amount
+          description: |
+            An amount of Ada spent or received, from the perspective of the wallet.
+
+            That is, for outgoing transaction, it represents the amount of Ada consumed
+            as inputs, minus the amount of Ada spent as fees, as deposits or to addresses
+            which do not belong to the wallet.
+
+            For incoming transaction, it represents the total amount of Ada received to
+            addresses that belong to the wallet.
+        fee: *amount
+        deposit: *amount
         inserted_at: *transactionInsertedAt
         expires_at: *transactionExpiresAt
         pending_since: *transactionPendingSince
@@ -1426,6 +1512,7 @@ components:
         - id
         - address_pool_gap
         - balance
+        - assets
         - delegation
         - name
         - state
@@ -1434,6 +1521,7 @@ components:
         id: *walletId
         address_pool_gap: *walletAddressPoolGap
         balance: *walletBalance
+        assets: *walletAssets
         delegation: *ApiWalletDelegation
         name: *walletName
         passphrase: *walletPassphraseInfo
@@ -1457,6 +1545,22 @@ components:
         passphrase: *walletPassphraseInfo
         state: *walletState
         tip: *blockReference
+
+    ApiAsset: &ApiAsset
+      type: object
+      required:
+        - policy_id
+        - policy_item
+        - quantity
+      properties:
+        policy_id: *assetPolicyId
+        policy_item: *assetPolicyItem
+        quantity: *assetQuantity
+        name: *assetName
+        acronym: *assetAcronym
+        url: *assetUrl
+        logo: *assetLogo
+        description: *assetDescription
 
     ApiWalletMigrationInfo: &ApiWalletMigrationInfo
       type: object
@@ -2670,6 +2774,25 @@ x-responsesListWallets: &responsesListWallets
           type: array
           items: *ApiWallet
 
+x-responsesListAssets: &responsesListAssets
+  <<: *responsesErr406
+  200:
+    description: Ok
+    content:
+      application/json:
+        schema:
+          type: array
+          items: *ApiAsset
+
+x-responsesGetAsset: &responsesGetAsset
+  <<: *responsesErr404
+  <<: *responsesErr406
+  200:
+    description: Ok
+    content:
+      application/json:
+        schema: *ApiAsset
+
 x-responsesListByronWallets: &responsesListByronWallets
   <<: *responsesErr406
   200:
@@ -3184,6 +3307,7 @@ x-tagGroups:
   - name: Shelley (Sequential)
     tags:
     - Wallets
+    - Assets
     - Addresses
     - Coin Selections
     - Transactions
@@ -3259,6 +3383,28 @@ paths:
 
         Return a list of known wallets, ordered from oldest to newest.
       responses: *responsesListWallets
+
+  /wallets/{walletId}/assets:
+    get:
+      operationId: listAssets
+      tags: ["Assets"]
+      summary: List Assets
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        List all assets available in the wallet, with their metadata if any.
+      responses: *responsesListAssets
+
+  /wallets/{walletId}/assets/{policy_id}/{policy_item}:
+    get:
+      operationId: getAsset
+      tags: ["Assets"]
+      summary: Get Asset
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        Fetch a single asset from its `policy_id` and `policy_item`, with its metadata if any.
+      responses: *responsesGetAsset
 
   /wallets/{walletId}/statistics/utxos:
     get:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -483,16 +483,26 @@ x-assetDisplayName: &assetDisplayName
 
 x-assetMetadataName: &assetMetadataName
   type: string
+  maxLength: 50
+  minLength: 1
   description: |
     A human-readable name for the asset. Good for display in user interfaces.
   example: SwaggerCoin
 
 x-assetMetadataAcronym: &assetMetadataAcronym
   type: string
+  maxLength: 4
+  minLength: 2
   description: |
     A human-readable short name for the asset. Good for display in
     user interfaces.
   example: SWAG
+
+x-assetMetadataDescription: &assetMetadataDescription
+  description: |
+    A human-readable description for the asset. Good for display in user interfaces.
+  type: string
+  maxLength: 500
 
 x-assetMetadataUnit: &assetMetadataUnit
   type: object
@@ -502,6 +512,7 @@ x-assetMetadataUnit: &assetMetadataUnit
   required:
     - decimals
     - name
+  additionalProperties: false
   properties:
     decimals:
       type: integer
@@ -511,6 +522,8 @@ x-assetMetadataUnit: &assetMetadataUnit
       maximum: 19
     name:
       type: string
+      minLength: 1
+      maxLength: 30
       description: |
         The human-readable name for the larger unit of the asset. Used
         for display in user interfaces.
@@ -519,44 +532,51 @@ x-assetMetadataUnit: &assetMetadataUnit
     decimals: 3
 
 x-assetMetadataUrl: &assetMetadataUrl
-  type: string
   description: |
     A URL to the policy's owner(s) or the entity website in charge of the asset.
+  type: string
+  format: uri
+  pattern: "^https://.+"
+  maxLength: 250
 
 x-assetMetadataLogo: &assetMetadataLogo
-  type: string
   description: |
     A base64-encoded `image/png` for displaying the asset. The end image can be expected
     to be smaller than 64KB.
+  type: string
   format: base64
-
-x-assetMetadataDescription: &assetMetadataDescription
-  type: object
-  description: |
-    A human-readable description for the asset. Good for display in user interfaces.
-  required:
-    - en
-  properties:
-    en:
-      type: string
-      description: The description, in English (en).
+  maxLength: 87400
 
 x-assetMetadata: &assetMetadata
-  type: object
+  title: Native Assets Metadata
   description: |
     <p>status: <strong>⚠ under development</strong></p>
 
     _This field is not implemented yet, and the values will always be empty._
 
-    Additional information about the asset which is not stored
-    on chain. This data is fetched from an external source.
+    In the Mary era of Cardano, UTxO may contain native assets. These
+    assets are represented on-chain by opaque identifiers which are
+    meaningless to end-users. Therefore, user-facing metadata
+    regarding each token must be stored off-chain, in a metadata
+    registry.
+
+    Token creators may publish metadata into the registry and client
+    applications can consume these metadata for display to end
+    users. This will work in a similar way to how it is done for stake
+    pool metadata.
+  type: object
+  additionalProperties: false
+  required:
+    - name
+    - acronym
+    - description
   properties:
     name: *assetMetadataName
     acronym: *assetMetadataAcronym
+    description: *assetMetadataDescription
     unit: *assetMetadataUnit
     url: *assetMetadataUrl
     logo: *assetMetadataLogo
-    description: *assetMetadataDescription
 
 x-walletMnemonicSentence: &walletMnemonicSentence
   description: A list of mnemonic words


### PR DESCRIPTION
### Issue Number

ADP-604

### Overview

Starting implementation of API spec in #2446.

- [x] listAssets endpoint
- [x] getAsset endpoint
- [x] Added `ApiWalletAssetsBalance` which provides the balance of non-ade assets.
- [x] Removed WalletBalance from Primitive.Types and replaced `ApiT WalletBalance` with `ApiWalletBalance`.
- [ ] Some kind of integration test for these endpoints.
- [x] Remove `Quantity "lovelace" a` where possible, except for the API.
- [x] TokenName inner type is now ByteString, add length validation.

### Comments
- This branch is based on top of the PR #2446 branch.

