### PR TITLE
Split change bundles with excessive asset counts

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -245,6 +245,7 @@ test-suite unit
     , cardano-addresses
     , cardano-api
     , cardano-crypto
+    , cardano-numeric
     , cardano-wallet-core
     , cardano-wallet-launcher
     , cardano-wallet-test-utils

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -248,7 +248,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     ( SelectionError (..)
     , SelectionResult (..)
-    , TokenBundleSizeAssessment (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , performSelection
@@ -314,6 +313,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , SealedTx (..)
+    , TokenBundleSizeAssessment (..)
     , TransactionInfo (..)
     , Tx
     , TxChange (..)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -313,7 +313,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , SealedTx (..)
-    , TokenBundleSizeAssessment (..)
     , TransactionInfo (..)
     , Tx
     , TxChange (..)
@@ -1404,9 +1403,7 @@ selectAssets ctx (utxo, cp, pending) tx outs transform = do
     sel <- performSelection
         (calcMinimumCoinValue tl pp)
         (calcMinimumCost tl pp tx)
-        -- TODO: Pass in the real implementation of this function here,
-        -- as determined by the protocol:
-        (const TokenBundleSizeWithinLimit)
+        (assessTokenBundleSize tl)
         (initSelectionCriteria tl pp tx utxo outs)
     liftIO $ traceWith tr $ MsgSelectionDone sel
     withExceptT ErrSelectAssetsSelectionError $ except $

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -248,6 +248,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
 import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     ( SelectionError (..)
     , SelectionResult (..)
+    , TokenBundleSizeAssessment (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , performSelection
@@ -1403,6 +1404,9 @@ selectAssets ctx (utxo, cp, pending) tx outs transform = do
     sel <- performSelection
         (calcMinimumCoinValue tl pp)
         (calcMinimumCost tl pp tx)
+        -- TODO: Pass in the real implementation of this function here,
+        -- as determined by the protocol:
+        (const TokenBundleSizeWithinLimit)
         (initSelectionCriteria tl pp tx utxo outs)
     liftIO $ traceWith tr $ MsgSelectionDone sel
     withExceptT ErrSelectAssetsSelectionError $ except $

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1403,7 +1403,7 @@ selectAssets ctx (utxo, cp, pending) tx outs transform = do
     sel <- performSelection
         (calcMinimumCoinValue tl pp)
         (calcMinimumCost tl pp tx)
-        (assessTokenBundleSize tl)
+        (tokenBundleSizeAssessor tl)
         (initSelectionCriteria tl pp tx utxo outs)
     liftIO $ traceWith tr $ MsgSelectionDone sel
     withExceptT ErrSelectAssetsSelectionError $ except $

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -89,7 +89,7 @@ import Prelude
 import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.Numeric.Util
-    ( padCoalesce, partitionNatural )
+    ( padCoalesce, partitionNatural, unsafePartitionNatural )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), addCoin, subtractCoin, sumCoins )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -1344,31 +1344,6 @@ equipartitionTokenMapWithMaxQuantity m (TokenQuantity maxQuantity)
     maxQuantityZeroError = error $ unwords
         [ "equipartitionTokenMapWithMaxQuantity:"
         , "the maximum allowable token quantity cannot be zero."
-        ]
-
---------------------------------------------------------------------------------
--- Unsafe partitioning
---------------------------------------------------------------------------------
-
--- | Partitions a natural number into a number of parts, where the size of each
---   part is proportional to the size of its corresponding element in the given
---   list of weights, and the number of parts is equal to the number of weights.
---
--- Throws a run-time error if the sum of weights is equal to zero.
---
-unsafePartitionNatural
-    :: HasCallStack
-    => Natural
-    -- ^ Natural number to partition
-    -> NonEmpty Natural
-    -- ^ List of weights
-    -> NonEmpty Natural
-unsafePartitionNatural target =
-    fromMaybe zeroWeightSumError . partitionNatural target
-  where
-    zeroWeightSumError = error $ unwords
-        [ "unsafePartitionNatural:"
-        , "specified weights must have a non-zero sum."
         ]
 
 --------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -55,6 +55,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
 
     -- * Splitting bundles
+    , splitBundleIfAssetCountExcessive
     , splitBundlesWithExcessiveTokenQuantities
 
     -- * Grouping and ungrouping
@@ -1202,6 +1203,26 @@ makeChangeForCoin targets excess =
 --------------------------------------------------------------------------------
 -- Splitting bundles
 --------------------------------------------------------------------------------
+
+-- | Splits a bundle into smaller bundles if its asset count is excessive when
+--   measured with the given 'isExcessive' indicator function.
+--
+-- Returns a list of smaller bundles for which 'isExcessive' returns 'False'.
+--
+splitBundleIfAssetCountExcessive
+    :: TokenBundle
+    -- ^ The token bundle suspected to have an excessive number of assets.
+    -> (TokenBundle -> Bool)
+    -- ^ A function that returns 'True' if (and only if) the asset count of
+    -- the given bundle is excessive.
+    -> NonEmpty TokenBundle
+splitBundleIfAssetCountExcessive b isExcessive
+    | isExcessive b =
+        splitInHalf b >>= flip splitBundleIfAssetCountExcessive isExcessive
+    | otherwise =
+        pure b
+  where
+    splitInHalf = flip TokenBundle.equipartitionAssets (() :| [()])
 
 -- | Splits bundles with excessive token quantities into smaller bundles.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1205,22 +1205,6 @@ makeChangeForCoin targets excess =
 --
 --------------------------------------------------------------------------------
 
--- | Computes the equipartition of a coin into 'n' smaller coins.
---
-equipartitionCoin
-    :: HasCallStack
-    => Coin
-    -- ^ The coin to be partitioned.
-    -> NonEmpty a
-    -- ^ Represents the number of portions in which to partition the coin.
-    -> NonEmpty Coin
-    -- ^ The partitioned coins.
-equipartitionCoin c =
-    -- Note: the natural-to-coin conversion is safe, as equipartitioning always
-    -- guarantees to produce values that are less than or equal to the original
-    -- value.
-    fmap unsafeNaturalToCoin . equipartitionNatural (coinToNatural c)
-
 -- | Computes the equipartition of a token map into 'n' smaller maps.
 --
 -- Each asset is partitioned independently.
@@ -1277,7 +1261,7 @@ equipartitionTokenBundleWithMaxQuantity
 equipartitionTokenBundleWithMaxQuantity b maxQuantity =
     NE.zipWith TokenBundle cs ms
   where
-    cs = equipartitionCoin (view #coin b) ms
+    cs = Coin.equipartition (view #coin b) ms
     ms = equipartitionTokenMapWithMaxQuantity (view #tokens b) maxQuantity
 
 -- | Applies 'equipartitionTokenBundleWithMaxQuantity' to a list of bundles.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -56,6 +56,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
 
     -- * Splitting bundles
     , splitBundleIfAssetCountExcessive
+    , splitBundlesWithExcessiveAssetCounts
     , splitBundlesWithExcessiveTokenQuantities
 
     -- * Grouping and ungrouping
@@ -1223,6 +1224,26 @@ splitBundleIfAssetCountExcessive b isExcessive
         pure b
   where
     splitInHalf = flip TokenBundle.equipartitionAssets (() :| [()])
+
+-- | Splits bundles with excessive asset counts into smaller bundles.
+--
+-- Only token bundles where the 'isExcessive' indicator function returns 'True'
+-- will be split.
+--
+-- Returns a list of smaller bundles for which 'isExcessive' returns 'False'.
+--
+-- If none of the bundles in the given list has an excessive asset count,
+-- this function will return the original list.
+--
+splitBundlesWithExcessiveAssetCounts
+    :: NonEmpty TokenBundle
+    -- ^ Token bundles.
+    -> (TokenBundle -> Bool)
+    -- ^ A function that returns 'True' if (and only if) the asset count of
+    -- the given bundle is excessive.
+    -> NonEmpty TokenBundle
+splitBundlesWithExcessiveAssetCounts bs isExcessive =
+    (`splitBundleIfAssetCountExcessive` isExcessive) =<< bs
 
 -- | Splits bundles with excessive token quantities into smaller bundles.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -54,7 +54,6 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
 
     -- * Partitioning
-    , equipartitionNatural
     , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenBundlesWithMaxQuantity
     , equipartitionTokenMap
@@ -89,7 +88,7 @@ import Prelude
 import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.Numeric.Util
-    ( padCoalesce, partitionNatural, unsafePartitionNatural )
+    ( equipartitionNatural, padCoalesce, partitionNatural )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), addCoin, subtractCoin, sumCoins )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -1221,22 +1220,6 @@ equipartitionCoin c =
     -- guarantees to produce values that are less than or equal to the original
     -- value.
     fmap unsafeNaturalToCoin . equipartitionNatural (coinToNatural c)
-
--- | Computes the equipartition of a natural number into 'n' smaller numbers.
---
-equipartitionNatural
-    :: HasCallStack
-    => Natural
-    -- ^ The natural number to be partitioned.
-    -> NonEmpty a
-    -- ^ Represents the number of portions in which to partition the number.
-    -> NonEmpty Natural
-    -- ^ The partitioned numbers.
-equipartitionNatural n count =
-    -- Note: due to the behaviour of the underlying partition algorithm, a
-    -- simple list reversal is enough to ensure that the resultant list is
-    -- sorted in ascending order.
-    NE.reverse $ unsafePartitionNatural n (1 <$ count)
 
 -- | Computes the equipartition of a token map into 'n' smaller maps.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -54,7 +54,6 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
 
     -- * Partitioning
-    , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenBundlesWithMaxQuantity
 
     -- * Grouping and ungrouping
@@ -116,8 +115,6 @@ import Data.Maybe
     ( fromMaybe )
 import Data.Ord
     ( comparing )
-import Data.Ratio
-    ( (%) )
 import Data.Set
     ( Set )
 import Data.Word
@@ -1206,26 +1203,8 @@ makeChangeForCoin targets excess =
 -- Equipartitioning according to a maximum token quantity
 --------------------------------------------------------------------------------
 
--- | Computes the equipartition of a token bundle into 'n' smaller bundles,
---   according to the given maximum token quantity.
---
--- The value 'n' is computed automatically, and is the minimum value required
--- to achieve the goal that no token quantity in any of the resulting bundles
--- exceeds the maximum allowable token quantity.
---
-equipartitionTokenBundleWithMaxQuantity
-    :: TokenBundle
-    -> TokenQuantity
-    -- ^ Maximum allowable token quantity.
-    -> NonEmpty TokenBundle
-    -- ^ The partitioned bundles.
-equipartitionTokenBundleWithMaxQuantity (TokenBundle c m) maxQuantity =
-    NE.zipWith TokenBundle cs ms
-  where
-    cs = Coin.equipartition c ms
-    ms = TokenMap.equipartitionQuantitiesWithUpperBound m maxQuantity
-
--- | Applies 'equipartitionTokenBundleWithMaxQuantity' to a list of bundles.
+-- | Applies 'TokenBundle.equipartitionQuantitiesWithUpperBound' to a list of
+--   bundles.
 --
 -- Only token bundles containing quantities that exceed the maximum token
 -- quantity will be partitioned.
@@ -1241,7 +1220,7 @@ equipartitionTokenBundlesWithMaxQuantity
     -> NonEmpty TokenBundle
     -- ^ The partitioned bundles.
 equipartitionTokenBundlesWithMaxQuantity bs maxQuantity =
-    (`equipartitionTokenBundleWithMaxQuantity` maxQuantity) =<< bs
+    (`TokenBundle.equipartitionQuantitiesWithUpperBound` maxQuantity) =<< bs
 
 --------------------------------------------------------------------------------
 -- Grouping and ungrouping

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -58,7 +58,6 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , equipartitionTokenBundlesWithMaxQuantity
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
-    , equipartitionTokenQuantity
 
     -- * Grouping and ungrouping
     , groupByKey
@@ -144,6 +143,7 @@ import Numeric.Natural
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Cardano.Wallet.Primitive.Types.Tx as Tx
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
@@ -1226,20 +1226,7 @@ equipartitionTokenMap m count =
         -> NonEmpty TokenMap
     accumulate maps (asset, quantity) = NE.zipWith (<>) maps $
         TokenMap.singleton asset <$>
-            equipartitionTokenQuantity quantity count
-
--- | Computes the equipartition of a token quantity into 'n' smaller quantities.
---
-equipartitionTokenQuantity
-    :: HasCallStack
-    => TokenQuantity
-    -- ^ The token quantity to be partitioned.
-    -> NonEmpty a
-    -- ^ Represents the number of portions in which to partition the quantity.
-    -> NonEmpty TokenQuantity
-    -- ^ The partitioned quantities.
-equipartitionTokenQuantity q =
-    fmap TokenQuantity . equipartitionNatural (unTokenQuantity q)
+            TokenQuantity.equipartition quantity count
 
 --------------------------------------------------------------------------------
 -- Equipartitioning according to a maximum token quantity

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -407,10 +407,12 @@ performSelection
         -- ^ A function that computes the extra cost corresponding to a given
         -- selection. This function must not depend on the magnitudes of
         -- individual asset quantities held within each change output.
+    -> (TokenBundle -> TokenBundleSizeAssessment)
+        -- ^ A function that assesses the size of a token bundle.
     -> SelectionCriteria
         -- ^ The selection goal to satisfy.
     -> m (Either SelectionError (SelectionResult TokenBundle))
-performSelection minCoinFor costFor criteria
+performSelection minCoinFor costFor assessBundleSize criteria
     | not (balanceRequired `leq` balanceAvailable) =
         pure $ Left $ BalanceInsufficient $ BalanceInsufficientError
             { balanceAvailable, balanceRequired }
@@ -501,7 +503,7 @@ performSelection minCoinFor costFor criteria
         (fmap (TokenMap.getAssets . view #tokens))
         (makeChange MakeChangeCriteria
             { minCoinFor = noMinimumCoin
-            , assessBundleSize = const TokenBundleSizeWithinLimit
+            , assessBundleSize
             , requiredCost = noCost
             , extraCoinSource
             , inputBundles
@@ -565,9 +567,7 @@ performSelection minCoinFor costFor criteria
         mChangeGenerated :: Either UnableToConstructChangeError [TokenBundle]
         mChangeGenerated = makeChange MakeChangeCriteria
             { minCoinFor
-            -- TODO: pass the implementation of this function in via
-            -- 'performSelection':
-            , assessBundleSize = const TokenBundleSizeWithinLimit
+            , assessBundleSize
             , requiredCost
             , extraCoinSource
             , inputBundles =  view #tokens . snd <$> inputsSelected

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -53,8 +53,8 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , makeChangeForNonUserSpecifiedAsset
     , assignCoinsToChangeMaps
 
-    -- * Partitioning
-    , equipartitionTokenBundlesWithMaxQuantity
+    -- * Splitting bundles
+    , splitBundlesWithExcessiveTokenQuantities
 
     -- * Grouping and ungrouping
     , groupByKey
@@ -888,7 +888,7 @@ makeChange minCoinFor requiredCost mExtraCoinSource inputBundles outputBundles
           where
             bundle (m, c) = TokenBundle c m
             unbundle (TokenBundle c m) = (m, c)
-            split = flip equipartitionTokenBundlesWithMaxQuantity
+            split = flip splitBundlesWithExcessiveTokenQuantities
                 maxTxOutTokenQuantity
 
     -- Change for user-specified assets: assets that were present in the
@@ -1176,50 +1176,25 @@ makeChangeForCoin targets excess =
     weights = coinToNatural <$> targets
 
 --------------------------------------------------------------------------------
--- Equipartitioning
+-- Splitting bundles
 --------------------------------------------------------------------------------
 
--- An /equipartition/ of a value 'v' (of some type) is a /partition/ of that
--- value into 'n' smaller values whose /sizes/ differ by no more than 1. The
--- the notion of /size/ is dependent on the type of value 'v'.
---
--- In this section, equipartitions have the following properties:
---
---  1.  The length is observed:
---      >>> length (equipartition v n) == n
---
---  2.  The sum is preserved:
---      >>> sum (equipartition v n) == v
---
---  3.  Each resulting value is less than or equal to the original value:
---      >>> all (`leq` v) (equipartition v n)
---
---  4.  The resultant list is sorted into ascending order when values are
---      compared with the 'leq' function.
---
---------------------------------------------------------------------------------
-
---------------------------------------------------------------------------------
--- Equipartitioning according to a maximum token quantity
---------------------------------------------------------------------------------
-
--- | Applies 'TokenBundle.equipartitionQuantitiesWithUpperBound' to a list of
---   bundles.
+-- | Splits bundles with excessive token quantities into smaller bundles.
 --
 -- Only token bundles containing quantities that exceed the maximum token
--- quantity will be partitioned.
+-- quantity will be split.
 --
 -- If none of the bundles in the given list contain a quantity that exceeds
 -- the maximum token quantity, this function will return the original list.
 --
-equipartitionTokenBundlesWithMaxQuantity
+splitBundlesWithExcessiveTokenQuantities
     :: NonEmpty TokenBundle
     -- ^ Token bundles.
     -> TokenQuantity
     -- ^ Maximum allowable token quantity.
     -> NonEmpty TokenBundle
     -- ^ The partitioned bundles.
-equipartitionTokenBundlesWithMaxQuantity bs maxQuantity =
+splitBundlesWithExcessiveTokenQuantities bs maxQuantity =
     (`TokenBundle.equipartitionQuantitiesWithUpperBound` maxQuantity) =<< bs
 
 --------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -70,9 +70,6 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     -- * Accessors
     , fullBalance
 
-    -- * Constants
-    , maxTxOutTokenQuantity
-
     -- * Utility classes
     , AssetCount (..)
 
@@ -97,7 +94,12 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment (..), TxIn, TxOut, txOutCoin )
+    ( TokenBundleSizeAssessment (..)
+    , TxIn
+    , TxOut
+    , txOutCoin
+    , txOutMaxTokenQuantity
+    )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex (..) )
 import Control.Monad.Random.Class
@@ -120,8 +122,6 @@ import Data.Ord
     ( comparing )
 import Data.Set
     ( Set )
-import Data.Word
-    ( Word64 )
 import Fmt
     ( Buildable (..)
     , Builder
@@ -939,7 +939,7 @@ makeChange criteria
                 & flip splitBundlesWithExcessiveAssetCounts
                     (tokenBundleSizeExceedsLimit assessBundleSize)
                 & flip splitBundlesWithExcessiveTokenQuantities
-                    maxTxOutTokenQuantity
+                    txOutMaxTokenQuantity
 
     -- Change for user-specified assets: assets that were present in the
     -- original set of user-specified outputs ('outputsToCover').
@@ -1360,16 +1360,6 @@ instance Ord (AssetCount TokenMap) where
 newtype AssetCount a = AssetCount
     { unAssetCount :: a }
     deriving (Eq, Show)
-
---------------------------------------------------------------------------------
--- Constants
---------------------------------------------------------------------------------
-
--- | The greatest token quantity that can be encoded within an output bundle of
---   a transaction.
---
-maxTxOutTokenQuantity :: TokenQuantity
-maxTxOutTokenQuantity = TokenQuantity $ fromIntegral (maxBound :: Word64)
 
 --------------------------------------------------------------------------------
 -- Utility functions

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -54,6 +54,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle
     , removeQuantity
 
     -- * Partitioning
+    , equipartitionAssets
     , equipartitionQuantitiesWithUpperBound
 
     -- * Policies
@@ -372,6 +373,29 @@ removeQuantity b a = b { tokens = TokenMap.removeQuantity (tokens b) a }
 --------------------------------------------------------------------------------
 -- Partitioning
 --------------------------------------------------------------------------------
+
+-- | Partitions a token bundle into 'n' smaller bundles, where the asset sets
+--   of the resultant bundles are disjoint.
+--
+-- In the resultant bundles, the smallest asset set size and largest asset set
+-- size will differ by no more than 1.
+--
+-- The ada 'Coin' quantity is equipartitioned across the resulting bundles.
+--
+-- The quantities of each non-ada asset are unchanged.
+--
+equipartitionAssets
+    :: TokenBundle
+    -- ^ The token bundle to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the bundle.
+    -> NonEmpty TokenBundle
+    -- ^ The partitioned bundles.
+equipartitionAssets (TokenBundle c m) count =
+    NE.zipWith TokenBundle cs ms
+  where
+    cs = Coin.equipartition c count
+    ms = TokenMap.equipartitionAssets m count
 
 -- | Partitions a token bundle into 'n' smaller bundles, where the quantity of
 --   each token is equipartitioned across the resultant bundles, with the goal

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -2,6 +2,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genFixedSizeTokenBundle
     , genTokenBundleSmallRange
     , genTokenBundleSmallRangePositive
+    , genVariableSizedTokenBundle
     , shrinkTokenBundleSmallRange
     , shrinkTokenBundleSmallRangePositive
     ) where
@@ -67,6 +68,16 @@ genFixedSizeTokenBundle fixedAssetCount
 
         integerToTokenQuantity :: Integer -> TokenQuantity
         integerToTokenQuantity = TokenQuantity . fromIntegral
+
+--------------------------------------------------------------------------------
+-- Token bundles with variable numbers of assets, with an upper bound.
+--
+-- Policy identifiers, asset names, token quantities are all allowed to vary.
+--------------------------------------------------------------------------------
+
+genVariableSizedTokenBundle :: Int -> Gen TokenBundle
+genVariableSizedTokenBundle maxAssetCount =
+    genFixedSizeTokenBundle =<< choose (0, maxAssetCount)
 
 --------------------------------------------------------------------------------
 -- Token bundles with coins, assets, and quantities chosen from small ranges

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -71,6 +71,9 @@ module Cardano.Wallet.Primitive.Types.TokenMap
     , removeQuantity
     , maximumQuantity
 
+    -- * Partitioning
+    , equipartitionQuantities
+
     -- * Policies
     , hasPolicy
 
@@ -639,6 +642,37 @@ maximumQuantity =
             challenger
         | otherwise =
             champion
+
+--------------------------------------------------------------------------------
+-- Partitioning
+--------------------------------------------------------------------------------
+
+-- | Partitions a token map into 'n' smaller maps, where the quantity of each
+--   token is equipartitioned across the resultant maps.
+--
+-- In the resultant maps, the smallest quantity and largest quantity of a given
+-- token will differ by no more than 1.
+--
+-- The resultant list is sorted into ascending order when maps are compared
+-- with the 'leq' function.
+--
+equipartitionQuantities
+    :: TokenMap
+    -- ^ The map to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the map.
+    -> NonEmpty TokenMap
+    -- ^ The partitioned maps.
+equipartitionQuantities m count =
+    F.foldl' accumulate (empty <$ count) (toFlatList m)
+  where
+    accumulate
+        :: NonEmpty TokenMap
+        -> (AssetId, TokenQuantity)
+        -> NonEmpty TokenMap
+    accumulate maps (asset, quantity) = NE.zipWith (<>) maps $
+        singleton asset <$>
+            TokenQuantity.equipartition quantity count
 
 --------------------------------------------------------------------------------
 -- Policies

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity.hs
@@ -16,6 +16,7 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity
     , subtract
     , pred
     , succ
+    , equipartition
 
       -- * Tests
     , isNonZero
@@ -29,6 +30,8 @@ module Cardano.Wallet.Primitive.Types.TokenQuantity
 import Prelude hiding
     ( pred, subtract, succ )
 
+import Cardano.Numeric.Util
+    ( equipartitionNatural )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad
@@ -39,6 +42,8 @@ import Data.Functor
     ( ($>) )
 import Data.Hashable
     ( Hashable )
+import Data.List.NonEmpty
+    ( NonEmpty (..) )
 import Data.Text.Class
     ( FromText (..), ToText (..) )
 import Fmt
@@ -121,6 +126,23 @@ pred (TokenQuantity q) = TokenQuantity $ Prelude.pred q
 
 succ :: TokenQuantity -> TokenQuantity
 succ (TokenQuantity q) = TokenQuantity $ Prelude.succ q
+
+-- | Computes the equipartition of a token quantity into 'n' smaller quantities.
+--
+-- An /equipartition/ of a token quantity is a /partition/ of that quantity
+-- into 'n' smaller quantities whose values differ by no more than 1.
+--
+-- The resultant list is sorted in ascending order.
+--
+equipartition
+    :: TokenQuantity
+    -- ^ The token quantity to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the quantity.
+    -> NonEmpty TokenQuantity
+    -- ^ The partitioned quantities.
+equipartition q =
+    fmap TokenQuantity . equipartitionNatural (unTokenQuantity q)
 
 --------------------------------------------------------------------------------
 -- Tests

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , UnsignedTx (..)
     , TransactionInfo (..)
     , Direction (..)
+    , TokenBundleSizeAssessment (..)
 
     -- * Functions
     , fromTransactionInfo
@@ -430,3 +431,15 @@ txMetadataIsNull (TxMetadata md) = Map.null md
 toTxHistory :: TransactionInfo -> (Tx, TxMeta)
 toTxHistory info =
     (fromTransactionInfo info, txInfoMeta info)
+
+-- | Indicates the size of a token bundle relative to the upper limit of what
+--   can be included in a single transaction output, defined by the protocol.
+--
+data TokenBundleSizeAssessment
+    = TokenBundleSizeWithinLimit
+    -- ^ Indicates that the size of a token bundle does not exceed the maximum
+    -- size that can be included in a transaction output.
+    | TokenBundleSizeExceedsLimit
+    -- ^ Indicates that the size of a token bundle exceeds the maximum size
+    -- that can be included in a transaction output.
+    deriving (Eq, Generic, Show)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -39,6 +39,11 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txMetadataIsNull
     , txOutCoin
     , txOutIsCoin
+
+    -- * Constants
+    , txOutMinTokenQuantity
+    , txOutMaxTokenQuantity
+
     ) where
 
 import Prelude
@@ -64,7 +69,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
-    ( TokenQuantity )
+    ( TokenQuantity (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -99,7 +104,7 @@ import Data.Text.Class
 import Data.Time.Clock
     ( UTCTime )
 import Data.Word
-    ( Word32 )
+    ( Word32, Word64 )
 import Fmt
     ( Buildable (..)
     , blockListF'
@@ -443,3 +448,23 @@ data TokenBundleSizeAssessment
     -- ^ Indicates that the size of a token bundle exceeds the maximum size
     -- that can be included in a transaction output.
     deriving (Eq, Generic, Show)
+
+--------------------------------------------------------------------------------
+-- Constants
+--------------------------------------------------------------------------------
+
+-- | The smallest token quantity that can appear in a transaction output's
+--   token bundle.
+--
+txOutMinTokenQuantity :: TokenQuantity
+txOutMinTokenQuantity = TokenQuantity 1
+
+-- | The greatest token quantity that can appear in a transaction output's
+--   token bundle.
+--
+-- Although the ledger specification allows token quantities of unlimited
+-- sizes, in practice we'll only see transaction outputs where the token
+-- quantities are bounded by the size of a 'Word64'.
+--
+txOutMaxTokenQuantity :: TokenQuantity
+txOutMaxTokenQuantity = TokenQuantity $ fromIntegral $ maxBound @Word64

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Primitive.Types.Tx
     , UnsignedTx (..)
     , TransactionInfo (..)
     , Direction (..)
+    , TokenBundleSizeAssessor (..)
     , TokenBundleSizeAssessment (..)
 
     -- * Functions
@@ -436,6 +437,30 @@ txMetadataIsNull (TxMetadata md) = Map.null md
 toTxHistory :: TransactionInfo -> (Tx, TxMeta)
 toTxHistory info =
     (fromTransactionInfo info, txInfoMeta info)
+
+-- | A function capable of assessing the size of a token bundle relative to the
+--   upper limit of what can be included in a single transaction output.
+--
+-- In general, a token bundle size assessment function 'f' should satisfy the
+-- following properties:
+--
+--    * Enlarging a bundle that exceeds the limit should also result in a
+--      bundle that exceeds the limit:
+--      @
+--              f  b1           == TokenBundleSizeExceedsLimit
+--          ==> f (b1 `add` b2) == TokenBundleSizeExceedsLimit
+--      @
+--
+--    * Shrinking a bundle that's within the limit should also result in a
+--      bundle that's within the limit:
+--      @
+--              f  b1                  == TokenBundleWithinLimit
+--          ==> f (b1 `difference` b2) == TokenBundleWithinLimit
+--      @
+--
+newtype TokenBundleSizeAssessor = TokenBundleSizeAssessor
+    { assessTokenBundleSize :: TokenBundle -> TokenBundleSizeAssessment
+    }
 
 -- | Indicates the size of a token bundle relative to the upper limit of what
 --   can be included in a single transaction output, defined by the protocol.

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -48,10 +48,17 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), Tx (..), TxMetadata, TxOut )
+    ( SealedTx (..)
+    , TokenBundleSizeAssessment (..)
+    , Tx (..)
+    , TxMetadata
+    , TxOut
+    )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Data.ByteString
@@ -116,6 +123,12 @@ data TransactionLayer k = TransactionLayer
             -- A bundle of native assets
         -> Coin
         -- ^ The minimum ada value needed in a UTxO carrying the asset bundle
+
+    , assessTokenBundleSize
+        :: TokenBundle
+            -- A token bundle
+        -> TokenBundleSizeAssessment
+        -- ^ An assessment of the token bundle's size.
 
     , decodeSignedTx
         :: AnyCardanoEra

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -48,17 +48,10 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..)
-    , TokenBundleSizeAssessment (..)
-    , Tx (..)
-    , TxMetadata
-    , TxOut
-    )
+    ( SealedTx (..), TokenBundleSizeAssessor, Tx (..), TxMetadata, TxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Data.ByteString
@@ -124,11 +117,9 @@ data TransactionLayer k = TransactionLayer
         -> Coin
         -- ^ The minimum ada value needed in a UTxO carrying the asset bundle
 
-    , assessTokenBundleSize
-        :: TokenBundle
-            -- A token bundle
-        -> TokenBundleSizeAssessment
-        -- ^ An assessment of the token bundle's size.
+    , tokenBundleSizeAssessor
+        :: TokenBundleSizeAssessor
+        -- ^ A function to assess the size of a token bundle.
 
     , decodeSignedTx
         :: AnyCardanoEra

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -19,6 +19,8 @@ import Prelude
 
 import Algebra.PartialOrd
     ( PartialOrd (..) )
+import Cardano.Numeric.Util
+    ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     ( AssetCount (..)
     , BalanceInsufficientError (..)
@@ -2236,9 +2238,6 @@ consecutivePairs :: [a] -> [(a, a)]
 consecutivePairs xs = case tailMay xs of
     Nothing -> []
     Just ys -> xs `zip` ys
-
-inAscendingPartialOrder :: (Foldable f, PartialOrd a) => f a -> Bool
-inAscendingPartialOrder = all (uncurry leq) . consecutivePairs . F.toList
 
 addExtraSource :: Maybe Coin -> TokenBundle -> TokenBundle
 addExtraSource extraSource =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -106,6 +106,8 @@ import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor
     ( bimap, second )
+import Data.ByteString
+    ( ByteString )
 import Data.Function
     ( on, (&) )
 import Data.Functor.Identity
@@ -1188,21 +1190,20 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     (q1, q2) = (TokenQuantity 1, TokenQuantity.pred maxTxOutTokenQuantity)
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(assetA, q1)])
-      , (Coin 1_000_000, [(assetA, q2)])
+      [ (Coin 1_000_000, [(mockAsset "A", q1)])
+      , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(assetA, q1)])
-      , (Coin 1_000_000, [(assetA, q2)])
+      [ (Coin 1_000_000, [(mockAsset "A", q1)])
+      , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(assetA, maxTxOutTokenQuantity)]) ]
+      [ (Coin 500_000, [(mockAsset "A", maxTxOutTokenQuantity)]) ]
 
 -- Reach (but do not exceed) the maximum token quantity by selecting inputs
 -- with the following quantities:
@@ -1218,21 +1219,20 @@ boundaryTest_largeTokenQuantities_2 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     q1 :| [q2] = TokenQuantity.equipartition maxTxOutTokenQuantity (() :| [()])
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(assetA, q1)])
-      , (Coin 1_000_000, [(assetA, q2)])
+      [ (Coin 1_000_000, [(mockAsset "A", q1)])
+      , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(assetA, q1)])
-      , (Coin 1_000_000, [(assetA, q2)])
+      [ (Coin 1_000_000, [(mockAsset "A", q1)])
+      , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(assetA, maxTxOutTokenQuantity)]) ]
+      [ (Coin 500_000, [(mockAsset "A", maxTxOutTokenQuantity)]) ]
 
 -- Slightly exceed the maximum token quantity by selecting inputs with the
 -- following quantities:
