### PR TITLE
Return fewer change outputs when the minimum ada quantity cannot be satisfied.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -821,7 +821,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
     describe "STAKE_POOLS_JOIN_01x - Fee boundary values" $ do
         it "STAKE_POOLS_JOIN_01x - \
             \I can join if I have just the right amount" $ \ctx -> runResourceT $ do
-            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx + minUTxOValue]
+            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx]
             pool:_ <- map (view #id) . snd <$>
                 unsafeRequest @[ApiStakePool]
                     ctx (Link.listStakePools arbitraryStake) Empty
@@ -833,7 +833,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         it "STAKE_POOLS_JOIN_01x - \
            \I cannot join if I have not enough fee to cover" $ \ctx -> runResourceT $ do
-            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx + minUTxOValue - 1]
+            w <- fixtureWalletWith @n ctx [costOfJoining ctx + depositAmt ctx - 1]
             pool:_ <- map (view #id) . snd <$>
                 unsafeRequest @[ApiStakePool]
                     ctx (Link.listStakePools arbitraryStake) Empty
@@ -906,7 +906,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         it "STAKE_POOLS_QUIT_01x - \
             \I cannot quit if I have not enough to cover fees" $ \ctx -> runResourceT $ do
-            let initBalance = [ costOfJoining ctx + depositAmt ctx + minUTxOValue ]
+            let initBalance = [costOfJoining ctx + depositAmt ctx]
             w <- fixtureWalletWith @n ctx initBalance
 
             pool:_ <- map (view #id) . snd
@@ -927,7 +927,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
             quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
                 [ expectResponseCode HTTP.status403
-                , expectErrorMessage errMsg403Fee
+                , expectErrorMessage errMsg403NotEnoughMoney
                 ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_01 - can estimate fees" $ \ctx -> runResourceT $ do

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1287,30 +1287,61 @@ selectAssetsNoOutputs ctx wid wal tx transform = do
         { outputsCovered = mempty
         , changeGenerated =
             let
-                -- NOTE 1: This subtraction and head are safe because of the
+                -- NOTE 1: There are in principle 6 cases we may ran into, which
+                -- can be grouped in 3 groups of 2 cases:
+                --
+                -- (1) When registering a key and delegating
+                -- (2) When delegating
+                -- (3) When de-registering a key
+                --
+                -- For each case, there may be one or zero change output. For
+                -- all 3 cases, we'll treat the case where there's no change
+                -- output as an edge-case and also leave no change. This may be
+                -- in practice more costly than necessary because, by removing
+                -- the fake output, we'd in practice have some more Ada
+                -- available to create a change (and a less expensive
+                -- transaction). Yet, this would require quite some extra logic
+                -- here in addition to all the existing logic inside the
+                -- CoinSelection/MA/RoundRobin module already. If we were not
+                -- able to add a change output already, let's not try to do it
+                -- here. Worse that can be list is:
+                --
+                --     max (minUTxOValue, keyDepositValue)
+                --
+                -- which we'll deem acceptable under the circumstances (that can
+                -- only really happen if one is trying to delegate with already
+                -- a very small Ada balance, so that it's left with no Ada after
+                -- having paid for the delegation certificate. Why would one be
+                -- delegating almost nothing certainly is an edge-case not worth
+                -- considering for too long).
+                --
+                -- However, if a change output has been create, then we want to
+                -- transfer the surplus of value from the change output to that
+                -- change output (which is already safe). That surplus is
+                -- non-null if the `minUTxOValue` protocol parameter is
+                -- non-null, and comes from the fact that the selection
+                -- algorithm automatically assigns this value when presented
+                -- with a null output. In the case of (1), the output's value is
+                -- equal to the stake key deposit value, which may be in
+                -- practice greater than the `minUTxOValue`. In the case of (2)
+                -- and (3), the deposit is null. So it suffices to subtract
+                -- `deposit` to the value of the covered output to get the
+                -- surplus.
+                --
+                -- NOTE 2: This subtraction and head are safe because of the
                 -- invariants enforced by the asset selection algorithm. The
                 -- output list has the exact same length as the input list, and
                 -- outputs are at least as large as the specified outputs.
-                --
-                -- NOTE 2: When presented with 0 Ada outputs, the selection
-                -- algorithm will assign a minimum default value to the output.
-                -- So the output covered may be in practice bigger than the
-                -- output specified. This is the case when 'deposit' is null, in
-                -- which case, we want to make sure to add this extra minimum
-                -- value to the resulting change and not completely discard it.
-                reclaim = TokenBundle.unsafeSubtract
+                surplus = TokenBundle.unsafeSubtract
                     (view #tokens (head $ outputsCovered sel))
                     (TokenBundle.fromCoin deposit)
             in
-                once
-                    (TokenBundle.empty)
-                    (TokenBundle.add reclaim)
-                    (changeGenerated sel)
+                surplus `addToHead` changeGenerated sel
         }
   where
-    once :: a -> (a -> a) -> [a] -> [a]
-    once _ f (a : as) = f a : as
-    once a _ [] = [a]
+    addToHead :: TokenBundle -> [TokenBundle] -> [TokenBundle]
+    addToHead _    [] = []
+    addToHead x (h:q) = TokenBundle.add x h : q
 
 -- | Selects assets from the wallet's UTxO to satisfy the requested outputs in
 -- the given transaction context. In case of success, returns the selection

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -800,7 +800,7 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
         totalOutputCoinValueIsZero
     | otherwise = do
         (bundles, remainder) <-
-            maybe (Left $ changeError excessCoin change) Right $
+            maybe (Left changeError) Right $
                 excessCoin `subtractCoin` requiredCost
                 >>=
                 runStateT
@@ -851,21 +851,17 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
     totalOutputCoinValueIsZero = error
         "makeChange: not (totalOutputCoinValue > 0)"
 
-    changeError
-        :: Coin
-        -> NonEmpty TokenMap
-        -> UnableToConstructChangeError
-    changeError excessCoin change =
-        UnableToConstructChangeError
-            { requiredCost
-            , shortfall =
-                -- This conversion is safe because we know that the distance is
-                -- small-ish. If it wasn't, we would have have enough coins to
-                -- construct the change.
-                unsafeNaturalToCoin $ distance
-                    (coinToNatural excessCoin)
-                    (coinToNatural requiredCost + totalMinCoinValue)
-            }
+    changeError :: UnableToConstructChangeError
+    changeError = UnableToConstructChangeError
+        { requiredCost
+        , shortfall =
+            -- This conversion is safe because we know that the distance is
+            -- small-ish. If it wasn't, we would have have enough coins to
+            -- construct the change.
+            unsafeNaturalToCoin $ distance
+                (coinToNatural excessCoin)
+                (coinToNatural requiredCost + totalMinCoinValue)
+        }
       where
         totalMinCoinValue =
             F.sum $ (coinToNatural . minCoinValueFor) <$> change

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -799,7 +799,7 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
     | TokenBundle.getCoin totalOutputValue == Coin 0 =
         totalOutputCoinValueIsZero
     | otherwise = do
-        (bundles, remainder) <-
+        (changeForAssetsWithMinimalCoins, remainder) <-
             maybe (Left changeError) Right $
                 excessCoin `subtractCoin` requiredCost
                 >>=
@@ -811,7 +811,9 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
             changeForCoins = TokenBundle.fromCoin
                 <$> makeChangeForCoin outputCoins remainder
 
-        pure $ NE.toList $ NE.zipWith (<>) bundles changeForCoins
+        pure $ NE.toList $ NE.zipWith (<>)
+            changeForAssetsWithMinimalCoins
+            changeForCoins
   where
     -- The following subtraction is safe, as we have already checked
     -- that the total input value is greater than the total output

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -915,8 +915,8 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
     totalOutputValue = F.fold outputBundles
 
     -- Identifiers of assets included in outputs.
-    knownAssetIds :: Set AssetId
-    knownAssetIds = TokenBundle.getAssets totalOutputValue
+    userSpecifiedAssetIds :: Set AssetId
+    userSpecifiedAssetIds = TokenBundle.getAssets totalOutputValue
 
     discardUserSpecifiedAssets
         :: TokenBundle
@@ -926,7 +926,7 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
         foldr (\(k, v) -> Map.insertWith (<>) k (v :| [])) m filtered
       where
         filtered = filter
-            ((`Set.notMember` knownAssetIds) . fst)
+            ((`Set.notMember` userSpecifiedAssetIds) . fst)
             (TokenMap.toFlatList tokens)
 
 -- | Assigns coin quantities to a list of pre-computed asset change maps.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -861,14 +861,6 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
         changeForUserSpecifiedAssets
         changeForNonUserSpecifiedAssets
 
-    -- Change for all assets, with the minimum ada amounts added.
-    changeForAssetsWithMinimalCoins :: NonEmpty TokenBundle
-    changeForAssetsWithMinimalCoins =
-        assignMinimumCoin minCoinFor <$> changeForAssets
-
-    totalMinimumCoinForAssets =
-        F.foldMap TokenBundle.getCoin changeForAssetsWithMinimalCoins
-
     totalInputValueInsufficient = error
         "makeChange: not (totalOutputValue <= totalInputValue)"
     totalOutputCoinValueIsZero = error
@@ -882,11 +874,12 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
             -- small-ish. If it wasn't, we would have have enough coins to
             -- construct the change.
             unsafeNaturalToCoin $ distance
-                ( coinToNatural excessCoin )
-                ( coinToNatural requiredCost
-                + coinToNatural totalMinimumCoinForAssets
-                )
-        }
+                (coinToNatural excessCoin)
+                (coinToNatural requiredCost + totalMinCoinValue)
+            }
+      where
+        totalMinCoinValue =
+            F.sum $ coinToNatural . minCoinFor <$> changeForAssets
 
     -- We aim, to the greatest extent possible, to generate change bundles
     -- where small quantities of non-user-specified assets are bundled together

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -51,6 +51,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , makeChangeForCoin
     , makeChangeForUserSpecifiedAsset
     , makeChangeForNonUserSpecifiedAsset
+    , assignCoinsToChangeMaps
 
     -- * Grouping and ungrouping
     , groupByKey

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1014,8 +1014,8 @@ assignCoin
     -> TokenMap
     -> Coin
     -> Maybe (TokenBundle, Coin)
-assignCoin minCoinValueFor tokens availableCoins@(Coin c)
-    | availableCoins < minCoin =
+assignCoin minCoinValueFor tokens availableCoin@(Coin c)
+    | availableCoin < minCoin =
         Nothing
     | otherwise =
         Just (TokenBundle minCoin tokens, Coin (c - m))

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -803,8 +803,9 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
             maybe (Left changeError) Right $
                 excessCoin `subtractCoin` requiredCost
                 >>=
-                runStateT
-                    (sequence (StateT . assignCoin minCoinValueFor <$> change))
+                runStateT (sequence
+                    (StateT . assignCoin minCoinValueFor <$> changeForAssets)
+                )
 
         let changeForCoins :: NonEmpty TokenBundle
             changeForCoins = TokenBundle.fromCoin
@@ -841,8 +842,9 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
         (TokenMap.empty <$ outputMapsOrdered)
         nonUserSpecifiedAssets
 
-    change :: NonEmpty TokenMap
-    change = NE.zipWith (<>)
+    -- Change for all assets: both user-specified and non-user-specified.
+    changeForAssets :: NonEmpty TokenMap
+    changeForAssets = NE.zipWith (<>)
         changeForUserSpecifiedAssets
         changeForNonUserSpecifiedAssets
 
@@ -864,7 +866,7 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
         }
       where
         totalMinCoinValue =
