### PR TITLE
Multi-Asset Coin Selection

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,6 +9,7 @@ packages:
   , lib/core-integration/
   , lib/cli/
   , lib/launcher/
+  , lib/numeric/
   , lib/text-class/
   , lib/test-utils/
   , lib/shelley/
@@ -142,6 +143,9 @@ source-repository-package
 
 allow-older: *
 allow-newer: *
+
+package cardano-numeric
+    ghc-options: -ddump-to-file -ddump-hi
 
 package cardano-wallet-core
     ghc-options: -ddump-to-file -ddump-hi

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -40,6 +40,7 @@ library
     , cardano-addresses
     , cardano-api
     , cardano-crypto
+    , cardano-numeric
     , cardano-slotting
     , cborg
     , containers
@@ -168,6 +169,7 @@ library
       Cardano.Wallet.Primitive.CoinSelection
       Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.CoinSelection.LargestFirst
+      Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
       Cardano.Wallet.Primitive.CoinSelection.Migration
       Cardano.Wallet.Primitive.CoinSelection.Random
       Cardano.Wallet.Primitive.Fee
@@ -348,6 +350,7 @@ test-suite unit
       Cardano.Wallet.Primitive.AddressDiscovery.SequentialSpec
       Cardano.Wallet.Primitive.AddressDiscoverySpec
       Cardano.Wallet.Primitive.CoinSelection.LargestFirstSpec
+      Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec
       Cardano.Wallet.Primitive.CoinSelection.MigrationSpec
       Cardano.Wallet.Primitive.CoinSelection.RandomSpec
       Cardano.Wallet.Primitive.CoinSelectionSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
