### PR TITLE
Revert "TokenMetadata: Add ticker to unit"

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -187,7 +187,7 @@ steveToken = ApiAssetMetadata
     "SteveToken" "A sample description" (Just "STV")
     (Just (ApiT (unsafeFromText "https://iohk.io/stevetoken")))
     (Just (ApiT (W.AssetLogo "Almost a logo")))
-    (Just (ApiT (W.AssetUnit "MegaSteve" 6 Nothing)))
+    (Just (ApiT (W.AssetUnit "MegaSteve" 6)))
 
 ---
 --- Helpers

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -217,7 +217,6 @@ instance NFData AssetMetadata
 data AssetUnit = AssetUnit
     { name :: Text -- ^ Name of the larger asset.
     , decimals :: Natural  -- ^ Number of zeroes to add to base unit.
-    , ticker :: Maybe Text -- ^ Optional abbreviation of larger asset name
     } deriving (Generic, Show, Eq, Ord)
 
 instance NFData AssetUnit
@@ -279,14 +278,10 @@ validateMetadataURL = fmap AssetURL .
           | otherwise = Left $ "Scheme must be https: but got " ++ scheme
 
 validateMetadataUnit :: AssetUnit -> Either String AssetUnit
-validateMetadataUnit = validateName >=> validateTicker >=> validateDecimals
+validateMetadataUnit = validateName >=> validateDecimals
   where
     validateName u@AssetUnit{name} =
         (validateMinLength 1 name >>= validateMaxLength 30) $> u
-    validateTicker u@AssetUnit{ticker} =
-        case fmap validateMetadataTicker ticker of
-            Just (Left e) -> Left e
-            _ -> Right u
     validateDecimals u@AssetUnit{decimals}
         | decimals > 0 && decimals < 20 = Right u
         | otherwise =

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -584,7 +584,6 @@ instance FromJSON AssetUnit where
     parseJSON = withObject "AssetUnit" $ \o -> AssetUnit
         <$> o .: "name"
         <*> o .: "decimals"
-        <*> o .:? "ticker"
 
 --
 -- Helpers

--- a/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/TokenMetadataSpec.hs
@@ -82,7 +82,7 @@ spec = do
                     , Just (AssetMetadata "Token1" "description1" (Just "tck1") Nothing Nothing Nothing)
                     , Nothing
                     , Just (AssetMetadata "Token2" "description2" Nothing Nothing Nothing Nothing)
-                    , Just (AssetMetadata "Token3" "description3" Nothing Nothing Nothing (Just (AssetUnit "BigToken3" 3 (Just "tck3"))))
+                    , Just (AssetMetadata "Token3" "description3" Nothing Nothing Nothing (Just (AssetUnit "BigToken3" 3)))
                     ]
 
             it "golden3.json - Required WKP are invalid" $ do
@@ -154,7 +154,7 @@ spec = do
             (Just "acr2")
             (AssetURL <$> parseURI "https://iohk.io")
             (Just $ AssetLogo $ unsafeFromBase64 "QWxtb3N0IGEgbG9nbw==")
-            (Just $ AssetUnit "unit2" 14 Nothing)
+            (Just $ AssetUnit "unit2" 14)
     golden2File = dir </> "golden2.json"
 
     sig s k = Signature (unsafeFromHex s) (unsafeFromHex k)
@@ -206,7 +206,7 @@ spec = do
                 , Just $ Property (Right "acr2") [] 0
                 , Just $ Property (parseAssetURL "https://iohk.io") [] 0
                 , Just $ Property (Right (AssetLogo $ unsafeFromBase64 "QWxtb3N0IGEgbG9nbw==")) [] 0
-                , Just $ Property (Right (AssetUnit "unit2" 14 Nothing)) [] 0
+                , Just $ Property (Right (AssetUnit "unit2" 14)) [] 0
                 )
            }
         ]

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -563,8 +563,6 @@ x-assetMetadataUnit: &assetMetadataUnit
       description: |
         The human-readable name for the larger unit of the asset. Used
         for display in user interfaces.
-    ticker: *assetMetadataTicker
-
   example:
     name: API
     decimals: 3


### PR DESCRIPTION
### Issue Number

ADP-700

### Overview

Removes the ticker sub-field of unit - Daedalus don't need it.
