### PR TITLE
Returns required minimum coin values as part of the fee estimation 

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -937,6 +937,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             , expectField (#deposit . #getQuantity) (`shouldBe` depositAmt ctx)
             , expectField (#estimatedMin . #getQuantity) (.< costOfJoining ctx)
             , expectField (#estimatedMax . #getQuantity) (.< costOfJoining ctx)
+            , expectField #minimumCoins (`shouldBe` [])
             ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_02 - \

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Transactions.hs
@@ -128,7 +128,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
         let amt = fromIntegral minUTxOValue
         args <- postTxArgs ctx wSrc wDest amt Nothing Nothing
         Stdout feeOut <- postTransactionFeeViaCLI ctx args
-        ApiFee (Quantity feeMin) (Quantity feeMax) (Quantity 0) <-
+        ApiFee (Quantity feeMin) (Quantity feeMax) _ (Quantity 0) <-
             expectValidJSON Proxy feeOut
 
         txJson <- postTxViaCLI ctx wSrc wDest amt Nothing Nothing
@@ -174,7 +174,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
                 ]
 
         Stdout feeOut <- postTransactionFeeViaCLI ctx args
-        ApiFee (Quantity feeMin) (Quantity feeMax) _ <- expectValidJSON Proxy feeOut
+        ApiFee (Quantity feeMin) (Quantity feeMax) _ _ <- expectValidJSON Proxy feeOut
 
         -- post transaction
         (c, out, err) <- postTransactionViaCLI ctx "cardano-wallet" args
@@ -322,7 +322,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
 
         args <- postTxArgs ctx wSrc wDest amt md Nothing
         Stdout feeOut <- postTransactionFeeViaCLI ctx args
-        ApiFee (Quantity feeMin) (Quantity feeMax) _ <- expectValidJSON Proxy feeOut
+        ApiFee (Quantity feeMin) (Quantity feeMax) _ _ <- expectValidJSON Proxy feeOut
 
         txJson <- postTxViaCLI ctx wSrc wDest amt md Nothing
         verify txJson
@@ -351,7 +351,7 @@ spec = describe "SHELLEY_CLI_TRANSACTIONS" $ do
 
       args <- postTxArgs ctx wSrc wDest amt Nothing ttl
       Stdout feeOut <- postTransactionFeeViaCLI ctx args
-      ApiFee (Quantity feeMin) (Quantity feeMax) _ <- expectValidJSON Proxy feeOut
+      ApiFee (Quantity feeMin) (Quantity feeMax) _ _ <- expectValidJSON Proxy feeOut
 
       txJson <- postTxViaCLI ctx wSrc wDest amt Nothing ttl
       verify txJson

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -129,6 +129,7 @@ module Cardano.Wallet
     , FeeEstimation (..)
     , estimateFee
     , calcMinimumDeposit
+    , calcMinimumCoinValues
 
     -- ** Transaction
     , forgetTx
@@ -1342,6 +1343,24 @@ selectAssetsNoOutputs ctx wid wal tx transform = do
     addToHead :: TokenBundle -> [TokenBundle] -> [TokenBundle]
     addToHead _    [] = []
     addToHead x (h:q) = TokenBundle.add x h : q
+
+-- | Calculate the minimum coin values required for a bunch of specified
+-- outputs.
+calcMinimumCoinValues
+    :: forall ctx k f.
+        ( HasTransactionLayer k ctx
+        , HasNetworkLayer ctx
+        , Applicative f
+        )
+    => ctx
+    -> f TxOut
+    -> IO (f Coin)
+calcMinimumCoinValues ctx outs = do
+    pp <- currentProtocolParameters nl
+    pure $ calcMinimumCoinValue tl pp . view (#tokens . #tokens) <$> outs
+  where
+    nl = ctx ^. networkLayer
+    tl = ctx ^. transactionLayer @k
 
 -- | Selects assets from the wallet's UTxO to satisfy the requested outputs in
 -- the given transaction context. In case of success, returns the selection

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -774,6 +774,7 @@ newtype PostExternalTransactionData = PostExternalTransactionData
 data ApiFee = ApiFee
     { estimatedMin :: !(Quantity "lovelace" Natural)
     , estimatedMax :: !(Quantity "lovelace" Natural)
+    , minimumCoins :: ![Quantity "lovelace" Natural]
     , deposit :: !(Quantity "lovelace" Natural)
     } deriving (Eq, Generic, Show)
 

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiFee.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiFee.json
@@ -1,143 +1,839 @@
 {
-    "seed": 7432432031974251767,
+    "seed": 5477206274405279323,
     "samples": [
         {
             "estimated_min": {
-                "quantity": 71,
+                "quantity": 19,
                 "unit": "lovelace"
             },
             "deposit": {
-                "quantity": 107,
+                "quantity": 115,
                 "unit": "lovelace"
             },
+            "minimum_coins": [
+                {
+                    "quantity": 83,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 107,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 79,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 179,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 247,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 217,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 77,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 208,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 117,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 72,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 49,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 1,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 247,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 246,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 89,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 134,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 215,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 171,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 130,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 164,
+                    "unit": "lovelace"
+                }
+            ],
             "estimated_max": {
-                "quantity": 172,
+                "quantity": 136,
                 "unit": "lovelace"
             }
         },
         {
             "estimated_min": {
-                "quantity": 218,
+                "quantity": 61,
                 "unit": "lovelace"
             },
             "deposit": {
-                "quantity": 169,
+                "quantity": 203,
                 "unit": "lovelace"
             },
+            "minimum_coins": [
+                {
+                    "quantity": 209,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 245,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 102,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 102,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 58,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 211,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 60,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 34,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 87,
+                    "unit": "lovelace"
+                }
+            ],
             "estimated_max": {
-                "quantity": 226,
+                "quantity": 153,
                 "unit": "lovelace"
             }
         },
         {
             "estimated_min": {
-                "quantity": 129,
+                "quantity": 113,
                 "unit": "lovelace"
             },
             "deposit": {
-                "quantity": 205,
+                "quantity": 54,
                 "unit": "lovelace"
             },
+            "minimum_coins": [
+                {
+                    "quantity": 73,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 141,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 230,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 51,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 60,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 199,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 207,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 67,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 216,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 19,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 144,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 232,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 254,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 116,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 38,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 254,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 215,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 245,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 187,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 125,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 38,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 156,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 73,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 211,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 158,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 39,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 99,
+                    "unit": "lovelace"
+                }
+            ],
             "estimated_max": {
-                "quantity": 173,
+                "quantity": 3,
                 "unit": "lovelace"
             }
         },
         {
             "estimated_min": {
-                "quantity": 30,
+                "quantity": 223,
                 "unit": "lovelace"
             },
             "deposit": {
+                "quantity": 220,
+                "unit": "lovelace"
+            },
+            "minimum_coins": [
+                {
+                    "quantity": 76,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 195,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 12,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 150,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 83,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 213,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 56,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 178,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 197,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 206,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 47,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 50,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 50,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 93,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 170,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 214,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 106,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 214,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 86,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 14,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 87,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 164,
+                    "unit": "lovelace"
+                }
+            ],
+            "estimated_max": {
+                "quantity": 127,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "estimated_min": {
+                "quantity": 249,
+                "unit": "lovelace"
+            },
+            "deposit": {
+                "quantity": 8,
+                "unit": "lovelace"
+            },
+            "minimum_coins": [
+                {
+                    "quantity": 191,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 205,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 214,
+                    "unit": "lovelace"
+                }
+            ],
+            "estimated_max": {
+                "quantity": 159,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "estimated_min": {
+                "quantity": 27,
+                "unit": "lovelace"
+            },
+            "deposit": {
+                "quantity": 120,
+                "unit": "lovelace"
+            },
+            "minimum_coins": [
+                {
+                    "quantity": 69,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 221,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 111,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 219,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 38,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 178,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 146,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 23,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 52,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 201,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 22,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 226,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 155,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 15,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 55,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 233,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 137,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 206,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 104,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 143,
+                    "unit": "lovelace"
+                }
+            ],
+            "estimated_max": {
+                "quantity": 18,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "estimated_min": {
+                "quantity": 161,
+                "unit": "lovelace"
+            },
+            "deposit": {
+                "quantity": 239,
+                "unit": "lovelace"
+            },
+            "minimum_coins": [
+                {
+                    "quantity": 124,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 11,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 176,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 31,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 164,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 146,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 98,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 180,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 7,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 45,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 61,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 207,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 77,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 238,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 152,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 224,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 166,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 136,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 9,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 147,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 202,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 98,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 56,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 42,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 205,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 204,
+                    "unit": "lovelace"
+                }
+            ],
+            "estimated_max": {
+                "quantity": 244,
+                "unit": "lovelace"
+            }
+        },
+        {
+            "estimated_min": {
                 "quantity": 221,
                 "unit": "lovelace"
             },
-            "estimated_max": {
-                "quantity": 122,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "estimated_min": {
-                "quantity": 50,
-                "unit": "lovelace"
-            },
             "deposit": {
-                "quantity": 174,
-                "unit": "lovelace"
-            },
-            "estimated_max": {
-                "quantity": 61,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "estimated_min": {
-                "quantity": 61,
-                "unit": "lovelace"
-            },
-            "deposit": {
-                "quantity": 188,
-                "unit": "lovelace"
-            },
-            "estimated_max": {
-                "quantity": 30,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "estimated_min": {
-                "quantity": 215,
-                "unit": "lovelace"
-            },
-            "deposit": {
-                "quantity": 211,
-                "unit": "lovelace"
-            },
-            "estimated_max": {
                 "quantity": 8,
                 "unit": "lovelace"
+            },
+            "minimum_coins": [
+                {
+                    "quantity": 100,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 172,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 170,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 249,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 83,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 71,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 116,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 95,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 134,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 191,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 120,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 106,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 96,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 116,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 56,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 88,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 153,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 86,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 49,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 114,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 153,
+                    "unit": "lovelace"
+                }
+            ],
+            "estimated_max": {
+                "quantity": 115,
+                "unit": "lovelace"
             }
         },
         {
             "estimated_min": {
-                "quantity": 254,
+                "quantity": 92,
                 "unit": "lovelace"
             },
             "deposit": {
-                "quantity": 88,
+                "quantity": 102,
                 "unit": "lovelace"
             },
+            "minimum_coins": [
+                {
+                    "quantity": 123,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 105,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 133,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 29,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 226,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 13,
+                    "unit": "lovelace"
+                }
+            ],
             "estimated_max": {
-                "quantity": 235,
+                "quantity": 17,
                 "unit": "lovelace"
             }
         },
         {
             "estimated_min": {
-                "quantity": 213,
+                "quantity": 122,
                 "unit": "lovelace"
             },
             "deposit": {
-                "quantity": 162,
+                "quantity": 119,
                 "unit": "lovelace"
             },
+            "minimum_coins": [
+                {
+                    "quantity": 202,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 73,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 192,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 159,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 106,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 94,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 108,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 234,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 255,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 62,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 18,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 77,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 39,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 243,
+                    "unit": "lovelace"
+                },
+                {
+                    "quantity": 109,
+                    "unit": "lovelace"
+                }
+            ],
             "estimated_max": {
-                "quantity": 166,
-                "unit": "lovelace"
-            }
-        },
-        {
-            "estimated_min": {
-                "quantity": 87,
-                "unit": "lovelace"
-            },
-            "deposit": {
-                "quantity": 147,
-                "unit": "lovelace"
-            },
-            "estimated_max": {
-                "quantity": 235,
+                "quantity": 22,
                 "unit": "lovelace"
             }
         }

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -821,6 +821,7 @@ spec = parallel $ do
                 x' = ApiFee
                     { estimatedMin = estimatedMin (x :: ApiFee)
                     , estimatedMax = estimatedMax (x :: ApiFee)
+                    , minimumCoins = minimumCoins (x :: ApiFee)
                     , deposit = deposit (x :: ApiFee)
                     }
             in

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1365,6 +1365,26 @@ x-deposits: &deposits
   minItems: 0
   items: *amount
 
+x-minimumCoins: &minimumCoins
+  description: |
+    A list of minimum coin values that each output in a payment must satisfy. The values themselves depends on two things:
+
+      - (a) Some updatable protocol parameters fixed by the network.
+      - (b) The nature of the outputs (i.e. the kind of assets it includes).
+
+    The list is a direct 1:1 mapping of the requested outputs. Said differently, it has the **same number of items** and **items
+    are ordered in the same way** as **requested outputs** are ordered. In the case where there's no explicitly requested outputs (e.g.
+    when calculating fee for delegation), this list is empty.
+
+    For example, an output containing only `Ada` may require to be of at least `1 Ada`. An output containing only an hypothetical `AppleCoin`
+    may require to also carry a minimum of `1.2 Ada`. Note that no matter what, a minimum coin value is always given in Lovelace / Ada.
+
+    > ℹ️ This mechanism is used by the protocol to protect against flooding of the network with worthless assets. By requiring a minimum coin value to every
+    UTxO, they are given an intrinsic value indexed itself on the value of Ada.
+  type: array
+  minItems: 0
+  items: *amount
+
 #############################################################################
 #                                                                           #
 #                              DEFINITIONS                                  #
@@ -1630,10 +1650,12 @@ components:
       required:
         - estimated_min
         - estimated_max
+        - minimum_coins
         - deposit
       properties:
         estimated_min: *amount
         estimated_max: *amount
+        minimum_coins: *minimumCoins
         deposit: *amount
 
     ApiPutAddressesData: &ApiPutAddressesData


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-712

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 8bce9c465a45623d808147ac6b364c616ff9e081
  :round_pushpin: **add 'minimumCoins' to fee estimation**
    This allows clients to know upfront what minimum Ada value is required for each of their output. Particularly useful in the context of native assets.

- b76a15203367c1908071a61552ac6ddd8aa88ba2
  :round_pushpin: **include assertions on the 'minimum_coins' in integration tests**

# Comments

<!-- Additional comments or screenshots to attach if any -->

![Screenshot from 2021-02-12 16-10-30](https://user-images.githubusercontent.com/5680256/107785435-deedca80-6d4c-11eb-97e1-dec171c345a6.png)

cc @nikolaglumac

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
