### PR TITLE
Split change outputs with asset quantities exceeding the maximum

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -57,6 +57,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , equipartitionCoin
     , equipartitionTokenBundle
     , equipartitionTokenMap
+    , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenMapWithMaxQuantity
 
     -- * Grouping and ungrouping
@@ -1230,6 +1231,27 @@ equipartitionTokenMap m count = NE.reverse $
 
     weights :: NonEmpty Natural
     weights = 1 <$ count
+
+-- | Partitions a token bundle into a number of smaller token bundles, where
+--   every quantity in the result is guaranteed to not exceed the maximum
+--   allowable token quantity.
+--
+-- This function partitions the given token bundle into 'n' approximately-equal
+-- bundles, where 'n' is the minimum value required to achieve the goal that no
+-- token quantity in any of the resulting bundles exceeds the maximum allowable
+-- token quantity.
+--
+equipartitionTokenBundleWithMaxQuantity
+    :: TokenBundle
+    -> TokenQuantity
+    -- ^ Maximum allowable token quantity.
+    -> NonEmpty TokenBundle
+    -- ^ The partitioned bundles.
+equipartitionTokenBundleWithMaxQuantity b maxQuantity =
+    NE.zipWith TokenBundle cs ms
+  where
+    cs = equipartitionCoin (view #coin b) ms
+    ms = equipartitionTokenMapWithMaxQuantity (view #tokens b) maxQuantity
 
 -- | Partitions a token map into a number of smaller token maps, where every
 --   quantity in the result is guaranteed to not exceed the maximum allowable

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1232,36 +1232,56 @@ equipartitionTokenMapWithMaxQuantity m (TokenQuantity maxAllowableQuantity)
         , "the maximum allowable token quantity cannot be zero."
         ]
 
+-- | Partitions a coin into a number of parts, where the size of each part is
+--   proportional to the size of its corresponding element in the given list of
+--   weights, and the number of parts is equal to the number of weights.
+--
+-- Throws a run-time error if the sum of weights is equal to zero.
+--
 unsafePartitionCoin
     :: HasCallStack
     => Coin
+    -- ^ Coin to partition
     -> NonEmpty Natural
+    -- ^ List of weights
     -> NonEmpty Coin
-unsafePartitionCoin coin =
-    maybe zeroWeightSumError (fmap unsafeNaturalToCoin)
-        . partitionNatural (coinToNatural coin)
-  where
-    coinToNatural :: Coin -> Natural
-    coinToNatural = fromIntegral . unCoin
+unsafePartitionCoin n weights =
+    unsafeNaturalToCoin <$> unsafePartitionNatural (coinToNatural n) weights
 
-    unsafeNaturalToCoin :: Natural -> Coin
-    unsafeNaturalToCoin = Coin . fromIntegral
-
-    zeroWeightSumError = error $ unwords
-        [ "unsafePartitionCoin:"
-        , "specified weights must have a non-zero sum."
-        ]
-
+-- | Partitions a token quantity into a number of parts, where the size of each
+--   part is proportional to the size of its corresponding element in the given
+--   list of weights, and the number of parts is equal to the number of weights.
+--
+-- Throws a run-time error if the sum of weights is equal to zero.
+--
 unsafePartitionTokenQuantity
     :: HasCallStack
     => TokenQuantity
+    -- ^ Token quantity to partition
     -> NonEmpty Natural
+    -- ^ List of weights
     -> NonEmpty TokenQuantity
-unsafePartitionTokenQuantity (TokenQuantity target) =
-    maybe zeroWeightSumError (fmap TokenQuantity) . partitionNatural target
+unsafePartitionTokenQuantity n weights =
+    TokenQuantity <$> unsafePartitionNatural (unTokenQuantity n) weights
+
+-- | Partitions a natural number into a number of parts, where the size of each
+--   part is proportional to the size of its corresponding element in the given
+--   list of weights, and the number of parts is equal to the number of weights.
+--
+-- Throws a run-time error if the sum of weights is equal to zero.
+--
+unsafePartitionNatural
+    :: HasCallStack
+    => Natural
+    -- ^ Natural number to partition
+    -> NonEmpty Natural
+    -- ^ List of weights
+    -> NonEmpty Natural
+unsafePartitionNatural target =
+    fromMaybe zeroWeightSumError . partitionNatural target
   where
     zeroWeightSumError = error $ unwords
-        [ "unsafePartitionTokenQuantity:"
+        [ "unsafePartitionNatural:"
         , "specified weights must have a non-zero sum."
         ]
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -72,7 +72,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , fullBalance
 
     -- * Constants
-    , maxTokenQuantity
+    , maxTxOutTokenQuantity
 
     -- * Utility classes
     , AssetCount (..)
@@ -887,7 +887,8 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
           where
             bundle (m, c) = TokenBundle c m
             unbundle (TokenBundle c m) = (m, c)
-            split = (`equipartitionTokenBundleWithMaxQuantity` maxTokenQuantity)
+            split = flip equipartitionTokenBundleWithMaxQuantity
+                maxTxOutTokenQuantity
 
     -- Change for user-specified assets: assets that were present in the
     -- original set of user-specified outputs ('outputsToCover').
@@ -1425,8 +1426,8 @@ newtype AssetCount a = AssetCount
 -- | The greatest token quantity that can be encoded within an output bundle of
 --   a transaction.
 --
-maxTokenQuantity :: TokenQuantity
-maxTokenQuantity = TokenQuantity $ fromIntegral (maxBound :: Word64)
+maxTxOutTokenQuantity :: TokenQuantity
+maxTxOutTokenQuantity = TokenQuantity $ fromIntegral (maxBound :: Word64)
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -55,6 +55,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
 
     -- * Partitioning
     , equipartitionCoin
+    , equipartitionTokenBundle
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
 
@@ -1167,6 +1168,24 @@ equipartitionCoin
     -> NonEmpty Coin
     -- ^ The partitioned coins.
 equipartitionCoin c count = NE.reverse $ unsafePartitionCoin c (1 <$ count)
+
+-- | Partitions a token bundle into 'n' approximately-equal token bundles.
+--
+-- This function has the same properties as 'equipartitionTokenMap', but extends
+-- the behaviour to include ada 'Coin' quantities.
+--
+equipartitionTokenBundle
+    :: HasCallStack
+    => TokenBundle
+    -- ^ The bundle to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the bundle.
+    -> NonEmpty TokenBundle
+    -- ^ The partitioned bundle.
+equipartitionTokenBundle (TokenBundle c m) count =
+    NE.zipWith TokenBundle
+        (equipartitionCoin c count)
+        (equipartitionTokenMap m count)
 
 -- | Partitions a token map into 'n' approximately-equal token maps.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -72,6 +72,9 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     -- * Accessors
     , fullBalance
 
+    -- * Constants
+    , maxTokenQuantity
+
     -- * Utility classes
     , AssetCount (..)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -54,6 +54,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
 
     -- * Partitioning
+    , equipartitionCoin
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
 
@@ -1154,6 +1155,18 @@ makeChangeForCoin targets excess =
 --------------------------------------------------------------------------------
 -- Partitioning
 --------------------------------------------------------------------------------
+
+-- | Partitions a coin into 'n' approximately-equal coins.
+--
+equipartitionCoin
+    :: HasCallStack
+    => Coin
+    -- ^ The coin to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the coin.
+    -> NonEmpty Coin
+    -- ^ The partitioned coins.
+equipartitionCoin c count = NE.reverse $ unsafePartitionCoin c (1 <$ count)
 
 -- | Partitions a token map into 'n' approximately-equal token maps.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1232,6 +1232,26 @@ equipartitionTokenMapWithMaxQuantity m (TokenQuantity maxAllowableQuantity)
         , "the maximum allowable token quantity cannot be zero."
         ]
 
+unsafePartitionCoin
+    :: HasCallStack
+    => Coin
+    -> NonEmpty Natural
+    -> NonEmpty Coin
+unsafePartitionCoin coin =
+    maybe zeroWeightSumError (fmap unsafeNaturalToCoin)
+        . partitionNatural (coinToNatural coin)
+  where
+    coinToNatural :: Coin -> Natural
+    coinToNatural = fromIntegral . unCoin
+
+    unsafeNaturalToCoin :: Natural -> Coin
+    unsafeNaturalToCoin = Coin . fromIntegral
+
+    zeroWeightSumError = error $ unwords
+        [ "unsafePartitionCoin:"
+        , "specified weights must have a non-zero sum."
+        ]
+
 unsafePartitionTokenQuantity
     :: HasCallStack
     => TokenQuantity

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -55,7 +55,6 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
 
     -- * Partitioning
     , equipartitionNatural
-    , equipartitionTokenBundle
     , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
@@ -1229,23 +1228,6 @@ equipartitionNatural n count =
     -- simple list reversal is enough to ensure that the resultant list is
     -- sorted in ascending order.
     NE.reverse $ unsafePartitionNatural n (1 <$ count)
-
--- | Computes the equipartition of a token bundle into 'n' smaller bundles.
---
--- Each asset is partitioned independently.
---
-equipartitionTokenBundle
-    :: HasCallStack
-    => TokenBundle
-    -- ^ The bundle to be partitioned.
-    -> NonEmpty a
-    -- ^ Represents the number of portions in which to partition the bundle.
-    -> NonEmpty TokenBundle
-    -- ^ The partitioned bundle.
-equipartitionTokenBundle (TokenBundle c m) count =
-    NE.zipWith TokenBundle
-        (equipartitionCoin c count)
-        (equipartitionTokenMap m count)
 
 -- | Computes the equipartition of a token map into 'n' smaller maps.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -38,6 +38,7 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
+    , equipartitionTokenQuantity
     , fullBalance
     , groupByKey
     , makeChange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assetSelectionLens
     , assignCoinsToChangeMaps
     , coinSelectionLens
+    , equipartitionTokenMap
     , fullBalance
     , groupByKey
     , makeChange
@@ -297,6 +298,17 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
             property prop_makeChangeForUserSpecifiedAsset_length
         unitTests "makeChangeForUserSpecifiedAsset"
             unit_makeChangeForUserSpecifiedAsset
+
+    parallel $ describe "Partitioning" $ do
+
+        it "prop_equipartitionTokenMap_fair" $
+            property prop_equipartitionTokenMap_fair
+        it "prop_equipartitionTokenMap_length" $
+            property prop_equipartitionTokenMap_length
+        it "prop_equipartitionTokenMap_order" $
+            property prop_equipartitionTokenMap_order
+        it "prop_equipartitionTokenMap_sum" $
+            property prop_equipartitionTokenMap_sum
 
     parallel $ describe "Grouping and ungrouping" $ do
 
@@ -1575,6 +1587,56 @@ unit_makeChangeForUserSpecifiedAsset =
 
     assetC :: AssetId
     assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "2")
