### PR TITLE
fix expect / include assertions in e2e tests & post release

### DIFF
--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -38,10 +38,6 @@ let
   # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.4.8:
   # nix-prefetch-url --unpack https://github.com/input-output-hk/cardano-wallet/archive/v2021-02-15.zip
   releases = [
-    { rev = "v2020-09-30";
-      sha256 = "19vmyq0m67ih295z1y8ng2rdn85mi0rvw26k711lbxsqri7fmyvz"; }
-    { rev = "v2020-10-13";
-      sha256 = "0kc1ddidp1vip8rfnm7vp5avx46xr9nvyzn7q9r3yn50ylhx0i0j"; }
     { rev = "v2020-11-03";
       sha256 = "1v2l46g0f8bkas7mhm624l3kmxz3g80095f4vqicz736bv7vsijc"; }
     { rev = "v2020-11-17";
@@ -58,6 +54,10 @@ let
       sha256 = "0xszv7k531p7jsragvhy5248ihni3alajzd5csjalpv28vd4j0sk"; }
     { rev = "v2021-02-15";
       sha256 = "1mg8n58j2mjqhhzjb4p5yp8z06b9arh40pagi9rddil2f3vxzihm"; }
+    { rev = "v2021-03-04";
+      sha256 = "07awzp8ifgkh966qirlmr8igbx8hx5nlaw3zgflnic3lqc8672sc"; }
+    { rev = "v2021-04-08";
+      sha256 = "06agcxjp3wzb76iiy79yap4qjn37mka0c2ccybnqswm3wr4ngkz2"; }
   ];
 
   # Download the sources for a release.

--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cardano_wallet', '~> 0.3.2'
-gem 'bip_mnemonic', '~> 0.0.4'
-gem 'rake', '~> 12.3'
-gem 'rspec'
+gem 'cardano_wallet', '0.3.2'
+gem 'bip_mnemonic', '0.0.4'
+gem 'rake', '12.3'
+gem 'rspec', '3.10.0'

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
     multi_xml (0.6.0)
-    rake (12.3.3)
+    rake (12.3.0)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -31,10 +31,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bip_mnemonic (~> 0.0.4)
-  cardano_wallet (~> 0.3.2)
-  rake (~> 12.3)
-  rspec
+  bip_mnemonic (= 0.0.4)
+  cardano_wallet (= 0.3.2)
+  rake (= 12.3)
+  rspec (= 3.10.0)
 
 BUNDLED WITH
    2.1.4

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to include "invalid_wallet_type"
+      expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
     it "I cannot import address - ledger" do
@@ -159,7 +159,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to include "invalid_wallet_type"
+      expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
     it "I cannot import address - trezor" do
@@ -167,7 +167,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to include "invalid_wallet_type"
+      expect(addr_import.to_s).to include "invalid_wallet_type"
     end
   end
 
@@ -188,7 +188,7 @@ RSpec.describe CardanoWallet::Byron do
       rnd = BYRON.coin_selections.random wid, addr_amount
 
       expect(rnd).to have_http 403
-      expect(rnd).to include "not_enough_money"
+      expect(rnd.to_s).to include "not_enough_money"
     end
 
     it "ArgumentError on bad argument address_amount" do
@@ -218,7 +218,7 @@ RSpec.describe CardanoWallet::Byron do
         wid = create_byron_wallet style
         txs = BYRON.transactions
         expect(txs.get(wid, TXID)).to have_http 404
-        expect(txs.get(wid, TXID)).to include "no_such_transaction"
+        expect(txs.get(wid, TXID).to_s).to include "no_such_transaction"
       end
 
       it "Can list transactions - #{style}" do
@@ -241,7 +241,7 @@ RSpec.describe CardanoWallet::Byron do
 
         tx_sent = BYRON.transactions.create(id, PASS, [{target_addr => 1000000}])
         expect(tx_sent).to have_http 403
-        expect(tx_sent).to include "not_enough_money"
+        expect(tx_sent.to_s).to include "not_enough_money"
       end
 
       it "I could estimate fees if I had money - #{style}" do
@@ -251,7 +251,7 @@ RSpec.describe CardanoWallet::Byron do
 
         fees = BYRON.transactions.payment_fees(id, [{target_addr => 1000000}])
         expect(fees).to have_http 403
-        expect(fees).to include "not_enough_money"
+        expect(fees.to_s).to include "not_enough_money"
       end
 
       it "I could forget transaction - #{style}" do

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           join = pools.join(SPID, @wid, PASS)
           expect(join).to have_http 404
-          expect(join).to include "no_such_pool"
+          expect(join.to_s).to include "no_such_pool"
         end
 
         it "I could check delegation fees - if I could cover fee" do
@@ -273,7 +273,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           pools = SHELLEY.stake_pools
           fees = pools.delegation_fees(id)
           expect(fees).to have_http 403
-          expect(fees).to include "not_enough_money"
+          expect(fees.to_s).to include "not_enough_money"
         end
 
         it "I could join Stake Pool - if I had enough to cover fee" do
@@ -283,7 +283,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           join = pools.join(pool_id, id, PASS)
           expect(join).to have_http 403
-          expect(join).to include "not_enough_money"
+          expect(join.to_s).to include "not_enough_money"
         end
 
         it "Can list stake pools only when stake is provided" do
@@ -291,7 +291,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           expect(pools.list({stake: 1000})).to have_http 200
 
           expect(pools.list).to have_http 400
-          expect(pools.list).to include "query_param_missing"
+          expect(pools.list.to_s).to include "query_param_missing"
         end
 
         it "Can join and quit Stake Pool" do
@@ -321,7 +321,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           join = pools.join(pool_id, @target_id_pools, PASS)
 
           expect(join).to have_http 202
