### PR TITLE
Validate user-specified output bundles when processing coin selection requests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -77,12 +77,19 @@ module Test.Integration.Framework.TestData
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     , errMsg403WrongIndex
+    , errMsg403TokenQuantityExceedsMaxBound
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiAssetMetadata (ApiAssetMetadata), ApiT (..) )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
+import Cardano.Wallet.Primitive.Types.TokenPolicy
+    ( TokenName, TokenPolicyId )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText )
 import Cardano.Wallet.Version
@@ -91,6 +98,8 @@ import Data.Text
     ( Text, pack, unpack )
 import Data.Word
     ( Word32 )
+import Fmt
+    ( pretty )
 import Test.Integration.Framework.DSL
     ( Payload (..), fixturePassphrase, json )
 
@@ -442,3 +451,30 @@ errMsg403WrongIndex :: String
 errMsg403WrongIndex = "It looks like you've provided a derivation index that is out of bound.\
      \ The index is well-formed, but I require indexes valid for hardened derivation only. That\
      \ is, indexes between 2147483648 and 4294967295 with a suffix 'H'."
+
+errMsg403TokenQuantityExceedsMaxBound
+    :: Address
+    -> TokenPolicyId
+    -> TokenName
+    -> TokenQuantity
+    -- ^ Specified token quantity
+    -> TokenQuantity
+    -- ^ Maximum allowable token quantity
+    -> String
+errMsg403TokenQuantityExceedsMaxBound
+    address policy asset quantity quantityMaxBound = mconcat
+        [ "One of the asset quantities you've specified is greater than the "
+        , "maximum quantity allowed in a single transaction output. Try "
+        , "splitting this quantity across two or more outputs. "
+        , "Destination address: "
+        , pretty address
+        , ". Token policy identifier: "
+        , pretty policy
+        , ". Asset name: "
+        , pretty asset
+        , ". Token quantity specified: "
+        , pretty quantity
+        , ". Maximum allowable token quantity: "
+        , pretty quantityMaxBound
+        , "."
+        ]

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -77,6 +77,7 @@ module Test.Integration.Framework.TestData
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     , errMsg403WrongIndex
+    , errMsg403TokenBundleSizeExceedsLimit
     , errMsg403TokenQuantityExceedsMaxBound
     ) where
 
@@ -451,6 +452,22 @@ errMsg403WrongIndex :: String
 errMsg403WrongIndex = "It looks like you've provided a derivation index that is out of bound.\
      \ The index is well-formed, but I require indexes valid for hardened derivation only. That\
      \ is, indexes between 2147483648 and 4294967295 with a suffix 'H'."
+
+errMsg403TokenBundleSizeExceedsLimit
+    :: Address
+    -> Int
+    -- ^ Asset count
+    -> String
+errMsg403TokenBundleSizeExceedsLimit
+    address assetCount = mconcat
+        [ "One of the outputs you've specified contains too many assets. "
+        , "Try splitting these assets across two or more outputs. "
+        , "Destination address: "
+        , pretty address
+        , ". Asset count: "
+        , pretty assetCount
+        , "."
+        ]
 
 errMsg403TokenQuantityExceedsMaxBound
     :: Address

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -77,8 +77,8 @@ module Test.Integration.Framework.TestData
     , errMsg403CouldntIdentifyAddrAsMine
     , errMsg503PastHorizon
     , errMsg403WrongIndex
-    , errMsg403TokenBundleSizeExceedsLimit
-    , errMsg403TokenQuantityExceedsMaxBound
+    , errMsg403OutputTokenBundleSizeExceedsLimit
+    , errMsg403OutputTokenQuantityExceedsLimit
     ) where
 
 import Prelude
@@ -453,12 +453,12 @@ errMsg403WrongIndex = "It looks like you've provided a derivation index that is 
      \ The index is well-formed, but I require indexes valid for hardened derivation only. That\
      \ is, indexes between 2147483648 and 4294967295 with a suffix 'H'."
 
