### PR TITLE
Re-write LocalStateQuery client logic to eliminate acquire failures

### DIFF
--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -151,8 +151,7 @@ data NetworkLayer m block = NetworkLayer
         -- ^ Broadcast a transaction to the chain producer
 
     , stakeDistribution
-        :: BlockHeader -- Point of interest
-        -> Coin -- Stake to consider for rewards
+        :: Coin -- Stake to consider for rewards
         -> ExceptT ErrStakeDistribution m StakePoolsSummary
 
     , getAccountBalance

--- a/lib/core/src/Ouroboros/Network/Client/Wallet.hs
+++ b/lib/core/src/Ouroboros/Network/Client/Wallet.hs
@@ -524,7 +524,7 @@ localStateQuery getTip queue =
         LSQ.SendMsgRelease (respond res >> clientStIdle)
             -- We /could/ read all LocalStateQueryCmds from the TQueue, and run
             -- them against the same tip, if re-acquiring takes a long time. As
-            -- of Jan 2020, it seems like queries themselves take significantly
+            -- of Jan 2021, it seems like queries themselves take significantly
             -- longer than the acquiring.
       where
           go

--- a/lib/core/src/Ouroboros/Network/Client/Wallet.hs
+++ b/lib/core/src/Ouroboros/Network/Client/Wallet.hs
@@ -38,7 +38,6 @@ module Ouroboros.Network.Client.Wallet
 
       -- * Helpers
     , send
-    , sendAsync
 
       -- * Logs
     , ChainSyncLog (..)
@@ -631,15 +630,6 @@ send queue cmd = do
     tvar <- newEmptyTMVarIO
     atomically $ writeTQueue queue (cmd (atomically . putTMVar tvar))
     atomically $ takeTMVar tvar
-
-
-sendAsync
-    :: MonadSTM m
-    => TQueue m (cmd m)
-    -> (cmd m)
-    -> m ()
-sendAsync queue cmd = do
-    atomically $ writeTQueue queue cmd
 
 -- Tracing
 

--- a/lib/core/src/Ouroboros/Network/Client/Wallet.hs
+++ b/lib/core/src/Ouroboros/Network/Client/Wallet.hs
@@ -473,9 +473,6 @@ data LocalStateQueryCmd block m = forall a. SomeLSQ
 --                │               │◀────────────┤          │
 --                └───────────────┘     Result  └──────────┘
 --
--- NOTE: Using AnyCardanoEra arguably goes against the grain of the abstract
--- block type. We might be able to use the (Header block) as replacemet for
--- (AnyCardanoEra, Tip block).
 localStateQuery
     :: forall m block . (MonadIO m, MonadSTM m)
     => TQueue m (LocalStateQueryCmd block m)

--- a/lib/core/src/Ouroboros/Network/Client/Wallet.hs
+++ b/lib/core/src/Ouroboros/Network/Client/Wallet.hs
@@ -458,25 +458,25 @@ data LocalStateQueryCmd block m = forall a. SomeLSQ
 --     Server has agency*                | Acquiring, Querying
 --     * A peer has agency if it is expected to send the next message.
 --
---
---                ┌───────────────┐    Done      ┌───────────────┐
---        ┌──────▶│     Idle      ├─────────────▶│     Done      │
---        │       └───┬───────────┘              └───────────────┘
+--                ┌───────────────┐    Done      ┌──────────┐
+--        ┌──────▶│     Idle      ├─────────────▶│   Done   │
+--        │       └───┬───────────┘              └──────────┘
 --        │           │       ▲
 --        │   Acquire │       │
 --        │           │       │ Failure
 --        │           ▼       │
---        │       ┌───────────┴───┐              Result
---        │       │   Acquiring   │◀─────────────────────┐
---        │       └───┬───────────┘                      │
--- Release│           │       ▲                          │
---        │           │       │                          │
---        │  Acquired ▼       │ ReAcquire                │
---        │       ┌───────────┴───┐             ┌────────┴───────┐
---        └───────┤   Acquired    │────────────>│   Querying     │
---                └───────────────┘             └────────────────┘
--- FIXME: I think the diagram is wrong. It is possible to query multiple times
--- while we're acquired.
+--        │       ┌───────────┴───┐
+--        │       │   Acquiring   │
+--        │       └───┬───────────┘
+-- Release│           │       ▲
+--        │           │       │
+--        │  Acquired │       │ ReAcquire
+--        │           │       │
+--        │           ▼       │
+--        │       ┌───────────┴───┐   Query     ┌──────────┐
+--        └───────┤   Acquired    ├────────────▶│ Querying │
+--                │               │◀────────────┤          │
+--                └───────────────┘     Result  └──────────┘
 --
 -- NOTE: Using AnyCardanoEra arguably goes against the grain of the abstract
 -- block type. We might be able to use the (Header block) as replacemet for

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -50,12 +50,7 @@ import Cardano.Wallet.Byron.Compatibility
 import Cardano.Wallet.Logging
     ( BracketLog (..), bracketTracer, combineTracers, produceTimings )
 import Cardano.Wallet.Network
-    ( Cursor
-    , ErrPostTx (..)
-    , ErrStakeDistribution (..)
-    , NetworkLayer (..)
-    , mapCursor
-    )
+    ( Cursor, ErrPostTx (..), NetworkLayer (..), mapCursor )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, TimeInterpreterLog, mkTimeInterpreter )
 import Cardano.Wallet.Shelley.Compatibility
@@ -82,14 +77,17 @@ import Cardano.Wallet.Shelley.Compatibility
     )
 import Control.Applicative
     ( liftA3 )
+import Control.Arrow
+    ( second )
 import Control.Monad
