### PR TITLE
Hash tx metadata before signing

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -1115,9 +1115,9 @@ spec = describe "SHELLEY_WALLETS" $ do
         let dummyChainCode = BS.replicate 32 0
         let sig = CC.xsignature $ BL.toStrict $ getFromResponse id rSig
         let key = unsafeXPub $ fst (getFromResponse #getApiVerificationKey rKey) <> dummyChainCode
-        let msg = unsafeFromHex "A10071706C65617365207369676E20746869732E"
+        let msgHash = unsafeFromHex "1228cd0fea46f9a091172829f0c492c0516dceff67de08f585a4e048a28a6c9f"
 
-        liftIO $ CC.verify key msg <$> sig `shouldBe` Right True
+        liftIO $ CC.verify key msgHash <$> sig `shouldBe` Right True
 
     it "WALLETS_SIGNATURES_02 - invalid index for signing key" $ \ctx -> runResourceT $  do
         w <- emptyWallet ctx

--- a/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Server/TlsSpec.hs
@@ -75,7 +75,7 @@ import System.FilePath
 import System.IO
     ( hPutStrLn, stderr )
 import Test.Hspec
-    ( Spec, describe, it, pendingWith, shouldBe, shouldThrow )
+    ( Spec, describe, it, shouldBe, shouldThrow )
 import Test.Utils.Paths
     ( getTestData )
 import Test.Utils.Windows
@@ -94,7 +94,6 @@ import qualified Network.Wai.Handler.Warp as Warp
 spec :: Spec
 spec = describe "TLS Client Authentication" $ do
     it "Respond to authenticated client if TLS is enabled" $ do
-        pendingWith "ADP-852: Tests are broken"
         pendingOnWine "CertOpenSystemStoreW is failing under Wine"
         withListeningSocket "*" ListenOnRandomPort $ \(Right (port, socket)) -> do
             tlsSv <- rootPKI 1 "server"
@@ -109,7 +108,6 @@ spec = describe "TLS Client Authentication" $ do
                 }
 
     it "Deny client with wrong certificate if TLS is enabled" $ do
-        pendingWith "ADP-852: Tests are broken"
         pendingOnWine "CertOpenSystemStoreW is failing under Wine"
         withListeningSocket "*" ListenOnRandomPort $ \(Right (port, socket)) -> do
             tlsSv <- rootPKI 1 "server"
@@ -126,7 +124,6 @@ spec = describe "TLS Client Authentication" $ do
                 _ -> False
 
     it "Properly deny HTTP connection if TLS is enabled" $ do
-        pendingWith "ADP-852: Tests are broken"
         withListeningSocket "*" ListenOnRandomPort $ \(Right (port, socket)) -> do
             tlsSv <- rootPKI 1 "server"
             link =<< async


### PR DESCRIPTION
### Issue Number

ADP-800

### Overview

When signing tx metadata using the `signMetadata` endpoint, hash the message first before signing.