-            F.sum $ (coinToNatural . minCoinValueFor) <$> change
+            F.sum $ (coinToNatural . minCoinValueFor) <$> changeForAssets
 
     -- We aim, to the greatest extent possible, to generate change bundles
     -- where small quantities of non-user-specified assets are bundled together

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -834,9 +834,6 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
 
     (excessCoin, excessAssets) = TokenBundle.toFlatList excess
 
-    nonUserSpecifiedAssets = Map.toList $
-        F.foldr discardUserSpecifiedAssets mempty inputBundles
-
     -- Change for user-specified assets: assets that were present in the
     -- original set of user-specified outputs ('outputsToCover').
     changeForUserSpecifiedAssets :: NonEmpty TokenMap
@@ -914,9 +911,20 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
     totalOutputValue :: TokenBundle
     totalOutputValue = F.fold outputBundles
 
-    -- Identifiers of assets included in outputs.
+    -- Identifiers of all user-specified assets: assets that were included in
+    -- the original set of outputs.
     userSpecifiedAssetIds :: Set AssetId
     userSpecifiedAssetIds = TokenBundle.getAssets totalOutputValue
+
+    -- Identifiers and quantities of all non-user-specified assets: assets that
+    -- were not included in the orginal set of outputs, but that were
+    -- nevertheless selected during the selection process.
+    --
+    -- Each asset is paired with the complete list of quantities of that asset
+    -- present in the selected inputs.
+    nonUserSpecifiedAssets :: [(AssetId, NonEmpty TokenQuantity)]
+    nonUserSpecifiedAssets = Map.toList $
+        F.foldr discardUserSpecifiedAssets mempty inputBundles
 
     discardUserSpecifiedAssets
         :: TokenBundle

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -799,7 +799,7 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
     | TokenBundle.getCoin totalOutputValue == Coin 0 =
         totalOutputCoinValueIsZero
     | otherwise = do