@@ -1248,23 +1248,22 @@ boundaryTest_largeTokenQuantities_3 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     q1 :| [q2] = TokenQuantity.equipartition
         (TokenQuantity.succ maxTxOutTokenQuantity) (() :| [()])
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(assetA, TokenQuantity 1)])
-      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", TokenQuantity 1)])
+      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(assetA, TokenQuantity 1)])
-      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", TokenQuantity 1)])
+      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
       ]
     boundaryTestChange =
-      [ (Coin 250_000, [(assetA, q1)])
-      , (Coin 250_000, [(assetA, q2)])
+      [ (Coin 250_000, [(mockAsset "A", q1)])
+      , (Coin 250_000, [(mockAsset "A", q2)])
       ]
 
 -- Reach (but do not exceed) exactly twice the maximum token quantity by
@@ -1281,21 +1280,20 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
-      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
-      , (Coin 1_000_000, [(assetA, maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
       ]
     boundaryTestChange =
-      [ (Coin 250_000, [(assetA, maxTxOutTokenQuantity)])
-      , (Coin 250_000, [(assetA, maxTxOutTokenQuantity)])
+      [ (Coin 250_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      , (Coin 250_000, [(mockAsset "A", maxTxOutTokenQuantity)])
       ]
 
 --------------------------------------------------------------------------------
@@ -1320,27 +1318,23 @@ boundaryTest_largeAssetCounts_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "1")
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "C") (UnsafeTokenName "1")
-    assetD = AssetId (UnsafeTokenPolicyId $ Hash "D") (UnsafeTokenName "1")
     boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 4
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 500_000, [(assetA, TokenQuantity 1)])
-      , (Coin 500_000, [(assetB, TokenQuantity 1)])
-      , (Coin 500_000, [(assetC, TokenQuantity 1)])
-      , (Coin 500_000, [(assetD, TokenQuantity 1)])
+      [ (Coin 500_000, [mockAssetQuantity "A" 1])
+      , (Coin 500_000, [mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1])
+      , (Coin 500_000, [mockAssetQuantity "D" 1])
       ]
     -- Expect that all entries will be selected:
     boundaryTestInputs = boundaryTestUTxO
     boundaryTestChange =
       [ ( Coin 1_000_000
-        , [ (assetA, TokenQuantity 1)
-          , (assetB, TokenQuantity 1)
-          , (assetC, TokenQuantity 1)
-          , (assetD, TokenQuantity 1)
+        , [ mockAssetQuantity "A" 1
+          , mockAssetQuantity "B" 1
+          , mockAssetQuantity "C" 1
+          , mockAssetQuantity "D" 1
           ]
         )
       ]
@@ -1355,32 +1349,20 @@ boundaryTest_largeAssetCounts_2 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "1")
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "C") (UnsafeTokenName "1")
-    assetD = AssetId (UnsafeTokenPolicyId $ Hash "D") (UnsafeTokenName "1")
     boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 3
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 500_000, [(assetA, TokenQuantity 1)])
-      , (Coin 500_000, [(assetB, TokenQuantity 1)])
-      , (Coin 500_000, [(assetC, TokenQuantity 1)])
-      , (Coin 500_000, [(assetD, TokenQuantity 1)])
+      [ (Coin 500_000, [mockAssetQuantity "A" 1])
+      , (Coin 500_000, [mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1])
+      , (Coin 500_000, [mockAssetQuantity "D" 1])
       ]
     -- Expect that all entries will be selected:
     boundaryTestInputs = boundaryTestUTxO
     boundaryTestChange =
