### PR TITLE
Enhance go-jira scripts

### DIFF
--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -28,5 +28,17 @@ custom-commands:
 
   - name: release-notes-bugs
     help: Produce unresolved issues list for cardano-wallet release notes
+    options:
+      - name: minPriority
+        short: p
+        help: Minimum priority for query
+      - name: showPriority
+        type: bool
+        help: Also show priority and severity in the list
+        default: false
+      - name: minSeverity
+        help: Minimum priority for query
+        default: "(1, 2)"
+        hidden: true
     script: |-
-      {{jira}} list --template release-notes-bugs --query "type = Bug and resolution = Unresolved and project=$JIRA_PROJECT and component = cardano-wallet ORDER BY priority DESC, created"
+      {{ if options.showPriority }}showPriority=1{{ end }} {{jira}} list --template release-notes-bugs --query "project=$JIRA_PROJECT and component = cardano-wallet and type = Bug and resolution = Unresolved{{ if options.minPriority }} and priority >= {{options.minPriority}}{{end}}{{ if options.minSeverity }} and 'Severity / Probability Score' in {{options.minSeverity}}{{end}} ORDER BY priority DESC, created" --queryfields=priority,customfield_12502

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -13,8 +13,15 @@ project: ADP
 custom-commands:
   - name: bugs
     help: List unresolved bug tickets
+    options:
+      - name: query
+        short: q
+    args:
+      - name: terms
+        required: false
     script: |-
-      {{jira}} list --template table --query "type = Bug and resolution = Unresolved and project=$JIRA_PROJECT and component = cardano-wallet ORDER BY priority DESC, updated DESC, rank ASC, created"
+      set -x
+      {{jira}} list --template table --query "type = Bug and resolution = Unresolved and project=$JIRA_PROJECT and component = cardano-wallet{{ with args.terms }} and text ~ \"{{ args.terms }}\"{{ end }}{{ with options.query }} and {{ options.query }}{{ end }} ORDER BY priority DESC, updated DESC, rank ASC, created"
 
   - name: mine
     help: Display unresolved issues assigned to me

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -42,3 +42,18 @@ custom-commands:
         hidden: true
     script: |-
       {{ if options.showPriority }}showPriority=1{{ end }} {{jira}} list --template release-notes-bugs --query "project=$JIRA_PROJECT and component = cardano-wallet and type = Bug and resolution = Unresolved{{ if options.minPriority }} and priority >= {{options.minPriority}}{{end}}{{ if options.minSeverity }} and 'Severity / Probability Score' in {{options.minSeverity}}{{end}} ORDER BY priority DESC, created" --queryfields=priority,customfield_12502
+
+  - name: grab
+    help: Download all attachments of a ticket
+    args:
+      - name: ISSUE
+        required: true
+        help: Jira ticket key
+        type: STRING
+    options:
+      - name: overwrite
+        help: Overwrite existing files
+        type: BOOL
+        default: false
+    script: |-
+      {{jira}} attach list --template debug {{args.ISSUE}} | jq -r '.[]|{{ if not options.overwrite }}"test -s \(.filename|@sh) && echo '"'"'\(.filename) already exists'"'"' || " + {{end}}(["{{jira}}", "attach", "get", .id]|@sh)' | sh

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -42,9 +42,22 @@ custom-commands:
       {{jira}} sprint_base full | pandoc -f jira -t markdown
 
   - name: sprint
+    help: List issues in active sprint (table format)
+    script: |-
+      {{jira}} sprint_base table
+      echo
+      {{jira}} active-sprint
+
+  - name: sprint-list
     help: List issues in active sprint
     script: |-
       {{jira}} sprint_base list
+
+  - name: active-sprint
+    help: Show name of active sprint
+    script: |-
+      board_id=$({{jira}} req "/rest/agile/1.0/board?projectKeyOrId=$JIRA_PROJECT" --gjq 'values.0.id')
+      {{jira}} req "/rest/agile/1.0/board/$board_id/sprint?state=active" --gjq 'values.#[name%"*Week*"]' | jq -r '"Sprint:  \(.name)", "Start:   \(.startDate|sub("T.*"; ""))", "End:     \(.endDate|sub("T.*";""))"'
 
   - name: release-notes-bugs
     help: Produce unresolved issues list for cardano-wallet release notes

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -53,4 +53,19 @@ custom-commands:
   - name: assigned
     help: What tickets we are assigned to
     script: |-