-        (changeForAssetsWithMinimalCoins, remainder) <-
+        (changeForAssetsWithMinimalCoins, leftoverCoin) <-
             maybe (Left changeError) Right $
                 excessCoin `subtractCoin` requiredCost
                 >>=
@@ -809,7 +809,7 @@ makeChange minCoinValueFor requiredCost mExtraCoinSource inputBundles outputBund
 
         let changeForCoins :: NonEmpty TokenBundle
             changeForCoins = TokenBundle.fromCoin
-                <$> makeChangeForCoin outputCoins remainder
+                <$> makeChangeForCoin outputCoins leftoverCoin
 
         pure $ NE.toList $ NE.zipWith (<>)
             changeForAssetsWithMinimalCoins

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1011,14 +1011,8 @@ assignCoinsToChangeMaps adaAvailable minCoinFor pairsAtStart =
             let adaRequired' = adaRequired `Coin.distance` minCoinFor m in
             loop adaRequired' (p :| ps)
 
-        (m, _) :| [] | TokenMap.isEmpty m && adaAvailable >= adaRequired ->
-            -- We didn't have any non-ada assets at all in our change. We can
-            -- simply return the available ada amount as a singleton change
-            -- bundle:
-            Just [TokenBundle.fromCoin adaAvailable]
-
         (m, _) :| [] | TokenMap.isEmpty m && adaAvailable < adaRequired ->
