### PR TITLE
Cleanup unused NetworkLayer errors and logic

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -146,7 +146,6 @@ module Cardano.Wallet
     , ErrListTransactions (..)
     , ErrGetTransaction (..)
     , ErrNoSuchTransaction (..)
-    , ErrNetworkUnavailable (..)
     , ErrStartTimeLaterThanEndTime (..)
 
     -- ** Root Key
@@ -190,7 +189,6 @@ import Cardano.Wallet.DB
     )
 import Cardano.Wallet.Network
     ( ErrGetAccountBalance (..)
-    , ErrNetworkUnavailable (..)
     , ErrPostTx (..)
     , FollowAction (..)
     , FollowExit (..)
@@ -1009,8 +1007,6 @@ queryRewardBalance ctx acct = do
         Right x -> Right x
         Left (ErrGetAccountBalanceAccountNotFound _) ->
             Right $ Coin 0
-        Left (ErrGetAccountBalanceNetworkUnreachable e) ->
-            Left $ ErrFetchRewardsNetworkUnreachable e
 
 manageRewardBalance
     :: forall ctx s k (n :: NetworkDiscriminant).
@@ -2189,9 +2185,8 @@ data ErrQuitStakePool
     deriving (Generic, Eq, Show)
 
 -- | Errors that can occur when fetching the reward balance of a wallet
-data ErrFetchRewards
-    = ErrFetchRewardsNetworkUnreachable ErrNetworkUnavailable
-    | ErrFetchRewardsReadRewardAccount ErrReadRewardAccount
+newtype ErrFetchRewards
+    = ErrFetchRewardsReadRewardAccount ErrReadRewardAccount
     deriving (Generic, Eq, Show)
 
 data ErrCheckWalletIntegrity

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -238,7 +238,7 @@ import Cardano.Wallet.Compat
 import Cardano.Wallet.DB
     ( DBFactory (..) )
 import Cardano.Wallet.Network
-    ( ErrNetworkUnavailable (..), NetworkLayer, timeInterpreter )
+    ( NetworkLayer, timeInterpreter )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DelegationAddress (..)
     , Depth (..)
@@ -2619,8 +2619,6 @@ instance LiftHandler ErrDecodeSignedTx where
 instance LiftHandler ErrSubmitExternalTx where
     handler = \case
         ErrSubmitExternalTxNetwork e -> case e of
-            ErrPostTxNetworkUnreachable e' ->
-                handler e'
             ErrPostTxBadRequest err ->
                 apiError err500 CreatedInvalidTransaction $ mconcat
                     [ "That's embarrassing. It looks like I've created an "
@@ -2659,7 +2657,6 @@ instance LiftHandler ErrRemoveTx where
 
 instance LiftHandler ErrPostTx where
     handler = \case
-        ErrPostTxNetworkUnreachable e -> handler e
         ErrPostTxBadRequest err ->
             apiError err500 CreatedInvalidTransaction $ mconcat
             [ "That's embarrassing. It looks like I've created an "
@@ -2685,19 +2682,6 @@ instance LiftHandler ErrSubmitTx where
             { errHTTPCode = 404
             , errReasonPhrase = errReasonPhrase err404
             }
-
-instance LiftHandler ErrNetworkUnavailable where
-    handler = \case
-        ErrNetworkUnreachable _err ->
-            apiError err503 NetworkUnreachable $ mconcat
-                [ "The node backend is unreachable at the moment. Trying again "
-                , "in a bit might work."
-                ]
-        ErrNetworkInvalid n ->
-            apiError err503 NetworkMisconfigured $ mconcat
-                [ "The node backend is configured for the wrong network: "
-                , n, "."
-                ]
 
 instance LiftHandler ErrUpdatePassphrase where
     handler = \case
@@ -2764,7 +2748,6 @@ instance LiftHandler ErrJoinStakePool where
 instance LiftHandler ErrFetchRewards where
     handler = \case
         ErrFetchRewardsReadRewardAccount e -> handler e
-        ErrFetchRewardsNetworkUnreachable e -> handler e
 
 instance LiftHandler ErrReadRewardAccount where
     handler = \case

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -224,26 +224,11 @@ mapCursor fn = \case
 -- | @FollowAction@ enables the callback of @follow@ to signal if the
 -- chain-following should @ExitWith@, @Continue@, or if the current callback
 -- should be forgotten and retried (@Retry@).
---
--- NOTE: @Retry@ is needed to handle data-races in
--- 'Cardano.Pool.Jormungandr.Metrics', where it is essensial that we fetch the
--- stake distribution while the node-tip
---
--- FIXME:
--- Retry actions with the Haskell nodes are not possible (or at least, requires
--- some additional manipulation to find a new intersection). As a possible fix,
--- we could use a type family to define 'FollowAction' in terms of the
--- underlying target. 'RetryImmediately' and 'RetryLater' could be authorized in
--- the context of Jormungandr but absent in the context of the Haskell nodes.
 data FollowAction err
     = ExitWith err
       -- ^ Stop following the chain.
     | Continue
       -- ^ Continue following the chain.
-    | RetryImmediately
-      -- ^ Forget about the blocks in the current callback, and retry immediately.
-    | RetryLater
-      -- ^ Like 'RetryImmediately' but only retries after a short delay
     deriving (Eq, Show, Functor)
 
 -- | Possibly scenarios that would cause 'follow' to exit so that client code
@@ -360,10 +345,6 @@ follow nl tr cps yield header =
                 return FollowDone
             Continue ->
                 step hrf cursor'
-            RetryImmediately ->
-                step hrf cursor
-            RetryLater ->
-                sleep delay0 hrf cursor
 
 {-------------------------------------------------------------------------------
                                     Logging

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -21,9 +21,6 @@ module Cardano.Wallet.Network
     , FollowExit (..)
 
     -- * Errors
-    , ErrNetworkUnavailable (..)
-    , ErrGetBlock (..)
-    , ErrGetTxParameters (..)
     , ErrPostTx (..)
     , ErrGetAccountBalance (..)
 
@@ -53,8 +50,6 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -62,7 +57,7 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Control.Monad
     ( when )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), runExceptT )
+    ( ExceptT (..) )
 import Control.Retry
     ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay )
 import Control.Tracer
@@ -92,7 +87,7 @@ import qualified Data.Text as T
 data NetworkLayer m block = NetworkLayer
     { nextBlocks
         :: Cursor
-        -> ExceptT ErrGetBlock m (NextBlocksResult Cursor block)
+        -> IO (NextBlocksResult Cursor block)
         -- ^ Starting from the given 'Cursor', fetches a contiguous sequence of
         -- blocks from the node, if they are available. An updated cursor will
         -- be returned with a 'RollFoward' result.
@@ -168,38 +163,16 @@ instance Functor m => Functor (NetworkLayer m) where
                                   Errors
 -------------------------------------------------------------------------------}
 
--- | Network is unavailable
-data ErrNetworkUnavailable
-    = ErrNetworkUnreachable Text
-      -- ^ Cannot connect to network backend.
-    | ErrNetworkInvalid Text
-      -- ^ Network backend reports that the requested network is invalid.
-    deriving (Generic, Show, Eq)
-
--- | Error while trying to get one or more blocks
-data ErrGetBlock
-    = ErrGetBlockNetworkUnreachable ErrNetworkUnavailable
-    | ErrGetBlockNotFound (Hash "BlockHeader")
-    deriving (Generic, Show, Eq)
-
--- | Error while querying local parameters state.
-data ErrGetTxParameters
-    = ErrGetTxParametersNetworkUnreachable ErrNetworkUnavailable
-    | ErrGetTxParametersNotFound
-    deriving (Generic, Show, Eq)
-
 -- | Error while trying to send a transaction
 data ErrPostTx
-    = ErrPostTxNetworkUnreachable ErrNetworkUnavailable
-    | ErrPostTxBadRequest Text
+    = ErrPostTxBadRequest Text
     | ErrPostTxProtocolFailure Text
     deriving (Generic, Show, Eq)
 
 instance Exception ErrPostTx
 
-data ErrGetAccountBalance
-    = ErrGetAccountBalanceNetworkUnreachable ErrNetworkUnavailable
-    | ErrGetAccountBalanceAccountNotFound RewardAccount
+newtype ErrGetAccountBalance
+    = ErrGetAccountBalanceAccountNotFound RewardAccount
     deriving (Generic, Eq, Show)
 
 {-------------------------------------------------------------------------------
@@ -315,17 +288,13 @@ follow nl tr cps yield header =
     delay0 :: Int
     delay0 = 500*1000 -- 500ms
 
-    retryDelay :: Int -> Int
-    retryDelay 0 = delay0
-    retryDelay delay = min (2*delay) (10 * delay0)
-
     -- | Wait a short delay before querying for blocks again. We also take this
     -- opportunity to refresh the chain tip as it has probably increased in
     -- order to refine our syncing status.
     sleep :: Int -> Bool -> Cursor -> IO FollowExit
     sleep delay hasRolledForward cursor = handle exitOnAnyException $ do
         when (delay > 0) (threadDelay delay)
-        step delay hasRolledForward cursor
+        step hasRolledForward cursor
       where
         -- Any unhandled synchronous exception should be logged and cause the
         -- chain follower to exit.
@@ -334,28 +303,24 @@ follow nl tr cps yield header =
             traceWith tr $ MsgUnhandledException $ T.pack $ show e
             pure FollowFailure
 
-    step :: Int -> Bool -> Cursor -> IO FollowExit
-    step delay hasRolledForward cursor = runExceptT (nextBlocks nl cursor) >>= \case
-        Left e -> do
-            traceWith tr $ MsgNextBlockFailed e
-            sleep (retryDelay delay) hasRolledForward cursor
-
-        Right AwaitReply -> do
+    step :: Bool -> Cursor -> IO FollowExit
+    step hasRolledForward cursor = nextBlocks nl cursor >>= \case
+        AwaitReply -> do
             traceWith tr MsgSynced
             sleep delay0 hasRolledForward cursor
 
-        Right (RollForward cursor' _ []) -> do -- FIXME Make RollForward return NE
+        RollForward cursor' _ [] -> do -- FIXME Make RollForward return NE
             traceWith tr MsgSynced
             sleep delay0 hasRolledForward cursor'
 
-        Right (RollForward cursor' tip (blockFirst : blocksRest)) -> do
+        RollForward cursor' tip (blockFirst : blocksRest) -> do
             let blocks = blockFirst :| blocksRest
             traceWith tr $ MsgApplyBlocks tip (header <$> blocks)
             action <- yield blocks tip
             traceWith tr $ MsgFollowAction (fmap show action)
             continueWith cursor' True action
 
-        Right (RollBackward cursor') ->
+        RollBackward cursor' ->
             -- After negotiating a tip, the node asks us to rollback to the
             -- intersection. We may have to rollback to our /current/ tip.
             --
@@ -373,11 +338,11 @@ follow nl tr cps yield header =
                     -- we can ignore it.
                     traceWith tr $ MsgWillIgnoreRollback sl "initial rollback, \
                         \cps=[]"
-                    step delay0 hasRolledForward cursor'
+                    step hasRolledForward cursor'
                 (sl, _:_, False) | sl == slotNo (last cps) -> do
                     traceWith tr $ MsgWillIgnoreRollback sl "initial rollback, \
                         \rollback point equals the last checkpoint"
-                    step delay0 hasRolledForward cursor'
+                    step hasRolledForward cursor'
                 (sl, _, _) -> do
                     traceWith tr $ MsgWillRollback sl
                     destroyCursor nl cursor' $> FollowRollback sl
@@ -394,9 +359,9 @@ follow nl tr cps yield header =
             ExitWith _ -> -- NOTE error logged as part of `MsgFollowAction`
                 return FollowDone
             Continue ->
-                step delay0 hrf cursor'
+                step hrf cursor'
             RetryImmediately ->
-                step delay0 hrf cursor
+                step hrf cursor
             RetryLater ->
                 sleep delay0 hrf cursor
 
@@ -407,7 +372,6 @@ follow nl tr cps yield header =
 data FollowLog
     = MsgFollowAction (FollowAction String)
     | MsgUnhandledException Text
-    | MsgNextBlockFailed ErrGetBlock
     | MsgSynced
     | MsgApplyBlocks BlockHeader (NonEmpty BlockHeader)
     | MsgWillRollback SlotNo
@@ -421,8 +385,6 @@ instance ToText FollowLog where
             _ -> T.pack $ "Follower says " <> show action
         MsgUnhandledException err ->
             "Unexpected error following the chain: " <> err
-        MsgNextBlockFailed e ->
-            T.pack $ "Failed to get next blocks: " <> show e
         MsgSynced ->
             "In sync with the node."
         MsgApplyBlocks tipHdr hdrs ->
@@ -447,7 +409,6 @@ instance HasSeverityAnnotation FollowLog where
         MsgFollowAction (ExitWith _) -> Error
         MsgFollowAction _ -> Debug
         MsgUnhandledException _ -> Error
-        MsgNextBlockFailed _ -> Warning
         MsgSynced -> Debug
         MsgApplyBlocks _ _ -> Info
         MsgWillRollback _ -> Debug

--- a/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/NetworkSpec.hs
@@ -5,26 +5,13 @@ module Cardano.Wallet.NetworkSpec
 import Prelude
 
 import Cardano.Wallet.Network
-    ( ErrGetBlock (..), ErrNetworkUnavailable (..), ErrPostTx (..) )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
+    ( ErrPostTx (..) )
 import Test.Hspec
     ( Spec, describe, it )
 
 spec :: Spec
 spec = do
     describe "Pointless tests to cover 'Show' instances for errors" $ do
-        testShow $ ErrNetworkUnreachable mempty
-        testShow $ ErrNetworkInvalid mempty
-        testShow $ ErrGetBlockNetworkUnreachable
-            $ ErrNetworkUnreachable mempty
-        testShow $ ErrGetBlockNetworkUnreachable
-            $ ErrNetworkInvalid mempty
-        testShow $ ErrGetBlockNotFound $ Hash mempty
-        testShow $ ErrPostTxNetworkUnreachable
-            $ ErrNetworkUnreachable mempty
-        testShow $ ErrPostTxNetworkUnreachable
-            $ ErrNetworkInvalid mempty
         testShow $ ErrPostTxBadRequest mempty
         testShow $ ErrPostTxProtocolFailure mempty
 


### PR DESCRIPTION
# Issue Number

ADP-630

# Overview


- [x] Remove unused `ErrNetworkUnavailable `, `ErrGetBlock`, `ErrGetTxParameters`
    - Does call into question what would happen if the node were to disconnect etc...
- [x] Remove `RetryImmediately` and `RetryLater` from `follow`, which were needed only for jormungandr 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
