### PR TITLE
Remove unused ErrListPools

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -204,7 +204,6 @@ import Cardano.Wallet.Network
     ( ErrGetAccountBalance (..)
     , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
-    , ErrStakeDistribution (..)
     , FollowAction (..)
     , FollowExit (..)
     , FollowLog (..)
@@ -2570,9 +2569,8 @@ data ErrWithdrawalNotWorth
     deriving (Generic, Eq, Show)
 
 -- | Errors that can occur when trying to list stake pool.
-data ErrListPools
-    = ErrListPoolsQueryFailed ErrStakeDistribution
-    | ErrListPoolsPastHorizonException PastHorizonException
+newtype ErrListPools
+    = ErrListPoolsPastHorizonException PastHorizonException
     deriving (Show)
 {-------------------------------------------------------------------------------
                                    Utils

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -172,9 +172,6 @@ module Cardano.Wallet
 
     -- * Logging
     , WalletLog (..)
-
-    -- * Stake pool listing
-    , ErrListPools (..)
     ) where
 
 import Prelude hiding
@@ -2568,10 +2565,6 @@ data ErrWithdrawalNotWorth
     = ErrWithdrawalNotWorth
     deriving (Generic, Eq, Show)
 
--- | Errors that can occur when trying to list stake pool.
-newtype ErrListPools
-    = ErrListPoolsPastHorizonException PastHorizonException
-    deriving (Show)
 {-------------------------------------------------------------------------------
                                    Utils
 -------------------------------------------------------------------------------}

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -227,11 +227,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.DB
     ( DBFactory (..) )
 import Cardano.Wallet.Network
-    ( ErrNetworkUnavailable (..)
-    , ErrStakeDistribution (..)
-    , NetworkLayer
-    , timeInterpreter
-    )
+    ( ErrNetworkUnavailable (..), NetworkLayer, timeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (..)
     , Depth (..)
@@ -2790,17 +2786,7 @@ instance LiftHandler ErrWithdrawalNotWorth where
 
 instance LiftHandler ErrListPools where
     handler = \case
-        ErrListPoolsQueryFailed e -> handler e
         ErrListPoolsPastHorizonException e -> handler e
-
-instance LiftHandler ErrStakeDistribution where
-    handler = \case
-        ErrStakeDistributionQuery _e ->
-            apiError err503 NetworkQueryFailed $ mconcat
-                [ "Unable to query the ledger at the moment. "
-                , "This error has been logged. "
-                , "Trying again in a bit might work."
-                ]
 
 instance LiftHandler ErrSignMetadataWith where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -115,7 +115,6 @@ import Cardano.Wallet
     , ErrImportRandomAddress (..)
     , ErrInvalidDerivationIndex (..)
     , ErrJoinStakePool (..)
-    , ErrListPools (..)
     , ErrListTransactions (..)
     , ErrListUTxOStatistics (..)
     , ErrMkTx (..)
@@ -2783,10 +2782,6 @@ instance LiftHandler ErrWithdrawalNotWorth where
                 , "enough to deserve being withdrawn. I won't proceed with that "
                 , "request."
                 ]
-
-instance LiftHandler ErrListPools where
-    handler = \case
-        ErrListPoolsPastHorizonException e -> handler e
 
 instance LiftHandler ErrSignMetadataWith where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -26,7 +26,6 @@ module Cardano.Wallet.Network
     , ErrGetTxParameters (..)
     , ErrPostTx (..)
     , ErrGetAccountBalance (..)
-    , ErrStakeDistribution (..)
 
     -- * Logging
     , FollowLog (..)
@@ -152,7 +151,7 @@ data NetworkLayer m block = NetworkLayer
 
     , stakeDistribution
         :: Coin -- Stake to consider for rewards
-        -> ExceptT ErrStakeDistribution m StakePoolsSummary
+        -> m StakePoolsSummary
 
     , getAccountBalance
         :: RewardAccount
@@ -204,12 +203,6 @@ data ErrGetAccountBalance
     = ErrGetAccountBalanceNetworkUnreachable ErrNetworkUnavailable
     | ErrGetAccountBalanceAccountNotFound RewardAccount
     deriving (Generic, Eq, Show)
-
--- | Error while querying stake distribution from ledger.
-newtype ErrStakeDistribution
-    = ErrStakeDistributionQuery Text
-    -- ^ Query failed.
-    deriving (Generic, Show, Eq)
 
 {-------------------------------------------------------------------------------
                               Initialization

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -278,7 +278,7 @@ server byron icarus shelley spl ntp =
         listStakePools_ = \case
             Just (ApiT stake) -> do
                 currentEpoch <- getCurrentEpoch shelley
-                liftHandler $ listStakePools spl currentEpoch stake
+                liftIO $ listStakePools spl currentEpoch stake
             Nothing -> Handler $ throwE $ apiError err400 QueryParamMissing $
                 mconcat
                 [ "The stake intended to delegate must be provided as a query "

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -343,7 +343,7 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
             era <- liftIO readCurrentNodeEra
             _postTx localTxSubmissionQ era sealed
         , stakeDistribution =
-            liftIO . _stakeDistribution queryRewardQ
+            _stakeDistribution queryRewardQ
         , getAccountBalance =
             _getAccountBalance rewardsObserver
         , timeInterpreter =
@@ -490,7 +490,7 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
             queue `send` (SomeLSQ qry )
 
         -- The result will be Nothing if query occurs during the byron era
-        liftIO $ traceWith tr $ MsgFetchStakePoolsData mres
+        traceWith tr $ MsgFetchStakePoolsData mres
         case mres of
             Just res@W.StakePoolsSummary{rewards,stake} -> do
                 liftIO $ traceWith tr $ MsgFetchStakePoolsDataSummary

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -119,7 +119,7 @@ import Control.Monad
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), mapExceptT, runExceptT )
+    ( ExceptT (..), runExceptT )
 import Control.Monad.Trans.State
     ( State, evalState, state )
 import Control.Retry
@@ -270,8 +270,7 @@ newStakePoolLayer gcStatus nl db@DBLayer {..} restartSyncThread = do
         -> Coin
         -> ExceptT ErrListPools IO [Api.ApiStakePool]
     _listPools currentEpoch userStake = do
-        rawLsqData <- mapExceptT (fmap (first ErrListPoolsQueryFailed))
-            $ stakeDistribution nl userStake
+        rawLsqData <- liftIO $ stakeDistribution nl userStake
         let lsqData = combineLsqData rawLsqData
         dbData <- liftIO $ readPoolDbData db currentEpoch
         seed <- liftIO $ atomically readSystemSeed

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -52,8 +52,6 @@ import Cardano.Pool.Metadata
     , registryUrlBuilder
     , toHealthCheckSMASH
     )
