### PR TITLE
Fix documentation wrongly specifying 'asset.fingerprint' in places where it never appears.

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -728,7 +728,6 @@ x-walletAsset: &walletAsset
   properties:
     policy_id: *assetPolicyId
     asset_name: *assetName
-    fingerprint: *assetFingerprint
     quantity: *assetQuantity
 
 x-walletAssets: &walletAssets
@@ -1791,6 +1790,7 @@ components:
       type: object
       required:
         - policy_id
+        - fingerprint
         - asset_name
       properties:
         policy_id: *assetPolicyId


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

N/A

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have made 'asset.fingerprint' non-required when specifying assets as inputs, but present in outputs.

# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