-            -- We didn't have any non-ada assets at all in our change, but we
+            -- We didn't have any non-ada assets at all in our change, and we
             -- also don't have enough ada available to pay even for a single
             -- change output. We just burn the available ada amount (which
             -- will be small), returning no change.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -584,14 +584,19 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             , pretty (Flat balanceSelected)
             , "change balance:"
             , pretty (Flat balanceChange)
+            , "cost:"
+            , pretty expectedCost
             , "absolute minimum coin quantity:"
             , pretty absoluteMinCoinValue
             , "actual coin delta:"
             , pretty (TokenBundle.getCoin delta)
+            , "maximum expected delta:"
+            , pretty maximumExpectedDelta
             , "number of outputs:"
             , pretty (length outputsCovered)
+            , "number of change outputs:"
+            , pretty (length changeGenerated)
             ]
-        assert True
         assert $ balanceSufficient criteria
         assert $ on (==) (view #tokens)
             balanceSelected (balanceRequired <> balanceChange)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -561,7 +561,7 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
                 UTxOIndex.fromSequence inputsSelected
             , outputsSkeleton =
                 NE.toList outputsToCover
-            , changeSkeleton  = NE.toList $
+            , changeSkeleton =
                 fmap (TokenMap.getAssets . view #tokens) changeGenerated
             }
         balanceSelected =
@@ -1028,7 +1028,7 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
 
 makeChangeWith
     :: MakeChangeData
-    -> Either UnableToConstructChangeError (NonEmpty TokenBundle)
+    -> Either UnableToConstructChangeError [TokenBundle]
 makeChangeWith p = makeChange
     (mkMinCoinValueFor $ minCoinValueDef p)
     (cost p)
@@ -1074,7 +1074,7 @@ prop_makeChange p =
 -- See also 'prop_makeChange' as a top-level property driver.
 prop_makeChange_success_delta
     :: MakeChangeData
-    -> NonEmpty TokenBundle
+    -> [TokenBundle]
     -> Property
 prop_makeChange_success_delta p change =
     let
@@ -1115,7 +1115,7 @@ prop_makeChange_success_delta p change =
 -- See also `prop_makeChange` as a top-level property driver.
 prop_makeChange_success_minValueRespected
     :: MakeChangeData
-    -> NonEmpty TokenBundle
+    -> [TokenBundle]
     -> Property
 prop_makeChange_success_minValueRespected p =
     F.foldr ((.&&.) . checkMinValue) (property True)
@@ -1219,7 +1219,7 @@ unit_makeChange =
           , Nothing
           , b 2 [] :| []
           , b 1 [] :| []
-          , Right $ b 1 [] :| []
+          , Right [b 1 []]
           )
 
         -- Two outputs, no cost, changes are proportional, no extra assets
