### PR TITLE
Give priority to singleton asset bundles during coin selection

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -53,6 +53,7 @@
 - ignore: {name: "Use ?~"} # It's actually much clearer to do (.~ Just ...) than having to load yet-another-lens-operator
 - ignore: {name: "Redundant multi-way if"} # Using this style might be appropriate given the circumstances.
 - ignore: {name: "Use const"} # Sometimes using a lambda expression is simpler and clearer.
+- ignore: {name: "Redundant id"} # Sometimes this is useful for vertical alignment of elements.
 
 # Add custom hints for this project
 #

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -527,7 +527,7 @@ performSelection minCoinValueFor costFor criteria
                 let
                     selectionErr = Left $ UnableToConstructChange changeErr
                 in
-                    selectMatchingQuantity selectionLimit [WithAdaOnly] s
+                    selectMatchingQuantity selectionLimit (WithAdaOnly :| []) s
                     >>=
                     maybe
                         (pure selectionErr)
@@ -615,9 +615,7 @@ assetSelectionLens limit (asset, minimumAssetQuantity) = SelectionLens
     { currentQuantity = assetQuantity asset . selected
     , minimumQuantity = unTokenQuantity minimumAssetQuantity
     , selectQuantity = selectMatchingQuantity limit
-        [ WithAssetOnly asset
-        , WithAsset asset
-        ]
+        (WithAssetOnly asset :| [WithAsset asset])
     }
 
 coinSelectionLens
@@ -632,9 +630,7 @@ coinSelectionLens limit mExtraCoinSource minimumCoinQuantity = SelectionLens
     { currentQuantity = \s -> coinQuantity (selected s) mExtraCoinSource
     , minimumQuantity = fromIntegral $ unCoin minimumCoinQuantity
     , selectQuantity  = selectMatchingQuantity limit
-        [ WithAdaOnly
-        , Any
-        ]
+        (WithAdaOnly :| [Any])
     }
 
 -- | Selects a UTxO entry that matches one of the specified filters.
@@ -657,7 +653,7 @@ selectMatchingQuantity
     :: MonadRandom m
     => SelectionLimit
         -- ^ A limit to adhere to when selecting entries.
-    -> [SelectionFilter]
+    -> NonEmpty SelectionFilter
         -- ^ A list of selection filters to be traversed from left-to-right,
         -- in descending order of priority.
     -> SelectionState
@@ -665,14 +661,12 @@ selectMatchingQuantity
     -> m (Maybe SelectionState)
         -- ^ An updated selection state that includes a matching UTxO entry,
         -- or 'Nothing' if no such entry could be found.
-selectMatchingQuantity _       []  _ = pure Nothing
-selectMatchingQuantity limit (h:q) s
+selectMatchingQuantity limit filters s
     | limitReached =
         pure Nothing
-    | otherwise = do
-        UTxOIndex.selectRandom (leftover s) h >>= \case
-            Just s' -> pure $ Just $ updateState s'
-            Nothing -> selectMatchingQuantity limit q s
+    | otherwise =
+        fmap updateState <$>
+            UTxOIndex.selectRandomWithPriority (leftover s) filters
   where
     limitReached = case limit of
         MaximumInputLimit m -> UTxOIndex.size (selected s) >= m

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -608,7 +608,8 @@ runSelection limit mExtraCoinSource available minimumBalance =
         { currentQuantity = assetQuantity asset . selected
         , minimumQuantity = unTokenQuantity minimumAssetQuantity
         , selectQuantity = selectMatchingQuantity limit
-            [ WithAsset asset
+            [ WithAssetOnly asset
+            , WithAsset asset
             ]
         }
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -49,6 +49,7 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     -- * Selection
     , SelectionFilter (..)
     , selectRandom
+    , selectRandomWithPriority
 
     ) where
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -85,7 +85,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxIn, TxOut, txOutIsCoin )
+    ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.DeepSeq
@@ -95,7 +95,7 @@ import Control.Monad.Random.Class
 import Data.Function
     ( (&) )
 import Data.Generics.Internal.VL.Lens
