### PR TITLE
More concise Follow-logs using aggregation

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -101,6 +101,7 @@ library
     , streaming-commons
     , strict-non-empty-containers
     , string-interpolate
+    , stm
     , template-haskell
     , text
     , text-class

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -101,7 +101,6 @@ library
     , streaming-commons
     , strict-non-empty-containers
     , string-interpolate
-    , stm
     , template-haskell
     , text
     , text-class

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -210,7 +210,7 @@ import Cardano.Wallet.Network
     ( ErrGetAccountBalance (..)
     , ErrPostTx (..)
     , FollowAction (..)
-    , FollowExit (..)
+    , FollowExceptionRecovery (..)
     , FollowLog (..)
     , NetworkLayer (..)
     , follow
@@ -782,18 +782,11 @@ restoreWallet
     -> WalletId
     -> ExceptT ErrNoSuchWallet IO ()
 restoreWallet ctx wid = db & \DBLayer{..} -> do
-    cps <- liftIO $ atomically $ listCheckpoints wid
+    let readCps = liftIO $ atomically $ listCheckpoints wid
     let forward bs h innerTr = run $ do
             restoreBlocks @ctx @s @k ctx innerTr wid bs h
-    liftIO (follow nw tr cps forward (view #header)) >>= \(innerTr, act) -> do
-        case act of
-            FollowFailure ->
-                restoreWallet @ctx @s @k ctx wid
-            FollowRollback point -> do
-                rollbackBlocks @ctx @s @k ctx innerTr wid point
-                restoreWallet @ctx @s @k ctx wid
-            FollowDone ->
-                pure ()
+    let backward = runExceptT . rollbackBlocks @ctx @s @k ctx wid
+    liftIO $ follow nw tr readCps forward backward RetryOnExceptions (view #header)
   where
     db = ctx ^. dbLayer @IO @s @k
     nw = ctx ^. networkLayer
@@ -807,14 +800,11 @@ restoreWallet ctx wid = db & \DBLayer{..} -> do
 rollbackBlocks
     :: forall ctx s k. (HasDBLayer IO s k ctx)
     => ctx
-    -> Tracer IO WalletFollowLog
     -> WalletId
     -> SlotNo
-    -> ExceptT ErrNoSuchWallet IO ()
-rollbackBlocks ctx tr wid point = db & \DBLayer{..} -> do
-    lift $ traceWith tr $ MsgTryingRollback point
-    point' <- mapExceptT atomically $ rollbackTo wid point
-    lift $ traceWith tr $ MsgRolledBack point'
+    -> ExceptT ErrNoSuchWallet IO SlotNo
+rollbackBlocks ctx wid point = db & \DBLayer{..} -> do
+    mapExceptT atomically $ rollbackTo wid point
   where
     db = ctx ^. dbLayer @IO @s @k
 
@@ -822,7 +812,7 @@ rollbackBlocks ctx tr wid point = db & \DBLayer{..} -> do
 -- transaction history and corresponding metadata.
 restoreBlocks
     :: forall ctx s k.
-        ( HasDBLayer s k ctx
+        ( HasDBLayer IO s k ctx
         , HasNetworkLayer IO ctx
         , IsOurs s Address
         , IsOurs s RewardAccount
@@ -892,11 +882,8 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} -> mapExceptT atomic
     prune wid epochStability
 
     liftIO $ do
-        progress <- walletSyncProgress @ctx @s ctx (NE.last cps)
         traceWith tr $ MsgWalletMetadata meta
-        traceWith tr $ MsgSyncProgress progress
         traceWith tr $ MsgDiscoveredTxs txs
-        traceWith tr $ MsgTip localTip
         traceWith tr $ MsgBlocks blocks
         traceWith tr $ MsgDiscoveredTxsContent txs
   where
@@ -2484,15 +2471,11 @@ instance HasSeverityAnnotation WalletWorkerLog where
 
 -- | Log messages arising from the restore and follow process.
 data WalletFollowLog
-    = MsgTryingRollback SlotNo
-    | MsgRolledBack SlotNo
-    | MsgDelegation SlotNo DelegationCertificate
+    = MsgDelegation SlotNo DelegationCertificate
     | MsgCheckpoint BlockHeader
     | MsgWalletMetadata WalletMetadata
-    | MsgSyncProgress SyncProgress
     | MsgDiscoveredTxs [(Tx, TxMeta)]
     | MsgDiscoveredTxsContent [(Tx, TxMeta)]
-    | MsgTip BlockHeader
     | MsgBlocks (NonEmpty Block)
     deriving (Show, Eq)
 
@@ -2512,10 +2495,6 @@ data WalletLog
 
 instance ToText WalletFollowLog where
     toText = \case
-        MsgTryingRollback point ->
-            "Try rolling back to " <> pretty point
-        MsgRolledBack point ->
-            "Rolled back to " <> pretty point
         MsgDelegation slotNo cert -> case cert of
             CertDelegateNone{} -> mconcat
                 [ "Discovered end of delegation within slot "
@@ -2536,14 +2515,10 @@ instance ToText WalletFollowLog where
             "Creating checkpoint at " <> pretty checkpointTip
         MsgWalletMetadata meta ->
             pretty meta
-        MsgSyncProgress progress ->
-            "syncProgress: " <> pretty progress
         MsgDiscoveredTxs txs ->
             "discovered " <> pretty (length txs) <> " new transaction(s)"
         MsgDiscoveredTxsContent txs ->
             "transactions: " <> pretty (blockListF (snd <$> txs))
-        MsgTip tip ->
-            "local tip: " <> pretty tip
         MsgBlocks blocks ->
             "blocks: " <> pretty (NE.toList blocks)
 
@@ -2583,15 +2558,11 @@ instance ToText WalletLog where
 instance HasPrivacyAnnotation WalletFollowLog
 instance HasSeverityAnnotation WalletFollowLog where
     getSeverityAnnotation = \case
-        MsgTryingRollback _ -> Info
-        MsgRolledBack _ -> Info
         MsgDelegation _ _ -> Info
         MsgCheckpoint _ -> Info
         MsgWalletMetadata _ -> Info
-        MsgSyncProgress _ -> Info
         MsgDiscoveredTxs _ -> Info
         MsgDiscoveredTxsContent _ -> Debug
-        MsgTip _ -> Info
         MsgBlocks _ -> Debug
 
 instance HasPrivacyAnnotation WalletLog

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2561,6 +2561,7 @@ instance HasSeverityAnnotation WalletFollowLog where
         MsgDiscoveredDelegationCert _ _ -> Info
         MsgCheckpoint _ -> Debug
         MsgWalletMetadata _ -> Debug
+        MsgDiscoveredTxs [] -> Debug
         MsgDiscoveredTxs _ -> Info
         MsgDiscoveredTxsContent _ -> Debug
         MsgBlocks _ -> Debug

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2564,7 +2564,7 @@ instance HasSeverityAnnotation WalletFollowLog where
         MsgDiscoveredTxs [] -> Debug
         MsgDiscoveredTxs _ -> Info
         MsgDiscoveredTxsContent _ -> Debug
-        MsgBlocks _ -> Debug
+        MsgBlocks _ -> Debug -- Ideally move to FollowLog or remove
 
 instance HasPrivacyAnnotation WalletLog
 instance HasSeverityAnnotation WalletLog where

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2558,9 +2558,9 @@ instance ToText WalletLog where
 instance HasPrivacyAnnotation WalletFollowLog
 instance HasSeverityAnnotation WalletFollowLog where
     getSeverityAnnotation = \case
-        MsgCheckpoint _ -> Info
-        MsgWalletMetadata _ -> Info
         MsgDiscoveredDelegationCert _ _ -> Info
+        MsgCheckpoint _ -> Debug
+        MsgWalletMetadata _ -> Debug
         MsgDiscoveredTxs _ -> Info
         MsgDiscoveredTxsContent _ -> Debug
         MsgBlocks _ -> Debug

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2046,7 +2046,7 @@ getNetworkInformation st nl = liftIO $ do
     progress <- syncProgress
             st
             (neverFails "syncProgress" $ timeInterpreter nl)
-            nodeTip
+            (view #slotNo nodeTip)
             now
     pure $ Api.ApiNetworkInformation
         { Api.syncProgress = ApiT progress

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -61,14 +61,18 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( SealedTx )
+import Control.DeepSeq
+    ( NFData, force )
 import Control.Monad
     ( when )
+import Control.Monad.Class.MonadSTM
+    ( TMVar, atomically, newTMVarIO, putTMVar, takeTMVar )
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Retry
     ( RetryPolicyM, constantDelay, limitRetriesByCumulativeDelay )
 import Control.Tracer
-    ( Tracer, traceWith )
+    ( Tracer, contramapM, traceWith )
 import Data.Functor
     ( ($>) )
 import Data.List.NonEmpty
@@ -79,12 +83,16 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( ToText (..) )
+import Data.Time.Clock
+    ( UTCTime, diffUTCTime, getCurrentTime )
 import Fmt
     ( pretty )
 import GHC.Generics
     ( Generic )
 import Safe
     ( lastMay )
+import UnliftIO.Async
+    ( race_ )
 import UnliftIO.Concurrent
     ( threadDelay )
 import UnliftIO.Exception
@@ -286,10 +294,11 @@ follow
     -> (block -> BlockHeader)
     -- ^ Getter on the abstract 'block' type
     -> IO ()
-follow nl tr readCursor forward' backward recovery header =
-    loop True
+follow nl tr' readCursor forward' backward recovery header =
+    withFollowStatsMonitoring tr' (syncProgress nl) $ \tr -> do
+        loop tr True
   where
-    loop firstTime = do
+    loop tr firstTime = do
         cursor <- readCursor
         when firstTime $ traceWith tr $ MsgStartFollowing cursor
 
@@ -313,7 +322,7 @@ follow nl tr readCursor forward' backward recovery header =
                     -- NOTE: follow' is tracing the error, so we don't have to
                     -- here
                     case recovery of
-                        RetryOnExceptions -> loop False
+                        RetryOnExceptions -> loop tr False
                         AbortOnExceptions -> return ()
                 FollowRollback requestedSlot -> do
                     -- NOTE: follow' is tracing MsgWillRollback
@@ -322,7 +331,7 @@ follow nl tr readCursor forward' backward recovery header =
                             traceWith tr $ MsgFailedRollingBack $ T.pack (show e)
                         Right actualSlot -> do
                             traceWith tr $ MsgDidRollback requestedSlot actualSlot
-                    loop False
+                    loop tr False
                 FollowDone ->
                     -- TODO: Pool used to log MsgHaltMonitoring
                     return ()
@@ -435,6 +444,7 @@ data FollowLog tr
     | MsgFollowAction (FollowAction String)
     | MsgUnhandledException Text
     | MsgFollowerTip (Maybe BlockHeader)
+    | MsgFollowStats (FollowStats LogState)
     | MsgApplyBlocks BlockHeader (NonEmpty BlockHeader)
     | MsgFollowLog tr -- Inner tracer
     | MsgWillRollback SlotNo
@@ -459,6 +469,7 @@ instance ToText tr => ToText (FollowLog tr) where
         MsgUnhandledException err ->
             "Unexpected error following the chain: " <> err
         MsgFollowerTip p -> "Tip" <> pretty p
+        MsgFollowStats s -> toText s
         MsgApplyBlocks tipHdr hdrs ->
             let slot = pretty . slotNo
                 buildRange (x :| []) = x
@@ -489,6 +500,7 @@ instance HasSeverityAnnotation tr => HasSeverityAnnotation (FollowLog tr) where
     getSeverityAnnotation = \case
         MsgStartFollowing _ -> Info
         MsgHaltMonitoring -> Info
+        MsgFollowStats s -> getSeverityAnnotation s
         MsgFollowerTip _ -> Debug
         MsgFollowAction (ExitWith _) -> Error
         MsgFollowAction _ -> Debug
@@ -499,3 +511,192 @@ instance HasSeverityAnnotation tr => HasSeverityAnnotation (FollowLog tr) where
         MsgDidRollback _ _ -> Debug
         MsgFailedRollingBack _ -> Error
         MsgWillIgnoreRollback _ _ -> Debug
+
+--
+-- Log aggregation
+--
+
+-- | Statistics of interest from the follow-function.
+--
+-- The @f@ allows us to use @LogState@ to keep track of both current and
+-- previously logged stats, and perform operations over it in a nice way.
+data FollowStats f = FollowStats
+    { blocksApplied :: f Int
+    , rollbacks :: f Int
+    , tip :: f SlotNo
+    , time :: f UTCTime
+      -- ^ NOTE: Current time is not updated until @flush@ is called.
+    , prog :: f SyncProgress
+      -- ^ NOTE: prog is not updated until @flush@ is called.
+    } deriving (Generic)
+
+deriving instance Show (FollowStats LogState)
+deriving instance Eq (FollowStats LogState)
+deriving instance NFData (FollowStats LogState)
+
+-- | Change the @f@ wrapping each record field.
+hoistStats
+    :: (forall a. f a -> g a)
+    -> FollowStats f
+    -> FollowStats g
+hoistStats f FollowStats{blocksApplied,rollbacks,tip,time,prog} = FollowStats
+    { blocksApplied = f blocksApplied
+    , rollbacks = f rollbacks
+    , tip = f tip
+    , time = f time
+    , prog = f prog
+    }
+
+-- | For keeping track of what we have logged and what we have not.
+--
+-- The idea is to
+-- 1. Reconstruct a model of the @current@ @state@ using a @Trace@
+-- 2. Sometimes log the difference between the @current@ state and the most
+-- recently logged one.
+data LogState a = LogState
+    { prev :: a -- ^ Most previously logged state
+    , current :: a -- ^ Not-yet logged state
+    } deriving (Eq, Show, Functor, Generic)
+
+deriving instance NFData a => NFData (LogState a)
+
+initLogState :: a -> LogState a
+initLogState a = LogState a a
+
+-- | Modify the current state of a @LogState state@
+overCurrent :: (a -> a) -> LogState a -> LogState a
+overCurrent f (LogState prev cur) = LogState prev (f cur)
+
+-- | /The way/ to log the current stats.
+--
+-- Returns the current stats from the TMVar, and sets each @prev@ state to
+-- @current@ as new value of the @TMVar@.
+flush
+    :: UTCTime
+    -> (SlotNo -> IO SyncProgress)
+    -> TMVar IO (FollowStats LogState)
+    -> IO (FollowStats LogState)
+flush t calcSyncProgress var = do
+    s <- atomically $ takeTMVar var
+    p <- calcSyncProgress (current $ tip s)
+    -- This is where we need to update the time and sync progress
+    let s' = s { time = overCurrent (const t) (time s) }
+               { prog = overCurrent (const p) (prog s) }
+    atomically $ putTMVar var (hoistStats forgetPrev s')
+    return s'
+  where
+    forgetPrev (LogState _prev cur) = LogState cur cur
+
+emptyStats :: UTCTime -> FollowStats LogState
+emptyStats t = FollowStats (f 0) (f 0) (f $ SlotNo 0) (f t) (f prog)
+  where
+    f = initLogState
+    prog = NotResponding -- Hijacked as an initial value for simplicity.
+
+
+-- | Update the stats based on a new log message.
+updateStats :: FollowLog tr -> FollowStats LogState -> FollowStats LogState
+updateStats msg s = force $ case msg of
+    MsgApplyBlocks _tip blocks ->
+        s { blocksApplied = overCurrent (+ NE.length blocks) (blocksApplied s) }
+    MsgDidRollback _ _ ->
+        s { rollbacks = overCurrent (1 +) (rollbacks s) }
+    MsgFollowerTip p ->
+        s { tip = overCurrent (const $ slotFromMaybeBh p) (tip s) }
+    _ -> s
+  where
+    slotFromMaybeBh = maybe (SlotNo 0) slotNo
+
+instance ToText (FollowStats LogState) where
+    toText st@(FollowStats b r tip t prog) = syncStatus <> " " <> stats <> sevExpl
+      where
+        syncStatus = case prog of
+            LogState NotResponding Ready ->
+                "In sync."
+            LogState Ready Ready ->
+                "Still in sync."
+            LogState NotResponding NotResponding ->
+                "Still not syncing."
+            LogState (Syncing _p) Ready ->
+                "In sync!"
+            LogState Ready (Syncing p) ->
+                "Fell out of sync (" <> (pretty p) <> ")"
+            LogState _ (Syncing p) ->
+                "Syncing (" <> (pretty p) <> ")"
+            LogState prev NotResponding ->
+                "Not responding. Previously " <> (pretty prev) <> "."
+        stats = mconcat
+            [ "Applied " <> pretty (using (-) b) <> " blocks, "
+            , pretty (using (-) r) <> " rollbacks "
+            , "in the last " <> pretty (using diffUTCTime t) <> ". "
+            , "Currently at slot " <> pretty (current tip) <> "."
+            ]
+          where
+            using f x = f (current x) (prev x)
+
+        sevExpl = maybe
+            ""
+            (\x -> " (" <> x <> ")")
+            (snd $ explainedSeverityAnnotation st)
+
+-- NOTE: Here we check if the sync progress is going backwards, which
+-- would be a sign the wallet is overloaded (or rollbacks)
+--
+-- But this check might be in the wrong place. Might be better to
+-- produce new logs from inside the updateStats function and immeditely
+-- warn there.
+explainedSeverityAnnotation :: FollowStats LogState -> (Severity, Maybe Text)
+explainedSeverityAnnotation s
+        | progressMovedBackwards = (Warning, Just "progress decreased")
+        | noBlocks && notRestored = (Warning, Just "not applying blocks")
+        | nowInSync = (Notice, Nothing)
+        | otherwise = (Info, Nothing)
+  where
+    progressMovedBackwards = current (prog s) < prev (prog s)
+    nowInSync = current (prog s) == Ready && prev (prog s) < Ready
+    notRestored = current (prog s) /= Ready
+    noBlocks = (current (blocksApplied s) - prev (blocksApplied s)) <= 0
+
+
+instance HasSeverityAnnotation (FollowStats LogState) where
+    getSeverityAnnotation = fst . explainedSeverityAnnotation
+
+-- | Starts a new thread for monitoring health and statistics from
+-- the returned @FollowLog tr@.
+withFollowStatsMonitoring
+    :: Tracer IO (FollowLog tr)
+    -> (SlotNo -> IO SyncProgress)
+    -> ((Tracer IO (FollowLog tr)) -> IO ())
+    -> IO ()
+withFollowStatsMonitoring tr calcSyncProgress act = do
+    t0' <- getCurrentTime
+    var <- newTMVarIO $ emptyStats t0'
+    let tr' = flip contramapM tr $ \msg -> do
+            atomically $ do
+                s <- takeTMVar var
+                putTMVar var (updateStats msg s)
+            pure msg
+    race_
+        (act tr')
+        (loop var startupDelay)
+  where
+    loop var delay = do
+        threadDelay delay
+        t <- getCurrentTime
+        s <- flush t calcSyncProgress var
+        traceWith tr $ MsgFollowStats s
+        let delay' =
+                if (current (prog s)) == Ready
+                then restoredDelay
+                else syncingDelay
+        loop var delay'
+
+    -- | Delay from launch to the first status update
+    startupDelay = 5 * second
+    -- | Delay between status updates when restored
+    restoredDelay = 5 * minute
+    -- | Delay between status updates when not restored
+    syncingDelay = 30 * second
+
+    second = 1000*1000
+    minute = 60 * second

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -493,9 +493,9 @@ instance HasSeverityAnnotation tr => HasSeverityAnnotation (FollowLog tr) where
         MsgFollowAction (ExitWith _) -> Error
         MsgFollowAction _ -> Debug
         MsgUnhandledException _ -> Error
-        MsgApplyBlocks _ _ -> Info
+        MsgApplyBlocks _ _ -> Debug
         MsgFollowLog msg -> getSeverityAnnotation msg
-        MsgWillRollback _ -> Info
-        MsgDidRollback _ _ -> Info
+        MsgWillRollback _ -> Debug
+        MsgDidRollback _ _ -> Debug
         MsgFailedRollingBack _ -> Error
         MsgWillIgnoreRollback _ _ -> Debug

--- a/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/SyncProgress.hs
@@ -22,7 +22,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, interpretQuery, slotToRelTime )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader (..) )
+    ( SlotNo (..) )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Bifunctor
@@ -120,13 +120,13 @@ syncProgress
         -- ^ A time tolerance inside which we consider ourselves synced
     -> TimeInterpreter m
         -- ^ Converts slots to actual time.
-    -> BlockHeader
-        -- ^ Local tip
+    -> SlotNo
+        -- ^ Slot of local tip
     -> RelativeTime
         -- ^ Current Time
     -> m SyncProgress
 syncProgress (SyncTolerance tolerance) ti tip now = do
-    timeCovered <- interpretQuery ti $ slotToRelTime $ slotNo tip
+    timeCovered <- interpretQuery ti $ slotToRelTime tip
     let progress
             | now == start = 0
             | otherwise = convert timeCovered % convert now

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -167,4 +167,5 @@ dummyNetworkLayer = NetworkLayer
     , stakeDistribution = error "stakeDistribution: not implemented"
     , getAccountBalance = error "getAccountBalance: not implemented"
     , timeInterpreter = error "timeInterpreter: not implemented"
+    , syncProgress = error "syncProgress: not implemented"
     }

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE Rank2Types #-}

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/SyncProgressSpec.hs
@@ -29,8 +29,6 @@ import Cardano.Wallet.Primitive.Types
     , SlottingParameters (..)
     , StartTime (..)
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeMkPercentage )
 import Control.DeepSeq
@@ -46,7 +44,7 @@ import Data.Quantity
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
     ( RelativeTime (..) )
 import Test.Hspec
-    ( Spec, describe, it, pendingWith, shouldBe )
+    ( Spec, describe, it, shouldBe )
 import Test.Hspec.Extra
     ( parallel )
 import Test.QuickCheck
@@ -73,34 +71,28 @@ spec = do
     parallel $ describe "syncProgress" $ do
         it "works for any two slots" $ property $ \tip (dt :: RelativeTime) ->
             runIdentity (syncProgress st ti tip dt) `deepseq` ()
-        let mkTip sl = BlockHeader
-                { slotNo = sl
-                , blockHeight = Quantity 0 -- Not needed
-                , headerHash = Hash "-"
-                , parentHeaderHash = Hash "-"
-                }
         let tolerance = SyncTolerance 0
 
         it "unit test #1 - 0/10   0%" $ do
-            let tip = mkTip (SlotNo 0)
+            let tip = (SlotNo 0)
             let ntwkTime = runQry $ slotToRelTime $ SlotNo 10
             runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0)
 
         it "unit test #2 - 10/20 50%" $ do
-            let tip = mkTip (SlotNo 10)
+            let tip = SlotNo 10
             let ntwkTime = runQry $ slotToRelTime $ SlotNo 20
             runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.5)
 
         it "unit test #4 - 10/10 100%" $ do
-            let tip = mkTip (SlotNo 10)
+            let tip = SlotNo 10
             let ntwkTime = runQry $ slotToRelTime $ SlotNo 10
             runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Ready
 
         it "unit test #4 - 11/10 100%" $ do
-            let tip = mkTip (SlotNo 11)
+            let tip = SlotNo 11
             let ntwkTime = runQry $ slotToRelTime $ SlotNo 10
             runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Ready
@@ -120,17 +112,17 @@ spec = do
         --
         it "unit test #5 - distribution over several slots" $ do
             let plots =
-                    [ (mkTip (SlotNo 0), 0.0)
-                    , (mkTip (SlotNo 1), 0.1)
-                    , (mkTip (SlotNo 2), 0.2)
-                    , (mkTip (SlotNo 3), 0.3)
-                    , (mkTip (SlotNo 4), 0.4)
-                    , (mkTip (SlotNo 5), 0.5)
-                    , (mkTip (SlotNo 6), 0.6)
-                    , (mkTip (SlotNo 7), 0.7)
-                    , (mkTip (SlotNo 8), 0.8)
-                    , (mkTip (SlotNo 9), 0.9)
-                    , (mkTip (SlotNo 10), 1.0)
+                    [ (SlotNo 0, 0.0)
+                    , (SlotNo 1, 0.1)
+                    , (SlotNo 2, 0.2)
+                    , (SlotNo 3, 0.3)
+                    , (SlotNo 4, 0.4)
+                    , (SlotNo 5, 0.5)
+                    , (SlotNo 6, 0.6)
+                    , (SlotNo 7, 0.7)
+                    , (SlotNo 8, 0.8)
+                    , (SlotNo 9, 0.9)
+                    , (SlotNo 10, 1.0)
                     ]
             forM_ plots $ \(nodeTip, p) -> do
                 let ntwkTime = runQry $ slotToRelTime $ SlotNo 10
@@ -141,28 +133,8 @@ spec = do
                     (syncProgress tolerance ti nodeTip ntwkTime)
                     `shouldBe` progress
 
-        it "unit test #6 - block height 0" $ do
-            pendingWith "new calculation was needed for shelley"
-            -- Very short chains on jormungandr will probably see the
-            -- syncProgress immediately jump to 90%, and then slowly continue,
-            -- but seems like an acceptable sacrifice. The ITN is long anyway.
-            let ntwkTime = runQry $ slotToRelTime $ SlotNo 10
-            let plots =
-                    [ (mkTip (SlotNo 8), 0)
-                    , (mkTip (SlotNo 9), 0)
-                    , (mkTip (SlotNo 10), 1)
-                    ]
-            forM_ plots $ \(nodeTip, p) -> do
-                let progress = if p == 1
-                        then Ready
-                        else Syncing (Quantity $ unsafeMkPercentage p)
-                runIdentity
-                    (syncProgress tolerance ti nodeTip ntwkTime)
-                    `shouldBe` progress
-
-
         it "unit test #7 - 1k/2M 0.5% (regression for overflow issue)" $ do
-            let tip = mkTip (SlotNo 1_000)
+            let tip = SlotNo 1_000
             let ntwkTime = runQry $ slotToRelTime $ SlotNo 2_000_000
             runIdentity (syncProgress tolerance ti tip ntwkTime)
                 `shouldBe` Syncing (Quantity $ unsafeMkPercentage 0.0005)

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1121,6 +1121,8 @@ mockNetworkLayer = dummyNetworkLayer
     , currentProtocolParameters =
         pure (protocolParameters dummyNetworkParameters)
     , timeInterpreter = dummyTimeInterpreter
+    , syncProgress =
+        error "dummyNetworkLayer: syncProgress not implemented"
     }
   where
     dummyTip = BlockHeader (SlotNo 0) (Quantity 0) dummyHash dummyHash

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -279,7 +279,7 @@ serveWallet
     poolDatabaseDecorator = fromMaybe Pool.undecoratedDB mPoolDatabaseDecorator
 
     serveApp socket = withIOManager $ \io -> do
-        withNetworkLayer networkTracer np conn vData $ \nl -> do
+        withNetworkLayer networkTracer np conn vData sTolerance $ \nl -> do
             withWalletNtpClient io ntpClientTracer $ \ntpClient -> do
                 let net = networkIdVal proxy
                 randomApi <- apiLayer (newTransactionLayer net) nl

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -56,7 +56,13 @@ import Cardano.Wallet.Logging
 import Cardano.Wallet.Network
     ( Cursor, ErrPostTx (..), NetworkLayer (..), mapCursor )
 import Cardano.Wallet.Primitive.Slotting
-    ( TimeInterpreter, TimeInterpreterLog, mkTimeInterpreter )
+    ( TimeInterpreter
+    , TimeInterpreterLog
+    , currentRelativeTime
+    , mkTimeInterpreter
+    )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncProgress (..), SyncTolerance )
 import Cardano.Wallet.Shelley.Compatibility
     ( AnyCardanoEra (..)
     , CardanoEra (..)
@@ -104,6 +110,7 @@ import Control.Monad.Class.MonadSTM
     , readTMVar
     , readTVar
     , takeTMVar
+    , tryReadTMVar
     , writeTVar
     )
 import Control.Monad.Class.MonadThrow
@@ -113,7 +120,7 @@ import Control.Monad.Class.MonadTimer
 import Control.Monad.IO.Unlift
     ( MonadIO, MonadUnliftIO, liftIO )
 import Control.Monad.Trans.Except
-    ( ExceptT (..), throwE )
+    ( ExceptT (..), runExceptT, throwE )
 import Control.Retry
     ( RetryPolicyM, RetryStatus (..), capDelay, fibonacciBackoff, recovering )
 import Control.Tracer
@@ -124,6 +131,8 @@ import Data.ByteString.Lazy
     ( ByteString )
 import Data.Function
     ( (&) )
+import Data.Functor.Identity
+    ( runIdentity )
 import Data.List
     ( isInfixOf )
 import Data.Map
@@ -245,6 +254,7 @@ import UnliftIO.Exception
     ( Handler (..), IOException )
 
 import qualified Cardano.Ledger.Core as SL.Core
+import qualified Cardano.Wallet.Primitive.SyncProgress as SyncProgress
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
@@ -283,12 +293,13 @@ withNetworkLayer
         -- ^ Socket for communicating with the node
     -> (NodeToClientVersionData, CodecCBORTerm Text NodeToClientVersionData)
         -- ^ Codecs for the node's client
+    -> SyncTolerance
     -> (NetworkLayer IO (CardanoBlock StandardCrypto) -> IO a)
         -- ^ Callback function with the network layer
     -> IO a
-withNetworkLayer tr np conn ver action = do
+withNetworkLayer tr np conn ver tol action = do
     trTimings <- traceQueryTimings tr
-    withNetworkLayerBase (tr <> trTimings) np conn ver action
+    withNetworkLayerBase (tr <> trTimings) np conn ver tol action
 
 withNetworkLayerBase
     :: HasCallStack
@@ -296,9 +307,10 @@ withNetworkLayerBase
     -> W.NetworkParameters
     -> CardanoNodeConn
     -> (NodeToClientVersionData, CodecCBORTerm Text NodeToClientVersionData)
+    -> SyncTolerance
     -> (NetworkLayer IO (CardanoBlock StandardCrypto) -> IO a)
     -> IO a
-withNetworkLayerBase tr np conn (versionData, _) action = do
+withNetworkLayerBase tr np conn (versionData, _) tol action = do
     -- NOTE: We keep client connections running for accessing the node tip,
     -- submitting transactions, querying parameters and delegations/rewards.
     --
@@ -347,6 +359,7 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
             _getAccountBalance rewardsObserver
         , timeInterpreter =
             _timeInterpreter (contramap MsgInterpreterLog tr) interpreterVar
+        , syncProgress = _syncProgress interpreterVar
         }
   where
     gp@W.GenesisParameters
@@ -544,6 +557,35 @@ withNetworkLayerBase tr np conn (versionData, _) action = do
     _timeInterpreter tr' var = do
         let readInterpreter = liftIO $ atomically $ readTMVar var
         mkTimeInterpreter tr' getGenesisBlockDate readInterpreter
+
+    _syncProgress
+        :: TMVar IO (CardanoInterpreter sc)
+        -> SlotNo
+        -> IO SyncProgress
+    _syncProgress var slot = do
+        liftIO (atomically $ tryReadTMVar var) >>= \case
+            -- If the wallet has been started, but not yet been able to connect
+            -- to the node, we don't have an interpreter summary, and can't
+            -- calculate the syncProgress using a @SlotNo@.
+            --
+            -- If we want to guarantee the availability of @SyncProgress@, we
+            -- could consider storing @UTCTime@ along with the follower tip in
+            -- question, but that would make chain-following dependent on
+            -- a TimeInterpreter.
+            Nothing -> return NotResponding
+            Just i -> do
+                let ti = mkTimeInterpreter nullTracer getGenesisBlockDate (pure i)
+                time <- currentRelativeTime ti
+                let res = SyncProgress.syncProgress tol ti slot time
+                case runIdentity $ runExceptT res of
+                    -- Getting a past horizon error here should be unlikely, but
+                    -- could happen if we switch from a in-sync node to a
+                    -- not-in-sync node, either by restarting the wallet, or
+                    -- restarting the node using the same socket but different
+                    -- db.
+                    Left _pastHorizon -> return NotResponding
+                    Right p -> return p
+
 
 --------------------------------------------------------------------------------
 --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -1273,8 +1273,9 @@ instance HasSeverityAnnotation NetworkLayerLog where
         MsgTxSubmission{}                  -> Info
         MsgHandshakeTracer{}               -> Debug
         MsgFindIntersectionTimeout         -> Warning
-        MsgFindIntersection{}              -> Info
-        MsgIntersectionFound{}             -> Info
+        MsgFindIntersection{}              -> Debug
+        -- MsgFindIntersection is duplicated by MsgStartFollowing
+        MsgIntersectionFound{}             -> Debug
         MsgPostTx{}                        -> Debug
         MsgLocalStateQuery{}               -> Debug
         MsgNodeTip{}                       -> Debug

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Pools.hs
@@ -864,8 +864,8 @@ instance HasSeverityAnnotation StakePoolLog where
     getSeverityAnnotation = \case
         MsgExitMonitoring msg -> getSeverityAnnotation msg
         MsgStakePoolGarbageCollection{} -> Debug
-        MsgStakePoolRegistration{} -> Info
-        MsgStakePoolRetirement{} -> Info
+        MsgStakePoolRegistration{} -> Debug
+        MsgStakePoolRetirement{} -> Debug
         MsgErrProduction{} -> Error
         MsgFetchPoolMetadata e -> getSeverityAnnotation e
         MsgFetchTakeBreak{} -> Debug

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -14,6 +14,8 @@ import Cardano.BM.Trace
     ( nullTracer, traceInTVarIO )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
+import Cardano.Wallet.Primitive.SyncProgress
+    ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters (..) )
 import Cardano.Wallet.Shelley.Compatibility
@@ -58,8 +60,9 @@ spec :: Spec
 spec = describe "NetworkLayer regression test #1708" $ do
     it "Parallel local socket connections" $
         withTestNode nullTracer $ \np sock vData -> do
+            let sTol = SyncTolerance 60
             tasks <- replicateM 10 $ async $
-                withNetworkLayer nullTracer np sock vData $ \nl -> do
+                withNetworkLayer nullTracer np sock vData sTol $ \nl -> do
                     -- Wait for the first tip result from the node
                     waiter <- newEmptyMVar
                     race_ (watchNodeTip nl (putMVar waiter)) (takeMVar waiter)


### PR DESCRIPTION
# Issue Number

ADP-630

# Overview

**1. Invert control to empower follow** 

The idea is: the more we can concentrate information in one place (follow), the better we can produce good logs.

- [x] Use `FollowLog tr` where `tr` can be `StakePoolLog` or `WalletWorkerLog`, instead of like now, having them both wrap `FollowLog`.
- [x] Move rollback-logic from call-sites to `follow`
   - [x] Ensure this commit _perfectly_ preserves previous behaviour -> should be pretty close

**2. Tweak logging**
- [x] Lower common messages to `Debug`
- [x] Add some kind of aggregation (I think doing manually is easier than learning how to use iohk-monitoring-framework for it, and maybe more powerful)
    - [x] Improve 
    - [x] Move `syncProgress` calculation to `follow` 
    - [x] Make sure we are strict where we need to, and don't create massive thunks


# Comments

- Based on PR #2581,  #2586 and #2615 branches - merge them first.

## Lost network connection + 5 min wait:

<img width="765" alt="Skärmavbild 2021-04-16 kl  16 58 45" src="https://user-images.githubusercontent.com/304423/115046205-7e5b4500-9ed7-11eb-945b-d098a855ba7b.png">

## On reconnection

<img width="774" alt="Skärmavbild 2021-04-20 kl  16 03 52" src="https://user-images.githubusercontent.com/304423/115409652-3b101780-a1f2-11eb-947d-eb3509b38919.png">


<!-- Additional comments or screenshots to attach if any -->
