### PR TITLE
Fix reloading of mock-token-metadata-server

### DIFF
--- a/lib/core/src/Cardano/Wallet/TokenMetadata/MockServer.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata/MockServer.hs
@@ -19,6 +19,7 @@
 module Cardano.Wallet.TokenMetadata.MockServer
     ( withMetadataServer
     , queryServerStatic
+    , queryServerReloading
 
     -- * Helpers
     , assetIdFromSubject
@@ -53,6 +54,8 @@ import Cardano.Wallet.TokenMetadata
     )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
+import Control.Monad.IO.Class
+    ( liftIO )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..), eitherDecodeFileStrict, object, (.=) )
 import Data.ByteArray.Encoding
@@ -132,6 +135,11 @@ queryServerStatic golden = do
         inProps :: KnownSymbol name => Maybe (Property name) -> Maybe (Property name)
         inProps (Just p) = if (propertyName p) `Set.member` props then Just p else Nothing
         inProps Nothing = Nothing
+
+queryServerReloading :: FilePath -> BatchRequest -> Handler BatchResponse
+queryServerReloading golden req = do
+    handler <- liftIO $ queryServerStatic golden
+    handler req
 
 -- | The reverse of subjectToAssetId
 assetIdFromSubject :: Subject -> AssetId

--- a/lib/shelley/exe/mock-token-metadata-server.hs
+++ b/lib/shelley/exe/mock-token-metadata-server.hs
@@ -5,7 +5,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types
     ( TokenMetadataServer (..) )
 import Cardano.Wallet.TokenMetadata.MockServer
-    ( queryServerStatic, withMetadataServer )
+    ( queryServerReloading, withMetadataServer )
 import Control.Concurrent
     ( threadDelay )
 import Options.Applicative
@@ -33,7 +33,7 @@ main = do
 
 startMetadataServer :: FilePath -> IO ()
 startMetadataServer fp =
-    withMetadataServer (queryServerStatic fp) $ \(TokenMetadataServer uri) -> do
+    withMetadataServer (pure $ queryServerReloading fp) $ \(TokenMetadataServer uri) -> do
         putStrLn $ "Mock metadata server running with url " <> show uri
         threadDelay maxBound
 
@@ -54,5 +54,3 @@ opts = helper <*> cmd
             , "server. E.g.:\n"
             , "https://github.com/input-output-hk/metadata-registry-testnet/blob/7eb91951a2adf6f9deff9f3fbe990abc536657fa/789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f16861707079636f696e.json"
             ])
-
-


### PR DESCRIPTION
### Issue Number

ADP-688

### Overview

This brings back reloading per request in the mock-token-metadata-server command.
