### PR TITLE
Nightly restore bench: Make buildkite red if it fails

### DIFF
--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -89,3 +89,9 @@ if [ -n "${BUILDKITE:-}" ]; then
   echo "+++ Restore plot"
   printf '\033]1338;url='"artifact://plot.svg"';alt='"Restore plot"'\a\n'
 fi
+
+if [ -z "$(cat $results)" ]; then
+  echo "+++ Bad news"
+  echo "FAILED - Missing results" > /dev/stderr
+  exit 1
+fi


### PR DESCRIPTION
### Issue Number

ADP-804

### Overview

If the nightly restore bench fails to produce a result, then make sure Buildkite has a red status.
