### PR TITLE
Token Metadata Server integration

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1389,18 +1389,16 @@ poolMetadataSourceOption = option (eitherReader reader) $ mempty
     reader :: String -> Either String PoolMetadataSource
     reader = fromTextS @PoolMetadataSource
 
+-- | [--token-metadata-server=URL]
 tokenMetadataSourceOption
     :: Parser TokenMetadataServerURI
-tokenMetadataSourceOption = option (eitherReader reader) $ mempty
+tokenMetadataSourceOption = optionT $ mempty
     <> long "token-metadata-server"
     <> metavar "URL"
-    <> help ("Sets the URL to the token metadata server. If not set, no "
-            <> "metadata will be fetched.\n"
-            <> "The metadata server is currently blindly trusted. This will be "
-            <> "changed at a later stage.")
-  where
-    reader :: String -> Either String TokenMetadataServerURI
-    reader = fromTextS @TokenMetadataServerURI
+    <> help ("Sets the URL of the token metadata server. "
+            <> "If unset, metadata will not be fetched.\n"
+            <> "By using this option, you are fully trusting the operator of "
+            <> "the metadata server to provide authentic token metadata.")
 
 -- | <wallet-id=WALLET_ID>
 walletIdArgument :: Parser WalletId

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -181,7 +181,7 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( PoolMetadataSource (..)
     , SortOrder
-    , TokenMetadataServerURI
+    , TokenMetadataServer
     , WalletId
     , WalletName
     )
@@ -1391,7 +1391,7 @@ poolMetadataSourceOption = option (eitherReader reader) $ mempty
 
 -- | [--token-metadata-server=URL]
 tokenMetadataSourceOption
-    :: Parser TokenMetadataServerURI
+    :: Parser TokenMetadataServer
 tokenMetadataSourceOption = optionT $ mempty
     <> long "token-metadata-server"
     <> metavar "URL"

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -56,6 +56,7 @@ module Cardano.CLI
     , syncToleranceOption
     , tlsOption
     , poolMetadataSourceOption
+    , tokenMetadataSourceOption
     , metadataOption
     , timeToLiveOption
 
@@ -178,7 +179,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
-    ( PoolMetadataSource (..), SortOrder, WalletId, WalletName )
+    ( PoolMetadataSource (..)
+    , SortOrder
+    , TokenMetadataServerURI
+    , WalletId
+    , WalletName
+    )
 import Cardano.Wallet.Primitive.Types.Address
     ( AddressState )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -1382,6 +1388,19 @@ poolMetadataSourceOption = option (eitherReader reader) $ mempty
   where
     reader :: String -> Either String PoolMetadataSource
     reader = fromTextS @PoolMetadataSource
+
+tokenMetadataSourceOption
+    :: Parser TokenMetadataServerURI
+tokenMetadataSourceOption = option (eitherReader reader) $ mempty
+    <> long "token-metadata-server"
+    <> metavar "URL"
+    <> help ("Sets the URL to the token metadata server. If not set, no "
+            <> "metadata will be fetched.\n"
+            <> "The metadata server is currently blindly trusted. This will be "
+            <> "changed at a later stage.")
+  where
+    reader :: String -> Either String TokenMetadataServerURI
+    reader = fromTextS @TokenMetadataServerURI
 
 -- | <wallet-id=WALLET_ID>
 walletIdArgument :: Parser WalletId

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -36,6 +36,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( AssetMetadata (AssetMetadata) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..), TxStatus (..) )
 import Cardano.Wallet.Unsafe
@@ -251,11 +253,12 @@ spec = describe "BYRON_TRANSACTIONS" $ do
                 pickAnAsset assetsSrc
         let ep = Link.getByronAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
+        let meta = ApiT (AssetMetadata "SteveToken" "A sample description")
         verify r
             [ expectSuccess
             , expectField #policyId (`shouldBe` ApiT polId)
             , expectField #assetName (`shouldBe` ApiT assName)
-            , expectField #metadata (`shouldBe` Nothing)
+            , expectField #metadata (`shouldBe` Just meta)
             ]
 
     describe "BYRON_TRANS_ASSETS_GET_02 - Asset not present when isn't associated" $

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -47,6 +47,8 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( AssetMetadata (AssetMetadata) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..), TxMetadata (..), TxMetadataValue (..), TxStatus (..) )
 import Cardano.Wallet.Unsafe
@@ -613,10 +615,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectField (#assets . #total . #getApiT) (`shouldNotBe` TokenMap.empty)
             ]
 
-        let meta = ApiT $ TokenPolicy.AssetMetadata
-                { TokenPolicy.name = "SteveToken"
-                , TokenPolicy.description = "A sample description"
-                }
+        let meta = ApiT $ AssetMetadata "SteveToken" "A sample description"
         r2 <- request @[ApiAsset] ctx (Link.listAssets w) Default Empty
         verify r2
             [ expectListField 0 #metadata (`shouldBe` Just meta)
@@ -804,11 +803,12 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 pickAnAsset assetsSrc
         let ep = Link.getAsset wal polId assName
         r <- request @(ApiAsset) ctx ep Default Empty
+        let meta = ApiT $ AssetMetadata "SteveToken" "A sample description"
         verify r
             [ expectSuccess
             , expectField #policyId (`shouldBe` ApiT polId)
             , expectField #assetName (`shouldBe` ApiT assName)
-            , expectField #metadata (`shouldBe` Nothing)
+            , expectField #metadata (`shouldBe` Just meta)
             ]
 
     it "TRANS_ASSETS_GET_02 - Asset not present when isn't associated" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -613,6 +613,15 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectField (#assets . #total . #getApiT) (`shouldNotBe` TokenMap.empty)
             ]
 
+        let meta = ApiT $ TokenPolicy.AssetMetadata
+                { TokenPolicy.name = "SteveToken"
+                , TokenPolicy.description = "A sample description"
+                }
+        r2 <- request @[ApiAsset] ctx (Link.listAssets w) Default Empty
+        verify r2
+            [ expectListField 0 #metadata (`shouldBe` Just meta)
+            ]
+
     it "TRANS_ASSETS_CREATE_01a - Multi-asset transaction with Ada" $ \ctx -> runResourceT $ do
 
         wSrc <- fixtureMultiAssetWallet ctx

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -185,6 +185,7 @@ library
       Cardano.Wallet.Primitive.Types.UTxO
       Cardano.Wallet.Primitive.Types.UTxOIndex
       Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+      Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Registry
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe
@@ -361,7 +362,6 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TokenMetadataSpec
-      Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.RegistrySpec
       Cardano.Wallet.TransactionSpec
       Cardano.WalletSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -37,6 +37,7 @@ library
     , bech32-th
     , binary
     , bytestring
+    , casing
     , cardano-addresses
     , cardano-api
     , cardano-crypto
@@ -159,6 +160,7 @@ library
       Cardano.Wallet.Network.BlockHeaders
       Cardano.Wallet.Network.Ports
       Cardano.Wallet.Orphans
+      Cardano.Wallet.TokenMetadata
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Byron
       Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -359,6 +361,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.UTxOIndexSpec
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec
+      Cardano.Wallet.TokenMetadataSpec
       Cardano.Wallet.RegistrySpec
       Cardano.Wallet.TransactionSpec
       Cardano.WalletSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -37,7 +37,6 @@ library
     , bech32-th
     , binary
     , bytestring
-    , casing
     , cardano-addresses
     , cardano-api
     , cardano-crypto

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -362,6 +362,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TokenMetadataSpec
+      Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.RegistrySpec
       Cardano.Wallet.TransactionSpec
       Cardano.WalletSpec

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -123,6 +123,8 @@ module Cardano.Wallet.Api
     , workerRegistry
     , HasDBFactory
     , dbFactory
+    , tokenMetadataClient
+    , HasTokenMetadataClient
     ) where
 
 import Prelude