-      {{jira}} list --template inprogress --query "project=$JIRA_PROJECT and statusCategory = 'In Progress' and assignee in ('rodney.lorrimar@iohk.io', 'pawel.jakubas@iohk.io', 'johannes.lund@iohk.io', 'jonathan.knowles@iohk.io', 'matthias.benkort@iohk.io', 'alex.apeldoorn@iohk.io', 'sergiy.savatyeyev@iohk.io') ORDER BY assignee ASC, updated DESC, rank ASC, created"
+      {{jira}} list --template debug --query "project=$JIRA_PROJECT and statusCategory = 'In Progress' and assignee in ('rodney.lorrimar@iohk.io', 'pawel.jakubas@iohk.io', 'johannes.lund@iohk.io', 'jonathan.knowles@iohk.io', 'matthias.benkort@iohk.io', 'alex.apeldoorn@iohk.io', 'sergiy.savatyeyev@iohk.io', 'simon.hafner@iohk.io') ORDER BY assignee ASC, updated DESC, rank ASC, created" | jq -r '[.issues[]|{key, summary: .fields.summary, type: .fields.issuetype.name, assignee: .fields.assignee.displayName, status: .fields.status.name}]|group_by(.assignee)[]|{assignee: .[0].assignee, issues: del(.[].assignee)}|[.assignee, (.issues[]|"- \(.key) (\(.type)) \(.summary) [\(.status)]"), ""]|join("\n")'
+
+  - name: grab
+    help: Download all attachments of a ticket
+    args:
+      - name: ISSUE
+        required: true
+        help: Jira ticket key
+        type: STRING
+    options:
+      - name: overwrite
+        help: Overwrite existing files
+        type: BOOL
+        default: false
+    script: |-
+      {{jira}} attach list --template debug {{args.ISSUE}} | jq -r '.[]|{{ if not options.overwrite }}"test -s \(.filename|@sh) && echo '"'"'\(.filename) already exists'"'"' || " + {{end}}(["{{jira}}", "attach", "get", .id]|@sh)' | sh

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -28,10 +28,23 @@ custom-commands:
     script: |-
       {{jira}} list --template table --query "resolution = Unresolved and assignee=currentuser() and project = $JIRA_PROJECT ORDER BY priority asc, created"
 
-  - name: sprint
-    help: Display issues for active sprint
+  - name: sprint_base
+    hidden: true
+    args:
+      - name: template
+        required: true
     script: |-
-      {{jira}} list --template table --query "sprint in openSprints() and type != epic and resolution = Unresolved and project=$JIRA_PROJECT ORDER BY rank asc, created"
+      {{jira}} list --template sprint-{{ args.template}} --query "project=$JIRA_PROJECT AND sprint IN openSprints() AND type != epic ORDER BY rank ASC, created" --queryfields=issuetype,summary,status,assignee,priority,customfield_12502,description,customfield_10023,customfield_10021
+
+  - name: sprint-full
+    help: Markdown dump of issues in active sprint
+    script: |-
+      {{jira}} sprint_base full | pandoc -f jira -t markdown
+
+  - name: sprint
+    help: List issues in active sprint
+    script: |-
+      {{jira}} sprint_base list
 
   - name: release-notes-bugs
     help: Produce unresolved issues list for cardano-wallet release notes
@@ -53,7 +66,7 @@ custom-commands:
   - name: assigned
     help: What tickets we are assigned to
     script: |-