-    ( view )
+    ( over, view )
 import Data.Generics.Labels
     ()
 import Data.Map.Strict
@@ -141,14 +141,21 @@ import qualified Data.Set.Strict.NonEmptySet as NonEmptySet
 -- the 'checkInvariant' function.
 --
 data UTxOIndex = UTxOIndex
-    { index
+    { assetsAll
         :: !(Map AssetId (NonEmptySet TxIn))
+        -- An index of all entries that contain at least one non-ada asset.
+    , assetsSingleton
+        :: !(Map AssetId (NonEmptySet TxIn))
+        -- An index of all entries that contain exactly one non-ada asset.
     , coins
         :: !(Set TxIn)
+        -- An index of all entries that contain no non-ada assets.
     , balance
         :: !TokenBundle
+        -- The total balance of all entries.
     , utxo
         :: !(Map TxIn TxOut)
+        -- The complete set of all entries.
     }
     deriving (Eq, Generic, Read, Show)
 
@@ -162,7 +169,8 @@ instance NFData UTxOIndex
 --
 empty :: UTxOIndex
 empty = UTxOIndex
-    { index = Map.empty
+    { assetsAll = Map.empty
+    , assetsSingleton = Map.empty
     , coins = Set.empty
     , balance = TokenBundle.empty
     , utxo = Map.empty
@@ -245,20 +253,24 @@ insertMany = flip $ F.foldl' $ \u (i, o) -> insert i o u
 -- of applying this function will be equivalent to the identity function.
 --
 delete :: TxIn -> UTxOIndex -> UTxOIndex
-delete i u = case Map.lookup i (utxo u) of
-    Nothing -> u
-    Just o -> UTxOIndex
-        { index = F.foldl' deleteEntry (index u) (txOutAssets o)
-          -- This operation is safe, since we have already determined that the
-          -- entry is a member of the index, and therefore the balance must be
-          -- greater than or equal to the value of this output:
-        , coins = Set.delete i (coins u)
-        , balance = balance u `TokenBundle.unsafeSubtract` view #tokens o
-        , utxo = Map.delete i $ utxo u
-        }
+delete i u =
+    maybe u updateIndex $ Map.lookup i $ utxo u
   where
-    txOutAssets :: TxOut -> Set AssetId
-    txOutAssets = TokenBundle.getAssets . view #tokens
+    updateIndex :: TxOut -> UTxOIndex
+    updateIndex o = u
+        -- This operation is safe, since we have already determined that the
+        -- entry is a member of the index, and therefore the balance must be
+        -- greater than or equal to the value of this output:
+        & over #balance (`TokenBundle.unsafeSubtract` view #tokens o)
+        & over #utxo (Map.delete i)
+        & case categorizeTxOut o of
+            IsCoin ->
+                over #coins (Set.delete i)
+            IsCoinWithSingletonAsset a -> id
+                . over #assetsSingleton (`deleteEntry` a)
+                . over #assetsAll (`deleteEntry` a)
+            IsCoinWithMultipleAssets as ->
+                over #assetsAll (flip (F.foldl' deleteEntry) as)
 
     deleteEntry
         :: Map AssetId (NonEmptySet TxIn)
@@ -280,7 +292,7 @@ deleteMany = flip $ F.foldl' $ \u i -> delete i u
 -- | Returns the complete set of all assets contained in an index.
 --
 assets :: UTxOIndex -> Set AssetId
-assets = Map.keysSet . index
+assets = Map.keysSet . assetsAll
 
 -- | Returns the output corresponding to the given input, if one exists.
 --
@@ -318,6 +330,9 @@ data SelectionFilter
     | WithAsset AssetId
         -- ^ Select any UTxO entry that has a non-zero quantity of the specified
         -- asset.
+    | WithAssetOnly AssetId
+        -- ^ Select any UTxO entry that has a non-zero quantity of the specified
+        -- asset, but no other non-ada assets.
     deriving (Eq, Show)
 
 -- | Selects an entry at random from the index according to the given filter.
@@ -343,6 +358,7 @@ selectRandom u selectionFilter =
         Any -> Map.keysSet $ utxo u
         WithAdaOnly -> entriesWithAdaOnly u
         WithAsset a -> entriesWithAsset a u
+        WithAssetOnly a -> entriesWithAssetOnly a u
 
 --------------------------------------------------------------------------------
 -- Internal Interface
@@ -352,6 +368,27 @@ selectRandom u selectionFilter =
 -- Utilities
 --------------------------------------------------------------------------------
 
+-- | Represents different categories of token bundles.
+--
+data BundleCategory
+    = IsCoin
+    | IsCoinWithSingletonAsset AssetId
+    | IsCoinWithMultipleAssets (Set AssetId)
+    deriving (Eq, Show)
+
+-- | Categorizes a transaction output by what kind of bundle it contains.
+--
+categorizeTxOut :: TxOut -> BundleCategory
+categorizeTxOut o = case F.toList bundleAssets of
+    []  -> IsCoin
+    [a] -> IsCoinWithSingletonAsset a
+    _   -> IsCoinWithMultipleAssets bundleAssets
+  where
+    bundle = view #tokens o
+    bundleAssets = TokenBundle.getAssets bundle
+
+-- | Returns the set of keys for entries that have no assets other than ada.
+--
 entriesWithAdaOnly :: UTxOIndex -> Set TxIn
 entriesWithAdaOnly = coins
 
@@ -359,7 +396,15 @@ entriesWithAdaOnly = coins
 --   given asset.
 --
 entriesWithAsset :: AssetId -> UTxOIndex -> Set TxIn
-entriesWithAsset a = maybe mempty NonEmptySet.toSet . Map.lookup a . index
+entriesWithAsset a =
+    maybe mempty NonEmptySet.toSet . Map.lookup a . assetsAll
+
+-- | Returns the set of keys for entries that have no non-ada assets other than
+--   the given asset.
+--
+entriesWithAssetOnly :: AssetId -> UTxOIndex -> Set TxIn
+entriesWithAssetOnly a =
+    maybe mempty NonEmptySet.toSet . Map.lookup a . assetsSingleton
 
 -- Inserts an entry, but without checking the following pre-condition:
 --
@@ -368,16 +413,18 @@ entriesWithAsset a = maybe mempty NonEmptySet.toSet . Map.lookup a . index
 -- See 'insert' for a safe version of this function.
 --
 insertUnsafe :: TxIn -> TxOut -> UTxOIndex -> UTxOIndex
-insertUnsafe i o u = UTxOIndex
-    { index = F.foldl' insertEntry (index u) (txOutAssets o)
-    , coins = coins u & if txOutIsCoin o then Set.insert i else id
-    , balance = balance u `TokenBundle.add` view #tokens o
-    , utxo = Map.insert i o $ utxo u
-    }
+insertUnsafe i o u = u
+    & over #balance (`TokenBundle.add` view #tokens o)
+    & over #utxo (Map.insert i o)
+    & case categorizeTxOut o of
+        IsCoin ->
+            over #coins (Set.insert i)
+        IsCoinWithSingletonAsset a -> id
+            . over #assetsSingleton (`insertEntry` a)
+            . over #assetsAll (`insertEntry` a)
+        IsCoinWithMultipleAssets as ->
+            over #assetsAll (flip (F.foldl' insertEntry) as)
   where
-    txOutAssets :: TxOut -> Set AssetId
-    txOutAssets = TokenBundle.getAssets . view #tokens
-
     insertEntry
         :: Map AssetId (NonEmptySet TxIn)
         -> AssetId
@@ -420,8 +467,6 @@ data InvariantStatus
     | InvariantAssetsInconsistent
       -- ^ Indicates that the 'index' and the cached 'balance' value disagree
       --   about which assets are included.
-    | InvariantIndexedCoinsAreNotCoins
-      -- ^ Indicates that at least one member of 'coins' is not ada-only.
     deriving (Eq, Show)
 
 -- | Checks whether or not the invariant holds.
@@ -436,8 +481,6 @@ checkInvariant u
         InvariantIndexNonMinimal
     | not (assetsConsistent u) =
         InvariantAssetsInconsistent
-    | not (indexedCoinsAreIndeedCoins u) =
-        InvariantIndexedCoinsAreNotCoins
     | otherwise =
         InvariantHolds
   where
@@ -474,52 +517,69 @@ checkBalance u
     balanceComputed = F.foldMap (view #tokens) (utxo u)
     balanceStored = balance u
 
--- | Checks that every entry in the 'utxo' map has a corresponding set of
---   entries in the 'index'.
+-- | Checks that every entry in the 'utxo' map is properly indexed.
 --
 indexIsComplete :: UTxOIndex -> Bool
-indexIsComplete u = F.all entryIndexed $ Map.toList $ utxo u
+indexIsComplete u = F.all hasEntry $ Map.toList $ utxo u
   where
-    entryIndexed :: (TxIn, TxOut) -> Bool
-    entryIndexed (i, o)
-        | txOutIsCoin o =
+    hasEntry :: (TxIn, TxOut) -> Bool
+    hasEntry (i, o) = case categorizeTxOut o of
+        IsCoin ->
             i `Set.member` coins u
-        | otherwise =
-            F.all (indexed i) (TokenBundle.getAssets $ view #tokens o)
+        IsCoinWithSingletonAsset a -> (&&)
+            (hasEntryForAsset a i assetsAll)
+            (hasEntryForAsset a i assetsSingleton)
+        IsCoinWithMultipleAssets as ->
+            F.all (\a -> hasEntryForAsset a i assetsAll) as
 
-    indexed :: TxIn -> AssetId -> Bool
-    indexed i asset =
-        case Map.lookup asset (index u) of
-            Nothing -> False
-            Just is -> NonEmptySet.member i is
+    hasEntryForAsset
+        :: AssetId
+        -> TxIn
+        -> (UTxOIndex -> Map AssetId (NonEmptySet TxIn))
+        -> Bool
+    hasEntryForAsset asset i assetsMap =
+        maybe False (NonEmptySet.member i) $ Map.lookup asset $ assetsMap u
 
--- | Checks that every entry in the 'index' is required by some entry in the
---   'utxo' map.
+-- | Checks that every indexed entry is required by some entry in the 'utxo'
+--   map.
 --
 indexIsMinimal :: UTxOIndex -> Bool
-indexIsMinimal u = F.all assetIsMinimal $ Map.toList $ index u
+indexIsMinimal u = F.and
+    [ assetsAll u
+        & Map.toList
+        & F.all (\(a, i) -> F.all (entryHasAsset a) i)
+    , assetsSingleton u
+        & Map.toList
+        & F.all (\(a, i) -> F.all (entryHasSingletonAsset a) i)
+    , coins u
+        & F.all entryIsCoin
+    ]
   where
-    assetIsMinimal :: (AssetId, NonEmptySet TxIn) -> Bool
-    assetIsMinimal (asset, is) =
-        F.all (entryHasAsset asset) is
-
     entryHasAsset :: AssetId -> TxIn -> Bool
-    entryHasAsset asset i =
-        case Map.lookup i (utxo u) of
-            Nothing ->
-                False
-            Just o ->
-                Set.member asset $ TokenBundle.getAssets $ view #tokens o
+    entryHasAsset a = entryMatches $
+        (`TokenBundle.hasQuantity` a) . view #tokens
 
--- | Checks that the set of assets in the cached 'balance' is equal to the set
---   of assets in the 'index'.
+    entryHasSingletonAsset :: AssetId -> TxIn -> Bool
+    entryHasSingletonAsset a = entryMatches $
+        (== IsCoinWithSingletonAsset a) . categorizeTxOut
+
+    entryIsCoin :: TxIn -> Bool
+    entryIsCoin = entryMatches $
+        (== IsCoin) . categorizeTxOut
+
+    entryMatches :: (TxOut -> Bool) -> TxIn -> Bool
+    entryMatches test i = maybe False test $ Map.lookup i $ utxo u
+
+-- | Checks that the asset sets are consistent.
+--
+-- In particular, the set of assets in the cached 'balance' must be:
+--
+--    - equal to the set of assets in 'assetsAll'
+--    - a superset of the set of assets in 'assetsSingleton'.
 --
 assetsConsistent :: UTxOIndex -> Bool
-assetsConsistent u =
-    Map.keysSet (index u) == TokenBundle.getAssets (balance u)
-
--- | Checks that the indexed set of 'coins' only refers to ada-only outputs.
---
-indexedCoinsAreIndeedCoins :: UTxOIndex -> Bool
-indexedCoinsAreIndeedCoins u =
-    F.all (maybe False txOutIsCoin . flip Map.lookup (utxo u)) (coins u)
+assetsConsistent u = (&&)
+    (Map.keysSet (assetsAll u) == balanceAssets)
+    (Map.keysSet (assetsSingleton u) `Set.isSubsetOf` balanceAssets)
+  where
+    balanceAssets = TokenBundle.getAssets (balance u)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 
@@ -92,6 +91,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Control.DeepSeq
     ( NFData )
+import Control.Monad.Extra
+    ( firstJustM )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
 import Data.Function
@@ -388,12 +389,8 @@ selectRandomWithPriority
     -- ^ A list of selection filters to be traversed in descending order of
     -- priority, from left to right.
     -> m (Maybe ((TxIn, TxOut), UTxOIndex))
-selectRandomWithPriority u filters =
-    selectRandom u (NE.head filters) >>= \case
-        Just en -> pure $ Just en
-        Nothing -> case NE.nonEmpty $ NE.tail filters of
-            Just fs -> selectRandomWithPriority u fs
-            Nothing -> pure Nothing
+selectRandomWithPriority u =
+    firstJustM (selectRandom u) . NE.toList
 
 --------------------------------------------------------------------------------
 -- Internal Interface


### PR DESCRIPTION
# Issue Number

ADP-605

# Overview

This PR adjusts the coin selection algorithm to give priority to **_single-asset inputs_** when selecting for a given asset, similar to how we already give priority to coin-only inputs when selecting for coins.

By doing so, we:
- decrease the chance of selecting a **non-user-specified asset**.
- decrease the chance of **overselecting** a user-specified asset.
- potentially decrease the size and cost of a transaction in the case where the more relaxed filter would have selected a multi-asset input.

# Changes

- ac578218b32d265ba050f9c3336c2033c33b4582
  Extends the `SelectionFilter` type of `UTxOIndex`, adding a `WithAssetOnly` constructor. This allows callers of `selectRandom` to specify that they want to select an entry containing only the specified non-ada asset, and no other non-ada assets.
- 830e36f80e84946a0da89cb18ebb2bfe8167ad9d
  When selecting for UTxO entries containing a particular non-ada asset, give priority to entries that contain no other non-ada assets apart from the given asset.
- fc960182dc4877fe85ab6881f337a04af17635bd
  Test that selection lenses obey the correct priorities:
    - The `coinSelectionLens` should give priority to _coins_.
    - The `assetSelectionLens` should give priority to _singleton asset token bundles_: token bundles where there is only one non-ada asset.
- 1c8e0884ed06eb81ed0f5dab796a39c54dd89c3a
   Extracts out the responsibility for traversing through selection filters to function `selectRandomWithPriority`. As a consequence, the `limitReached` condition is now tested just once, regardless of how many filters are supplied, rather than repeatedly testing it on each recursive call to `selectMatchingQuantity`.