### PR TITLE
Allow individual JSON entries to fail parsing

### DIFF
--- a/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden2.json
+++ b/lib/core/test/data/Cardano/Wallet/TokenMetadata/golden2.json
@@ -1,0 +1,83 @@
+{
+  "subjects":
+    [
+      {
+        "subject": "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27",
+        "owner": {
+          "signature": "62e800b8c540b218396174f9c42fc253ab461961e20a4cc8ed4ba8b3fdff760cf8422e80d2504829a1d84458093880f02629524416f895b802cb9211f5145808",
+          "publicKey": "25912b3081c20782aaa576af51ef3b17d7370d9fdf6641fec28012678ac1d179"
+        },
+        "name": {
+          "value": "SteveToken",
+          "anSignatures": [
+            {
+              "signature": "7ef6ed44ba9456737ef8d2e31596fdafb66d5775ac1a254086a553b666516e5895bb0c6b7ba8bef1f6b4d9bd9253b4449d1354de2f9e043ea4eb43fd42f87108",
+              "publicKey": "0ee262f062528667964782777917cd7139e19e8eb2c591767629e4200070c661"
+            },
+            {
+              "signature": "c95cf87b74d1e4d3b413c927c65de836f0905ba2cd176c7cbff83d8b886b30fe1560c542c1f77bb88280dff55c2d267c9840fe36560fb13ba4a78b6429e51500",
+              "publicKey": "7c3bfe2a11290a9b6ea054b4d0932678f88130511cfbfe3f634ee77d71edebe7"
+            },
+            {
+              "signature": "f88692b13212bac8121151a99a4de4d5244e5f63566babd2b8ac20950ede74073af0570772b3ce3d11b72e972079199f02306e947cd5fcca688a9d4664eddb04",
+              "publicKey": "8899d0777f399fffd44f72c85a8aa51605123a7ebf20bba42650780a0c81096a"
+            },
+            {
+              "signature": "c2b30fa5f2c09323d81e5050af681c023089d832d0b85d05f60f4278fba3011ab03e6bd9bd2b8649080a368ecfe51573cd232efe8f1e7ca69ff8334ced7b6801",
+              "publicKey": "d40688a3eeda1f229c64efc56dd53b363ff981f71a7462f78c8cc444117a03db"
+            }
+          ]
+        },
+        "preImage": {
+          "value": "f026b38d5bfdd8d8d838df4c4cc5d6aa4e",
+          "hashFn": "blake2b-256"
+        },
+        "description": {
+          "value": "A sample description",
+          "anSignatures": [
+            {
+              "signature": "83ef5c04882e43e5f1c8e9bc386bd51cdda163f5cbd1996d1d066238de063d4b79b1648b48aec63dddff05649911ca116579842c8e9a08a3bc7ae1a0ec7ef000",
+              "publicKey": "1446c9d327b0f07aa691014c08578867674f3a88b36f2017a58c37a8a7799058"
+            },
+            {
+              "signature": "4e29a00feaeb24b25315f0eac28bbfc550dabfb847bf6a06cb8086120201f90c64fab778037d0ef009ab4669121a38fe9b8c0a6aec99c68366c5187c0889520a",
+              "publicKey": "1910312a9a6998c7e4f585dc138f85a90f50a28397b8ea05eb23355fb8ea4fa0"
+            },
+            {
+              "signature": "ce939acca5677bc6d436bd8f054ed8fb03d143e0a9792c1f58592c43f175e89bb72d4d7114c1474b86e0d8fbf7807f4506325b56fcc6b87b2cb7002872527106",
+              "publicKey": "4c5bbbbe7caaa18372aa8edc1ef2d2a770d18a5c2d142b9d695619c3365dd297"
+            },
+            {
+              "signature": "5a1d55048234d92057dfd1938f49935a33751ee604b7dbd02a315418ced6f0836a51107512b192eae6133403bb437c6850b1af1c62c3b17a372acce77adf9903",
+              "publicKey": "57fa73123c3b39489c4d6c2ff3cab9952e56e556daab9f8f333bc5ca6984fa5e"
+            },
+            {
+              "signature": "e13c9ba5b084dc126d34f3f1120fff75495b64a41a98a69071b5c5ed01bb9d273f51d570cf4fdaa42969fa2c775c12ec05c496cd8f61323d343970136781f60e",
+              "publicKey": "8cc8963b65ddd0a49f7ce1acc2915d8baff505bbc4f8727a22bd1d28f8ad6632"
+            }
+          ]
+        }
+      },
+      {
+        "subject": "missing sigs",
+        "name": {
+          "value": "Token1",
+          "anSignatures": []
+        },
+        "description": {
+          "value": "description1"
+        }
+      },
+      { "subject": "bad00000000000000000000000000000000000000000000000000000",
+        "_description": {
+          "value": "missing fields"
+        }
+      },
+      {
+        "subject": "extra fields",
+        "name": { "value": "Token2" },
+        "description": { "value": "description2" },
+        "acronym": { "value": "acronym2" }
+      }
+    ]
+}

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -51,6 +51,14 @@ spec = describe "Token Metadata" $ do
                 let aid = AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
                 getTokenMetadata client [assetIdFromSubject (Subject subj)]
                     `shouldReturn` Right [(aid, golden1Metadata0)]
+        it "ill-formatted entry doesn't make the entire response fail to parse" $ do
+            withMetadataServer (queryServerStatic golden2File) $ \url -> do
+                client <- newMetadataClient nullTracer (Just url)
+                let aid subj  =  AssetId (UnsafeTokenPolicyId (unsafeFromText subj)) nullTokenName
+                let aid1 = aid "7f71940915ea5fe85e840f843c929eba467e6f050475bad1f10b9c27"
+                let aid2 = aid "bad00000000000000000000000000000000000000000000000000000"
+                getTokenMetadata client [aid1, aid2 ]
+                    `shouldReturn` Right [(aid1, golden1Metadata0)]
         it "missing subject" $
             withMetadataServer (queryServerStatic golden1File) $ \url -> do
                 client <- newMetadataClient nullTracer (Just url)
@@ -62,6 +70,7 @@ spec = describe "Token Metadata" $ do
     dir = $(getTestData) </> "Cardano" </> "Wallet" </> "TokenMetadata"
 
     golden1File = dir </> "golden1.json"
+    golden2File = dir </> "golden2.json"
     golden1Metadata0 = AssetMetadata "SteveToken" "A sample description"
     golden1Metadata1 = AssetMetadata "Token1" "description1"
     golden1Metadata2 = AssetMetadata "Token2" "description2"


### PR DESCRIPTION
# Issue Number

ADP-688

# Overview

- [x] Failing test case demonstrating problem
- [x] Fix using `<|>`


# Comments

- I haven't checked out #2505 yet.
- The mock server uses the same JSON instances when serving, which got a bit interesting when I tried including the faulty entry in the existing golden file, used by the other unit tests.

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