-          expect(join).to include "status"
+          expect(join.to_s).to include "status"
 
           join_tx_id = join['id']
           eventually "Checking if join tx id (#{join_tx_id}) is in_ledger" do
@@ -334,7 +334,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           quit = pools.quit(@target_id_pools, PASS)
 
           expect(quit).to have_http 202
-          expect(quit).to include "status"
+          expect(quit.to_s).to include "status"
 
           quit_tx_id = quit['id']
           eventually "Checking if quit tx id (#{quit_tx_id}) is in_ledger" do
@@ -397,7 +397,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_join
           expect(rnd).to have_http 403
-          expect(rnd).to include "not_enough_money"
+          expect(rnd.to_s).to include "not_enough_money"
         end
 
         it "I could trigger random coin selection delegation action - if I known pool id" do
@@ -408,11 +408,11 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_join
           expect(rnd).to have_http 404
-          expect(rnd).to include "no_such_pool"
+          expect(rnd.to_s).to include "no_such_pool"
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
           expect(rnd).to have_http 403
-          expect(rnd).to include "not_delegating_to"
+          expect(rnd.to_s).to include "not_delegating_to"
         end
 
       end

--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "addr"
       res = UTILS.addresses addr
       expect(res).to have_http 400
-      expect(res).to include "bad_request"
+      expect(res.to_s).to include "bad_request"
     end
 
     it "Inspect Shelley payment address" do

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount
       expect(rnd).to have_http 403
-      expect(rnd).to include "not_enough_money"
+      expect(rnd.to_s).to include "not_enough_money"
     end
   end
 
@@ -164,7 +164,7 @@ RSpec.describe CardanoWallet::Shelley do
       wid = create_shelley_wallet
       txs = SHELLEY.transactions
       expect(txs.get(wid, TXID)).to have_http 404
-      expect(txs.get(wid, TXID)).to include "no_such_transaction"
+      expect(txs.get(wid, TXID).to_s).to include "no_such_transaction"
     end
 
     it "Can list transactions" do
@@ -190,7 +190,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       tx_sent = txs.create(id, PASS, amt)
       expect(tx_sent).to have_http 403
-      expect(tx_sent).to include "not_enough_money"
+      expect(tx_sent.to_s).to include "not_enough_money"
     end
 
     it "I could create transaction using rewards - if I had money" do
@@ -202,7 +202,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       tx_sent = txs.create(id, PASS, amt, 'self')
       expect(tx_sent).to have_http 403
-      expect(tx_sent).to include "not_enough_money"
+      expect(tx_sent.to_s).to include "not_enough_money"
     end
 
     it "I could estimate transaction fee - if I had money" do
@@ -215,11 +215,11 @@ RSpec.describe CardanoWallet::Shelley do
 
       fees = txs.payment_fees(id, amt)
       expect(fees).to have_http 403
-      expect(fees).to include "not_enough_money"
+      expect(fees.to_s).to include "not_enough_money"
 
       fees = txs.payment_fees(id, amt, 'self')
       expect(fees).to have_http 403
-      expect(fees).to include "not_enough_money"
+      expect(fees.to_s).to include "not_enough_money"
 
       metadata = { "0"=>{ "string"=>"cardano" },
                    "1"=>{ "int"=>14 },
@@ -230,7 +230,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       fees = txs.payment_fees(id, amt, 'self', metadata)
       expect(fees).to have_http 403
-      expect(fees).to include "not_enough_money"
+      expect(fees.to_s).to include "not_enough_money"
     end
 
     it "I could forget transaction" do
@@ -314,7 +314,7 @@ RSpec.describe CardanoWallet::Shelley do
       pools = SHELLEY.stake_pools
       quit = pools.quit(id, PASS)
       expect(quit).to have_http 403
-      expect(quit).to include "not_delegating_to"
+      expect(quit.to_s).to include "not_delegating_to"
     end
 
   end
@@ -328,7 +328,7 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       cost = SHELLEY.migrations.cost(id)
       expect(cost).to have_http 501
-      expect(cost).to include "not_implemented"
+      expect(cost.to_s).to include "not_implemented"
     end
 
     it "I could migrate all my funds" do
@@ -337,7 +337,7 @@ RSpec.describe CardanoWallet::Shelley do
       addrs = SHELLEY.addresses.list(target_id).map{ |a| a['id'] }
       migr = SHELLEY.migrations.migrate(id, PASS, addrs)
       expect(migr).to have_http 501
-      expect(migr).to include "not_implemented"
+      expect(migr.to_s).to include "not_implemented"
     end
   end
 
@@ -375,7 +375,7 @@ RSpec.describe CardanoWallet::Shelley do
       ["0H", "1H", "2147483647H", "44H"].each do |index|
         res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, extended = true)
         expect(res).to have_http 202
-        expect(res).to include "acc"
+        expect(res.to_s).to include "acc"
       end
     end
 
@@ -384,7 +384,7 @@ RSpec.describe CardanoWallet::Shelley do
       ["0H", "1H", "2147483647H", "44H"].each do |index|
         res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, extended = false)
         expect(res).to have_http 202
-        expect(res).to include "acc"
+        expect(res.to_s).to include "acc"
       end
     end
 


### PR DESCRIPTION
# Issue Number

n/a


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- 66dd5f1e48c9ec3dbea4c7023febe6690a4da07f
  fix expect / include assertions
  
- 606ef89d53c517625c9ffe5fe5844ba6dedba0a9
  update migration-tests.nix



# Comments

They suddenly started to fail, on checking if response includes some text. Probably due to some silent dependency update (perhaps httparty?). The fix is to explicitly cast response to string...