@@ -878,12 +880,19 @@ workerRegistry =
     typed @(WorkerRegistry WalletId (DBLayer IO s k))
 
 type HasDBFactory s k = HasType (DBFactory IO s k)
+type HasTokenMetadataClient = HasType (TokenMetadataClient IO)
 
 dbFactory
     :: forall s k ctx. (HasDBFactory s k ctx)
     => Lens' ctx (DBFactory IO s k)
 dbFactory =
     typed @(DBFactory IO s k)
+
+tokenMetadataClient
+    :: forall ctx. (HasTokenMetadataClient ctx)
+    => Lens' ctx (TokenMetadataClient IO)
+tokenMetadataClient =
+    typed @(TokenMetadataClient IO)
 
 {-------------------------------------------------------------------------------
                               Type Families

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -200,7 +200,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog, WorkerRegistry )
 import Cardano.Wallet.TokenMetadata
-    ( TokenMetadataClient (..) )
+    ( TokenMetadataClient )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Tracer

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -197,6 +197,8 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId )
 import Cardano.Wallet.Registry
     ( HasWorkerCtx (..), WorkerLog, WorkerRegistry )
+import Cardano.Wallet.TokenMetadata
+    ( TokenMetadataClient (..) )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Tracer
@@ -848,13 +850,14 @@ data ApiLayer s (k :: Depth -> * -> *)
         (TransactionLayer k)
         (DBFactory IO s k)
         (WorkerRegistry WalletId (DBLayer IO s k))
+        (TokenMetadataClient IO)
     deriving (Generic)
 
 instance HasWorkerCtx (DBLayer IO s k) (ApiLayer s k) where
     type WorkerCtx (ApiLayer s k) = WalletLayer s k
     type WorkerMsg (ApiLayer s k) = WalletLog
     type WorkerKey (ApiLayer s k) = WalletId
-    hoistResource db transform (ApiLayer tr gp nw tl _ _) =
+    hoistResource db transform (ApiLayer tr gp nw tl _ _ _) =
         WalletLayer (contramap transform tr) gp nw tl db
 
 {-------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -346,7 +346,7 @@ import Cardano.Wallet.Registry
     , workerResource
     )
 import Cardano.Wallet.TokenMetadata
-    ( fillMetadata, nullTokenMetadataServer )
+    ( fillMetadata, nullMetadataClient )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , TransactionCtx (..)
@@ -1315,8 +1315,8 @@ listAssetsAvailable ctx (ApiT wid) = do
     let assets = W.getAssets utxo
 
     -- TODO: Use data from metadata server
-    let metadataServer = nullTokenMetadataServer
-    liftIO $ F.toList <$> fillMetadata metadataServer assets toApiAsset
+    let client = nullMetadataClient
+    liftIO $ F.toList <$> fillMetadata client assets toApiAsset
 
 listAssets
     :: forall ctx s k.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -346,7 +346,7 @@ import Cardano.Wallet.Registry
     , workerResource
     )
 import Cardano.Wallet.TokenMetadata
-    ( fillMetadata, nullMetadataClient )
+    ( TokenMetadataClient, fillMetadata, nullMetadataClient )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , TransactionCtx (..)
@@ -2307,12 +2307,13 @@ newApiLayer
     -> NetworkLayer IO Block
     -> TransactionLayer k
     -> DBFactory IO s k
+    -> TokenMetadataClient IO
     -> (WorkerCtx ctx -> WalletId -> IO ())
         -- ^ Action to run concurrently with wallet restore
     -> IO ctx
-newApiLayer tr g0 nw tl df coworker = do
+newApiLayer tr g0 nw tl df tokenMeta coworker = do
     re <- Registry.empty
-    let ctx = ApiLayer tr g0 nw tl df re
+    let ctx = ApiLayer tr g0 nw tl df re tokenMeta
     listDatabases df >>= mapM_ (registerWorker ctx coworker)
     return ctx
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -382,6 +382,8 @@ import Data.Function
     ( (&) )
 import Data.Functor
     ( (<&>) )
+import Data.Functor.Identity
+    ( Identity (..) )
 import Data.Generics.Internal.VL.Lens
     ( Lens', view, (.~), (^.) )
 import Data.Generics.Internal.VL.Prism
@@ -1312,11 +1314,11 @@ listAssetsAvailable ctx (ApiT wid) = do
     utxo <- withWorkerCtx @_ @s @k ctx wid liftE liftE $ \wrk -> liftHandler $ do
        (cp, _meta, _pending) <- W.readWallet @_ @s @k wrk wid
        pure (cp ^. #utxo)
-    let assets = W.getAssets utxo
+    let assets = F.toList $ W.getAssets utxo
 
     -- TODO: Use data from metadata server
     let client = nullMetadataClient
-    liftIO $ F.toList <$> fillMetadata client assets toApiAsset
+    liftIO $ fillMetadata client assets toApiAsset
 
 listAssets
     :: forall ctx s k.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -346,7 +346,7 @@ import Cardano.Wallet.Registry
     , workerResource
     )
 import Cardano.Wallet.TokenMetadata
-    ( TokenMetadataServer (..), fillMetadata, nullTokenMetadataServer )
+    ( fillMetadata, nullTokenMetadataServer )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , TransactionCtx (..)
@@ -476,7 +476,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
-import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as W
 import qualified Cardano.Wallet.Registry as Registry

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -448,7 +448,7 @@ data ApiAsset = ApiAsset
     { policyId :: ApiT W.TokenPolicyId
     , assetName :: ApiT W.TokenName
     , metadata :: Maybe (ApiT W.AssetMetadata)
-    } deriving (Eq, Generic, Show)
+    } deriving (Eq, Generic, Ord, Show)
       deriving anyclass NFData
 
 toApiAsset :: Maybe W.AssetMetadata -> W.AssetId -> ApiAsset

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -143,7 +143,7 @@ module Cardano.Wallet.Primitive.Types
     , defaultSettings
     , unsafeToPMS
 
-    , TokenMetadataServerURI (..)
+    , TokenMetadataServer (..)
 
     -- * InternalState
     , InternalState (..)
@@ -1356,31 +1356,38 @@ distance :: (Ord a, Num a) => a -> a -> a
 distance a b =
     if a < b then b - a else a - b
 
+{-------------------------------------------------------------------------------
+                               Metadata services
+-------------------------------------------------------------------------------}
 
-newtype TokenMetadataServerURI = TokenMetadataServerURI
-    { unTokenMetadataServerURI :: URI }
-    deriving (Show, Generic, Eq)
+uriToText :: URI -> Text
+uriToText uri = T.pack $ uriToString id uri ""
 
-instance ToText TokenMetadataServerURI where
-    toText (TokenMetadataServerURI uri) = T.pack $ uriToString id uri ""
-
-instance FromText TokenMetadataServerURI where
-    fromText (T.unpack -> uri) = runIdentity $ runExceptT $ do
-        uri' <- parseAbsoluteURI uri ?? TextDecodingError
-            ("Not a valid absolute URI.")
-        case uri' of
+parseURI :: Text -> Either TextDecodingError URI
+parseURI (T.unpack -> uri) = runIdentity $ runExceptT $ do
+    uri' <- parseAbsoluteURI uri ??
+        (TextDecodingError "Not a valid absolute URI.")
+    let res = case uri' of
             (URI {uriAuthority, uriScheme, uriPath, uriQuery, uriFragment})
                 | uriScheme `notElem` ["http:", "https:"] ->
-                    throwE (TextDecodingError
-                        "Not a valid URI scheme, only http/https is supported.")
+                    Left "Not a valid URI scheme, only http/https is supported."
                 | isNothing uriAuthority ->
-                    throwE
-                        (TextDecodingError "URI must contain a domain part.")
+                    Left "URI must contain a domain part."
                 | not ((uriPath == "" || uriPath == "/")
                 && uriQuery == "" && uriFragment == "") ->
