### PR TITLE
bump actions/cache to v2.1.4 in e2e workflows

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Cache node db
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: ~/node-db-nightly-docker
         key: ${{ runner.os }}-node-cache

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Cache node db
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: test/e2e/state/node_db
         key: ${{ runner.os }}-node-cache

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Cache node db
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: test/e2e/state/node_db
         key: ${{ runner.os }}-node-cache

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Cache node db
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.4
       with:
         path: test/e2e/state/node_db
         key: ${{ runner.os }}-node-cache


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have bumped actions/cache to fix caching issue on Windows workflow


# Comments

Currently caching of node-db in Windows workflow [fails](https://github.com/input-output-hk/cardano-wallet/runs/2179176487?check_suite_focus=true) and as a result run takes ~3.5h instead of modest ~1h.
Apparently the issue(https://github.com/actions/cache/issues/468) is fixed in actions/cache@v2.1.4