### PR TITLE
API: Add content-type to all structured error responses

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
@@ -1430,7 +1428,7 @@ unsafeToPMS = FetchSMASH . SmashServer
 --
 -- @Settings@ here is neither of that. It's a real product type, that is supposed
 -- to be extended in the future.
-{-# HLINT ignore Settings "Use newtype instead of data" #-}
+{- HLINT ignore Settings "Use newtype instead of data" -}
 -- | Wallet application settings. These are stored at runtime and
 -- potentially mutable.
 data Settings = Settings {
@@ -1445,7 +1443,7 @@ defaultSettings = Settings {
 -- | Various internal states of the pool DB
 --  that need to survive wallet restarts. These aren't
 --  exposed settings.
-{-# HLINT ignore InternalState "Use newtype instead of data" #-}
+{- HLINT ignore InternalState "Use newtype instead of data" -}
 data InternalState = InternalState
     { lastMetadataGC :: Maybe POSIXTime
     } deriving (Generic, Show, Eq)

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -14,10 +14,15 @@ import Cardano.BM.Trace
     ( nullTracer )
 import Cardano.Slotting.Slot
     ( EpochNo (..) )
+import Cardano.Wallet
+    ( ErrNoSuchWallet (..) )
 import Cardano.Wallet.Api.Server
-    ( Listen (..)
+    ( IsServerError (..)
+    , Listen (..)
     , ListenError (..)
+    , getNetworkClock
     , getNetworkInformation
+    , liftHandler
     , withListeningSocket
     )
 import Cardano.Wallet.Api.Types
@@ -32,10 +37,12 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..), BlockHeader (..), SlotNo (..), StartTime (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromText )
 import Control.Monad
     ( void )
 import Control.Monad.Trans.Except
-    ( ExceptT )
+    ( ExceptT (..), throwE )
 import Data.Maybe
     ( isJust, isNothing )
 import Data.Quantity
@@ -59,10 +66,10 @@ import Ouroboros.Consensus.Config.SecurityParam
     ( SecurityParam (..) )
 import Ouroboros.Consensus.Util.Counting
     ( exactlyOne )
-import Servant.Server.Internal.Handler
-    ( runHandler )
+import Servant.Server
+    ( ServerError (..), runHandler )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe, shouldReturn )
+    ( Spec, describe, it, pendingWith, shouldBe, shouldReturn )
 import Test.QuickCheck.Modifiers
     ( NonNegative (..) )
 import Test.QuickCheck.Monadic
@@ -81,7 +88,13 @@ import qualified Ouroboros.Consensus.HardFork.History.Qry as HF
 import qualified Ouroboros.Consensus.HardFork.History.Summary as HF
 
 spec :: Spec
-spec = describe "API Server" $ do
+spec = do
+    serverSpec
+    networkInfoSpec
+    errorHandlingSpec
+
+serverSpec :: Spec
+serverSpec = describe "API Server" $ do
     let lo = tupleToHostAddress (0x7f, 0, 0, 1)
 
     it "binds to the local interface" $ do
@@ -141,33 +154,34 @@ spec = describe "API Server" $ do
                     res `shouldBe` Left (ListenErrorAddressAlreadyInUse (Just port))
             Left e -> fail (show e)
 
-    describe "getNetworkInformation" $ do
-        it "doesn't return 500 when the time interpreter horizon is behind\
-           \ the current time" $ property $ \(gap' ::(NonNegative Int)) ->
-            monadicIO $ do
-            let gap = fromRational $ toRational $ getNonNegative gap'
-            st <- run $ StartTime . ((negate gap) `addUTCTime`)
-                    <$> getCurrentTime
-            let ti = forkInterpreter st
-            let nodeTip' = SlotNo 0
-            let nl = dummyNetworkLayer nodeTip' ti
-            let tolerance = mkSyncTolerance 5
-            Right info <- run $ runHandler $ getNetworkInformation tolerance nl
+networkInfoSpec :: Spec
+networkInfoSpec = describe "getNetworkInformation" $ do
+    it "doesn't return 500 when the time interpreter horizon is behind\
+       \ the current time" $ property $ \(gap' ::(NonNegative Int)) ->
+        monadicIO $ do
+        let gap = fromRational $ toRational $ getNonNegative gap'
+        st <- run $ StartTime . ((negate gap) `addUTCTime`)
+                <$> getCurrentTime
+        let ti = forkInterpreter st
+        let nodeTip' = SlotNo 0
+        let nl = dummyNetworkLayer nodeTip' ti
+        let tolerance = mkSyncTolerance 5
+        Right info <- run $ runHandler $ getNetworkInformation tolerance nl
 
-            --  0              20
-            --  *               |        *
-            --  Node tip     Horizon   Network Tip
-            --  <------------------------>
-            --            gap
-            --
-            --  20 = epoch length = 10*k
-            if gap >= 20
-            then do
-                assertWith "networkTip is Nothing" $ isNothing $ networkTip info
-                assertWith "nextEpoch is Nothing" $ isNothing $ nextEpoch info
-            else do
-                assertWith "networkTip is Just " $ isJust $ networkTip info
-                assertWith "nextEpoch is Just" $ isJust $ nextEpoch info
+        --  0              20
+        --  *               |        *
+        --  Node tip     Horizon   Network Tip
+        --  <------------------------>
+        --            gap
+        --
+        --  20 = epoch length = 10*k
+        if gap >= 20
+        then do
+            assertWith "networkTip is Nothing" $ isNothing $ networkTip info
+            assertWith "nextEpoch is Nothing" $ isNothing $ nextEpoch info
+        else do
+            assertWith "networkTip is Just " $ isJust $ networkTip info
+            assertWith "nextEpoch is Just" $ isJust $ nextEpoch info
 
   where
     assertWith :: String -> Bool -> PropertyM IO ()
@@ -180,24 +194,14 @@ spec = describe "API Server" $ do
         :: SlotNo
         -> TimeInterpreter (ExceptT PastHorizonException IO)
         -> NetworkLayer IO Block
-    dummyNetworkLayer sl ti = NetworkLayer
-        { nextBlocks = error "nextBlocks: not implemented"
-        , initCursor = error "initCursor: not implemented"
-        , destroyCursor = error "destroyCursor: not implemented"
-        , cursorSlotNo = error "cursorSlotNo: not implemented"
-        , currentNodeEra = return $ AnyCardanoEra MaryEra
+    dummyNetworkLayer sl ti = mockNetworkLayer
+        { currentNodeEra = return $ AnyCardanoEra MaryEra
         , currentNodeTip = return $
                 BlockHeader
                     sl
                     (Quantity $ fromIntegral $ unSlotNo sl)
                     (Hash "header hash")
                     (Hash "prevHeaderHash")
-        , watchNodeTip = error "todo"
-        , currentProtocolParameters = error "currentProtocolParameters: not implemented"
-        , currentSlottingParameters = error "currentSlottingParameters: not implemented"
-        , postTx = error "postTx: not implemented"
-        , stakeDistribution = error "stakeDistribution: not implemented"
-        , getAccountBalance = error "getAccountBalance: not implemented"
         , timeInterpreter = ti
         }
 
@@ -214,3 +218,60 @@ spec = describe "API Server" $ do
                 HF.EraSummary start (HF.EraEnd end) era1Params
             int = HF.mkInterpreter summary
         in mkTimeInterpreter nullTracer startTime (pure int)
+
+mockNetworkLayer :: NetworkLayer IO a
+mockNetworkLayer = NetworkLayer
+    { nextBlocks = error "nextBlocks: not implemented"
+    , initCursor = error "initCursor: not implemented"
+    , destroyCursor = error "destroyCursor: not implemented"
+    , cursorSlotNo = error "cursorSlotNo: not implemented"
+    , currentNodeEra = error "currentNodeEra: not implemented"
+    , currentNodeTip = error "currentNodeTip: not implemented"
+    , watchNodeTip = error "watchNodeTip: not implemented"
+    , currentProtocolParameters = error "currentProtocolParameters: not implemented"
+    , currentSlottingParameters = error "currentSlottingParameters: not implemented"
+    , postTx = error "postTx: not implemented"
+    , stakeDistribution = error "stakeDistribution: not implemented"
+    , getAccountBalance = error "getAccountBalance: not implemented"
+    , timeInterpreter = error "timeInterpreter: not implemented"
+    }
+
+errorHandlingSpec :: Spec
+errorHandlingSpec = describe "liftHandler and toServerError" $ do
+    let testWalletHandler
+            :: IsServerError e
+            => ExceptT e IO a
+            -> IO (Either ServerError a)
+        testWalletHandler = runHandler . liftHandler
+
+    -- Check that an example error handled by the wallet API server produces a
+    -- structured JSON error message response.
+    it "ErrNoSuchWallet" $ do
+        let handler :: ExceptT ErrNoSuchWallet IO ()
+            handler = throwE $ ErrNoSuchWallet wid
+            wid = unsafeFromText "0000000000000000000000000000000000000000"
+        let expectedErr = ServerError
+                { errHTTPCode = 404
+                , errReasonPhrase = "Not Found"
+                , errBody = mconcat
+                    [ "{\"code\":\"no_such_wallet\",\"message\":\"I couldn't "
+                    , "find a wallet with the given id: 0000000000000000000000000000000000000000\"}" ]
+                , errHeaders =
+                    [("Content-Type","application/json;charset=utf-8")]
+                }
+        testWalletHandler handler `shouldReturn` Left expectedErr
+
+    it "Unhandled exception" $ do
+        pendingWith "TODO: ADP-641 catch all exceptions in application"
+        let expectedErr = ServerError
+                { errHTTPCode = 500
+                , errReasonPhrase = "Internal Server Error"
+                , errBody = mconcat
+                    [ "{\"code\":\"internal_server_error\","
+                    , "\"message\":\"Something went wrong\"}" ]
+                , errHeaders =
+                    [("Content-Type","application/json;charset=utf-8")]
+                }
+
+        runHandler (getNetworkClock (error "bomb") True)
+            `shouldReturn` Left expectedErr

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -346,7 +346,7 @@ instance GenericApiSpec (Map [Text] [Method])
 
 application :: Application
 application = serve api server
-    & handleRawError (curry handler)
+    & handleRawError (curry toServerError)
 
 -- Note: Doesn't validate the jormungandr api.
 api :: Proxy (Api ('Testnet 0) ApiStakePool)

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -27,11 +27,8 @@
 -- mount an existing request body in a request.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
--- See comment in Cardano.Wallet.Jormungandr.Compatibility
+-- See comment in Cardano.Wallet.Shelley.Compatibility
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-
--- Required to use the HLINT pragma
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
 module Cardano.Wallet.ApiSpec
     ( spec
@@ -272,7 +269,7 @@ instance
             (\(a,b) -> gSpec (\c -> toRequest a b c) toSpec)
 
         -- The lambda above helps readability and make the pattern obvious
-        {-# HLINT ignore "Avoid lambda" #-}
+        {- HLINT ignore "Avoid lambda" -}
 
 instance
     ( Typeable a, Malformed (BodyParam a)

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -63,12 +63,12 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
-import Control.Arrow
-    ( first )
 import Control.Monad
     ( forM_ )
 import Data.Aeson.QQ
     ( aesonQQ )
+import Data.Bifunctor
+    ( first )
 import Data.Function
     ( (&) )
 import Data.IORef
@@ -112,7 +112,14 @@ import Network.Wai
 import Network.Wai.Middleware.ServerError
     ( handleRawError )
 import Network.Wai.Test
-    ( Session, assertBody, assertStatus, request, runSession )
+    ( SResponse
+    , Session
+    , assertBody
+    , assertHeader
+    , assertStatus
+    , request
+    , runSession
+    )
 import Servant
     ( Accept (..), Application, ReqBody, Server, StdMethod (..), Verb, serve )
 import Servant.API
@@ -120,7 +127,7 @@ import Servant.API
 import Servant.API.Verbs
     ( NoContentVerb, ReflectMethod (..) )
 import Test.Hspec
-    ( Spec, describe, it, runIO, xdescribe )
+    ( HasCallStack, Spec, describe, it, runIO, xdescribe )
 import Test.Hspec.Extra
     ( parallel )
 import Type.Reflection
@@ -166,41 +173,40 @@ spec = parallel $ do
             forM_ tests $ \(req, msg) -> it (titleize proxy req) $
                 runSession (spec_NotAllowedMethod req msg) application
 
-spec_MalformedParam :: Request -> ExpectedError -> Session ()
-spec_MalformedParam malformedRequest (ExpectedError msg) = do
-    response <- request malformedRequest
-    response & assertStatus 400
+assertErrorResponse
+    :: HasCallStack
+    => Int -- ^ Expected status
+    -> Text -- ^ Expected error code string
+    -> ExpectedError
+    -> SResponse
+    -> Session ()
+assertErrorResponse status code (ExpectedError msg) response = do
+    response & assertStatus status
+    response & assertHeader "Content-Type" "application/json;charset=utf-8"
     response & assertBody (Aeson.encode [aesonQQ|
-        { "code": "bad_request"
+        { "code": #{code}
         , "message": #{msg}
         }|])
+
+spec_MalformedParam :: Request -> ExpectedError -> Session ()
+spec_MalformedParam malformedRequest expectedError = do
+    response <- request malformedRequest
+    assertErrorResponse 400 "bad_request" expectedError response
 
 spec_WrongAcceptHeader :: Request -> ExpectedError -> Session ()
-spec_WrongAcceptHeader malformedRequest (ExpectedError msg) = do
+spec_WrongAcceptHeader malformedRequest expectedError = do
     response <- request malformedRequest
-    response & assertStatus 406
-    response & assertBody (Aeson.encode [aesonQQ|
-        { "code": "not_acceptable"
-        , "message": #{msg}
-        }|])
+    assertErrorResponse 406 "not_acceptable" expectedError response
 
 spec_WrongContentTypeHeader :: Request -> ExpectedError -> Session ()
-spec_WrongContentTypeHeader malformedRequest (ExpectedError msg) = do
+spec_WrongContentTypeHeader malformedRequest expectedError = do
     response <- request malformedRequest
-    response & assertStatus 415
-    response & assertBody (Aeson.encode [aesonQQ|
-        { "code": "unsupported_media_type"
-        , "message": #{msg}
-        }|])
+    assertErrorResponse 415 "unsupported_media_type" expectedError response
 
 spec_NotAllowedMethod :: Request -> ExpectedError -> Session ()
-spec_NotAllowedMethod malformedRequest (ExpectedError msg) = do
+spec_NotAllowedMethod malformedRequest expectedError = do
     response <- request malformedRequest
-    response & assertStatus 405
-    response & assertBody (Aeson.encode [aesonQQ|
-        { "code": "method_not_allowed"
-        , "message": #{msg}
-        }|])
+    assertErrorResponse 405 "method_not_allowed" expectedError response
 
 --
 -- Generic API Spec
@@ -348,7 +354,6 @@ application :: Application
 application = serve api server
     & handleRawError (curry toServerError)
 
--- Note: Doesn't validate the jormungandr api.
 api :: Proxy (Api ('Testnet 0) ApiStakePool)
 api = Proxy
 
@@ -376,13 +381,16 @@ instance DecodeStakeAddress ('Testnet 0) where
 everyPathParam :: GEveryEndpoints api => Proxy api -> MkPathRequest api
 everyPathParam proxy = gEveryPathParam proxy defaultRequest
 
-everyBodyParam :: GEveryEndpoints api => Proxy api -> MkBodyRequest api
-everyBodyParam proxy = gEveryBodyParam proxy $ defaultRequest
+defaultApiRequest :: Request
+defaultApiRequest = defaultRequest
     { requestHeaders =
         [ (hContentType, "application/json")
         , (hAccept, "*/*")
         ]
     }
+
+everyBodyParam :: GEveryEndpoints api => Proxy api -> MkBodyRequest api
+everyBodyParam proxy = gEveryBodyParam proxy defaultApiRequest
 
 everyHeader :: GEveryEndpoints api => Proxy api -> MkHeaderRequest api
 everyHeader proxy = gEveryHeader proxy defaultRequest

--- a/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/ApiSpec.hs
@@ -49,7 +49,7 @@ import Cardano.Wallet.Api.Malformed
     , wellformed
     )
 import Cardano.Wallet.Api.Server
-    ( LiftHandler (..) )
+    ( IsServerError (..) )
 import Cardano.Wallet.Api.Types
     ( ApiStakePool
     , DecodeAddress (..)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-
 -- |
 -- Copyright: © 2018-2020 IOHK
 -- License: Apache-2.0
@@ -252,7 +250,7 @@ server byron icarus shelley spl ntp =
 
     -- Hlint doesn't seem to care about inlining properties:
     --   https://github.com/quchen/articles/blob/master/fbut.md#f-x---is-not-f--x---
-    {-# HLINT ignore "Redundant lambda" #-}
+    {- HLINT ignore "Redundant lambda" -}
     coinSelections :: Server (CoinSelections n)
     coinSelections = (\wid ascd -> case ascd of
         (ApiSelectForPayment ascp) ->


### PR DESCRIPTION
### Issue Number

#2596 / ADP-853

### Overview

- [x] Make the `LiftHandler` type class simpler.
- [x] Add content-type header for all uses of `apiError`
- [x] Add regression test.
- [x] Add content-type to generic api error handler tests.