-                    throwE
-                        (TextDecodingError "URI must not contain a path/query/fragment.")
-            _ -> pure $ TokenMetadataServerURI uri'
+                    Left "URI must not contain a path/query/fragment."
+            _ -> Right uri'
+    either (throwE . TextDecodingError) pure res
+
+newtype TokenMetadataServer = TokenMetadataServer
+    { unTokenMetadataServer :: URI }
+    deriving (Show, Generic, Eq)
+
+instance ToText TokenMetadataServer where
+    toText = uriToText . unTokenMetadataServer
+
+instance FromText TokenMetadataServer where
+    fromText = fmap TokenMetadataServer . parseURI
 
 -- | A SMASH server is either an absolute http or https url.
 --
@@ -1389,25 +1396,10 @@ newtype SmashServer = SmashServer { unSmashServer :: URI }
     deriving (Show, Generic, Eq)
 
 instance ToText SmashServer where
-    toText (SmashServer uri) = T.pack $ uriToString id uri ""
+    toText = uriToText . unSmashServer
 
 instance FromText SmashServer where
-    fromText (T.unpack -> uri) = runIdentity $ runExceptT $ do
-        uri' <- parseAbsoluteURI uri ?? TextDecodingError
-            ("Not a valid absolute URI.")
-        case uri' of
-            (URI {uriAuthority, uriScheme, uriPath, uriQuery, uriFragment})
-                | uriScheme `notElem` ["http:", "https:"] ->
-                    throwE (TextDecodingError
-                        "Not a valid URI scheme, only http/https is supported.")
-                | isNothing uriAuthority ->
-                    throwE
-                        (TextDecodingError "URI must contain a domain part.")
-                | not ((uriPath == "" || uriPath == "/")
-                && uriQuery == "" && uriFragment == "") ->
-                    throwE
-                        (TextDecodingError "URI must not contain a path/query/fragment.")
-            _ -> pure $ SmashServer uri'
+    fromText = fmap SmashServer . parseURI
 
 -- | Source of Stake Pool Metadata aggregation.
 data PoolMetadataSource

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -126,7 +126,11 @@ instance FromText TokenName where
 -- | Information about an asset, from a source external to the chain.
 data AssetMetadata = AssetMetadata
     { name :: Text
-    , description :: Text
+    -- , acronym :: Text  -- TODO: needs metadata-server support
+    , description :: Text   -- TODO: needs metadata-server support
+    -- , url :: Text   -- TODO: needs metadata-server support
+    -- , logoBase64 :: ByteString   -- TODO: needs metadata-server support
+    -- , unit :: AssetUnit   -- TODO: needs metadata-server support
     } deriving stock (Eq, Ord, Generic)
     deriving (Read, Show) via (Quiet AssetMetadata)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -126,11 +126,11 @@ instance FromText TokenName where
 -- | Information about an asset, from a source external to the chain.
 data AssetMetadata = AssetMetadata
     { name :: Text
-    -- , acronym :: Text  -- TODO: needs metadata-server support
-    , description :: Text   -- TODO: needs metadata-server support
-    -- , url :: Text   -- TODO: needs metadata-server support
+    -- , acronym :: Text            -- TODO: needs metadata-server support
+    , description :: Text
+    -- , url :: Text                -- TODO: needs metadata-server support
     -- , logoBase64 :: ByteString   -- TODO: needs metadata-server support
-    -- , unit :: AssetUnit   -- TODO: needs metadata-server support
+    -- , unit :: AssetUnit          -- TODO: needs metadata-server support
     } deriving stock (Eq, Ord, Generic)
     deriving (Read, Show) via (Quiet AssetMetadata)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -124,8 +124,9 @@ instance FromText TokenName where
         . T.encodeUtf8
 
 -- | Information about an asset, from a source external to the chain.
