### PR TITLE
Database changes for resubmission of pending transactions

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -34,6 +34,7 @@ module Cardano.DB.Sqlite
     -- * Helpers
     , chunkSize
     , dbChunked
+    , dbChunkedFor
     , dbChunked'
     , handleConstraint
     , unsafeRunQuery
@@ -617,7 +618,16 @@ dbChunked
     => ([record] -> SqlPersistT IO b)
     -> [record]
     -> SqlPersistT IO ()
-dbChunked = chunkedM (chunkSizeFor @record)
+dbChunked = dbChunkedFor @record
+
+-- | Like 'dbChunked', but generalized for the case where the input list is not
+-- the same type as the record.
+dbChunkedFor
+    :: forall record a b. PersistEntity record
+    => ([a] -> SqlPersistT IO b)
+    -> [a]
+    -> SqlPersistT IO ()
+dbChunkedFor = chunkedM (chunkSizeFor @record)
 
 -- | Like 'dbChunked', but allows bundling elements with a 'Key'. Useful when
 -- used with 'repsertMany'.

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -187,6 +187,7 @@ import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.DB
     ( DBLayer (..)
+    , ErrNoSuchTransaction (..)
     , ErrNoSuchWallet (..)
     , ErrRemoveTx (..)
     , ErrWalletAlreadyExists (..)
@@ -1695,7 +1696,7 @@ getTransaction ctx wid tid = db & \DBLayer{..} -> do
         Left err -> do
             throwE (ErrGetTransactionNoSuchWallet err)
         Right Nothing -> do
-            let err' = ErrNoSuchTransaction tid
+            let err' = ErrNoSuchTransaction wid tid
             throwE (ErrGetTransactionNoSuchTransaction err')
         Right (Just tx) ->
             pure tx
@@ -2222,10 +2223,6 @@ data ErrListTransactions
 data ErrGetTransaction
     = ErrGetTransactionNoSuchWallet ErrNoSuchWallet
     | ErrGetTransactionNoSuchTransaction ErrNoSuchTransaction
-    deriving (Show, Eq)
-
--- | Indicates that the specified transaction hash is not found.
-newtype ErrNoSuchTransaction = ErrNoSuchTransaction (Hash "Tx")
     deriving (Show, Eq)
 
 -- | Indicates that the specified start time is later than the specified end

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2864,7 +2864,7 @@ instance IsServerError ErrSubmitExternalTx where
 instance IsServerError ErrRemoveTx where
     toServerError = \case
         ErrRemoveTxNoSuchWallet wid -> toServerError wid
-        ErrRemoveTxNoSuchTransaction tid ->
+        ErrRemoveTxNoSuchTransaction (ErrNoSuchTransaction _wid tid) ->
             apiError err404 NoSuchTransaction $ mconcat
                 [ "I couldn't find a transaction with the given id: "
                 , toText tid
@@ -2942,7 +2942,7 @@ instance IsServerError ErrGetTransaction where
 
 instance IsServerError ErrNoSuchTransaction where
     toServerError = \case
-        ErrNoSuchTransaction tid ->
+        ErrNoSuchTransaction _wid tid ->
             apiError err404 NoSuchTransaction $ mconcat
                 [ "I couldn't find a transaction with the given id: "
                 , toText tid

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -37,7 +37,6 @@ import Cardano.Wallet.DB.Model
     , mIsStakeKeyRegistered
     , mListCheckpoints
     , mListWallets
-    , mPrune
     , mPutCheckpoint
     , mPutDelegationCertificate
     , mPutDelegationRewardBalance
@@ -117,9 +116,7 @@ newDBLayer timeInterpreter = do
             alterDB errNoSuchWallet db $
             mRollbackTo pk pt
 
-        , prune = \pk epochStability -> ExceptT $
-                alterDB errNoSuchWallet db $
-                mPrune pk epochStability
+        , prune = \_ _ -> error "MVar.prune: not implemented"
 
         {-----------------------------------------------------------------------
                                    Wallet Metadata
@@ -156,6 +153,7 @@ newDBLayer timeInterpreter = do
                     range
                     mstatus
 
+        -- TODO: shift implementation to mGetTx
         , getTx = \pk tid -> ExceptT $
             alterDB errNoSuchWallet db (mCheckWallet pk) >>= \case
                 Left err -> pure $ Left err

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -184,6 +184,7 @@ LocalTxSubmission
 
     UniqueLocalTxSubmission localTxSubmissionTxId localTxSubmissionWalletId
     Primary localTxSubmissionTxId localTxSubmissionWalletId
+    Foreign TxMeta OnDeleteCascade fk_tx_meta localTxSubmissionTxId localTxSubmissionWalletId
     deriving Show Generic
 
 -- A checkpoint for a given wallet is referred to by (wallet_id, slot).

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -172,6 +172,20 @@ TxWithdrawal
     Primary txWithdrawalTxId txWithdrawalAccount
     deriving Show Generic
 
+-- | Transactions sent to the node by LocalTxSubmission.
+-- Submission will be retried until the transaction is no longer pending.
+-- Accepted transactions will be stored in this table until they can no longer be
+-- rolled back.
+LocalTxSubmission
+    localTxSubmissionTxId       TxId         sql=tx_id
+    localTxSubmissionWalletId   W.WalletId   sql=wallet_id
+    localTxSubmissionLastSlot   SlotNo       sql=last_slot
+    localTxSubmissionTx         W.SealedTx   sql=tx
+
+    UniqueLocalTxSubmission localTxSubmissionTxId localTxSubmissionWalletId
+    Primary localTxSubmissionTxId localTxSubmissionWalletId
+    deriving Show Generic
+
 -- A checkpoint for a given wallet is referred to by (wallet_id, slot).
 -- Volatile checkpoint data such as AD state will refer to this table.
 Checkpoint

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -70,7 +70,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Direction (..), TxMetadata, TxStatus (..) )
+    ( Direction (..), SealedTx (..), TxMetadata, TxStatus (..) )
 import Control.Arrow
     ( left )
 import Control.Monad
@@ -244,7 +244,8 @@ instance PathPiece WalletId where
 ----------------------------------------------------------------------------
 -- TxId
 
--- Wraps Hash "Tx" because the persistent dsl doesn't like (Hash "Tx")
+-- | Wraps 'Hash "Tx"' because the persistent entity syntax doesn't seem to
+-- support parameterized types.
 newtype TxId = TxId { getTxId :: Hash "Tx" } deriving (Show, Eq, Ord, Generic)
 
 instance PersistField TxId where
@@ -434,6 +435,16 @@ instance PersistField TxMetadata where
 
 instance PersistFieldSql TxMetadata where
     sqlType _ = sqlType (Proxy @Text)
+
+----------------------------------------------------------------------------
+-- SealedTx - store the serialised tx as a binary blob
+
+instance PersistField SealedTx where
+    toPersistValue = toPersistValue . getSealedTx
+    fromPersistValue = fmap SealedTx . fromPersistValue
+
+instance PersistFieldSql SealedTx where
+    sqlType _ = sqlType (Proxy @ByteString)
 
 ----------------------------------------------------------------------------
 -- Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -14,7 +14,10 @@
 --
 -- Types and functions relating to hash values.
 --
-module Cardano.Wallet.Primitive.Types.Hash where
+module Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..)
+    , hashFromText
+    ) where
 
 import Prelude
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -448,7 +449,7 @@ data LocalTxSubmissionStatus tx = LocalTxSubmissionStatus
     -- ^ Time of first successful submission to the local node.
     , latestSubmission :: !SlotNo
     -- ^ Time of most recent resubmission attempt.
-    } deriving (Generic, Show, Eq)
+    } deriving stock (Generic, Show, Eq, Functor)
 
 -- | A function capable of assessing the size of a token bundle relative to the
 --   upper limit of what can be included in a single transaction output.

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -73,7 +73,6 @@ import Cardano.Wallet.DB.Model
     , WalletDatabase (..)
     , emptyDatabase
     , mCleanDB
