### PR TITLE
Add extra `difference` properties to Token{Bundle,Map}

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -6,12 +6,13 @@ module Cardano.Wallet.Primitive.Types.TokenBundleSpec
     ( spec
     ) where
 
-import Prelude
+import Prelude hiding
+    ( subtract )
 
 import Algebra.PartialOrd
     ( leq )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle, add, difference )
+    ( TokenBundle, add, difference, subtract )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Test.Hspec
@@ -19,7 +20,7 @@ import Test.Hspec
 import Test.Hspec.Core.QuickCheck
     ( modifyMaxSuccess )
 import Test.QuickCheck
-    ( Arbitrary (..), Property, counterexample, property, (===) )
+    ( Arbitrary (..), Property, counterexample, property, (===), (==>) )
 import Test.QuickCheck.Classes
     ( eqLaws, monoidLaws, semigroupLaws, semigroupMonoidLaws )
 import Test.Utils.Laws
@@ -52,6 +53,8 @@ spec =
             property prop_difference_leq
         it "prop_difference_add ((x - y) + y ⊇ x)" $
             property prop_difference_add
+        it "prop_difference_subtract" $
+            property prop_difference_subtract
 
 --------------------------------------------------------------------------------
 -- Arithmetic properties
@@ -84,6 +87,12 @@ prop_difference_add x y =
         counterexample ("x - y = " <> show delta) $
         counterexample ("(x - y) + y = " <> show yAndDelta) $
         property $ x `leq` yAndDelta
+
+prop_difference_subtract :: TokenBundle -> TokenBundle -> Property
+prop_difference_subtract x y =
+    y `leq` x ==> (===)
+        (x `subtract` y)
+        (Just $ x `difference` y)
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -53,6 +53,10 @@ spec =
         it "prop_difference_add ((x - y) + y ⊇ x)" $
             property prop_difference_add
 
+--------------------------------------------------------------------------------
+-- Arithmetic properties
+--------------------------------------------------------------------------------
+
 prop_difference_zero :: TokenBundle -> Property
 prop_difference_zero x =
     x `difference` mempty === x

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -191,6 +191,8 @@ spec =
             property prop_difference_add
         it "prop_difference_subtract" $
             property prop_difference_subtract
+        it "prop_difference_equality" $
+            property prop_difference_equality
 
     parallel $ describe "Quantities" $ do
 
@@ -435,6 +437,17 @@ prop_difference_subtract x y =
     y `leq` x ==> (===)
         (x `TokenMap.subtract` y)
         (Just $ x `TokenMap.difference` y)
+
+prop_difference_equality :: TokenMap -> TokenMap -> Property
+prop_difference_equality x y = checkCoverage $
+    cover 5 (TokenMap.isNotEmpty xReduced)
+        "reduced maps are not empty" $
+    xReduced === yReduced
+  where
+    xReduced = x `TokenMap.unsafeSubtract` xExcess
+    yReduced = y `TokenMap.unsafeSubtract` yExcess
+    xExcess = x `TokenMap.difference` y
+    yExcess = y `TokenMap.difference` x
 
 --------------------------------------------------------------------------------
 -- Quantity properties

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -189,6 +189,8 @@ spec =
             property prop_difference_leq
         it "prop_difference_add ((x - y) + y ⊇ x)" $
             property prop_difference_add
+        it "prop_difference_subtract" $
+            property prop_difference_subtract
 
     parallel $ describe "Quantities" $ do
 
@@ -427,6 +429,12 @@ prop_difference_add x y =
         counterexample ("x - y = " <> show delta) $
         counterexample ("(x - y) + y = " <> show yAndDelta) $
         property $ x `leq` yAndDelta
+
+prop_difference_subtract :: TokenMap -> TokenMap -> Property
+prop_difference_subtract x y =
+    y `leq` x ==> (===)
+        (x `TokenMap.subtract` y)
+        (Just $ x `TokenMap.difference` y)
 
 --------------------------------------------------------------------------------
 -- Quantity properties

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -138,6 +138,8 @@ spec =
             property prop_add_invariant
         it "prop_subtract_invariant" $
             property prop_subtract_invariant
+        it "prop_difference_invariant" $
+            property prop_difference_invariant
         it "prop_setQuantity_invariant" $
             property prop_setQuantity_invariant
         it "prop_adjustQuantity_invariant" $
@@ -187,8 +189,6 @@ spec =
             property prop_difference_leq
         it "prop_difference_add ((x - y) + y ⊇ x)" $
             property prop_difference_add
-        it "prop_difference_invariant" $
-            property prop_difference_invariant
 
     parallel $ describe "Quantities" $ do
 
@@ -267,33 +267,6 @@ prop_subtract_invariant m1 m2 = property $
     m2 `leq` m1 ==> invariantHolds result
   where
     Just result = TokenMap.subtract m1 m2
-
-prop_difference_zero :: TokenMap -> Property
-prop_difference_zero x =
-    x `difference` mempty === x
-
-prop_difference_zero2 :: TokenMap-> Property
-prop_difference_zero2 x =
-    mempty `difference` x === mempty
-
-prop_difference_zero3 :: TokenMap -> Property
-prop_difference_zero3 x =
-    x `difference` x === mempty
-
-prop_difference_leq :: TokenMap -> TokenMap -> Property
-prop_difference_leq x y = property $
-    x `difference` y `leq` x
-
--- (x - y) + y ⊇ x
-prop_difference_add :: TokenMap -> TokenMap -> Property
-prop_difference_add x y =
-    let
-        delta = x `difference` y
-        yAndDelta = delta `TokenMap.add` y
-    in
-        counterexample ("x - y = " <> show delta) $
-        counterexample ("(x - y) + y = " <> show yAndDelta) $
-        property $ x `leq` yAndDelta
 
 prop_difference_invariant :: TokenMap -> TokenMap -> Property
 prop_difference_invariant m1 m2 =
@@ -427,6 +400,33 @@ prop_add_subtract_associative m1 m2 m3 =
 prop_subtract_null :: TokenMap -> Property
 prop_subtract_null m =
     m `TokenMap.subtract` m === Just TokenMap.empty
+
+prop_difference_zero :: TokenMap -> Property
+prop_difference_zero x =
+    x `difference` mempty === x
+
+prop_difference_zero2 :: TokenMap-> Property
+prop_difference_zero2 x =
+    mempty `difference` x === mempty
+
+prop_difference_zero3 :: TokenMap -> Property
+prop_difference_zero3 x =
+    x `difference` x === mempty
+
+prop_difference_leq :: TokenMap -> TokenMap -> Property
+prop_difference_leq x y = property $
+    x `difference` y `leq` x
+
+-- (x - y) + y ⊇ x
+prop_difference_add :: TokenMap -> TokenMap -> Property
+prop_difference_add x y =
+    let
+        delta = x `difference` y
+        yAndDelta = delta `TokenMap.add` y
+    in
+        counterexample ("x - y = " <> show delta) $
+        counterexample ("(x - y) + y = " <> show yAndDelta) $
+        property $ x `leq` yAndDelta
 
 --------------------------------------------------------------------------------
 -- Quantity properties


### PR DESCRIPTION
# Issue Number

#2542 

# Overview

This PR adds the following properties that relate to the `difference` function:

- [x] `prop_difference_subtract`: relates the `difference` function to the `subtract` function.
- [x] `prop_difference_equality`: for bundles **x** and **y**, tests that reducing **x** by its excess over **y** gives the same result as reducing **y** by its excess over **x**.