### PR TITLE
API: get and list only assets associated with the wallet

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -863,27 +863,18 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
     it "TRANS_ASSETS_GET_02 - Asset not present when isn't associated" $ \ctx -> runResourceT $ do
         wal <- fixtureMultiAssetWallet ctx
-        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ B8.replicate 56 '1'
-        let assName = TokenPolicy.UnsafeTokenName $ B8.replicate 4 '1'
+        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
+        let assName = TokenPolicy.UnsafeTokenName $ B8.replicate 4 'x'
         let ep = Link.getAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
-        liftIO $ print r
-        liftIO $ pendingWith "ADP-604 - check that asset is present in wallet"
-        verify r
-            [ expectResponseCode HTTP.status404
-            -- todo: check nothing is returned?
-            ]
+        expectResponseCode HTTP.status404 r
 
     it "TRANS_ASSETS_GET_02a - Asset not present when isn't associated" $ \ctx -> runResourceT $ do
         wal <- fixtureMultiAssetWallet ctx
-        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ B8.replicate 56 '1'
+        let polId = TokenPolicy.UnsafeTokenPolicyId $ Hash $ BS.replicate 28 0
         let ep = Link.getAsset wal polId TokenPolicy.nullTokenName
         r <- request @(ApiAsset) ctx ep Default Empty
-        liftIO $ pendingWith "ADP-604 - check that asset is present in wallet"
-        verify r
-            [ expectResponseCode HTTP.status404
-            -- todo: check nothing is returned?
-            ]
+        expectResponseCode HTTP.status404 r
 
     let absSlotB = view (#absoluteSlotNumber . #getApiT)
     let absSlotS = view (#absoluteSlotNumber . #getApiT)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1034,6 +1034,7 @@ data ApiErrorCode
     | UnableToAssignInputOutput
     | SoftDerivationRequired
     | HardenedDerivationRequired
+    | AssetNotPresent
     deriving (Eq, Generic, Show, Data, Typeable)
     deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -275,4 +275,5 @@ computeStatistics getCoins btype utxos =
 
 -- | List all assets seen in the UTxO.
 getAssets :: UTxO -> Set TB.AssetId
-getAssets = Set.unions . map (TB.getAssets . view #tokens . snd) . Map.toList . getUTxO
+getAssets =
+    Set.unions . map (TB.getAssets . view #tokens . snd) . Map.toList . getUTxO

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2927,6 +2927,19 @@ x-errUnableToAssignInputOutput: &errUnableToAssignInputOutput
       type: string
       enum: ['unable_to_assign_input_output']
 
+x-errAssetNotPresent: &errAssetNotPresent
+  <<: *responsesErr
+  title: asset_not_present
+  properties:
+    message:
+      type: string
+      description: |
+        Occurs when requesting information about an asset which is not
+        involved in any transaction related to the wallet.
+    code:
+      type: string
+      enum: ['asset_not_present']
+
 x-responsesErr400: &responsesErr400
   400:
     description: Bad Request
@@ -3014,6 +3027,13 @@ x-responsesListWallets: &responsesListWallets
           type: array
           items: *ApiWallet
 
+x-responsesErr404AssetNotPresent: &responsesErr404AssetNotPresent
+  404:
+    description: Not Found
+    content:
+      application/json:
+        schema: *errAssetNotPresent
+
 x-responsesListAssets: &responsesListAssets
   <<: *responsesErr406
   200:
@@ -3025,7 +3045,7 @@ x-responsesListAssets: &responsesListAssets
           items: *ApiAsset
 
 x-responsesGetAsset: &responsesGetAsset
-  <<: *responsesErr404
+  <<: *responsesErr404AssetNotPresent
   <<: *responsesErr406
   200:
     description: Ok


### PR DESCRIPTION
### Issue Number

ADP-603 / ADP-604

### Overview

- The list assets endpoint now returns all assets of the wallet, not just available assets.
- The get asset endpoint checks that the asset id really is associated with the wallet.