@@ -1227,7 +1227,10 @@ unit_makeChange =
           , Nothing
           , b 9 [(assetA, 9), (assetB, 6)] :| []
           , b 2 [(assetA, 1)] :| [b 1 [(assetA, 2), (assetB, 3)]]
-          , Right $ b 4 [(assetA, 2)] :| [b 2 [(assetA, 4), (assetB, 3)]]
+          , Right
+              [ b 4 [(assetA, 2)]
+              , b 2 [(assetA, 4), (assetB, 3)]
+              ]
           )
 
         -- Extra non-user-specified assets. Large assets end up in 'large'
@@ -1236,7 +1239,10 @@ unit_makeChange =
           , Nothing
           , b 1 [(assetA, 10), (assetC, 1)] :| [b 1 [(assetB, 2), (assetC, 8)]]
           , b 1 [(assetA, 5)] :| [b 1 [(assetB, 1)]]
-          , Right $ b 0 [(assetB, 1), (assetC, 1)] :| [b 0 [(assetA, 5), (assetC, 8)]]
+          , Right
+              [ b 0 [(assetB, 1), (assetC, 1)]
+              , b 0 [(assetA, 5), (assetC, 8)]
+              ]
           )
         ]
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -989,7 +989,7 @@ linearCost SelectionSkeleton{inputsSkeleton, outputsSkeleton, changeSkeleton}
 data MakeChangeData = MakeChangeData
     { inputBundles
         :: NonEmpty TokenBundle
-    , extraInputCoins
+    , extraInputCoin
         :: Maybe Coin
     , outputBundles
         :: NonEmpty TokenBundle
@@ -1006,7 +1006,7 @@ isValidMakeChangeData p = (&&)
   where
     totalInputValue = TokenBundle.add
         (F.fold $ inputBundles p)
-        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoins p))
+        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoin p))
     totalOutputValue = F.fold $ outputBundles p
     totalOutputCoinValue = TokenBundle.getCoin totalOutputValue
 
@@ -1032,7 +1032,7 @@ makeChangeWith
 makeChangeWith p = makeChange
     (mkMinCoinValueFor $ minCoinValueDef p)
     (cost p)
-    (extraInputCoins p) (inputBundles p)
+    (extraInputCoin p) (inputBundles p)
     (outputBundles p)
 
 prop_makeChange_identity
@@ -1050,7 +1050,7 @@ prop_makeChange_length p =
         Right xs -> length xs === length (outputBundles p)
   where
     change = makeChange noMinCoin noCost