-      [ ( Coin 500_000
-        , [ (assetA, TokenQuantity 1)
-          , (assetB, TokenQuantity 1)
-          ]
-        )
-      , ( Coin 500_000
-        , [ (assetC, TokenQuantity 1)
-          , (assetD, TokenQuantity 1)
-          ]
-        )
+      [ (Coin 500_000, [mockAssetQuantity "A" 1, mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1, mockAssetQuantity "D" 1])
       ]
 
 -- Exceed the maximum per-bundle asset count of 2.
@@ -1393,32 +1375,20 @@ boundaryTest_largeAssetCounts_3 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "1")
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "C") (UnsafeTokenName "1")
-    assetD = AssetId (UnsafeTokenPolicyId $ Hash "D") (UnsafeTokenName "1")
     boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 2
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 500_000, [(assetA, TokenQuantity 1)])
-      , (Coin 500_000, [(assetB, TokenQuantity 1)])
-      , (Coin 500_000, [(assetC, TokenQuantity 1)])
-      , (Coin 500_000, [(assetD, TokenQuantity 1)])
+      [ (Coin 500_000, [mockAssetQuantity "A" 1])
+      , (Coin 500_000, [mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1])
+      , (Coin 500_000, [mockAssetQuantity "D" 1])
       ]
     -- Expect that all entries will be selected:
     boundaryTestInputs = boundaryTestUTxO
     boundaryTestChange =