+    (
+    -- * Making change
+      makeChange
+    , makeChangeForCoin
+    , makeChangeForPaymentAssets
+    , makeChangeForSurplusAssets
+
+    -- * Partitioning
+    , partitionCoin
+    , partitionTokenQuantity
+    , partitionValue
+
+    -- * Grouping and ungrouping
+    , groupByKey
+    , ungroupByKey
+
+    ) where
+
+import Prelude
+
+import Algebra.PartialOrd
+    ( PartialOrd (..) )
+import Cardano.Numeric.Util
+    ( padCoalesce, partitionNatural )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId, TokenMap )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Data.Generics.Labels
+    ()
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Map.Strict
+    ( Map )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Set
+    ( Set )
+import GHC.Stack
+    ( HasCallStack )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+--------------------------------------------------------------------------------
+-- Making change
+--------------------------------------------------------------------------------
+
+makeChange
+    :: NonEmpty TokenBundle
+        -- ^ Token bundles of selected inputs
+    -> NonEmpty TokenBundle
+        -- ^ Token bundles of original outputs
+    -> NonEmpty TokenBundle
+        -- ^ Change bundles
+makeChange inputBundles outputBundles
+    | not (totalOutputValue `leq` totalInputValue) =
+        totalInputValueInsufficient
+    | totalOutputCoinValue == Coin 0 =
+        totalOutputCoinValueIsZero
+    | otherwise =
+        change
+  where
+    totalInputValueInsufficient = error
+        "makeChange: not (totalOutputValue <= totalInputValue)"
+    totalOutputCoinValueIsZero = error
+        "makeChange: not (totalOutputCoinValue > 0)"
+
+    totalInputValue :: TokenBundle
+    totalInputValue = F.fold inputBundles
+
+    totalOutputValue :: TokenBundle
+    totalOutputValue = F.fold outputBundles
+
+    totalOutputCoinValue :: Coin
+    totalOutputCoinValue = TokenBundle.getCoin totalOutputValue
+
+    excess :: TokenBundle
+    excess =
+        -- The following subtraction is safe, as we have already checked that
+        -- the total input value is greater than the total output value:
+        totalInputValue `TokenBundle.unsafeSubtract` totalOutputValue
+
+    change :: NonEmpty TokenBundle
+    change
+        = TokenBundle.fromCoin <$> changeForCoin
+        & NE.zipWith (<>) (TokenBundle.fromTokenMap <$> changeForPaymentAssets)
+        -- Here we sort in ascending order of coin value so that surplus assets
+        -- and coin values are in increasing order in the resulting bundles:
+        & NE.sortWith TokenBundle.getCoin
+        & NE.zipWith (<>) (TokenBundle.fromTokenMap <$> changeForSurplusAssets)
+
+    -- Change for the excess coin quantity.
+    changeForCoin :: NonEmpty Coin
+    changeForCoin = makeChangeForCoin
+        (TokenBundle.getCoin excess)
+        (TokenBundle.getCoin <$> outputBundles)
+
+    -- Change for excess quantities of assets included in outputs.
+    changeForPaymentAssets :: NonEmpty TokenMap
+    changeForPaymentAssets = makeChangeForPaymentAssets
+        (TokenMap.filter (`Set.member` paymentAssetIds) (view #tokens excess))
+        (view #tokens <$> outputBundles)
+
+    -- Change for excess quantities of assets NOT included in outputs.
+    changeForSurplusAssets :: NonEmpty TokenMap
+    changeForSurplusAssets =
+        makeChangeForSurplusAssets surplusAssetsGrouped outputBundles
+      where
+        surplusAssetsGrouped :: Map AssetId (NonEmpty TokenQuantity)
+        surplusAssetsGrouped = groupByKey surplusAssets
+
+        surplusAssets :: [(AssetId, TokenQuantity)]
+        surplusAssets = filter
+            ((`Set.notMember` paymentAssetIds) . fst)
+            (TokenMap.toFlatList . view #tokens =<< NE.toList inputBundles)
+
+    -- Identifiers of assets included in outputs.
+    paymentAssetIds :: Set AssetId
+    paymentAssetIds = TokenBundle.getAssets totalOutputValue
+
+-- | Makes change for the excess quantity of ada.
+--
+makeChangeForCoin
+    :: HasCallStack
+    => Coin
+    -> NonEmpty Coin
+    -> NonEmpty Coin
+makeChangeForCoin = partitionCoin
+
+-- | Makes change for excess quantities of assets included in the outputs.
+--
+makeChangeForPaymentAssets
+    :: HasCallStack
+    => TokenMap
+        -- ^ Excess to be distributed
+    -> NonEmpty TokenMap
+        -- ^ Maps from original outputs
+    -> NonEmpty TokenMap
+        -- ^ Change maps
+makeChangeForPaymentAssets excess outputMaps =
+    F.foldl'
+        (NE.zipWith (<>))
+        (TokenMap.empty <$ outputMaps)
+        (changeForAsset <$> assetsToConsider)
+  where
+    assetsToConsider :: [AssetId]
+    assetsToConsider = F.toList $ TokenMap.getAssets excess
+
+    changeForAsset :: AssetId -> NonEmpty TokenMap
+    changeForAsset asset = TokenMap.singleton asset <$>
+        partitionTokenQuantity
+            (TokenMap.getQuantity excess asset)
+            (flip TokenMap.getQuantity asset <$> outputMaps)
+
+-- | Makes change for excess quantities of assets NOT included in the outputs.
+--
+-- Distributes quantities to a number of token maps, where the number of token
+-- maps to create is equal to the length of the target list.
+--
+-- If a given asset has fewer quantities than the target length, each of these
+-- quantities will be distributed without modification to a separate token map.
+--
+-- If a given asset has more quantities than the target length, the smallest of
+-- these quantities will be repeatedly coalesced together before distributing
+-- them to token maps.
+--
+-- This function guarantees that:
+--
+--    - The total value of each asset is preserved.
+--
+--    - The resulting list of token maps is sorted in ascending order, so that
+--      each token map in the list is less than or equal to its immediate
+--      successor, when compared with the 'PartialOrder.leq' function.
+--
+-- Examples (shown with pseudo-code):
+--
+-- >>> makeChangeForSurplusAssets [("A", [1, 2])] [1]
+-- [ TokenMap [("A", 3)] ]
+--
+-- >>> makeChangeForSurplusAssets [("A", [1, 2])] [1 .. 3]
+-- [ TokenMap [        ]
+-- , TokenMap [("A", 1)]
+-- , TokenMap [("A", 2)]
+-- ]
+--
+-- >>> makeChangeForSurplusAssets [("A", [1]), ("B", [2, 3, 4])] [1 .. 2]
+-- [ TokenMap [          ("B", 4)]
+-- , TokenMap [("A", 1), ("B", 5)]
+-- ]
+--
+makeChangeForSurplusAssets
+    :: Map AssetId (NonEmpty TokenQuantity)
+    -- ^ Asset quantities
+    -> NonEmpty a
+    -- ^ Target list (denotes the desired length of the result)
+    -> NonEmpty TokenMap
+makeChangeForSurplusAssets assetQuantities target =
+    F.foldl'
+        (NE.zipWith (<>))
+        (TokenMap.empty <$ target)
+        (Map.mapWithKey distribute assetQuantities)
+  where
+    distribute :: AssetId -> NonEmpty TokenQuantity -> NonEmpty TokenMap
+    distribute asset quantities =
+        TokenMap.singleton asset <$> padCoalesce quantities target
+
+--------------------------------------------------------------------------------
+-- Partitioning
+--------------------------------------------------------------------------------
+
+partitionCoin
+    :: HasCallStack
+    => Coin
+        -- ^ Target
+    -> NonEmpty Coin
+        -- ^ Weights
+    -> NonEmpty Coin
+partitionCoin = partitionValue coinToNatural naturalToCoin
+  where
+    -- This conversion is safe, because 'partitionValue' guarantees to produce
+    -- a list where every entry is less than or equal to the target value.
+    naturalToCoin :: Natural -> Coin
+    naturalToCoin = Coin . fromIntegral
+
+    coinToNatural :: Coin -> Natural
+    coinToNatural = fromIntegral . unCoin
+
+partitionTokenQuantity
+    :: HasCallStack
+    => TokenQuantity
+        -- ^ Target
+    -> NonEmpty TokenQuantity
+        -- ^ Weights
+    -> NonEmpty TokenQuantity
+partitionTokenQuantity = partitionValue unTokenQuantity TokenQuantity
+
+partitionValue
+    :: forall a. HasCallStack
+    => (a -> Natural) -> (Natural -> a)
+    -> a
+    -> NonEmpty a
+    -> NonEmpty a
+partitionValue toNatural fromNatural target weights =
+    fromMaybe zeroWeightSum maybeResult
+  where
+    maybeResult :: Maybe (NonEmpty a)
+    maybeResult =
+        fmap fromNatural <$> partitionNatural
+            (toNatural target)
+            (toNatural <$> weights)
+    zeroWeightSum = error
+        "partitionValue: The specified weights must have a non-zero sum."
+
+--------------------------------------------------------------------------------
+-- Grouping and ungrouping
+--------------------------------------------------------------------------------
+
+groupByKey :: forall k v. Ord k => [(k, v)] -> Map k (NonEmpty v)
+groupByKey = F.foldl' acc mempty
+  where
+    acc :: Map k (NonEmpty v) -> (k, v) -> Map k (NonEmpty v)
+    acc m (k, v) = Map.alter (Just . maybe (v :| []) (NE.cons v)) k m
+
+ungroupByKey :: forall k v. Map k (NonEmpty v) -> [(k, v)]
+ungroupByKey m = [(k, v) | (k, vs) <- Map.toList m, v <- NE.toList vs]

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -5,6 +5,16 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
+-- Provides an implementation of the Random-Round-Robin coin selection
+-- algorithm for multi-asset UTxO sets.
+--
+-- See documentation for the 'performSelection' function for more details on
+-- how to perform a selection.
+--
 module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     (
     -- * Performing a selection

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -24,6 +24,8 @@ module Cardano.Wallet.Primitive.Types.TokenBundle
     , empty
     , fromFlatList
     , fromNestedList
+    , fromTokenMap
+    , fromTokenQuantity
 
     -- * Deconstruction
     , toFlatList
@@ -193,6 +195,12 @@ fromNestedList
     -> [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
     -> TokenBundle
 fromNestedList c = TokenBundle c . TokenMap.fromNestedList
+
+fromTokenMap :: TokenMap -> TokenBundle
+fromTokenMap = TokenBundle (Coin 0)
+
+fromTokenQuantity :: AssetId -> TokenQuantity -> TokenBundle
+fromTokenQuantity a q = TokenBundle (Coin 0) (TokenMap.singleton a q)
 
 --------------------------------------------------------------------------------
 -- Deconstruction

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -6,7 +6,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinSmall, shrinkCoinSmall )
+    ( genCoinSmallPositive, shrinkCoinSmallPositive )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
@@ -22,11 +22,11 @@ import Test.QuickCheck.Extra
 
 genTokenBundleSmallRange :: Gen TokenBundle
 genTokenBundleSmallRange = TokenBundle
-    <$> genCoinSmall
+    <$> genCoinSmallPositive
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRange (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
-        (c, shrinkCoinSmall)
+        (c, shrinkCoinSmallPositive)
         (m, shrinkTokenMapSmallRange)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -1,12 +1,18 @@
 module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange
+    , genTokenBundleSmallRangePositive
     , shrinkTokenBundleSmallRange
+    , shrinkTokenBundleSmallRangePositive
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinSmallPositive, shrinkCoinSmallPositive )
+    ( genCoinSmall
+    , genCoinSmallPositive
+    , shrinkCoinSmall
+    , shrinkCoinSmallPositive
+    )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
@@ -22,11 +28,22 @@ import Test.QuickCheck.Extra
 
 genTokenBundleSmallRange :: Gen TokenBundle
 genTokenBundleSmallRange = TokenBundle
-    <$> genCoinSmallPositive
+    <$> genCoinSmall
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRange (TokenBundle c m) =
+    uncurry TokenBundle <$> shrinkInterleaved
+        (c, shrinkCoinSmall)
+        (m, shrinkTokenMapSmallRange)
+
+genTokenBundleSmallRangePositive :: Gen TokenBundle
+genTokenBundleSmallRangePositive = TokenBundle
+    <$> genCoinSmallPositive
+    <*> genTokenMapSmallRange
+
+shrinkTokenBundleSmallRangePositive :: TokenBundle -> [TokenBundle]
+shrinkTokenBundleSmallRangePositive (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
         (c, shrinkCoinSmallPositive)
         (m, shrinkTokenMapSmallRange)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -49,6 +49,9 @@ module Cardano.Wallet.Primitive.Types.TokenMap
     , toFlatList
     , toNestedList
 
+    -- * Filtering
+    , filter
+
     -- * Arithmetic
     , add
     , subtract
@@ -80,7 +83,7 @@ module Cardano.Wallet.Primitive.Types.TokenMap
     ) where
 
 import Prelude hiding
-    ( subtract )
+    ( filter, subtract )
 
 import Algebra.PartialOrd
     ( PartialOrd (..) )
@@ -124,6 +127,7 @@ import Quiet
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Data.Aeson as Aeson
 import qualified Data.Foldable as F
+import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.Map.Strict.NonEmptyMap as NEMap
@@ -459,6 +463,13 @@ toNestedList
     :: TokenMap -> [(TokenPolicyId, NonEmpty (TokenName, TokenQuantity))]
 toNestedList =
     fmap (fmap NEMap.toList) . Map.toList . unTokenMap
+
+--------------------------------------------------------------------------------
+-- Filtering
+--------------------------------------------------------------------------------
+
+filter :: (AssetId -> Bool) -> TokenMap -> TokenMap
+filter f = fromFlatList . L.filter (f . fst) . toFlatList
 
 --------------------------------------------------------------------------------
 -- Arithmetic

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -1,7 +1,9 @@
 module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenNameSmallRange
+    , genTokenNameMediumRange
     , genTokenPolicyIdSmallRange
     , shrinkTokenNameSmallRange
+    , shrinkTokenNameMediumRange
     , shrinkTokenPolicyIdSmallRange
     ) where
 
@@ -25,13 +27,27 @@ import qualified Data.Text as T
 --------------------------------------------------------------------------------
 
 genTokenNameSmallRange :: Gen TokenName
-genTokenNameSmallRange = elements tokenNames
+genTokenNameSmallRange = elements tokenNamesSmallRange
 
 shrinkTokenNameSmallRange :: TokenName -> [TokenName]
-shrinkTokenNameSmallRange name = filter (< name) tokenNames
+shrinkTokenNameSmallRange name = filter (< name) tokenNamesSmallRange
 
-tokenNames :: [TokenName]
-tokenNames = mkTokenName . ("Token" `T.snoc`) <$> ['A' .. 'D']
+tokenNamesSmallRange :: [TokenName]
+tokenNamesSmallRange = mkTokenName . ("Token" `T.snoc`) <$> ['A' .. 'D']
+
+--------------------------------------------------------------------------------
+-- Token names chosen from a medium-sized range (to minimize the risk of
+-- collisions)
+--------------------------------------------------------------------------------
+
+genTokenNameMediumRange :: Gen TokenName
+genTokenNameMediumRange = elements tokenNamesMediumRange
+
+shrinkTokenNameMediumRange :: TokenName -> [TokenName]
+shrinkTokenNameMediumRange name = filter (< name) tokenNamesMediumRange
+
+tokenNamesMediumRange :: [TokenName]
+tokenNamesMediumRange = mkTokenName . ("Token" `T.snoc`) <$> ['A' .. 'Z']
 
 --------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a small range (to allow collisions)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Gen.hs
@@ -1,5 +1,6 @@
 module Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndexSmall
+    , genUTxOIndexLarge
     , shrinkUTxOIndexSmall
     ) where
 
@@ -8,7 +9,8 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxInSmallRange
+    ( genTxInLargeRange
+    , genTxInSmallRange
     , genTxOutSmallRange
     , shrinkTxInSmallRange
     , shrinkTxOutSmallRange
@@ -23,6 +25,10 @@ import Test.QuickCheck.Extra
     ( shrinkInterleaved )
 
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+
+--------------------------------------------------------------------------------
+-- Small indices
+--------------------------------------------------------------------------------
 
 genUTxOIndexSmall :: Gen UTxOIndex
 genUTxOIndexSmall = do
@@ -49,3 +55,19 @@ shrinkEntrySmallRange :: (TxIn, TxOut) -> [(TxIn, TxOut)]
 shrinkEntrySmallRange (i, o) = uncurry (,) <$> shrinkInterleaved
     (i, shrinkTxInSmallRange)
     (o, shrinkTxOutSmallRange)
+
+--------------------------------------------------------------------------------
+-- Large indices
+--------------------------------------------------------------------------------
+
+genUTxOIndexLarge :: Gen UTxOIndex
+genUTxOIndexLarge = do
+    entryCount <- choose (1024, 4096)
+    UTxOIndex.fromSequence <$> replicateM entryCount genEntryLargeRange
+
+genEntryLargeRange :: Gen (TxIn, TxOut)
+genEntryLargeRange = (,)
+    <$> genTxInLargeRange
+    -- Note that we don't need to choose outputs from a large range, as inputs
+    -- are already chosen from a large range:
+    <*> genTxOutSmallRange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Algebra.PartialOrd
+    ( PartialOrd (..) )
+import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
+    ( groupByKey, makeChange, makeChangeForSurplusAssets, ungroupByKey )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
+    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..) )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genAssetIdSmallRange, shrinkAssetIdSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity )
+import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
+    ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
+import Control.Monad
+    ( replicateM )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Map.Strict
+    ( Map )
+import Safe
+    ( tailMay )
+import Test.Hspec
+    ( Spec, describe, it, parallel )
+import Test.Hspec.Core.QuickCheck
+    ( modifyMaxSuccess )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Property
+    , choose
+    , genericShrink
+    , property
+    , suchThat
+    , (===)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Data.Foldable as F
+import qualified Data.List as L
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+
+spec :: Spec
+spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
+
+    modifyMaxSuccess (const 1000) $ do
+
+    parallel $ describe "Making change" $ do
+
+        it "prop_makeChange_identity" $
+            property prop_makeChange_identity
+        it "prop_makeChange_length" $
+            property prop_makeChange_length
+        it "prop_makeChange_sum" $
+            property prop_makeChange_sum
+
+    parallel $ describe "Making change for surplus assets" $ do
+
+        it "prop_makeChangeForSurplusAssets_length" $
+            property prop_makeChangeForSurplusAssets_length
+        it "prop_makeChangeForSurplusAssets_sort" $
+            property prop_makeChangeForSurplusAssets_sort
+        it "prop_makeChangeForSurplusAssets_sum" $
+            property prop_makeChangeForSurplusAssets_sum
+
+    parallel $ describe "Grouping and ungrouping" $ do
+
+        it "prop_groupByKey_ungroupByKey" $
+            property $ prop_groupByKey_ungroupByKey @Int @Int
+        it "prop_ungroupByKey_groupByKey" $
+            property $ prop_ungroupByKey_groupByKey @Int @Int
+
+--------------------------------------------------------------------------------
+-- Making change
+--------------------------------------------------------------------------------
+
+data MakeChangeData = MakeChangeData
+    { inputBundles
+        :: NonEmpty TokenBundle
+    , outputBundles
+        :: NonEmpty TokenBundle
+    } deriving (Eq, Show)
+
+isValidMakeChangeData :: MakeChangeData -> Bool
+isValidMakeChangeData p = (&&)
+    (totalOutputValue `leq` totalInputValue)
+    (totalOutputCoinValue > Coin 0)
+  where
+    totalInputValue = F.fold $ inputBundles p
+    totalOutputValue = F.fold $ outputBundles p
+    totalOutputCoinValue = TokenBundle.getCoin totalOutputValue
+
+genMakeChangeData :: Gen MakeChangeData
+genMakeChangeData = flip suchThat isValidMakeChangeData $ do
+    outputBundleCount <- choose (0, 15)
+    let inputBundleCount = outputBundleCount * 4
+    MakeChangeData
+        <$> genTokenBundles inputBundleCount
+        <*> genTokenBundles outputBundleCount
+  where
+    genTokenBundles :: Int -> Gen (NonEmpty TokenBundle)
+    genTokenBundles count = (:|)
+        <$> genTokenBundleSmallRange
+        <*> replicateM count genTokenBundleSmallRange
+
+prop_makeChange_identity
+    :: NonEmpty TokenBundle -> Property
+prop_makeChange_identity bundles =
+    F.fold (makeChange bundles bundles) === TokenBundle.empty
+
+prop_makeChange_length
+    :: MakeChangeData -> Property
+prop_makeChange_length p = (===)
+    (length $ outputBundles p)
+    (length $ makeChange (inputBundles p) (outputBundles p))
+
+prop_makeChange_sum
+    :: MakeChangeData -> Property
+prop_makeChange_sum p =
+    totalInputValue === totalOutputValue <> totalChangeValue
+  where
+    change = makeChange (inputBundles p) (outputBundles p)
+    totalInputValue = F.fold $ inputBundles p
+    totalOutputValue = F.fold $ outputBundles p
+    totalChangeValue = F.fold change
+
+--------------------------------------------------------------------------------
+-- Making change for surplus assets
+--------------------------------------------------------------------------------
+
+prop_makeChangeForSurplusAssets_length
+    :: Map AssetId (NonEmpty TokenQuantity) -> NonEmpty () -> Property
+prop_makeChangeForSurplusAssets_length assetQuantities target =
+    NE.length (makeChangeForSurplusAssets assetQuantities target)
+        === NE.length target
+
+prop_makeChangeForSurplusAssets_sort
+    :: Map AssetId (NonEmpty TokenQuantity) -> NonEmpty () -> Property
+prop_makeChangeForSurplusAssets_sort assetQuantities target = property $
+    inAscendingPartialOrder (makeChangeForSurplusAssets assetQuantities target)
+
+prop_makeChangeForSurplusAssets_sum
+    :: Map AssetId (NonEmpty TokenQuantity) -> NonEmpty () -> Property
+prop_makeChangeForSurplusAssets_sum assetQuantities target =
+    sumActual === sumExpected
+  where
+    sumActual =
+        F.fold $ makeChangeForSurplusAssets assetQuantities target
+    sumExpected =
+        TokenMap.fromFlatList $ Map.toList $ F.fold <$> assetQuantities
+
+--------------------------------------------------------------------------------
+-- Grouping and ungrouping
+--------------------------------------------------------------------------------
+
+prop_groupByKey_ungroupByKey
+    :: forall k v. (Ord k, Ord v, Show k, Show v)
+    => [(k, v)]
+    -> Property
+prop_groupByKey_ungroupByKey kvs =
+    L.sort kvs === L.sort (ungroupByKey $ groupByKey kvs)
+
+prop_ungroupByKey_groupByKey
+    :: forall k v. (Ord k, Ord v, Show k, Show v)
+    => Map k (NonEmpty v)
+    -> Property
+prop_ungroupByKey_groupByKey kvs =
+    fmap NE.sort kvs === fmap NE.sort (groupByKey $ ungroupByKey kvs)
+
+--------------------------------------------------------------------------------
+-- Utility functions
+--------------------------------------------------------------------------------
+
+consecutivePairs :: [a] -> [(a, a)]
+consecutivePairs xs = case tailMay xs of
+    Nothing -> []
+    Just ys -> xs `zip` ys
+
+inAscendingPartialOrder :: (Foldable f, PartialOrd a) => f a -> Bool
+inAscendingPartialOrder = all (uncurry leq) . consecutivePairs . F.toList
+
+--------------------------------------------------------------------------------
+-- Arbitraries
+--------------------------------------------------------------------------------
+
+instance Arbitrary a => Arbitrary (NonEmpty a) where
+    arbitrary = (:|) <$> arbitrary <*> arbitrary
+    shrink = genericShrink
+
+instance Arbitrary AssetId where
+    arbitrary = genAssetIdSmallRange
+    shrink = shrinkAssetIdSmallRange
+
+instance Arbitrary MakeChangeData where
+    arbitrary = genMakeChangeData
+
+instance Arbitrary TokenBundle where
+    arbitrary = genTokenBundleSmallRange
+    shrink = shrinkTokenBundleSmallRange
+
+instance Arbitrary TokenQuantity where
+    arbitrary = genTokenQuantitySmallPositive
+    shrink = shrinkTokenQuantitySmallPositive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -11,7 +13,12 @@ import Prelude
 import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
-    ( groupByKey, makeChange, makeChangeForSurplusAssets, ungroupByKey )
+    ( groupByKey
+    , makeChange
+    , makeChangeForSurplusAssets
+    , runRoundRobin
+    , ungroupByKey
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -22,16 +29,28 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetIdSmallRange, shrinkAssetIdSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName )
+import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
+    ( genTokenNameMediumRange )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
 import Control.Monad
     ( replicateM )
+import Data.Function
+    ( (&) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
     ( Map )
+import Data.Set
+    ( Set )
+import Data.Tuple
+    ( swap )
+import Data.Word
+    ( Word8 )
 import Safe
     ( tailMay )
 import Test.Hspec
@@ -45,6 +64,7 @@ import Test.QuickCheck
     , choose
     , genericShrink
     , property
+    , shrinkList
     , suchThat
     , (===)
     )
@@ -55,6 +75,7 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 spec :: Spec
 spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
@@ -85,6 +106,19 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
             property $ prop_groupByKey_ungroupByKey @Int @Int
         it "prop_ungroupByKey_groupByKey" $
             property $ prop_ungroupByKey_groupByKey @Int @Int
+
+    parallel $ describe "Round-robin processing" $ do
+
+        it "prop_runRoundRobin_identity" $
+            property $ prop_runRoundRobin_identity @Int
+        it "prop_runRoundRobin_iterationCount" $
+            property $ prop_runRoundRobin_iterationCount @TokenName @Word8
+        it "prop_runRoundRobin_iterationOrder" $
+            property $ prop_runRoundRobin_iterationOrder @TokenName @Word8
+        it "prop_runRoundRobin_generationCount" $
+            property $ prop_runRoundRobin_generationCount @TokenName @Word8
+        it "prop_runRoundRobin_generationOrder" $
+            property $ prop_runRoundRobin_generationOrder @TokenName @Word8
 
 --------------------------------------------------------------------------------
 -- Making change
@@ -184,6 +218,129 @@ prop_ungroupByKey_groupByKey kvs =
     fmap NE.sort kvs === fmap NE.sort (groupByKey $ ungroupByKey kvs)
 
 --------------------------------------------------------------------------------
+-- Round-robin processing
+--------------------------------------------------------------------------------
+
+data MockRoundRobinState k n = MockRoundRobinState
+    { processorLifetimes :: Map k n
+    , accumulatedEntries :: [(k, n)]
+    } deriving (Eq, Show)
+
+genMockRoundRobinState
+    :: forall k n. Ord k => Gen k -> Gen n -> Gen (MockRoundRobinState k n)
+genMockRoundRobinState genKey genLifetime = do
+    processorCount <- choose (0, 16)
+    MockRoundRobinState
+        <$> genProcessorLifetimes processorCount
+        <*> pure []
+  where
+    genProcessorLifetimes :: Int -> Gen (Map k n)
+    genProcessorLifetimes processorCount =
+        Map.fromList <$> replicateM processorCount genProcessorLifetime
+
+    genProcessorLifetime :: Gen (k, n)
+    genProcessorLifetime = (,)
+        <$> genKey
+        <*> genLifetime
+
+shrinkMockRoundRobinState
+    :: Ord k
+    => (n -> [n])
+    -> MockRoundRobinState k n
+    -> [MockRoundRobinState k n]
+shrinkMockRoundRobinState shrinkLifetime s =
+    [ s { processorLifetimes = processorLifetimes' }
+    | processorLifetimes' <- shrinkProcessorLifetimes $ processorLifetimes s
+    ]
+  where
+    shrinkProcessorLifetimes
+        = fmap Map.fromList
+        . shrinkList shrinkProcessorLifetime
+        . Map.toList
+    shrinkProcessorLifetime (k, n) = (k, ) <$> shrinkLifetime n
+
+runMockRoundRobin
+    :: forall k n. (Ord k, Integral n)
+    => MockRoundRobinState k n
+    -> MockRoundRobinState k n
+runMockRoundRobin initialState = runRoundRobin initialState processors
+  where
+    processors :: [MockRoundRobinState k n -> Maybe (MockRoundRobinState k n)]
+    processors = mkProcessor <$> Map.toList (processorLifetimes initialState)
+
+    mkProcessor
+        :: (k, n) -> MockRoundRobinState k n -> Maybe (MockRoundRobinState k n)
+    mkProcessor (k, n) s
+        | remainingLifetime <= 0 =
+            Nothing
+        | otherwise = Just $ MockRoundRobinState
+            { processorLifetimes = Map.adjust pred k (processorLifetimes s)
+            , accumulatedEntries = entry : accumulatedEntries s
+            }
+      where
+        entry :: (k, n)
+        entry = (k, n - remainingLifetime)
+
+        remainingLifetime :: n
+        remainingLifetime = Map.findWithDefault 0 k (processorLifetimes s)
+
+prop_runRoundRobin_identity
+    :: forall state. (Eq state, Show state) => state -> [()] -> Property
+prop_runRoundRobin_identity state processors =
+    runRoundRobin state (const Nothing <$ processors) === state
+
+prop_runRoundRobin_iterationCount
+    :: forall k n. (Ord k, Integral n)
+    => MockRoundRobinState k n
+    -> Property
+prop_runRoundRobin_iterationCount initialState = (===)
+    (toInteger $ length $ accumulatedEntries finalState)
+    (F.sum $ toInteger <$> processorLifetimes initialState)
+  where
+    finalState = runMockRoundRobin initialState
+
+prop_runRoundRobin_iterationOrder
+    :: forall k n. (Ord k, Show k, Integral n, Show n)
+    => MockRoundRobinState k n
+    -> Property
+prop_runRoundRobin_iterationOrder initialState =
+    sortDescending entries === entries
+  where
+    finalState = runMockRoundRobin initialState
+    entries = swap <$> accumulatedEntries finalState
+    sortDescending = L.sortBy (flip compare)
+
+prop_runRoundRobin_generationCount
+    :: forall k n. (Ord k, Show k, Integral n, Show n)
+    => MockRoundRobinState k n
+    -> Property
+prop_runRoundRobin_generationCount initialState =
+    Map.filter (> 0) (processorLifetimes initialState)
+        === generationCounts
+  where
+    finalState = runMockRoundRobin initialState
+    generationCounts :: Map k n
+    generationCounts = accumulatedEntries finalState
+        & groupByKey
+        & fmap (fromIntegral . NE.length)
+
+prop_runRoundRobin_generationOrder
+    :: forall k n. (Ord k, Integral n)
+    => MockRoundRobinState k n
+    -> Property
+prop_runRoundRobin_generationOrder initialState = property $
+    all (uncurry Set.isSubsetOf)
+        $ consecutivePairs
+        $ snd <$> Map.toDescList generations
+  where
+    finalState = runMockRoundRobin initialState
+    generations :: Map n (Set k)
+    generations = accumulatedEntries finalState
+        & fmap swap
+        & groupByKey
+        & fmap (Set.fromList . F.toList)
+
+--------------------------------------------------------------------------------
 -- Utility functions
 --------------------------------------------------------------------------------
 
@@ -209,6 +366,10 @@ instance Arbitrary AssetId where
 
 instance Arbitrary MakeChangeData where
     arbitrary = genMakeChangeData
+
+instance Arbitrary (MockRoundRobinState TokenName Word8) where
+    arbitrary = genMockRoundRobinState genTokenNameMediumRange arbitrary
+    shrink = shrinkMockRoundRobinState shrink
 
 instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -38,7 +38,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
-    ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+    ( genTokenBundleSmallRangePositive, shrinkTokenBundleSmallRangePositive )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
@@ -561,8 +561,8 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
   where
     genTokenBundles :: Int -> Gen (NonEmpty TokenBundle)
     genTokenBundles count = (:|)
-        <$> genTokenBundleSmallRange
-        <*> replicateM count genTokenBundleSmallRange
+        <$> genTokenBundleSmallRangePositive
+        <*> replicateM count genTokenBundleSmallRangePositive
 
 prop_makeChange_identity
     :: NonEmpty TokenBundle -> Property
@@ -805,8 +805,8 @@ instance Arbitrary (MockRoundRobinState TokenName Word8) where
     shrink = shrinkMockRoundRobinState shrink
 
 instance Arbitrary TokenBundle where
-    arbitrary = genTokenBundleSmallRange
-    shrink = shrinkTokenBundleSmallRange
+    arbitrary = genTokenBundleSmallRangePositive
+    shrink = shrinkTokenBundleSmallRangePositive
 
 instance Arbitrary TokenQuantity where
     arbitrary = genTokenQuantitySmallPositive

--- a/lib/numeric/cardano-numeric.cabal
+++ b/lib/numeric/cardano-numeric.cabal
@@ -1,0 +1,62 @@
+name:                cardano-numeric
+version:             2020.12.8
+synopsis:            Types and functions for performing numerical calculations.
+homepage:            https://github.com/input-output-hk/cardano-wallet
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+copyright:           2018-2020 IOHK
+license:             Apache-2.0
+category:            Math
+build-type:          Simple
+cabal-version:       >=1.10
+
+flag release
+    description: Enable optimization and `-Werror`
+    default: False
+    manual: True
+
+library
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -Wall
+      -Wcompat
+      -fwarn-redundant-constraints
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+      base
+  hs-source-dirs:
+      src
+  exposed-modules:
+      Cardano.Numeric.Util
+
+test-suite unit
+  default-language:
+      Haskell2010
+  default-extensions:
+      NoImplicitPrelude
+      OverloadedStrings
+  ghc-options:
+      -threaded -rtsopts
+      -Wall
+  if (flag(release))
+    ghc-options: -O2 -Werror
+  build-depends:
+      base
+    , cardano-numeric
+    , hspec
+    , QuickCheck
+  build-tools:
+      hspec-discover
+  type:
+     exitcode-stdio-1.0
+  hs-source-dirs:
+      test/unit
+  main-is:
+      Main.hs
+  other-modules:
+      Cardano.Numeric.UtilSpec

--- a/lib/numeric/src/Cardano/Numeric/Util.hs
+++ b/lib/numeric/src/Cardano/Numeric/Util.hs
@@ -1,0 +1,164 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Numeric.Util
+    ( partitionNatural
+    ) where
+
+import Prelude hiding
+    ( round )
+
+import Control.Arrow
+    ( (&&&) )
+import Data.Function
+    ( (&) )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Ord
+    ( Down (..), comparing )
+import Data.Ratio
+    ( (%) )
+import Numeric.Natural
+    ( Natural )
+
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
+
+--------------------------------------------------------------------------------
+-- Public functions
+--------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Partitioning natural numbers
+--------------------------------------------------------------------------------
+
+-- | Partitions a natural number into a number of parts, where the size of each
+--   part is proportional to the size of its corresponding element in the given
+--   list of weights, and the number of parts is equal to the number of weights.
+--
+-- Examples:
+--
+--      >>> partitionNatural 9 (1 :| [1, 1])
+--      Just (3 :| [3, 3])
+--
+--      >>> partitionNatural 10 (1 :| [])
+--      10
+--
+--      >>> partitionNatural 30 (1 :| [2, 4, 8])
+--      Just (2 :| [4, 8, 16])
+--
+-- Pre-condition: there must be at least one non-zero weight.
+--
+-- If the pre-condition is not satisfied, this function returns 'Nothing'.
+--
+-- If the pre-condition is satisfied, this function guarantees that:
+--
+--  1.  The length of the resulting list is identical to the length of the
+--      specified list:
+--
+--      >>> fmap length (partitionNatural n weights) == Just (length weights)
+--
+--  2.  The sum of elements in the resulting list is equal to the original
+--      natural number:
+--
+--      >>> fmap sum (partitionNatural n weights) == Just n
+--
+--  3.  The size of each element in the resulting list is within unity of the
+--      ideal proportion.
+--
+partitionNatural
+    :: Natural
+        -- ^ Natural number to partition
+    -> NonEmpty Natural
+        -- ^ List of weights
+    -> Maybe (NonEmpty Natural)
+partitionNatural target weights
+    | totalWeight == 0 = Nothing
+    | otherwise = Just portionsRounded
+  where
+    portionsRounded :: NonEmpty Natural
+    portionsRounded
+        -- 1. Start with the list of unrounded portions:
+        = portionsUnrounded
+        -- 2. Attach an index to each portion, so that we can remember the
+        --    original order:
+        & NE.zip indices
+        -- 3. Sort the portions into descending order of their fractional
+        --    parts, and then sort each subsequence with equal fractional
+        --    parts into descending order of their integral parts:
+        & NE.sortBy (comparing (Down . (fractionalPart &&& integralPart) . snd))
+        -- 4. Apply pre-computed roundings to each portion:
+        & NE.zipWith (fmap . round) roundings
+        -- 5. Restore the original order:
+        & NE.sortBy (comparing fst)
+        -- 6. Strip away the indices:
+        & fmap snd
+      where
+        indices :: NonEmpty Int
+        indices = 0 :| [1 ..]
+
+    portionsUnrounded :: NonEmpty Rational
+    portionsUnrounded = computeIdealPortion <$> weights
+      where
+        computeIdealPortion c
+            = fromIntegral target
+            * fromIntegral c
+            % fromIntegral totalWeight
+
+    roundings :: NonEmpty RoundingDirection
+    roundings =
+        applyN shortfall (NE.cons RoundUp) (NE.repeat RoundDown)
+      where
+        shortfall
+            = fromIntegral target
+            - fromIntegral @Integer
+                (F.sum $ round RoundDown <$> portionsUnrounded)
+
+    totalWeight :: Natural
+    totalWeight = F.sum weights
+
+--------------------------------------------------------------------------------
+-- Internal types and functions
+--------------------------------------------------------------------------------
+
+-- Apply the same function multiple times to a value.
+--
+applyN :: Int -> (a -> a) -> a -> a
+applyN n f = F.foldr (.) id (replicate n f)
+
+-- Extract the fractional part of a rational number.
+--
+-- Examples:
+--
+-- >>> fractionalPart (3 % 2)
+-- 1 % 2
+--
+-- >>> fractionalPart (11 % 10)
+-- 1 % 10
+--
+fractionalPart :: Rational -> Rational
+fractionalPart = snd . properFraction @_ @Integer
+
+integralPart :: Rational -> Integer
+integralPart = floor
+
+-- | Indicates a rounding direction to be used when converting from a
+--   fractional value to an integral value.
+--
+-- See 'round'.
+--
+data RoundingDirection
+    = RoundUp
+      -- ^ Round up to the nearest integral value.
+    | RoundDown
+      -- ^ Round down to the nearest integral value.
+    deriving (Eq, Show)
+
+-- | Use the given rounding direction to round the given fractional value,
+--   producing an integral result.
+--
+round :: (RealFrac a, Integral b) => RoundingDirection -> a -> b
+round = \case
+    RoundUp -> ceiling
+    RoundDown -> floor

--- a/lib/numeric/src/Cardano/Numeric/Util.hs
+++ b/lib/numeric/src/Cardano/Numeric/Util.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Numeric.Util
-    ( partitionNatural
+    ( padCoalesce
+    , partitionNatural
     ) where
 
 import Prelude hiding
@@ -28,6 +29,68 @@ import qualified Data.List.NonEmpty as NE
 --------------------------------------------------------------------------------
 -- Public functions
 --------------------------------------------------------------------------------
+
+--------------------------------------------------------------------------------
+-- Coalescing values
+--------------------------------------------------------------------------------
+
+-- | Adjusts the source list so that its length is the same as the target list,
+--   either by padding the list, or by coalescing a subset of the elements,
+--   while preserving the total sum.
+--
+-- If the source list is shorter than the target list, this function repeatedly
+-- inserts 'mempty' into the list until the desired length has been reached.
+--
+-- If the source list is longer than the target list, this function repeatedly
+-- coalesces the smallest pair of elements with '<>' until the desired length
+-- has been reached.
+--
+-- The resulting list is guaranteed to be sorted into ascending order, and the
+-- sum of the elements is guaranteed to be the same as the sum of elements in
+-- the source list.
+--
+-- Examples (shown with ordinary list notation):
+--
+-- >>> padCoalesce [Sum 1] (replicate 4 ())
+-- [Sum 0, Sum 0, Sum 0, Sum 1]
+--
+-- >>> padCoalesce [Sum (-1)] (replicate 4 ())
+-- [Sum (-1), Sum 0, Sum 0, Sum 0]
+--
+-- >>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 3 ())
+-- [Sum 3, Sum 4, Sum 8]
+--
+-- >>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 2 ())
+-- [Sum 7, Sum 8]
+--
+-- >>> padCoalesce [Sum 8, Sum 4, Sum 2, Sum 1] (replicate 1 ())
+-- [Sum 15]
+--
+padCoalesce :: forall m a. (Monoid m, Ord m)
+    => NonEmpty m
+    -- ^ Source list
+    -> NonEmpty a
+    -- ^ Target list
+    -> NonEmpty m
+padCoalesce sourceUnsorted target
+    | sourceLength < targetLength =
+        applyN (targetLength - sourceLength) pad source
+    | sourceLength > targetLength =
+        applyN (sourceLength - targetLength) coalesce source
+    | otherwise =
+        source
+  where
+    source = NE.sort sourceUnsorted
+
+    sourceLength = NE.length source
+    targetLength = NE.length target
+
+    pad :: NonEmpty m -> NonEmpty m
+    pad = NE.insert mempty
+
+    coalesce :: NonEmpty m -> NonEmpty m
+    coalesce (x :| y : zs) = NE.insert (x <> y) zs
+    coalesce xs = xs
 
 --------------------------------------------------------------------------------
 -- Partitioning natural numbers

--- a/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
+++ b/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
@@ -1,0 +1,108 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Numeric.UtilSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Numeric.Util
+    ( partitionNatural )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
+import Data.Maybe
+    ( catMaybes )
+import Data.Ratio
+    ( (%) )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Property
+    , arbitrarySizedNatural
+    , checkCoverage
+    , property
+    , shrink
+    , shrinkIntegral
+    , withMaxSuccess
+    , (.&&.)
+    , (===)
+    )
+
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
+
+spec :: Spec
+spec = do
+
+    describe "partitionNatural" $ do
+
+        it "prop_partitionNatural_length" $
+            property prop_partitionNatural_length
+        it "prop_partitionNatural_sum" $
+            property prop_partitionNatural_sum
+        it "prop_partitionNatural_fair" $
+            withMaxSuccess 1000 $ checkCoverage prop_partitionNatural_fair
+
+--------------------------------------------------------------------------------
+-- Partitioning natural numbers
+--------------------------------------------------------------------------------
+
+prop_partitionNatural_length
+    :: Natural
+    -> NonEmpty Natural
+    -> Property
+prop_partitionNatural_length target weights =
+    case partitionNatural target weights of
+        Nothing -> F.sum weights === 0
+        Just ps -> F.length ps === F.length weights
+
+prop_partitionNatural_sum
+    :: Natural
+    -> NonEmpty Natural
+    -> Property
+prop_partitionNatural_sum target weights =
+    case partitionNatural target weights of
+        Nothing -> F.sum weights === 0
+        Just ps -> F.sum ps === target
+
+-- | Check that portions are all within unity of ideal unrounded portions.
+--
+prop_partitionNatural_fair
+    :: Natural
+    -> NonEmpty Natural
+    -> Property
+prop_partitionNatural_fair target weights =
+    case partitionNatural target weights of
+        Nothing -> F.sum weights === 0
+        Just ps -> prop ps
+  where
+    prop portions = (.&&.)
+        (F.all (uncurry (<=)) (NE.zip portions portionUpperBounds))
+        (F.all (uncurry (>=)) (NE.zip portions portionLowerBounds))
+      where
+        portionUpperBounds = ceiling . computeIdealPortion <$> weights
+        portionLowerBounds = floor   . computeIdealPortion <$> weights
+
+        computeIdealPortion :: Natural -> Rational
+        computeIdealPortion c
+            = fromIntegral target
+            * fromIntegral c
+            % fromIntegral totalWeight
+
+        totalWeight :: Natural
+        totalWeight = F.sum weights
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary a => Arbitrary (NE.NonEmpty a) where
+    arbitrary = (:|) <$> arbitrary <*> arbitrary
+    shrink xs = catMaybes $ NE.nonEmpty <$> shrink (NE.toList xs)
+
+instance Arbitrary Natural where
+    arbitrary = arbitrarySizedNatural
+    shrink = shrinkIntegral

