### PR TITLE
Prototype multi-stake key wallet

### DIFF
--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -53,8 +53,8 @@ import Cardano.Mnemonic
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationType (..)
     , HardDerivation (..)
+    , MkAddress (..)
     , NetworkDiscriminant (..)
-    , PaymentAddress (..)
     , Role (..)
     , WalletKey (..)
     , deriveRewardAccount
@@ -2002,8 +2002,8 @@ genByronFaucets = genFaucet encodeAddress genAddresses
             addrXPrv =
                 Byron.deriveAddressPrivateKey pwd accXPrv
         in
-            [ paymentAddress @'Mainnet
-                $ publicKey $ addrXPrv $ liftIndex @'Hardened ix
+            [ mkAddress @'Mainnet
+                (publicKey $ addrXPrv $ liftIndex @'Hardened ix) Nothing
             | ix <- [minBound..maxBound]
             ]
 
@@ -2029,7 +2029,7 @@ genIcarusFaucets = genFaucet encodeAddress genAddresses
             addrXPrv =
                 deriveAddressPrivateKey pwd accXPrv UtxoExternal
         in
-            [ paymentAddress @'Mainnet $ publicKey $ addrXPrv ix
+            [ mkAddress @'Mainnet (publicKey $ addrXPrv ix) Nothing
             | ix <- [minBound..maxBound]
             ]
 
@@ -2055,7 +2055,7 @@ genShelleyAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @'Mainnet $ publicKey $ addrXPrv ix
+        [ mkAddress @'Mainnet (publicKey $ addrXPrv ix) Nothing
         | ix <- [minBound..maxBound]
         ]
 

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -228,9 +228,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( HardDerivation (..)
+    , MkAddress (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PaymentAddress (..)
     , PersistPublicKey (..)
     , Role (..)
     , WalletKey (..)
@@ -1387,7 +1387,7 @@ fixtureRandomWallet = fmap fst . fixtureRandomWalletMws
 
 fixtureRandomWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n ByronKey
+        ( MkAddress n ByronKey
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1409,7 +1409,7 @@ fixtureRandomWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1447,7 +1447,7 @@ fixtureIcarusWallet = fmap fst . fixtureIcarusWalletMws
 
 fixtureIcarusWalletAddrs
     :: forall (n :: NetworkDiscriminant) m.
-        ( PaymentAddress n IcarusKey
+        ( MkAddress n IcarusKey
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1469,7 +1469,7 @@ fixtureIcarusWalletWith
         ( EncodeAddress n
         , DecodeAddress n
         , DecodeStakeAddress n
-        , PaymentAddress n IcarusKey
+        , MkAddress n IcarusKey
         , MonadIO m
         , MonadUnliftIO m
         )
@@ -1791,7 +1791,7 @@ delegationFee ctx w = do
 -- >>> take 1 (randomAddresses @n)
 -- [addr]
 randomAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey)
+    :: forall (n :: NetworkDiscriminant). (MkAddress n ByronKey)
     => Mnemonic 12
     -> [Address]
 randomAddresses mw =
@@ -1805,7 +1805,7 @@ randomAddresses mw =
         addrXPrv =
             Byron.deriveAddressPrivateKey pwd accXPrv
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ mkAddress @n (publicKey $ addrXPrv ix) Nothing
         | ix <- [minBound..maxBound]
         ]
 
@@ -1816,7 +1816,7 @@ randomAddresses mw =
 -- >>> take 1 (icarusAddresses @n)
 -- [addr]
 icarusAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n IcarusKey)
+    :: forall (n :: NetworkDiscriminant). (MkAddress n IcarusKey)
     => Mnemonic 15
     -> [Address]
 icarusAddresses mw =
@@ -1830,7 +1830,7 @@ icarusAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ mkAddress @n (publicKey $ addrXPrv ix) Nothing
         | ix <- [minBound..maxBound]
         ]
 
@@ -1841,7 +1841,7 @@ icarusAddresses mw =
 -- >>> take 1 (shelleyAddresses @n)
 -- [addr]
 shelleyAddresses
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ShelleyKey)
+    :: forall (n :: NetworkDiscriminant). (MkAddress n ShelleyKey)
     => Mnemonic 15
     -> [Address]
 shelleyAddresses mw =
@@ -1855,7 +1855,7 @@ shelleyAddresses mw =
         addrXPrv =
             deriveAddressPrivateKey pwd accXPrv UtxoExternal
     in
-        [ paymentAddress @n (publicKey $ addrXPrv ix)
+        [ mkAddress @n (publicKey $ addrXPrv ix) Nothing
         | ix <- [minBound..maxBound]
         ]
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Addresses.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
+    ( MkAddress, NetworkDiscriminant )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -88,8 +88,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , MkAddress n ByronKey
+    , MkAddress n IcarusKey
     ) => SpecWith Context
 spec = do
     describe "BYRON_ADDRESSES" $ do
@@ -300,7 +300,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -329,7 +329,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey
+        , MkAddress n IcarusKey
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 15))
     -> SpecWith Context
@@ -351,7 +351,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context
@@ -375,7 +375,7 @@ scenario_ADDRESS_IMPORT_04
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => (Context -> ResourceT IO ApiByronWallet)
     -> SpecWith Context
@@ -404,7 +404,7 @@ scenario_ADDRESS_IMPORT_05
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => Int
     -> (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
@@ -438,7 +438,7 @@ scenario_ADDRESS_IMPORT_06
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => (Context -> ResourceT IO (ApiByronWallet, Mnemonic 12))
     -> SpecWith Context

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/CoinSelections.hs
@@ -24,7 +24,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..), DerivationType (..), Index (..), PaymentAddress )
+    ( DerivationIndex (..), DerivationType (..), Index (..), MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -76,8 +76,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "BYRON_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -36,11 +36,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( HardDerivation (..)
-    , PaymentAddress
-    , PersistPublicKey (..)
-    , WalletKey (..)
-    )
+    ( HardDerivation (..), MkAddress, PersistPublicKey (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -103,7 +99,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
+    , MkAddress n IcarusKey
     ) => SpecWith Context
 spec = describe "BYRON_HW_WALLETS" $ do
     it "HW_WALLETS_01 - Restoration from account public key preserves funds" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -110,9 +110,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n ShelleyKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "BYRON_MIGRATIONS" $ do
     it "BYRON_CALCULATE_01 - \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -29,7 +29,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -126,8 +126,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , MkAddress n ByronKey
+    , MkAddress n IcarusKey
     ) => SpecWith Context
 spec = describe "BYRON_TRANSACTIONS" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -25,7 +25,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PassphraseMaxLength (..), PassphraseMinLength (..), PaymentAddress )