-newtype AssetMetadata = AssetMetadata
+data AssetMetadata = AssetMetadata
     { name :: Text
+    , description :: Text
     } deriving stock (Eq, Ord, Generic)
     deriving (Read, Show) via (Quiet AssetMetadata)
 

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Wallet.TokenMetadata
+    ( TokenMetadataServer (..)
+    , tokenMetadataServerFromFile
+    , nullTokenMetadataServer
+
+    -- * Convenience
+    , fillMetadata
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( AssetMetadata (..), TokenPolicyId )
+import Control.Monad
+    ( mapM )
+import Data.Aeson
+    ( FromJSON (..)
+    , Object
+    , Value
+    , eitherDecodeFileStrict
+    , withArray
+    , withObject
+    , (.:)
+    )
+import Data.Aeson.Types
+    ( Parser )
+import Data.Foldable
+    ( toList )
+import Data.Map
+    ( Map )
+import Data.Set
+    ( Set )
+import Data.Text
+    ( Text )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+
+-- | Helper for adding metadata to sets of assets.
+fillMetadata
+    :: Ord a
+    => Monad m
+    => TokenMetadataServer m
+    -> Set AssetId
+    -> (Maybe AssetMetadata -> AssetId -> a)
+    -> m (Set a)
+fillMetadata server assets f = do
+    let policies = Set.map tokenPolicyId assets
+    m <- fetchTokenMeta server (toList policies)
+    return $ Set.map (\aid -> f (Map.lookup (tokenPolicyId aid) m) aid) assets
+
+
+-- | Mock metadata server which pulls the response from a file.
+--
+-- Doesn't care about which policy ids we request metadata for.
+tokenMetadataServerFromFile :: FilePath -> TokenMetadataServer IO
+tokenMetadataServerFromFile fp = TokenMetadataServer
+    { fetchTokenMeta = \_tokens -> do
+        either (fail . show) (pure . unTokenMetadataMap)
+            =<< eitherDecodeFileStrict fp
+    }
+
+nullTokenMetadataServer :: Monad m => TokenMetadataServer m
+nullTokenMetadataServer = TokenMetadataServer
+    { fetchTokenMeta = \_ -> pure Map.empty
+    }
+
+newtype TokenMetadataServer m = TokenMetadataServer
+    { fetchTokenMeta :: [TokenPolicyId] -> m (Map TokenPolicyId AssetMetadata)
+    }
+
+-- Makes it easier to work with Aeson. TODO: probably remove.
+newtype TokenMetadataMap = TokenMetadataMap
+    { unTokenMetadataMap :: (Map TokenPolicyId AssetMetadata) }
+
+instance FromJSON TokenMetadataMap where
+    parseJSON = fmap TokenMetadataMap . parseTokenMetadataMap
+
+-- NOTE: This parser assumes we will be able to fetch multiple metadata at once,
+-- which we hopefully will be:
+-- https://github.com/input-output-hk/metadata-server/blob/fc6eb8fda07c259da4e0ef3e6e1c9c62f137a0d0/john-instructions.md
+parseTokenMetadataMap :: Value -> Parser (Map TokenPolicyId AssetMetadata)
+parseTokenMetadataMap = fmap Map.fromList . withArray "list of subjects"
+    (mapM parseTokenMetadataEntry . toList)
+  where
+    parseTokenMetadataEntry :: Value -> Parser (TokenPolicyId, AssetMetadata)
+    parseTokenMetadataEntry = withObject "token metadata" $ \o -> do
+        subject <- o .: "subject"
+        name' <- AssetMetadata <$> o `getProperty` "name"
+        return (subject, name')
+      where
+        -- | Properties contain both a value an a signature.
+        getProperty :: Object -> Text -> Parser Text
+        getProperty obj key =
+            (obj .: key) >>= withObject (T.unpack key) (\propObj -> do
+                (val :: Text)
+                    <- propObj .: "value"
+                --(sigs :: [Signature])
+                --    <- propObj .: "signatures" -- maybe "anSignatures" in server?
+                return val
+                )

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -47,7 +47,7 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation, HasSeverityAnnotation (..) )
 import Cardano.Wallet.Primitive.Types
-    ( TokenMetadataServerURI (..) )
+    ( TokenMetadataServer (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -267,9 +267,9 @@ metadataClient tr baseURI manager =
 
 metadataClientFromURI
     :: Tracer IO TokenMetadataLog
-    -> TokenMetadataServerURI
+    -> TokenMetadataServer
     -> IO (TokenMetadataClient IO)
-metadataClientFromURI tr (TokenMetadataServerURI uri) = do
+metadataClientFromURI tr (TokenMetadataServer uri) = do
     mgr <- newManager defaultManagerSettings
     return $ metadataClient tr uri mgr
 

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
+
 module Cardano.Wallet.TokenMetadata
     ( TokenMetadataServer (..)
     , tokenMetadataServerFromFile
@@ -9,6 +11,10 @@ module Cardano.Wallet.TokenMetadata
 
     -- * Convenience
     , fillMetadata
+
+    -- * Client
+    , metadataClient
+    , getTokenMetadata
     ) where
 
 import Prelude
@@ -18,18 +24,25 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetMetadata (..), TokenPolicyId )
 import Control.Monad
-    ( mapM )
+    ( mapM, (<=<) )
 import Data.Aeson
     ( FromJSON (..)
     , Object
+    , ToJSON (..)
     , Value
     , eitherDecodeFileStrict
+    , eitherDecodeStrict'
+    , encode
     , withArray
     , withObject
     , (.:)
     )
 import Data.Aeson.Types
     ( Parser )
+import Data.Bifunctor
+    ( bimap )
+import Data.ByteString
+    ( ByteString )
 import Data.Foldable
     ( toList )
 import Data.Map
@@ -38,10 +51,20 @@ import Data.Set
     ( Set )
 import Data.Text
     ( Text )
+import GHC.Generics
+    ( Generic )
+import Network.HTTP.Client
+import UnliftIO.Exception
+    ( Exception, throwIO, tryAny )
 
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as T
+
+{-------------------------------------------------------------------------------
+   Token Metadata
+-------------------------------------------------------------------------------}
 
 -- | Helper for adding metadata to sets of assets.
 fillMetadata
@@ -93,8 +116,8 @@ parseTokenMetadataMap = fmap Map.fromList . withArray "list of subjects"
     parseTokenMetadataEntry :: Value -> Parser (TokenPolicyId, AssetMetadata)
     parseTokenMetadataEntry = withObject "token metadata" $ \o -> do
         subject <- o .: "subject"
-        name' <- AssetMetadata <$> o `getProperty` "name"
-        return (subject, name')
+        md <- AssetMetadata <$> o `getProperty` "name" <*> o `getProperty` "description"
+        return (subject, md)
       where
         -- | Properties contain both a value an a signature.
         getProperty :: Object -> Text -> Parser Text
@@ -106,3 +129,97 @@ parseTokenMetadataMap = fmap Map.fromList . withArray "list of subjects"
                 --    <- propObj .: "signatures" -- maybe "anSignatures" in server?
                 return val
                 )
+
+{-------------------------------------------------------------------------------
+                            Cardano Metadata Server
+-------------------------------------------------------------------------------}
+
+-- | Models a request to the @POST /metadata/query@ endpoint of the metadata
+-- server -- the only one that we need.
+data BatchRequest = BatchRequest
+    { subjects :: [Subject]
+    , properties :: [PropertyName]
+    } deriving (Generic, Show, Eq)
+
+type BatchResponse = [Properties]
+
+data Properties = Properties
+    { subject :: Subject
+    , owner :: Signature
+    , properties :: [(PropertyName, (PropertyValue, [Signature]))]
+    } deriving (Generic, Show, Eq)
+
+newtype Subject = Subject { unSubject :: Text }
+    deriving (Generic, Show, Eq)
+
+newtype PropertyName = PropertyName { unPropertyName :: Text }
+    deriving (Generic, Show, Eq)
+
+-- Properties can actually have any json value.
+-- But for now, limit to text.
+newtype PropertyValue = PropertyValue { unPropertyValue :: Text }
+    deriving (Generic, Show, Eq)
+
+newtype Hex = Hex ByteString
+ deriving (Generic, Show, Eq)
+data Signature = Signature
+    { signature :: Hex
+    , publicKey :: Hex
+    } deriving (Generic, Show, Eq)
+
+-- todo: use generic
+instance ToJSON BatchRequest where
+instance ToJSON PropertyName where
+instance FromJSON PropertyName where
+instance ToJSON Subject where
+instance FromJSON Subject where
+instance FromJSON Properties where
+instance FromJSON Signature where
+instance FromJSON Hex where
+    parseJSON = error "hex decode bytestring"
+instance FromJSON PropertyValue where
+
+newtype JSONParseError = JSONParseError String
+    deriving (Show, Eq)
+instance Exception JSONParseError
+
+metadataClient :: String -> Manager -> BatchRequest -> IO BatchResponse
+metadataClient baseURL manager =
+    parseResponse <=< flip httpLbs manager <=< makeHttpReq
+  where
+    makeHttpReq query = do
+        req <- parseRequest (baseURL ++ "metadata/query")
+        pure req {
+            method = "POST",
+            requestBody = RequestBodyLBS $ encode query
+            }
+    parseResponse = either (throwIO . JSONParseError) pure
+        . eitherDecodeStrict'
+        . BL.toStrict
+        . responseBody
+
+{-------------------------------------------------------------------------------
+                           Requesting token metadata
+-------------------------------------------------------------------------------}
+
+data TokenMetadataError = TokenMetadataError String -- todo: constructors
+
+getTokenMetadata
+    :: (BatchRequest -> IO BatchResponse)
+    -> [AssetId]
+    -> IO (Either TokenMetadataError [(AssetId, AssetMetadata)])
+getTokenMetadata client =
+    fmap (bimap (TokenMetadataError . show) fromResponse) . tryAny . client . toRequest
+  where
+    toRequest :: [AssetId] -> BatchRequest
+    toRequest as = BatchRequest (map toSubject as)
+        [PropertyName "name", PropertyName "description"]
+    toSubject = error "todo: hex-encode policyId + assetName"
+    fromResponse :: BatchResponse -> [(AssetId, AssetMetadata)]
+    fromResponse = error "todo"
+
+testIt :: IO ()
+testIt = do
+    client <- metadataClient "http://localhost:8000/api/" <$> newManager defaultManagerSettings
+    Right r <- getTokenMetadata client []
+    pure ()

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -58,7 +58,7 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( AssetMetadata (..), TokenName (..), TokenPolicyId (..) )
+    ( AssetMetadata (..), TokenPolicyId (..) )
 import Control.Tracer
     ( Tracer, contramap, traceWith )
 import Data.Aeson
@@ -189,7 +189,7 @@ deriving instance Eq (PropertyValue name) => Eq (Property name)
 
 -- | A metadata server subject, which can be any string.
 newtype Subject = Subject { unSubject :: Text }
-    deriving (Generic, Show, Eq)
+    deriving (Generic, Show, Eq, Ord)
     deriving newtype (IsString, Hashable)
 
 -- | Metadata property identifier.
@@ -398,10 +398,12 @@ getTokenMetadata (TokenMetadataClient client) as =
         . view #subjects
 
 -- | Creates a metadata server subject from an AssetId. The subject is the
--- policy id and asset name hex-encoded.
+-- policy id.
+--
+-- FIXME: Not oficially decided.
 assetIdToSubject :: AssetId -> Subject
-assetIdToSubject (AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)) =
-    Subject $ T.decodeLatin1 $ convertToBase Base16 (p <> n)
+assetIdToSubject (AssetId (UnsafeTokenPolicyId (Hash p)) _) =
+    Subject $ T.decodeLatin1 $ convertToBase Base16 p
 
 -- | Convert metadata server properties response into an 'AssetMetadata' record.
 -- Only the values are taken. Signatures are ignored (for now).

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -68,8 +68,6 @@ import Data.Hashable
     ( Hashable )
 import Data.Maybe
     ( mapMaybe )
-import Data.Set
-    ( Set )
 import Data.String
     ( IsString (..) )
 import Data.Text
@@ -94,7 +92,6 @@ import UnliftIO.Exception
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 
 {-------------------------------------------------------------------------------
@@ -103,20 +100,20 @@ import qualified Data.Text.Encoding as T
 
 -- | Helper for adding metadata to sets of assets.
 fillMetadata
-    :: Ord a
+    :: (Foldable t, Functor t)
     => TokenMetadataClient IO
-    -> Set AssetId
+    -> t AssetId
     -> (Maybe AssetMetadata -> AssetId -> a)
-    -> IO (Set a)
+    -> IO (t a)
 fillMetadata client assets f = do
     res <- getTokenMetadata client (toList assets)
     case res of
         Right l -> do
             let m = Map.fromList l
-            return $ Set.map (\aid -> f (Map.lookup aid m) aid) assets
+            return $ fmap (\aid -> f (Map.lookup aid m) aid) assets
         Left _e -> do
             -- TODO: Trace error?
-            return $ Set.map (f Nothing) assets
+            return $ fmap (f Nothing) assets
 
 {-------------------------------------------------------------------------------
                             Cardano Metadata Server

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -32,7 +32,7 @@ module Cardano.Wallet.TokenMetadata
     -- * Generic metadata server client
     , metadataClient
     , BatchRequest (..)
-    , BatchResponse
+    , BatchResponse (..)
     , SubjectProperties (..)
     , Property (..)
     , PropertyValue

--- a/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
+++ b/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
@@ -57,6 +57,22 @@
             }
           ]
         }