-errMsg403TokenBundleSizeExceedsLimit
+errMsg403OutputTokenBundleSizeExceedsLimit
     :: Address
     -> Int
     -- ^ Asset count
     -> String
-errMsg403TokenBundleSizeExceedsLimit
+errMsg403OutputTokenBundleSizeExceedsLimit
     address assetCount = mconcat
         [ "One of the outputs you've specified contains too many assets. "
         , "Try splitting these assets across two or more outputs. "
@@ -469,7 +469,7 @@ errMsg403TokenBundleSizeExceedsLimit
         , "."
         ]
 
-errMsg403TokenQuantityExceedsMaxBound
+errMsg403OutputTokenQuantityExceedsLimit
     :: Address
     -> TokenPolicyId
     -> TokenName
@@ -478,9 +478,9 @@ errMsg403TokenQuantityExceedsMaxBound
     -> TokenQuantity
     -- ^ Maximum allowable token quantity
     -> String
-errMsg403TokenQuantityExceedsMaxBound
+errMsg403OutputTokenQuantityExceedsLimit
     address policy asset quantity quantityMaxBound = mconcat
-        [ "One of the asset quantities you've specified is greater than the "
+        [ "One of the token quantities you've specified is greater than the "
         , "maximum quantity allowed in a single transaction output. Try "
         , "splitting this quantity across two or more outputs. "
         , "Destination address: "

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/CoinSelections.hs
@@ -97,8 +97,8 @@ import Test.Integration.Framework.DSL
     )
 import Test.Integration.Framework.TestData
     ( errMsg400TxMetadataStringTooLong
-    , errMsg403TokenBundleSizeExceedsLimit
-    , errMsg403TokenQuantityExceedsMaxBound
+    , errMsg403OutputTokenBundleSizeExceedsLimit
+    , errMsg403OutputTokenQuantityExceedsLimit
     , errMsg404NoWallet
     , errMsg406
     , errMsg415
@@ -331,7 +331,7 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
                     @_ @'Shelley ctx sourceWallet (payment :| [])
             makeRequest >>= flip verify
                 [ expectResponseCode HTTP.status403
-                , expectErrorMessage $ errMsg403TokenQuantityExceedsMaxBound
+                , expectErrorMessage $ errMsg403OutputTokenQuantityExceedsLimit
                     (getApiT $ fst targetAddress)
                     (policyId)
                     (assetName)
@@ -364,7 +364,7 @@ spec = describe "SHELLEY_COIN_SELECTION" $ do
                     @_ @'Shelley ctx sourceWallet (payment :| [])
             makeRequest >>= flip verify
                 [ expectResponseCode HTTP.status403
-                , expectErrorMessage $ errMsg403TokenBundleSizeExceedsLimit
+                , expectErrorMessage $ errMsg403OutputTokenBundleSizeExceedsLimit
                     (getApiT $ fst targetAddress)
                     (assetCount)
                 ]

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -354,9 +354,9 @@ import Cardano.Wallet.TokenMetadata
     ( TokenMetadataClient, fillMetadata )
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
+    , ErrOutputTokenBundleSizeExceedsLimit (..)
+    , ErrOutputTokenQuantityExceedsLimit (..)
     , ErrSelectionCriteria (..)
-    , ErrTokenBundleSizeExceedsLimit (..)
-    , ErrTokenQuantityExceedsMaxBound (..)
     , TransactionCtx (..)
     , TransactionLayer
     , Withdrawal (..)
@@ -2873,11 +2873,11 @@ instance LiftHandler ErrSelectionCriteria where
     handler = \case
         ErrSelectionCriteriaOutputTokenBundleSizeExceedsLimit e ->
             handler e
-        ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound e ->
+        ErrSelectionCriteriaOutputTokenQuantityExceedsLimit e ->
             handler e
 
-instance LiftHandler ErrTokenBundleSizeExceedsLimit where
-    handler e = apiError err403 TokenBundleSizeExceedsLimit $ mconcat
+instance LiftHandler ErrOutputTokenBundleSizeExceedsLimit where
+    handler e = apiError err403 OutputTokenBundleSizeExceedsLimit $ mconcat
         [ "One of the outputs you've specified contains too many assets. "
         , "Try splitting these assets across two or more outputs. "
         , "Destination address: "
@@ -2887,9 +2887,9 @@ instance LiftHandler ErrTokenBundleSizeExceedsLimit where
         , "."
         ]
 
-instance LiftHandler ErrTokenQuantityExceedsMaxBound where
-    handler e = apiError err403 TokenQuantityExceedsMaxBound $ mconcat
-        [ "One of the asset quantities you've specified is greater than the "
+instance LiftHandler ErrOutputTokenQuantityExceedsLimit where
+    handler e = apiError err403 OutputTokenQuantityExceedsLimit $ mconcat
+        [ "One of the token quantities you've specified is greater than the "
         , "maximum quantity allowed in a single transaction output. Try "
         , "splitting this quantity across two or more outputs. "
         , "Destination address: "

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -355,6 +355,7 @@ import Cardano.Wallet.TokenMetadata
 import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrSelectionCriteria (..)
+    , ErrTokenBundleSizeExceedsLimit (..)
     , ErrTokenQuantityExceedsMaxBound (..)
     , TransactionCtx (..)
     , TransactionLayer
@@ -2870,8 +2871,21 @@ instance LiftHandler (ErrInvalidDerivationIndex 'Soft level) where
 
 instance LiftHandler ErrSelectionCriteria where
     handler = \case
+        ErrSelectionCriteriaOutputTokenBundleSizeExceedsLimit e ->
+            handler e
         ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound e ->
             handler e
+
+instance LiftHandler ErrTokenBundleSizeExceedsLimit where
+    handler e = apiError err403 TokenBundleSizeExceedsLimit $ mconcat
+        [ "One of the outputs you've specified contains too many assets. "
+        , "Try splitting these assets across two or more outputs. "
+        , "Destination address: "
+        , pretty (view #address e)
+        , ". Asset count: "
+        , pretty (view #assetCount e)
+        , "."
+        ]
 
 instance LiftHandler ErrTokenQuantityExceedsMaxBound where
     handler e = apiError err403 TokenQuantityExceedsMaxBound $ mconcat

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1084,6 +1084,7 @@ data ApiErrorCode
     | SoftDerivationRequired
     | HardenedDerivationRequired
     | AssetNotPresent
+    | TokenQuantityExceedsMaxBound
     deriving (Eq, Generic, Show, Data, Typeable)
     deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1084,8 +1084,8 @@ data ApiErrorCode
     | SoftDerivationRequired
     | HardenedDerivationRequired
     | AssetNotPresent
-    | TokenBundleSizeExceedsLimit
-    | TokenQuantityExceedsMaxBound
+    | OutputTokenBundleSizeExceedsLimit
+    | OutputTokenQuantityExceedsLimit
     deriving (Eq, Generic, Show, Data, Typeable)
     deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1084,6 +1084,7 @@ data ApiErrorCode
     | SoftDerivationRequired
     | HardenedDerivationRequired
     | AssetNotPresent
+    | TokenBundleSizeExceedsLimit
     | TokenQuantityExceedsMaxBound
     deriving (Eq, Generic, Show, Data, Typeable)
     deriving anyclass NFData

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -843,7 +843,7 @@ tokenBundleSizeExceedsLimit (TokenBundleSizeAssessor assess) b =
     case assess b of
         TokenBundleSizeWithinLimit->
             False
-        TokenBundleSizeExceedsLimit ->
+        OutputTokenBundleSizeExceedsLimit ->
             True
 
 -- | Constructs change bundles for a set of selected inputs and outputs.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -85,7 +85,7 @@ import Prelude
 import Algebra.PartialOrd
     ( PartialOrd (..) )
 import Cardano.Numeric.Util
-    ( padCoalesce, partitionNatural )
+    ( padCoalesce )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), addCoin, subtractCoin, sumCoins )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -143,6 +143,7 @@ import Numeric.Natural
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Cardano.Wallet.Primitive.Types.Tx as Tx
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
@@ -1176,20 +1177,15 @@ makeChangeForUserSpecifiedAsset
     -> (AssetId, TokenQuantity)
         -- ^ A surplus token quantity to distribute.
     -> NonEmpty TokenMap
-makeChangeForUserSpecifiedAsset targets (asset, TokenQuantity excess) =
-    let
-        partition = fromMaybe zeros (partitionNatural excess weights)
-    in
-        TokenMap.singleton asset . TokenQuantity <$> partition
+makeChangeForUserSpecifiedAsset targets (asset, excess) =
+    TokenMap.singleton asset <$>
+        fromMaybe zeros (TokenQuantity.partition excess weights)
   where
-    weights :: NonEmpty Natural
-    weights = byAsset asset <$> targets
-      where
-        byAsset :: AssetId -> TokenMap -> Natural
-        byAsset x = unTokenQuantity . flip TokenMap.getQuantity x
+    weights :: NonEmpty TokenQuantity
+    weights = flip TokenMap.getQuantity asset <$> targets
 
-    zeros :: NonEmpty Natural
-    zeros = 0 :| replicate (length targets - 1) 0
+    zeros :: NonEmpty TokenQuantity
+    zeros = TokenQuantity 0 <$ targets
 
 -- | Constructs change outputs for a non-user-specified asset: an asset that
 --   was not present in the original set of outputs.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1233,19 +1233,7 @@ makeChangeForCoin
     -> Coin
         -- ^ A surplus ada quantity to be distributed.
     -> NonEmpty Coin
-makeChangeForCoin targets excess =
-    -- The 'Natural -> Coin' conversion is safe, because 'partitionNatural'
-    -- guarantees to produce a list where every entry is less than or equal to
-    -- the target value.
-    maybe zeroWeightSum (fmap unsafeNaturalToCoin)
-        (partitionNatural (coinToNatural excess) weights)
-  where
-    zeroWeightSum :: HasCallStack => a
-    zeroWeightSum = error
-        "partitionValue: The specified weights must have a non-zero sum."
-
-    weights :: NonEmpty Natural
-    weights = coinToNatural <$> targets
+makeChangeForCoin = flip Coin.unsafePartition
 
 --------------------------------------------------------------------------------
 -- Splitting bundles

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -447,8 +447,8 @@ toTxHistory info =
 --    * Enlarging a bundle that exceeds the limit should also result in a
 --      bundle that exceeds the limit:
 --      @
---              f  b1           == TokenBundleSizeExceedsLimit
---          ==> f (b1 `add` b2) == TokenBundleSizeExceedsLimit
+--              f  b1           == OutputTokenBundleSizeExceedsLimit
+--          ==> f (b1 `add` b2) == OutputTokenBundleSizeExceedsLimit
 --      @
 --
 --    * Shrinking a bundle that's within the limit should also result in a
@@ -469,7 +469,7 @@ data TokenBundleSizeAssessment
     = TokenBundleSizeWithinLimit
     -- ^ Indicates that the size of a token bundle does not exceed the maximum
     -- size that can be included in a transaction output.
-    | TokenBundleSizeExceedsLimit
+    | OutputTokenBundleSizeExceedsLimit
     -- ^ Indicates that the size of a token bundle exceeds the maximum size
     -- that can be included in a transaction output.
     deriving (Eq, Generic, Show)

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -29,6 +30,7 @@ module Cardano.Wallet.Transaction
     , ErrMkTx (..)
     , ErrDecodeSignedTx (..)
     , ErrSelectionCriteria (..)
+    , ErrTokenBundleSizeExceedsLimit (..)
     , ErrTokenQuantityExceedsMaxBound (..)
 
     ) where
@@ -174,9 +176,19 @@ data DelegationAction = RegisterKeyAndJoin PoolId | Join PoolId | Quit
     deriving (Show, Eq, Generic)
 
 -- | Indicates a problem with the selection criteria for a coin selection.
-newtype ErrSelectionCriteria
-    = ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound
+data ErrSelectionCriteria
+    = ErrSelectionCriteriaOutputTokenBundleSizeExceedsLimit
+        ErrTokenBundleSizeExceedsLimit
+    | ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound
         ErrTokenQuantityExceedsMaxBound
+    deriving (Eq, Generic, Show)
+
+data ErrTokenBundleSizeExceedsLimit = ErrTokenBundleSizeExceedsLimit
+    { address :: !Address
+      -- ^ The address to which this token bundle was to be sent.
+    , assetCount :: !Int
+      -- ^ The number of assets within the token bundle.
+    }
     deriving (Eq, Generic, Show)
 
 -- | Indicates that a token quantity exceeds the maximum quantity that can

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -28,6 +28,9 @@ module Cardano.Wallet.Transaction
     -- * Errors
     , ErrMkTx (..)
     , ErrDecodeSignedTx (..)
+    , ErrSelectionCriteria (..)
+    , ErrTokenQuantityExceedsMaxBound (..)
+
     ) where
 
 import Prelude
@@ -49,7 +52,9 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( TokenMap )
+    ( AssetId, TokenMap )
+import Cardano.Wallet.Primitive.Types.TokenQuantity
+    ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx (..), TokenBundleSizeAssessor, Tx (..), TxMetadata, TxOut )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
@@ -96,7 +101,7 @@ data TransactionLayer k = TransactionLayer
             -- Available UTxO from which inputs should be selected.
         -> NonEmpty TxOut
             -- A list of target outputs
-        -> SelectionCriteria
+        -> Either ErrSelectionCriteria SelectionCriteria
 
     , calcMinimumCost
         :: ProtocolParameters
@@ -167,6 +172,27 @@ defaultTransactionCtx = TransactionCtx
 -- | Whether the user is attempting any particular delegation action.
 data DelegationAction = RegisterKeyAndJoin PoolId | Join PoolId | Quit
     deriving (Show, Eq, Generic)
+
+-- | Indicates a problem with the selection criteria for a coin selection.
+newtype ErrSelectionCriteria
+    = ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound
+        ErrTokenQuantityExceedsMaxBound
+    deriving (Eq, Generic, Show)
+
+-- | Indicates that a token quantity exceeds the maximum quantity that can
+--   appear in a transaction output's token bundle.
+--
+data ErrTokenQuantityExceedsMaxBound = ErrTokenQuantityExceedsMaxBound
+    { address :: !Address
+      -- ^ The address to which this token quantity was to be sent.
+    , asset :: !AssetId
+      -- ^ The asset identifier to which this token quantity corresponds.
+    , quantity :: !TokenQuantity
+      -- ^ The token quantity that exceeded the bound.
+    , quantityMaxBound :: !TokenQuantity
+      -- ^ The maximum allowable token quantity.
+    }
+    deriving (Eq, Generic, Show)
 
 -- | Error while trying to decode externally signed transaction
 data ErrDecodeSignedTx

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -30,8 +30,8 @@ module Cardano.Wallet.Transaction
     , ErrMkTx (..)
     , ErrDecodeSignedTx (..)
     , ErrSelectionCriteria (..)
-    , ErrTokenBundleSizeExceedsLimit (..)
-    , ErrTokenQuantityExceedsMaxBound (..)
+    , ErrOutputTokenBundleSizeExceedsLimit (..)
+    , ErrOutputTokenQuantityExceedsLimit (..)
 
     ) where
 
@@ -178,12 +178,12 @@ data DelegationAction = RegisterKeyAndJoin PoolId | Join PoolId | Quit
 -- | Indicates a problem with the selection criteria for a coin selection.
 data ErrSelectionCriteria
     = ErrSelectionCriteriaOutputTokenBundleSizeExceedsLimit
-        ErrTokenBundleSizeExceedsLimit
-    | ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound
-        ErrTokenQuantityExceedsMaxBound
+        ErrOutputTokenBundleSizeExceedsLimit
+    | ErrSelectionCriteriaOutputTokenQuantityExceedsLimit
+        ErrOutputTokenQuantityExceedsLimit
     deriving (Eq, Generic, Show)
 
-data ErrTokenBundleSizeExceedsLimit = ErrTokenBundleSizeExceedsLimit
+data ErrOutputTokenBundleSizeExceedsLimit = ErrOutputTokenBundleSizeExceedsLimit
     { address :: !Address
       -- ^ The address to which this token bundle was to be sent.
     , assetCount :: !Int
@@ -194,7 +194,7 @@ data ErrTokenBundleSizeExceedsLimit = ErrTokenBundleSizeExceedsLimit
 -- | Indicates that a token quantity exceeds the maximum quantity that can
 --   appear in a transaction output's token bundle.
 --
-data ErrTokenQuantityExceedsMaxBound = ErrTokenQuantityExceedsMaxBound
+data ErrOutputTokenQuantityExceedsLimit = ErrOutputTokenQuantityExceedsLimit
     { address :: !Address
       -- ^ The address to which this token quantity was to be sent.
     , asset :: !AssetId

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1499,7 +1499,7 @@ mkBundleSizeAssessor m = TokenBundleSizeAssessor $ case m of
             case assetCount `compare` upperLimit of
                 LT -> TokenBundleSizeWithinLimit
                 EQ -> TokenBundleSizeWithinLimit
-                GT -> TokenBundleSizeExceedsLimit
+                GT -> OutputTokenBundleSizeExceedsLimit
 
 isValidMakeChangeData :: MakeChangeData -> Bool
 isValidMakeChangeData p = (&&)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -1238,7 +1238,7 @@ tokenBundleSizeAssessor = W.TokenBundleSizeAssessor {..}
         | serializedLengthBytes <= maxTokenBundleSerializedLengthBytes =
             W.TokenBundleSizeWithinLimit
         | otherwise =
-            W.TokenBundleSizeExceedsLimit
+            W.OutputTokenBundleSizeExceedsLimit
       where
         serializedLengthBytes :: Int
         serializedLengthBytes = computeTokenBundleSerializedLengthBytes tb

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -123,9 +123,9 @@ import Cardano.Wallet.Transaction
     ( DelegationAction (..)
     , ErrDecodeSignedTx (..)
     , ErrMkTx (..)
+    , ErrOutputTokenBundleSizeExceedsLimit (..)
+    , ErrOutputTokenQuantityExceedsLimit (..)
     , ErrSelectionCriteria (..)
-    , ErrTokenBundleSizeExceedsLimit (..)
-    , ErrTokenQuantityExceedsMaxBound (..)
     , TransactionCtx (..)
     , TransactionLayer (..)
     , withdrawalToCoin
@@ -437,13 +437,13 @@ _initSelectionCriteria pp ctx utxoAvailable outputsUnprepared
             -- We encountered one or more excessively large token bundles.
             -- Just report the first such bundle:
             ErrSelectionCriteriaOutputTokenBundleSizeExceedsLimit $
-            ErrTokenBundleSizeExceedsLimit {address, assetCount}
+            ErrOutputTokenBundleSizeExceedsLimit {address, assetCount}
     | (address, asset, quantity) : _ <- excessiveTokenQuantities =
         Left $
             -- We encountered one or more excessive token quantities.
             -- Just report the first such quantity:
-            ErrSelectionCriteriaOutputTokenQuantityExceedsMaxBound $
-            ErrTokenQuantityExceedsMaxBound
+            ErrSelectionCriteriaOutputTokenQuantityExceedsLimit $
+            ErrOutputTokenQuantityExceedsLimit
                 { address
                 , asset
                 , quantity
@@ -468,7 +468,7 @@ _initSelectionCriteria pp ctx utxoAvailable outputsUnprepared
       where
         bundleIsExcessivelyLarge b = case assessSize b of
             TokenBundleSizeWithinLimit -> False
-            TokenBundleSizeExceedsLimit -> True
+            OutputTokenBundleSizeExceedsLimit -> True
           where
             assessSize =
                 assessTokenBundleSize Compatibility.tokenBundleSizeAssessor

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -374,11 +374,11 @@ prop_assessTokenBundleSize_enlarge
     -> Blind (VariableSize16 TokenBundle)
     -> Property
 prop_assessTokenBundleSize_enlarge b1' b2' =
-    assess b1 == TokenBundleSizeExceedsLimit ==> conjoin
+    assess b1 == OutputTokenBundleSizeExceedsLimit ==> conjoin
         [ assess (b1 `TokenBundle.add` b2)
-            === TokenBundleSizeExceedsLimit
+            === OutputTokenBundleSizeExceedsLimit
         , assess (b1 `TokenBundle.setCoin` maxBound)
-            === TokenBundleSizeExceedsLimit
+            === OutputTokenBundleSizeExceedsLimit
         ]
   where
     assess = assessTokenBundleSize tokenBundleSizeAssessor
@@ -462,14 +462,14 @@ unit_assessTokenBundleSize_fixedSizeBundle_64
     :: Blind (FixedSize64 TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_64 (Blind (FixedSize64 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeExceedsLimit
+        OutputTokenBundleSizeExceedsLimit
         4228 4748
 
 unit_assessTokenBundleSize_fixedSizeBundle_128
     :: Blind (FixedSize128 TokenBundle) -> Property
 unit_assessTokenBundleSize_fixedSizeBundle_128 (Blind (FixedSize128 b)) =
     unit_assessTokenBundleSize_fixedSizeBundle b
-        TokenBundleSizeExceedsLimit
+        OutputTokenBundleSizeExceedsLimit
         8452 9484
 
 toKeyHash :: Text -> Script KeyHash

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2693,6 +2693,33 @@ x-errInvalidCoinSelection: &errInvalidCoinSelection
       type: string
       enum: ['invalid_coin_selection']
 
+x-errTokenBundleSizeExceedsLimit: &errTokenBundleSizeExceedsLimit
+  <<: *responsesErr
+  title: token_bundle_size_exceeds_limit
+  properties:
+    message:
+      type: string
+      description: |
+        Returned when a user-specified transaction output contains a token
+        bundle whose serialized length is longer than the upper size limit
+        supported by the protocol.
+    code:
+      type: string
+      enum: ['token_bundle_size_exceeds_limit']
+
+x-errTokenQuantityExceedsMaxBound: &errTokenQuantityExceedsMaxBound
+  <<: *responsesErr
+  title: token_quantity_exceeds_max_bound
+  properties:
+    message:
+      type: string
+      description: |
+        Returned when a user-specified transaction output contains a token
+        quantity that exceeds the maximum bound supported by the protocol.
+    code:
+      type: string
+      enum: ['token_quantity_exceeds_max_bound']
+
 # TODO: Map this error to the place it belongs.
 x-errNetworkUnreachable: &errNetworkUnreachable
   <<: *responsesErr
@@ -3306,6 +3333,8 @@ x-responsesSelectCoins: &responsesSelectCoins
             - <<: *errCannotCoverFee
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
+            - <<: *errTokenQuantityExceedsMaxBound
+            - <<: *errTokenBundleSizeExceedsLimit
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   <<: *responsesErr415UnsupportedMediaType
@@ -3445,6 +3474,8 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
             - <<: *errNotEnoughMoney
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
+            - <<: *errTokenQuantityExceedsMaxBound
+            - <<: *errTokenBundleSizeExceedsLimit
             - <<: *errTransactionIsTooBig
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2693,32 +2693,33 @@ x-errInvalidCoinSelection: &errInvalidCoinSelection
       type: string
       enum: ['invalid_coin_selection']
 
-x-errTokenBundleSizeExceedsLimit: &errTokenBundleSizeExceedsLimit
+x-errOutputTokenBundleSizeExceedsLimit: &errOutputTokenBundleSizeExceedsLimit
   <<: *responsesErr
-  title: token_bundle_size_exceeds_limit
+  title: output_token_bundle_size_exceeds_limit
   properties:
     message:
       type: string
       description: |
         Returned when a user-specified transaction output contains a token
-        bundle whose serialized length is longer than the upper size limit
-        supported by the protocol.
+        bundle whose serialized length exceeds the limit supported by the
+        protocol.
     code:
       type: string
-      enum: ['token_bundle_size_exceeds_limit']
+      enum: ['output_token_bundle_size_exceeds_limit']
 
-x-errTokenQuantityExceedsMaxBound: &errTokenQuantityExceedsMaxBound
+x-errOutputTokenQuantityExceedsLimit: &errOutputTokenQuantityExceedsLimit
   <<: *responsesErr
-  title: token_quantity_exceeds_max_bound
+  title: output_token_quantity_exceeds_limit
   properties:
     message:
       type: string
       description: |
-        Returned when a user-specified transaction output contains a token
-        quantity that exceeds the maximum bound supported by the protocol.
+        Returned when a user-specified transaction output contains, for some
+        asset, a token quantity that exceeds the limit supported by the
+        protocol.
     code:
       type: string
-      enum: ['token_quantity_exceeds_max_bound']
+      enum: ['output_token_quantity_exceeds_limit']
 
 # TODO: Map this error to the place it belongs.
 x-errNetworkUnreachable: &errNetworkUnreachable
@@ -3333,8 +3334,8 @@ x-responsesSelectCoins: &responsesSelectCoins
             - <<: *errCannotCoverFee
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
-            - <<: *errTokenQuantityExceedsMaxBound
-            - <<: *errTokenBundleSizeExceedsLimit
+            - <<: *errOutputTokenQuantityExceedsLimit
+            - <<: *errOutputTokenBundleSizeExceedsLimit
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   <<: *responsesErr415UnsupportedMediaType
@@ -3474,8 +3475,8 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
             - <<: *errNotEnoughMoney
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
-            - <<: *errTokenQuantityExceedsMaxBound
-            - <<: *errTokenBundleSizeExceedsLimit
+            - <<: *errOutputTokenQuantityExceedsLimit
+            - <<: *errOutputTokenBundleSizeExceedsLimit
             - <<: *errTransactionIsTooBig
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406


### PR DESCRIPTION
# Issue Number

ADP-727
ADP-782

# Overview

This PR adds validation to coin selection requests, checking all **user-specified outputs** meet the following pre-conditions:

- output bundles do not include token quantities in excess of the maximum bound:
    `maxBound :: Word64`
- output bundles, when serialized, are within the size limit specified by the protocol:
    `4000` bytes
    
If either of the above pre-conditions are violated, an API error is returned, with a message that informs the user how they can solve the problem (usually by breaking up bundles into smaller bundles):

- `ErrOutputTokenBundleSizeExceedsLimit`
- `ErrOutputTokenQuantityExceedsLimit`

# Testing

This PR adds integration tests for both of the above scenarios:

- `WALLETS_COIN_SELECTION_07`
- `WALLETS_COIN_SELECTION_08`

# Refactoring

This PR also performs a small refactoring in the same spirit as the refactorings included in PR #2552.

We extract out `partition` functions for `Coin` and `TokenQuantity` values into the modules that define their types, similarly to the `X.equipartition` functions.