-      [ ( Coin 500_000
-        , [ (assetA, TokenQuantity 1)
-          , (assetB, TokenQuantity 1)
-          ]
-        )
-      , ( Coin 500_000
-        , [ (assetC, TokenQuantity 1)
-          , (assetD, TokenQuantity 1)
-          ]
-        )
+      [ (Coin 500_000, [mockAssetQuantity "A" 1, mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1, mockAssetQuantity "D" 1])
       ]
 
 -- Exceed the maximum per-bundle asset count of 1.
@@ -1431,26 +1401,22 @@ boundaryTest_largeAssetCounts_4 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    assetB = AssetId (UnsafeTokenPolicyId $ Hash "B") (UnsafeTokenName "1")
-    assetC = AssetId (UnsafeTokenPolicyId $ Hash "C") (UnsafeTokenName "1")
-    assetD = AssetId (UnsafeTokenPolicyId $ Hash "D") (UnsafeTokenName "1")
     boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 1
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 500_000, [(assetA, TokenQuantity 1)])
-      , (Coin 500_000, [(assetB, TokenQuantity 1)])
-      , (Coin 500_000, [(assetC, TokenQuantity 1)])
-      , (Coin 500_000, [(assetD, TokenQuantity 1)])
+      [ (Coin 500_000, [mockAssetQuantity "A" 1])
+      , (Coin 500_000, [mockAssetQuantity "B" 1])
+      , (Coin 500_000, [mockAssetQuantity "C" 1])
+      , (Coin 500_000, [mockAssetQuantity "D" 1])
       ]
     -- Expect that all entries will be selected:
     boundaryTestInputs = boundaryTestUTxO
     boundaryTestChange =