-        (extraInputCoins p) (inputBundles p) (outputBundles p)
+        (extraInputCoin p) (inputBundles p) (outputBundles p)
 
 prop_makeChange
     :: MakeChangeData
@@ -1099,7 +1099,7 @@ prop_makeChange_success_delta p change =
         ]
     totalInputValue = TokenBundle.add
         (F.fold (inputBundles p))
-        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoins p))
+        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoin p))
     totalInputCoin =
         TokenBundle.getCoin totalInputValue
     totalOutputValue =
@@ -1155,7 +1155,7 @@ prop_makeChange_fail_costTooBig p =
   where
     totalInputValue = TokenBundle.add
         (F.fold (inputBundles p))
-        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoins p))
+        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoin p))
     totalOutputValue =
         F.fold $ outputBundles p
 
@@ -1202,7 +1202,7 @@ prop_makeChange_fail_minValueTooBig p =
   where
     totalInputValue = TokenBundle.add
         (F.fold (inputBundles p))
-        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoins p))
+        (maybe TokenBundle.empty TokenBundle.fromCoin (extraInputCoin p))
     totalOutputValue =
         F.fold $ outputBundles p
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -545,7 +545,7 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
             Nothing
         , outputsCovered =
             [ TxOut (Address "destination") (TokenBundle.fromCoin $ Coin 14) ]
-        , changeGenerated = NE.fromList
+        , changeGenerated =
             [ (TokenBundle.fromCoin $ Coin 1) ]
         , utxoRemaining =
             UTxOIndex.empty

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -237,7 +237,7 @@ spec = do
                       { inputsSelected = NE.fromList inps
                       , extraCoinSource = Nothing
                       , outputsCovered = outs
-                      , changeGenerated = NE.fromList chgs
+                      , changeGenerated = chgs
                       , utxoRemaining = UTxOIndex.empty
                       }
                   inps = Map.toList $ getUTxO utxo
@@ -331,7 +331,7 @@ spec = do
                     { inputsSelected = NE.fromList inps
                     , extraCoinSource = Nothing
                     , outputsCovered = outs
-                    , changeGenerated = NE.fromList chgs
+                    , changeGenerated = chgs
                     , utxoRemaining = UTxOIndex.empty
                     }
                   inps = Map.toList $ getUTxO utxo
@@ -457,7 +457,7 @@ prop_decodeSignedShelleyTxRoundtrip shelleyEra (DecodeShelleySetup utxo outs md 
         { inputsSelected = NE.fromList inps
         , extraCoinSource = Nothing
         , outputsCovered = []
-        , changeGenerated = NE.fromList outs
+        , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
         }
 
@@ -483,7 +483,7 @@ prop_decodeSignedByronTxRoundtrip (DecodeByronSetup utxo outs slotNo ntwrk pairs
         { inputsSelected = NE.fromList inps
         , extraCoinSource = Nothing
         , outputsCovered = []
-        , changeGenerated = NE.fromList outs
+        , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
         }
 


### PR DESCRIPTION
# Issue Number

https://jira.iohk.io/projects/ADP/issues/ADP-696

# Overview

By default, the coin selection algorithm attempts to make exactly one change output for each user-specified output.

But in situations where the supply of ada is limited, this strategy can lead to failure if it is not possible to assign the minimum ada quantities to all change outputs.

This PR relaxes this restriction, so that in situations where ada is limited, we allow the algorithm to return fewer change outputs. 

# Comments

- [x] Adjust coin selection algorithm to allow a reduced number of change outputs when the supply of ada is limited.
- [x] Update property tests to allow a slightly-increased fee in the case when change outputs have been dropped.
- [x] Revises the way we sort change maps within `makeChange` so that:
    - Empty change bundles are placed at the start.
    - Empty change bundles deriving from **_user-specified assets_** and empty change bundles deriving from **_non-user-specified assets_** are combined together, if possible.
- [x] Add property test to check that sorting token bundles by `AssetCount` always places coins before non-coins.
- [ ] Add property test to check that it is possible to send the entire balance to another wallet.
    - [ ] Generalize this property to work with non-zero minimum ada quantities.