### PR TITLE
Add mock-token-metadata-server --port CLI option

### DIFF
--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -177,8 +177,10 @@ executable mock-token-metadata-server
     ghc-options: -O2 -Werror
   build-depends:
       base
+    , ansi-wl-pprint
     , cardano-wallet-core
     , optparse-applicative
+    , wai-extra
   hs-source-dirs:
       exe
   main-is:

--- a/lib/shelley/exe/mock-token-metadata-server.hs
+++ b/lib/shelley/exe/mock-token-metadata-server.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Main where
 
 import Prelude
@@ -5,52 +7,104 @@ import Prelude
 import Cardano.Wallet.Primitive.Types
     ( TokenMetadataServer (..) )
 import Cardano.Wallet.TokenMetadata.MockServer
-    ( queryServerReloading, withMetadataServer )
+    ( queryServerReloading, withMetadataServerOptions )
 import Control.Concurrent
     ( threadDelay )
+import Control.Monad
+    ( forever )
+import Network.Wai.Middleware.RequestLogger
+    ( logStdoutDev )
 import Options.Applicative
-    ( Parser
+    ( ParserInfo
     , argument
+    , auto
     , customExecParser
+    , footerDoc
+    , fullDesc
+    , header
     , help
     , helper
-    , idm
     , info
+    , long
     , metavar
+    , option
+    , optional
     , prefs
     , showHelpOnEmpty
     , str
     )
+import Text.PrettyPrint.ANSI.Leijen
+    ( hang, indent, linebreak, text, (</>) )
 
-newtype MetadataServerArgs = MetadataServerArgs
+data MetadataServerArgs = MetadataServerArgs
     { sourceJson :: FilePath
+    , port :: Maybe Int
     } deriving Show
 
 main :: IO ()
 main = do
-    args <- customExecParser (prefs showHelpOnEmpty) (info opts idm)
-    startMetadataServer $ sourceJson args
+    args <- customExecParser (prefs showHelpOnEmpty) parserInfo
+    startMetadataServer args
 
-startMetadataServer :: FilePath -> IO ()
-startMetadataServer fp =
-    withMetadataServer (pure $ queryServerReloading fp) $ \(TokenMetadataServer uri) -> do
-        putStrLn $ "Mock metadata server running with url " <> show uri
-        threadDelay maxBound
+startMetadataServer :: MetadataServerArgs -> IO a
+startMetadataServer MetadataServerArgs{sourceJson,port} = do
+    let server = queryServerReloading sourceJson
+    withMetadataServerOptions logStdoutDev port (pure server)
+        $ \(TokenMetadataServer uri) -> do
+            putStrLn $ "Mock metadata server running with url " <> show uri
+            forever $ threadDelay maxBound
 
-opts :: Parser MetadataServerArgs
-opts = helper <*> cmd
+parserInfo :: ParserInfo MetadataServerArgs
+parserInfo = info (helper <*> argsParser) $ mconcat
+    [ fullDesc
+    , footerDoc (Just docs)
+    , header $ "mock-token-metadata-server"
+        <> " - for testing cardano-wallet native asset metadata"
+    ]
   where
-   cmd = fmap MetadataServerArgs $ argument str $
-        metavar "FILE"
-        <> help (mconcat
-            [ "Path to json file containing the mock data to be used."
-            , "On requests, the server will read the file, filter and "
-            , "return the queried metadata."
-            , "\n\n"
-            , "The format of the json file must match the POST /metadata/query "
-            , "endpoint. That is: "
-            , "  { \"subjects\": [entry1, entry2, ...] }, "
-            , " where the entries match what is usually submitted to the metadata "
-            , "server. E.g.:\n"
-            , "https://github.com/input-output-hk/metadata-registry-testnet/blob/7eb91951a2adf6f9deff9f3fbe990abc536657fa/789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f16861707079636f696e.json"
-            ])
+    docs = mconcat
+        [ p [ "This serves only the `POST /metadata/query' endpoint of Cardano "
+            , "metadata-server. Other endpoints are unimplemented because they "
+            , "are not used by cardano-wallet."
+            ]
+        , p [ "The OpenAPI specification of the real metadata-server is here:" ]
+        , code $ "https://github.com/input-output-hk/metadata-server"
+            <> "/blob/master/specifications/api/openapi.yaml"
+        , p [ "To use this, create a `registry.json' file in the same format "
+            , "of that returned by the metadata-server query endpoint. That is:"
+            ]
+        , code "{ \"subjects\": [entry1, entry2, ...] }"
+        , p [ "Each entry should match what is usually submitted to the "
+            , "metadata server. There are some example json files in this "
+            , "registry:"
+            ]
+        , code "https://github.com/input-output-hk/metadata-registry-testnet"
+        , p [ "To connect your wallet backend to the mock metadata server, use "
+            , "the URL which is printed out when this program starts."
+            ]
+        , p [ "Pass the URL to the wallet like so:" ]
+        , code "cardano-wallet serve --token-metadata-server URL ..."
+        , p [ "On every request, the server will read the file, filter and "
+            , "return the queried metadata. So you don't need to restart the "
+            , "mock server after editing metadata."
+            ]
+        , p [ "You can make test requests to the metadata server using curl: " ]
+        , code $ hang 2 $
+            "curl -i -H \"Content-type: application/json\" \\" <> linebreak <>
+            "--data '{\"subjects\":[\"entry1\", \"entry2\", ...]," <>
+            "\"properties\":[\"name\",\"description\"]}' \\"
+            <> linebreak <> "http://localhost:PORT/metadata/query"
+        ]
+    p = (<> sep) . foldr ((</>) . text) mempty . words . mconcat
+    sep = linebreak <> linebreak
+    code d = indent 2 d <> sep
+
+    argsParser = MetadataServerArgs <$> fileArg <*> portOpt
+    fileArg = argument str $
+        metavar "FILE" <>
+        help "Path to the JSON file containing metadata."
+
+    portOpt = optional $ option auto $
+        long "port" <>
+        metavar "PORT" <>
+        help "Port to listen on (default: random unused port)"

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -130,8 +130,10 @@
         "mock-token-metadata-server" = {
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
+            (hsPkgs."ansi-wl-pprint" or (errorHandler.buildDepError "ansi-wl-pprint"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
+            (hsPkgs."wai-extra" or (errorHandler.buildDepError "wai-extra"))
             ];
           buildable = true;
           };


### PR DESCRIPTION
### Overview

Allows the mock server to use a fixed port - otherwise it's a bit annoying.

### Documentation

```
mock-token-metadata-server - for testing cardano-wallet native asset metadata

Usage: mock-token-metadata-server FILE [--port PORT]

Available options:
  -h,--help                Show this help text
  FILE                     Path to the JSON file containing metadata.
  --port PORT              Port to listen on (default: random unused port)

This serves only the `POST /metadata/query' endpoint of Cardano metadata-server.
Other endpoints are unimplemented because they are not used by cardano-wallet. 

The OpenAPI specification of the real metadata-server is here: 

  https://github.com/input-output-hk/metadata-server/blob/master/specifications/api/openapi.yaml

To use this, create a `registry.json' file in the same format of that returned
by the metadata-server query endpoint. That is: 

  { "subjects": [entry1, entry2, ...] }

Each entry should match what is usually submitted to the metadata server. There
are some example json files in this registry: 

  https://github.com/input-output-hk/metadata-registry-testnet

To connect your wallet backend to the mock metadata server, use the URL which is
printed out when this program starts. 

Pass the URL to the wallet like so: 

  cardano-wallet serve --token-metadata-server URL ...

On every request, the server will read the file, filter and return the queried
metadata. So you don't need to restart the mock server after editing metadata. 

You can make test requests to the metadata server using curl: 

  curl -i -H "Content-type: application/json" \
    --data '{"subjects":["entry1", "entry2", ...],"properties":["name","description"]}' \
    http://localhost:PORT/metadata/query
```