-      [ (Coin 250_000, [(assetA, TokenQuantity 1)])
-      , (Coin 250_000, [(assetB, TokenQuantity 1)])
-      , (Coin 250_000, [(assetC, TokenQuantity 1)])
-      , (Coin 250_000, [(assetD, TokenQuantity 1)])
+      [ (Coin 250_000, [mockAssetQuantity "A" 1])
+      , (Coin 250_000, [mockAssetQuantity "B" 1])
+      , (Coin 250_000, [mockAssetQuantity "C" 1])
+      , (Coin 250_000, [mockAssetQuantity "D" 1])
       ]
 
 --------------------------------------------------------------------------------
@@ -2375,6 +2341,12 @@ addExtraSource :: Maybe Coin -> TokenBundle -> TokenBundle
 addExtraSource extraSource =
     TokenBundle.add
         (maybe TokenBundle.empty TokenBundle.fromCoin extraSource)
+
+mockAsset :: ByteString -> AssetId
+mockAsset a = AssetId (UnsafeTokenPolicyId $ Hash a) (UnsafeTokenName "1")
+
+mockAssetQuantity :: ByteString -> Natural -> (AssetId, TokenQuantity)
+mockAssetQuantity a q = (mockAsset a, TokenQuantity q)
 
 unitTests :: String -> [Expectation] -> SpecWith ()
 unitTests lbl cases =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1102,7 +1102,9 @@ data BoundaryTestData = BoundaryTestData
     deriving (Eq, Show)
 
 data BoundaryTestCriteria = BoundaryTestCriteria
-    { boundaryTestOutputs
+    { boundaryTestBundleSizeAssessor
+        :: BundleSizeAssessor
+    , boundaryTestOutputs
         :: [BoundaryTestEntry]
     , boundaryTestUTxO
         :: [BoundaryTestEntry]
@@ -1124,7 +1126,7 @@ mkBoundaryTestExpectation (BoundaryTestData criteria expectedResult) = do
     actualResult <- performSelection
         (noMinCoin)
         (mkCostFor NoCost)
-        (mkBundleSizeAssessor NoBundleSizeLimit)
+        (mkBundleSizeAssessor $ boundaryTestBundleSizeAssessor criteria)
         (encodeBoundaryTestCriteria criteria)
     fmap decodeBoundaryTestResult actualResult `shouldBe` Right expectedResult
 
@@ -1182,6 +1184,7 @@ boundaryTest1 = BoundaryTestData
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     (q1, q2) = (TokenQuantity 1, TokenQuantity.pred maxTxOutTokenQuantity)
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1211,6 +1214,7 @@ boundaryTest2 = BoundaryTestData
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     q1 :| [q2] = TokenQuantity.equipartition maxTxOutTokenQuantity (() :| [()])
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1241,6 +1245,7 @@ boundaryTest3 = BoundaryTestData
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
     q1 :| [q2] = TokenQuantity.equipartition
         (TokenQuantity.succ maxTxOutTokenQuantity) (() :| [()])
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1271,6 +1276,7 @@ boundaryTest4 = BoundaryTestData
     }
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -36,7 +36,6 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
     , balanceMissing
     , coinSelectionLens
-    , equipartitionNatural
     , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenBundlesWithMaxQuantity
     , equipartitionTokenMap
@@ -163,7 +162,6 @@ import Test.QuickCheck
     , suchThat
     , withMaxSuccess
     , (.&&.)
-    , (.||.)
     , (===)
     , (==>)
     )
@@ -321,17 +319,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
             property prop_makeChangeForUserSpecifiedAsset_length
         unitTests "makeChangeForUserSpecifiedAsset"
             unit_makeChangeForUserSpecifiedAsset
-
-    parallel $ describe "Equipartitioning natural numbers" $ do
-
-        it "prop_equipartitionNatural_fair" $
-            property prop_equipartitionNatural_fair
-        it "prop_equipartitionNatural_length" $
-            property prop_equipartitionNatural_length
-        it "prop_equipartitionNatural_order" $
-            property prop_equipartitionNatural_order
-        it "prop_equipartitionNatural_sum" $
-            property prop_equipartitionNatural_sum
 
     parallel $ describe "Equipartitioning token maps" $ do
 
@@ -1874,40 +1861,6 @@ unit_makeChangeForUserSpecifiedAsset =
 
     assetC :: AssetId
     assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "2")
-
---------------------------------------------------------------------------------
--- Equipartitioning natural numbers
---------------------------------------------------------------------------------
-
--- Test that natural numbers are equipartitioned fairly:
---
--- Each portion must be within unity of the ideal portion.
---
-prop_equipartitionNatural_fair
-    :: Natural -> NonEmpty () -> Property
-prop_equipartitionNatural_fair n count = (.||.)
-    (difference === 0)
-    (difference === 1)
-  where
-    difference :: Natural
-    difference = F.maximum results - F.minimum results
-
-    results :: NonEmpty Natural
-    results = equipartitionNatural n count
-
-prop_equipartitionNatural_length :: Natural -> NonEmpty () -> Property
-prop_equipartitionNatural_length n count =
-    NE.length (equipartitionNatural n count) === NE.length count
-
-prop_equipartitionNatural_order :: Natural -> NonEmpty () -> Property
-prop_equipartitionNatural_order n count =
-    NE.sort results === results
-  where
-    results = equipartitionNatural n count
-
-prop_equipartitionNatural_sum :: Natural -> NonEmpty () -> Property
-prop_equipartitionNatural_sum n count =
-    F.sum (equipartitionNatural n count) === n
 
 --------------------------------------------------------------------------------
 -- Equipartitioning token maps

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -38,7 +38,6 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , assignCoinsToChangeMaps
     , balanceMissing
     , coinSelectionLens
-    , equipartitionTokenBundleWithMaxQuantity
     , equipartitionTokenBundlesWithMaxQuantity
     , fullBalance
     , groupByKey
@@ -320,15 +319,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec" $
             unit_makeChangeForUserSpecifiedAsset
 
     parallel $ describe "Equipartitioning token bundles by max quantity" $ do
-
-        describe "Individual token bundles" $ do
-
-            it "prop_equipartitionTokenBundleWithMaxQuantity_length" $
-                property prop_equipartitionTokenBundleWithMaxQuantity_length
-            it "prop_equipartitionTokenBundleWithMaxQuantity_order" $
-                property prop_equipartitionTokenBundleWithMaxQuantity_order
-            it "prop_equipartitionTokenBundleWithMaxQuantity_sum" $
-                property prop_equipartitionTokenBundleWithMaxQuantity_sum
 
         describe "Lists of token bundles" $ do
 
@@ -1836,42 +1826,6 @@ unit_makeChangeForUserSpecifiedAsset =
 
     assetC :: AssetId
     assetC = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "2")
-
---------------------------------------------------------------------------------
--- Equipartitioning token bundles according to a maximum quantity
---------------------------------------------------------------------------------
-
--- | Computes the number of parts that 'equipartitionTokenBundleWithMaxQuantity'
---   should return.
---
-equipartitionTokenBundleWithMaxQuantity_expectedLength
-    :: TokenBundle -> TokenQuantity -> Int
-equipartitionTokenBundleWithMaxQuantity_expectedLength
-    (TokenBundle _ m) (TokenQuantity maxQuantity) =
-        max 1 $ ceiling $ currentMaxQuantity % maxQuantity
-  where
-    TokenQuantity currentMaxQuantity = TokenMap.maximumQuantity m
-
-prop_equipartitionTokenBundleWithMaxQuantity_length
-    :: TokenBundle -> TokenQuantity -> Property
-prop_equipartitionTokenBundleWithMaxQuantity_length m maxQuantity =
-    maxQuantity > TokenQuantity.zero ==>
-        length (equipartitionTokenBundleWithMaxQuantity m maxQuantity)
-            === equipartitionTokenBundleWithMaxQuantity_expectedLength
-                m maxQuantity
-
-prop_equipartitionTokenBundleWithMaxQuantity_order
-    :: TokenBundle -> TokenQuantity -> Property
-prop_equipartitionTokenBundleWithMaxQuantity_order m maxQuantity =
-    maxQuantity > TokenQuantity.zero ==>
-        inAscendingPartialOrder
-            (equipartitionTokenBundleWithMaxQuantity m maxQuantity)
-
-prop_equipartitionTokenBundleWithMaxQuantity_sum
-    :: TokenBundle -> TokenQuantity -> Property
-prop_equipartitionTokenBundleWithMaxQuantity_sum m maxQuantity =
-    maxQuantity > TokenQuantity.zero ==>
-        F.fold (equipartitionTokenBundleWithMaxQuantity m maxQuantity) === m
 
 --------------------------------------------------------------------------------
 -- Equipartitioning lists of token bundles according to a maximum quantity

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -40,7 +40,6 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , equipartitionTokenBundlesWithMaxQuantity
     , equipartitionTokenMap
     , equipartitionTokenMapWithMaxQuantity
