### PR TITLE
Update latency benchmarks

### DIFF
--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -305,7 +305,7 @@ walletApiBench capture ctx = do
         fmtResult "listTransactions   " t5
 
         (_, txs) <- unsafeRequest @[ApiTransaction n] ctx (Link.listTransactions @'Shelley wal1) Empty
-        let txid = (txs !! 0) ^. #id
+        let txid = (head txs) ^. #id
         t5a <- measureApiLogs capture
             (request @[ApiTransaction n] ctx (Link.getTransaction @'Shelley wal1 (ApiTxId txid)) Default Empty)
         fmtResult "getTransaction     " t5a

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -29,6 +29,7 @@ import Cardano.Startup
     ( withUtf8Encoding )
 import Cardano.Wallet.Api.Types
     ( ApiAddress
+    , ApiAsset (..)
     , ApiFee
     , ApiNetworkInformation
     , ApiStakePool
@@ -66,10 +67,13 @@ import Cardano.Wallet.Shelley.Launch.Cluster
     ( LocalClusterConfig (..)
     , LogFileConfig (..)
     , RunningNode (..)
+    , sendFaucetAssetsTo
     , sendFaucetFundsTo
     , walletListenFromEnv
     , withCluster
     )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromText )
 import Control.Arrow
     ( first )
 import Control.Monad
@@ -78,6 +82,8 @@ import Control.Monad.IO.Class
     ( liftIO )
 import Data.Aeson
     ( Value )
+import Data.Bifunctor
+    ( bimap )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
 import Data.Proxy
@@ -99,7 +105,7 @@ import System.FilePath
 import Test.Hspec
     ( shouldBe )
 import Test.Integration.Faucet
-    ( shelleyIntegrationTestFunds )
+    ( maryIntegrationTestAssets, shelleyIntegrationTestFunds )
 import Test.Integration.Framework.DSL
     ( Context (..)
     , Headers (..)
@@ -110,11 +116,14 @@ import Test.Integration.Framework.DSL
     , expectSuccess
     , expectWalletUTxO
     , faucetAmt
+    , fixtureMultiAssetWallet
     , fixturePassphrase
     , fixtureWallet
     , fixtureWalletWith
     , json
     , minUTxOValue
+    , mkTxPayloadMA
+    , pickAnAsset
     , request
     , runResourceT
     , unsafeRequest
@@ -198,10 +207,11 @@ walletApiBench capture ctx = do
     fmtTitle "CURRENTLY DISABLED. SEE #2006 & #2051"
   where
 
-    -- Creates n fixture wallets and return two of them
+    -- Creates n fixture wallets and return 3 of them
     nFixtureWallet n = do
         wal1 : wal2 : _ <- replicateM n (fixtureWallet ctx)
-        pure (wal1, wal2)
+        walMA <- fixtureMultiAssetWallet ctx
+        pure (wal1, wal2, walMA)
 
     -- Creates n fixture wallets and send 1-ada transactions to one of them
     -- (m times). The money is sent in batches (see batchSize below) from
@@ -209,7 +219,7 @@ walletApiBench capture ctx = do
     -- to be accommodated in recipient wallet. After that the source fixture
     -- wallet is removed.
     nFixtureWalletWithTxs n m = do
-        (wal1, wal2) <- nFixtureWallet n
+        (wal1, wal2, walMA) <- nFixtureWallet n
 
         let amt = minUTxOValue
         let batchSize = 10
@@ -224,12 +234,12 @@ walletApiBench capture ctx = do
         let expInflows' = filter (/=0) expInflows
 
         mapM_ (repeatPostTx wal1 amt batchSize . amtExp) expInflows'
-        pure (wal1, wal2)
+        pure (wal1, wal2, walMA)
 
     nFixtureWalletWithUTxOs n utxoNumber = do
         let utxoExp = replicate utxoNumber minUTxOValue
         wal1 <- fixtureWalletWith @n ctx utxoExp
-        (_, wal2) <- nFixtureWallet n
+        (_, wal2, walMA) <- nFixtureWallet n
 
         eventually "Wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet ctx
@@ -245,7 +255,7 @@ walletApiBench capture ctx = do
                 (Link.getUTxOsStatistics @'Shelley wal1) Default Empty
         expectResponseCode HTTP.status200 rStat
         expectWalletUTxO (fromIntegral <$> utxoExp) (snd rStat)
-        pure (wal1, wal2)
+        pure (wal1, wal2, walMA)
 
     repeatPostTx wDest amtToSend batchSize amtExp = do
         wSrc <- fixtureWallet ctx
@@ -281,7 +291,7 @@ walletApiBench capture ctx = do
         expectResponseCode HTTP.status202 r
         return r
 
-    runScenario scenario = runResourceT $ scenario >>= \(wal1, wal2) -> liftIO $ do
+    runScenario scenario = runResourceT $ scenario >>= \(wal1, wal2, walMA) -> liftIO $ do
         t1 <- measureApiLogs capture
             (request @[ApiWallet] ctx (Link.listWallets @'Shelley) Default Empty)
         fmtResult "listWallets        " t1
@@ -356,14 +366,31 @@ walletApiBench capture ctx = do
             (Link.createTransaction @'Shelley wal2) Default payloadTxTo5Addr
         fmtResult "postTransTo5Addrs  " t7a
 
+        let assetsToSend = walMA ^. #assets . #total . #getApiT
+        let val = minUTxOValue <$ pickAnAsset assetsToSend
+        payloadMA <- mkTxPayloadMA @n destination (2*minUTxOValue) [val] fixturePassphrase
+        t7b <- measureApiLogs capture $ request @(ApiTransaction n) ctx
+            (Link.createTransaction @'Shelley walMA) Default payloadMA
+        fmtResult "postTransactionMA  " t7b
+
         t8 <- measureApiLogs capture $ request @[ApiStakePool] ctx
             (Link.listStakePools arbitraryStake) Default Empty
-
         fmtResult "listStakePools     " t8
 
         t9 <- measureApiLogs capture $ request @ApiNetworkInformation ctx
             Link.getNetworkInfo Default Empty
         fmtResult "getNetworkInfo     " t9
+
+        t10 <- measureApiLogs capture $ request @([ApiAsset]) ctx
+            (Link.listAssets walMA) Default Empty
+        fmtResult "listMultiAssets    " t10
+
+        let assetsSrc = walMA ^. #assets . #total . #getApiT
+        let (polId, assName) = bimap unsafeFromText unsafeFromText $ fst $
+                pickAnAsset assetsSrc
+        t11 <- measureApiLogs capture $ request @([ApiAsset]) ctx
+            (Link.getAsset walMA polId assName) Default Empty
+        fmtResult "getMultiAsset      " t11
 
         pure ()
      where
@@ -420,7 +447,9 @@ withShelleyServer tracers action = do
     setupFaucet conn dir = do
         let encodeAddr = T.unpack . encodeAddress @'Mainnet
         let addresses = map (first encodeAddr) shelleyIntegrationTestFunds
+        let addressesMA = map (first encodeAddr) (maryIntegrationTestAssets (Coin 10_000_000))
         sendFaucetFundsTo nullTracer conn dir addresses
+        sendFaucetAssetsTo nullTracer conn dir 20 addressesMA
 
     onClusterStart act dir db (RunningNode conn block0 (np, vData)) = do
         listen <- walletListenFromEnv

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -33,6 +33,7 @@ import Cardano.Wallet.Api.Types
     , ApiNetworkInformation
     , ApiStakePool
     , ApiTransaction
+    , ApiTxId (..)
     , ApiUtxoStatistics
     , ApiWallet
     , EncodeAddress (..)
@@ -300,6 +301,12 @@ walletApiBench capture ctx = do
         t5 <- measureApiLogs capture
             (request @[ApiTransaction n] ctx (Link.listTransactions @'Shelley wal1) Default Empty)
         fmtResult "listTransactions   " t5
+
+        (_, txs) <- unsafeRequest @[ApiTransaction n] ctx (Link.listTransactions @'Shelley wal1) Empty
+        let txid = (txs !! 0) ^. #id
+        t5a <- measureApiLogs capture
+            (request @[ApiTransaction n] ctx (Link.getTransaction @'Shelley wal1 (ApiTxId txid)) Default Empty)
+        fmtResult "getTransaction     " t5a
 
         (_, addrs) <- unsafeRequest @[ApiAddress n] ctx (Link.listAddresses @'Shelley wal2) Empty
         let amt = minUTxOValue

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -195,16 +195,8 @@ walletApiBench capture ctx = do
     fmtTitle "Latencies for 2 fixture wallets with 500 utxos scenario"
     runScenario (nFixtureWalletWithUTxOs 2 500)
 
-    {-- PENDING: Fee estimation is taking way longer than it should and this
-       scenario is not resolving in a timely manner.
-
-    To be re-enabled once #2006 & #2051 are fixed.
-
     fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenario"
     runScenario (nFixtureWalletWithUTxOs 2 1000)
-    --}
-    fmtTitle "Latencies for 2 fixture wallets with 1000 utxos scenario"
-    fmtTitle "CURRENTLY DISABLED. SEE #2006 & #2051"
   where
 
     -- Creates n fixture wallets and return 3 of them


### PR DESCRIPTION
# Issue Number

ADP-841


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 6a4c399109480e4524f84773e4f50bd9cce37340
  add getTransaction latency benchmark
  
- fad3cf56e8ece626b18fe1a345f51b83c2c9d10e
  add listMultiAssets, getMultiAssets, postTransactionMA latency benchmarks
  
- 9228f5e91b0e4ca9053639d29669565336affbfa
  turn on 1000 utxos scenario benchmarks


# Comments

Testing benchmarks -> https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/897


Local run:
```
+++ Run benchmark - shelley
    Non-cached run
        getNetworkInfo      - 0.2 ms
    Latencies for 2 fixture wallets scenario
        listWallets         - 2.1 ms
        getWallet           - 0.8 ms
        getUTxOsStatistics  - 0.7 ms
        listAddresses       - 1.5 ms
        listTransactions    - 7.0 ms
        getTransaction      - 7.0 ms
        postTransactionFee  - 546.1 ms
        postTransaction     - 200.8 ms
        postTransTo5Addrs   - 412.2 ms
        postTransactionMA   - 22.8 ms
        listStakePools      - 3.8 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 4.7 ms
        getMultiAsset       - 4.4 ms
    Latencies for 10 fixture wallets scenario
        listWallets         - 5.4 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.6 ms
        listAddresses       - 1.4 ms
        listTransactions    - 5.1 ms
        getTransaction      - 4.8 ms
        postTransactionFee  - 520.9 ms
        postTransaction     - 202.2 ms
        postTransTo5Addrs   - 317.2 ms
        postTransactionMA   - 21.9 ms
        listStakePools      - 2.9 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 3.6 ms
        getMultiAsset       - 3.5 ms
    Latencies for 100 fixture wallets
        listWallets         - 126.2 ms
        getWallet           - 0.9 ms
        getUTxOsStatistics  - 0.7 ms
        listAddresses       - 2.0 ms
        listTransactions    - 7.8 ms
        getTransaction      - 8.2 ms
        postTransactionFee  - 1159.0 ms
        postTransaction     - 299.7 ms
        postTransTo5Addrs   - 520.8 ms
        postTransactionMA   - 67.0 ms
        listStakePools      - 3.6 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 5.0 ms
        getMultiAsset       - 4.9 ms
    Latencies for 2 fixture wallets with 10 txs scenario
        listWallets         - 1.8 ms
        getWallet           - 0.7 ms
        getUTxOsStatistics  - 0.5 ms
        listAddresses       - 1.4 ms
        listTransactions    - 9.8 ms
        getTransaction      - 3.0 ms
        postTransactionFee  - 522.9 ms
        postTransaction     - 274.6 ms
        postTransTo5Addrs   - 311.2 ms
        postTransactionMA   - 23.5 ms
        listStakePools      - 3.4 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 4.6 ms
        getMultiAsset       - 4.3 ms
    Latencies for 2 fixture wallets with 20 txs scenario
        listWallets         - 1.6 ms
        getWallet           - 0.6 ms
        getUTxOsStatistics  - 0.5 ms
        listAddresses       - 1.3 ms
        listTransactions    - 22.0 ms
        getTransaction      - 5.8 ms
        postTransactionFee  - 537.6 ms
        postTransaction     - 379.9 ms
        postTransTo5Addrs   - 394.8 ms
        postTransactionMA   - 21.0 ms
        listStakePools      - 4.0 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 5.5 ms
        getMultiAsset       - 5.7 ms
    Latencies for 2 fixture wallets with 100 txs scenario
        listWallets         - 2.3 ms
        getWallet           - 0.9 ms
        getUTxOsStatistics  - 0.7 ms
        listAddresses       - 1.8 ms
        listTransactions    - 35.2 ms
        getTransaction      - 0.7 ms
        postTransactionFee  - 506.1 ms
        postTransaction     - 505.3 ms
        postTransTo5Addrs   - 398.0 ms
        postTransactionMA   - 18.7 ms
        listStakePools      - 4.2 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 4.2 ms
        getMultiAsset       - 4.0 ms
    Latencies for 10 fixture wallets with 10 txs scenario
        listWallets         - 6.8 ms
        getWallet           - 0.8 ms
        getUTxOsStatistics  - 0.6 ms
        listAddresses       - 1.5 ms
        listTransactions    - 9.8 ms
        getTransaction      - 0.7 ms
        postTransactionFee  - 573.9 ms
        postTransaction     - 337.0 ms
        postTransTo5Addrs   - 340.7 ms
        postTransactionMA   - 26.4 ms
        listStakePools      - 3.8 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 9.6 ms
        getMultiAsset       - 6.5 ms
    Latencies for 10 fixture wallets with 20 txs scenario
        listWallets         - 6.9 ms
        getWallet           - 0.7 ms
        getUTxOsStatistics  - 0.8 ms
        listAddresses       - 1.5 ms
        listTransactions    - 13.0 ms
        getTransaction      - 0.9 ms
        postTransactionFee  - 557.4 ms
        postTransaction     - 341.9 ms
        postTransTo5Addrs   - 347.9 ms
        postTransactionMA   - 21.2 ms
        listStakePools      - 3.5 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 5.2 ms
        getMultiAsset       - 4.0 ms
    Latencies for 10 fixture wallets with 100 txs scenario
        listWallets         - 5.1 ms
        getWallet           - 0.6 ms
        getUTxOsStatistics  - 0.5 ms
        listAddresses       - 1.2 ms
        listTransactions    - 29.6 ms
        getTransaction      - 0.6 ms
        postTransactionFee  - 503.9 ms
        postTransaction     - 470.9 ms
        postTransTo5Addrs   - 258.2 ms
        postTransactionMA   - 22.5 ms
        listStakePools      - 6.1 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 6.8 ms
        getMultiAsset       - 6.1 ms
    Latencies for 2 fixture wallets with 100 utxos scenario
        listWallets         - 2.3 ms
        getWallet           - 0.6 ms
        getUTxOsStatistics  - 0.6 ms
        listAddresses       - 1.3 ms
        listTransactions    - 23.3 ms
        getTransaction      - 3.3 ms
        postTransactionFee  - 476.1 ms
        postTransaction     - 537.9 ms
        postTransTo5Addrs   - 290.2 ms
        postTransactionMA   - 20.5 ms
        listStakePools      - 4.7 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 4.0 ms
        getMultiAsset       - 3.9 ms
    Latencies for 2 fixture wallets with 200 utxos scenario
        listWallets         - 3.4 ms
        getWallet           - 0.9 ms
        getUTxOsStatistics  - 0.8 ms
        listAddresses       - 1.9 ms
        listTransactions    - 34.5 ms
        getTransaction      - 2.0 ms
        postTransactionFee  - 414.0 ms
        postTransaction     - 452.2 ms
        postTransTo5Addrs   - 263.2 ms
        postTransactionMA   - 17.3 ms
        listStakePools      - 4.7 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 3.4 ms
        getMultiAsset       - 3.4 ms
    Latencies for 2 fixture wallets with 500 utxos scenario
        listWallets         - 1.8 ms
        getWallet           - 0.5 ms
        getUTxOsStatistics  - 0.4 ms
        listAddresses       - 1.1 ms
        listTransactions    - 137.7 ms
        getTransaction      - 3.1 ms
        postTransactionFee  - 508.5 ms
        postTransaction     - 540.9 ms
        postTransTo5Addrs   - 298.6 ms
        postTransactionMA   - 20.5 ms
        listStakePools      - 5.7 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 3.9 ms
        getMultiAsset       - 3.8 ms
    Latencies for 2 fixture wallets with 1000 utxos scenario
        listWallets         - 3.0 ms
        getWallet           - 1.0 ms
        getUTxOsStatistics  - 1.1 ms
        listAddresses       - 1.9 ms
        listTransactions    - 325.9 ms
        getTransaction      - 2.9 ms
        postTransactionFee  - 586.6 ms
        postTransaction     - 555.6 ms
        postTransTo5Addrs   - 318.3 ms
        postTransactionMA   - 21.7 ms
        listStakePools      - 8.1 ms
        getNetworkInfo      - 0.1 ms
        listMultiAssets     - 4.2 ms
        getMultiAsset       - 4.8 ms
```