### PR TITLE
Add `WithAdaOnly` constructor to `SelectionFilter` for `UTxOIndex`.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -218,6 +218,7 @@ library
       Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
       Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
       Cardano.Wallet.Primitive.Types.Tx.Gen
+      Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
   other-modules:
       Paths_cardano_wallet_core
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
 import Control.Monad
     ( replicateM )
 import Test.QuickCheck
-    ( Gen, choose, shrinkList )
+    ( Gen, choose, oneof, shrinkList )
 import Test.QuickCheck.Extra
     ( shrinkInterleaved )
 
@@ -46,7 +46,11 @@ shrinkAssetIdSmallRange (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
 
 genTokenMapSmallRange :: Gen TokenMap
 genTokenMapSmallRange = do
-    assetCount <- choose (0, 16)
+    assetCount <- oneof
+        [ pure 0
+        , pure 1
+        , choose (2, 16)
+        ]
     TokenMap.fromFlatList <$> replicateM assetCount genAssetQuantity
   where
     genAssetQuantity = (,)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -1,0 +1,47 @@
+module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndexSmall
+    , shrinkUTxOIndexSmall
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxInSmallRange
+    , genTxOutSmallRange
+    , shrinkTxInSmallRange
+    , shrinkTxOutSmallRange
+    )
+import Cardano.Wallet.Primitive.Types.UTxOIndex
+    ( UTxOIndex )
+import Control.Monad
+    ( replicateM )
+import Test.QuickCheck
+    ( Gen, choose, shrinkList )
+import Test.QuickCheck.Extra
+    ( shrinkInterleaved )
+
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+
+genUTxOIndexSmall :: Gen UTxOIndex
+genUTxOIndexSmall = do
+    entryCount <- choose (0, 64)
+    UTxOIndex.fromSequence <$> replicateM entryCount genEntrySmallRange
+
+shrinkUTxOIndexSmall :: UTxOIndex -> [UTxOIndex]
+shrinkUTxOIndexSmall
+    = take 16
+    . fmap UTxOIndex.fromSequence
+    . shrinkList shrinkEntrySmallRange
+    . UTxOIndex.toList
+
+genEntrySmallRange :: Gen (TxIn, TxOut)
+genEntrySmallRange = (,)
+    <$> genTxInSmallRange
+    <*> genTxOutSmallRange
+
+shrinkEntrySmallRange :: (TxIn, TxOut) -> [(TxIn, TxOut)]
+shrinkEntrySmallRange (i, o) = uncurry (,) <$> shrinkInterleaved
+    (i, shrinkTxInSmallRange)
+    (o, shrinkTxOutSmallRange)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -18,7 +18,7 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
 import Control.Monad
     ( replicateM )
 import Test.QuickCheck
-    ( Gen, choose, shrinkList )
+    ( Gen, choose, frequency, shrinkList )
 import Test.QuickCheck.Extra
     ( shrinkInterleaved )
 
@@ -26,7 +26,11 @@ import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 
 genUTxOIndexSmall :: Gen UTxOIndex
 genUTxOIndexSmall = do
-    entryCount <- choose (0, 64)
+    entryCount <- frequency
+        [ (1, pure 0)
+        , (1, pure 1)
+        , (32, choose (2, 64))
+        ]
     UTxOIndex.fromSequence <$> replicateM entryCount genEntrySmallRange
 
 shrinkUTxOIndexSmall :: UTxOIndex -> [UTxOIndex]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -307,6 +307,8 @@ size = Map.size . utxo
 data SelectionFilter
     = Any
         -- ^ Select any UTxO entry from the entire set.
+    | WithAdaOnly
+        -- ^ Select any UTxO entry that only has ada and no other assets.
     | WithAsset AssetId
         -- ^ Select any UTxO entry that has a non-zero quantity of the specified
         -- asset.
@@ -333,6 +335,7 @@ selectRandom u selectionFilter =
     selectionSet :: Set TxIn
     selectionSet = case selectionFilter of
         Any -> Map.keysSet $ utxo u
+        WithAdaOnly -> entriesWithAdaOnly u
         WithAsset a -> entriesWithAsset a u
 
 --------------------------------------------------------------------------------
@@ -342,6 +345,12 @@ selectRandom u selectionFilter =
 --------------------------------------------------------------------------------
 -- Utilities
 --------------------------------------------------------------------------------
+
+entriesWithAdaOnly :: UTxOIndex -> Set TxIn
+entriesWithAdaOnly u = Map.foldl'
+    (Set.difference)
+    (Map.keysSet $ utxo u)
+    (NonEmptySet.toSet <$> index u)
 
 -- | Returns the set of keys for entries that have non-zero quantities of the
 --   given asset.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -23,6 +23,8 @@ import Cardano.Wallet.Primitive.Types.Tx.Gen
     , shrinkTxInSmallRange
     , shrinkTxOutSmallRange
     )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO (..) )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndexSmall, shrinkUTxOIndexSmall )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