-    , equipartitionTokenQuantity
     , fullBalance
     , groupByKey
     , makeChange
@@ -1218,7 +1217,7 @@ boundaryTest2 = BoundaryTestData
     }
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    q1 :| [q2] = equipartitionTokenQuantity maxTxOutTokenQuantity (() :| [()])
+    q1 :| [q2] = TokenQuantity.equipartition maxTxOutTokenQuantity (() :| [()])
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1247,7 +1246,7 @@ boundaryTest3 = BoundaryTestData
     }
   where
     assetA = AssetId (UnsafeTokenPolicyId $ Hash "A") (UnsafeTokenName "1")
-    q1 :| [q2] = equipartitionTokenQuantity
+    q1 :| [q2] = TokenQuantity.equipartition
         (TokenQuantity.succ maxTxOutTokenQuantity) (() :| [()])
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -46,7 +46,6 @@ import Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , makeChangeForNonUserSpecifiedAsset
     , makeChangeForUserSpecifiedAsset
     , mapMaybe
-    , maxTxOutTokenQuantity
     , performSelection
     , prepareOutputsWith
     , runRoundRobin
@@ -91,7 +90,12 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment (..), TxIn (..), TxOut (..), txOutCoin )
+    ( TokenBundleSizeAssessment (..)
+    , TxIn (..)
+    , TxOut (..)
+    , txOutCoin
+    , txOutMaxTokenQuantity
+    )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
     ( genTxOutSmallRange, shrinkTxOutSmallRange )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
@@ -1190,7 +1194,7 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    (q1, q2) = (TokenQuantity 1, TokenQuantity.pred maxTxOutTokenQuantity)
+    (q1, q2) = (TokenQuantity 1, TokenQuantity.pred txOutMaxTokenQuantity)
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
@@ -1203,7 +1207,7 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
       , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(mockAsset "A", maxTxOutTokenQuantity)]) ]
+      [ (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)]) ]
 
 -- Reach (but do not exceed) the maximum token quantity by selecting inputs
 -- with the following quantities:
@@ -1219,7 +1223,7 @@ boundaryTest_largeTokenQuantities_2 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    q1 :| [q2] = TokenQuantity.equipartition maxTxOutTokenQuantity (() :| [()])
+    q1 :| [q2] = TokenQuantity.equipartition txOutMaxTokenQuantity (() :| [()])
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
@@ -1232,7 +1236,7 @@ boundaryTest_largeTokenQuantities_2 = BoundaryTestData
       , (Coin 1_000_000, [(mockAsset "A", q2)])
       ]
     boundaryTestChange =
-      [ (Coin 500_000, [(mockAsset "A", maxTxOutTokenQuantity)]) ]
+      [ (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)]) ]
 
 -- Slightly exceed the maximum token quantity by selecting inputs with the
 -- following quantities:
@@ -1249,17 +1253,17 @@ boundaryTest_largeTokenQuantities_3 = BoundaryTestData
     }
   where
     q1 :| [q2] = TokenQuantity.equipartition
