### PR TITLE
Add TOKEN_METADATA_SERVER variable for local-cluster and more properties

### DIFF
--- a/lib/shelley/exe/local-cluster.hs
+++ b/lib/shelley/exe/local-cluster.hs
@@ -53,6 +53,7 @@ import Cardano.Wallet.Shelley.Launch.Cluster
     , sendFaucetAssetsTo
     , sendFaucetFundsTo
     , testMinSeverityFromEnv
+    , tokenMetadataServerFromEnv
     , walletListenFromEnv
     , walletMinSeverityFromEnv
     , withCluster
@@ -201,6 +202,9 @@ import qualified Data.Text as T
 --     "virtual hard forks" in the node config files.
 --     The final era can be changed with this variable.
 --
+-- - TOKEN_METADATA_SERVER  (default: none)
+--     Use this URL for the token metadata server.
+--
 -- - NO_POOLS  (default: stake pools nodes are started and registered)
 --     If set, the cluster will only start a BFT leader and a relay, no
 --     stake pools. This can be used for running test scenarios which do
@@ -241,6 +245,7 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
             let db = dir </> "wallets"
             createDirectory db
             listen <- walletListenFromEnv
+            tokenMetadataServer <- tokenMetadataServerFromEnv
 
             prometheusUrl <- (maybe "none"
                     (\(h, p) -> T.pack h <> ":" <> toText @(Port "Prometheus") p)
@@ -261,7 +266,7 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
                 listen
                 Nothing
                 Nothing
-                Nothing
+                tokenMetadataServer
                 socketPath
                 block0
                 (gp, vData)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -53,6 +53,7 @@ module Cardano.Wallet.Shelley.Launch.Cluster
     , testMinSeverityFromEnv
     , testLogDirFromEnv
     , walletListenFromEnv
+    , tokenMetadataServerFromEnv
 
       -- * Faucets
     , sendFaucetFundsTo
@@ -112,7 +113,12 @@ import Cardano.Wallet.Network.Ports
 import Cardano.Wallet.Primitive.AddressDerivation
     ( hex )
 import Cardano.Wallet.Primitive.Types
-    ( Block (..), EpochNo (..), NetworkParameters (..), PoolId (..) )
+    ( Block (..)
+    , EpochNo (..)
+    , NetworkParameters (..)
+    , PoolId (..)
+    , TokenMetadataServer (..)
+    )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -274,6 +280,12 @@ walletListenFromEnv :: IO Listen
 walletListenFromEnv = envFromText "CARDANO_WALLET_PORT" >>= \case
     Nothing -> pure ListenOnRandomPort
     Just (Right port) -> pure $ ListenOnPort port
+    Just (Left e) -> die $ show e
+
+tokenMetadataServerFromEnv :: IO (Maybe TokenMetadataServer)
+tokenMetadataServerFromEnv = envFromText "TOKEN_METADATA_SERVER" >>= \case
+    Nothing -> pure Nothing
+    Just (Right s) -> pure (Just s)
     Just (Left e) -> die $ show e
 
 -- | Directory for extra logging. Buildkite will set this environment variable


### PR DESCRIPTION
# Issue Number

ADP-688

# Overview

- Adds TOKEN_METADATA_SERVER environment variable for the local test cluster
- ~Adds parsing of the other metadata properties - in such a way that parse failures of a single field should not cause a parse failure of the entire batch.~ ⇒ moved to #2507