@@ -67,6 +69,7 @@ import Test.Utils.Laws
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex.Internal as UTxOIndex
 import qualified Data.List as L
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
 spec :: Spec
@@ -136,10 +139,14 @@ spec =
             property prop_selectRandom_singleton
         it "prop_selectRandom_one_any" $
             property prop_selectRandom_one_any
+        it "prop_selectRandom_one_withAdaOnly" $
+            property prop_selectRandom_one_withAdaOnly
         it "prop_selectRandom_one_withAsset" $
             property prop_selectRandom_one_withAsset
         it "prop_selectRandom_all_any" $
             property prop_selectRandom_all_any
+        it "prop_selectRandom_all_withAdaOnly" $
+            property prop_selectRandom_all_withAdaOnly
         it "prop_selectRandom_all_withAsset" $
             property prop_selectRandom_all_withAsset
 
@@ -337,6 +344,10 @@ prop_selectRandom_singleton selectionFilter i o = monadicIO $ do
     expected = case selectionFilter of
         Any ->
             Just ((i, o), UTxOIndex.empty)
+        WithAdaOnly | txOutIsAdaOnly o ->
+            Just ((i, o), UTxOIndex.empty)
+        WithAdaOnly ->
+            Nothing
         WithAsset a | txOutHasAsset o a ->
             Just ((i, o), UTxOIndex.empty)
         WithAsset _ ->
@@ -360,6 +371,26 @@ prop_selectRandom_one_any u = checkCoverage $ monadicIO $ do
             assert $ UTxOIndex.member i u
             assert $ not $ UTxOIndex.member i u'
             assert $ u /= u'
