### PR TITLE
Bump cabal version to v2021-04-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
+> | [v2021-04-08](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-04-08) | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
 > | [v2021-03-04](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-03-04) | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
 > | [v2021-02-15](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-02-15) | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
-> | [v2021-02-12](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-02-12) | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
-> | [v2021-01-28](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-01-28) | [1.25.1](https://github.com/input-output-hk/cardano-node/releases/tag/1.25.1) | [1.3.0](https://github.com/input-output-hk/smash/releases/tag/1.3.0)
 
 ## How to build from sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2021.3.4-shelley
+    image: inputoutput/cardano-wallet:2021.4.8-shelley
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Wallet backend protocol-specific bits implemented using Shelley nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2021.3.4
+version:             2021.4.8
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2021.3.4"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2021.4.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2021.3.4";
+        version = "2021.4.8";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2021.3.4"; };
+      identifier = { name = "cardano-wallet-core"; version = "2021.4.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2021.3.4"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2021.4.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2021.3.4";
+        version = "2021.4.8";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2021.3.4"; };
+      identifier = { name = "cardano-wallet"; version = "2021.4.8"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2021.3.4"; };
+      identifier = { name = "text-class"; version = "2021.4.8"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -35,7 +35,7 @@ with pkgs.lib;
 let
 
   # List of git revisions to test against.
-  # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.3.4:
+  # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.4.8:
   # nix-prefetch-url --unpack https://github.com/input-output-hk/cardano-wallet/archive/v2021-02-15.zip
   releases = [
     { rev = "v2020-09-30";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -18,8 +18,8 @@ set -euo pipefail
 ################################################################################
 # Release-specific parameters (Change when you bump the version)
 # Release tags must follow format vYYYY-MM-DD.
-OLD_GIT_TAG="v2021-02-15"
-GIT_TAG="v2021-03-04"
+OLD_GIT_TAG="v2021-03-04"
+GIT_TAG="v2021-04-08"
 
 CARDANO_NODE_TAG="1.25.1"
 

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Cardano Wallet Backend API
-  version: 2021.3.4
+  version: 2021.4.8
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
### Overview

- Updates cabal package versions from v2021-03-04 to v2021-04-08.

### Comments

Following https://github.com/input-output-hk/cardano-wallet/wiki/Release-Checklist
