### PR TITLE
Print results to stdOut instead of stdErr in restoration benchmark

### DIFF
--- a/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
+++ b/lib/core-integration/src/Cardano/Wallet/BenchShared.hs
@@ -88,7 +88,7 @@ import Options.Applicative
     , value
     )
 import Say
-    ( sayErr )
+    ( say )
 import System.Directory
     ( createDirectoryIfMissing )
 import System.Environment
@@ -258,18 +258,18 @@ runBenchmarks bs = do
     -- NOTE: Adding an artificial delay between successive runs to get a better
     -- output for the heap profiling.
     rs <- forM bs $ \io -> io <* let _2s = 2000000 in threadDelay _2s
-    sayErr "\n\nAll results:"
-    mapM_ (sayErr . pretty) rs
+    say "\n\nAll results:"
+    mapM_ (say . pretty) rs
 
 bench :: NFData a => Text -> IO a -> IO (a, Time)
 bench benchName action = do
-    sayErr $ "Running " <> benchName
+    say $ "Running " <> benchName
     start <- getTime
     res <- action
     evaluate (rnf res)
     finish <- getTime
     let t = Time $ finish - start
-    (res, t) <$ sayErr (pretty $ nameF (build benchName) (build t))
+    (res, t) <$ say (pretty $ nameF (build benchName) (build t))
 
 initBenchmarkLogging :: Text -> Severity -> IO (CM.Configuration, Trace IO Text)
 initBenchmarkLogging name minSeverity = do


### PR DESCRIPTION
# Issue Number

ADP-804


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] Print results to stdOut instead of stdErr in restoration benchmark

# Comments

It seems that results that should go to restoration-mainnet.txt file are printed to stdErr, which is for some reason not picked up. Trying to print them to stdOut and run benchmark on this branch to see if this helps...