### PR TITLE
Add missing "Byron Assets" heading to OpenAPI docs

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3642,6 +3642,7 @@ x-tagGroups:
   - name: Byron (Random)
     tags:
     - Byron Wallets
+    - Byron Assets
     - Byron Addresses
     - Byron Coin Selections
     - Byron Transactions


### PR DESCRIPTION
### Issue Number

ADP-603

### Overview

All the `/byron-wallets/{walletId}/assets` endpoints were missing from the OpenAPI docs. This fixes it.

### Comments

[Rendered version](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/input-output-hk/cardano-wallet/rvl/adp-603/fix-swagger-byron-assets/specifications/api/swagger.yaml)