-        (TokenQuantity.succ maxTxOutTokenQuantity) (() :| [()])
+        (TokenQuantity.succ txOutMaxTokenQuantity) (() :| [()])
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
       [ (Coin 1_000_000, [(mockAsset "A", TokenQuantity 1)])
-      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
     boundaryTestInputs =
       [ (Coin 1_000_000, [(mockAsset "A", TokenQuantity 1)])
-      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
     boundaryTestChange =
       [ (Coin 250_000, [(mockAsset "A", q1)])
@@ -1284,16 +1288,16 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
-      [ (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
-      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
     boundaryTestInputs =
-      [ (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
-      , (Coin 1_000_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
     boundaryTestChange =
-      [ (Coin 250_000, [(mockAsset "A", maxTxOutTokenQuantity)])
-      , (Coin 250_000, [(mockAsset "A", maxTxOutTokenQuantity)])
+      [ (Coin 250_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 250_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
 
 --------------------------------------------------------------------------------

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -11,10 +11,10 @@ import Prelude hiding
 
 import Algebra.PartialOrd
     ( leq )
-import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle (..), add, difference, isCoin, subtract, unsafeSubtract )
 import Cardano.Numeric.Util
     ( inAscendingPartialOrder )
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle (..), add, difference, isCoin, subtract, unsafeSubtract )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenQuantity

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TypeApplications #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Primitive.Types.TokenBundleSpec
     ( spec
@@ -12,9 +12,17 @@ import Prelude hiding
 import Algebra.PartialOrd
     ( leq )
 import Cardano.Wallet.Primitive.Types.TokenBundle
-    ( TokenBundle, add, difference, isCoin, subtract, unsafeSubtract )
+    ( TokenBundle (..), add, difference, isCoin, subtract, unsafeSubtract )
+import Cardano.Numeric.Util
+    ( inAscendingPartialOrder )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity (..) )
+import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
+    ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
+import Data.Ratio
+    ( (%) )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.Hspec.Core.QuickCheck
@@ -35,6 +43,11 @@ import Test.Utils.Laws
     ( testLawsMany )
 import Test.Utils.Laws.PartialOrd
     ( partialOrdLaws )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
+import qualified Data.Foldable as F
 
 spec :: Spec
 spec =
@@ -65,6 +78,14 @@ spec =
             property prop_difference_subtract
         it "prop_difference_equality" $
             property prop_difference_equality
+
+    describe "Partitioning quantities with an upper bound" $ do
+        it "prop_equipartitionQuantitiesWithUpperBound_length" $
+            property prop_equipartitionQuantitiesWithUpperBound_length
+        it "prop_equipartitionQuantitiesWithUpperBound_order" $
+            property prop_equipartitionQuantitiesWithUpperBound_order
+        it "prop_equipartitionQuantitiesWithUpperBound_sum" $
+            property prop_equipartitionQuantitiesWithUpperBound_sum
 
 --------------------------------------------------------------------------------
 -- Arithmetic properties
@@ -116,9 +137,50 @@ prop_difference_equality x y = checkCoverage $
     yExcess = y `difference` x
 
 --------------------------------------------------------------------------------
+-- Partitioning quantities according to an upper bound
+--------------------------------------------------------------------------------
+
+-- | Computes the number of parts that 'equipartitionQuantitiesWithUpperBound'
+--   should return.
+--
+equipartitionQuantitiesWithUpperBound_expectedLength
+    :: TokenBundle -> TokenQuantity -> Int
+equipartitionQuantitiesWithUpperBound_expectedLength
+    (TokenBundle _ m) (TokenQuantity maxQuantity) =
+        max 1 $ ceiling $ currentMaxQuantity % maxQuantity
+  where
+    TokenQuantity currentMaxQuantity = TokenMap.maximumQuantity m
+
+prop_equipartitionQuantitiesWithUpperBound_length
+    :: TokenBundle -> TokenQuantity -> Property
+prop_equipartitionQuantitiesWithUpperBound_length m maxQuantity =
+    maxQuantity > TokenQuantity.zero ==>
+        length (TokenBundle.equipartitionQuantitiesWithUpperBound m maxQuantity)
+            === equipartitionQuantitiesWithUpperBound_expectedLength
+                m maxQuantity
+
+prop_equipartitionQuantitiesWithUpperBound_order
+    :: TokenBundle -> TokenQuantity -> Property
+prop_equipartitionQuantitiesWithUpperBound_order m maxQuantity =
+    maxQuantity > TokenQuantity.zero ==>
+        inAscendingPartialOrder
+            (TokenBundle.equipartitionQuantitiesWithUpperBound m maxQuantity)
+
+prop_equipartitionQuantitiesWithUpperBound_sum
+    :: TokenBundle -> TokenQuantity -> Property
+prop_equipartitionQuantitiesWithUpperBound_sum m maxQuantity =
+    maxQuantity > TokenQuantity.zero ==>
+        F.fold (TokenBundle.equipartitionQuantitiesWithUpperBound m maxQuantity)
+            === m
+
+--------------------------------------------------------------------------------
 -- Arbitrary instances
 --------------------------------------------------------------------------------
 
 instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange
     shrink = shrinkTokenBundleSmallRange
+
+instance Arbitrary TokenQuantity where
+    arbitrary = genTokenQuantitySmallPositive
+    shrink = shrinkTokenQuantitySmallPositive

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -715,6 +715,8 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: calcMinimumCost not implemented"
     , calcMinimumCoinValue =
         error "dummyTransactionLayer: calcMinimumCoinValue not implemented"
+    , assessTokenBundleSize =
+        error "dummyTransactionLayer: assessTokenBundleSize not implemented"
     , decodeSignedTx =
         error "dummyTransactionLayer: decodeSignedTx not implemented"
     }

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -715,8 +715,8 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: calcMinimumCost not implemented"
     , calcMinimumCoinValue =
         error "dummyTransactionLayer: calcMinimumCoinValue not implemented"
-    , assessTokenBundleSize =
-        error "dummyTransactionLayer: assessTokenBundleSize not implemented"
+    , tokenBundleSizeAssessor =
+        error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
     , decodeSignedTx =
         error "dummyTransactionLayer: decodeSignedTx not implemented"
     }

--- a/lib/numeric/cardano-numeric.cabal
+++ b/lib/numeric/cardano-numeric.cabal
@@ -29,6 +29,8 @@ library
     ghc-options: -O2 -Werror
   build-depends:
       base
+    , lattices
+    , safe
   hs-source-dirs:
       src
   exposed-modules:

--- a/lib/numeric/src/Cardano/Numeric/Util.hs
+++ b/lib/numeric/src/Cardano/Numeric/Util.hs
@@ -12,11 +12,16 @@ module Cardano.Numeric.Util
     , partitionNatural
     , unsafePartitionNatural
 
+      -- * Partial orders
+    , inAscendingPartialOrder
+
     ) where
 
 import Prelude hiding
     ( round )
 
+import Algebra.PartialOrd
+    ( PartialOrd (..) )
 import Control.Arrow
     ( (&&&) )
 import Data.Function
@@ -33,6 +38,8 @@ import GHC.Stack
     ( HasCallStack )
 import Numeric.Natural
     ( Natural )
+import Safe
+    ( tailMay )
 
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
@@ -239,6 +246,13 @@ unsafePartitionNatural target =
         ]
 
 --------------------------------------------------------------------------------
+-- Partial orders
+--------------------------------------------------------------------------------
+
+inAscendingPartialOrder :: (Foldable f, PartialOrd a) => f a -> Bool
+inAscendingPartialOrder = all (uncurry leq) . consecutivePairs . F.toList
+
+--------------------------------------------------------------------------------
 -- Internal types and functions
 --------------------------------------------------------------------------------
 
@@ -246,6 +260,11 @@ unsafePartitionNatural target =
 --
 applyN :: Int -> (a -> a) -> a -> a
 applyN n f = F.foldr (.) id (replicate n f)
+
+consecutivePairs :: [a] -> [(a, a)]
+consecutivePairs xs = case tailMay xs of
+    Nothing -> []
+    Just ys -> xs `zip` ys
 
 -- Extract the fractional part of a rational number.
 --

--- a/lib/numeric/src/Cardano/Numeric/Util.hs
+++ b/lib/numeric/src/Cardano/Numeric/Util.hs
@@ -5,6 +5,7 @@
 module Cardano.Numeric.Util
     ( padCoalesce
     , partitionNatural
+    , unsafePartitionNatural
     ) where
 
 import Prelude hiding
@@ -16,10 +17,14 @@ import Data.Function
     ( (&) )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
+import Data.Maybe
+    ( fromMaybe )
 import Data.Ord
     ( Down (..), comparing )
 import Data.Ratio
     ( (%) )
+import GHC.Stack
+    ( HasCallStack )
 import Numeric.Natural
     ( Natural )
 
@@ -180,6 +185,31 @@ partitionNatural target weights
 
     totalWeight :: Natural
     totalWeight = F.sum weights
+
+--------------------------------------------------------------------------------
+-- Unsafe partitioning
+--------------------------------------------------------------------------------
+
+-- | Partitions a natural number into a number of parts, where the size of each
+--   part is proportional to the size of its corresponding element in the given
+--   list of weights, and the number of parts is equal to the number of weights.
+--
+-- Throws a run-time error if the sum of weights is equal to zero.
+--
+unsafePartitionNatural
+    :: HasCallStack
+    => Natural
+    -- ^ Natural number to partition
+    -> NonEmpty Natural
+    -- ^ List of weights
+    -> NonEmpty Natural
+unsafePartitionNatural target =
+    fromMaybe zeroWeightSumError . partitionNatural target
+  where
+    zeroWeightSumError = error $ unwords
+        [ "unsafePartitionNatural:"
+        , "specified weights must have a non-zero sum."
+        ]
 
 --------------------------------------------------------------------------------
 -- Internal types and functions

--- a/lib/numeric/src/Cardano/Numeric/Util.hs
+++ b/lib/numeric/src/Cardano/Numeric/Util.hs
@@ -3,9 +3,15 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Numeric.Util
-    ( padCoalesce
+    (
+      -- * Coalescing values
+      padCoalesce
+
+      -- * Partitioning natural numbers
+    , equipartitionNatural
     , partitionNatural
     , unsafePartitionNatural
+
     ) where
 
 import Prelude hiding
@@ -100,6 +106,27 @@ padCoalesce sourceUnsorted target
 --------------------------------------------------------------------------------
 -- Partitioning natural numbers
 --------------------------------------------------------------------------------
+
+-- | Computes the equipartition of a natural number into 'n' smaller numbers.
+--
+-- An /equipartition/ of a natural number 'n' is a /partition/ of that number
+-- into 'n' smaller numbers whose values differ by no more than 1.
+--
+-- The resultant list is sorted in ascending order.
+--
+equipartitionNatural
+    :: HasCallStack
+    => Natural
+    -- ^ The natural number to be partitioned.
+    -> NonEmpty a
+    -- ^ Represents the number of portions in which to partition the number.
+    -> NonEmpty Natural
+    -- ^ The partitioned numbers.
+equipartitionNatural n count =
+    -- Note: due to the behaviour of the underlying partition algorithm, a
+    -- simple list reversal is enough to ensure that the resultant list is
+    -- sorted in ascending order.
+    NE.reverse $ unsafePartitionNatural n (1 <$ count)
 
 -- | Partitions a natural number into a number of parts, where the size of each
 --   part is proportional to the size of its corresponding element in the given

--- a/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
+++ b/lib/numeric/test/unit/Cardano/Numeric/UtilSpec.hs
@@ -8,7 +8,7 @@ module Cardano.Numeric.UtilSpec
 import Prelude
 
 import Cardano.Numeric.Util
-    ( padCoalesce, partitionNatural )
+    ( equipartitionNatural, padCoalesce, partitionNatural )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
@@ -31,6 +31,7 @@ import Test.QuickCheck
     , shrinkIntegral
     , withMaxSuccess
     , (.&&.)
+    , (.||.)
     , (===)
     )
 
@@ -48,6 +49,17 @@ spec = do
             property $ prop_padCoalesce_sort @(Sum Int)
         it "prop_padCoalesce_sum" $
             property $ prop_padCoalesce_sum @(Sum Int)
+
+    describe "equipartitionNatural" $ do
+
+        it "prop_equipartitionNatural_fair" $
+            property prop_equipartitionNatural_fair
+        it "prop_equipartitionNatural_length" $
+            property prop_equipartitionNatural_length
+        it "prop_equipartitionNatural_order" $
+            property prop_equipartitionNatural_order
+        it "prop_equipartitionNatural_sum" $
+            property prop_equipartitionNatural_sum
 
     describe "partitionNatural" $ do
 
@@ -78,6 +90,40 @@ prop_padCoalesce_sum
     :: (Monoid a, Ord a, Show a) => NonEmpty a -> NonEmpty () -> Property
 prop_padCoalesce_sum source target =
     F.fold source === F.fold (padCoalesce source target)
+
+--------------------------------------------------------------------------------
+-- Equipartitioning natural numbers
+--------------------------------------------------------------------------------
+
+-- Test that natural numbers are equipartitioned fairly:
+--
+-- Each portion must be within unity of the ideal portion.
+--
+prop_equipartitionNatural_fair
+    :: Natural -> NonEmpty () -> Property
+prop_equipartitionNatural_fair n count = (.||.)
+    (difference === 0)
+    (difference === 1)
+  where
+    difference :: Natural
+    difference = F.maximum results - F.minimum results
+
+    results :: NonEmpty Natural
+    results = equipartitionNatural n count
+
+prop_equipartitionNatural_length :: Natural -> NonEmpty () -> Property
+prop_equipartitionNatural_length n count =
+    NE.length (equipartitionNatural n count) === NE.length count
+
+prop_equipartitionNatural_order :: Natural -> NonEmpty () -> Property
+prop_equipartitionNatural_order n count =
+    NE.sort results === results
+  where
+    results = equipartitionNatural n count
+
+prop_equipartitionNatural_sum :: Natural -> NonEmpty () -> Property
+prop_equipartitionNatural_sum n count =
+    F.sum (equipartitionNatural n count) === n
 
 --------------------------------------------------------------------------------
 -- Partitioning natural numbers

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -1250,7 +1250,7 @@ computeTokenBundleSerializedLengthBytes =
 -- See: https://jira.iohk.io/projects/ADP/issues/ADP-779
 --
 maxTokenBundleSerializedLengthBytes :: Int
-maxTokenBundleSerializedLengthBytes = 4096
+maxTokenBundleSerializedLengthBytes = 4000
 
 {-------------------------------------------------------------------------------
                       Address Encoding / Decoding

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -74,7 +74,7 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromCardanoValue
 
       -- ** Assessing sizes of token bundles
-    , assessTokenBundleSize
+    , tokenBundleSizeAssessor
     , computeTokenBundleSerializedLengthBytes
     , maxTokenBundleSerializedLengthBytes
 
@@ -1229,15 +1229,19 @@ toStakePoolDlgCert xpub (W.PoolId pid) =
 -- | Assesses a token bundle size in relation to the maximum size that can be
 --   included in a transaction output.
 --
-assessTokenBundleSize :: TokenBundle.TokenBundle -> W.TokenBundleSizeAssessment
-assessTokenBundleSize tb
-    | serializedLengthBytes <= maxTokenBundleSerializedLengthBytes =
-        W.TokenBundleSizeWithinLimit
-    | otherwise =
-        W.TokenBundleSizeExceedsLimit
+-- See 'W.TokenBundleSizeAssessor' for the expected properties of this function.
+--
+tokenBundleSizeAssessor :: W.TokenBundleSizeAssessor
+tokenBundleSizeAssessor = W.TokenBundleSizeAssessor {..}
   where
-    serializedLengthBytes :: Int
-    serializedLengthBytes = computeTokenBundleSerializedLengthBytes tb
+    assessTokenBundleSize tb
+        | serializedLengthBytes <= maxTokenBundleSerializedLengthBytes =
+            W.TokenBundleSizeWithinLimit
+        | otherwise =
+            W.TokenBundleSizeExceedsLimit
+      where
+        serializedLengthBytes :: Int
+        serializedLengthBytes = computeTokenBundleSerializedLengthBytes tb
 
 computeTokenBundleSerializedLengthBytes :: TokenBundle.TokenBundle -> Int
 computeTokenBundleSerializedLengthBytes =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -73,6 +73,11 @@ module Cardano.Wallet.Shelley.Compatibility
     , toCardanoValue
     , fromCardanoValue
 
+      -- ** Assessing sizes of token bundles
+    , assessTokenBundleSize
+    , computeTokenBundleSerializedLengthBytes
+    , maxTokenBundleSerializedLengthBytes
+
       -- ** Stake pools
     , fromPoolId
     , fromPoolDistr
@@ -260,6 +265,7 @@ import Type.Reflection
 import qualified Cardano.Address.Style.Shelley as CA
 import qualified Cardano.Api.Shelley as Cardano
 import qualified Cardano.Api.Typed as Cardano
+import qualified Cardano.Binary as Binary
 import qualified Cardano.Byron.Codec.Cbor as CBOR
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Core as SL.Core
@@ -1215,6 +1221,36 @@ toStakePoolDlgCert xpub (W.PoolId pid) =
   where
     cred = SL.KeyHash $ UnsafeHash $ toShort $ blake2b224 $ xpubPublicKey xpub
     pool = SL.KeyHash $ UnsafeHash $ toShort pid
+
+{-------------------------------------------------------------------------------
+                   Assessing sizes of token bundles
+-------------------------------------------------------------------------------}
+
+-- | Assesses a token bundle size in relation to the maximum size that can be
+--   included in a transaction output.
+--
+assessTokenBundleSize :: TokenBundle.TokenBundle -> W.TokenBundleSizeAssessment
+assessTokenBundleSize tb
+    | serializedLengthBytes <= maxTokenBundleSerializedLengthBytes =
+        W.TokenBundleSizeWithinLimit
+    | otherwise =
+        W.TokenBundleSizeExceedsLimit
+  where
+    serializedLengthBytes :: Int
+    serializedLengthBytes = computeTokenBundleSerializedLengthBytes tb
+
+computeTokenBundleSerializedLengthBytes :: TokenBundle.TokenBundle -> Int
+computeTokenBundleSerializedLengthBytes =
+    BS.length . Binary.serialize' . Cardano.toMaryValue . toCardanoValue
+
+-- NOTE: This hard-coded limit may change in future. Ideally, we should
+-- delegate the assessment of whether a token bundle is too large to a
+-- function exported by Cardano API.
+--
+-- See: https://jira.iohk.io/projects/ADP/issues/ADP-779
+--
+maxTokenBundleSerializedLengthBytes :: Int
+maxTokenBundleSerializedLengthBytes = 4096
 
 {-------------------------------------------------------------------------------
                       Address Encoding / Decoding

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -148,6 +148,7 @@ import qualified Cardano.Crypto.Wallet as Crypto.HD
 import qualified Cardano.Ledger.Core as SL
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString as BS
@@ -344,6 +345,8 @@ newTransactionLayer networkId = TransactionLayer
 
     , calcMinimumCoinValue =
         _calcMinimumCoinValue
+
+    , assessTokenBundleSize = Compatibility.assessTokenBundleSize
 
     , decodeSignedTx =
         _decodeSignedTx

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -346,7 +346,8 @@ newTransactionLayer networkId = TransactionLayer
     , calcMinimumCoinValue =
         _calcMinimumCoinValue
 
-    , assessTokenBundleSize = Compatibility.assessTokenBundleSize
+    , tokenBundleSizeAssessor =
+        Compatibility.tokenBundleSizeAssessor
 
     , decodeSignedTx =
         _decodeSignedTx

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -28,6 +28,8 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityMixed, shrinkTokenQuantityMixed )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( txOutMaxTokenQuantity, txOutMinTokenQuantity )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
     ( Convert (..), computeMinimumAdaQuantityInternal )
 import Control.Monad
@@ -278,26 +280,6 @@ newtype FixedSize64 a = FixedSize64 { unFixedSize64 :: a }
 
 newtype FixedSize256 a = FixedSize256 { unFixedSize256 :: a }
     deriving (Eq, Show)
-
---------------------------------------------------------------------------------
--- Constants
---------------------------------------------------------------------------------
-
--- | The smallest token quantity that can appear in a transaction output's
---   token bundle.
---
-txOutMinTokenQuantity :: TokenQuantity
-txOutMinTokenQuantity = TokenQuantity 1
-
--- | The greatest token quantity that can appear in a transaction output's
---   token bundle.
---
--- Although the ledger specification allows token quantities of unlimited
--- sizes, in practice we'll only see transaction outputs where the token
--- quantities are bounded by the size of a 'Word64'.
---
-txOutMaxTokenQuantity :: TokenQuantity
-txOutMaxTokenQuantity = TokenQuantity $ fromIntegral @Word64 $ maxBound
 
 --------------------------------------------------------------------------------
 -- Arbitraries

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -67,11 +67,10 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     , shrinkTokenBundleSmallRange
     )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TokenBundleSizeAssessment (..) )
+    ( TokenBundleSizeAssessment (..), TokenBundleSizeAssessor (..) )
 import Cardano.Wallet.Shelley.Compatibility
     ( CardanoBlock
     , StandardCrypto
-    , assessTokenBundleSize
     , computeTokenBundleSerializedLengthBytes
     , decentralizationLevelFromPParams
     , fromCardanoValue
@@ -83,6 +82,7 @@ import Cardano.Wallet.Shelley.Compatibility
     , toCardanoHash
     , toCardanoValue
     , toPoint
+    , tokenBundleSizeAssessor
     )
 import Cardano.Wallet.Unsafe
     ( unsafeMkEntropy )
@@ -385,7 +385,7 @@ unit_assessTokenBundleSize_fixedSizeBundle
             , actualLengthBytes <= expectedMaxLengthBytes
             ]
   where
-    actualAssessment = assessTokenBundleSize bundle
+    actualAssessment = assessTokenBundleSize tokenBundleSizeAssessor bundle
     actualLengthBytes = computeTokenBundleSerializedLengthBytes bundle
     counterexampleText = unlines
         [ "Expected min length bytes:"

--- a/nix/.stack.nix/cardano-numeric.nix
+++ b/nix/.stack.nix/cardano-numeric.nix
@@ -25,7 +25,11 @@
       };
     components = {
       "library" = {
-        depends = [ (hsPkgs."base" or (errorHandler.buildDepError "base")) ];
+        depends = [
+          (hsPkgs."base" or (errorHandler.buildDepError "base"))
+          (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+          (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
+          ];
         buildable = true;
         };
       tests = {

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -129,6 +129,7 @@
             (hsPkgs."cardano-addresses" or (errorHandler.buildDepError "cardano-addresses"))
             (hsPkgs."cardano-api" or (errorHandler.buildDepError "cardano-api"))
             (hsPkgs."cardano-crypto" or (errorHandler.buildDepError "cardano-crypto"))
+            (hsPkgs."cardano-numeric" or (errorHandler.buildDepError "cardano-numeric"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
             (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))


### PR DESCRIPTION
# Issue Number

ADP-727

# Overview

This PR has two main areas:

## Refactoring
- [x] Relocates all existing type-specific `equipartition` functions into the modules that define their types. We now have:
    | Module | Function |
    | -- | -- |
    | `Numeric.Util` | `equipartitionNatural` |
    | `Coin` | `equipartition` |
    | `TokenQuantity` | `equipartition` |
    | `TokenMap` | `equipartitionQuantities` |
    | `TokenMap` | `equipartitionQuantitiesWithUpperBound` |
    | `TokenBundle` | `equipartitionQuantitiesWithUpperBound` |
    
    **Justification:**
    - This PR will add **_more_** functions for splitting up bundles and maps, and the existing naming scheme was becoming too cumbersome to extend.
    - Equipartitioning a value of type `T` is something that relates to the definition of type `T`, so the natural home for such a function is within module `T`.
    
- [x] Adjusts `makeChange` to accept a record type, and unifies that type with `MakeChangeData` from the test suite.

    **Justification:**
    - Adding further arguments to this function is now less cumbersome, since the compiler will tell us that **_a field is missing_** in all the required call sites (both in implementation code and in test code), rather than producing a series of long type errors.
    - We cut down on some boilerplate from the test suite.

## New Functionality
- [x] Adds the following functions for equipartitioning the asset sets of maps and bundles:
    | Module | Function |
    | -- | -- |
    | `TokenMap` | `equipartitionAssets` |
    | `TokenBundle` | `equipartitionAssets` |
    
- [x] Adds an `assessBundleSize` parameter to `makeChange` and `performSelection`:
    ```hs
    assessBundleSize :: TokenBundle -> TokenBundleSizeAssessment
        
    data TokenBundleSizeAssessment
        = TokenBundleSizeWithinLimit
        -- ^ Indicates that the size of a token bundle does not exceed the maximum
        -- size that can be included in a transaction output.
        | TokenBundleSizeExceedsLimit
        -- ^ Indicates that the size of a token bundle exceeds the maximum size
        -- that can be included in a transaction output.
    ```
    
- [x] Adds function `splitBundlesWithExcessiveAssetCounts` to split change bundles with excessive asset counts, and calls it from `makeChange`.

- [x] Provides a definition of `assessTokenBundleSize` based on functionality exported by `Cardano.Api`.

## Testing

This PR adds:

- [x] Property tests for `equipartitionAssets` functions.  
- [x] Boundary unit tests for `performSelection` to show that change bundles are correctly split when they exceed the maximum size.
- [x] Unit tests for `Shelley.Compatibility.tokenBundleSizeAssessor` to verify that it gives sensible results for token bundles of various fixed sizes.
- [x] Property tests for `Shelley.Compatibility.tokenBundleSizeAssessor` to verify that it has the properties expected by `performSelection`.