-      {{jira}} list --template debug --query "project=$JIRA_PROJECT and statusCategory = 'In Progress' and assignee in ('rodney.lorrimar@iohk.io', 'pawel.jakubas@iohk.io', 'johannes.lund@iohk.io', 'jonathan.knowles@iohk.io', 'matthias.benkort@iohk.io', 'alex.apeldoorn@iohk.io', 'sergiy.savatyeyev@iohk.io', 'simon.hafner@iohk.io') ORDER BY assignee ASC, updated DESC, rank ASC, created" | jq -r '[.issues[]|{key, summary: .fields.summary, type: .fields.issuetype.name, assignee: .fields.assignee.displayName, status: .fields.status.name}]|group_by(.assignee)[]|{assignee: .[0].assignee, issues: del(.[].assignee)}|[.assignee, (.issues[]|"- \(.key) (\(.type)) \(.summary) [\(.status)]"), ""]|join("\n")'
+      {{jira}} list --template debug --query "project=$JIRA_PROJECT and statusCategory = 'In Progress' and assignee in ('rodney.lorrimar@iohk.io', 'pawel.jakubas@iohk.io', 'johannes.lund@iohk.io', 'jonathan.knowles@iohk.io', 'matthias.benkort@iohk.io', 'alex.apeldoorn@iohk.io', 'sergiy.savatyeyev@iohk.io', 'samuel.evans-powell@iohk.io') ORDER BY assignee ASC, updated DESC, rank ASC, created" | jq -r '[.issues[]|{key, summary: .fields.summary, type: .fields.issuetype.name, assignee: .fields.assignee.displayName, status: .fields.status.name}]|group_by(.assignee)[]|{assignee: .[0].assignee, issues: del(.[].assignee)}|[.assignee, (.issues[]|"- \(.key) (\(.type)) \(.summary) [\(.status)]"), ""]|join("\n")'
 
   - name: grab
     help: Download all attachments of a ticket

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -50,17 +50,7 @@ custom-commands:
     script: |-
       {{ if options.showPriority }}showPriority=1{{ end }} {{jira}} list --template release-notes-bugs --query "project=$JIRA_PROJECT and component = cardano-wallet and type = Bug and resolution = Unresolved{{ if options.minPriority }} and priority >= {{options.minPriority}}{{end}}{{ if options.minSeverity }} and 'Severity / Probability Score' in {{options.minSeverity}}{{end}} ORDER BY priority DESC, created" --queryfields=priority,customfield_12502
 
-  - name: grab
-    help: Download all attachments of a ticket
-    args:
-      - name: ISSUE
-        required: true
-        help: Jira ticket key
-        type: STRING
-    options:
-      - name: overwrite
-        help: Overwrite existing files
-        type: BOOL
-        default: false
+  - name: assigned
+    help: What tickets we are assigned to
     script: |-
-      {{jira}} attach list --template debug {{args.ISSUE}} | jq -r '.[]|{{ if not options.overwrite }}"test -s \(.filename|@sh) && echo '"'"'\(.filename) already exists'"'"' || " + {{end}}(["{{jira}}", "attach", "get", .id]|@sh)' | sh
+      {{jira}} list --template inprogress --query "project=$JIRA_PROJECT and statusCategory = 'In Progress' and assignee in ('rodney.lorrimar@iohk.io', 'pawel.jakubas@iohk.io', 'johannes.lund@iohk.io', 'jonathan.knowles@iohk.io', 'matthias.benkort@iohk.io', 'alex.apeldoorn@iohk.io', 'sergiy.savatyeyev@iohk.io') ORDER BY assignee ASC, updated DESC, rank ASC, created"

--- a/.jira.d/templates/edit
+++ b/.jira.d/templates/edit
@@ -32,6 +32,8 @@ fields:
 {{- if .meta.fields.priority }}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
     name: {{ or .overrides.priority .fields.priority.name "" }}{{end}}
+
+  # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
   description: |~
     {{ or .overrides.description .fields.description "" | indent 4 }}
 # votes: {{ .fields.votes.votes }}

--- a/.jira.d/templates/inprogress
+++ b/.jira.d/templates/inprogress
@@ -1,0 +1,13 @@
+{{- headers "Assignee" "Issue" "Summary" "Type" "Status" -}}
+{{- range .issues -}}
+  {{- row -}}
+  {{- if .fields.assignee -}}
+    {{- cell .fields.assignee.displayName -}}
+  {{- else -}}
+    {{- cell "<unassigned>" -}}
+  {{- end -}}
+  {{- cell .key -}}
+  {{- cell .fields.summary -}}
+  {{- cell .fields.issuetype.name -}}
+  {{- cell .fields.status.name -}}
+{{- end -}}