+
+--------------------------------------------------------------------------------
+-- Partitioning
+--------------------------------------------------------------------------------
+
+-- Test that token maps are partitioned fairly:
+--
+-- Each token quantity portion must be within unity of the ideal portion.
+--
+prop_equipartitionTokenMap_fair :: TokenMap -> NonEmpty () -> Property
+prop_equipartitionTokenMap_fair m count = property $
+    isZeroOrOne maximumDifference
+  where
+    -- Here we take advantage of the fact that the resultant maps are sorted
+    -- into ascending order when compared with the 'leq' function.
+    --
+    -- Consequently:
+    --
+    --  - the head map will be the smallest;
+    --  - the last map will be the greatest.
+    --
+    -- Therefore, subtracting the head map from the last map will produce a map
+    -- where each token quantity is equal to the difference between:
+    --
+    --  - the smallest quantity of that token in the resulting maps;
+    --  - the greatest quantity of that token in the resulting maps.
+    --
+    differences :: TokenMap
+    differences = NE.last results `TokenMap.unsafeSubtract` NE.head results
+
+    isZeroOrOne :: TokenQuantity -> Bool
+    isZeroOrOne (TokenQuantity q) = q == 0 || q == 1
+
+    maximumDifference :: TokenQuantity
+    maximumDifference = TokenMap.maximumQuantity differences
+
+    results :: NonEmpty TokenMap
+    results = equipartitionTokenMap m count
+
+prop_equipartitionTokenMap_length :: TokenMap -> NonEmpty () -> Property
+prop_equipartitionTokenMap_length m count =
+    NE.length (equipartitionTokenMap m count) === NE.length count
+
+prop_equipartitionTokenMap_order :: TokenMap -> NonEmpty () -> Property
+prop_equipartitionTokenMap_order m count = property $
+    inAscendingPartialOrder (equipartitionTokenMap m count)
+
+prop_equipartitionTokenMap_sum :: TokenMap -> NonEmpty () -> Property
+prop_equipartitionTokenMap_sum m count =
+    F.fold (equipartitionTokenMap m count) === m
 
 --------------------------------------------------------------------------------
 -- Grouping and ungrouping

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -46,7 +46,7 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , makeChangeForNonUserSpecifiedAsset
     , makeChangeForUserSpecifiedAsset
     , mapMaybe