-import Cardano.Wallet
-    ( ErrListPools (..) )
 import Cardano.Wallet.Api.Types
     ( ApiT (..), HealthCheckSMASH (..), toApiEpochInfo )
 import Cardano.Wallet.Byron.Compatibility
@@ -204,7 +202,7 @@ data StakePoolLayer = StakePoolLayer
         :: EpochNo
         -- Exclude all pools that retired in or before this epoch.
         -> Coin
-        -> ExceptT ErrListPools IO [Api.ApiStakePool]
+        -> IO [Api.ApiStakePool]
 
     , forceMetadataGC :: IO ()
 
@@ -268,7 +266,7 @@ newStakePoolLayer gcStatus nl db@DBLayer {..} restartSyncThread = do
         :: EpochNo
         -- Exclude all pools that retired in or before this epoch.
         -> Coin
-        -> ExceptT ErrListPools IO [Api.ApiStakePool]
+        -> IO [Api.ApiStakePool]
     _listPools currentEpoch userStake = do
         rawLsqData <- liftIO $ stakeDistribution nl userStake
         let lsqData = combineLsqData rawLsqData


### PR DESCRIPTION
# Issue Number

ADP-647


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Remove `ErrStakeDistributionQuery` which is unused since #2449
- [x] Remove `ErrListPoolsPastHorizonException` which is also unused (we use `unsafeExtendSafeZone`, so it will never fail)
- [x] Remove the `ErrListPools` type entirely 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
