### PR TITLE
Rework checkpoint reading from database to avoid quadratic queries with number of assets

### DIFF
--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -741,17 +741,16 @@ utxoDiskSpaceTests tr = do
     putStrLn "Database disk space usage tests for UTxO\n"
     sequence_
         --      #Checkpoints   UTxO Size
-        [ bUTxO          100           0
-        , bUTxO         1000           0
+        [ bUTxO            1          10
         , bUTxO           10          10
-        , bUTxO          100          10
-        , bUTxO         1000          10
+        , bUTxO            1         100
         , bUTxO           10         100
-        , bUTxO          100         100
-        , bUTxO         1000         100
+        , bUTxO            1        1000
         , bUTxO           10        1000
-        , bUTxO          100        1000
-        , bUTxO         1000        1000
+        , bUTxO            1       10000
+        , bUTxO           10       10000
+        , bUTxO            1      100000
+        , bUTxO           10      100000
         ]
   where
     bUTxO n s = benchDiskSize tr $ \db -> do
@@ -763,15 +762,11 @@ txHistoryDiskSpaceTests :: Tracer IO DBLog -> IO ()
 txHistoryDiskSpaceTests tr = do
     putStrLn "Database disk space usage tests for TxHistory\n"
     sequence_
-        --       #NTransactions  #NInputs #NOutputs
-        [ bTxs             100         10        20
-        , bTxs            1000         10        20
-        , bTxs           10000         10        20
-        , bTxs          100000         10        20
-        , bTxs             100         50       100
-        , bTxs            1000         50       100
-        , bTxs           10000         50       100
-        , bTxs          100000         50       100
+        --       #NTransactions  #NInputs  #NOutputs
+        [ bTxs             100         20         20
+        , bTxs            1000         20         20
+        , bTxs           10000         20         20
+        , bTxs          100000         20         20
         ]
   where
     bTxs n i o = benchDiskSize tr $ \db -> do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-627

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->


Before this commit, every asset will trigger a database query. For, a UTxO of ~1000 entries, with 1 asset on each entry would generate an extra 1000 queries! This was noticeable from benchmarks with large query times on the read utxo benchmarks.

  | Bench                                                | Before   | After    |
  | ---                                                  | ---      | ---      |
  | UTxO (Read)/1 CP (ada-only) x 10000 UTxO             | 441.8 ms | 104.3 ms |
  | UTxO (Read)/1 CP (1 assets per output) x 10000 UTxO  | 12.36 s  | 183.5 ms |
  | UTxO (Read)/1 CP (2 assets per output) x 10000 UTxO  | 29.15 s  | 267.3 ms |
  | UTxO (Read)/1 CP (10 assets per output) x 10000 UTxO | 144.3 s  | 1.132 s  |
  | UTxO (Read)/1 CP (20 assets per output) x 10000 UTxO | /        | 2.242 s  |


# Comments

<!-- Additional comments or screenshots to attach if any -->

Normally, I would have solved this with a nice JOIN query... but joining with `persistent` is unpractical (especially because we don't have any intermediate model to unserialize to..). So, doing the merge in-memory since _anyway_, the whole thing is going to end up in memory eventually. 

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