-    ( forever, unless, void, when, (>=>) )
+    ( forever, guard, unless, void, when, (>=>) )
 import Control.Monad.Class.MonadAsync
     ( MonadAsync )
 import Control.Monad.Class.MonadST
     ( MonadST )
 import Control.Monad.Class.MonadSTM
     ( MonadSTM
+    , STM
     , TMVar
     , TQueue
     , TVar
@@ -112,9 +110,9 @@ import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTimer
     ( MonadTimer, threadDelay )
 import Control.Monad.IO.Unlift
-    ( MonadUnliftIO, liftIO )
+    ( MonadIO, MonadUnliftIO, liftIO )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), throwE, withExceptT )
+    ( ExceptT (..), throwE )
 import Control.Retry
     ( RetryPolicyM, RetryStatus (..), capDelay, fibonacciBackoff, recovering )
 import Control.Tracer
@@ -123,12 +121,8 @@ import Data.ByteArray.Encoding
     ( Base (..), convertToBase )
 import Data.ByteString.Lazy
     ( ByteString )
-import Data.Either.Extra
-    ( eitherToMaybe )
 import Data.Function
     ( (&) )
-import Data.Functor
-    ( (<$) )
 import Data.List
     ( isInfixOf )
 import Data.Map
@@ -138,7 +132,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
-    ( Quantity (..) )
+    ( Percentage, Quantity (..) )
 import Data.Set
     ( Set )
 import Data.Text
@@ -172,8 +166,6 @@ import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
     ( MismatchEraInfo )
 import Ouroboros.Consensus.HardFork.History.Qry
     ( Interpreter, PastHorizonException (..) )