-    , mGetTx
     , mInitializeWallet
     , mIsStakeKeyRegistered
     , mListCheckpoints
@@ -425,8 +424,11 @@ runMock = \case
     ReadTxHistory wid minW order range status ->
         first (Resp . fmap TxHistory)
         . mReadTxHistory timeInterpreter wid minW order range status
-    GetTx wid tid ->
-        first (Resp . fmap (TxHistory . maybe [] pure)) . mGetTx wid tid
+    GetTx _wid _tid ->
+        first (Resp . fmap (TxHistory . maybe [] pure))
+        -- TODO: Implement mGetTx
+        -- . mGetTx wid tid
+        . (Right Nothing,)
     PutLocalTxSubmission wid tid sl ->
         first (Resp . fmap Unit)
         . mPutLocalTxSubmission wid tid (unMockSealedTx tid) sl
@@ -714,6 +716,9 @@ generatorWithWid wids =
         $ ReadPrivateKey <$> genId
     , declareGenerator "RollbackTo" 1
         $ RollbackTo <$> genId <*> arbitrary
+    -- TODO: Implement mPrune
+    -- , declareGenerator "Prune" 1
+    --     $ Prune <$> genId <*> arbitrary
     , declareGenerator "ReadGenesisParameters" 1
         $ ReadGenesisParameters <$> genId
     ]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -62,7 +62,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxIn (..)
     , TxMeta (direction)
     , TxOut (..)
-    , txId
     , txIns
     , txOutCoin
     )

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -104,7 +104,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMetadata
     , TxOut (..)
     , TxStatus (..)
-    , txId
     , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.UTxO

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4993,6 +4993,11 @@ paths:
         <p align="right">status: <strong>stable</strong></p>
 
         Submits a transaction that was created and signed outside of cardano-wallet.
+
+        NOTE: Unlike the postTransaction endpoint, there are no
+        guarantees that a transaction accepted by this endpoint will
+        actually be included in the chain. It's up to the caller to
+        retry submission until the transaction is confirmed.
       requestBody:
         content:
           application/octet-stream:


### PR DESCRIPTION
### Issue Number

ADP-764

### Overview

Database layer support for transaction resubmission.

   - [x] Adds a new table with serialized transactions, and the latest slot that they have been submitted at.
   - [x] Add DBLayer method to list pending transactions for resubmissions
   - [x] Add DBLayer method to add a submitted transaction to the pool of transactions.
   - [x] Update db model and state machine tests with generators for new methods
   - [x] Swagger update

The wallet layer and server changes are in PR #2611.
