### PR TITLE
Log to stderr for (>= Notice) and tweak severities

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1580,9 +1580,8 @@ data LogOutput
     = LogToStdStreams Severity
     -- ^ Log to console, with the given minimum 'Severity'.
     --
-    -- Logs of Notice or higher severity will be output to stderr. Info or lower
-    -- severity logs will be output to stdout.
-    --
+    -- Logs of Warning or higher severity will be output to stderr. Notice or
+    -- lower severity logs will be output to stdout.
     | LogToFile FilePath Severity
     deriving (Eq, Show)
 
@@ -1598,8 +1597,8 @@ mkScribe (LogToFile path sev) = pure $ ScribeDefinition
     , scRotation = Nothing
     }
 mkScribe (LogToStdStreams sev) =
-    [ mkScribe' (max Notice sev, maxBound, StderrSK)
-    , mkScribe' (sev, pred Notice, StdoutSK)
+    [ mkScribe' (max Warning sev, maxBound, StderrSK)
+    , mkScribe' (sev, pred Warning, StdoutSK)
     ]
   where
     mkScribe' (minSev, maxSev, kind) = ScribeDefinition

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1577,22 +1577,18 @@ data Verbosity
     deriving (Eq, Show)
 
 data LogOutput
-    = LogToStdout Severity
+    = LogToStdStreams Severity
+    -- ^ Log to console, with the given minimum 'Severity'.
+    --
+    -- Logs of Notice or higher severity will be output to stderr. Info or lower
+    -- severity logs will be output to stdout.
+    --
     | LogToFile FilePath Severity
     deriving (Eq, Show)
 
 
-mkScribe :: LogOutput -> ScribeDefinition
-mkScribe (LogToStdout sev) = ScribeDefinition
-    { scName = "text"
-    , scFormat = ScText
-    , scKind = StdoutSK
-    , scMinSev = sev
-    , scMaxSev = Critical
-    , scPrivacy = ScPublic
-    , scRotation = Nothing
-    }
-mkScribe (LogToFile path sev) = ScribeDefinition
+mkScribe :: LogOutput -> [ScribeDefinition]
+mkScribe (LogToFile path sev) = pure $ ScribeDefinition
     { scName = T.pack path
     , scFormat = ScText
     , scKind = FileSK
@@ -1601,10 +1597,25 @@ mkScribe (LogToFile path sev) = ScribeDefinition
     , scPrivacy = ScPublic
     , scRotation = Nothing
     }
+mkScribe (LogToStdStreams sev) =
+    [ mkScribe' (max Notice sev, maxBound, StderrSK)
+    , mkScribe' (sev, pred Notice, StdoutSK)
+    ]
+  where
+    mkScribe' (minSev, maxSev, kind) = ScribeDefinition
+        { scName = "text"
+        , scFormat = ScText
+        , scKind = kind
+        , scMinSev = minSev
+        , scMaxSev = maxSev
+        , scPrivacy = ScPublic
+        , scRotation = Nothing
+        }
 
-mkScribeId :: LogOutput -> ScribeId
-mkScribeId (LogToStdout _) = "StdoutSK::text"
-mkScribeId (LogToFile file _) = T.pack $ "FileSK::" <> file
+
+mkScribeId :: LogOutput -> [ScribeId]
+mkScribeId (LogToStdStreams _) = ["StdoutSK::text", "StderrSK::text"]
+mkScribeId (LogToFile file _) = pure $ T.pack $ "FileSK::" <> file
 
 getPrometheusURL :: IO (Maybe (String, Port "Prometheus"))
 getPrometheusURL = do
@@ -1649,8 +1660,8 @@ initTracer loggerName outputs = do
         c <- defaultConfigStdout
         CM.setSetupBackends c [CM.KatipBK, CM.AggregationBK, CM.EKGViewBK, CM.EditorBK]
         CM.setDefaultBackends c [CM.KatipBK]
-        CM.setSetupScribes c $ map mkScribe outputs
-        CM.setDefaultScribes c $ map mkScribeId outputs
+        CM.setSetupScribes c $ outputs >>= mkScribe
+        CM.setDefaultScribes c $ outputs >>= mkScribeId
         CM.setBackends c "test-cluster.metrics" (Just [CM.EKGViewBK])
         CM.setBackends c "cardano-wallet.metrics" (Just [CM.EKGViewBK])
         forM_ ekgHP $ \(h, p) -> do

--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1597,10 +1597,11 @@ mkScribe (LogToFile path sev) = pure $ ScribeDefinition
     , scRotation = Nothing
     }
 mkScribe (LogToStdStreams sev) =
