### PR TITLE
Bump version to 2021.2.12

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -88,12 +88,18 @@ let
     inherit (project.hsPkgs.cardano-addresses-cli.components.exes) cardano-address;
     inherit (project.hsPkgs.cardano-transactions.components.exes) cardano-tx;
 
+    # The main executable
     cardano-wallet = import ./nix/package-cardano-node.nix {
       inherit pkgs gitrev;
       haskellBuildUtils = haskellBuildUtils.package;
       exe = project.hsPkgs.cardano-wallet.components.exes.cardano-wallet;
       inherit (self) cardano-node;
     };
+
+    # Local test cluster and mock metadata server
+    inherit (project.hsPkgs.cardano-wallet.components.exes)
+      local-cluster
+      mock-token-metadata-server;
 
     # `tests` are the test suites which have been built.
     tests = collectComponents "tests" isProjectPackage coveredProject.hsPkgs;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2021.2.10-shelley
+    image: inputoutput/cardano-wallet:2021.2.12-shelley
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Wallet backend protocol-specific bits implemented using Shelley nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2021.2.10
+version:             2021.2.12
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2021.2.10"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2021.2.12"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2021.2.10";
+        version = "2021.2.12";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2021.2.10"; };
+      identifier = { name = "cardano-wallet-core"; version = "2021.2.12"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2021.2.10"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2021.2.12"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2021.2.10";
+        version = "2021.2.12";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2021.2.10"; };
+      identifier = { name = "cardano-wallet"; version = "2021.2.12"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2021.2.10"; };
+      identifier = { name = "text-class"; version = "2021.2.12"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # Release-specific parameters (Change when you bump the version)
 # Release tags must follow format vYYYY-MM-DD.
 OLD_GIT_TAG="v2021-01-28"
-GIT_TAG="v2021-02-10"
+GIT_TAG="v2021-02-12"
 
 CARDANO_NODE_TAG="1.25.1"
 
@@ -74,9 +74,9 @@ echo "Generating changelog into $CHANGELOG..."
 ./scripts/make_changelog.sh $OLD_DATE > $CHANGELOG
 echo ""
 
-# echo "Generating unresolved issues list into $KNOWN_ISSUES..."
-# ( jira release-notes-bugs || echo "TBD" ) > $KNOWN_ISSUES
-# echo ""
+echo "Generating unresolved issues list into $KNOWN_ISSUES..."
+( jira release-notes-bugs || echo "TBD" ) > $KNOWN_ISSUES
+echo ""
 
 echo "Filling in template into $OUT..."
 sed -e "s/{{GIT_TAG}}/$GIT_TAG/g"                   \

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Cardano Wallet Backend API
-  version: 2021.2.10
+  version: 2021.2.12
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
- Bumps version to 2021.2.12. The previous pre-release is 2021.1.28. Version 2021.2.10 was not released.
- Adds top-level attributes to default.nix for local-cluster and mock-token-metadata-server.