### PR TITLE
Create completely new TVars in LoggingSpec

### DIFF
--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -91,7 +91,7 @@ import Servant
 import Servant.Server
     ( Handler )
 import Test.Hspec
-    ( Spec, after, afterAll, beforeAll, describe, it, shouldBe, shouldContain )
+    ( Spec, after, before, describe, it, shouldBe, shouldContain )
 import Test.QuickCheck
     ( Arbitrary (..), choose, counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
@@ -112,7 +112,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 
 spec :: Spec
 spec = describe "Logging Middleware"
-    $ beforeAll setup $ after clearLogs $ afterAll tearDown $ do
+    $ before setup $ after tearDown $ do
     it "GET, 200, no query" $ \ctx -> do
         get ctx "/get"
         expectLogs ctx
@@ -296,9 +296,6 @@ skipPrevLogs = dropWhile (notLogRequestStart . logMsg)
 -- ensure that /all/ the response logs are captured before checking assertions.
 waitForServerToComplete :: IO ()
 waitForServerToComplete = threadDelay 500_000
-
-clearLogs :: Context -> IO ()
-clearLogs = atomically . flip writeTVar [] . logs
 
 {-------------------------------------------------------------------------------
                                 Test Helpers


### PR DESCRIPTION
# Issue Number

#2368 


# Overview


- Use different TVars in LoggingSpec. 
    - It seems the flakiness is caused by different test runs interfering with each other. Using a new TVar each run should hopefully fix it.


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
