### PR TITLE
Remove 0.2% restore bench to prevent nightly timeouts

### DIFF
--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -308,12 +308,10 @@ cardanoRestoreBench tr c socketFile = do
 
         , benchRestoreSeqWithOwnership (Proxy @0)
         , benchRestoreSeqWithOwnership (Proxy @1)
-        , benchRestoreSeqWithOwnership (Proxy @2)
         , benchRestoreSeqWithOwnership (Proxy @4)
 
         , benchRestoreRndWithOwnership (Proxy @0)
         , benchRestoreRndWithOwnership (Proxy @1)
-        , benchRestoreRndWithOwnership (Proxy @2)
         , benchRestoreRndWithOwnership (Proxy @4)
         ]
   where


### PR DESCRIPTION
# Context

The original problem in ADP-639 just disappeared... But now, a few recent nightlies are timing out:

- [Build #833](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/833#f00662b3-a0d0-4e59-bdaf-d097ef06f86c) -> about to timeout
    - Node sync took 2.3h
        - [2021-01-29 00:32:52.77 UTC]
        - [2021-01-29 02:52:00.75 UTC]
- [Build #832](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/832#55f4c9bb-40fa-41ee-a6a8-c028b6bdcc4b) timed out
    - Node sync took 2.4h
        - [2021-01-28 00:31:59.32 UTC]
        - [2021-01-28 02:56:13.76 UTC]
- [Build #830](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/830#31d4a3e2-eec2-4344-bad5-e8bbddffbe85) succeeded
    - Node sync took 2.3h
        - [2021-01-27 01:08:39.55 UTC]
        - [2021-01-27 03:28:23.57 UTC]


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Removed 0.2% seq and 0.2% rnd benchmarks to gain about an hour

# Comments

- Now we have 0%, 0.1% and 0.4%. Don't think 0.2% provides anything that 0.4% doesn't.

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
