### PR TITLE
Multi-asset coin selection integration: test suite additions

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -365,6 +365,7 @@ prepareOutputsWith minCoinValueFor = fmap $ \out ->
 --
 --    inputsSelected ∪ utxoRemaining == utxoAvailable
 --    inputsSelected ∩ utxoRemaining == ∅
+--    outputsCovered == outputsToCover
 --
 performSelection
     :: forall m. (HasCallStack, MonadRandom m)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -533,6 +533,7 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             == UTxOIndex.insertMany inputsSelected utxoRemaining
         assert $ utxoRemaining
             == UTxOIndex.deleteMany (fst <$> inputsSelected) utxoAvailable
+        assert $ view #outputsCovered result == NE.toList outputsToCover
         case selectionLimit of
             MaximumInputLimit limit ->
                 assert $ NE.length inputsSelected <= limit


### PR DESCRIPTION
# Issue Number

ADP-506 / ADP-605

# Overview

This PR:

- [x] Updates the types within the `RoundRobinSpec` test suite in light of recent changes to the `RoundRobin` module, allowing it to compile.

- [x] Tests the value of `outputsCovered` returned by `performSelection`, to ensure that the following property holds: `outputsCovered == outputsToCover`