-import Ouroboros.Consensus.HardFork.History.Summary
-    ( Bound (..) )
 import Ouroboros.Consensus.Network.NodeToClient
     ( ClientCodecs, Codecs' (..), DefaultCodecs, clientCodecs, defaultCodecs )
 import Ouroboros.Consensus.Node.NetworkProtocolVersion
@@ -195,14 +187,17 @@ import Ouroboros.Network.Block
 import Ouroboros.Network.Client.Wallet
     ( ChainSyncCmd (..)
     , ChainSyncLog (..)
+    , LSQ (..)
     , LocalStateQueryCmd (..)
     , LocalTxSubmissionCmd (..)
     , chainSyncFollowTip
     , chainSyncWithBlocks
+    , currentEra
     , localStateQuery
     , localTxSubmission
     , mapChainSyncLog
     , send
+    , sendAsync
     )
 import Ouroboros.Network.CodecCBORTerm
     ( CodecCBORTerm )
@@ -238,7 +233,7 @@ import Ouroboros.Network.Protocol.Handshake.Version
 import Ouroboros.Network.Protocol.LocalStateQuery.Client
     ( localStateQueryClientPeer )
 import Ouroboros.Network.Protocol.LocalStateQuery.Type
-    ( AcquireFailure, LocalStateQuery )
+    ( LocalStateQuery )
 import Ouroboros.Network.Protocol.LocalTxSubmission.Client
     ( localTxSubmissionClientPeer )
 import Ouroboros.Network.Protocol.LocalTxSubmission.Type
@@ -247,8 +242,6 @@ import System.IO.Error
     ( isDoesNotExistError )
 import UnliftIO.Async
     ( Async, async, asyncThreadId, cancel, link )
-import UnliftIO.Chan
-    ( Chan, dupChan, newChan, readChan, writeChan )
 import UnliftIO.Compat
     ( coerceHandlers )
 import UnliftIO.Concurrent
@@ -318,43 +311,36 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
     -- doesn't rely on the intersection to be up-to-date.
     let handlers = retryOnConnectionLost tr
 
-    queryRewardQ <- connectDelegationRewardsClient handlers
-
-    (nodeTipChan, networkParamsVar, interpreterVar, localTxSubmissionQ) <-
+    (readNodeEraAndTip, networkParamsVar, interpreterVar, localTxSubmissionQ) <-
         connectNodeTipClient handlers
+
+
+    queryRewardQ <- connectDelegationRewardsClient handlers
+        (second getTipPoint <$> readNodeEraAndTip)
 
     (rewardsObserver, refreshRewards) <-
         newRewardBalanceFetcher tr gp queryRewardQ
 
-    -- We store the last known tip and last known era in TVars. The only writer
-    -- of this TVar is 'updateNodeTip' just below, but many reads from them in
-    -- the network layer.
-    nodeTipVar <- atomically $ newTVar TipGenesis
-    nodeEraVar <- atomically $ newTVar (AnyCardanoEra ByronEra)
 
-    let updateNodeTip = do
-            (maybeEra, tip) <- readChan nodeTipChan
-            atomically $ writeTVar nodeTipVar tip
-            -- If the node just rolled back, we'll get only a tip and no era and
-            -- we'll only update the era on the next roll forward. So it may
-            -- happen that for a short time, there's an era mismatch if we make
-            -- a request right after a rollback that crossed two eras.
-            --
-            -- Worse that can happen though is the query being invalid or in the
-            -- wrong era which is handled everywhere already.
-            era <- case maybeEra of
-                Just era -> era <$ atomically (writeTVar nodeEraVar era)
-                Nothing  -> atomically $ readTVar nodeEraVar
-            refreshRewards (era, tip)
-    link =<< async (forever updateNodeTip)
+    let refreshRewardLoop :: (AnyCardanoEra, Tip (CardanoBlock StandardCrypto)) -> IO ()
+        refreshRewardLoop oldTip = do
+            tip <- atomically $ do
+                tip <- readNodeEraAndTip
+                guard (oldTip /= tip)
+                return tip
+            refreshRewards tip
+            refreshRewardLoop tip
+    link =<< async (refreshRewardLoop (AnyCardanoEra ByronEra, TipGenesis ))
+
+    let readCurrentNodeEra = fst <$> atomically readNodeEraAndTip
+    let readCurrentNodeTip = snd <$> atomically readNodeEraAndTip
 
     action $ NetworkLayer
         { currentNodeTip =
-            liftIO $ _currentNodeTip nodeTipVar
-        , currentNodeEra =
-            _currentNodeEra nodeEraVar
-        , watchNodeTip =
-            _watchNodeTip nodeTipChan
+            fromTip getGenesisBlockHash <$> readCurrentNodeTip
+        , currentNodeEra = readCurrentNodeEra
+        , watchNodeTip = do
+            _watchNodeTip readNodeEraAndTip
         , nextBlocks =
             _nextBlocks
         , initCursor =
@@ -367,10 +353,11 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
             fst <$> atomically (readTVar networkParamsVar)
         , currentSlottingParameters =
             snd <$> atomically (readTVar networkParamsVar)
-        , postTx =
-            _postTx localTxSubmissionQ nodeEraVar
+        , postTx = \sealed -> do
+            era <- liftIO readCurrentNodeEra
+            _postTx localTxSubmissionQ era sealed
         , stakeDistribution =
-            _stakeDistribution queryRewardQ nodeEraVar
+            liftIO . _stakeDistribution queryRewardQ
         , getAccountBalance =
             _getAccountBalance rewardsObserver
         , timeInterpreter =
@@ -392,10 +379,11 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
         unless e $ void $ takeTMVar var
         putTMVar var x
 
+
     connectNodeTipClient
         :: HasCallStack
         => RetryHandlers
-        -> IO ( Chan (Maybe AnyCardanoEra, Tip (CardanoBlock StandardCrypto))
+        -> IO ( STM IO (AnyCardanoEra, Tip (CardanoBlock StandardCrypto))
               , TVar IO (W.ProtocolParameters, W.SlottingParameters)
               , TMVar IO (CardanoInterpreter StandardCrypto)
               , TQueue IO (LocalTxSubmissionCmd
@@ -405,28 +393,27 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
               )
     connectNodeTipClient handlers = do
         localTxSubmissionQ <- atomically newTQueue
-        nodeTipChan <- newChan
         networkParamsVar <- atomically $ newTVar
             ( W.protocolParameters np
             , W.slottingParameters np
             )
         interpreterVar <- atomically newEmptyTMVar
-        nodeTipClient <- mkTipSyncClient tr np
+        (nodeTipClient, readTip) <- mkTipSyncClient tr np
             localTxSubmissionQ
-            (writeChan nodeTipChan)
             (curry (atomically . writeTVar networkParamsVar))
             (atomically . repsertTMVar interpreterVar)
         link =<< async (connectClient tr handlers nodeTipClient versionData conn)
-        pure (nodeTipChan, networkParamsVar, interpreterVar, localTxSubmissionQ)
+        pure (readTip, networkParamsVar, interpreterVar, localTxSubmissionQ)
 
     connectDelegationRewardsClient
         :: HasCallStack
         => RetryHandlers
+        -> STM IO (AnyCardanoEra, Point (CardanoBlock StandardCrypto))
         -> IO (TQueue IO
                 (LocalStateQueryCmd (CardanoBlock StandardCrypto) IO))
-    connectDelegationRewardsClient handlers = do
+    connectDelegationRewardsClient handlers readNodeTip = do
         cmdQ <- atomically newTQueue
-        let cl = mkDelegationRewardsClient tr cfg cmdQ
+        let cl = mkDelegationRewardsClient tr readNodeTip cfg cmdQ
         link =<< async (connectClient tr handlers cl versionData conn)
         pure cmdQ
 
@@ -466,9 +453,6 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
     _cursorSlotNo (Cursor _ point _) = do
         fromWithOrigin (SlotNo 0) $ pointSlot point
 
-    _currentNodeTip nodeTipVar =
-        fromTip getGenesisBlockHash <$> atomically (readTVar nodeTipVar)
-
     _currentNodeEra nodeEraVar =
         atomically (readTVar nodeEraVar)
 
@@ -481,8 +465,7 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
     -- all form of type-level indicator about the era. The 'SealedTx' type
     -- shouldn't be needed anymore since we've dropped jormungandr, so we could
     -- instead carry a transaction from cardano-api types with proper typing.
-    _postTx localTxSubmissionQ nodeEraVar tx = do
-        era <- liftIO $ atomically $ readTVar nodeEraVar
+    _postTx localTxSubmissionQ era tx = do
         liftIO $ traceWith tr $ MsgPostTx tx
         case era of
             AnyCardanoEra ByronEra ->
@@ -509,115 +492,45 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
                     SubmitSuccess -> pure ()
                     SubmitFail err -> throwE $ ErrPostTxBadRequest $ T.pack (show err)
 
-    _stakeDistribution queue eraVar bh coin = do
+    _stakeDistribution queue coin = do
         liftIO $ traceWith tr $ MsgWillQueryRewardsForStake coin
 
-        era <- liftIO $ atomically $ readTVar eraVar
-        let pt = toPoint getGenesisBlockHash bh
+        let qry :: LSQ (CardanoBlock StandardCrypto) IO (Maybe W.StakePoolsSummary)
+            qry = liftA3 (liftA3 W.StakePoolsSummary)
+                getNOpt
+                queryNonMyopicMemberRewards
+                stakeDistr
 
-        mres <- liftA3 (liftA3 W.StakePoolsSummary)
-            (getNOpt pt era)
-            (queryNonMyopicMemberRewards pt era)
-            (queryStakeDistribution pt era)
+        mres <- bracketQuery "stakePoolsSummary" tr $
+            queue `send` (SomeLSQ qry )
 
         -- The result will be Nothing if query occurs during the byron era
-        liftIO $ traceWith tr $ MsgFetchStakePoolsData (eitherToMaybe mres)
+        liftIO $ traceWith tr $ MsgFetchStakePoolsData mres
         case mres of
-            Right res@W.StakePoolsSummary{rewards,stake} -> do
+            Just res@W.StakePoolsSummary{rewards,stake} -> do
                 liftIO $ traceWith tr $ MsgFetchStakePoolsDataSummary
                     (Map.size stake)
                     (Map.size rewards)
                 return res
-            Left{} -> pure $ W.StakePoolsSummary 0 mempty mempty
+            Nothing -> pure $ W.StakePoolsSummary 0 mempty mempty
       where
-        -- fixme: ADP-647 AcquireFailure usually means rollback. So this
-        -- function can fail at arbitrary times.
-        handleQueryResult
-            :: String
-            -> IO (Either AcquireFailure r)
-            -> ExceptT ErrStakeDistribution IO r
-        handleQueryResult label =
-            withExceptT mkErr . ExceptT . bracketQuery label tr
-          where
-            mkErr = ErrStakeDistributionQuery . T.pack . show
 
-        queryStakeDistribution pt = \case
-            AnyCardanoEra ShelleyEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentShelley Shelley.GetStakeDistribution)
-                result <- handleQueryResult "GetStakeDistribution"
-                    (queue `send` cmd)
-                return $ fromPoolDistr <$> result
+        stakeDistr
+            :: LSQ (CardanoBlock StandardCrypto) IO
+                (Maybe (Map W.PoolId Percentage))
+        stakeDistr = shelleyBased
+            (fromPoolDistr <$> LSQry Shelley.GetStakeDistribution)
 
-            AnyCardanoEra AllegraEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentAllegra Shelley.GetStakeDistribution)
-                result <- handleQueryResult "GetStakeDistribution"
-                    (queue `send` cmd)
-                return $ fromPoolDistr <$> result
-
-            AnyCardanoEra MaryEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentMary Shelley.GetStakeDistribution)
-                result <- handleQueryResult "GetStakeDistribution"
-                    (queue `send` cmd)
-                return $ fromPoolDistr <$> result
-            AnyCardanoEra ByronEra ->
-                -- see also: #2419
-                throwE $ ErrStakeDistributionQuery "Can't query stake distribution in byron era"
-
-        getNOpt pt = \case
-            AnyCardanoEra ShelleyEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentShelley Shelley.GetCurrentPParams)
-                result <- handleQueryResult "GetCurrentPParams"
-                    (queue `send` cmd)
-                return $ optimumNumberOfPools <$> result
-
-            AnyCardanoEra AllegraEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentAllegra Shelley.GetCurrentPParams)
-                result <- handleQueryResult "GetCurrentPParams"
-                    (queue `send` cmd)
-                return $ optimumNumberOfPools <$> result
-
-            AnyCardanoEra MaryEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentMary Shelley.GetCurrentPParams)
-                result <- handleQueryResult "GetCurrentPParams"
-                    (queue `send` cmd)
-                return $ optimumNumberOfPools <$> result
-
-            AnyCardanoEra ByronEra ->
-                -- see also: #2419
-                throwE $ ErrStakeDistributionQuery "Can't query pparams in byron era"
+        getNOpt :: LSQ (CardanoBlock StandardCrypto) IO (Maybe Int)
+        getNOpt = shelleyBased $
+            optimumNumberOfPools <$> LSQry Shelley.GetCurrentPParams
 
         queryNonMyopicMemberRewards