+
+-- | Attempt to select a random entry with only ada.
+--
+prop_selectRandom_one_withAdaOnly :: UTxOIndex -> Property
+prop_selectRandom_one_withAdaOnly u = checkCoverage $ monadicIO $ do
+    result <- run $ UTxOIndex.selectRandom u WithAdaOnly
+    monitor $ cover 90 (isJust result)
+        "selected an entry"
+    case result of
+        Nothing ->
+            assert utxoHasNoAdaOnlyEntries
+        Just ((i, o), u') -> do
+            assert $ UTxOIndex.delete i u == u'
+            assert $ UTxOIndex.insert i o u' == u
+            assert $ UTxOIndex.member i u
+            assert $ not $ UTxOIndex.member i u'
+            assert $ u /= u'
+  where
+    utxoHasNoAdaOnlyEntries =
+        Map.null $ Map.filter txOutIsAdaOnly $ getUTxO $ UTxOIndex.toUTxO u
 
 -- | Attempt to select a random element with a specific asset.
 --
@@ -401,6 +432,18 @@ prop_selectRandom_all_any u = checkCoverage $ monadicIO $ do
     assert $ UTxOIndex.fromSequence selectedEntries == u
     assert $ UTxOIndex.null u'
     assert $ length selectedEntries == UTxOIndex.size u
+
+-- | Attempt to select all entries with only ada from the index.
+--
+prop_selectRandom_all_withAdaOnly :: UTxOIndex -> Property
+prop_selectRandom_all_withAdaOnly u = checkCoverage $ monadicIO $ do
+    (selectedEntries, u') <- run $ selectAll WithAdaOnly u
+    monitor $ cover 80 (not (null selectedEntries))
+        "selected at least one entry"
+    assert $ L.all (\(_, o) -> not (txOutIsAdaOnly o)) (UTxOIndex.toList u')
+    assert $ L.all (\(_, o) -> txOutIsAdaOnly o) selectedEntries
+    assert $ UTxOIndex.deleteMany (fst <$> selectedEntries) u == u'
+    assert $ UTxOIndex.insertMany selectedEntries u' == u
 
 -- | Attempt to select all entries with the given asset from the index.
 --
@@ -517,6 +560,12 @@ selectAll sf = go []
 txOutHasAsset :: TxOut -> AssetId -> Bool
 txOutHasAsset = TokenBundle.hasQuantity . view #tokens
 
+-- | Returns 'True' if (and only if) the given transaction output contains no
+--   assets other than ada.
+--
+txOutIsAdaOnly :: TxOut -> Bool
+txOutIsAdaOnly = TokenBundle.isCoin . view #tokens
+
 --------------------------------------------------------------------------------
 -- Arbitrary instances
 --------------------------------------------------------------------------------
@@ -544,10 +593,15 @@ instance Arbitrary SelectionFilter where
 genSelectionFilterSmallRange :: Gen SelectionFilter
 genSelectionFilterSmallRange = oneof
     [ pure Any
+    , pure WithAdaOnly
     , WithAsset <$> genAssetIdSmallRange
     ]
 
 shrinkSelectionFilterSmallRange :: SelectionFilter -> [SelectionFilter]
 shrinkSelectionFilterSmallRange = \case
     Any -> []
-    WithAsset a -> Any : (WithAsset <$> shrinkAssetIdSmallRange a)
+    WithAdaOnly -> [Any]
+    WithAsset a ->
+        case WithAsset <$> shrinkAssetIdSmallRange a of
+            [] -> [WithAdaOnly]
+            xs -> xs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -369,11 +369,11 @@ prop_selectRandom_one_any u = checkCoverage $ monadicIO $ do
 prop_selectRandom_one_withAsset :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_one_withAsset u a = checkCoverage $ monadicIO $ do
     result <- run $ UTxOIndex.selectRandom u (WithAsset a)
-    monitor $ cover 90 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 80 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 90 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 80 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 90 (isJust result)
+    monitor $ cover 80 (isJust result)
         "selected an entry"
     case result of
         Nothing ->
@@ -407,11 +407,11 @@ prop_selectRandom_all_any u = checkCoverage $ monadicIO $ do
 prop_selectRandom_all_withAsset :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_all_withAsset u a = checkCoverage $ monadicIO $ do
     (selectedEntries, u') <- run $ selectAll (WithAsset a) u
-    monitor $ cover 90 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 80 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 90 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 80 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 90 (not (null selectedEntries))
+    monitor $ cover 80 (not (null selectedEntries))
         "selected at least one entry"
     assert $ L.all (\(_, o) -> not (txOutHasAsset o a)) (UTxOIndex.toList u')
     assert $ L.all (\(_, o) -> txOutHasAsset o a) selectedEntries

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -23,10 +23,10 @@ import Cardano.Wallet.Primitive.Types.Tx.Gen
     , shrinkTxInSmallRange
     , shrinkTxOutSmallRange
     )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndexSmall, shrinkUTxOIndexSmall )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     ( InvariantStatus (..), SelectionFilter (..), UTxOIndex, checkInvariant )
-import Control.Monad
-    ( replicateM )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Data.Generics.Internal.VL.Lens
@@ -48,21 +48,17 @@ import Test.QuickCheck
     , Property
     , checkCoverage
     , checkCoverageWith
-    , choose
     , conjoin
     , counterexample
     , cover
     , oneof
     , property
-    , shrinkList
     , stdConfidence
     , withMaxSuccess
     , (===)
     )
 import Test.QuickCheck.Classes
     ( eqLaws )
-import Test.QuickCheck.Extra
-    ( shrinkInterleaved )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
 import Test.Utils.Laws
@@ -530,24 +526,8 @@ instance Arbitrary AssetId where
     shrink = shrinkAssetIdSmallRange
 
 instance Arbitrary UTxOIndex where
-    arbitrary = do
-        entryCount <- choose (0, 64)
-        UTxOIndex.fromSequence <$> replicateM entryCount genEntrySmallRange
-    shrink
-        = take 16
-        . fmap UTxOIndex.fromSequence
-        . shrinkList shrinkEntrySmallRange
-        . UTxOIndex.toList
-
-genEntrySmallRange :: Gen (TxIn, TxOut)
-genEntrySmallRange = (,)
-    <$> genTxInSmallRange
-    <*> genTxOutSmallRange
-
-shrinkEntrySmallRange :: (TxIn, TxOut) -> [(TxIn, TxOut)]
-shrinkEntrySmallRange (i, o) = uncurry (,) <$> shrinkInterleaved
-    (i, shrinkTxInSmallRange)
-    (o, shrinkTxOutSmallRange)
+    arbitrary = genUTxOIndexSmall
+    shrink = shrinkUTxOIndexSmall
 
 instance Arbitrary TxIn where
     arbitrary = genTxInSmallRange


### PR DESCRIPTION
# Issue Number

ADP-605
ADP-633

# Overview

This PR adds the `WithAdaOnly` constructor to the `SelectionFilter` type of `UTxOIndex`.

It's now possible to select a UTxO entry containing **only ada** in the following way:

```hs
UTxOIndex.selectRandom index WithAdaOnly
```

If there is such an entry, the function will return `Just ((i, o), reducedIndex)`.
If there is no such entry, the function will return `Nothing`.

# Motivation

For MA coin selection, we need the ability to randomly select UTxO entries containing only ada, and no other asset quantities.