-    , maxTokenQuantity
+    , maxTxOutTokenQuantity
     , performSelection
     , prepareOutputsWith
     , runRoundRobin
@@ -1165,7 +1165,7 @@ boundaryTest1 = BoundaryTestData
     }
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    (q1, q2) = (TokenQuantity 1, TokenQuantity.pred maxTokenQuantity)
+    (q1, q2) = (TokenQuantity 1, TokenQuantity.pred maxTxOutTokenQuantity)
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1177,7 +1177,7 @@ boundaryTest1 = BoundaryTestData
       , (Coin 1_000_000, [(assetA, q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(assetA, maxTokenQuantity)]) ]
+      [ (Coin 500_000, [(assetA, maxTxOutTokenQuantity)]) ]
 
 -- Reach (but do not exceed) the maximum token quantity by selecting inputs
 -- with the following quantities:
@@ -1194,7 +1194,7 @@ boundaryTest2 = BoundaryTestData
     }
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    q1 :| [q2] = equipartitionTokenQuantity maxTokenQuantity (() :| [()])
+    q1 :| [q2] = equipartitionTokenQuantity maxTxOutTokenQuantity (() :| [()])
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1206,7 +1206,7 @@ boundaryTest2 = BoundaryTestData
       , (Coin 1_000_000, [(assetA, q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(assetA, maxTokenQuantity)]) ]
