### PR TITLE
Fix flaky `validateGenerators`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -32,7 +32,11 @@ genTokenNameSmallRange :: Gen TokenName
 genTokenNameSmallRange = elements tokenNamesSmallRange
 
 shrinkTokenNameSmallRange :: TokenName -> [TokenName]
-shrinkTokenNameSmallRange name = filter (< name) tokenNamesSmallRange
+shrinkTokenNameSmallRange x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head tokenNamesSmallRange
 
 tokenNamesSmallRange :: [TokenName]
 tokenNamesSmallRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'D']
@@ -46,7 +50,11 @@ genTokenNameMediumRange :: Gen TokenName
 genTokenNameMediumRange = elements tokenNamesMediumRange
 
 shrinkTokenNameMediumRange :: TokenName -> [TokenName]
-shrinkTokenNameMediumRange name = filter (< name) tokenNamesMediumRange
+shrinkTokenNameMediumRange x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head tokenNamesMediumRange
 
 tokenNamesMediumRange :: [TokenName]
 tokenNamesMediumRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'Z']
@@ -59,7 +67,11 @@ genTokenPolicyIdSmallRange :: Gen TokenPolicyId
 genTokenPolicyIdSmallRange = elements tokenPolicies
 
 shrinkTokenPolicyIdSmallRange :: TokenPolicyId -> [TokenPolicyId]
-shrinkTokenPolicyIdSmallRange policy = filter (< policy) tokenPolicies
+shrinkTokenPolicyIdSmallRange x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head tokenPolicies
 
 tokenPolicies :: [TokenPolicyId]
 tokenPolicies = mkTokenPolicyId <$> ['A' .. 'D']

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -52,7 +52,11 @@ genTxHashSmallRange :: Gen (Hash "Tx")
 genTxHashSmallRange = elements txHashes
 
 shrinkTxHashSmallRange :: Hash "Tx" -> [Hash "Tx"]
-shrinkTxHashSmallRange hash = filter (< hash) txHashes
+shrinkTxHashSmallRange x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head txHashes
 
 txHashes :: [Hash "Tx"]
 txHashes = mkTxHash <$> ['0' .. '7']
@@ -72,7 +76,8 @@ genTxIndexSmallRange :: Gen Word32
 genTxIndexSmallRange = elements txIndices
 
 shrinkTxIndexSmallRange :: Word32 -> [Word32]
-shrinkTxIndexSmallRange i = filter (< i) txIndices
+shrinkTxIndexSmallRange 0 = []
+shrinkTxIndexSmallRange _ = [0]
 
 txIndices :: [Word32]
 txIndices = [0 .. 7]


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

#2393 

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- deb387a4f0389e035a3feebdbb5610361cc751c3
  :round_pushpin: **rework 'validateGenerators' for the db arbitrary instance to be more reliable**
    And also give more information on failure. This should reduce the flakyness and provide more metrics on failure.

- 977078cc5881770612dc217fed6e8d594df67771
  :round_pushpin: **rework shrinkers on PolicyId, AssetName and TxId to be more aggressive**
    There's really nothing simpler between 'TokenB' compared to 'TokenC', or between '1111111111111111111111111' compared to '22222222222222222222222'

  The goal of a shrinker is to provide smaller counter examples, if shrinking a value doesn't make it smaller, the shrinker is pointless. In this very case, the shrinkers are actually sucking of CPU time for nothing as noted by the 'validateGenerators' property sometimes failing to shrink large data structures in a reasonable time.

  However, allowing values to shrink down to one common denominator help to make a counter example more readable by reducing the amount of noise in an output. That is, it's easier if all values of a particular types are the same. Thus, this commit changes shrinkers to reach that common denominator much more aggressively (in one step).

# Comments

<!-- Additional comments or screenshots to attach if any -->

Occurred quite often lately, so I thought I'd give it a shot. 

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