--- a/.jira.d/templates/release-notes-bugs
+++ b/.jira.d/templates/release-notes-bugs
@@ -1,4 +1,3 @@
 {{/* -*- mode: markdown -*- */ -}}
-{{ range .issues }}* {{ if .fields.priority }}[{{ .fields.priority.name }}]{{ end }} {{ .fields.summary }} ({{ .key }})
-
+{{ range .issues }}* {{ if (and env.showPriority .fields.priority) }}[{{ if .fields.customfield_12502.value }}S{{ .fields.customfield_12502.value }} {{end}}{{ .fields.priority.name }}] {{ end }}{{ .fields.summary }} ({{ .key }})
 {{ end }}

--- a/.jira.d/templates/sprint-full
+++ b/.jira.d/templates/sprint-full
@@ -1,0 +1,14 @@
+{{ range .issues }}
+h1. [{{ .key }}|https://jira.iohk.io/browse/{{ .key }}] {{ .fields.summary }}
+
+|Type|{{ .fields.issuetype.name }}|
+|Priority|{{ if .fields.priority }}{{ .fields.priority.name }}{{ end }}|
+|Severity|{{ if .fields.customfield_12502 }}{{ .fields.customfield_12502.value }}{{ else }}?{{ end }}|
+|Status  |{{ .fields.status.name }}|
+|Assignee|{{ if .fields.assignee }} {{ .fields.assignee.displayName }}{{ end }}|
+|Story points|{{ if .fields.customfield_10023 }}{{ .fields.customfield_10023 }}{{ else }}?{{ end }}|
+
+{{ .fields.description }}
+----
+
+{{ end }}

--- a/.jira.d/templates/sprint-list
+++ b/.jira.d/templates/sprint-list
@@ -1,0 +1,10 @@
+{{- range .issues -}}
+{{ .key }}       {{ .fields.summary }}
+Type          {{ .fields.issuetype.name }}
+Priority      {{ if .fields.priority }}{{ .fields.priority.name }}{{ end }}
+Severity      {{ if .fields.customfield_12502 }}{{ .fields.customfield_12502.value }}{{ else }}-{{ end }}
+Status        {{ .fields.status.name }}
+Assignee      {{ if .fields.assignee }}{{ .fields.assignee.displayName }}{{ end }}
+Story points  {{ if .fields.customfield_10023 }}{{ .fields.customfield_10023 }}{{ else }}?{{ end }}
+
+{{ end }}

--- a/.jira.d/templates/sprint-table
+++ b/.jira.d/templates/sprint-table
@@ -1,0 +1,28 @@
+{{- headers "Issue" "Summary" "Type" "Priority" "Severity" "Status" "Assignee" "Points" -}}
+{{- range .issues -}}
+  {{- row -}}
+  {{- cell .key -}}
+  {{- cell .fields.summary -}}
+  {{- cell .fields.issuetype.name -}}
+  {{- if .fields.priority -}}
+    {{- cell .fields.priority.name -}}
+  {{- else -}}
+    {{- cell "<none>" -}}
+  {{- end -}}
+  {{- if .fields.customfield_12502 -}}
+    {{- cell .fields.customfield_12502.value -}}
+  {{- else -}}
+    {{- cell "<none>" -}}
+  {{- end -}}
+  {{- cell .fields.status.name -}}
+  {{- if .fields.assignee -}}
+    {{- cell .fields.assignee.displayName -}}
+  {{- else -}}
+    {{- cell "<unassigned>" -}}
+  {{- end -}}
+  {{- if .fields.customfield_10023 -}}
+    {{- cell .fields.customfield_10023 -}}
+  {{- else -}}
+    {{- cell "?" -}}
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
- Change auto-generated known issues list in release notes to use Severity <= 2 instead of Priority.
- Add a script to dump the issue list of the current sprint.
- Add a script to download all attachments from a particular ticket.
- Add a script to show tickets assigned to each team member.