+    ( MkAddress, PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -103,8 +103,8 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "BYRON_WALLETS" $ do
     it "BYRON_GET_04, DELETE_01 - Deleted wallet is not available" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..), DerivationType (..), Index (..), PaymentAddress )
+    ( DerivationIndex (..), DerivationType (..), Index (..), MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -83,9 +83,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n ShelleyKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "SHELLEY_COIN_SELECTION" $ do
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -109,9 +109,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n ShelleyKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "SHELLEY_MIGRATIONS" $ do
     it "SHELLEY_CALCULATE_01 - \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Settings.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -64,9 +64,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n ShelleyKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "SHELLEY_SETTINGS" $ do
     it "SETTINGS_01 - Can put and read settings" $ \ctx -> do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -271,7 +271,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             unsafeRequest @[ApiStakePool] ctx
             (Link.listStakePools arbitraryStake) Empty
         rJoin <- joinStakePool @n ctx pool (src, fixturePassphrase)
-        let nKeys = 1
+        let nKeys = 8
         verify rJoin
             [ expectResponseCode HTTP.status202
             , expectField (#status . #getApiT) (`shouldBe` Pending)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -33,7 +33,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.Types
@@ -153,7 +153,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
+    , MkAddress n ShelleyKey
     ) => SpecWith Context
 spec = describe "SHELLEY_STAKE_POOLS" $ do
     let listPools ctx stake = request @[ApiStakePool] ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -271,7 +271,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             unsafeRequest @[ApiStakePool] ctx
             (Link.listStakePools arbitraryStake) Empty
         rJoin <- joinStakePool @n ctx pool (src, fixturePassphrase)
-        let nKeys = 8
+        let nKeys = 1
         verify rJoin
             [ expectResponseCode HTTP.status202
             , expectField (#status . #getApiT) (`shouldBe` Pending)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -39,7 +39,7 @@ import Cardano.Wallet.Api.Types
     , pendingSince
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PaymentAddress )
+    ( MkAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.Types
@@ -199,7 +199,7 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n IcarusKey
+    , MkAddress n IcarusKey
     ) => SpecWith Context
 spec = describe "SHELLEY_TRANSACTIONS" $ do
     it "TRANS_MIN_UTXO_01 - I cannot spend less than minUTxOValue" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -33,9 +33,9 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex (..)
+    , MkAddress
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
-    , PaymentAddress
     , Role (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -144,9 +144,9 @@ spec :: forall n.
     ( DecodeAddress n
     , DecodeStakeAddress n
     , EncodeAddress n
-    , PaymentAddress n ShelleyKey
-    , PaymentAddress n IcarusKey
-    , PaymentAddress n ByronKey
+    , MkAddress n ShelleyKey
+    , MkAddress n IcarusKey
+    , MkAddress n ByronKey
     ) => SpecWith Context
 spec = describe "SHELLEY_WALLETS" $ do
     it "WALLETS_CREATE_01 - Create a wallet" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Addresses.hs
@@ -21,7 +21,7 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( NetworkDiscriminant, PaymentAddress )
+    ( MkAddress, NetworkDiscriminant )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
@@ -73,8 +73,8 @@ import qualified Data.Text as T
 spec :: forall n.
     ( DecodeAddress n
     , EncodeAddress n
-    , PaymentAddress n ByronKey
-    , PaymentAddress n IcarusKey
+    , MkAddress n ByronKey
+    , MkAddress n IcarusKey
     ) => SpecWith Context
 spec = do
     describe "BYRON_CLI_ADDRESSES" $ do
@@ -327,7 +327,7 @@ scenario_ADDRESS_IMPORT_01
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_01 = it title $ \ctx -> runResourceT @IO $ do
@@ -344,7 +344,7 @@ scenario_ADDRESS_IMPORT_02
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n IcarusKey
+        , MkAddress n IcarusKey
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_02 = it title $ \ctx -> runResourceT @IO $ do
@@ -361,7 +361,7 @@ scenario_ADDRESS_IMPORT_03
     :: forall (n :: NetworkDiscriminant).
         ( DecodeAddress n
         , EncodeAddress n
-        , PaymentAddress n ByronKey
+        , MkAddress n ByronKey
         )
     => SpecWith Context
 scenario_ADDRESS_IMPORT_03 = it title $ \ctx -> runResourceT @IO $ do

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -168,6 +168,7 @@ library
       Cardano.Wallet.Primitive.Slotting
       Cardano.Wallet.Primitive.AddressDiscovery.Random
       Cardano.Wallet.Primitive.AddressDiscovery.Sequential
+      Cardano.Wallet.Primitive.AddressDiscovery.Delegation
       Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
       Cardano.Wallet.Primitive.Model

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -671,7 +671,7 @@ postShelleyWallet
     -> WalletPostData
     -> Handler ApiWallet
 postShelleyWallet ctx generateKey body = do
-    let ds acc = mkDelegationState 8 0 acc
+    let ds acc = mkDelegationState 1 0 acc
     let state = mkSeqStateFromRootXPrv (rootXPrv, pwd) purposeCIP1852 g ds
     void $ liftHandler $ initWorker @_ @s @k ctx wid
         (\wrk -> W.createWallet  @(WorkerCtx ctx) @s @k wrk wid wName state)

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -671,7 +671,7 @@ postShelleyWallet
     -> WalletPostData
     -> Handler ApiWallet
 postShelleyWallet ctx generateKey body = do
-    let ds acc = mkDelegationState 1 0 acc
+    let ds acc = mkDelegationState 8 0 acc
     let state = mkSeqStateFromRootXPrv (rootXPrv, pwd) purposeCIP1852 g ds
     void $ liftHandler $ initWorker @_ @s @k ctx wid
         (\wrk -> W.createWallet  @(WorkerCtx ctx) @s @k wrk wid wName state)

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -37,7 +37,7 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..) )
+    ( Depth (..), RewardAccount (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
@@ -177,6 +177,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , isStakeKeyRegistered
         :: PrimaryKey WalletId
+        -> RewardAccount
         -> ExceptT ErrNoSuchWallet stm Bool
 
     , putDelegationCertificate

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -127,8 +127,8 @@ newDBLayer timeInterpreter = do
             cert `deepseq` sl `deepseq`
                 alterDB errNoSuchWallet db (mPutDelegationCertificate pk cert sl)
 
-        , isStakeKeyRegistered =
-            ExceptT . alterDB errNoSuchWallet db . mIsStakeKeyRegistered
+        , isStakeKeyRegistered = error "todo"
+            --ExceptT . alterDB errNoSuchWallet db . mIsStakeKeyRegistered
 
         {-----------------------------------------------------------------------
                                      Tx History

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -201,6 +201,7 @@ ProtocolParameters
 -- Track whether the wallet's stake key is registered or not.
 StakeKeyCertificate
     stakeKeyCertWalletId             W.WalletId            sql=wallet_id
+    stakeKeyCertStakeKey             W.RewardAccount       sql=stake_key
     stakeKeyCertSlot                 SlotNo                sql=slot
     stakeKeyCertType                 W.StakeKeyCertificate sql=type
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -37,7 +37,7 @@ import Data.Text
 import Data.Time.Clock
     ( UTCTime )
 import Data.Word
-    ( Word16, Word32, Word64 )
+    ( Word16, Word32, Word64, Word8 )
 import Database.Persist.Class
     ( AtLeastOneUniqueKey (..), OnlyOneUniqueKey (..) )
 import Database.Persist.TH
@@ -300,6 +300,8 @@ SeqState
     seqStateRewardXPub        B8.ByteString      sql=reward_xpub
     seqStateDerivationPrefix  W.DerivationPrefix sql=derivation_prefix
     seqStateScriptGap         W.AddressPoolGap   sql=script_gap
+    seqStateStakeKeys         Word8              sql=num_stake_keys
+    seqStateStakeEdge         Word8              sql=stake_edge
 
     Primary seqStateWalletId
     Foreign Wallet seq_state seqStateWalletId ! ON DELETE CASCADE

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -772,6 +772,9 @@ class MkAddress (network :: NetworkDiscriminant) key where
     -- The stake key may be omitted.
     -- FIXME: Omitting a stake key for ShelleyKey should be impossible, and it
     -- should be represented as such.
+    --
+    -- TODO: We should concider re-defining mkAddress as
+    -- mkAddress :: KeyFingerprint "payment" -> RewardAccount -> Address
     mkAddress
         :: key 'AddressK XPub
             -- ^ Payment key

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -67,10 +67,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , ErrMkKeyFingerprint (..)
     , Index (..)
     , KeyFingerprint (..)
+    , MkAddress (..)
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PaymentAddress (..)
     , PersistPrivateKey (..)
     , WalletKey (..)
     , fromHex
@@ -153,8 +153,8 @@ instance WalletKey ByronKey where
     liftRawKey = error "not supported"
     keyTypeDescriptor _ = "rnd"
 
-instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey where
-    paymentAddress k = Address
+instance KnownNat pm => MkAddress ('Testnet pm) ByronKey where
+    mkAddress k _ = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
             [ CBOR.encodeDerivationPathAttr pwd acctIx addrIx
@@ -163,18 +163,18 @@ instance KnownNat pm => PaymentAddress ('Testnet pm) ByronKey where
       where
         (acctIx, addrIx) = derivationPath k
         pwd = payloadPassphrase k
-    liftPaymentAddress (KeyFingerprint bytes) =
+    mkAddressFromFingerprint (KeyFingerprint bytes) _ =
         Address bytes
 
-instance PaymentAddress 'Mainnet ByronKey where
-    paymentAddress k = Address
+instance MkAddress 'Mainnet ByronKey where
+    mkAddress k _ = Address
         $ CBOR.toStrictByteString
         $ CBOR.encodeAddress (getKey k)
             [ CBOR.encodeDerivationPathAttr pwd acctIx addrIx ]
       where
         (acctIx, addrIx) = derivationPath k
         pwd = payloadPassphrase k
-    liftPaymentAddress (KeyFingerprint bytes) =
+    mkAddressFromFingerprint (KeyFingerprint bytes) _ =
         Address bytes
 
 instance MkKeyFingerprint ByronKey Address where

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -68,6 +69,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery.Delegation
+    ( HasRewardAccounts (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, coinTypeAda, purposeBIP44 )
 import Cardano.Wallet.Primitive.Types
@@ -422,3 +425,6 @@ instance PersistPublicKey (IcarusKey depth) where
       where
         xpubFromText = xpub <=< fromHex @ByteString
         err _ = error "unsafeDeserializeXPub: unable to deserialize IcarusKey"
+
+instance {-# OVERLAPS #-} HasRewardAccounts (SeqState n IcarusKey) where
+    listRewardAccounts _ = []

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Delegation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Delegation.hs
@@ -1,0 +1,258 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Cardano.Wallet.Primitive.AddressDiscovery.Delegation
+    ( -- * Creation
+      DelegationState (..)
+    , mkEmptyDelegationState
+    , mkDelegationState
+
+      -- * Operations
+    , assignStakeKeys
+    , allStakeKeys
+    , takeStakeKey
+    , isOurStakeKey
+    , allRewardAccountsWithPaths
+    )
+    where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPub )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationIndex (..)
+    , DerivationPrefix
+    , DerivationType (..)
+    , Index (..)
+    , Role (..)
+    , SoftDerivation (..)
+    , ToRewardAccount (..)
+    , stakeDerivationPath
+    )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount )
+import Control.DeepSeq
+    ( NFData )
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Word
+    ( Word8 )
+import GHC.Generics
+    ( Generic )
+
+import Data.Map.Strict
+    ( Map )
+
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+
+--------------------------------------------------------------------------------
+-- Delegation State
+--------------------------------------------------------------------------------
+
+-- | @DelegationState@ keeps track of stake keys on-chain. It allows you to
+-- delegate to multiple pools, by allowing multiple stake keys to be registered.
+--
+-- == Deriving set of keys from chain data
+--
+-- Normal wallets start with a single stake key. It may or may not be registered
+-- in the ledger.
+--
+-- Using pseudo-syntax:
+--
+-- >>> s0 = { n=1, indexedKeys=[0] }
+--
+-- -- FIXME: What happens if the keys for some reason are registered out of
+-- order?
+--
+-- If we see a stake key registration for the edge, we add it. This can be done
+-- repeatedly in a single tx, e.g. if the user wants to delegate to 10 different
+-- pools.
+--
+-- >>> stake key registration certificates for 1,2,3,4,5,6,7,8,9,10
+--
+-- >>> s1 = { n=10, indexedKeys=[0,1,2,3,4,5,6,7,8,9,10] }
+--
+-- The state can only be shrunk from de-registering the last indexed key. To go
+-- to 5 keys, we would now de-register key 10,9,8,6 and 5 in order, leaving us
+-- with:
+--
+-- >>> s1 = { n=5, indexedKeys=[0,1,2,3,4] }
+--
+-- == Assigning stake keys to addresses
+--
+-- There are two ways of generating addresses: users can either have funds sent
+-- to addresses listed by the wallet, or change addresses can be generated when
+-- the users themselves make transactions.
+--
+-- ==== Recieving funds in listed addresses
+--
+-- See @assignStakeKeys@.
+--
+-- ==== Generating change addresses
+--
+-- See @takeStakeKey@.
+-- -- FIXME: How does this ensure balancing?
+-- -- FIXME: How does this interact with the address listing?
+-- -- FIXME: Describe how the cursor should work.
+--
+-- There are two ways of generating address
+--
+-- NOTE: Assuming delegation to n stake pools with equal weights.
+data DelegationState k = DelegationState
+    { -- | Availible number of stake keys
+      numberOfStakeKeys :: Word8
+
+      -- | Points to the stake key to be assigned to the next address.
+      --
+      -- Invariant: cursor \in [0 .. numberOfStakeKeys - 1]
+    , cursor :: Word8
+
+      -- | The account public key from which the stake keys should be derived.
+    , rewardAccountKey :: k 'AccountK XPub
+
+      -- | Index of known stake keys
+      --
+      -- Invariant: indices should form a consecutive range.
+    , dsIndexedKeys
+        :: !(Map
+                (RewardAccount)
+                ((Index 'Soft 'AddressK), k 'AddressK XPub)
+            )
+    } deriving (Generic)
+
+--------------------------------------------------------------------------------
+-- Constructors
+--------------------------------------------------------------------------------
+
+-- | Construct a empty @DelegationState@. It has no stake keys, and is not
+-- capable of delegation.
+--
+-- NOTE: The reward account key is needed for the DB. This could be changed.
+mkEmptyDelegationState :: k 'AccountK XPub -> DelegationState k
+mkEmptyDelegationState accK = DelegationState 0 0 accK Map.empty
+
+-- | Construct a @DelegationState@.
+mkDelegationState
+    :: (ToRewardAccount k, SoftDerivation k)
+    => Word8 -- Number of stake keys
+    -> Word8 -- Current cursor (0, unless deserializing from DB)
+    -> k 'AccountK XPub
+    -> DelegationState k
+mkDelegationState n c accountK =
+    let
+        -- FIXME: Do nicer
+        indexes = map (toEnum . fromEnum) [0 .. (n - 1)] -- FIXME: Unsafe!
+        m = Map.fromList $ map mkEntry indexes
+    in
+        DelegationState n c accountK m
+  where
+    mkEntry ix =
+        let
+            xpub = deriveAddressPublicKey accountK MutableAccount ix
+            acct = toRewardAccount xpub
+        in (acct, (ix, xpub))
+
+--------------------------------------------------------------------------------
+-- Operations
+--------------------------------------------------------------------------------
+
+-- | @withStakeKeys@ allows you to assign stake keys to a list of payment keys,
+-- to construct a list of addresses.
+--
+-- Respects the cursor of the delegation state. If a stake key was used in a
+-- change output via @takeStakeKey@, it won't immediately be used again here.
+--
+-- TODO: Test.
+assignStakeKeys
+    :: DelegationState k
+    -> (a -> Maybe (k 'AddressK XPub) -> b)
+    -> [a]
+    -> [b]
+assignStakeKeys s f as = zipWith f as (drop (fromEnum $ cursor s) $ safeCycle stakeKeys)
+  where
+    stakeKeys = map (snd . snd) $ Map.toList $ dsIndexedKeys s
+    safeCycle [] = repeat Nothing
+    safeCycle xs = map Just $ cycle xs
+
+-- Repeated application should yield:
+-- (n, i)
+-- 3 0
+-- 3 1
+-- 3 2
+-- 3 0
+-- 3 1
+-- ...
+takeStakeKeyIndex :: DelegationState k -> (Word8, DelegationState k)
+takeStakeKeyIndex (DelegationState n i k ix)
+    | (i + 1) < n     = (i, DelegationState n (i + 1) k ix)
+    | otherwise = (i, DelegationState n 0 k ix)
+
+-- Take one of the stake keys in the "pool".
+--
+-- If called to retrieve stake keys for each generated address, the addresses
+-- will get a even distribution of @numberOfStakeKeys@ stake keys.
+takeStakeKey
+    :: SoftDerivation k
+    => DelegationState k
+    -> (k 'AddressK XPub, DelegationState k)
+takeStakeKey s =
+    let
+      (ix, s') = takeStakeKeyIndex s
+      ix' = toEnum $ fromEnum ix -- FIXME: Use better types!
+    in (deriveAddressPublicKey (rewardAccountKey s) MutableAccount ix', s')
+    -- FIXME: This way of deriving the stake key is probably wrong!
+
+allStakeKeys
+    :: DelegationState k
+    -> [k 'AddressK XPub]
+allStakeKeys = map (snd . snd) . Map.toList . dsIndexedKeys
+
+allRewardAccountsWithPaths
+    :: DerivationPrefix
+    -> DelegationState k
+    -> [(RewardAccount, NonEmpty DerivationIndex)]
+allRewardAccountsWithPaths prefix = map (\(r,(d,_)) -> (r, toFullPath d) ) . Map.toList . dsIndexedKeys
+  where
+    toFullPath = stakeDerivationPath prefix
+
+-- | Helper to define @IsOurs@
+isOurStakeKey
+    :: RewardAccount
+    -> [DerivationIndex]
+    -> DelegationState k
+    -> (Maybe (NonEmpty DerivationIndex), DelegationState k)
+isOurStakeKey acc basePath s@DelegationState{dsIndexedKeys} =
+    let
+        ix = fst <$> Map.lookup acc dsIndexedKeys
+        -- FIXME: Allow extending the map.
+        --
+        -- FIXME: We should write nice properties, showing that whatever certs
+        -- appear on-chain, it works correctly.
+        path x = append (DerivationIndex $ getIndex @'Soft x) basePath
+
+        -- | Like :|, but the element is put last.
+        append :: x -> [x] -> NonEmpty x
+        append x xs = NE.reverse (x NE.:| reverse xs)
+    in
+        (path <$> ix, s)
+
+instance (NFData (k 'AccountK XPub), NFData (k 'AddressK XPub))
+    => NFData (DelegationState k)
+
+deriving instance
+    ( Show (k 'AccountK XPub)
+    , Show (k 'AddressK XPub)
+    ) => Show (DelegationState k)
+
+deriving instance
+    ( Eq (k 'AccountK XPub)
+    , Eq (k 'AddressK XPub)
+    ) => Eq (DelegationState k)

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Delegation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Delegation.hs
@@ -129,6 +129,9 @@ data DelegationState k = DelegationState
 
       -- | Index of known stake keys
       --
+      -- TODO: We shouldn't need to have k 'AddressK XPub here. But we need to
+      -- change mkAddress then.
+      --
       -- Invariant: indices should form a consecutive range.
     , dsIndexedKeys
         :: !(Map

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -68,6 +68,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , IsOwned (..)
     , KnownAddresses (..)
     )
+import Cardano.Wallet.Primitive.AddressDiscovery.Delegation
+    ( HasRewardAccounts (..), IsRewardAccountOwned (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -434,3 +436,16 @@ instance CompareDiscovery (RndAnyState n p) where
 
 instance KnownAddresses (RndAnyState n p) where
     knownAddresses (RndAnyState s) = knownAddresses s
+
+-- FIXME: I think forcing this module to be aware of reward accounts is kind of
+-- ugly.
+instance IsRewardAccountOwned (RndAnyState n p) k where
+    lookupRewardXPrv _ _ _ = Nothing
+    lookupRewardXPub _ _ = Nothing
+
+instance IsRewardAccountOwned (RndState n) k where
+    lookupRewardXPrv _ _ _ = Nothing
+    lookupRewardXPub _ _ = Nothing
+
+instance HasRewardAccounts (RndState n) where
+    listRewardAccounts _ = []

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -53,9 +53,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationIndex (..)
     , DerivationType (..)
     , Index (..)
+    , MkAddress (..)
     , NetworkDiscriminant
     , Passphrase (..)
-    , PaymentAddress (..)
     , liftIndex
     , publicKey
     )
@@ -264,7 +264,7 @@ newtype ErrImportAddress
     = ErrAddrDoesNotBelong Address
     deriving (Generic, Eq, Show)
 
-instance PaymentAddress n ByronKey => GenChange (RndState n) where
+instance MkAddress n ByronKey => GenChange (RndState n) where
     type ArgGenChange (RndState n) = (ByronKey 'RootK XPrv, Passphrase "encryption")
     genChange (rootXPrv, pwd) st = (address, st')
       where
@@ -316,13 +316,13 @@ deriveAddressKeyFromPath rootXPrv passphrase (accIx, addrIx) = addrXPrv
 
 -- | Use the key material in 'RndState' to derive a change address.
 deriveRndStateAddress
-    :: forall n. (PaymentAddress n ByronKey)
+    :: forall n. (MkAddress n ByronKey)
     => ByronKey 'RootK XPrv
     -> Passphrase "encryption"
     -> DerivationPath
     -> Address
 deriveRndStateAddress k passphrase path =
-    paymentAddress @n $ publicKey $ deriveAddressKeyFromPath k passphrase path
+    mkAddress @n (publicKey $ deriveAddressKeyFromPath k passphrase path) Nothing
 
 -- Unlike sequential derivation, we can't derive an order from the index only
 -- (they are randomly generated), nor anything else in the address itself.
@@ -425,7 +425,7 @@ instance IsOurs (RndAnyState n p) RewardAccount where
 instance KnownNat p => IsOwned (RndAnyState n p) ByronKey where
     isOwned _ _ _ = Nothing
 
-instance PaymentAddress n ByronKey => GenChange (RndAnyState n p) where
+instance MkAddress n ByronKey => GenChange (RndAnyState n p) where
     type ArgGenChange (RndAnyState n p) = ArgGenChange (RndState n)
     genChange a (RndAnyState s) = RndAnyState <$> genChange a s
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Scripts.hs
@@ -58,7 +58,7 @@ isShared
     => Script KeyHash
     -> SeqState n k
     -> ([k 'ScriptK XPub], SeqState n k)
-isShared script (SeqState !s1 !s2 !pending !rpk !prefix !s3) =
+isShared script (SeqState !s1 !s2 !pending !prefix !s3 !ds) =
     let
         hashes = retrieveAllVerKeyHashes script
         accXPub = verPoolAccountPubKey s3
@@ -75,12 +75,13 @@ isShared script (SeqState !s1 !s2 !pending !rpk !prefix !s3) =
     in
         if null ixs then
             ( []
-            , SeqState s1 s2 pending rpk prefix s3
+            , SeqState s1 s2 pending prefix s3 ds
             )
         else
             ( deriveVerificationKey accXPub <$> ixs
-            , SeqState s1 s2 pending rpk prefix
+            , SeqState s1 s2 pending prefix
               (extendVerificationKeyPool (maximum ixs) s3')
+              ds
             )
 
 

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -38,12 +38,7 @@ import Cardano.Address.Derivation
 import Cardano.Api.Typed
     ( AnyCardanoEra )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
-    , Passphrase
-    , RewardAccount (..)
-    )
+    ( Depth (..), Passphrase, RewardAccount (..) )
 import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     ( SelectionCriteria, SelectionResult, SelectionSkeleton )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -79,9 +79,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
     , Index
+    , MkAddress
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PaymentAddress (..)
     , PersistPrivateKey
     , WalletKey
     , encryptPassphrase
@@ -94,6 +94,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..), generateKeyFromSeed )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( KnownAddresses (..) )
+import Cardano.Wallet.Primitive.AddressDiscovery.Delegation
+    ( mkDelegationState )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
@@ -430,7 +432,7 @@ testMigrationTxMetaFee
         , WalletKey k
         , PersistState s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , MkAddress 'Mainnet k
         )
     => String
     -> Int
@@ -486,7 +488,7 @@ testMigrationCleanupCheckpoints
         , WalletKey k
         , PersistState s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , MkAddress 'Mainnet k
         )
     => String
     -> GenesisParameters
@@ -527,7 +529,7 @@ testMigrationRole
         , WalletKey k
         , PersistState s
         , PersistPrivateKey (k 'RootK)
-        , PaymentAddress 'Mainnet k
+        , MkAddress 'Mainnet k
         )
     => String
     -> IO ()
@@ -1163,7 +1165,8 @@ testCp :: Wallet (SeqState 'Mainnet ShelleyKey)
 testCp = snd $ initWallet block0 initDummyState
   where
     initDummyState :: SeqState 'Mainnet ShelleyKey
-    initDummyState = mkSeqStateFromRootXPrv (xprv, mempty) purposeCIP1852 defaultAddressPoolGap
+    initDummyState = mkSeqStateFromRootXPrv (xprv, mempty)
+        purposeCIP1852 defaultAddressPoolGap (mkDelegationState 1 0)
       where
         mw = SomeMnemonic . unsafePerformIO . generate $ genMnemonic @15
         xprv = generateKeyFromSeed (mw, Nothing) mempty
@@ -1224,7 +1227,8 @@ testCpSeq :: Wallet (SeqState 'Mainnet ShelleyKey)
 testCpSeq = snd $ initWallet block0 initDummyStateSeq
 
 initDummyStateSeq :: SeqState 'Mainnet ShelleyKey
-initDummyStateSeq = mkSeqStateFromRootXPrv (xprv, mempty) purposeCIP1852 defaultAddressPoolGap
+initDummyStateSeq = mkSeqStateFromRootXPrv (xprv, mempty)
+    purposeCIP1852 defaultAddressPoolGap (mkDelegationState 1 0)
   where
       mw = SomeMnemonic $ unsafePerformIO (generate $ genMnemonic @15)
       xprv = Seq.generateKeyFromSeed (mw, Nothing) mempty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -26,10 +26,10 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , HardDerivation (..)
     , Index
+    , MkAddress (..)
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PaymentAddress (..)
     , Role (..)
     , SoftDerivation (..)
     , WalletKey (..)
@@ -122,7 +122,8 @@ prop_roundtripFingerprintLift
 prop_roundtripFingerprintLift addr =
     let
         fingerprint = paymentKeyFingerprint @IcarusKey addr
-        eAddr = liftPaymentAddress @'Mainnet <$> fingerprint
+        eAddr = flip (mkAddressFromFingerprint @'Mainnet) Nothing
+            <$> fingerprint
     in
         eAddr === Right addr
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -23,11 +23,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (AccountK, AddressK, RootK)
     , DerivationType (..)
     , Index
+    , MkAddress (..)
     , NetworkDiscriminant (..)
     , Passphrase (..)
-    , PaymentAddress (..)
     , passphraseMaxLength
     , passphraseMinLength
+    , paymentAddress
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -75,7 +76,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_derivedKeysAreOurs
-    :: forall (n :: NetworkDiscriminant). (PaymentAddress n ByronKey)
+    :: forall (n :: NetworkDiscriminant). (MkAddress n ByronKey)
     => SomeMnemonic
     -> Passphrase "encryption"
     -> Index 'WholeDomain 'AccountK

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -80,10 +80,10 @@ import Cardano.Wallet.Network
     ( FollowLog (..), NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
+    , MkAddress
     , NetworkDiscriminant (..)
     , NetworkDiscriminantVal (..)
     , Passphrase (..)
-    , PaymentAddress
     , PersistPrivateKey
     , WalletKey
     , digest
@@ -421,7 +421,7 @@ benchmarksRnd
     :: forall (n :: NetworkDiscriminant) s k p.
         ( s ~ RndAnyState n p
         , k ~ ByronKey
-        , PaymentAddress n k
+        , MkAddress n k
         , NetworkDiscriminantVal n
         , KnownNat p
         )
@@ -443,7 +443,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listAddresses w wid (const pure)
+        $ W.listAddresses w wid
 
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)
@@ -511,7 +511,7 @@ benchmarksSeq
     :: forall (n :: NetworkDiscriminant) s k p.
         ( s ~ SeqAnyState n k p
         , k ~ ShelleyKey
-        , PaymentAddress n k
+        , MkAddress n k
         , NetworkDiscriminantVal n
         , KnownNat p
         )
@@ -533,7 +533,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
     (addresses, listAddressesTime) <- bench "list addresses"
         $ fmap (fromIntegral . length)
         $ unsafeRunExceptT
-        $ W.listAddresses w wid (const pure)
+        $ W.listAddresses w wid
 
     (transactions, listTransactionsTime) <- bench "list transactions"
         $ fmap (fromIntegral . length)

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -78,11 +78,10 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DelegationAddress (..)
-    , Depth (..)
+    ( Depth (..)
+    , MkAddress (..)
     , NetworkDiscriminant (..)
     , NetworkDiscriminantVal
-    , PaymentAddress
     , PersistPrivateKey
     , WalletKey
     , networkDiscriminantVal
@@ -197,10 +196,9 @@ data SomeNetworkDiscriminant where
     SomeNetworkDiscriminant
         :: forall (n :: NetworkDiscriminant).
             ( NetworkDiscriminantVal n
-            , PaymentAddress n IcarusKey
-            , PaymentAddress n ByronKey
-            , PaymentAddress n ShelleyKey
-            , DelegationAddress n ShelleyKey
+            , MkAddress n IcarusKey
+            , MkAddress n ByronKey
+            , MkAddress n ShelleyKey
             , HasNetworkId n
             , DecodeAddress n
             , EncodeAddress n
@@ -306,9 +304,9 @@ serveWallet
 
     startServer
         :: forall n.
-            ( PaymentAddress n IcarusKey
-            , PaymentAddress n ByronKey
-            , DelegationAddress n ShelleyKey
+            ( MkAddress n IcarusKey
+            , MkAddress n ByronKey
+            , MkAddress n ShelleyKey
             , DecodeAddress n
             , EncodeAddress n
             , EncodeStakeAddress n

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -1240,7 +1240,7 @@ instance HasSeverityAnnotation NetworkLayerLog where
             | isSlowQuery qry dt           -> Notice
             | otherwise                    -> Debug
         MsgInterpreterLog msg              -> getSeverityAnnotation msg
-        MsgObserverLog{}                   -> Debug
+        MsgObserverLog{}                   -> Info -- TODO: Revert back to Debug
 
 
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -39,8 +39,6 @@ module Cardano.Wallet.Shelley.Transaction
 
 import Prelude
 
-import Debug.Trace
-
 import Cardano.Address.Derivation
     ( XPrv, toXPub )
 import Cardano.Api.Typed
@@ -271,7 +269,7 @@ mkTx networkId payload ttl rewardCreds keyFrom cs fees era = do
     let withResolvedInputs tx = tx
             { resolvedInputs = second txOutCoin <$> F.toList (inputsSelected cs)
             }
-    Right $ trace ("*** Tx *** " <> show unsigned) $ first withResolvedInputs $ case era of
+    Right $ first withResolvedInputs $ case era of
         ShelleyBasedEraShelley -> sealShelleyTx fromShelleyTx signed
         ShelleyBasedEraAllegra -> sealShelleyTx fromAllegraTx signed
         ShelleyBasedEraMary    -> sealShelleyTx fromMaryTx signed
@@ -314,12 +312,7 @@ newTransactionLayer networkId = TransactionLayer
                             _ -> 0
                     let fees = unsafeSubtractCoin selection delta
                             (mconcat $ replicate numberOfRegistrations $ stakeKeyDeposit pp)
-                    let msg = mconcat
-                            [ "Actions: " <> show actions
-                            , " | "
-                            , "Certs: " <> show (length (stakeCreds))
-                            ]
-                    trace msg $mkTx networkId payload ttl wdrlCreds keystore selection fees
+                    mkTx networkId payload ttl wdrlCreds keystore selection fees
 
     , initSelectionCriteria = \pp ctx utxoAvailable outputsUnprepared ->
         let

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -41,8 +41,8 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
-    , PaymentAddress (..)
     , WalletKey
+    , paymentAddress
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron


### PR DESCRIPTION
# Issue Number

ADP-709

# Overview

- [x] Support creating wallets with `n` stake keys
- [x] When listing addresses we cycle through the available stake keys
    - Unsure if this is the behaviour we ultimately want though
- [x] Rewards are fetched for all accounts 
- [x] Joining a pool should do so with all keys
- [ ] Existing tests should pass
    - [x] Refine abstractions such that byron and icarus wallets are no longer broken (by unifying PaymentAddress and DelegationAddress vaguely in the style of #1702 ) 
    - [x] Integration tests passing after adding DelegationState
    - [ ] Integration tests passing after TransactionLayer changes
    - [ ] Unit tests passing / green CI
- [ ] We should be able to discover stake keys on chain — i.e. creating a 100 stake key wallet and restoring an existing one, should yield the same result. Probably modulo the 100 keys are actually delegated also.

# Comments

- State machine tests seemed to fail with other delegation states than the default one
- Should ensure property tests use arbitrary delegation states
- Should remove magic `mkDelegationState 1 0` with something more descriptive

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