+      },
+      {
+        "subject": "missing sigs",
+        "name": {
+          "value": "Token1",
+          "anSignatures": []
+        },
+        "description": {
+          "value": "description1"
+        }
+      },
+      {
+        "subject": "extra fields",
+        "name": { "value": "Token2" },
+        "description": { "value": "description2" },
+        "acronym": { "value": "acronym2" }
       }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
+++ b/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
@@ -1,59 +1,62 @@
-[
-  {
-    "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27",
-    "owner": {
-      "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
-      "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
-    },
-    "name": {
-      "value": "SteveToken",
-      "anSignatures": [
-        {
-          "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
-          "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+{
+  "subjects":
+    [
+      {
+        "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27",
+        "owner": {
+          "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
+          "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
         },
-        {
-          "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
-          "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+        "name": {
+          "value": "SteveToken",
+          "anSignatures": [
+            {
+              "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+              "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+            },
+            {
+              "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
+              "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+            },
+            {
+              "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
+              "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+            },
+            {
+              "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
+              "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+            }
+          ]
         },
-        {
-          "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
-          "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+        "preImage": {
+          "value": "f026b38d5bfdd8d8d838df4c4cc5d6aa4e",
+          "hashFn": "blake2b-256"
         },
-        {
-          "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
-          "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+        "description": {
+          "value": "A sample description",
+          "anSignatures": [
+            {
+              "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+              "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+            },
+            {
+              "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
+              "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+            },
+            {
+              "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
+              "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+            },
+            {
+              "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
+              "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+            },
+            {
+              "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
+              "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+            }
+          ]
         }
-      ]
-    },
-    "preImage": {
-      "value": "f026b38d5bfdd8d8d838df4c4cc5d6aa4e",
-      "hashFn": "blake2b-256"
-    },
-    "description": {
-      "value": "A sample description",
-      "anSignatures": [
-        {
-          "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
-          "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
-        },
-        {
-          "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
-          "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
-        },
-        {
-          "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
-          "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
-        },
-        {
-          "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
-          "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
-        },
-        {
-          "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
-          "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
-        }
-      ]
-    }
-  }
-]
+      }
+    ]
+}

--- a/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
+++ b/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden1.json
@@ -1,0 +1,59 @@
+[
+  {
+    "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27",
+    "owner": {
+      "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
+      "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
+    },
+    "name": {
+      "value": "SteveToken",
+      "anSignatures": [
+        {
+          "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+          "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+        },
+        {
+          "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
+          "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+        },
+        {
+          "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
+          "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+        },
+        {
+          "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
+          "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+        }
+      ]
+    },
+    "preImage": {
+      "value": "f026b38d5bfdd8d8d838df4c4cc5d6aa4e",
+      "hashFn": "blake2b-256"
+    },
+    "description": {
+      "value": "A sample description",
+      "anSignatures": [
+        {
+          "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+          "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+        },
+        {
+          "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
+          "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+        },
+        {
+          "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
+          "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+        },
+        {
+          "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
+          "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+        },
+        {
+          "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
+          "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+        }
+      ]
+    }
+  }
+]

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.TokenMetadata.MockServer
+    ( withMetadataServer
+    , queryServer
+    , queryServerStatic
+    , assetIdFromSubject
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Cardano.Wallet.Primitive.Types.Hash (Hash (..))
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( AssetId (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( AssetMetadata (..), TokenPolicyId (..), TokenName (..) )
+import Cardano.Wallet.TokenMetadata
+    ( BatchRequest(..),
+      BatchResponse,
+      Signature(..),
+      Subject (..),
+      PropertyValue,
+      Subject,
+      Property(..),
+      SubjectProperties(..) )
+import Data.Aeson
+    ( FromJSON (..), ToJSON (..), object, (.=), eitherDecodeFileStrict )
+import Data.ByteArray.Encoding
+    ( Base (Base16), convertToBase )
+import Data.Proxy
+    ( Proxy (..) )
+import Network.Wai.Handler.Warp
+    ( withApplication )
+import Servant.API ( JSON, ReqBody, type (:>), Post )
+import Servant.Server
+    ( Server, serve, Handler (..) )
+import Control.Monad.Trans.Except (ExceptT(..))
+import Data.Maybe (fromJust)
+
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString as BS
+
+{-------------------------------------------------------------------------------
+                              Mock metadata-server
+-------------------------------------------------------------------------------}
+
+type MetadataQueryApi = "metadata" :> "query"
+    :> ReqBody '[JSON] BatchRequest :> Post '[JSON] BatchResponse
+
+-- | Serve a list of metadata.
+queryServer :: [(AssetId, AssetMetadata)] -> Server MetadataQueryApi
+queryServer md = pure . map respond . subjects
+  where
+    respond subj = case lookup (assetIdFromSubject subj) md of
+        Nothing -> error "doh"
+        Just _md -> error "todo"
+
+assetIdFromSubject :: Subject -> AssetId
+assetIdFromSubject = mk . BS.splitAt 32 . unsafeFromHex . T.encodeUtf8 . unSubject
+  where
+    mk (p, n) = AssetId (UnsafeTokenPolicyId (Hash p)) (UnsafeTokenName n)
+
+-- | Serve a json file.
+queryServerStatic :: FilePath -> IO (Server MetadataQueryApi)
+queryServerStatic golden = do
+    Right mds <- eitherDecodeFileStrict golden
+    pure $ queryHandlerBase mds
+
+queryHandlerBase :: [SubjectProperties] -> BatchRequest -> Handler BatchResponse
+queryHandlerBase ps = Handler . ExceptT . pure . Right . map respond . subjects
+  where
+    subs = zip (map subject ps) ps
+    respond subj = fromJust $ lookup subj subs
+
+queryApi :: Proxy MetadataQueryApi
+queryApi = Proxy
+
+withMetadataServer :: IO (Server MetadataQueryApi) -> (String -> IO a) -> IO a
+withMetadataServer srv action = withApplication app (action . mkUrl)
+  where
+    app = serve queryApi <$> srv
+    mkUrl port = "http://localhost:" ++ show port ++ "/"
+
+{-------------------------------------------------------------------------------
+                              JSON orphans
+-------------------------------------------------------------------------------}
+
+instance FromJSON BatchRequest where
+
+instance ToJSON SubjectProperties where
+   toJSON (SubjectProperties s o (n, d)) = object
+       [ "subject" .= s
+       , "owner" .= o
+       , "name" .= n
+       , "description" .= d
+       ]
+
+instance ToJSON (PropertyValue name) => ToJSON (Property name) where
+    toJSON (Property v s) = object [ "value" .= v, "anSignatures" .= s ]
+
+instance ToJSON Signature where
+    toJSON (Signature s k) = object
+        [ "signature" .= hex s
+        , "publicKey" .= hex k
+        ]
+      where
+        hex = T.decodeLatin1 . convertToBase Base16

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -14,39 +14,45 @@ module Cardano.Wallet.TokenMetadata.MockServer
 
 import Prelude
 
-import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
-import Cardano.Wallet.Primitive.Types.Hash (Hash (..))
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( AssetMetadata (..), TokenPolicyId (..), TokenName (..) )
+    ( AssetMetadata (..), TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.TokenMetadata
-    ( BatchRequest(..),
-      BatchResponse,
-      Signature(..),
-      Subject (..),
-      PropertyValue,
-      Subject,
-      Property(..),
-      SubjectProperties(..) )
+    ( BatchRequest (..)
+    , BatchResponse
+    , Property (..)
+    , PropertyValue
+    , Signature (..)
+    , Subject (..)
+    , Subject
+    , SubjectProperties (..)
+    )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Control.Monad.Trans.Except
+    ( ExceptT (..) )
 import Data.Aeson
-    ( FromJSON (..), ToJSON (..), object, (.=), eitherDecodeFileStrict )
+    ( FromJSON (..), ToJSON (..), eitherDecodeFileStrict, object, (.=) )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertToBase )
+import Data.Maybe
+    ( fromJust, fromMaybe )
 import Data.Proxy
     ( Proxy (..) )
+import Network.URI
+    ( URI, parseURI )
 import Network.Wai.Handler.Warp
     ( withApplication )
-import Network.URI (URI, parseURI)
-import Servant.API ( JSON, ReqBody, type (:>), Post )
+import Servant.API
+    ( (:>), JSON, Post, ReqBody )
 import Servant.Server
-    ( Server, serve, Handler (..) )
-import Control.Monad.Trans.Except (ExceptT(..))
-import Data.Maybe (fromJust, fromMaybe)
+    ( Handler (..), Server, serve )
 
-import qualified Data.Text.Encoding as T
 import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as T
 
 {-------------------------------------------------------------------------------
                               Mock metadata-server

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -14,6 +14,8 @@ module Cardano.Wallet.TokenMetadata.MockServer
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types
+    ( TokenMetadataServer (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -89,11 +91,15 @@ queryHandlerBase ps = Handler . ExceptT . pure . Right . map respond . subjects
 queryApi :: Proxy MetadataQueryApi
 queryApi = Proxy
 
-withMetadataServer :: IO (Server MetadataQueryApi) -> (URI -> IO a) -> IO a
-withMetadataServer srv action = withApplication app (action . mkUrl)
+withMetadataServer
+    :: IO (Server MetadataQueryApi)
+    -> (TokenMetadataServer -> IO a)
+    -> IO a
+withMetadataServer mkServer action = withApplication app (action . mkUrl)
   where
-    app = serve queryApi <$> srv
-    mkUrl port = fromMaybe (error "withMetadataServer: bad uri")
+    app = serve queryApi <$> mkServer
+    mkUrl port = TokenMetadataServer
+        $ fromMaybe (error "withMetadataServer: bad uri")
         $ parseURI
         $ "http://localhost:" ++ show port ++ "/"
 

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -45,7 +45,7 @@ import Data.Maybe
 import Data.Proxy
     ( Proxy (..) )
 import Network.URI
-    ( URI, parseURI )
+    ( parseURI )
 import Network.Wai.Handler.Warp
     ( withApplication )
 import Servant.API

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -8,7 +8,6 @@
 
 module Cardano.Wallet.TokenMetadata.MockServer
     ( withMetadataServer
-    , queryServer
     , queryServerStatic
     , assetIdFromSubject
     ) where
@@ -22,7 +21,7 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( AssetMetadata (..), TokenName (..), TokenPolicyId (..) )
+    ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.TokenMetadata
     ( BatchRequest (..)
     , BatchResponse (..)
@@ -65,14 +64,6 @@ import qualified Data.Text.Encoding as T
 
 type MetadataQueryApi = "metadata" :> "query"
     :> ReqBody '[JSON] BatchRequest :> Post '[JSON] BatchResponse
-
--- | Serve a list of metadata.
-queryServer :: [(AssetId, AssetMetadata)] -> Server MetadataQueryApi
-queryServer md = pure . BatchResponse . foldMap respond . view #subjects
-  where
-    respond subj = case lookup (assetIdFromSubject subj) md of
-        Nothing -> error "doh"
-        Just _md -> error "todo"
 
 assetIdFromSubject :: Subject -> AssetId
 assetIdFromSubject = mk . BS.splitAt 32 . unsafeFromHex . T.encodeUtf8 . unSubject

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -1,39 +1,89 @@
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
+
 module Cardano.Wallet.TokenMetadataSpec where
+
+import Prelude
 
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenPolicyId (..) )
+    ( AssetMetadata (..), TokenPolicyId (..) )
 import Cardano.Wallet.TokenMetadata
-import Prelude
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Data.Aeson
+    ( eitherDecodeFileStrict )
+import Network.HTTP.Client
+    ( defaultManagerSettings, newManager )
 import System.FilePath
     ( (</>) )
 import Test.Hspec
+    ( Spec, describe, it, shouldBe, shouldReturn )
 import Test.Utils.Paths
     ( getTestData )
 
 import qualified Data.Map as Map
 
 spec :: Spec
-spec = do
-    describe "Token Metadata" $ do
-        let dir = $(getTestData) </> "Cardano" </> "Wallet" </> "TokenMetadata"
-        describe "tokenMetadataServerFromFile" $ do
-            -- From https://github.com/input-output-hk/metadata-server/pull/1/files
-            -- with manually added wrapping []
-            --
-            -- TODO: Check relevance.
-            it "golden" $ do
-                let fp = dir </> "golden1.json"
-                let server = tokenMetadataServerFromFile fp
-                m <- fetchTokenMeta server []
-                m `shouldBe` Map.fromList
-                    [ (UnsafeTokenPolicyId
-                        ( Hash "\DELq\148\t\NAK\234_\232^\132\SI\132<\146\
-                               \\158\186F~o\ENQ\EOTu\186\209\241\v\156'")
-                        ,"SteveToken" )
+spec = describe "Token Metadata" $ do
+    describe "tokenMetadataServerFromFile" $ do
+        -- From https://github.com/input-output-hk/metadata-server/pull/1/files
+        -- with manually added wrapping []
+        --
+        -- TODO: Check relevance.
+        it "golden" $ do
+            let fp = dir </> "golden1.json"
+            let server = tokenMetadataServerFromFile fp
+            m <- fetchTokenMeta server []
+            m `shouldBe` Map.fromList
+                [ (UnsafeTokenPolicyId
+                    (Hash "\DELq\148\t\NAK\234_\232^\132\SI\132<\146\
+                           \\158\186F~o\ENQ\EOTu\186\209\241\v\156'")
+                    , golden1Metadata )
+                ]
+
+
+    describe "JSON decoding" $ do
+        it "golden1.json" $
+            eitherDecodeFileStrict (dir </> "golden1.json")
+                `shouldReturn` Right golden1Properties
+
+        it "metadataFromProperties" $
+            map metadataFromProperties golden1Properties
+                `shouldBe` [golden1Metadata]
+
+  where
+    dir = $(getTestData) </> "Cardano" </> "Wallet" </> "TokenMetadata"
+
+    golden1Metadata = AssetMetadata "SteveToken" "A sample description"
+    sig s k = Signature (unsafeFromHex s) (unsafeFromHex k)
+    golden1Properties = [SubjectProperties
+            { subject = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
+            , owner = sig "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808" "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
+            , properties =
+                ( Property "SteveToken"
+                    [  sig "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108" "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+                    , sig "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500" "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+                    , sig "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04"
+           "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+                    , sig "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801"
+           "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
                     ]
+                , Property "A sample description"
+                    [ sig "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000" "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+                    , sig "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a" "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+                    , sig "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106" "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+                    , sig "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903" "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+                    , sig "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e" "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+                    ]
+                )
+           }]
 
 
+testIt :: IO ()
+testIt = do
+    client <- metadataClient "http://localhost:8000/api/" <$> newManager defaultManagerSettings
+    Right r <- getTokenMetadata client []
+    pure ()

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Wallet.TokenMetadataSpec where
+
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenPolicyId (..) )
+import Cardano.Wallet.TokenMetadata
+import Prelude
+import System.FilePath
+    ( (</>) )
+import Test.Hspec
+import Test.Utils.Paths
+    ( getTestData )
+
+import qualified Data.Map as Map
+
+spec :: Spec
+spec = do
+    describe "Token Metadata" $ do
+        let dir = $(getTestData) </> "Cardano" </> "Wallet" </> "TokenMetadata"
+        describe "tokenMetadataServerFromFile" $ do
+            -- From https://github.com/input-output-hk/metadata-server/pull/1/files
+            -- with manually added wrapping []
+            --
+            -- TODO: Check relevance.
+            it "golden" $ do
+                let fp = dir </> "golden1.json"
+                let server = tokenMetadataServerFromFile fp
+                m <- fetchTokenMeta server []
+                m `shouldBe` Map.fromList
+                    [ (UnsafeTokenPolicyId
+                        ( Hash "\DELq\148\t\NAK\234_\232^\132\SI\132<\146\
+                               \\158\186F~o\ENQ\EOTu\186\209\241\v\156'")
+                        ,"SteveToken" )
+                    ]
+
+

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -14,7 +14,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetMetadata (..), TokenPolicyId (..), nullTokenName )
 import Cardano.Wallet.TokenMetadata
 import Cardano.Wallet.TokenMetadata.MockServer
-    ( assetIdFromSubject, queryServerStatic, withMetadataServer )
+    ( queryServerStatic, withMetadataServer )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeFromText )
 import Data.Aeson
@@ -49,7 +49,7 @@ spec = describe "Token Metadata" $ do
                 client <- newMetadataClient stdoutTextTracer (Just url)
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
-                getTokenMetadata client [assetIdFromSubject (Subject subj)]
+                getTokenMetadata client [aid]
                     `shouldReturn` Right [(aid, golden1Metadata)]
 
   where

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -15,6 +15,8 @@ import Cardano.Wallet.TokenMetadata.MockServer
     ( assetIdFromSubject, queryServerStatic, withMetadataServer )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeFromText )
+import Control.Tracer
+    ( Tracer, nullTracer )
 import Data.Aeson
     ( eitherDecodeFileStrict )
 import Network.HTTP.Client
@@ -40,11 +42,11 @@ spec = describe "Token Metadata" $ do
     describe "Mock server tests" $ do
         it "testing empty req" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- metadataClient url <$> newManager defaultManagerSettings
+                client <- metadataClient nullTracer url <$> newManager defaultManagerSettings
                 getTokenMetadata client [] `shouldReturn` Right []
         it "testing golden1.json" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- metadataClient url <$> newManager defaultManagerSettings
+                client <- metadataClient nullTracer url <$> newManager defaultManagerSettings
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -6,6 +6,8 @@ module Cardano.Wallet.TokenMetadataSpec where
 
 import Prelude
 
+import Cardano.Wallet.Logging
+    ( stdoutTextTracer )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -40,11 +42,11 @@ spec = describe "Token Metadata" $ do
     describe "Mock server tests" $ do
         it "testing empty req" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- newMetadataClient nullTracer (Just url)
+                client <- newMetadataClient stdoutTextTracer (Just url)
                 getTokenMetadata client [] `shouldReturn` Right []
         it "testing golden1.json" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- newMetadataClient nullTracer (Just url)
+                client <- newMetadataClient stdoutTextTracer (Just url)
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -16,11 +16,9 @@ import Cardano.Wallet.TokenMetadata.MockServer
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeFromText )
 import Control.Tracer
-    ( Tracer, nullTracer )
+    ( nullTracer )
 import Data.Aeson
     ( eitherDecodeFileStrict )
-import Network.HTTP.Client
-    ( defaultManagerSettings, newManager )
 import System.FilePath
     ( (</>) )
 import Test.Hspec
@@ -42,11 +40,11 @@ spec = describe "Token Metadata" $ do
     describe "Mock server tests" $ do
         it "testing empty req" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- metadataClient nullTracer url <$> newManager defaultManagerSettings
+                client <- newMetadataClient nullTracer (Just url)
                 getTokenMetadata client [] `shouldReturn` Right []
         it "testing golden1.json" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
-                client <- metadataClient nullTracer url <$> newManager defaultManagerSettings
+                client <- newMetadataClient nullTracer (Just url)
                 let subj = "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
                 let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -31,7 +31,7 @@ spec = describe "Token Metadata" $ do
     describe "JSON decoding" $ do
         it "golden1.json" $
             eitherDecodeFileStrict golden1File
-                `shouldReturn` Right golden1Properties
+                `shouldReturn` Right (BatchResponse golden1Properties)
 
         it "metadataFromProperties" $
             map metadataFromProperties golden1Properties

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -17,8 +17,6 @@ import Cardano.Wallet.TokenMetadata.MockServer
     ( assetIdFromSubject, queryServerStatic, withMetadataServer )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex, unsafeFromText )
-import Control.Tracer
-    ( nullTracer )
 import Data.Aeson
     ( eitherDecodeFileStrict )
 import System.FilePath
@@ -41,6 +39,8 @@ spec = describe "Token Metadata" $ do
 
     describe "Mock server tests" $ do
         it "testing empty req" $
+            -- TODO: We shouldn't pollute stdout. We should trace to a TVar
+            -- instead.
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
                 client <- newMetadataClient stdoutTextTracer (Just url)
                 getTokenMetadata client [] `shouldReturn` Right []

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -6,8 +6,6 @@ module Cardano.Wallet.TokenMetadataSpec where
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -28,25 +26,8 @@ import Test.Hspec
 import Test.Utils.Paths
     ( getTestData )
 
-import qualified Data.Map as Map
-
 spec :: Spec
 spec = describe "Token Metadata" $ do
-    describe "tokenMetadataServerFromFile" $ do
-        -- From https://github.com/input-output-hk/metadata-server/pull/1/files
-        -- with manually added wrapping []
-        --
-        -- TODO: Check relevance.
-        it "golden" $ do
-            let server = tokenMetadataServerFromFile golden1File
-            m <- fetchTokenMeta server []
-            m `shouldBe` Map.fromList
-                [ (UnsafeTokenPolicyId
-                    (Hash "\DELq\148\t\NAK\234_\232^\132\SI\132<\146\
-                           \\158\186F~o\ENQ\EOTu\186\209\241\v\156'")
-                    , golden1Metadata )
-                ]
-
     describe "JSON decoding" $ do
         it "golden1.json" $
             eitherDecodeFileStrict golden1File
@@ -80,7 +61,7 @@ spec = describe "Token Metadata" $ do
             , owner = sig "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808" "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
             , properties =
                 ( Property "SteveToken"
-                    [  sig "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108" "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+                    [ sig "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108" "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
                     , sig "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500" "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
                     , sig "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04"
            "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -427,6 +427,7 @@ withShelleyServer tracers action = do
             listen
             Nothing
             Nothing
+            Nothing
             conn
             block0
             (np, vData)

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -335,6 +335,7 @@ tracerSeveritiesOption :: Parser TracerSeverities
 tracerSeveritiesOption = Tracers
     <$> traceOpt applicationTracer (Just Info)
     <*> traceOpt apiServerTracer (Just Info)
+    <*> traceOpt tokenMetadataTracer (Just Info)
     <*> traceOpt walletEngineTracer (Just Info)
     <*> traceOpt walletDbTracer (Just Info)
     <*> traceOpt poolsEngineTracer (Just Info)

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -60,6 +60,7 @@ import Cardano.CLI
     , shutdownHandlerFlag
     , syncToleranceOption
     , tlsOption
+    , tokenMetadataSourceOption
     , withLogging
     )
 import Cardano.Launcher.Node
@@ -86,7 +87,7 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( PoolMetadataSource (..), Settings (..) )
+    ( PoolMetadataSource (..), Settings (..), TokenMetadataServerURI (..) )
 import Cardano.Wallet.Shelley
     ( TracerSeverities
     , Tracers
@@ -187,6 +188,7 @@ data ServeArgs = ServeArgs
     , _syncTolerance :: SyncTolerance
     , _enableShutdownHandler :: Bool
     , _poolMetadataSourceOpt :: Maybe PoolMetadataSource
+    , _tokenMetadataSourceOpt :: Maybe TokenMetadataServerURI
     , _logging :: LoggingOptions TracerSeverities
     } deriving (Show)
 
@@ -207,6 +209,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $ mempty
         <*> syncToleranceOption
         <*> shutdownHandlerFlag
         <*> optional poolMetadataSourceOption
+        <*> optional tokenMetadataSourceOption
         <*> loggingOptions tracerSeveritiesOption
     exec
         :: ServeArgs -> IO ()
@@ -220,6 +223,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $ mempty
       sTolerance
       enableShutdownHandler
       poolMetadataFetching
+      tokenMetadataServerURI
       logOpt) = do
         withTracers logOpt $ \tr tracers -> do
             withShutdownHandlerMaybe tr enableShutdownHandler $ do
@@ -243,6 +247,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $ mempty
                     listen
                     tlsConfig
                     (fmap Settings poolMetadataFetching)
+                    tokenMetadataServerURI
                     conn
                     block0
                     (gp, vData)

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -87,7 +87,7 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance )
 import Cardano.Wallet.Primitive.Types
-    ( PoolMetadataSource (..), Settings (..), TokenMetadataServerURI (..) )
+    ( PoolMetadataSource (..), Settings (..), TokenMetadataServer (..) )
 import Cardano.Wallet.Shelley
     ( TracerSeverities
     , Tracers
@@ -188,7 +188,7 @@ data ServeArgs = ServeArgs
     , _syncTolerance :: SyncTolerance
     , _enableShutdownHandler :: Bool
     , _poolMetadataSourceOpt :: Maybe PoolMetadataSource
-    , _tokenMetadataSourceOpt :: Maybe TokenMetadataServerURI
+    , _tokenMetadataSourceOpt :: Maybe TokenMetadataServer
     , _logging :: LoggingOptions TracerSeverities
     } deriving (Show)
 

--- a/lib/shelley/exe/local-cluster.hs
+++ b/lib/shelley/exe/local-cluster.hs
@@ -261,6 +261,7 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
                 listen
                 Nothing
                 Nothing
+                Nothing
                 socketPath
                 block0
                 (gp, vData)

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -110,7 +110,7 @@ import Cardano.Wallet.Primitive.Types
     , ProtocolParameters (..)
     , Settings (..)
     , SlottingParameters (..)
-    , TokenMetadataServerURI (..)
+    , TokenMetadataServer (..)
     , WalletId
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -235,7 +235,7 @@ serveWallet
     -- ^ An optional TLS configuration
     -> Maybe Settings
     -- ^ Settings to be set at application start, will be written into DB.
-    -> Maybe TokenMetadataServerURI
+    -> Maybe TokenMetadataServer
     -> CardanoNodeConn
     -- ^ Socket for communicating with the node
     -> Block

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -137,7 +137,7 @@ import Cardano.Wallet.Shelley.Pools
 import Cardano.Wallet.Shelley.Transaction
     ( newTransactionLayer )
 import Cardano.Wallet.TokenMetadata
-    ( TokenMetadataLog, metadataClientFromURI, nullMetadataClient )
+    ( TokenMetadataLog, newMetadataClient )
 import Cardano.Wallet.Transaction
     ( TransactionLayer )
 import Control.Applicative
@@ -379,10 +379,7 @@ serveWallet
         -> IO (ApiLayer s k)
     apiLayer tl nl coworker = do
         let params = (block0, np, sTolerance)
-        tokenMetaClient <- maybe
-                (pure (nullMetadataClient tokenMetadataTracer))
-                (metadataClientFromURI tokenMetadataTracer)
-                tokenMetaUri
+        tokenMetaClient <- newMetadataClient tokenMetadataTracer tokenMetaUri
         db <- Sqlite.newDBFactory
             walletDbTracer
             (DefaultFieldValues

--- a/lib/shelley/test/data/token-metadata.json
+++ b/lib/shelley/test/data/token-metadata.json
@@ -28,6 +28,38 @@
             }
           ]
         }
+    },
+    {
+      "subject": "f4137b0691b01c7ca46c2fc05576f4f0ab8eebb8f8e4946cb9107e0f6170706c65",
+      "name": {
+        "value": "Apple",
+        "anSignatures": []
+      },
+      "description": {
+        "value": "A healthy kind of fruit",
+        "anSignatures": []
       }
+    },
+    {
+      "subject": "f4137b0691b01c7ca46c2fc05576f4f0ab8eebb8f8e4946cb9107e0f62616e616e61",
+      "name": {
+        "value": "Banana",
+        "anSignatures": []
+      },
+      "description": {
+        "value": "A yummy kind of fruit",
+        "anSignatures": []
+      }
+    },
+    {
+      "subject": "f4137b0691b01c7ca46c2fc05576f4f0ab8eebb8f8e4946cb9107e0f62636865727279",
+      "name": {
+        "value": "Cherry",
+        "anSignatures": []
+      },
+      "description": {
+        "value": "A special kind of fruit"
+      }
+    }
   ]
 }

--- a/lib/shelley/test/data/token-metadata.json
+++ b/lib/shelley/test/data/token-metadata.json
@@ -1,0 +1,33 @@
+{
+  "subjects": [
+    {
+        "subject": "4bfe7acae1bd2599649962b146a1e47d2e14933809b367e804c61f86",
+        "preImage": {
+            "value": "6d792d676f6775656e2d736372697074",
+            "hashFn": "sha256"
+        },
+        "owner": {
+          "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
+          "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
+        },
+        "name": {
+          "value": "SteveToken",
+          "anSignatures": [
+            {
+              "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+              "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+            }
+          ]
+        },
+        "description": {
+          "value": "A sample description",
+          "anSignatures": [
+            {
+              "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+              "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+            }
+          ]
+        }
+      }
+  ]
+}

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -320,6 +320,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
             listen
             Nothing
             Nothing
+            Nothing -- TokenMetaData
             conn
             block0
             (gp, vData)


### PR DESCRIPTION
# Issue Number

ADP-688


# Overview

- Metadata client for input-output-hk/metadata-server#1
- New types to represent metadata according to CIP draft
- JSON parsers
- unit tests 
- plumbing of client into listAssets and getAssets
- mock metadata server

# Comments

I presume implementation details will change (e.g. metadata per asset vs metadata per policy).

### Todo

- [x] Start mock server for integration tests
- [x] add some metadata assertions to getAsset and listAsset.
- [x] more unit tests hmmm
- [x] manually try logged requests against deployed metadata server
     ```
     curl -i -H "Content-type: application/json" --data '{"subjects":["7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c274d1888c0"],"properties":["name","description", "asttd"]}' **https://metadata.cardano-testnet.iohkdev.io/metadata/query
     ```

### Next PR
- Unit test `fillMetadata`
- Manually test with testnet metadata server (fixme: paste details)
- More integration tests perhaps