-            :: Point (CardanoBlock StandardCrypto)
-            -> AnyCardanoEra
-            -> ExceptT
-                 ErrStakeDistribution
-                 IO
-                 (Either
-                    (MismatchEraInfo (CardanoEras StandardCrypto))
-                    (Map W.PoolId (Quantity "lovelace" Word64)))
-        queryNonMyopicMemberRewards pt = \case
-            AnyCardanoEra ByronEra ->
-                -- see also: #2419
-                throwE $ ErrStakeDistributionQuery "Can't query pparams in byron era"
-
-            AnyCardanoEra ShelleyEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentShelley (Shelley.GetNonMyopicMemberRewards stake))
-                result <- handleQueryResult "GetNonMyopicMemberRewards"
-                    (queue `send` cmd)
-                return $ getRewardMap . fromNonMyopicMemberRewards <$> result
-
-            AnyCardanoEra AllegraEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentAllegra (Shelley.GetNonMyopicMemberRewards stake))
-                result <- handleQueryResult "GetNonMyopicMemberRewards"
-                    (queue `send` cmd)
-                return $ getRewardMap . fromNonMyopicMemberRewards <$> result
-
-            AnyCardanoEra MaryEra -> do
-                let cmd = CmdQueryLocalState pt (QueryIfCurrentMary (Shelley.GetNonMyopicMemberRewards stake))
-                result <- handleQueryResult "GetNonMyopicMemberRewards"
-                    (queue `send` cmd)
-                return $ getRewardMap . fromNonMyopicMemberRewards <$> result
-
+            :: LSQ (CardanoBlock StandardCrypto) IO
+                    (Maybe (Map W.PoolId (Quantity "lovelace" Word64)))
+        queryNonMyopicMemberRewards = shelleyBased $
+            (getRewardMap . fromNonMyopicMemberRewards)
+                <$> LSQry (Shelley.GetNonMyopicMemberRewards stake)
           where
             stake :: Set (Either SL.Coin a)
             stake = Set.singleton $ Left $ toShelleyCoin coin
@@ -633,13 +546,16 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
             getRewardMap =
                 fromJustRewards . Map.lookup (Left coin)
 
-    _watchNodeTip nodeTipChan cb = do
-        chan <- dupChan nodeTipChan
+    _watchNodeTip readNodeEraAndTip cb = do
         let toBlockHeader = fromTip getGenesisBlockHash
