### PR TITLE
swagger.yaml: Fix asset metadata unit decimals minimum value

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -550,7 +550,7 @@ x-assetMetadataUnit: &assetMetadataUnit
       type: integer
       description: |
         The number of digits after the decimal point.
-      minimum: 0
+      minimum: 1
       maximum: 19
     name:
       type: string


### PR DESCRIPTION
### Issue Number

ADP-688

### Overview

Found via PR input-output-hk/metadata-registry-testnet#18
