### PR TITLE
Do not fail with 'WithdrawalNotWorth' when estimating fees

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -2540,6 +2540,14 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                     (`shouldBe` Quantity 0)
                 ]
 
+        -- Even though there are no rewards left, it should be possible to
+        -- estimate the cost of a withdrawal.
+        rFee <- request @ApiFee ctx
+            (Link.getTransactionFee @'Shelley wSelf) Default payload
+        verify rFee
+            [ expectResponseCode HTTP.status202
+            ]
+
         -- Try withdrawing AGAIN, rewards that aren't there anymore.
         rTx <- request @(ApiTransaction n) ctx
             (Link.createTransaction @'Shelley wSelf) Default payload


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-345

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- a8bcc3cc82092c3c3b9269c2fb4bfefa2c9c9e08
  :round_pushpin: **Add extra check in existing scenario to capture regression regarding external withdrawals**
    This now fails with:

  ```
  403 Forbidden
  {
      "code": "withdrawal_not_worth",
      "message": "I've noticed that you're requesting a withdrawal from an account that is either empty or doesn't have a balance big enough to deserve being withdrawn. I won't proceed with that request."
  }
  ```

  which captures the regression.

- 23a698adf3387937a6f18bcc25ac67d08eb018d0
  :round_pushpin: **do not fail with 'WithdrawalNotWorth' when estimating fees**
    It used to be the case, and was changed when generalizing the management of the withdrawal in the API handlers. This commit re-introduces it.



# Comments

<!-- Additional comments or screenshots to attach if any -->

cc @nikolaglumac

NOTE: After discussion with the Daedalus team, we are no longer sure whether this is indeed a desired behavior. They'll discuss the matter and come back to us to know whether we should close or merge this PR.

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