-        forever $ do
-            header <- toBlockHeader . snd <$> readChan chan
-            bracketTracer (contramap (MsgWatcherUpdate header) tr) $
-                cb header
+        let go oldTip = do
+                tip <- atomically $ do
+                    tip <- readNodeEraAndTip
+                    guard (oldTip /= tip)
+                    return tip
+                cb (toBlockHeader . snd $ tip)
+                go tip
+        go (AnyCardanoEra ByronEra, TipGenesis )
 
     -- TODO(#2042): Make wallets call manually, with matching
     -- stopObserving.
@@ -720,14 +636,15 @@ mkWalletClient tr cfg gp chainSyncQ = do
 -- | Construct a network client with the given communication channel, for the
 -- purposes of querying delegations and rewards.
 mkDelegationRewardsClient
-    :: forall m. (MonadThrow m, MonadST m, MonadTimer m)
+    :: forall m. (MonadThrow m, MonadST m, MonadTimer m, MonadIO m)
     => Tracer m NetworkLayerLog
         -- ^ Base trace for underlying protocols
+    -> STM m (AnyCardanoEra, Point (CardanoBlock StandardCrypto))
     -> CodecConfig (CardanoBlock StandardCrypto)
     -> TQueue m (LocalStateQueryCmd (CardanoBlock StandardCrypto) m)
         -- ^ Communication channel with the LocalStateQuery client
     -> NetworkClient m
-mkDelegationRewardsClient tr cfg queryRewardQ =
+mkDelegationRewardsClient tr readNodeTip cfg queryRewardQ =
     nodeToClientProtocols (const $ return $ NodeToClientProtocols
         { localChainSyncProtocol =
             doNothingProtocol
@@ -739,7 +656,7 @@ mkDelegationRewardsClient tr cfg queryRewardQ =
             InitiatorProtocolOnly $ MuxPeerRaw
                 $ \channel -> runPeer tr' codec channel
                 $ localStateQueryClientPeer
-                $ localStateQuery queryRewardQ
+                $ localStateQuery readNodeTip queryRewardQ
         })
         nodeToClientVersion
   where
@@ -801,121 +718,45 @@ mkTipSyncClient
             (CardanoApplyTxErr StandardCrypto)
             m)
         -- ^ Communication channel with the LocalTxSubmission client
-    -> ((Maybe AnyCardanoEra, Tip (CardanoBlock StandardCrypto)) -> m ())
-        -- ^ Notifier callback for when tip changes
     -> (W.ProtocolParameters -> W.SlottingParameters -> m ())
         -- ^ Notifier callback for when parameters for tip change.
     -> (CardanoInterpreter StandardCrypto -> m ())
         -- ^ Notifier callback for when time interpreter is updated.
-    -> m (NetworkClient m)
-mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onPParamsUpdate onInterpreterUpdate = do
-    localStateQueryQ <- atomically newTQueue
+    -> m (NetworkClient m, STM m (AnyCardanoEra, Tip (CardanoBlock StandardCrypto)))
+mkTipSyncClient tr np localTxSubmissionQ onPParamsUpdate onInterpreterUpdate = do
+    (localStateQueryQ :: TQueue m (LocalStateQueryCmd (CardanoBlock StandardCrypto) m))
+        <- atomically newTQueue
+
+    tipVar <- atomically $ newTVar (AnyCardanoEra ByronEra, TipGenesis)
 
     (onPParamsUpdate' :: (W.ProtocolParameters, W.SlottingParameters) -> m ()) <-
         debounce $ \(pp, sp) -> do
             traceWith tr $ MsgProtocolParameters pp sp
             onPParamsUpdate pp sp
 
-    let
-        queryLocalState
-            :: Maybe AnyCardanoEra
-            -> Point (CardanoBlock StandardCrypto)
-            -> m ()
-        queryLocalState Nothing    __ = return ()
-        queryLocalState (Just era) pt = do
-            mb <- bracketQuery "GetEraStart" tr $ localStateQueryQ `send`
-                -- TODO: What should this code actually do? Return the most
-                -- recent hard-fork?
-                (case era of
-                    AnyCardanoEra ShelleyEra ->
-                        CmdQueryLocalState pt (QueryAnytimeShelley GetEraStart)
-                    _ ->
-                        CmdQueryLocalState pt (QueryAnytimeMary GetEraStart)
-                )
+    let queryParams = do
+            mb <- currentEra >>= \case
+                AnyCardanoEra ShelleyEra ->
+                    LSQry $ QueryAnytimeShelley GetEraStart
+                _ ->
+                    LSQry $ QueryAnytimeMary GetEraStart
+            sp <- byronOrShelleyBased
+                (pure $ W.slottingParameters np)
+                ((slottingParametersFromGenesis . getCompactGenesis)
+                    <$> LSQry Shelley.GetGenesisConfig)
+            pp <- byronOrShelleyBased
+                (protocolParametersFromUpdateState mb
+                    <$> LSQry Byron.GetUpdateInterfaceState)
+                (fromShelleyPParams mb
+                    <$> LSQry Shelley.GetCurrentPParams)
+            return (pp, sp)
 
-            (sp :: Either AcquireFailure (Either (MismatchEraInfo (CardanoEras StandardCrypto)) W.SlottingParameters)) <- case era of
-                AnyCardanoEra ByronEra ->
-                    pure $ pure $ pure $ W.slottingParameters np
+    let queryInterpreter = LSQry (QueryHardFork GetInterpreter)
 
-                AnyCardanoEra ShelleyEra -> do
-                    let cmd = CmdQueryLocalState pt (QueryIfCurrentShelley Shelley.GetGenesisConfig)
-                    gp <- bracketQuery "GetGenesisParams" tr $ localStateQueryQ `send` cmd
-                    pure (fmap (slottingParametersFromGenesis . getCompactGenesis) <$> gp)
-
-                AnyCardanoEra AllegraEra -> do
-                    let cmd = CmdQueryLocalState pt (QueryIfCurrentAllegra Shelley.GetGenesisConfig)
-                    gp <- bracketQuery "GetGenesisParams" tr $ localStateQueryQ `send` cmd
-                    pure (fmap (slottingParametersFromGenesis . getCompactGenesis) <$> gp)
-
-                AnyCardanoEra MaryEra -> do
-                    let cmd = CmdQueryLocalState pt (QueryIfCurrentMary Shelley.GetGenesisConfig)
-                    gp <- bracketQuery "GetGenesisParams" tr $ localStateQueryQ `send` cmd
-                    pure (fmap (slottingParametersFromGenesis . getCompactGenesis) <$> gp)
-
-            case era of
-                AnyCardanoEra ByronEra -> do
-                    st <- bracketQuery "GetUpdateInterfaceState" tr $ localStateQueryQ `send`
-                        CmdQueryLocalState pt (QueryIfCurrentByron Byron.GetUpdateInterfaceState)
-                    sequence (handleParamsUpdate protocolParametersFromUpdateState <$> mb <*> st <*> sp)
-                        >>= handleAcquireFailure
-
-                AnyCardanoEra ShelleyEra -> do
-                    pp <- bracketQuery "GetCurrentPParams" tr $ localStateQueryQ `send`
-                        (CmdQueryLocalState pt (QueryIfCurrentShelley Shelley.GetCurrentPParams))
-                    sequence (handleParamsUpdate fromShelleyPParams <$> mb <*> pp <*> sp)
-                        >>= handleAcquireFailure
-                AnyCardanoEra AllegraEra -> do
-                    pp <- bracketQuery "GetCurrentPParams" tr $ localStateQueryQ `send`
-                        (CmdQueryLocalState pt (QueryIfCurrentAllegra Shelley.GetCurrentPParams))
-                    sequence (handleParamsUpdate fromShelleyPParams <$> mb <*> pp <*> sp)
-                        >>= handleAcquireFailure
-                AnyCardanoEra MaryEra -> do
-                    pp <- bracketQuery "GetCurrentPParams" tr $ localStateQueryQ `send`
-                        (CmdQueryLocalState pt (QueryIfCurrentMary Shelley.GetCurrentPParams))
-                    sequence (handleParamsUpdate fromShelleyPParams <$> mb <*> pp <*> sp)
-                        >>= handleAcquireFailure
-
-        handleAcquireFailure
-            :: Either AcquireFailure ()
-            -> m ()
-        handleAcquireFailure = \case
-            Right () ->
-                pure ()
-            Left e ->
-                traceWith tr $ MsgLocalStateQueryError TipSyncClient $ show e
-
-        handleParamsUpdate
-            :: (Maybe Bound -> p -> W.ProtocolParameters)
-            -> (Maybe Bound)
-            -> (Either (MismatchEraInfo (CardanoEras StandardCrypto)) p)
-            -> (Either (MismatchEraInfo (CardanoEras StandardCrypto)) W.SlottingParameters)
-            -> m ()
-        handleParamsUpdate convert boundM epp esp = case (epp, esp) of
-            (Right pp, Right sp) -> do
-                onPParamsUpdate' (convert boundM pp, sp)
-
-            (Left mismatch, _) ->
-                traceWith tr $ MsgLocalStateQueryEraMismatch mismatch
-
-            (_, Left mismatch) ->
-                traceWith tr $ MsgLocalStateQueryEraMismatch mismatch
-
-        queryInterpreter
-            :: Point (CardanoBlock StandardCrypto)
-            -> m ()
-        queryInterpreter pt = do
-            res <- localStateQueryQ `send` CmdQueryLocalState pt (QueryHardFork GetInterpreter)
-            case res of
-                Left (e :: AcquireFailure) ->
-                    traceWith tr $ MsgLocalStateQueryError TipSyncClient $ show e
-                Right interpreter -> do
-                    traceWith tr $ MsgInterpreter interpreter
-                    onInterpreterUpdate interpreter
-
-        W.GenesisParameters
+    let W.GenesisParameters
              { getGenesisBlockHash
              } = W.genesisParameters np
-        cfg = codecConfig (W.slottingParameters np)
+    let cfg = codecConfig (W.slottingParameters np)
 
     onTipUpdate' <- debounce @_ @m $ \(era, tip') -> do
         -- FIXME: Store / replace / keep track of the era and make it available