--- a/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
+++ b/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.Numeric.UtilSpec
@@ -7,11 +8,13 @@ module Cardano.Numeric.UtilSpec
 import Prelude
 
 import Cardano.Numeric.Util
-    ( partitionNatural )
+    ( padCoalesce, partitionNatural )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
     ( catMaybes )
+import Data.Monoid
+    ( Sum (..) )
 import Data.Ratio
     ( (%) )
 import Numeric.Natural
@@ -37,6 +40,15 @@ import qualified Data.List.NonEmpty as NE
 spec :: Spec
 spec = do
 
+    describe "padCoalesce" $ do
+
+        it "prop_padCoalesce_length" $
+            property $ prop_padCoalesce_length @(Sum Int)
+        it "prop_padCoalesce_sort" $
+            property $ prop_padCoalesce_sort @(Sum Int)
+        it "prop_padCoalesce_sum" $
+            property $ prop_padCoalesce_sum @(Sum Int)
+
     describe "partitionNatural" $ do
 
         it "prop_partitionNatural_length" $
@@ -45,6 +57,27 @@ spec = do
             property prop_partitionNatural_sum
         it "prop_partitionNatural_fair" $
             withMaxSuccess 1000 $ checkCoverage prop_partitionNatural_fair
+
+--------------------------------------------------------------------------------
+-- Coalescing values
+--------------------------------------------------------------------------------
+
+prop_padCoalesce_length
+    :: (Monoid a, Ord a, Show a) => NonEmpty a -> NonEmpty () -> Property
+prop_padCoalesce_length source target =
+    NE.length (padCoalesce source target) === NE.length target
+
+prop_padCoalesce_sort
+    :: (Monoid a, Ord a, Show a) => NonEmpty a -> NonEmpty () -> Property
+prop_padCoalesce_sort source target =
+    NE.sort result === result
+  where
+    result = padCoalesce source target
+
+prop_padCoalesce_sum
+    :: (Monoid a, Ord a, Show a) => NonEmpty a -> NonEmpty () -> Property
+prop_padCoalesce_sum source target =
+    F.fold source === F.fold (padCoalesce source target)
 
 --------------------------------------------------------------------------------
 -- Partitioning natural numbers

