### PR TITLE
Repair database benchmarks

### DIFF
--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -475,13 +475,10 @@ bgroupWriteTxHistory db = bgroup "TxHistory (Write)"
     , bTxHistory            10        1        1         0     [1..10]
     , bTxHistory            10       10       10         0     [1..10]
     , bTxHistory            10       50      100         0     [1..10]
-    , bTxHistory            10      255      255         0    [1..100]
     , bTxHistory           100       10       10         0    [1..100]
     , bTxHistory           100       50      100         0    [1..100]
-    , bTxHistory           100      255      255         0    [1..100]
     , bTxHistory          1000       10       10         0   [1..1000]
     , bTxHistory          1000       50      100         0   [1..1000]
-    , bTxHistory          1000      255      255         0   [1..1000]
     , bTxHistory         10000       10       10         0  [1..10000]
     ]
   where

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -123,6 +123,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -208,6 +210,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.Char as Char
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 
@@ -611,8 +614,8 @@ mkOutputsToken assetCount tokenQuantity prefix n =
     mkTxOut i = TxOut
         (mkAddress prefix i)
         (TokenBundle.TokenBundle (Coin 1) (TokenMap.fromFlatList tokens))
-    mkTokenName = fromRight (error "Couldn't decode tokenName")
-        . fromText . T.pack . show
+    mkTokenName =
+        UnsafeTokenName . B8.singleton . Char.chr
     mkTokenPolicyId = fromRight (error "Couldn't decode tokenPolicyId")
         . fromText
         . T.pack

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -61,7 +61,11 @@ import Cardano.Startup
 import Cardano.Wallet.DB
     ( DBLayer (..), PrimaryKey (..), cleanDB )
 import Cardano.Wallet.DB.Sqlite
-    ( DefaultFieldValues (..), PersistState, newDBLayer )
+    ( CacheBehavior (..)
+    , DefaultFieldValues (..)
+    , PersistState
+    , newDBLayerWith
+    )
 import Cardano.Wallet.DummyTarget.Primitive.Types
     ( block0, dummyGenesisParameters, mkTxId )
 import Cardano.Wallet.Logging
@@ -655,7 +659,7 @@ setupDB
     -> IO (FilePath, SqliteContext, DBLayer IO s k)
 setupDB tr = do
     f <- emptySystemTempFile "bench.db"
-    (ctx, db) <- newDBLayer tr defaultFieldValues (Just f) ti
+    (ctx, db) <- newDBLayerWith NoCache tr defaultFieldValues (Just f) ti
     pure (f, ctx, db)
   where
     ti = hoistTimeInterpreter (pure . runIdentity) $ mkSingleEraInterpreter


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 13e4e742e039ea2393a7d89ed38f4dc994c4fabb
  :round_pushpin: **fix TokenName creation in database benchmarks**
  
- 84331a37e395cf9706cbac5c51a25f7730d7859d
  :round_pushpin: **rewrite benchmark to allow specifiying a number of assets directly in the bench description**
    Rather than parameterizing functions with an output constructor, this is more readable and more 'idiomatic' of the current benchmark declaration style. So far, this commits sets all values to '0' just to preserve the original behavior before assets were introduced to benchmarks. From there it is easy to add more cases while also preserving the old ones.

- a0ba7e37cd49d29354693fe5b5dec4e7c0df26cc
  :round_pushpin: **disable latest checkpoint caching during database benchmarks**
    This otherwise causes criterion to take a MASSIVE time for each bench case, because it is basically measuring how long it takes to access an IORef (for the record, about ~15us) and needs to re-run each bench a lot to get a rather precise value. For larger cases with a lot of UTxOs, we are therefore re-paying the cost of setting up the benchmark environment much more than necessary. So, I've altered newDBLayer to allow disabling the cache of the latest checkpoint, so that we can have meaningful benchmarks

- 619e71a012c902dbdd3127abf12e15c0f7fee5ab
  :round_pushpin: **remove i=255, o=255 cases for write tx history benchmarks**
    We actually have some real order of magnitudes for transactions in some other unit tests. What this tells us is that it cannot get much worse than 50/100 (actually, real life is closer to i=50/o=50 in worse case). These specific bench take a large amount of time to cover a totally unrealistic case, so removed.

- d425d0297720aeb0158c760a7e6610883b2d1d1a
  :round_pushpin: **Add multi-assets specific benchmark cases**

# Comments

<!-- Additional comments or screenshots to attach if any -->


~~Re-running this locally, my machine is "getting stuck" (i.e. taking quite long) at:~~

**edit:** It completed after a while with mediocre results: 

```
benchmarking UTxO (Read)/1 CP (10 assets per output) x 10000 UTxO
time                 144.3 s    (142.9 s .. 145.0 s)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 145.4 s    (144.8 s .. 145.8 s)
std dev              579.3 ms   (296.1 ms .. 807.1 ms)
variance introduced by outliers: 19% (moderately inflated)
```

which suggests something quite wrong may be going performance-wise w.r.t read of multi-assets UTxOs. Writes are quite slower but seems "acceptable" provided that the benchmarks are a bit extreme in how they add assets to every TxOut 

```
benchmarking UTxO (Write)/1 CP (ada-only) x 10000 UTxO
time                 252.9 ms   (229.4 ms .. 275.2 ms)
                     0.997 R²   (0.996 R² .. 1.000 R²)
mean                 227.8 ms   (218.7 ms .. 237.4 ms)
std dev              12.74 ms   (6.916 ms .. 17.35 ms)
variance introduced by outliers: 16% (moderately inflated)
                                 
benchmarking UTxO (Write)/1 CP (10 assets per output) x 10000 UTxO
time                 836.8 ms   (777.8 ms .. 931.9 ms)
                     0.998 R²   (0.998 R² .. 1.000 R²)
mean                 843.3 ms   (824.1 ms .. 863.8 ms)
std dev              24.92 ms   (12.23 ms .. 31.69 ms)
variance introduced by outliers: 19% (moderately inflated)
                                 
benchmarking UTxO (Write)/1 CP (20 assets per output) x 10000 UTxO
time                 1.683 s    (1.583 s .. 1.796 s)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 1.577 s    (1.446 s .. 1.623 s)
std dev              87.59 ms   (6.295 ms .. 107.2 ms)
variance introduced by outliers: 19% (moderately inflated)
```

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
