### PR TITLE
Fix nightly benchmarks

### DIFF
--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -764,7 +764,7 @@ waitForNodeSync
     => Tracer IO (BenchmarkLog n)
     -> NetworkLayer IO Block
     -> IO SlotNo
-waitForNodeSync tr nw = loop 10
+waitForNodeSync tr nw = loop 120 -- allow 30 minutes for first tip
   where
     loop :: Int -> IO SlotNo
     loop retries = do
@@ -788,7 +788,7 @@ waitForNodeSync tr nw = loop 10
                  traceWith tr $ MsgRetryShortly delay
                  threadDelay delay
                  loop (retries - 1)
-            else throwString "Gave up waitForNodeSync"
+            else throwString "Gave up in waitForNodeSync, waiting a tip"
 
 data BenchmarkLog (n :: NetworkDiscriminant)
     = MsgNodeTipTick BlockHeader SyncProgress


### PR DESCRIPTION
### Issue Number

ADP-804

### Overview

Nightly restore bench is still failing.

1. Restore bench: Increase cardano-node startup time allowance

   If the cardano-node database is shared between bench runs, it may need to rebuild the ledger, etc, at startup. So increase the time available for that.

2. Latency bench: Fix working directory

   The meaning of `$src` seems to have changed since the Haskell.nix bump in PR #2533.

3. DB Bench: I broke the criterion env setup - fixed now.