--- a/lib/numeric/test/unit/Main.hs
+++ b/lib/numeric/test/unit/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/nix/.stack.nix/cardano-numeric.nix
+++ b/nix/.stack.nix/cardano-numeric.nix
@@ -32,8 +32,9 @@
         "unit" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
-            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             ];
           build-tools = [
             (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))

--- a/nix/.stack.nix/cardano-numeric.nix
+++ b/nix/.stack.nix/cardano-numeric.nix
@@ -1,0 +1,45 @@
+{ system
+  , compiler
+  , flags
+  , pkgs
+  , hsPkgs
+  , pkgconfPkgs
+  , errorHandler
+  , config
+  , ... }:
+  {
+    flags = { release = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-numeric"; version = "2020.12.8"; };
+      license = "Apache-2.0";
+      copyright = "2018-2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "https://github.com/input-output-hk/cardano-wallet";
+      url = "";
+      synopsis = "Types and functions for performing numerical calculations.";
+      description = "";
+      buildType = "Simple";
+      isLocal = true;
+      };
+    components = {
+      "library" = {
+        depends = [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ];
+        buildable = true;
+        };
+      tests = {
+        "unit" = {
+          depends = [
+            (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
+            (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
+            ];
+          build-tools = [
+            (hsPkgs.buildPackages.hspec-discover or (pkgs.buildPackages.hspec-discover or (errorHandler.buildToolDepError "hspec-discover")))
+            ];
+          buildable = true;
+          };
+        };
+      };
+    } // rec { src = (pkgs.lib).mkDefault ../.././lib/numeric; }

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -36,6 +36,7 @@
           (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
           (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
           (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+          (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
           (hsPkgs."cardano-slotting" or (errorHandler.buildDepError "cardano-slotting"))
           (hsPkgs."cborg" or (errorHandler.buildDepError "cborg"))
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -95,6 +95,7 @@
         cardano-wallet-core-integration = ./cardano-wallet-core-integration.nix;
         cardano-wallet-cli = ./cardano-wallet-cli.nix;
         cardano-wallet-launcher = ./cardano-wallet-launcher.nix;
+        cardano-numeric = ./cardano-numeric.nix;
         text-class = ./text-class.nix;
         cardano-wallet-test-utils = ./cardano-wallet-test-utils.nix;
         cardano-wallet = ./cardano-wallet.nix;

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ packages:
 - lib/core-integration
 - lib/cli
 - lib/launcher
+- lib/numeric
 - lib/text-class
 - lib/test-utils
 - lib/shelley


### PR DESCRIPTION
# Issue Number

ADP-605

## Overview

This PR implements the **Random-Round-Robin** coin selection algorithm for multi-asset UTxO sets.

The **Random-Round-Robin** algorithm is inspired by the **Random-Improve** algorithm, but with some differences to accommodate UTxO sets with multiple assets.

## Top-Level Algorithm Description

The **Random-Round-Robin** algorithm considers the sum of all outputs **collectively**, selecting inputs to cover the total sum of all asset quantities, rather than running a separate selection for each input. It therefore drops the cardinality restriction of the original Random-Improve algorithm implementation.

### Steps

1. When selecting inputs, consider tokens in **round-robin fashion**, selecting one input per token before moving to the next token, to reduce the chance of over-selecting for any particular token.
2. For each token quantity under consideration, select enough inputs to cover at least 100% of that quantity, but aim to get as close to a target of 200% as possible. When we can make no further improvement for a given token, we eliminate that token from the round-robin selection process. An _improvement_ is defined as an additional selection that takes the total selected token quantity closer to 200% of the output token quantity, but not further away.
3. The round-robin selection phase terminates when we can make no further improvement for any token in the set under consideration.
4. After the selection phase is over, divide any excess token quantities (inputs − outputs) into change bundles, where:
    -  there is exactly one change bundle for each output.
    - the quantity of a given token in a change bundle is proportional to the quantity of that token in the corresponding output (modulo rounding).
    - the total quantity of a given token across all change bundles is equal to the total excess quantity of that token.
5. Redistribute additionally-selected tokens not present in the original outputs to the change bundles, where:
    - if there are fewer quantities for a given token than the number of change bundles, include these quantities without changing them.
    - if there are more quantities for a given token than the number of change bundles, repeatedly coalesce the smallest pair of quantities together until the total number of quantities is exactly equal to the number of change bundles.