+      [ (Coin 500_000, [(assetA, maxTxOutTokenQuantity)]) ]
 
 -- Slightly exceed the maximum token quantity by selecting inputs with the
 -- following quantities:
@@ -1224,16 +1224,16 @@ boundaryTest3 = BoundaryTestData
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     q1 :| [q2] = equipartitionTokenQuantity
-        (TokenQuantity.succ maxTokenQuantity) (() :| [()])
+        (TokenQuantity.succ maxTxOutTokenQuantity) (() :| [()])
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
       [ (Coin 1_000_000, [(assetA, TokenQuantity 1)])
-      , (Coin 1_000_000, [(assetA, maxTokenQuantity)])
+      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
       ]
     boundaryTestInputs =
       [ (Coin 1_000_000, [(assetA, TokenQuantity 1)])
-      , (Coin 1_000_000, [(assetA, maxTokenQuantity)])
+      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
       ]
     boundaryTestChange =
       [ (Coin 250_000, [(assetA, q1)])
@@ -1258,16 +1258,16 @@ boundaryTest4 = BoundaryTestData
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(assetA, maxTokenQuantity)])
-      , (Coin 1_000_000, [(assetA, maxTokenQuantity)])
+      [ (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(assetA, maxTokenQuantity)])
-      , (Coin 1_000_000, [(assetA, maxTokenQuantity)])
+      [ (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
       ]
     boundaryTestChange =
-      [ (Coin 250_000, [(assetA, maxTokenQuantity)])
-      , (Coin 250_000, [(assetA, maxTokenQuantity)])
+      [ (Coin 250_000, [(assetA, maxTxOutTokenQuantity)])
+      , (Coin 250_000, [(assetA, maxTxOutTokenQuantity)])
       ]
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -35,7 +35,6 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
     , coinSelectionLens
     , equipartitionNatural
-    , equipartitionTokenBundle
     , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
@@ -330,17 +329,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
             property prop_equipartitionNatural_order
         it "prop_equipartitionNatural_sum" $
             property prop_equipartitionNatural_sum
-
-    parallel $ describe "Equipartitioning token bundles" $ do
-
-        it "prop_equipartitionTokenBundle_fair" $
-            property prop_equipartitionTokenBundle_fair
-        it "prop_equipartitionTokenBundle_length" $
-            property prop_equipartitionTokenBundle_length
-        it "prop_equipartitionTokenBundle_order" $
-            property prop_equipartitionTokenBundle_order
-        it "prop_equipartitionTokenBundle_sum" $
-            property prop_equipartitionTokenBundle_sum
 
     parallel $ describe "Equipartitioning token maps" $ do
 
@@ -1886,39 +1874,6 @@ prop_equipartitionNatural_sum n count =
     F.sum (equipartitionNatural n count) === n
 
 --------------------------------------------------------------------------------
--- Equipartitioning token bundles
---------------------------------------------------------------------------------
-
--- Test that token bundles are equipartitioned fairly:
---
--- Each token quantity portion must be within unity of the ideal portion.
---
-prop_equipartitionTokenBundle_fair :: TokenBundle -> NonEmpty () -> Property
-prop_equipartitionTokenBundle_fair m count = (.&&.)
-    (prop_equipartitionNatural_fair_inner $
-        coinToNatural . view #coin <$> results)
-    (prop_equipartitionTokenMap_fair_inner $
-        view #tokens <$> results)
-  where
-    coinToNatural :: Coin -> Natural
-    coinToNatural = fromIntegral . unCoin
-
-    results :: NonEmpty TokenBundle
-    results = equipartitionTokenBundle m count
-
-prop_equipartitionTokenBundle_length :: TokenBundle -> NonEmpty () -> Property
-prop_equipartitionTokenBundle_length m count =
-    NE.length (equipartitionTokenBundle m count) === NE.length count
-
-prop_equipartitionTokenBundle_order :: TokenBundle -> NonEmpty () -> Property
-prop_equipartitionTokenBundle_order m count = property $
-    inAscendingPartialOrder (equipartitionTokenBundle m count)
-
-prop_equipartitionTokenBundle_sum :: TokenBundle -> NonEmpty () -> Property
-prop_equipartitionTokenBundle_sum m count =
-    F.fold (equipartitionTokenBundle m count) === m
-
---------------------------------------------------------------------------------
 -- Equipartitioning token maps
 --------------------------------------------------------------------------------
 
@@ -1927,11 +1882,7 @@ prop_equipartitionTokenBundle_sum m count =
 -- Each token quantity portion must be within unity of the ideal portion.
 --
 prop_equipartitionTokenMap_fair :: TokenMap -> NonEmpty () -> Property
-prop_equipartitionTokenMap_fair m count =
-    prop_equipartitionTokenMap_fair_inner $ equipartitionTokenMap m count
-
-prop_equipartitionTokenMap_fair_inner :: NonEmpty TokenMap -> Property
-prop_equipartitionTokenMap_fair_inner results = property $
+prop_equipartitionTokenMap_fair m count = property $
     isZeroOrOne maximumDifference
   where
     -- Here we take advantage of the fact that the resultant maps are sorted
@@ -1956,6 +1907,8 @@ prop_equipartitionTokenMap_fair_inner results = property $
 
     maximumDifference :: TokenQuantity
     maximumDifference = TokenMap.maximumQuantity differences
+
+    results = equipartitionTokenMap m count
 
 prop_equipartitionTokenMap_length :: TokenMap -> NonEmpty () -> Property
 prop_equipartitionTokenMap_length m count =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1848,16 +1848,15 @@ unit_makeChangeForUserSpecifiedAsset =
 --
 prop_equipartitionNatural_fair
     :: Natural -> NonEmpty () -> Property
-prop_equipartitionNatural_fair n count =
-    prop_equipartitionNatural_fair_inner $ equipartitionNatural n count
-
-prop_equipartitionNatural_fair_inner :: NonEmpty Natural -> Property
-prop_equipartitionNatural_fair_inner results = (.||.)
+prop_equipartitionNatural_fair n count = (.||.)
     (difference === 0)
     (difference === 1)
   where
     difference :: Natural
     difference = F.maximum results - F.minimum results
+
+    results :: NonEmpty Natural
+    results = equipartitionNatural n count
 
 prop_equipartitionNatural_length :: Natural -> NonEmpty () -> Property
 prop_equipartitionNatural_length n count =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec
     ( spec


### PR DESCRIPTION
# Issue Number

https://github.com/input-output-hk/cardano-wallet/issues/2532
ADP-726

# Overview

Although quantities of individual assets are effectively unlimited, a transaction on the blockchain can never include an asset quantity greater than `maxBound :: Word64`.

This PR tweaks the coin selection algorithm to detect change bundles containing excessively large asset quantities.

If such a change bundle is detected, we now split the change bundle up into smaller bundles using [equipartitioning](https://en.wiktionary.org/wiki/equipartition).

# Example

Let's suppose the maximum allowable token quantity is **`5`**, and we have a change map with the following quantities:

```haskell
[("a", 11), ("b", 5), ("c", 12)]
```

In this case, we must divide the map into **_at least three_** smaller maps in order to not exceed the maximum allowable token quantity.

Under the equipartitioning scheme, this would give us:

```haskell
[("a", 3), ("b", 1), ("c", 4)]
[("a", 4), ("b", 2), ("c", 4)]
[("a", 4), ("b", 2), ("c", 4)]
```

Note that while the overall sum is preserved, the individual bundles are almost equal, **_but not quite_**: this is because `11` and `5` are not divisible by `3`. We must therefore accept a small loss of proportionality in the result.

# Details

An **_equipartition_** of a bundle **_b_** is a _partition_ into multiple bundles, where for every asset **_a_** in the set of assets contained in **_b_**, the difference between the following quantities is either _zero_ or _one_ :

- The smallest quantity of asset **_a_** in the resultant bundles
- The greatest quantity of asset **_a_** in the resultant bundles

In order to determine the number of parts in which to split a given bundle, we choose the **_smallest_** number of parts that still allows us satisfy the goal of not exceeding the maximum allowable quantity in any given bundle.

# Performance

In order to avoid evaluating a partition for every single change output, we **_short circuit_** in the event that there is no token quantity greater than the maximum allowable quantity:

```haskell
equipartitionTokenMapWithMaxQuantity m (TokenQuantity maxQuantity)
    | maxQuantity == 0 =
        maxQuantityZeroError
    | currentMaxQuantity <= maxQuantity =
        m :| []
    | otherwise =
        equipartitionTokenMap m (() :| replicate extraPartCount ())
```

# Testing

## Property tests

Equipartitioning behaviour is tested by the following property tests:
- `prop_equipartitionTokenBundle*`
- `prop_equipartitionTokenMap*`

## Unit tests

As a sanity check, this PR also provides unit tests for `performSelection` with inputs containing token quantities that are close to the maximum, and demonstrates that change bundles are correctly partitioned in the results.