-    [ mkScribe' (max Warning sev, maxBound, StderrSK)
-    , mkScribe' (sev, pred Warning, StdoutSK)
+    [ mkScribe' (max errMin sev, maxBound, StderrSK)
+    , mkScribe' (sev, pred errMin, StdoutSK)
     ]
   where
+    errMin = Warning
     mkScribe' (minSev, maxSev, kind) = ScribeDefinition
         { scName = "text"
         , scFormat = ScText

--- a/lib/core/src/Network/Ntp.hs
+++ b/lib/core/src/Network/Ntp.hs
@@ -147,8 +147,9 @@ instance HasSeverityAnnotation NtpTrace where
         NtpTraceClientStartQuery -> Debug
         NtpTraceNoLocalAddr -> Notice
         NtpTraceResult (NtpDrift micro)
-            | abs micro < 500000 -> Debug
-            | otherwise          -> Notice
+            | abs micro < (500*ms)  -> Debug   -- Not sure what limits actually
+            | abs micro < (1000*ms) -> Notice  -- matter, but these seem
+            | otherwise             -> Warning -- reasonable.
         NtpTraceResult _ -> Debug
         NtpTraceRunProtocolResults _ -> Debug
         NtpTracePacketSent _ _ -> Debug
@@ -156,6 +157,8 @@ instance HasSeverityAnnotation NtpTrace where
         NtpTracePacketDecodeError _ _ -> Notice
         NtpTracePacketReceived _ _ -> Debug
         NtpTraceWaitingForRepliesTimeout _ -> Notice
+      where
+        ms = 1000
 
 getNtpStatus
     :: NtpClient

--- a/lib/core/src/Network/Ntp.hs
+++ b/lib/core/src/Network/Ntp.hs
@@ -139,14 +139,17 @@ instance ToText NtpTrace where
 instance HasPrivacyAnnotation NtpTrace
 instance HasSeverityAnnotation NtpTrace where
     getSeverityAnnotation ev = case ev of
-        NtpTraceStartNtpClient -> Info
-        NtpTraceRestartDelay _ -> Info
-        NtpTraceRestartingClient -> Info
+        NtpTraceStartNtpClient -> Debug
+        NtpTraceRestartDelay _ -> Debug
+        NtpTraceRestartingClient -> Debug
         NtpTraceIOError _ -> Notice
         NtpTraceLookupsFails -> Notice
-        NtpTraceClientStartQuery -> Info
+        NtpTraceClientStartQuery -> Debug
         NtpTraceNoLocalAddr -> Notice
-        NtpTraceResult _ -> Info
+        NtpTraceResult (NtpDrift micro)
+            | abs micro < 500000 -> Debug
+            | otherwise          -> Notice
+        NtpTraceResult _ -> Debug
         NtpTraceRunProtocolResults _ -> Debug
         NtpTracePacketSent _ _ -> Debug
         NtpTracePacketSendError _ _ -> Notice

--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -345,14 +345,14 @@ logMessage :: ApiLog -> Maybe Text
 logMessage (ApiLog _ theMsg) = case theMsg of
     LogRequestStart -> Just "LogRequestStart"
     LogRequestFinish -> Just "LogRequestFinish"
-    LogResponse _ Nothing -> Nothing
+    LogResponse _ _ Nothing -> Nothing
     _ -> Just (toText theMsg)
 
 -- | Extract the execution time, in microseconds, from a log request.
 -- Returns 'Nothing' if the log line doesn't contain any time indication.
 captureTime :: ApiLog -> Maybe Int
 captureTime (ApiLog _ theMsg) = case theMsg of
-    LogResponse time _ ->
+    LogResponse time _ _ ->
         Just $ round $ toMicro $ realToFrac @_ @Double time
     _ ->
         Nothing

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -314,7 +314,7 @@ withTracers
     -> (Trace IO MainLog -> Tracers IO -> IO a)
     -> IO a
 withTracers logOpt action =
-    withLogging [LogToStdout (loggingMinSeverity logOpt)] $ \(sb, (cfg, tr)) -> do
+    withLogging [LogToStdStreams (loggingMinSeverity logOpt)] $ \(sb, (cfg, tr)) -> do
         ekgEnabled >>= flip when (EKG.plugin cfg tr sb >>= loadPlugin sb)
         let trMain = appendName "main" (transformTextTrace tr)
         let tracers = setupTracers (loggingTracers logOpt) tr

--- a/lib/shelley/exe/local-cluster.hs
+++ b/lib/shelley/exe/local-cluster.hs
@@ -294,7 +294,7 @@ withLocalClusterSetup action = do
         withSystemTempDir stdoutTextTracer "test-cluster" $ \dir -> do
             let logOutputs name minSev =
                     [ LogToFile (dir </> name) (min minSev Info)
-                    , LogToStdout minSev ]
+                    , LogToStdStreams minSev ]
 
             clusterLogs <- logOutputs "cluster.log" <$> testMinSeverityFromEnv
             walletLogs <- logOutputs "wallet.log" <$> walletMinSeverityFromEnv

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -262,7 +262,7 @@ nodeMinSeverityFromEnv =
 -- @CARDANO_WALLET_TRACING_MIN_SEVERITY@ environment variable.
 walletMinSeverityFromEnv :: IO Severity
 walletMinSeverityFromEnv =
-    minSeverityFromEnv Critical "CARDANO_WALLET_TRACING_MIN_SEVERITY"
+    minSeverityFromEnv Warning "CARDANO_WALLET_TRACING_MIN_SEVERITY"
 
 -- Allow configuring integration tests and wallet log level with
 -- @TESTS_TRACING_MIN_SEVERITY@ environment variable.

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -398,7 +398,7 @@ withTracers testDir action = do
             logDir <- fromMaybe testDir <$> testLogDirFromEnv
             pure
                 [ LogToFile (logDir </> name) (min minSev Info)
-                , LogToStdout minSev
+                , LogToStdStreams minSev
                 ]
 
     walletLogOutputs <- getLogOutputs walletMinSeverityFromEnv "wallet.log"


### PR DESCRIPTION
# Issue Number

ADP-630


# Overview

- [x] Log `>= Warning` to stderr and `< Warning` to stdout, such that they can be redirected to separate files
- [x] Tweaked the severities some messages

# Comments

- We could allow logging config via CLI, but do we really need it?
- I had a somewhat handwritten aggregation logic draft for the pool worker, but I didn't add include it in this PR. Maybe we should use iohk-monitoring for it instead.

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