@@ -923,43 +764,50 @@ mkTipSyncClient tr np localTxSubmissionQ onTipUpdate onPParamsUpdate onInterpret
         let tip = castTip tip'
         traceWith tr $ MsgNodeTip $
             fromTip getGenesisBlockHash tip
-        onTipUpdate (era, tip)
-        queryLocalState era (getTipPoint tip)
-        -- NOTE: interpeter is updated every block. This is far more often than
+
+        atomically $ writeTVar tipVar (era, tip)
+
+        -- NOTE: If these queries are not sent with sendAsync, we'd cause
+        -- deadlock, as the local state query client might need to waiy for the
+        -- tip client to find a new tip.
+        --
+        -- NOTE 2: interpeter is updated every block. This is far more often than
         -- necessary.
-        queryInterpreter (getTipPoint tip)
+        sendAsync localStateQueryQ $ SomeLSQ queryParams onPParamsUpdate'
+        sendAsync localStateQueryQ $ SomeLSQ queryInterpreter onInterpreterUpdate
 
-    pure $ nodeToClientProtocols (const $ return $ NodeToClientProtocols
-        { localChainSyncProtocol =
-            let
-                codec = cChainSyncCodec $ codecs cfg
-            in
-            InitiatorProtocolOnly $ MuxPeerRaw
-                $ \channel -> runPeer nullTracer codec channel
-                $ chainSyncClientPeer
-                $ chainSyncFollowTip toCardanoEra (curry onTipUpdate')
+    let client = nodeToClientProtocols (const $ return $ NodeToClientProtocols
+            { localChainSyncProtocol =
+                let
+                    codec = cChainSyncCodec $ codecs cfg
+                in
+                InitiatorProtocolOnly $ MuxPeerRaw
+                    $ \channel -> runPeer nullTracer codec channel
+                    $ chainSyncClientPeer
+                    $ chainSyncFollowTip toCardanoEra (curry onTipUpdate')
 
-        , localTxSubmissionProtocol =
-            let
-                tr' = contramap MsgTxSubmission tr
-                codec = cTxSubmissionCodec $ serialisedCodecs cfg
-            in
-            InitiatorProtocolOnly $ MuxPeerRaw
-                $ \channel -> runPeer tr' codec channel
-                $ localTxSubmissionClientPeer
-                $ localTxSubmission localTxSubmissionQ
+            , localTxSubmissionProtocol =
+                let
+                    tr' = contramap MsgTxSubmission tr
+                    codec = cTxSubmissionCodec $ serialisedCodecs cfg
+                in
+                InitiatorProtocolOnly $ MuxPeerRaw
+                    $ \channel -> runPeer tr' codec channel
+                    $ localTxSubmissionClientPeer
+                    $ localTxSubmission localTxSubmissionQ
 
-        , localStateQueryProtocol =
-            let
-                tr' = contramap (MsgLocalStateQuery TipSyncClient) tr
-                codec = cStateQueryCodec $ serialisedCodecs cfg
-            in
-            InitiatorProtocolOnly $ MuxPeerRaw
-                $ \channel -> runPeer tr' codec channel
-                $ localStateQueryClientPeer
-                $ localStateQuery localStateQueryQ
-        })
-        nodeToClientVersion
+            , localStateQueryProtocol =
+                let
+                    tr' = contramap (MsgLocalStateQuery TipSyncClient) tr
+                    codec = cStateQueryCodec $ serialisedCodecs cfg
+                in
+                InitiatorProtocolOnly $ MuxPeerRaw
+                    $ \channel -> runPeer tr' codec channel
+                    $ localStateQueryClientPeer
+                    $ localStateQuery (second getTipPoint <$> (readTVar tipVar)) localStateQueryQ
+            })
+            nodeToClientVersion
+    return (client, readTVar tipVar)
 
 -- Reward Account Balances
 
@@ -992,65 +840,33 @@ newRewardBalanceFetcher tr gp queryRewardQ =
         :: (AnyCardanoEra, Tip (CardanoBlock StandardCrypto))
         -> Set W.RewardAccount
         -> IO (Maybe (Map W.RewardAccount W.Coin))
-    fetch (era, tip) accounts = do
+    fetch (_era, tip) accounts = do
         liftIO $ traceWith tr $
             MsgGetRewardAccountBalance (fromTip' gp tip) accounts
-        case era of
-            AnyCardanoEra ByronEra -> do
-                return (Just defaultValue)
-            AnyCardanoEra ShelleyEra -> do
-                let creds = Set.map toStakeCredential accounts
-                let q = QueryIfCurrentShelley (Shelley.GetFilteredDelegationsAndRewardAccounts creds)
-                let cmd = CmdQueryLocalState (getTipPoint tip) q
-                res <- bracketQuery queryName tr (queryRewardQ `send` cmd)
-                handleBalanceResult defaultValue res
-            AnyCardanoEra AllegraEra -> do
-                let creds = Set.map toStakeCredential accounts
-                let q = QueryIfCurrentAllegra (Shelley.GetFilteredDelegationsAndRewardAccounts creds)
-                let cmd = CmdQueryLocalState (getTipPoint tip) q
-                res <- bracketQuery queryName tr (queryRewardQ `send` cmd)
-                handleBalanceResult defaultValue res
-            AnyCardanoEra MaryEra -> do
-                let creds = Set.map toStakeCredential accounts
-                let q = QueryIfCurrentMary (Shelley.GetFilteredDelegationsAndRewardAccounts creds)
-                let cmd = CmdQueryLocalState (getTipPoint tip) q
-                res <- bracketQuery queryName tr (queryRewardQ `send` cmd)
-                handleBalanceResult defaultValue res
+
+        let qry = byronOrShelleyBased
+                (pure defaultValue)
+                (fromBalanceResult <$>
+                    LSQry (Shelley.GetFilteredDelegationsAndRewardAccounts
+                        $ Set.map toStakeCredential accounts))
+
+        -- FIXME: Re-add trace
+        --liftIO $ traceWith tr $ MsgAccountDelegationAndRewards deleg rewardAccounts
+        Just <$> bracketQuery "queryRewards" tr (send queryRewardQ (SomeLSQ qry))
+
       where
         defaultValue :: Map W.RewardAccount W.Coin
         defaultValue = Map.fromList . map (, minBound) $ Set.toList accounts
 
-        queryName :: String
-        queryName = "getAccountBalance"
-
-    handleBalanceResult
-        :: Map W.RewardAccount W.Coin
-        -> Either AcquireFailure
-            (Either
-                ( MismatchEraInfo (CardanoEras StandardCrypto))
-                ( Map (SL.Credential 'SL.Staking crypto)
-                     (SL.KeyHash 'SL.StakePool StandardCrypto)
-                , SL.RewardAccounts crypto
-                )
+    fromBalanceResult
+        :: ( Map (SL.Credential 'SL.Staking crypto)
+                 (SL.KeyHash 'SL.StakePool crypto)
+            , SL.RewardAccounts crypto
             )
-        -> IO (Maybe (Map W.RewardAccount W.Coin))
-    handleBalanceResult defaultValue = \case
-        Right (Right (deleg, rewardAccounts)) -> do
-            liftIO $ traceWith tr $ MsgAccountDelegationAndRewards deleg rewardAccounts
-            let convert = Map.mapKeys fromStakeCredential . Map.map fromShelleyCoin
-            return $ Just $ convert rewardAccounts
-
-        Right (Left mismatch) -> do
-            liftIO $ traceWith tr $ MsgLocalStateQueryEraMismatch mismatch
-            return (Just defaultValue)
-
-        Left acqFail -> do
-            -- NOTE: this could possibly happen in rare circumstances when
-            -- the chain is switched and the local state query is made
-            -- before the node tip variable is updated.
-            let msg = MsgLocalStateQueryError DelegationRewardsClient $ show acqFail
-            liftIO $ traceWith tr msg
-            return Nothing
+        -> Map W.RewardAccount W.Coin
+    fromBalanceResult (_deleg, rewardAccounts) =
+        Map.mapKeys fromStakeCredential $
+            Map.map fromShelleyCoin rewardAccounts
 
 data ObserverLog key value
     = MsgWillFetch (Set key)
@@ -1458,3 +1274,42 @@ instance HasSeverityAnnotation NetworkLayerLog where
             | otherwise                    -> Debug
         MsgInterpreterLog msg              -> getSeverityAnnotation msg
         MsgObserverLog{}                   -> Debug
+
+--
+-- LSQ Helpers
+--
+
+-- Create a local state query specific to the current era — either Byron or one
+-- of the Shelley-based eras (Shelley, Allegra, Mary).
+--
+-- This combinator treats @MismatchEraInfo@ as impossible, which is true if the
+-- @LSQEra@ value the @LSQ@ interpreter uses always matches the era of the
+-- acquired point.
+byronOrShelleyBased
+    :: LSQ Byron.ByronBlock m a
+    -> (forall shelleyEra. LSQ (Shelley.ShelleyBlock (shelleyEra StandardCrypto)) m a)
+    -> LSQ (CardanoBlock StandardCrypto) m a
+byronOrShelleyBased onByron onShelleyBased = currentEra >>= \case
+    AnyCardanoEra ByronEra -> mapQuery QueryIfCurrentByron onByron
+    AnyCardanoEra ShelleyEra -> mapQuery QueryIfCurrentShelley onShelleyBased
+    AnyCardanoEra AllegraEra -> mapQuery QueryIfCurrentAllegra onShelleyBased
+    AnyCardanoEra MaryEra -> mapQuery QueryIfCurrentMary onShelleyBased
+  where
+    mapQuery
+        :: (forall r. Query block1 r -> Query block2 ((Either (MismatchEraInfo (CardanoEras StandardCrypto))) r))
+        -> LSQ block1 m a
+        -> LSQ block2 m a
+    mapQuery _ (LSQPure x) = LSQPure x
+    mapQuery f (LSQBind ma f') = LSQBind (mapQuery f ma) (mapQuery f . f')
+    mapQuery f (LSQry q) = unwrap <$> LSQry (f q)
+    mapQuery _ LSQEra = LSQEra
+
+    unwrap = either (error "impossible: byronOrShelleyBased query resulted in an \
+        \era mismatch") id
+
+shelleyBased
+    :: (forall shelleyEra. LSQ (Shelley.ShelleyBlock (shelleyEra StandardCrypto)) m a)
+    -> LSQ (CardanoBlock StandardCrypto) m (Maybe a)
+shelleyBased onShelleyBased = byronOrShelleyBased
+    (pure Nothing) -- on byron
+    (Just <$> onShelleyBased)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -544,7 +544,8 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
                     tip <- readNodeEraAndTip
                     guard (oldTip /= tip)
                     return tip
-                cb (toBlockHeader . snd $ tip)
+                let header = toBlockHeader . snd $ tip
+                bracketTracer (contramap (MsgWatcherUpdate header) tr) $ cb header
                 go tip
         go (Just $ AnyCardanoEra ByronEra, TipGenesis )
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -270,9 +270,8 @@ newStakePoolLayer gcStatus nl db@DBLayer {..} restartSyncThread = do
         -> Coin
         -> ExceptT ErrListPools IO [Api.ApiStakePool]
     _listPools currentEpoch userStake = do
-        tip <- liftIO $ currentNodeTip nl
         rawLsqData <- mapExceptT (fmap (first ErrListPoolsQueryFailed))
-            $ stakeDistribution nl tip userStake
+            $ stakeDistribution nl userStake
         let lsqData = combineLsqData rawLsqData
         dbData <- liftIO $ readPoolDbData db currentEpoch
         seed <- liftIO $ atomically readSystemSeed


### PR DESCRIPTION
# Issue Number

ADP-647, #2320

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->


# Overview

- [x] Allow `send`-ing a composition of queries against a single acquired point, not just one.
- [x] Makes acquire failures practically impossible
- [x] Re-add multi-era support with reduced boilerplate
- [x] Some polish still needed
- [x] Re-add tracing of query times (less granular than before, but done)

# Comments

Pretty sure this _is_
- eliminating acquire failures
- the right direction

But also
- Might introduce a new set of problems

<!-- Additional comments or screenshots to attach if any -->

## Failures

I have run tests locally a lot on this branch. One new failure I _occasionally_ see is
```
  src/Test/Integration/Framework/DSL.hs:1797:7:
  1) API Specifications, SHELLEY_STAKE_POOLS, STAKE_POOLS_JOIN_01rewards - Can join a pool, earn rewards and collect them
       expected a successful response but got an error: DecodeFailure "{\"code\":\"created_invalid_transaction\",\"message\":\"That's embarrassing. It looks like I've created an invalid transaction that could not be parsed by the node. Here's an error message that may help with debugging: HardForkApplyTxErrFromEra S (S (S (Z (WrapApplyTxErr {unwrapApplyTxErr = ApplyTxError [LedgerFailure (DelegsFailure (WithdrawalsNotInRewardsDELEGS (fromList [(RewardAcnt {getRwdNetwork = Mainnet, getRwdCred = KeyHashObj (KeyHash \\\"9c0ff007dd21bbf24960bd12ae4009efb8cad076228ef1a54c7b5dbe\\\")},Coin 7010064794)])))]}))))\"}"
       While verifying (Status {statusCode = 500, statusMessage = "Internal Server Error"},Left (DecodeFailure "{\"code\":\"created_invalid_transaction\",\"message\":\"That's embarrassing. It looks like I've created an invalid transaction that could not be parsed by the node. Here's an error message that may help with debugging: HardForkApplyTxErrFromEra S (S (S (Z (WrapApplyTxErr {unwrapApplyTxErr = ApplyTxError [LedgerFailure (DelegsFailure (WithdrawalsNotInRewardsDELEGS (fromList [(RewardAcnt {getRwdNetwork = Mainnet, getRwdCred = KeyHashObj (KeyHash \\\"9c0ff007dd21bbf24960bd12ae4009efb8cad076228ef1a54c7b5dbe\\\")},Coin 7010064794)])))]}))))\"}"))

  To rerun use: --match "/API Specifications/SHELLEY_STAKE_POOLS/STAKE_POOLS_JOIN_01rewards - Can join a pool, earn rewards and collect them/"
```
Important part is `WithdrawalsNotInRewardsDELEGS`. So seems we are not aware of the rewards having already been spent. Maybe this PR makes the rewards slower to update, somehow, not sure.

Edit: digging through my notes, I _have_ seen this failure on another branch — once. I think this PR makes it more likely to occur, but not be inherently related, then.