### PR TITLE
e2e tests: additional checks for application/json response headers

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -44,25 +44,25 @@ end
 task :fixture_wallets_template do
   puts "\n  >> Creating #{FIXTURES_FILE}"
 
-  fixture_wallets = { :linux => {:shelley => mnemonic_sentence(24),
+  fixture_wallets = { :linux => { :shelley => mnemonic_sentence(24),
                                  :icarus => mnemonic_sentence(15),
                                  :byron => mnemonic_sentence(12) },
-                      :macos => {:shelley => mnemonic_sentence(24),
+                      :macos => { :shelley => mnemonic_sentence(24),
                                  :icarus => mnemonic_sentence(15),
                                  :byron => mnemonic_sentence(12) },
-                      :windows => {:shelley => mnemonic_sentence(24),
+                      :windows => { :shelley => mnemonic_sentence(24),
                                    :icarus => mnemonic_sentence(15),
                                    :byron => mnemonic_sentence(12) }
                     }
   if File.exists?(FIXTURES_FILE)
-    err = %Q{
+    err = "
               File #{FIXTURES_FILE} already exists!
               I don't want to overwrite it in case it
               contains fixture wallets already...
-            }
+            "
     STDERR.puts err
   else
-    File.open(FIXTURES_FILE, 'w') {|f| f.write JSON.pretty_generate(fixture_wallets) }
+    File.open(FIXTURES_FILE, 'w') { |f| f.write JSON.pretty_generate(fixture_wallets) }
   end
 
 end
@@ -209,7 +209,7 @@ task :get_latest_configs, [:env] do |task, args|
   env = args[:env]
   out = File.join(CONFIGS, env)
 
-  if (File.exist?(out) and not File.writable?(out))
+  if (File.exist?(out) && (not File.writable?(out)))
     # The config directory is probably a /nix/store path
     puts "\n  >> Using config directory '#{out}'"
   else
@@ -227,7 +227,7 @@ task :get_latest_configs, [:env] do |task, args|
     # remove environment names from genesis files
     config = File.read(config_file)
     config_edited = config.gsub(/#{env}-([^-]+)-genesis.json/, 'genesis-\1.json')
-    File.open(config_file, "w") {|file| file.puts config_edited }
+    File.open(config_file, "w") { |file| file.puts config_edited }
   end
 end
 
@@ -235,8 +235,8 @@ task :get_docker_logs do
   puts "\n  >> Getting docker logs into #{LOGS}"
 
   mk_dir(LOGS)
-  node_logfile = `docker inspect --format='{{.LogPath}}' cardano-node`.gsub("\n",'')
-  wallet_logfile = `docker inspect --format='{{.LogPath}}' cardano-wallet`.gsub("\n",'')
+  node_logfile = `docker inspect --format='{{.LogPath}}' cardano-node`.gsub("\n", '')
+  wallet_logfile = `docker inspect --format='{{.LogPath}}' cardano-wallet`.gsub("\n", '')
 
   cmd "sudo cp #{node_logfile} #{LOGS}/node.log"
   cmd "sudo cp #{wallet_logfile} #{LOGS}/wallet.log"

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -1,6 +1,41 @@
 require "rspec/expectations"
 
-RSpec::Matchers.define :have_http do |code|
+RSpec::Matchers.define :be_correct_and_respond do |code|
+  match do |response|
+    if code == 204
+      response.code == code
+    else
+      ((response.code == code) && ({ 'content-type' => ['application/json;charset=utf-8'] } <= response.headers))
+    end
+  end
+  failure_message do |response|
+    method = response.request.http_method.to_s.split('::').last.upcase
+    uri = response.request.last_uri
+    body = response.request.options[:body]
+    headers = response.request.options[:headers]
+
+    "
+        The response did not return expected HTTP code or header 'content-type: application/json'!
+        Expected code = #{code}
+        Actual code = #{response.code}
+
+        Actual request:
+        #{method} #{uri}
+        #{'Body: ' + body if body}
+        #{'Headers: ' + headers.to_s if headers}
+
+        Actual response:
+        #{response}
+
+        Actual response headers:
+        #{response.headers}
+
+        Time: #{Time.now}
+      "
+  end
+end
+
+RSpec::Matchers.define :respond_with do |code|
   match do |response|
     response.code == code
   end
@@ -23,33 +58,8 @@ RSpec::Matchers.define :have_http do |code|
         Actual response:
         #{response}
 
-        Time: #{Time.now}
-      "
-  end
-end
-
-RSpec::Matchers.define :have_expected_headers do
-  match do |response|
-    { 'content-type' => ['application/json;charset=utf-8'] } <= response.headers
-  end
-  failure_message do |response|
-    method = response.request.http_method.to_s.split('::').last.upcase
-    uri = response.request.last_uri
-    body = response.request.options[:body]
-    headers = response.request.options[:headers]
-
-    "
-        The response did not return expected HTTP header!
-        Expected response headers = #{expected_headers}
-        Actual response headers = #{response.headers}
-
-        Actual request:
-        #{method} #{uri}
-        #{'Body: ' + body if body}
-        #{'Headers: ' + headers.to_s if headers}
-
-        Actual response:
-        #{response}
+        Actual response headers:
+        #{response.headers}
 
         Time: #{Time.now}
       "

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -27,3 +27,31 @@ RSpec::Matchers.define :have_http do |code|
         }
     end
   end
+
+  RSpec::Matchers.define :have_headers do |expected_headers|
+      match do |response|
+        expected_headers <= response.headers
+      end
+      failure_message do |response|
+        method = response.request.http_method.to_s.split('::').last.upcase
+        uri = response.request.last_uri
+        body = response.request.options[:body]
+        headers = response.request.options[:headers]
+
+        %Q{
+            The response did not return expected HTTP header!
+            Expected response headers = #{expected_headers}
+            Actual response headers = #{response.headers}
+
+            Actual request:
+            #{method} #{uri}
+            #{'Body: ' + body if body}
+            #{'Headers: ' + headers.to_s if headers}
+
+            Actual response:
+            #{response}
+
+            Time: #{Time.now}
+          }
+      end
+    end

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -1,57 +1,57 @@
 require "rspec/expectations"
 
 RSpec::Matchers.define :have_http do |code|
-    match do |response|
-      response.code == code
-    end
-    failure_message do |response|
-      method = response.request.http_method.to_s.split('::').last.upcase
-      uri = response.request.last_uri
-      body = response.request.options[:body]
-      headers = response.request.options[:headers]
-
-      %Q{
-          The response did not return expected HTTP code!
-          Expected code = #{code}
-          Actual code = #{response.code}
-
-          Actual request:
-          #{method} #{uri}
-          #{'Body: ' + body if body}
-          #{'Headers: ' + headers.to_s if headers}
-
-          Actual response:
-          #{response}
-
-          Time: #{Time.now}
-        }
-    end
+  match do |response|
+    response.code == code
   end
+  failure_message do |response|
+    method = response.request.http_method.to_s.split('::').last.upcase
+    uri = response.request.last_uri
+    body = response.request.options[:body]
+    headers = response.request.options[:headers]
 
-  RSpec::Matchers.define :have_headers do |expected_headers|
-      match do |response|
-        expected_headers <= response.headers
-      end
-      failure_message do |response|
-        method = response.request.http_method.to_s.split('::').last.upcase
-        uri = response.request.last_uri
-        body = response.request.options[:body]
-        headers = response.request.options[:headers]
+    "
+        The response did not return expected HTTP code!
+        Expected code = #{code}
+        Actual code = #{response.code}
 
-        %Q{
-            The response did not return expected HTTP header!
-            Expected response headers = #{expected_headers}
-            Actual response headers = #{response.headers}
+        Actual request:
+        #{method} #{uri}
+        #{'Body: ' + body if body}
+        #{'Headers: ' + headers.to_s if headers}
 
-            Actual request:
-            #{method} #{uri}
-            #{'Body: ' + body if body}
-            #{'Headers: ' + headers.to_s if headers}
+        Actual response:
+        #{response}
 
-            Actual response:
-            #{response}
+        Time: #{Time.now}
+      "
+  end
+end
 
-            Time: #{Time.now}
-          }
-      end
-    end
+RSpec::Matchers.define :have_headers do |expected_headers|
+  match do |response|
+    expected_headers <= response.headers
+  end
+  failure_message do |response|
+    method = response.request.http_method.to_s.split('::').last.upcase
+    uri = response.request.last_uri
+    body = response.request.options[:body]
+    headers = response.request.options[:headers]
+
+    "
+        The response did not return expected HTTP header!
+        Expected response headers = #{expected_headers}
+        Actual response headers = #{response.headers}
+
+        Actual request:
+        #{method} #{uri}
+        #{'Body: ' + body if body}
+        #{'Headers: ' + headers.to_s if headers}
+
+        Actual response:
+        #{response}
+
+        Time: #{Time.now}
+      "
+  end
+end

--- a/test/e2e/helpers/matchers.rb
+++ b/test/e2e/helpers/matchers.rb
@@ -28,9 +28,9 @@ RSpec::Matchers.define :have_http do |code|
   end
 end
 
-RSpec::Matchers.define :have_headers do |expected_headers|
+RSpec::Matchers.define :have_expected_headers do
   match do |response|
-    expected_headers <= response.headers
+    { 'content-type' => ['application/json;charset=utf-8'] } <= response.headers
   end
   failure_message do |response|
     method = response.request.http_method.to_s.split('::').last.upcase

--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -4,7 +4,6 @@ require 'fileutils'
 
 module Helpers
   module Utils
-
     def cmd(cmd)
       puts cmd
       puts `#{cmd}`

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe CardanoWallet::Byron do
     it "I can list byron wallets" do
       l = BYRON.wallets.list
       expect(l).to have_http 200
-      expect(l).to have_headers(EXPECTED_HEADERS)
+      expect(l).to have_expected_headers
     end
 
     it "I could get a wallet" do
       g = BYRON.wallets.get "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
       expect(g).to have_http 404
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
     end
 
     it "I could delete a wallet" do
       g = BYRON.wallets.delete "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
       expect(g).to have_http 404
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
     end
 
     it "I can create, get and delete byron icarus wallet from mnemonics" do
@@ -31,11 +31,11 @@ RSpec.describe CardanoWallet::Byron do
                          mnemonic_sentence: mnemonic_sentence(15),
                          })
       expect(wallet).to have_http 201
-      expect(wallet).to have_headers(EXPECTED_HEADERS)
+      expect(wallet).to have_expected_headers
       wid = wallet['id']
       g = BYRON.wallets.get(wid)
       expect(g).to have_http 200
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
 
       expect(BYRON.wallets.delete(wid)).to have_http 204
     end
@@ -47,12 +47,12 @@ RSpec.describe CardanoWallet::Byron do
                          mnemonic_sentence: mnemonic_sentence(12),
                          })
       expect(wallet).to have_http 201
-      expect(wallet).to have_headers(EXPECTED_HEADERS)
+      expect(wallet).to have_expected_headers
 
       wid = wallet['id']
       g = BYRON.wallets.get(wid)
       expect(g).to have_http 200
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
 
       expect(BYRON.wallets.delete(wid)).to have_http 204
     end
@@ -62,7 +62,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       u = w.update_metadata(id, { name: "New wallet name" })
       expect(u).to have_http 200
-      expect(u).to have_headers(EXPECTED_HEADERS)
+      expect(u).to have_expected_headers
     end
 
     it "Can update_passphrase" do
@@ -77,7 +77,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       utxo = BYRON.wallets.utxo(id)
       expect(utxo).to have_http 200
-      expect(utxo).to have_headers(EXPECTED_HEADERS)
+      expect(utxo).to have_expected_headers
     end
   end
 
@@ -91,13 +91,13 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
-      expect(addresses).to have_headers(EXPECTED_HEADERS)
+      expect(addresses).to have_expected_headers
       expect(addresses.size).to eq 0
 
       BYRON.addresses.create(id, { passphrase: PASS })
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
-      expect(addresses).to have_headers(EXPECTED_HEADERS)
+      expect(addresses).to have_expected_headers
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path'][0]).to eq '0H'
       expect(addresses.first['derivation_path'][1]).to end_with 'H'
@@ -107,7 +107,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "icarus"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
+      expect(addresses_unused).to have_expected_headers
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -118,7 +118,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "ledger"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
+      expect(addresses_unused).to have_expected_headers
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -129,7 +129,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "trezor"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
+      expect(addresses_unused).to have_expected_headers
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -141,12 +141,12 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.create(id, { passphrase: PASS,
                                          address_index: 2147483648 })
       expect(addr).to have_http 201
-      expect(addr).to have_headers(EXPECTED_HEADERS)
+      expect(addr).to have_expected_headers
       expect(addr['derivation_path']).to eq ['0H', '0H']
 
       addr_r = BYRON.addresses.create(id, { passphrase: PASS })
       expect(addr_r).to have_http 201
-      expect(addr_r).to have_headers(EXPECTED_HEADERS)
+      expect(addr_r).to have_expected_headers
       expect(addr_r['derivation_path'][0]).to eq '0H'
       expect(addr_r['derivation_path'][1]).to end_with 'H'
     end
@@ -159,7 +159,7 @@ RSpec.describe CardanoWallet::Byron do
 
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
-      expect(addresses).to have_headers(EXPECTED_HEADERS)
+      expect(addresses).to have_expected_headers
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path']).to eq ['0H', '2147483647H']
     end
@@ -169,7 +169,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to have_headers(EXPECTED_HEADERS)
+      expect(addr_import).to have_expected_headers
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -178,7 +178,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to have_headers(EXPECTED_HEADERS)
+      expect(addr_import).to have_expected_headers
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -187,7 +187,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
-      expect(addr_import).to have_headers(EXPECTED_HEADERS)
+      expect(addr_import).to have_expected_headers
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
   end
@@ -209,7 +209,7 @@ RSpec.describe CardanoWallet::Byron do
       rnd = BYRON.coin_selections.random wid, addr_amount
 
       expect(rnd).to have_http 403
-      expect(rnd).to have_headers(EXPECTED_HEADERS)
+      expect(rnd).to have_expected_headers
       expect(rnd.to_s).to include "not_enough_money"
     end
 
@@ -228,7 +228,7 @@ RSpec.describe CardanoWallet::Byron do
         txs = BYRON.transactions
         g = txs.get(wid, TXID)
         expect(g).to have_http 404
-        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g).to have_expected_headers
         expect(g.to_s).to include "no_such_transaction"
       end
 
@@ -252,7 +252,7 @@ RSpec.describe CardanoWallet::Byron do
 
         tx_sent = BYRON.transactions.create(id, PASS, [{ target_addr => 1000000 }])
         expect(tx_sent).to have_http 403
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "not_enough_money"
       end
 
@@ -263,7 +263,7 @@ RSpec.describe CardanoWallet::Byron do
 
         fees = BYRON.transactions.payment_fees(id, [{ target_addr => 1000000 }])
         expect(fees).to have_http 403
-        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees).to have_expected_headers
         expect(fees.to_s).to include "not_enough_money"
       end
 
@@ -272,7 +272,7 @@ RSpec.describe CardanoWallet::Byron do
         txs = BYRON.transactions
         res = txs.forget(id, TXID)
         expect(res).to have_http 404
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
       end
     end
   end
@@ -286,7 +286,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "icarus"
       cost = BYRON.migrations.cost(id)
       expect(cost).to have_http 501
-      expect(cost).to have_headers(EXPECTED_HEADERS)
+      expect(cost).to have_expected_headers
     end
 
     it "I could migrate all my funds" do
@@ -295,7 +295,7 @@ RSpec.describe CardanoWallet::Byron do
       addresses = BYRON.addresses.list(target_wal_id).map { |a| a['id'] }
       migr = BYRON.migrations.migrate(id, PASS, addresses)
       expect(migr).to have_http 501
-      expect(migr).to have_headers(EXPECTED_HEADERS)
+      expect(migr).to have_expected_headers
     end
   end
 end

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -8,20 +8,17 @@ RSpec.describe CardanoWallet::Byron do
 
     it "I can list byron wallets" do
       l = BYRON.wallets.list
-      expect(l).to have_http 200
-      expect(l).to have_expected_headers
+      expect(l).to be_correct_and_respond 200
     end
 
     it "I could get a wallet" do
       g = BYRON.wallets.get "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
-      expect(g).to have_http 404
-      expect(g).to have_expected_headers
+      expect(g).to be_correct_and_respond 404
     end
 
     it "I could delete a wallet" do
       g = BYRON.wallets.delete "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
-      expect(g).to have_http 404
-      expect(g).to have_expected_headers
+      expect(g).to be_correct_and_respond 404
     end
 
     it "I can create, get and delete byron icarus wallet from mnemonics" do
@@ -30,14 +27,12 @@ RSpec.describe CardanoWallet::Byron do
                          passphrase: "Secure Passphrase",
                          mnemonic_sentence: mnemonic_sentence(15),
                          })
-      expect(wallet).to have_http 201
-      expect(wallet).to have_expected_headers
+      expect(wallet).to be_correct_and_respond 201
+
       wid = wallet['id']
       g = BYRON.wallets.get(wid)
-      expect(g).to have_http 200
-      expect(g).to have_expected_headers
-
-      expect(BYRON.wallets.delete(wid)).to have_http 204
+      expect(g).to be_correct_and_respond 200
+      expect(BYRON.wallets.delete(wid)).to be_correct_and_respond 204
     end
 
     it "I can create, get and delete byron random wallet from mnemonics" do
@@ -46,23 +41,23 @@ RSpec.describe CardanoWallet::Byron do
                          passphrase: "Secure Passphrase",
                          mnemonic_sentence: mnemonic_sentence(12),
                          })
-      expect(wallet).to have_http 201
-      expect(wallet).to have_expected_headers
+      expect(wallet).to be_correct_and_respond 201
+
 
       wid = wallet['id']
       g = BYRON.wallets.get(wid)
-      expect(g).to have_http 200
-      expect(g).to have_expected_headers
+      expect(g).to be_correct_and_respond 200
 
-      expect(BYRON.wallets.delete(wid)).to have_http 204
+
+      expect(BYRON.wallets.delete(wid)).to be_correct_and_respond 204
     end
 
     it "Can update_metadata" do
       w = BYRON.wallets
       id = create_byron_wallet
       u = w.update_metadata(id, { name: "New wallet name" })
-      expect(u).to have_http 200
-      expect(u).to have_expected_headers
+      expect(u).to be_correct_and_respond 200
+
     end
 
     it "Can update_passphrase" do
@@ -70,14 +65,14 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
                                     new_passphrase: "Securer Passphrase" })
-      expect(upd).to have_http 204
+      expect(upd).to be_correct_and_respond 204
     end
 
     it "Can see utxo" do
       id = create_byron_wallet
       utxo = BYRON.wallets.utxo(id)
-      expect(utxo).to have_http 200
-      expect(utxo).to have_expected_headers
+      expect(utxo).to be_correct_and_respond 200
+
     end
   end
 
@@ -90,14 +85,14 @@ RSpec.describe CardanoWallet::Byron do
     it "Can list addresses - random" do
       id = create_byron_wallet
       addresses = BYRON.addresses.list id
-      expect(addresses).to have_http 200
-      expect(addresses).to have_expected_headers
+      expect(addresses).to be_correct_and_respond 200
+
       expect(addresses.size).to eq 0
 
       BYRON.addresses.create(id, { passphrase: PASS })
       addresses = BYRON.addresses.list id
-      expect(addresses).to have_http 200
-      expect(addresses).to have_expected_headers
+      expect(addresses).to be_correct_and_respond 200
+
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path'][0]).to eq '0H'
       expect(addresses.first['derivation_path'][1]).to end_with 'H'
@@ -106,8 +101,8 @@ RSpec.describe CardanoWallet::Byron do
     it "Can list addresses - icarus" do
       id = create_byron_wallet "icarus"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
-      expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_expected_headers
+      expect(addresses_unused).to be_correct_and_respond 200
+
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -117,8 +112,8 @@ RSpec.describe CardanoWallet::Byron do
     it "Can list addresses - ledger" do
       id = create_byron_wallet "ledger"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
-      expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_expected_headers
+      expect(addresses_unused).to be_correct_and_respond 200
+
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -128,8 +123,8 @@ RSpec.describe CardanoWallet::Byron do
     it "Can list addresses - trezor" do
       id = create_byron_wallet "trezor"
       addresses_unused = BYRON.addresses.list id, { state: "unused" }
-      expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_expected_headers
+      expect(addresses_unused).to be_correct_and_respond 200
+
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -140,13 +135,11 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       addr = BYRON.addresses.create(id, { passphrase: PASS,
                                          address_index: 2147483648 })
-      expect(addr).to have_http 201
-      expect(addr).to have_expected_headers
+      expect(addr).to be_correct_and_respond 201
       expect(addr['derivation_path']).to eq ['0H', '0H']
 
       addr_r = BYRON.addresses.create(id, { passphrase: PASS })
-      expect(addr_r).to have_http 201
-      expect(addr_r).to have_expected_headers
+      expect(addr_r).to be_correct_and_respond 201
       expect(addr_r['derivation_path'][0]).to eq '0H'
       expect(addr_r['derivation_path'][1]).to end_with 'H'
     end
@@ -155,11 +148,10 @@ RSpec.describe CardanoWallet::Byron do
       id = create_fixture_byron_wallet
       addr = '37btjrVyb4KEciULDrqJDBh6SjgPqi9JJ5qQqWGgvtsB7GcsuqorKceMTBRudFK8zDu3btoC5FtN7K1PEHmko4neQPfV9TDVfivc9JTZVNPKtRd4w2'
       addr_import = BYRON.addresses.import(id, addr)
-      expect(addr_import).to have_http 204
+      expect(addr_import).to be_correct_and_respond 204
 
       addresses = BYRON.addresses.list id
-      expect(addresses).to have_http 200
-      expect(addresses).to have_expected_headers
+      expect(addresses).to be_correct_and_respond 200
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path']).to eq ['0H', '2147483647H']
     end
@@ -168,8 +160,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "icarus"
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
-      expect(addr_import).to have_http 403
-      expect(addr_import).to have_expected_headers
+      expect(addr_import).to be_correct_and_respond 403
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -177,8 +168,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "ledger"
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
-      expect(addr_import).to have_http 403
-      expect(addr_import).to have_expected_headers
+      expect(addr_import).to be_correct_and_respond 403
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -186,8 +176,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "trezor"
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
-      expect(addr_import).to have_http 403
-      expect(addr_import).to have_expected_headers
+      expect(addr_import).to be_correct_and_respond 403
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
   end
@@ -208,8 +197,7 @@ RSpec.describe CardanoWallet::Byron do
 
       rnd = BYRON.coin_selections.random wid, addr_amount
 
-      expect(rnd).to have_http 403
-      expect(rnd).to have_expected_headers
+      expect(rnd).to be_correct_and_respond 403
       expect(rnd.to_s).to include "not_enough_money"
     end
 
@@ -227,8 +215,7 @@ RSpec.describe CardanoWallet::Byron do
         wid = create_byron_wallet style
         txs = BYRON.transactions
         g = txs.get(wid, TXID)
-        expect(g).to have_http 404
-        expect(g).to have_expected_headers
+        expect(g).to be_correct_and_respond 404
         expect(g.to_s).to include "no_such_transaction"
       end
 
@@ -236,13 +223,13 @@ RSpec.describe CardanoWallet::Byron do
         id = create_byron_wallet style
         txs = BYRON.transactions
 
-        expect(txs.list(id)).to have_http 200
+        expect(txs.list(id)).to be_correct_and_respond 200
         expect(txs.list(id,
                         { start: "2012-09-25T10:15:00Z",
                          end: "2016-11-21T10:15:00Z",
                          order: "ascending" }).code).
                         to eq 200
-        expect(txs.list(id, { order: "bad_order" })).to have_http 400
+        expect(txs.list(id, { order: "bad_order" })).to be_correct_and_respond 400
       end
 
       it "I could send tx if I had money - #{style}" do
@@ -251,8 +238,7 @@ RSpec.describe CardanoWallet::Byron do
         target_addr = BYRON.addresses.list(target_id)[0]['id']
 
         tx_sent = BYRON.transactions.create(id, PASS, [{ target_addr => 1000000 }])
-        expect(tx_sent).to have_http 403
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 403
         expect(tx_sent.to_s).to include "not_enough_money"
       end
 
@@ -262,8 +248,7 @@ RSpec.describe CardanoWallet::Byron do
         target_addr = BYRON.addresses.list(target_id)[0]['id']
 
         fees = BYRON.transactions.payment_fees(id, [{ target_addr => 1000000 }])
-        expect(fees).to have_http 403
-        expect(fees).to have_expected_headers
+        expect(fees).to be_correct_and_respond 403
         expect(fees.to_s).to include "not_enough_money"
       end
 
@@ -271,8 +256,7 @@ RSpec.describe CardanoWallet::Byron do
         id = create_byron_wallet style
         txs = BYRON.transactions
         res = txs.forget(id, TXID)
-        expect(res).to have_http 404
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 404
       end
     end
   end
@@ -285,8 +269,7 @@ RSpec.describe CardanoWallet::Byron do
     it "I could calculate migration cost" do
       id = create_byron_wallet "icarus"
       cost = BYRON.migrations.cost(id)
-      expect(cost).to have_http 501
-      expect(cost).to have_expected_headers
+      expect(cost).to be_correct_and_respond 501
     end
 
     it "I could migrate all my funds" do
@@ -294,8 +277,7 @@ RSpec.describe CardanoWallet::Byron do
       target_wal_id = create_byron_wallet "icarus"
       addresses = BYRON.addresses.list(target_wal_id).map { |a| a['id'] }
       migr = BYRON.migrations.migrate(id, PASS, addresses)
-      expect(migr).to have_http 501
-      expect(migr).to have_expected_headers
+      expect(migr).to be_correct_and_respond 501
     end
   end
 end

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -9,16 +9,19 @@ RSpec.describe CardanoWallet::Byron do
     it "I can list byron wallets" do
       l = BYRON.wallets.list
       expect(l).to have_http 200
+      expect(l).to have_headers(EXPECTED_HEADERS)
     end
 
     it "I could get a wallet" do
       g = BYRON.wallets.get "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
       expect(g).to have_http 404
+      expect(g).to have_headers(EXPECTED_HEADERS)
     end
 
     it "I could delete a wallet" do
       g = BYRON.wallets.delete "db66f3d0d796c6aa0ad456a36d5a3ee88d62bd5d"
       expect(g).to have_http 404
+      expect(g).to have_headers(EXPECTED_HEADERS)
     end
 
     it "I can create, get and delete byron icarus wallet from mnemonics" do
@@ -28,8 +31,12 @@ RSpec.describe CardanoWallet::Byron do
                          mnemonic_sentence: mnemonic_sentence(15),
                          })
       expect(wallet).to have_http 201
+      expect(wallet).to have_headers(EXPECTED_HEADERS)
       wid = wallet['id']
-      expect(BYRON.wallets.get(wid)).to have_http 200
+      g = BYRON.wallets.get(wid)
+      expect(g).to have_http 200
+      expect(g).to have_headers(EXPECTED_HEADERS)
+
       expect(BYRON.wallets.delete(wid)).to have_http 204
     end
 
@@ -40,20 +47,22 @@ RSpec.describe CardanoWallet::Byron do
                          mnemonic_sentence: mnemonic_sentence(12),
                          })
       expect(wallet).to have_http 201
-      wid = wallet['id']
-      expect(BYRON.wallets.get(wid)).to have_http 200
-      expect(BYRON.wallets.delete(wid)).to have_http 204
-    end
+      expect(wallet).to have_headers(EXPECTED_HEADERS)
 
-    it "Create param must be hash" do
-      w = BYRON.wallets
-      expect{w.create("That's bad param")}.to raise_error ArgumentError, "argument should be Hash"
+      wid = wallet['id']
+      g = BYRON.wallets.get(wid)
+      expect(g).to have_http 200
+      expect(g).to have_headers(EXPECTED_HEADERS)
+
+      expect(BYRON.wallets.delete(wid)).to have_http 204
     end
 
     it "Can update_metadata" do
       w = BYRON.wallets
       id = create_byron_wallet
-      expect(w.update_metadata(id,{name: "New wallet name"})).to have_http 200
+      u = w.update_metadata(id,{name: "New wallet name"})
+      expect(u).to have_http 200
+      expect(u).to have_headers(EXPECTED_HEADERS)
     end
 
     it "Can update_passphrase" do
@@ -68,6 +77,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       utxo = BYRON.wallets.utxo(id)
       expect(utxo).to have_http 200
+      expect(utxo).to have_headers(EXPECTED_HEADERS)
     end
   end
 
@@ -81,11 +91,13 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
+      expect(addresses).to have_headers(EXPECTED_HEADERS)
       expect(addresses.size).to eq 0
 
       BYRON.addresses.create(id, {passphrase: PASS})
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
+      expect(addresses).to have_headers(EXPECTED_HEADERS)
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path'][0]).to eq '0H'
       expect(addresses.first['derivation_path'][1]).to end_with 'H'
@@ -95,6 +107,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "icarus"
       addresses_unused = BYRON.addresses.list id, {state: "unused"}
       expect(addresses_unused).to have_http 200
+      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a,i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -105,6 +118,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "ledger"
       addresses_unused = BYRON.addresses.list id, {state: "unused"}
       expect(addresses_unused).to have_http 200
+      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a,i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -115,6 +129,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "trezor"
       addresses_unused = BYRON.addresses.list id, {state: "unused"}
       expect(addresses_unused).to have_http 200
+      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a,i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
@@ -126,10 +141,12 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.create(id, {passphrase: PASS,
                                          address_index: 2147483648})
       expect(addr).to have_http 201
+      expect(addr).to have_headers(EXPECTED_HEADERS)
       expect(addr['derivation_path']).to eq ['0H', '0H']
 
       addr_r = BYRON.addresses.create(id, {passphrase: PASS})
       expect(addr_r).to have_http 201
+      expect(addr_r).to have_headers(EXPECTED_HEADERS)
       expect(addr_r['derivation_path'][0]).to eq '0H'
       expect(addr_r['derivation_path'][1]).to end_with 'H'
     end
@@ -142,6 +159,7 @@ RSpec.describe CardanoWallet::Byron do
 
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
+      expect(addresses).to have_headers(EXPECTED_HEADERS)
       expect(addresses.size).to eq 1
       expect(addresses.first['derivation_path']).to eq ['0H', '2147483647H']
     end
@@ -151,6 +169,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
+      expect(addr_import).to have_headers(EXPECTED_HEADERS)
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -159,6 +178,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
+      expect(addr_import).to have_headers(EXPECTED_HEADERS)
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
 
@@ -167,6 +187,7 @@ RSpec.describe CardanoWallet::Byron do
       addr = BYRON.addresses.list(id)[0]['id']
       addr_import = BYRON.addresses.import(id, addr)
       expect(addr_import).to have_http 403
+      expect(addr_import).to have_headers(EXPECTED_HEADERS)
       expect(addr_import.to_s).to include "invalid_wallet_type"
     end
   end
@@ -188,22 +209,10 @@ RSpec.describe CardanoWallet::Byron do
       rnd = BYRON.coin_selections.random wid, addr_amount
 
       expect(rnd).to have_http 403
+      expect(rnd).to have_headers(EXPECTED_HEADERS)
       expect(rnd.to_s).to include "not_enough_money"
     end
 
-    it "ArgumentError on bad argument address_amount" do
-      wid = create_byron_wallet
-      p =[[{addr1: 1, addr2: 2}], "addr:123", 123]
-      cs = BYRON.coin_selections
-      expect{ cs.random(wid, p[0]) }.to raise_error ArgumentError,
-            "argument should be Array of single Hashes"
-
-      expect{ cs.random(wid, p[1]) }.to raise_error ArgumentError,
-            "argument should be Array"
-
-      expect{ cs.random(wid, p[2]) }.to raise_error ArgumentError,
-            "argument should be Array"
-    end
   end
 
   describe CardanoWallet::Byron::Transactions do
@@ -217,8 +226,10 @@ RSpec.describe CardanoWallet::Byron do
       it "I could get a tx if I had proper id - #{style}" do
         wid = create_byron_wallet style
         txs = BYRON.transactions
-        expect(txs.get(wid, TXID)).to have_http 404
-        expect(txs.get(wid, TXID).to_s).to include "no_such_transaction"
+        g = txs.get(wid, TXID)
+        expect(g).to have_http 404
+        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g.to_s).to include "no_such_transaction"
       end
 
       it "Can list transactions - #{style}" do
@@ -241,6 +252,7 @@ RSpec.describe CardanoWallet::Byron do
 
         tx_sent = BYRON.transactions.create(id, PASS, [{target_addr => 1000000}])
         expect(tx_sent).to have_http 403
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
         expect(tx_sent.to_s).to include "not_enough_money"
       end
 
@@ -251,6 +263,7 @@ RSpec.describe CardanoWallet::Byron do
 
         fees = BYRON.transactions.payment_fees(id, [{target_addr => 1000000}])
         expect(fees).to have_http 403
+        expect(fees).to have_headers(EXPECTED_HEADERS)
         expect(fees.to_s).to include "not_enough_money"
       end
 
@@ -259,6 +272,7 @@ RSpec.describe CardanoWallet::Byron do
         txs = BYRON.transactions
         res = txs.forget(id, TXID)
         expect(res).to have_http 404
+        expect(res).to have_headers(EXPECTED_HEADERS)
       end
     end
   end
@@ -272,6 +286,7 @@ RSpec.describe CardanoWallet::Byron do
       id = create_byron_wallet "icarus"
       cost = BYRON.migrations.cost(id)
       expect(cost).to have_http 501
+      expect(cost).to have_headers(EXPECTED_HEADERS)
     end
 
     it "I could migrate all my funds" do
@@ -280,6 +295,7 @@ RSpec.describe CardanoWallet::Byron do
       addresses = BYRON.addresses.list(target_wal_id).map{ |a| a['id'] }
       migr = BYRON.migrations.migrate(id, PASS, addresses)
       expect(migr).to have_http 501
+      expect(migr).to have_headers(EXPECTED_HEADERS)
     end
   end
 end

--- a/test/e2e/spec/byron_spec.rb
+++ b/test/e2e/spec/byron_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CardanoWallet::Byron do
     end
 
     it "I can create, get and delete byron icarus wallet from mnemonics" do
-      wallet = BYRON.wallets.create({style: "icarus",
+      wallet = BYRON.wallets.create({ style: "icarus",
                          name: "Wallet from mnemonic_sentence",
                          passphrase: "Secure Passphrase",
                          mnemonic_sentence: mnemonic_sentence(15),
@@ -41,7 +41,7 @@ RSpec.describe CardanoWallet::Byron do
     end
 
     it "I can create, get and delete byron random wallet from mnemonics" do
-      wallet = BYRON.wallets.create({style: "random",
+      wallet = BYRON.wallets.create({ style: "random",
                          name: "Wallet from mnemonic_sentence",
                          passphrase: "Secure Passphrase",
                          mnemonic_sentence: mnemonic_sentence(12),
@@ -60,7 +60,7 @@ RSpec.describe CardanoWallet::Byron do
     it "Can update_metadata" do
       w = BYRON.wallets
       id = create_byron_wallet
-      u = w.update_metadata(id,{name: "New wallet name"})
+      u = w.update_metadata(id, { name: "New wallet name" })
       expect(u).to have_http 200
       expect(u).to have_headers(EXPECTED_HEADERS)
     end
@@ -68,8 +68,8 @@ RSpec.describe CardanoWallet::Byron do
     it "Can update_passphrase" do
       w = BYRON.wallets
       id = create_byron_wallet
-      upd = w.update_passphrase(id,{old_passphrase: "Secure Passphrase",
-                                    new_passphrase: "Securer Passphrase"})
+      upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
+                                    new_passphrase: "Securer Passphrase" })
       expect(upd).to have_http 204
     end
 
@@ -94,7 +94,7 @@ RSpec.describe CardanoWallet::Byron do
       expect(addresses).to have_headers(EXPECTED_HEADERS)
       expect(addresses.size).to eq 0
 
-      BYRON.addresses.create(id, {passphrase: PASS})
+      BYRON.addresses.create(id, { passphrase: PASS })
       addresses = BYRON.addresses.list id
       expect(addresses).to have_http 200
       expect(addresses).to have_headers(EXPECTED_HEADERS)
@@ -105,46 +105,46 @@ RSpec.describe CardanoWallet::Byron do
 
     it "Can list addresses - icarus" do
       id = create_byron_wallet "icarus"
-      addresses_unused = BYRON.addresses.list id, {state: "unused"}
+      addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
       expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
-      addresses_unused.each_with_index do |a,i|
+      addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
       end
     end
 
     it "Can list addresses - ledger" do
       id = create_byron_wallet "ledger"
-      addresses_unused = BYRON.addresses.list id, {state: "unused"}
+      addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
       expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
-      addresses_unused.each_with_index do |a,i|
+      addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
       end
     end
 
     it "Can list addresses - trezor" do
       id = create_byron_wallet "trezor"
-      addresses_unused = BYRON.addresses.list id, {state: "unused"}
+      addresses_unused = BYRON.addresses.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
       expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
-      addresses_unused.each_with_index do |a,i|
+      addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['44H', '1815H', '0H', '0', i.to_s]
       end
     end
 
     it "Can create address - random" do
       id = create_byron_wallet
-      addr = BYRON.addresses.create(id, {passphrase: PASS,
-                                         address_index: 2147483648})
+      addr = BYRON.addresses.create(id, { passphrase: PASS,
+                                         address_index: 2147483648 })
       expect(addr).to have_http 201
       expect(addr).to have_headers(EXPECTED_HEADERS)
       expect(addr['derivation_path']).to eq ['0H', '0H']
 
-      addr_r = BYRON.addresses.create(id, {passphrase: PASS})
+      addr_r = BYRON.addresses.create(id, { passphrase: PASS })
       expect(addr_r).to have_http 201
       expect(addr_r).to have_headers(EXPECTED_HEADERS)
       expect(addr_r['derivation_path'][0]).to eq '0H'
@@ -238,11 +238,11 @@ RSpec.describe CardanoWallet::Byron do
 
         expect(txs.list(id)).to have_http 200
         expect(txs.list(id,
-                        {start: "2012-09-25T10:15:00Z",
+                        { start: "2012-09-25T10:15:00Z",
                          end: "2016-11-21T10:15:00Z",
-                         order: "ascending"}).code).
+                         order: "ascending" }).code).
                         to eq 200
-        expect(txs.list(id, {order: "bad_order"})).to have_http 400
+        expect(txs.list(id, { order: "bad_order" })).to have_http 400
       end
 
       it "I could send tx if I had money - #{style}" do
@@ -250,7 +250,7 @@ RSpec.describe CardanoWallet::Byron do
         target_id = create_byron_wallet "icarus"
         target_addr = BYRON.addresses.list(target_id)[0]['id']
 
-        tx_sent = BYRON.transactions.create(id, PASS, [{target_addr => 1000000}])
+        tx_sent = BYRON.transactions.create(id, PASS, [{ target_addr => 1000000 }])
         expect(tx_sent).to have_http 403
         expect(tx_sent).to have_headers(EXPECTED_HEADERS)
         expect(tx_sent.to_s).to include "not_enough_money"
@@ -261,7 +261,7 @@ RSpec.describe CardanoWallet::Byron do
         target_id = create_byron_wallet "icarus"
         target_addr = BYRON.addresses.list(target_id)[0]['id']
 
-        fees = BYRON.transactions.payment_fees(id, [{target_addr => 1000000}])
+        fees = BYRON.transactions.payment_fees(id, [{ target_addr => 1000000 }])
         expect(fees).to have_http 403
         expect(fees).to have_headers(EXPECTED_HEADERS)
         expect(fees.to_s).to include "not_enough_money"
@@ -292,7 +292,7 @@ RSpec.describe CardanoWallet::Byron do
     it "I could migrate all my funds" do
       id = create_byron_wallet "random"
       target_wal_id = create_byron_wallet "icarus"
-      addresses = BYRON.addresses.list(target_wal_id).map{ |a| a['id'] }
+      addresses = BYRON.addresses.list(target_wal_id).map { |a| a['id'] }
       migr = BYRON.migrations.migrate(id, PASS, addresses)
       expect(migr).to have_http 501
       expect(migr).to have_headers(EXPECTED_HEADERS)

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can list native assets" do
         assets = SHELLEY.assets.get @wid
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -66,7 +66,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can get native assets by policy_id" do
         assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[0]["policy_id"])
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -77,7 +77,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can get native assets by policy_id and asset_name" do
         assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
@@ -105,7 +105,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         tx_sent = SHELLEY.transactions.create(@wid, PASS, payload)
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Assets are on target wallet: #{@target_id_assets}" do
@@ -141,7 +141,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }])
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id}" do
@@ -164,7 +164,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               ttl_in_s)
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id}" do
@@ -188,7 +188,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               ttl_in_s)
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "TX `#{tx_sent['id']}' expires on `#{@wid}'" do
@@ -209,7 +209,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }], 'self')
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
@@ -232,7 +232,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                              )
 
         expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent).to have_expected_headers
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id_meta}" do
@@ -257,15 +257,15 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         txs = SHELLEY.transactions
         fees = txs.payment_fees(@wid, amt)
         expect(fees).to have_http 202
-        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees).to have_expected_headers
 
         fees = txs.payment_fees(@wid, amt, 'self')
         expect(fees).to have_http 202
-        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees).to have_expected_headers
 
         fees = txs.payment_fees(@wid, amt, 'self', metadata)
         expect(fees).to have_http 202
-        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees).to have_expected_headers
       end
     end
 
@@ -276,7 +276,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         join = pools.join(SPID, @wid, PASS)
         expect(join).to have_http 404
-        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join).to have_expected_headers
         expect(join.to_s).to include "no_such_pool"
       end
 
@@ -286,7 +286,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         pools = SHELLEY.stake_pools
         fees = pools.delegation_fees(id)
         expect(fees).to have_http 403
-        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees).to have_expected_headers
         expect(fees.to_s).to include "not_enough_money"
       end
 
@@ -297,7 +297,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         join = pools.join(pool_id, id, PASS)
         expect(join).to have_http 403
-        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join).to have_expected_headers
         expect(join.to_s).to include "not_enough_money"
       end
 
@@ -306,10 +306,10 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         l = pools.list({ stake: 1000 })
         l_bad = pools.list
         expect(l).to have_http 200
-        expect(l).to have_headers(EXPECTED_HEADERS)
+        expect(l).to have_expected_headers
 
         expect(l_bad).to have_http 400
-        expect(l_bad).to have_headers(EXPECTED_HEADERS)
+        expect(l_bad).to have_expected_headers
         expect(l_bad.to_s).to include "query_param_missing"
       end
 
@@ -340,7 +340,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         join = pools.join(pool_id, @target_id_pools, PASS)
 
         expect(join).to have_http 202
-        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join).to have_expected_headers
         expect(join.to_s).to include "status"
 
         join_tx_id = join['id']
@@ -354,7 +354,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         quit = pools.quit(@target_id_pools, PASS)
 
         expect(quit).to have_http 202
-        expect(quit).to have_headers(EXPECTED_HEADERS)
+        expect(quit).to have_expected_headers
         expect(quit.to_s).to include "status"
 
         quit_tx_id = quit['id']
@@ -387,7 +387,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         rnd = SHELLEY.coin_selections.random(@wid, payload, withdrawal = "self", m = METADATA)
 
         expect(rnd).to have_http 200
-        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd).to have_expected_headers
         expect(rnd.to_s).to include "outputs"
         expect(rnd.to_s).to include "change"
         expect(rnd.to_s).to include "metadata"
@@ -402,7 +402,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
 
         expect(rnd).to have_http 200
-        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd).to have_expected_headers
         expect(rnd.to_s).to include "outputs"
         expect(rnd.to_s).to include "change"
         expect(rnd['inputs']).not_to be_empty
@@ -420,7 +420,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_join
         expect(rnd).to have_http 403
-        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd).to have_expected_headers
         expect(rnd.to_s).to include "not_enough_money"
       end
 
@@ -432,12 +432,12 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_join
         expect(rnd).to have_http 404
-        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd).to have_expected_headers
         expect(rnd.to_s).to include "no_such_pool"
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
         expect(rnd).to have_http 403
-        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd).to have_expected_headers
         expect(rnd.to_s).to include "not_delegating_to"
       end
 
@@ -453,7 +453,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_sent = BYRON.transactions.create(source_wid, PASS, [{ address => amt }])
 
       expect(tx_sent).to have_http 202
-      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent).to have_expected_headers
       expect(tx_sent.to_s).to include "pending"
 
       eventually "Funds are on target wallet: #{target_wid}" do
@@ -483,7 +483,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       tx_sent = BYRON.transactions.create(source_id, PASS, payload)
 
       expect(tx_sent).to have_http 202
-      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent).to have_expected_headers
       expect(tx_sent.to_s).to include "pending"
 
       eventually "Assets are on target wallet: #{target_id}" do
@@ -525,7 +525,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can list assets -> random" do
         assets = BYRON.assets.get @wid_rnd
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -537,7 +537,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can list assets -> icarus" do
         assets = BYRON.assets.get @wid_ic
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -549,7 +549,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can get native assets by policy_id -> random" do
         assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[0]["policy_id"])
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -560,7 +560,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
       it "I can get native assets by policy_id and asset_name -> random" do
         assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
         expect(assets).to have_http 200
-        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets).to have_expected_headers
         expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[1]["metadata"]

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
     describe "Native Assets" do
       it "I can list native assets" do
         assets = SHELLEY.assets.get @wid
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -65,8 +64,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can get native assets by policy_id" do
         assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[0]["policy_id"])
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -76,8 +74,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can get native assets by policy_id and asset_name" do
         assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
@@ -104,8 +101,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         tx_sent = SHELLEY.transactions.create(@wid, PASS, payload)
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Assets are on target wallet: #{@target_id_assets}" do
@@ -140,8 +136,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         address = SHELLEY.addresses.list(@target_id)[0]['id']
         tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }])
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id}" do
@@ -163,8 +158,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               metadata = nil,
                                               ttl_in_s)
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id}" do
@@ -187,8 +181,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               metadata = nil,
                                               ttl_in_s)
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "TX `#{tx_sent['id']}' expires on `#{@wid}'" do
@@ -196,10 +189,10 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         end
 
         res = SHELLEY.transactions.forget(@wid, tx_sent['id'])
-        expect(res).to have_http 204
+        expect(res).to be_correct_and_respond 204
 
         fres = SHELLEY.transactions.get(@wid, tx_sent['id'])
-        expect(fres).to have_http 404
+        expect(fres).to be_correct_and_respond 404
       end
 
       it "I can send transaction using 'withdrawal' flag and funds are received" do
@@ -208,8 +201,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }], 'self')
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
@@ -231,8 +223,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               metadata
                                              )
 
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_expected_headers
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id_meta}" do
@@ -256,16 +247,13 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         txs = SHELLEY.transactions
         fees = txs.payment_fees(@wid, amt)
-        expect(fees).to have_http 202
-        expect(fees).to have_expected_headers
+        expect(fees).to be_correct_and_respond 202
 
         fees = txs.payment_fees(@wid, amt, 'self')
-        expect(fees).to have_http 202
-        expect(fees).to have_expected_headers
+        expect(fees).to be_correct_and_respond 202
 
         fees = txs.payment_fees(@wid, amt, 'self', metadata)
-        expect(fees).to have_http 202
-        expect(fees).to have_expected_headers
+        expect(fees).to be_correct_and_respond 202
       end
     end
 
@@ -275,8 +263,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         pools = SHELLEY.stake_pools
 
         join = pools.join(SPID, @wid, PASS)
-        expect(join).to have_http 404
-        expect(join).to have_expected_headers
+        expect(join).to be_correct_and_respond 404
         expect(join.to_s).to include "no_such_pool"
       end
 
@@ -285,8 +272,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         pools = SHELLEY.stake_pools
         fees = pools.delegation_fees(id)
-        expect(fees).to have_http 403
-        expect(fees).to have_expected_headers
+        expect(fees).to be_correct_and_respond 403
         expect(fees.to_s).to include "not_enough_money"
       end
 
@@ -296,8 +282,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         pool_id = pools.list({ stake: 1000 })[0]['id']
 
         join = pools.join(pool_id, id, PASS)
-        expect(join).to have_http 403
-        expect(join).to have_expected_headers
+        expect(join).to be_correct_and_respond 403
         expect(join.to_s).to include "not_enough_money"
       end
 
@@ -305,11 +290,9 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         pools = SHELLEY.stake_pools
         l = pools.list({ stake: 1000 })
         l_bad = pools.list
-        expect(l).to have_http 200
-        expect(l).to have_expected_headers
+        expect(l).to be_correct_and_respond 200
 
-        expect(l_bad).to have_http 400
-        expect(l_bad).to have_expected_headers
+        expect(l_bad).to be_correct_and_respond 400
         expect(l_bad.to_s).to include "query_param_missing"
       end
 
@@ -322,7 +305,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                               PASS,
                                               [{ address => amt }])
 
-        expect(tx_sent).to have_http 202
+        expect(tx_sent).to be_correct_and_respond 202
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{@target_id_pools}" do
@@ -339,8 +322,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         puts "Joining pool: #{pool_id}"
         join = pools.join(pool_id, @target_id_pools, PASS)
 
-        expect(join).to have_http 202
-        expect(join).to have_expected_headers
+        expect(join).to be_correct_and_respond 202
         expect(join.to_s).to include "status"
 
         join_tx_id = join['id']
@@ -353,8 +335,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         puts "Quitting pool: #{pool_id}"
         quit = pools.quit(@target_id_pools, PASS)
 
-        expect(quit).to have_http 202
-        expect(quit).to have_expected_headers
+        expect(quit).to be_correct_and_respond 202
         expect(quit.to_s).to include "status"
 
         quit_tx_id = quit['id']
@@ -386,8 +367,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         rnd = SHELLEY.coin_selections.random(@wid, payload, withdrawal = "self", m = METADATA)
 
-        expect(rnd).to have_http 200
-        expect(rnd).to have_expected_headers
+        expect(rnd).to be_correct_and_respond 200
         expect(rnd.to_s).to include "outputs"
         expect(rnd.to_s).to include "change"
         expect(rnd.to_s).to include "metadata"
@@ -401,8 +381,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
         rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
 
-        expect(rnd).to have_http 200
-        expect(rnd).to have_expected_headers
+        expect(rnd).to be_correct_and_respond 200
         expect(rnd.to_s).to include "outputs"
         expect(rnd.to_s).to include "change"
         expect(rnd['inputs']).not_to be_empty
@@ -419,8 +398,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         action_join = { action: "join", pool: pid }
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_join
-        expect(rnd).to have_http 403
-        expect(rnd).to have_expected_headers
+        expect(rnd).to be_correct_and_respond 403
         expect(rnd.to_s).to include "not_enough_money"
       end
 
@@ -431,13 +409,11 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         action_quit = { action: "quit" }
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_join
-        expect(rnd).to have_http 404
-        expect(rnd).to have_expected_headers
+        expect(rnd).to be_correct_and_respond 404
         expect(rnd.to_s).to include "no_such_pool"
 
         rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
-        expect(rnd).to have_http 403
-        expect(rnd).to have_expected_headers
+        expect(rnd).to be_correct_and_respond 403
         expect(rnd.to_s).to include "not_delegating_to"
       end
 
@@ -452,8 +428,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       tx_sent = BYRON.transactions.create(source_wid, PASS, [{ address => amt }])
 
-      expect(tx_sent).to have_http 202
-      expect(tx_sent).to have_expected_headers
+      expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
 
       eventually "Funds are on target wallet: #{target_wid}" do
@@ -482,8 +457,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       tx_sent = BYRON.transactions.create(source_id, PASS, payload)
 
-      expect(tx_sent).to have_http 202
-      expect(tx_sent).to have_expected_headers
+      expect(tx_sent).to be_correct_and_respond 202
       expect(tx_sent.to_s).to include "pending"
 
       eventually "Assets are on target wallet: #{target_id}" do
@@ -524,8 +498,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can list assets -> random" do
         assets = BYRON.assets.get @wid_rnd
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -536,8 +509,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can list assets -> icarus" do
         assets = BYRON.assets.get @wid_ic
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets.to_s).to include ASSETS[0]["policy_id"]
         expect(assets.to_s).to include ASSETS[0]["asset_name"]
         expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -548,8 +520,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can get native assets by policy_id -> random" do
         assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[0]["policy_id"])
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -559,8 +530,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
       it "I can get native assets by policy_id and asset_name -> random" do
         assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
-        expect(assets).to have_http 200
-        expect(assets).to have_expected_headers
+        expect(assets).to be_correct_and_respond 200
         expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
         expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
         expect(assets["metadata"]).to eq ASSETS[1]["metadata"]

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can list native assets" do
           assets = SHELLEY.assets.get @wid
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets.to_s).to include ASSETS[0]["policy_id"]
           expect(assets.to_s).to include ASSETS[0]["asset_name"]
           expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -65,6 +66,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can get native assets by policy_id" do
           assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[0]["policy_id"])
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
           expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
           expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -75,6 +77,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can get native assets by policy_id and asset_name" do
           assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
           expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
           expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
@@ -102,6 +105,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           tx_sent = SHELLEY.transactions.create(@wid, PASS, payload)
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "Assets are on target wallet: #{@target_id_assets}" do
@@ -137,6 +141,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           tx_sent = SHELLEY.transactions.create(@wid, PASS, [{address => amt}])
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "Funds are on target wallet: #{@target_id}" do
@@ -159,6 +164,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                                 ttl_in_s)
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "Funds are on target wallet: #{@target_id}" do
@@ -182,6 +188,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                                 ttl_in_s)
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "TX `#{tx_sent['id']}' expires on `#{@wid}'" do
@@ -202,6 +209,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           tx_sent = SHELLEY.transactions.create(@wid, PASS, [{address => amt}], 'self')
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
@@ -224,6 +232,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
                                                )
 
           expect(tx_sent).to have_http 202
+          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
           expect(tx_sent.to_s).to include "pending"
 
           eventually "Funds are on target wallet: #{@target_id_meta}" do
@@ -248,12 +257,15 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           txs = SHELLEY.transactions
           fees = txs.payment_fees(@wid, amt)
           expect(fees).to have_http 202
+          expect(fees).to have_headers(EXPECTED_HEADERS)
 
           fees = txs.payment_fees(@wid, amt, 'self')
           expect(fees).to have_http 202
+          expect(fees).to have_headers(EXPECTED_HEADERS)
 
           fees = txs.payment_fees(@wid, amt, 'self', metadata)
           expect(fees).to have_http 202
+          expect(fees).to have_headers(EXPECTED_HEADERS)
         end
       end
 
@@ -264,6 +276,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           join = pools.join(SPID, @wid, PASS)
           expect(join).to have_http 404
+          expect(join).to have_headers(EXPECTED_HEADERS)
           expect(join.to_s).to include "no_such_pool"
         end
 
@@ -273,6 +286,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           pools = SHELLEY.stake_pools
           fees = pools.delegation_fees(id)
           expect(fees).to have_http 403
+          expect(fees).to have_headers(EXPECTED_HEADERS)
           expect(fees.to_s).to include "not_enough_money"
         end
 
@@ -283,15 +297,20 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           join = pools.join(pool_id, id, PASS)
           expect(join).to have_http 403
+          expect(join).to have_headers(EXPECTED_HEADERS)
           expect(join.to_s).to include "not_enough_money"
         end
 
         it "Can list stake pools only when stake is provided" do
           pools = SHELLEY.stake_pools
-          expect(pools.list({stake: 1000})).to have_http 200
+          l = pools.list({stake: 1000})
+          l_bad = pools.list
+          expect(l).to have_http 200
+          expect(l).to have_headers(EXPECTED_HEADERS)
 
-          expect(pools.list).to have_http 400
-          expect(pools.list.to_s).to include "query_param_missing"
+          expect(l_bad).to have_http 400
+          expect(l_bad).to have_headers(EXPECTED_HEADERS)
+          expect(l_bad.to_s).to include "query_param_missing"
         end
 
         it "Can join and quit Stake Pool" do
@@ -321,6 +340,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           join = pools.join(pool_id, @target_id_pools, PASS)
 
           expect(join).to have_http 202
+          expect(join).to have_headers(EXPECTED_HEADERS)
           expect(join.to_s).to include "status"
 
           join_tx_id = join['id']
@@ -334,6 +354,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           quit = pools.quit(@target_id_pools, PASS)
 
           expect(quit).to have_http 202
+          expect(quit).to have_headers(EXPECTED_HEADERS)
           expect(quit.to_s).to include "status"
 
           quit_tx_id = quit['id']
@@ -366,6 +387,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           rnd = SHELLEY.coin_selections.random(@wid, payload, withdrawal = "self", m = METADATA)
 
           expect(rnd).to have_http 200
+          expect(rnd).to have_headers(EXPECTED_HEADERS)
           expect(rnd.to_s).to include "outputs"
           expect(rnd.to_s).to include "change"
           expect(rnd.to_s).to include "metadata"
@@ -380,6 +402,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
           rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
 
           expect(rnd).to have_http 200
+          expect(rnd).to have_headers(EXPECTED_HEADERS)
           expect(rnd.to_s).to include "outputs"
           expect(rnd.to_s).to include "change"
           expect(rnd['inputs']).not_to be_empty
@@ -397,6 +420,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_join
           expect(rnd).to have_http 403
+          expect(rnd).to have_headers(EXPECTED_HEADERS)
           expect(rnd.to_s).to include "not_enough_money"
         end
 
@@ -408,10 +432,12 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_join
           expect(rnd).to have_http 404
+          expect(rnd).to have_headers(EXPECTED_HEADERS)
           expect(rnd.to_s).to include "no_such_pool"
 
           rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
           expect(rnd).to have_http 403
+          expect(rnd).to have_headers(EXPECTED_HEADERS)
           expect(rnd.to_s).to include "not_delegating_to"
         end
 
@@ -427,6 +453,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         tx_sent = BYRON.transactions.create(source_wid, PASS, [{address => amt}])
 
         expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Funds are on target wallet: #{target_wid}" do
@@ -456,6 +483,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         tx_sent = BYRON.transactions.create(source_id, PASS, payload)
 
         expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
         expect(tx_sent.to_s).to include "pending"
 
         eventually "Assets are on target wallet: #{target_id}" do
@@ -497,6 +525,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can list assets -> random" do
           assets = BYRON.assets.get @wid_rnd
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets.to_s).to include ASSETS[0]["policy_id"]
           expect(assets.to_s).to include ASSETS[0]["asset_name"]
           expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -508,6 +537,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can list assets -> icarus" do
           assets = BYRON.assets.get @wid_ic
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets.to_s).to include ASSETS[0]["policy_id"]
           expect(assets.to_s).to include ASSETS[0]["asset_name"]
           expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
@@ -519,6 +549,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can get native assets by policy_id -> random" do
           assets = BYRON.assets.get(@wid_rnd , policy_id = ASSETS[0]["policy_id"])
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
           expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
           expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
@@ -529,6 +560,7 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         it "I can get native assets by policy_id and asset_name -> random" do
           assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
           expect(assets).to have_http 200
+          expect(assets).to have_headers(EXPECTED_HEADERS)
           expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
           expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
           expect(assets["metadata"]).to eq ASSETS[1]["metadata"]

--- a/test/e2e/spec/e2e_spec.rb
+++ b/test/e2e/spec/e2e_spec.rb
@@ -1,507 +1,129 @@
 RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
 
-    before(:all) do
-      #shelley tests
-      @wid = create_fixture_shelley_wallet
-      @target_id = create_shelley_wallet("Target tx wallet")
-      @target_id_assets = create_shelley_wallet("Target asset tx wallet")
-      @target_id_withdrawal = create_shelley_wallet("Target tx withdrawal wallet")
-      @target_id_meta = create_shelley_wallet("Target tx metadata wallet")
-      @target_id_ttl = create_shelley_wallet("Target tx ttl wallet")
-      @target_id_pools = create_shelley_wallet("Target tx pool join/quit wallet")
+  before(:all) do
+    # shelley tests
+    @wid = create_fixture_shelley_wallet
+    @target_id = create_shelley_wallet("Target tx wallet")
+    @target_id_assets = create_shelley_wallet("Target asset tx wallet")
+    @target_id_withdrawal = create_shelley_wallet("Target tx withdrawal wallet")
+    @target_id_meta = create_shelley_wallet("Target tx metadata wallet")
+    @target_id_ttl = create_shelley_wallet("Target tx ttl wallet")
+    @target_id_pools = create_shelley_wallet("Target tx pool join/quit wallet")
 
-      #byron tests
-      @wid_rnd = create_fixture_byron_wallet "random"
-      @wid_ic = create_fixture_byron_wallet "icarus"
-      @target_id_rnd = create_shelley_wallet("Target tx wallet")
-      @target_id_ic = create_shelley_wallet("Target tx wallet")
-      @target_id_rnd_assets = create_shelley_wallet("Target asset tx wallet")
-      @target_id_ic_assets = create_shelley_wallet("Target asset tx wallet")
+    # byron tests
+    @wid_rnd = create_fixture_byron_wallet "random"
+    @wid_ic = create_fixture_byron_wallet "icarus"
+    @target_id_rnd = create_shelley_wallet("Target tx wallet")
+    @target_id_ic = create_shelley_wallet("Target tx wallet")
+    @target_id_rnd_assets = create_shelley_wallet("Target asset tx wallet")
+    @target_id_ic_assets = create_shelley_wallet("Target asset tx wallet")
 
-      @nighly_byron_wallets = [ @wid_rnd, @wid_ic ]
-      @nightly_shelley_wallets = [
-                                    @wid,
-                                    @target_id,
-                                    @target_id_assets,
-                                    @target_id_withdrawal,
-                                    @target_id_meta,
-                                    @target_id_ttl,
-                                    @target_id_rnd,
-                                    @target_id_ic,
-                                    @target_id_rnd_assets,
-                                    @target_id_ic_assets,
-                                    @target_id_pools
-                                  ]
-      wait_for_all_byron_wallets(@nighly_byron_wallets)
-      wait_for_all_shelley_wallets(@nightly_shelley_wallets)
+    @nighly_byron_wallets = [ @wid_rnd, @wid_ic ]
+    @nightly_shelley_wallets = [
+                                  @wid,
+                                  @target_id,
+                                  @target_id_assets,
+                                  @target_id_withdrawal,
+                                  @target_id_meta,
+                                  @target_id_ttl,
+                                  @target_id_rnd,
+                                  @target_id_ic,
+                                  @target_id_rnd_assets,
+                                  @target_id_ic_assets,
+                                  @target_id_pools
+                                ]
+    wait_for_all_byron_wallets(@nighly_byron_wallets)
+    wait_for_all_shelley_wallets(@nightly_shelley_wallets)
 
 
-      # @wid = "b1fb863243a9ae451bc4e2e662f60ff217b126e2"
-      # @target_id_pools = "4eff7771b9975e0731e2c5eb9695fece9067ee92"
+    # @wid = "b1fb863243a9ae451bc4e2e662f60ff217b126e2"
+    # @target_id_pools = "4eff7771b9975e0731e2c5eb9695fece9067ee92"
+  end
+
+  after(:all) do
+    @nighly_byron_wallets.each do |wid|
+      BYRON.wallets.delete wid
     end
-
-    after(:all) do
-      @nighly_byron_wallets.each do |wid|
-        BYRON.wallets.delete wid
-      end
-      @nightly_shelley_wallets.each do |wid|
-        SHELLEY.wallets.delete wid
-      end
+    @nightly_shelley_wallets.each do |wid|
+      SHELLEY.wallets.delete wid
     end
+  end
 
-    describe "E2E Shelley" do
-      describe "Native Assets" do
-        it "I can list native assets" do
-          assets = SHELLEY.assets.get @wid
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets.to_s).to include ASSETS[0]["policy_id"]
-          expect(assets.to_s).to include ASSETS[0]["asset_name"]
-          expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
-          expect(assets.to_s).to include ASSETS[1]["policy_id"]
-          expect(assets.to_s).to include ASSETS[1]["asset_name"]
-          expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
-        end
-
-        it "I can get native assets by policy_id" do
-          assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[0]["policy_id"])
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
-          expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
-          expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
-          expect(assets["asset_name"]).not_to eq ASSETS[1]["asset_name"]
-          expect(assets["metadata"]).not_to eq ASSETS[1]["metadata"]
-        end
-
-        it "I can get native assets by policy_id and asset_name" do
-          assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
-          expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
-          expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
-          expect(assets["asset_name"]).not_to eq ASSETS[0]["asset_name"]
-          expect(assets["metadata"]).not_to eq ASSETS[0]["metadata"]["name"]
-        end
-
-        it "I can send native assets tx and they are received" do
-          asset_quantity = 1
-          address = SHELLEY.addresses.list(@target_id_assets)[1]['id']
-          payload = [{"address" => address,
-                      "amount" => { "quantity"=> 0, "unit"=> "lovelace" },
-                      "assets" => [ { "policy_id"=> ASSETS[0]["policy_id"],
-                                      "asset_name"=> ASSETS[0]["asset_name"],
-                                      "quantity"=> asset_quantity
-                                    },
-                                    { "policy_id"=> ASSETS[1]["policy_id"],
-                                      "asset_name"=> ASSETS[1]["asset_name"],
-                                      "quantity"=> asset_quantity
-                                    }
-                                  ]
-                      }
-                     ]
-
-          tx_sent = SHELLEY.transactions.create(@wid, PASS, payload)
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Assets are on target wallet: #{@target_id_assets}" do
-            first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
-            second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
-            total_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['total']
-            available_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['available']
-            total = Hash.new
-            available = Hash.new
-
-            unless total_assets.empty?
-              total[first] = total_assets.select {|a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"]}.first["quantity"]
-              total[second] = total_assets.select {|a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"]}.first["quantity"]
-            end
-
-            unless available_assets.empty?
-              available[first] = available_assets.select {|a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"]}.first["quantity"]
-              available[second] = available_assets.select {|a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"]}.first["quantity"]
-            end
-
-            (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
-            (available[first] == asset_quantity) && (available[second] == asset_quantity)
-          end
-        end
-
+  describe "E2E Shelley" do
+    describe "Native Assets" do
+      it "I can list native assets" do
+        assets = SHELLEY.assets.get @wid
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets.to_s).to include ASSETS[0]["policy_id"]
+        expect(assets.to_s).to include ASSETS[0]["asset_name"]
+        expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
+        expect(assets.to_s).to include ASSETS[1]["policy_id"]
+        expect(assets.to_s).to include ASSETS[1]["asset_name"]
+        expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
       end
 
-      describe "Shelley Transactions" do
-        it "I can send transaction and funds are received" do
-          amt = 1000000
-
-          address = SHELLEY.addresses.list(@target_id)[0]['id']
-          tx_sent = SHELLEY.transactions.create(@wid, PASS, [{address => amt}])
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Funds are on target wallet: #{@target_id}" do
-            available = SHELLEY.wallets.get(@target_id)['balance']['available']['quantity']
-            total = SHELLEY.wallets.get(@target_id)['balance']['total']['quantity']
-            (available == amt) && (total == amt)
-          end
-        end
-
-        it "I can send transaction with ttl and funds are received" do
-          amt = 1000000
-          ttl_in_s = 120
-
-          address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
-          tx_sent = SHELLEY.transactions.create(@wid,
-                                                PASS,
-                                                [{address => amt}],
-                                                withdrawal = nil,
-                                                metadata = nil,
-                                                ttl_in_s)
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Funds are on target wallet: #{@target_id}" do
-            available = SHELLEY.wallets.get(@target_id_ttl)['balance']['available']['quantity']
-            total = SHELLEY.wallets.get(@target_id_ttl)['balance']['total']['quantity']
-            (available == amt) && (total == amt)
-          end
-        end
-
-        it "Transaction with ttl = 0 would expire and I can forget it" do
-          skip "Test is flaky due to ADP-608"
-          amt = 1000000
-          ttl_in_s = 0
-
-          address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
-          tx_sent = SHELLEY.transactions.create(@wid,
-                                                PASS,
-                                                [{address => amt}],
-                                                withdrawal = nil,
-                                                metadata = nil,
-                                                ttl_in_s)
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "TX `#{tx_sent['id']}' expires on `#{@wid}'" do
-            SHELLEY.transactions.get(@wid, tx_sent['id'])['status'] == 'expired'
-          end
-
-          res = SHELLEY.transactions.forget(@wid, tx_sent['id'])
-          expect(res).to have_http 204
-
-          fres = SHELLEY.transactions.get(@wid, tx_sent['id'])
-          expect(fres).to have_http 404
-        end
-
-        it "I can send transaction using 'withdrawal' flag and funds are received" do
-          amt = 1000000
-          address = SHELLEY.addresses.list(@target_id_withdrawal)[0]['id']
-
-          tx_sent = SHELLEY.transactions.create(@wid, PASS, [{address => amt}], 'self')
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
-            available = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['available']['quantity']
-            total = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['total']['quantity']
-            (available == amt) && (total == amt)
-          end
-        end
-
-        it "I can send transaction with metadata" do
-          amt = 1000000
-          metadata = METADATA
-
-          address = SHELLEY.addresses.list(@target_id_meta)[0]['id']
-          tx_sent = SHELLEY.transactions.create(@wid,
-                                                PASS,
-                                                [{address => amt}],
-                                                nil,
-                                                metadata
-                                               )
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Funds are on target wallet: #{@target_id_meta}" do
-            available = SHELLEY.wallets.get(@target_id_meta)['balance']['available']['quantity']
-            total = SHELLEY.wallets.get(@target_id_meta)['balance']['total']['quantity']
-            (available == amt) && (total == amt)
-          end
-
-          eventually "Metadata is present on sent tx: #{tx_sent['id']}" do
-            meta_src = SHELLEY.transactions.get(@wid, tx_sent['id'])['metadata']
-            meta_dst = SHELLEY.transactions.get(@target_id_meta, tx_sent['id'])['metadata']
-            (meta_src == metadata) && (meta_dst == metadata)
-          end
-        end
-
-        it "I can estimate fee" do
-          metadata = METADATA
-
-          address = SHELLEY.addresses.list(@target_id)[0]['id']
-          amt = [{address => 1000000}]
-
-          txs = SHELLEY.transactions
-          fees = txs.payment_fees(@wid, amt)
-          expect(fees).to have_http 202
-          expect(fees).to have_headers(EXPECTED_HEADERS)
-
-          fees = txs.payment_fees(@wid, amt, 'self')
-          expect(fees).to have_http 202
-          expect(fees).to have_headers(EXPECTED_HEADERS)
-
-          fees = txs.payment_fees(@wid, amt, 'self', metadata)
-          expect(fees).to have_http 202
-          expect(fees).to have_headers(EXPECTED_HEADERS)
-        end
+      it "I can get native assets by policy_id" do
+        assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[0]["policy_id"])
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
+        expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
+        expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
+        expect(assets["asset_name"]).not_to eq ASSETS[1]["asset_name"]
+        expect(assets["metadata"]).not_to eq ASSETS[1]["metadata"]
       end
 
-      describe "Stake Pools" do
-
-        it "I could join Stake Pool - if I knew it's id" do
-          pools = SHELLEY.stake_pools
-
-          join = pools.join(SPID, @wid, PASS)
-          expect(join).to have_http 404
-          expect(join).to have_headers(EXPECTED_HEADERS)
-          expect(join.to_s).to include "no_such_pool"
-        end
-
-        it "I could check delegation fees - if I could cover fee" do
-          id = create_shelley_wallet
-
-          pools = SHELLEY.stake_pools
-          fees = pools.delegation_fees(id)
-          expect(fees).to have_http 403
-          expect(fees).to have_headers(EXPECTED_HEADERS)
-          expect(fees.to_s).to include "not_enough_money"
-        end
-
-        it "I could join Stake Pool - if I had enough to cover fee" do
-          id = create_shelley_wallet
-          pools = SHELLEY.stake_pools
-          pool_id = pools.list({stake: 1000})[0]['id']
-
-          join = pools.join(pool_id, id, PASS)
-          expect(join).to have_http 403
-          expect(join).to have_headers(EXPECTED_HEADERS)
-          expect(join.to_s).to include "not_enough_money"
-        end
-
-        it "Can list stake pools only when stake is provided" do
-          pools = SHELLEY.stake_pools
-          l = pools.list({stake: 1000})
-          l_bad = pools.list
-          expect(l).to have_http 200
-          expect(l).to have_headers(EXPECTED_HEADERS)
-
-          expect(l_bad).to have_http 400
-          expect(l_bad).to have_headers(EXPECTED_HEADERS)
-          expect(l_bad.to_s).to include "query_param_missing"
-        end
-
-        it "Can join and quit Stake Pool" do
-
-          # Get funds on the wallet
-          address = SHELLEY.addresses.list(@target_id_pools)[0]['id']
-          amt = 10000000
-          tx_sent = SHELLEY.transactions.create(@wid,
-                                                PASS,
-                                                [{address => amt}])
-
-          expect(tx_sent).to have_http 202
-          expect(tx_sent.to_s).to include "pending"
-
-          eventually "Funds are on target wallet: #{@target_id_pools}" do
-            available = SHELLEY.wallets.get(@target_id_pools)['balance']['available']['quantity']
-            total = SHELLEY.wallets.get(@target_id_pools)['balance']['total']['quantity']
-            (available == amt) && (total == amt)
-          end
-
-          #Pick up pool id to join
-          pools = SHELLEY.stake_pools
-          pool_id = pools.list({stake: 1000}).sample['id']
-
-          #Join pool
-          puts "Joining pool: #{pool_id}"
-          join = pools.join(pool_id, @target_id_pools, PASS)
-
-          expect(join).to have_http 202
-          expect(join).to have_headers(EXPECTED_HEADERS)
-          expect(join.to_s).to include "status"
-
-          join_tx_id = join['id']
-          eventually "Checking if join tx id (#{join_tx_id}) is in_ledger" do
-            tx = SHELLEY.transactions.get(@target_id_pools, join_tx_id)
-            tx['status'] == "in_ledger"
-          end
-
-          # Quit pool
-          puts "Quitting pool: #{pool_id}"
-          quit = pools.quit(@target_id_pools, PASS)
-
-          expect(quit).to have_http 202
-          expect(quit).to have_headers(EXPECTED_HEADERS)
-          expect(quit.to_s).to include "status"
-
-          quit_tx_id = quit['id']
-          eventually "Checking if quit tx id (#{quit_tx_id}) is in_ledger" do
-            tx = SHELLEY.transactions.get(@target_id_pools, quit_tx_id)
-            tx['status'] == "in_ledger"
-          end
-        end
+      it "I can get native assets by policy_id and asset_name" do
+        assets = SHELLEY.assets.get(@wid, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
+        expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
+        expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
+        expect(assets["asset_name"]).not_to eq ASSETS[0]["asset_name"]
+        expect(assets["metadata"]).not_to eq ASSETS[0]["metadata"]["name"]
       end
 
-      describe "Coin Selection" do
-
-        it "I can trigger random coin selection" do
-          wid = create_shelley_wallet
-          addresses = SHELLEY.addresses.list(wid)
-          payload = [{"address" => addresses[0]['id'],
-                      "amount" => { "quantity"=> 2000000, "unit"=> "lovelace" },
-                      "assets" => [ { "policy_id"=> ASSETS[0]["policy_id"],
-                                      "asset_name"=> ASSETS[0]["asset_name"],
-                                      "quantity"=> 1
-                                    },
-                                    { "policy_id"=> ASSETS[1]["policy_id"],
-                                      "asset_name"=> ASSETS[1]["asset_name"],
-                                      "quantity"=> 1
-                                    }
-                                  ]
-                      }
-                     ]
-
-          rnd = SHELLEY.coin_selections.random(@wid, payload, withdrawal = "self", m = METADATA)
-
-          expect(rnd).to have_http 200
-          expect(rnd).to have_headers(EXPECTED_HEADERS)
-          expect(rnd.to_s).to include "outputs"
-          expect(rnd.to_s).to include "change"
-          expect(rnd.to_s).to include "metadata"
-          expect(rnd['inputs']).not_to be_empty
-          expect(rnd['outputs']).not_to be_empty
-        end
-
-        it "I can trigger random coin selection delegation action" do
-          pid = SHELLEY.stake_pools.list({stake: 1000000}).sample['id']
-          action_join = {action: "join", pool: pid}
-
-          rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
-
-          expect(rnd).to have_http 200
-          expect(rnd).to have_headers(EXPECTED_HEADERS)
-          expect(rnd.to_s).to include "outputs"
-          expect(rnd.to_s).to include "change"
-          expect(rnd['inputs']).not_to be_empty
-          expect(rnd['change']).not_to be_empty
-          expect(rnd['outputs']).to be_empty
-          expect(rnd['certificates']).not_to be_empty
-          # expect(rnd['certificates'].to_s).to include "register_reward_account"
-          expect(rnd['certificates'].to_s).to include "join_pool"
-        end
-
-        it "I could trigger random coin selection delegation action - if I had money" do
-          wid = create_shelley_wallet
-          pid = SHELLEY.stake_pools.list({stake: 1000000}).sample['id']
-          action_join = {action: "join", pool: pid}
-
-          rnd = SHELLEY.coin_selections.random_deleg wid, action_join
-          expect(rnd).to have_http 403
-          expect(rnd).to have_headers(EXPECTED_HEADERS)
-          expect(rnd.to_s).to include "not_enough_money"
-        end
-
-        it "I could trigger random coin selection delegation action - if I known pool id" do
-          wid = create_shelley_wallet
-          addresses = SHELLEY.addresses.list(wid)
-          action_join = {action: "join", pool: SPID_BECH32}
-          action_quit = {action: "quit"}
-
-          rnd = SHELLEY.coin_selections.random_deleg wid, action_join
-          expect(rnd).to have_http 404
-          expect(rnd).to have_headers(EXPECTED_HEADERS)
-          expect(rnd.to_s).to include "no_such_pool"
-
-          rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
-          expect(rnd).to have_http 403
-          expect(rnd).to have_headers(EXPECTED_HEADERS)
-          expect(rnd.to_s).to include "not_delegating_to"
-        end
-
-      end
-    end
-
-    describe "E2E Byron" do
-
-      def test_byron_tx(source_wid, target_wid)
-        amt = 1000000
-        address = SHELLEY.addresses.list(target_wid)[0]['id']
-
-        tx_sent = BYRON.transactions.create(source_wid, PASS, [{address => amt}])
-
-        expect(tx_sent).to have_http 202
-        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
-        expect(tx_sent.to_s).to include "pending"
-
-        eventually "Funds are on target wallet: #{target_wid}" do
-          available = SHELLEY.wallets.get(target_wid)['balance']['available']['quantity']
-          total = SHELLEY.wallets.get(target_wid)['balance']['total']['quantity']
-          (available == amt) && (total == amt)
-        end
-      end
-
-      def test_byron_assets_tx(source_id, target_id)
+      it "I can send native assets tx and they are received" do
         asset_quantity = 1
-        address = SHELLEY.addresses.list(target_id)[1]['id']
-        payload = [{"address" => address,
-                    "amount" => { "quantity"=> 0, "unit"=> "lovelace" },
-                    "assets" => [ { "policy_id"=> ASSETS[0]["policy_id"],
-                                    "asset_name"=> ASSETS[0]["asset_name"],
-                                    "quantity"=> asset_quantity
+        address = SHELLEY.addresses.list(@target_id_assets)[1]['id']
+        payload = [{ "address" => address,
+                    "amount" => { "quantity" => 0, "unit" => "lovelace" },
+                    "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
+                                    "asset_name" => ASSETS[0]["asset_name"],
+                                    "quantity" => asset_quantity
                                   },
-                                  { "policy_id"=> ASSETS[1]["policy_id"],
-                                    "asset_name"=> ASSETS[1]["asset_name"],
-                                    "quantity"=> asset_quantity
+                                  { "policy_id" => ASSETS[1]["policy_id"],
+                                    "asset_name" => ASSETS[1]["asset_name"],
+                                    "quantity" => asset_quantity
                                   }
                                 ]
                     }
                    ]
 
-        tx_sent = BYRON.transactions.create(source_id, PASS, payload)
+        tx_sent = SHELLEY.transactions.create(@wid, PASS, payload)
 
         expect(tx_sent).to have_http 202
         expect(tx_sent).to have_headers(EXPECTED_HEADERS)
         expect(tx_sent.to_s).to include "pending"
 
-        eventually "Assets are on target wallet: #{target_id}" do
+        eventually "Assets are on target wallet: #{@target_id_assets}" do
           first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
           second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
-          total_assets = SHELLEY.wallets.get(target_id)['assets']['total']
-          available_assets = SHELLEY.wallets.get(target_id)['assets']['available']
+          total_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['total']
+          available_assets = SHELLEY.wallets.get(@target_id_assets)['assets']['available']
           total = Hash.new
           available = Hash.new
 
           unless total_assets.empty?
-            total[first] = total_assets.select {|a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"]}.first["quantity"]
-            total[second] = total_assets.select {|a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"]}.first["quantity"]
+            total[first] = total_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
+            total[second] = total_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
           end
 
           unless available_assets.empty?
-            available[first] = available_assets.select {|a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"]}.first["quantity"]
-            available[second] = available_assets.select {|a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"]}.first["quantity"]
+            available[first] = available_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
+            available[second] = available_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
           end
 
           (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
@@ -509,75 +131,453 @@ RSpec.describe "Cardano Wallet E2E tests", :e2e => true do
         end
       end
 
-      describe "Byron Transactions" do
+    end
 
-        it "I can send transaction and funds are received, random -> shelley" do
-          test_byron_tx(@wid_rnd, @target_id_rnd_assets)
-        end
+    describe "Shelley Transactions" do
+      it "I can send transaction and funds are received" do
+        amt = 1000000
 
-        it "I can send transaction and funds are received, icarus -> shelley" do
-          test_byron_tx(@wid_ic, @target_id_ic_assets)
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
+        tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }])
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "Funds are on target wallet: #{@target_id}" do
+          available = SHELLEY.wallets.get(@target_id)['balance']['available']['quantity']
+          total = SHELLEY.wallets.get(@target_id)['balance']['total']['quantity']
+          (available == amt) && (total == amt)
         end
       end
 
-      describe "Native Assets" do
+      it "I can send transaction with ttl and funds are received" do
+        amt = 1000000
+        ttl_in_s = 120
 
-        it "I can list assets -> random" do
-          assets = BYRON.assets.get @wid_rnd
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets.to_s).to include ASSETS[0]["policy_id"]
-          expect(assets.to_s).to include ASSETS[0]["asset_name"]
-          expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
-          expect(assets.to_s).to include ASSETS[1]["policy_id"]
-          expect(assets.to_s).to include ASSETS[1]["asset_name"]
-          expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
+        address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
+        tx_sent = SHELLEY.transactions.create(@wid,
+                                              PASS,
+                                              [{ address => amt }],
+                                              withdrawal = nil,
+                                              metadata = nil,
+                                              ttl_in_s)
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "Funds are on target wallet: #{@target_id}" do
+          available = SHELLEY.wallets.get(@target_id_ttl)['balance']['available']['quantity']
+          total = SHELLEY.wallets.get(@target_id_ttl)['balance']['total']['quantity']
+          (available == amt) && (total == amt)
+        end
+      end
+
+      it "Transaction with ttl = 0 would expire and I can forget it" do
+        skip "Test is flaky due to ADP-608"
+        amt = 1000000
+        ttl_in_s = 0
+
+        address = SHELLEY.addresses.list(@target_id_ttl)[0]['id']
+        tx_sent = SHELLEY.transactions.create(@wid,
+                                              PASS,
+                                              [{ address => amt }],
+                                              withdrawal = nil,
+                                              metadata = nil,
+                                              ttl_in_s)
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "TX `#{tx_sent['id']}' expires on `#{@wid}'" do
+          SHELLEY.transactions.get(@wid, tx_sent['id'])['status'] == 'expired'
         end
 
-        it "I can list assets -> icarus" do
-          assets = BYRON.assets.get @wid_ic
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets.to_s).to include ASSETS[0]["policy_id"]
-          expect(assets.to_s).to include ASSETS[0]["asset_name"]
-          expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
-          expect(assets.to_s).to include ASSETS[1]["policy_id"]
-          expect(assets.to_s).to include ASSETS[1]["asset_name"]
-          expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
+        res = SHELLEY.transactions.forget(@wid, tx_sent['id'])
+        expect(res).to have_http 204
+
+        fres = SHELLEY.transactions.get(@wid, tx_sent['id'])
+        expect(fres).to have_http 404
+      end
+
+      it "I can send transaction using 'withdrawal' flag and funds are received" do
+        amt = 1000000
+        address = SHELLEY.addresses.list(@target_id_withdrawal)[0]['id']
+
+        tx_sent = SHELLEY.transactions.create(@wid, PASS, [{ address => amt }], 'self')
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "Funds are on target wallet: #{@target_id_withdrawal}" do
+          available = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['available']['quantity']
+          total = SHELLEY.wallets.get(@target_id_withdrawal)['balance']['total']['quantity']
+          (available == amt) && (total == amt)
+        end
+      end
+
+      it "I can send transaction with metadata" do
+        amt = 1000000
+        metadata = METADATA
+
+        address = SHELLEY.addresses.list(@target_id_meta)[0]['id']
+        tx_sent = SHELLEY.transactions.create(@wid,
+                                              PASS,
+                                              [{ address => amt }],
+                                              nil,
+                                              metadata
+                                             )
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "Funds are on target wallet: #{@target_id_meta}" do
+          available = SHELLEY.wallets.get(@target_id_meta)['balance']['available']['quantity']
+          total = SHELLEY.wallets.get(@target_id_meta)['balance']['total']['quantity']
+          (available == amt) && (total == amt)
         end
 
-        it "I can get native assets by policy_id -> random" do
-          assets = BYRON.assets.get(@wid_rnd , policy_id = ASSETS[0]["policy_id"])
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
-          expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
-          expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
-          expect(assets["asset_name"]).not_to eq ASSETS[1]["asset_name"]
-          expect(assets["metadata"]).not_to eq ASSETS[1]["metadata"]
+        eventually "Metadata is present on sent tx: #{tx_sent['id']}" do
+          meta_src = SHELLEY.transactions.get(@wid, tx_sent['id'])['metadata']
+          meta_dst = SHELLEY.transactions.get(@target_id_meta, tx_sent['id'])['metadata']
+          (meta_src == metadata) && (meta_dst == metadata)
         end
+      end
 
-        it "I can get native assets by policy_id and asset_name -> random" do
-          assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
-          expect(assets).to have_http 200
-          expect(assets).to have_headers(EXPECTED_HEADERS)
-          expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
-          expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
-          expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
-          expect(assets["asset_name"]).not_to eq ASSETS[0]["asset_name"]
-          expect(assets["metadata"]).not_to eq ASSETS[0]["metadata"]["name"]
-        end
+      it "I can estimate fee" do
+        metadata = METADATA
 
-        it "I can send native assets tx and they are received (random -> shelley)" do
-          test_byron_assets_tx(@wid_rnd, @target_id_rnd_assets)
-        end
+        address = SHELLEY.addresses.list(@target_id)[0]['id']
+        amt = [{ address => 1000000 }]
 
-        it "I can send native assets tx and they are received (icarus -> shelley)" do
-          test_byron_assets_tx(@wid_ic, @target_id_ic_assets)
-        end
+        txs = SHELLEY.transactions
+        fees = txs.payment_fees(@wid, amt)
+        expect(fees).to have_http 202
+        expect(fees).to have_headers(EXPECTED_HEADERS)
 
+        fees = txs.payment_fees(@wid, amt, 'self')
+        expect(fees).to have_http 202
+        expect(fees).to have_headers(EXPECTED_HEADERS)
+
+        fees = txs.payment_fees(@wid, amt, 'self', metadata)
+        expect(fees).to have_http 202
+        expect(fees).to have_headers(EXPECTED_HEADERS)
       end
     end
+
+    describe "Stake Pools" do
+
+      it "I could join Stake Pool - if I knew it's id" do
+        pools = SHELLEY.stake_pools
+
+        join = pools.join(SPID, @wid, PASS)
+        expect(join).to have_http 404
+        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join.to_s).to include "no_such_pool"
+      end
+
+      it "I could check delegation fees - if I could cover fee" do
+        id = create_shelley_wallet
+
+        pools = SHELLEY.stake_pools
+        fees = pools.delegation_fees(id)
+        expect(fees).to have_http 403
+        expect(fees).to have_headers(EXPECTED_HEADERS)
+        expect(fees.to_s).to include "not_enough_money"
+      end
+
+      it "I could join Stake Pool - if I had enough to cover fee" do
+        id = create_shelley_wallet
+        pools = SHELLEY.stake_pools
+        pool_id = pools.list({ stake: 1000 })[0]['id']
+
+        join = pools.join(pool_id, id, PASS)
+        expect(join).to have_http 403
+        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join.to_s).to include "not_enough_money"
+      end
+
+      it "Can list stake pools only when stake is provided" do
+        pools = SHELLEY.stake_pools
+        l = pools.list({ stake: 1000 })
+        l_bad = pools.list
+        expect(l).to have_http 200
+        expect(l).to have_headers(EXPECTED_HEADERS)
+
+        expect(l_bad).to have_http 400
+        expect(l_bad).to have_headers(EXPECTED_HEADERS)
+        expect(l_bad.to_s).to include "query_param_missing"
+      end
+
+      it "Can join and quit Stake Pool" do
+
+        # Get funds on the wallet
+        address = SHELLEY.addresses.list(@target_id_pools)[0]['id']
+        amt = 10000000
+        tx_sent = SHELLEY.transactions.create(@wid,
+                                              PASS,
+                                              [{ address => amt }])
+
+        expect(tx_sent).to have_http 202
+        expect(tx_sent.to_s).to include "pending"
+
+        eventually "Funds are on target wallet: #{@target_id_pools}" do
+          available = SHELLEY.wallets.get(@target_id_pools)['balance']['available']['quantity']
+          total = SHELLEY.wallets.get(@target_id_pools)['balance']['total']['quantity']
+          (available == amt) && (total == amt)
+        end
+
+        # Pick up pool id to join
+        pools = SHELLEY.stake_pools
+        pool_id = pools.list({ stake: 1000 }).sample['id']
+
+        # Join pool
+        puts "Joining pool: #{pool_id}"
+        join = pools.join(pool_id, @target_id_pools, PASS)
+
+        expect(join).to have_http 202
+        expect(join).to have_headers(EXPECTED_HEADERS)
+        expect(join.to_s).to include "status"
+
+        join_tx_id = join['id']
+        eventually "Checking if join tx id (#{join_tx_id}) is in_ledger" do
+          tx = SHELLEY.transactions.get(@target_id_pools, join_tx_id)
+          tx['status'] == "in_ledger"
+        end
+
+        # Quit pool
+        puts "Quitting pool: #{pool_id}"
+        quit = pools.quit(@target_id_pools, PASS)
+
+        expect(quit).to have_http 202
+        expect(quit).to have_headers(EXPECTED_HEADERS)
+        expect(quit.to_s).to include "status"
+
+        quit_tx_id = quit['id']
+        eventually "Checking if quit tx id (#{quit_tx_id}) is in_ledger" do
+          tx = SHELLEY.transactions.get(@target_id_pools, quit_tx_id)
+          tx['status'] == "in_ledger"
+        end
+      end
+    end
+
+    describe "Coin Selection" do
+
+      it "I can trigger random coin selection" do
+        wid = create_shelley_wallet
+        addresses = SHELLEY.addresses.list(wid)
+        payload = [{ "address" => addresses[0]['id'],
+                    "amount" => { "quantity" => 2000000, "unit" => "lovelace" },
+                    "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
+                                    "asset_name" => ASSETS[0]["asset_name"],
+                                    "quantity" => 1
+                                  },
+                                  { "policy_id" => ASSETS[1]["policy_id"],
+                                    "asset_name" => ASSETS[1]["asset_name"],
+                                    "quantity" => 1
+                                  }
+                                ]
+                    }
+                   ]
+
+        rnd = SHELLEY.coin_selections.random(@wid, payload, withdrawal = "self", m = METADATA)
+
+        expect(rnd).to have_http 200
+        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd.to_s).to include "outputs"
+        expect(rnd.to_s).to include "change"
+        expect(rnd.to_s).to include "metadata"
+        expect(rnd['inputs']).not_to be_empty
+        expect(rnd['outputs']).not_to be_empty
+      end
+
+      it "I can trigger random coin selection delegation action" do
+        pid = SHELLEY.stake_pools.list({ stake: 1000000 }).sample['id']
+        action_join = { action: "join", pool: pid }
+
+        rnd = SHELLEY.coin_selections.random_deleg @wid, action_join
+
+        expect(rnd).to have_http 200
+        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd.to_s).to include "outputs"
+        expect(rnd.to_s).to include "change"
+        expect(rnd['inputs']).not_to be_empty
+        expect(rnd['change']).not_to be_empty
+        expect(rnd['outputs']).to be_empty
+        expect(rnd['certificates']).not_to be_empty
+        # expect(rnd['certificates'].to_s).to include "register_reward_account"
+        expect(rnd['certificates'].to_s).to include "join_pool"
+      end
+
+      it "I could trigger random coin selection delegation action - if I had money" do
+        wid = create_shelley_wallet
+        pid = SHELLEY.stake_pools.list({ stake: 1000000 }).sample['id']
+        action_join = { action: "join", pool: pid }
+
+        rnd = SHELLEY.coin_selections.random_deleg wid, action_join
+        expect(rnd).to have_http 403
+        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd.to_s).to include "not_enough_money"
+      end
+
+      it "I could trigger random coin selection delegation action - if I known pool id" do
+        wid = create_shelley_wallet
+        addresses = SHELLEY.addresses.list(wid)
+        action_join = { action: "join", pool: SPID_BECH32 }
+        action_quit = { action: "quit" }
+
+        rnd = SHELLEY.coin_selections.random_deleg wid, action_join
+        expect(rnd).to have_http 404
+        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd.to_s).to include "no_such_pool"
+
+        rnd = SHELLEY.coin_selections.random_deleg wid, action_quit
+        expect(rnd).to have_http 403
+        expect(rnd).to have_headers(EXPECTED_HEADERS)
+        expect(rnd.to_s).to include "not_delegating_to"
+      end
+
+    end
+  end
+
+  describe "E2E Byron" do
+
+    def test_byron_tx(source_wid, target_wid)
+      amt = 1000000
+      address = SHELLEY.addresses.list(target_wid)[0]['id']
+
+      tx_sent = BYRON.transactions.create(source_wid, PASS, [{ address => amt }])
+
+      expect(tx_sent).to have_http 202
+      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent.to_s).to include "pending"
+
+      eventually "Funds are on target wallet: #{target_wid}" do
+        available = SHELLEY.wallets.get(target_wid)['balance']['available']['quantity']
+        total = SHELLEY.wallets.get(target_wid)['balance']['total']['quantity']
+        (available == amt) && (total == amt)
+      end
+    end
+
+    def test_byron_assets_tx(source_id, target_id)
+      asset_quantity = 1
+      address = SHELLEY.addresses.list(target_id)[1]['id']
+      payload = [{ "address" => address,
+                  "amount" => { "quantity" => 0, "unit" => "lovelace" },
+                  "assets" => [ { "policy_id" => ASSETS[0]["policy_id"],
+                                  "asset_name" => ASSETS[0]["asset_name"],
+                                  "quantity" => asset_quantity
+                                },
+                                { "policy_id" => ASSETS[1]["policy_id"],
+                                  "asset_name" => ASSETS[1]["asset_name"],
+                                  "quantity" => asset_quantity
+                                }
+                              ]
+                  }
+                 ]
+
+      tx_sent = BYRON.transactions.create(source_id, PASS, payload)
+
+      expect(tx_sent).to have_http 202
+      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent.to_s).to include "pending"
+
+      eventually "Assets are on target wallet: #{target_id}" do
+        first = ASSETS[0]["policy_id"] + ASSETS[0]["asset_name"]
+        second = ASSETS[1]["policy_id"] + ASSETS[1]["asset_name"]
+        total_assets = SHELLEY.wallets.get(target_id)['assets']['total']
+        available_assets = SHELLEY.wallets.get(target_id)['assets']['available']
+        total = Hash.new
+        available = Hash.new
+
+        unless total_assets.empty?
+          total[first] = total_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
+          total[second] = total_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
+        end
+
+        unless available_assets.empty?
+          available[first] = available_assets.select { |a| a['policy_id'] == ASSETS[0]["policy_id"] && a['asset_name'] == ASSETS[0]["asset_name"] }.first["quantity"]
+          available[second] = available_assets.select { |a| a['policy_id'] == ASSETS[1]["policy_id"] && a['asset_name'] == ASSETS[1]["asset_name"] }.first["quantity"]
+        end
+
+        (total[first] == asset_quantity) && (total[second] == asset_quantity) &&
+        (available[first] == asset_quantity) && (available[second] == asset_quantity)
+      end
+    end
+
+    describe "Byron Transactions" do
+
+      it "I can send transaction and funds are received, random -> shelley" do
+        test_byron_tx(@wid_rnd, @target_id_rnd_assets)
+      end
+
+      it "I can send transaction and funds are received, icarus -> shelley" do
+        test_byron_tx(@wid_ic, @target_id_ic_assets)
+      end
+    end
+
+    describe "Native Assets" do
+
+      it "I can list assets -> random" do
+        assets = BYRON.assets.get @wid_rnd
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets.to_s).to include ASSETS[0]["policy_id"]
+        expect(assets.to_s).to include ASSETS[0]["asset_name"]
+        expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
+        expect(assets.to_s).to include ASSETS[1]["policy_id"]
+        expect(assets.to_s).to include ASSETS[1]["asset_name"]
+        expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
+      end
+
+      it "I can list assets -> icarus" do
+        assets = BYRON.assets.get @wid_ic
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets.to_s).to include ASSETS[0]["policy_id"]
+        expect(assets.to_s).to include ASSETS[0]["asset_name"]
+        expect(assets.to_s).to include ASSETS[0]["metadata"]["name"]
+        expect(assets.to_s).to include ASSETS[1]["policy_id"]
+        expect(assets.to_s).to include ASSETS[1]["asset_name"]
+        expect(assets.to_s).to include ASSETS[1]["metadata"]["name"]
+      end
+
+      it "I can get native assets by policy_id -> random" do
+        assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[0]["policy_id"])
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets["policy_id"]).to eq ASSETS[0]["policy_id"]
+        expect(assets["asset_name"]).to eq ASSETS[0]["asset_name"]
+        expect(assets["metadata"]).to eq ASSETS[0]["metadata"]
+        expect(assets["asset_name"]).not_to eq ASSETS[1]["asset_name"]
+        expect(assets["metadata"]).not_to eq ASSETS[1]["metadata"]
+      end
+
+      it "I can get native assets by policy_id and asset_name -> random" do
+        assets = BYRON.assets.get(@wid_rnd, policy_id = ASSETS[1]["policy_id"], asset_name = ASSETS[1]["asset_name"])
+        expect(assets).to have_http 200
+        expect(assets).to have_headers(EXPECTED_HEADERS)
+        expect(assets["policy_id"]).to eq ASSETS[1]["policy_id"]
+        expect(assets["asset_name"]).to eq ASSETS[1]["asset_name"]
+        expect(assets["metadata"]).to eq ASSETS[1]["metadata"]
+        expect(assets["asset_name"]).not_to eq ASSETS[0]["asset_name"]
+        expect(assets["metadata"]).not_to eq ASSETS[0]["metadata"]["name"]
+      end
+
+      it "I can send native assets tx and they are received (random -> shelley)" do
+        test_byron_assets_tx(@wid_rnd, @target_id_rnd_assets)
+      end
+
+      it "I can send native assets tx and they are received (icarus -> shelley)" do
+        test_byron_assets_tx(@wid_ic, @target_id_ic_assets)
+      end
+
+    end
+  end
 
 
 end

--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe CardanoWallet::Misc do
 
     describe "SMASH health" do
       it "SMASH health - unreachable" do
-        r = UTILS.smash_health({url: "http://onet.pl"})
+        r = UTILS.smash_health({ url: "http://onet.pl" })
         expect(r).to have_http 200
         expect(r).to have_headers(EXPECTED_HEADERS)
         expect(r.to_s).to include "unreachable"
       end
 
       it "SMASH health - bad url" do
-        r = UTILS.smash_health({url: "dsds"})
+        r = UTILS.smash_health({ url: "dsds" })
         expect(r).to have_http 400
         expect(r).to have_headers(EXPECTED_HEADERS)
         expect(r.to_s).to include "bad_request"
@@ -284,16 +284,16 @@ RSpec.describe CardanoWallet::Misc do
   describe CardanoWallet::Misc::Settings do
 
     after(:all) do
-      SETTINGS.update({:pool_metadata_source => "none"})
+      SETTINGS.update({ :pool_metadata_source => "none" })
     end
 
-    matrix = {"direct" => "no_smash_configured",
+    matrix = { "direct" => "no_smash_configured",
               "https://smash.pl" => "unreachable",
-              "none" => "no_smash_configured"}
+              "none" => "no_smash_configured" }
 
     matrix.each do |strategy, smash_health_response|
       it "I can read and update settings to #{strategy} and verify SMASH health = #{smash_health_response}" do
-        s = SETTINGS.update({:pool_metadata_source => strategy})
+        s = SETTINGS.update({ :pool_metadata_source => strategy })
         expect(s).to have_http 204
 
         g = SETTINGS.get
@@ -301,7 +301,7 @@ RSpec.describe CardanoWallet::Misc do
         expect(g).to have_http 200
         expect(g).to have_headers(EXPECTED_HEADERS)
 
-        #check smash health
+        # check smash health
         r = UTILS.smash_health
         expect(r).to have_http 200
         expect(r).to have_headers(EXPECTED_HEADERS)

--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -4,20 +4,17 @@ RSpec.describe CardanoWallet::Misc do
 
     it "Can get network information" do
       res = NETWORK.information
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
     end
 
     it "Can check network clock offset" do
       res = NETWORK.clock
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
     end
 
     it "Can check network parameters" do
       res = NETWORK.parameters
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
     end
   end
 
@@ -26,15 +23,13 @@ RSpec.describe CardanoWallet::Misc do
     describe "SMASH health" do
       it "SMASH health - unreachable" do
         r = UTILS.smash_health({ url: "http://onet.pl" })
-        expect(r).to have_http 200
-        expect(r).to have_expected_headers
+        expect(r).to be_correct_and_respond 200
         expect(r.to_s).to include "unreachable"
       end
 
       it "SMASH health - bad url" do
         r = UTILS.smash_health({ url: "dsds" })
-        expect(r).to have_http 400
-        expect(r).to have_expected_headers
+        expect(r).to be_correct_and_respond 400
         expect(r.to_s).to include "bad_request"
       end
     end
@@ -42,8 +37,7 @@ RSpec.describe CardanoWallet::Misc do
     it "Inspect invalid address" do
       addr = "addr"
       res = UTILS.addresses addr
-      expect(res).to have_http 400
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 400
       expect(res.to_s).to include "bad_request"
     end
 
@@ -51,8 +45,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "addr1qqlgm2dh3vpv07cjfcyuu6vhaqhf8998qcx6s8ucpkly6f8l0dw5r75vk42mv3ykq8vyjeaanvpytg79xqzymqy5acmqej0mk7"
       res = UTILS.addresses addr
 
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "ff7b5d41fa8cb555b6449601d84967bd9b0245a3c530044d8094ee36"
@@ -64,8 +57,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "stake_test1uzws33ghf8kugc8ea8p7h8mr7dcsl6ggw7tfy479y9t0d4qp48dkq"
       res = UTILS.addresses addr
 
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "9d08c51749edc460f9e9c3eb9f63f3710fe90877969257c52156f6d4"
@@ -76,8 +68,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "37btjrVyb4KEzz6YprjHfqz3DS4JvoDpAf3QWLABzQ7uzMEk7g3PD2AwL1SbYWekneuRFkyTipbyKMZyEMed5LroZtQAvA2LqcWmJuwaqt6oJLbssS"
       res = UTILS.addresses addr
 
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
       expect(res['address_style']).to eq "Byron"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "c23a0f86c7bc977f0dee4721c9850467047a0e6acd928a991b5cbba8"
@@ -89,8 +80,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "2cWKMJemoBajQcoTotf4xYba7fV7Ztx7AvbnzvaQY6PbezPWM6DtJD6Df2bVejBCpykmt"
       res = UTILS.addresses addr
 
-      expect(res).to have_http 200
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 200
       expect(res['address_style']).to eq "Icarus"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "88940c753ee50d556ecaefadd0d2fee9fabacf4366a7d4a8cdfa2b64"
@@ -103,8 +93,7 @@ RSpec.describe CardanoWallet::Misc do
                   "payment": "script_vkh1yf07000d4ml3ywd3d439kmwp07xzgv6p35cwx8h605jfx0dtd4a"
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1wp6eswctz5wzrv3ceh3h4y3na2t6d95sjn23dawy0zlzg0q569eke"
       end
 
@@ -118,8 +107,7 @@ RSpec.describe CardanoWallet::Misc do
                       }
                   }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1wzt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2ykp4j"
       end
 
@@ -133,8 +121,7 @@ RSpec.describe CardanoWallet::Misc do
                       }
                   }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1wp4h4mtdkxr2x68zx4tk0cgmd9hymjgsuhmzaxkg5tkl3scr8umfh"
       end
 
@@ -152,8 +139,7 @@ RSpec.describe CardanoWallet::Misc do
                    }
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1wq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5taclcp983gu"
       end
 
@@ -167,8 +153,7 @@ RSpec.describe CardanoWallet::Misc do
                       }
                   }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "stake_test17zt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2vgezc"
       end
 
@@ -192,8 +177,7 @@ RSpec.describe CardanoWallet::Misc do
                         }
                   }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1xq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacluk59zrmajh6vra9cx6slk090pkkr2x59f5zmrmgpr9wvfsjg2j62"
       end
 
@@ -202,8 +186,7 @@ RSpec.describe CardanoWallet::Misc do
                   "payment": "addr_vk1lqglg77z6kajsdz4739q22c0zm0yhuy567z6xk2vc0z5ucjtkwpschzd2j"
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1vpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfgdmxm9u"
       end
 
@@ -212,8 +195,7 @@ RSpec.describe CardanoWallet::Misc do
                   "stake": "stake_vk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7qau558d"
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "stake_test1uq6pmlvyl3wn4ca6807e26gy2gek9hqu0gastzh5tk0xx0gdfvj8f"
       end
 
@@ -223,8 +205,7 @@ RSpec.describe CardanoWallet::Misc do
                   "stake": "stake_vk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7qau558d"
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1qpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wff5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7ser7yl4"
       end
 
@@ -243,8 +224,7 @@ RSpec.describe CardanoWallet::Misc do
                   "stake": "stake_vk16apaenn9ut6s40lcw3l8v68xawlrlq20z2966uzcx8jmv2q9uy7qau558d"
                  }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1zq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacle5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7su0qjlj"
       end
 
@@ -263,8 +243,7 @@ RSpec.describe CardanoWallet::Misc do
                       }
                    }
         res = UTILS.post_address(script)
-        expect(res).to have_http 202
-        expect(res).to have_expected_headers
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "addr_test1ypqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfffxzlhgvlzh6drdsm04j43jk2wpsnqw7uketsgelghm3lsmpggt5"
       end
 
@@ -276,8 +255,7 @@ RSpec.describe CardanoWallet::Misc do
       binary_blob = "82839f8200d81858248258201d4ca4d72a1e02fbb79bec42392d9eb3da179f8a2316fd9e9a5ffe9c441d8bce01ff9f8282d818582883581c9c19ec69f7d3acad269e4bbbfcad67129c268bd772060b426b7e23cba102451a4170cb17001a1c281652018282d818582883581c95eaa323cac6cd8916a02c58b133d9b576ceb7bcb1f8c0716a701118a102451a4170cb17001a5e6fce581a0096048effa0818200d8185885825840b8cdd384ec1ef3dffe4db999d6bfce40afaa964543e2e1592c932f552fe9e8301233bbc1f45472837b904b719db5d32d947ec521e7fccd1aec6ad6cf884fc45858403964714f761d79a67b34c8e1fcc337af6ef44a894e6e740927dbec86d1be63e9987dc9ceb7905a53a0ddddf3a9ea4508e41a02d18ed3994461eb20cb0ba2710b"
       PROXY = CardanoWallet.new.misc.proxy
       res = PROXY.submit_external_transaction(binary_blob)
-      expect(res).to have_http 400
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 400
     end
   end
 
@@ -294,17 +272,15 @@ RSpec.describe CardanoWallet::Misc do
     matrix.each do |strategy, smash_health_response|
       it "I can read and update settings to #{strategy} and verify SMASH health = #{smash_health_response}" do
         s = SETTINGS.update({ :pool_metadata_source => strategy })
-        expect(s).to have_http 204
+        expect(s).to be_correct_and_respond 204
 
         g = SETTINGS.get
         expect(g['pool_metadata_source']).to eq strategy
-        expect(g).to have_http 200
-        expect(g).to have_expected_headers
+        expect(g).to be_correct_and_respond 200
 
         # check smash health
         r = UTILS.smash_health
-        expect(r).to have_http 200
-        expect(r).to have_expected_headers
+        expect(r).to be_correct_and_respond 200
         expect(r.to_s).to include smash_health_response
       end
     end

--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -3,15 +3,21 @@ RSpec.describe CardanoWallet::Misc do
   describe CardanoWallet::Misc::Network do
 
     it "Can get network information" do
-      expect(NETWORK.information).to have_http 200
+      res = NETWORK.information
+      expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
     end
 
     it "Can check network clock offset" do
-      expect(NETWORK.clock).to have_http 200
+      res = NETWORK.clock
+      expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
     end
 
     it "Can check network parameters" do
-      expect(NETWORK.parameters).to have_http 200
+      res = NETWORK.parameters
+      expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
     end
   end
 
@@ -21,13 +27,15 @@ RSpec.describe CardanoWallet::Misc do
       it "SMASH health - unreachable" do
         r = UTILS.smash_health({url: "http://onet.pl"})
         expect(r).to have_http 200
+        expect(r).to have_headers(EXPECTED_HEADERS)
         expect(r.to_s).to include "unreachable"
       end
 
       it "SMASH health - bad url" do
         r = UTILS.smash_health({url: "dsds"})
-        expect(r.to_s).to include "bad_request"
         expect(r).to have_http 400
+        expect(r).to have_headers(EXPECTED_HEADERS)
+        expect(r.to_s).to include "bad_request"
       end
     end
 
@@ -35,15 +43,16 @@ RSpec.describe CardanoWallet::Misc do
       addr = "addr"
       res = UTILS.addresses addr
       expect(res).to have_http 400
+      expect(res).to have_headers(EXPECTED_HEADERS)
       expect(res.to_s).to include "bad_request"
     end
 
     it "Inspect Shelley payment address" do
       addr = "addr1qqlgm2dh3vpv07cjfcyuu6vhaqhf8998qcx6s8ucpkly6f8l0dw5r75vk42mv3ykq8vyjeaanvpytg79xqzymqy5acmqej0mk7"
       res = UTILS.addresses addr
-      expect(res.to_s).to include "Shelley"
 
       expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "ff7b5d41fa8cb555b6449601d84967bd9b0245a3c530044d8094ee36"
@@ -54,9 +63,9 @@ RSpec.describe CardanoWallet::Misc do
     it "Inspect Shelley stake address" do
       addr = "stake_test1uzws33ghf8kugc8ea8p7h8mr7dcsl6ggw7tfy479y9t0d4qp48dkq"
       res = UTILS.addresses addr
-      expect(res.to_s).to include "Shelley"
 
       expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "9d08c51749edc460f9e9c3eb9f63f3710fe90877969257c52156f6d4"
@@ -66,9 +75,9 @@ RSpec.describe CardanoWallet::Misc do
     it "Inspect Byron Random address" do
       addr = "37btjrVyb4KEzz6YprjHfqz3DS4JvoDpAf3QWLABzQ7uzMEk7g3PD2AwL1SbYWekneuRFkyTipbyKMZyEMed5LroZtQAvA2LqcWmJuwaqt6oJLbssS"
       res = UTILS.addresses addr
-      expect(res.to_s).to include "Byron"
 
       expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
       expect(res['address_style']).to eq "Byron"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "c23a0f86c7bc977f0dee4721c9850467047a0e6acd928a991b5cbba8"
@@ -79,9 +88,9 @@ RSpec.describe CardanoWallet::Misc do
     it "Inspect Byron Icarus address" do
       addr = "2cWKMJemoBajQcoTotf4xYba7fV7Ztx7AvbnzvaQY6PbezPWM6DtJD6Df2bVejBCpykmt"
       res = UTILS.addresses addr
-      expect(res.to_s).to include "Icarus"
 
       expect(res).to have_http 200
+      expect(res).to have_headers(EXPECTED_HEADERS)
       expect(res['address_style']).to eq "Icarus"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "88940c753ee50d556ecaefadd0d2fee9fabacf4366a7d4a8cdfa2b64"
@@ -95,6 +104,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1wp6eswctz5wzrv3ceh3h4y3na2t6d95sjn23dawy0zlzg0q569eke"
       end
 
@@ -109,6 +119,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1wzt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2ykp4j"
       end
 
@@ -123,6 +134,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1wp4h4mtdkxr2x68zx4tk0cgmd9hymjgsuhmzaxkg5tkl3scr8umfh"
       end
 
@@ -141,6 +153,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1wq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5taclcp983gu"
       end
 
@@ -155,6 +168,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "stake_test17zt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2vgezc"
       end
 
@@ -179,6 +193,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1xq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacluk59zrmajh6vra9cx6slk090pkkr2x59f5zmrmgpr9wvfsjg2j62"
       end
 
@@ -188,6 +203,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1vpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfgdmxm9u"
       end
 
@@ -197,6 +213,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "stake_test1uq6pmlvyl3wn4ca6807e26gy2gek9hqu0gastzh5tk0xx0gdfvj8f"
       end
 
@@ -207,6 +224,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1qpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wff5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7ser7yl4"
       end
 
@@ -226,6 +244,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1zq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacle5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7su0qjlj"
       end
 
@@ -245,6 +264,7 @@ RSpec.describe CardanoWallet::Misc do
                    }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
+        expect(res).to have_headers(EXPECTED_HEADERS)
         expect(res.to_s).to include "addr_test1ypqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfffxzlhgvlzh6drdsm04j43jk2wpsnqw7uketsgelghm3lsmpggt5"
       end
 
@@ -257,6 +277,7 @@ RSpec.describe CardanoWallet::Misc do
       PROXY = CardanoWallet.new.misc.proxy
       res = PROXY.submit_external_transaction(binary_blob)
       expect(res).to have_http 400
+      expect(res).to have_headers(EXPECTED_HEADERS)
     end
   end
 
@@ -278,11 +299,13 @@ RSpec.describe CardanoWallet::Misc do
         g = SETTINGS.get
         expect(g['pool_metadata_source']).to eq strategy
         expect(g).to have_http 200
+        expect(g).to have_headers(EXPECTED_HEADERS)
 
         #check smash health
         r = UTILS.smash_health
-        expect(r.to_s).to include smash_health_response
         expect(r).to have_http 200
+        expect(r).to have_headers(EXPECTED_HEADERS)
+        expect(r.to_s).to include smash_health_response
       end
     end
   end

--- a/test/e2e/spec/misc_spec.rb
+++ b/test/e2e/spec/misc_spec.rb
@@ -5,19 +5,19 @@ RSpec.describe CardanoWallet::Misc do
     it "Can get network information" do
       res = NETWORK.information
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
     end
 
     it "Can check network clock offset" do
       res = NETWORK.clock
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
     end
 
     it "Can check network parameters" do
       res = NETWORK.parameters
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
     end
   end
 
@@ -27,14 +27,14 @@ RSpec.describe CardanoWallet::Misc do
       it "SMASH health - unreachable" do
         r = UTILS.smash_health({ url: "http://onet.pl" })
         expect(r).to have_http 200
-        expect(r).to have_headers(EXPECTED_HEADERS)
+        expect(r).to have_expected_headers
         expect(r.to_s).to include "unreachable"
       end
 
       it "SMASH health - bad url" do
         r = UTILS.smash_health({ url: "dsds" })
         expect(r).to have_http 400
-        expect(r).to have_headers(EXPECTED_HEADERS)
+        expect(r).to have_expected_headers
         expect(r.to_s).to include "bad_request"
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe CardanoWallet::Misc do
       addr = "addr"
       res = UTILS.addresses addr
       expect(res).to have_http 400
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
       expect(res.to_s).to include "bad_request"
     end
 
@@ -52,7 +52,7 @@ RSpec.describe CardanoWallet::Misc do
       res = UTILS.addresses addr
 
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "ff7b5d41fa8cb555b6449601d84967bd9b0245a3c530044d8094ee36"
@@ -65,7 +65,7 @@ RSpec.describe CardanoWallet::Misc do
       res = UTILS.addresses addr
 
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
       expect(res['address_style']).to eq "Shelley"
       expect(res['stake_reference']).to eq "by value"
       expect(res['stake_key_hash']).to eq "9d08c51749edc460f9e9c3eb9f63f3710fe90877969257c52156f6d4"
@@ -77,7 +77,7 @@ RSpec.describe CardanoWallet::Misc do
       res = UTILS.addresses addr
 
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
       expect(res['address_style']).to eq "Byron"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "c23a0f86c7bc977f0dee4721c9850467047a0e6acd928a991b5cbba8"
@@ -90,7 +90,7 @@ RSpec.describe CardanoWallet::Misc do
       res = UTILS.addresses addr
 
       expect(res).to have_http 200
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
       expect(res['address_style']).to eq "Icarus"
       expect(res['stake_reference']).to eq "none"
       expect(res['address_root']).to eq "88940c753ee50d556ecaefadd0d2fee9fabacf4366a7d4a8cdfa2b64"
@@ -104,7 +104,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1wp6eswctz5wzrv3ceh3h4y3na2t6d95sjn23dawy0zlzg0q569eke"
       end
 
@@ -119,7 +119,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1wzt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2ykp4j"
       end
 
@@ -134,7 +134,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1wp4h4mtdkxr2x68zx4tk0cgmd9hymjgsuhmzaxkg5tkl3scr8umfh"
       end
 
@@ -153,7 +153,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1wq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5taclcp983gu"
       end
 
@@ -168,7 +168,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "stake_test17zt2z3pa7etaxp7jurdg0m8jhsmtp4r2z56pd3a5q3jhxyc2vgezc"
       end
 
@@ -193,7 +193,7 @@ RSpec.describe CardanoWallet::Misc do
                   }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1xq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacluk59zrmajh6vra9cx6slk090pkkr2x59f5zmrmgpr9wvfsjg2j62"
       end
 
@@ -203,7 +203,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1vpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfgdmxm9u"
       end
 
@@ -213,7 +213,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "stake_test1uq6pmlvyl3wn4ca6807e26gy2gek9hqu0gastzh5tk0xx0gdfvj8f"
       end
 
@@ -224,7 +224,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1qpqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wff5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7ser7yl4"
       end
 
@@ -244,7 +244,7 @@ RSpec.describe CardanoWallet::Misc do
                  }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1zq5np0m5x03tax3kcdh6e2cet98qcfs80wtv4cyvl5tacle5rh7cflza8t3m5wlaj45sg53nvtwpc73mqk90ghv7vv7su0qjlj"
       end
 
@@ -264,7 +264,7 @@ RSpec.describe CardanoWallet::Misc do
                    }
         res = UTILS.post_address(script)
         expect(res).to have_http 202
-        expect(res).to have_headers(EXPECTED_HEADERS)
+        expect(res).to have_expected_headers
         expect(res.to_s).to include "addr_test1ypqthemrg5kczwfjjnahwt65elhrl95e9hcgufnajtp6wfffxzlhgvlzh6drdsm04j43jk2wpsnqw7uketsgelghm3lsmpggt5"
       end
 
@@ -277,7 +277,7 @@ RSpec.describe CardanoWallet::Misc do
       PROXY = CardanoWallet.new.misc.proxy
       res = PROXY.submit_external_transaction(binary_blob)
       expect(res).to have_http 400
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
     end
   end
 
@@ -299,12 +299,12 @@ RSpec.describe CardanoWallet::Misc do
         g = SETTINGS.get
         expect(g['pool_metadata_source']).to eq strategy
         expect(g).to have_http 200
-        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g).to have_expected_headers
 
         # check smash health
         r = UTILS.smash_health
         expect(r).to have_http 200
-        expect(r).to have_headers(EXPECTED_HEADERS)
+        expect(r).to have_expected_headers
         expect(r.to_s).to include smash_health_response
       end
     end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CardanoWallet::Shelley do
     describe "Create wallets" do
       it "I can create, get and delete wallet from mnemonics" do
         w = SHELLEY.wallets
-        wallet = w.create({name: "Wallet from mnemonic_sentence",
+        wallet = w.create({ name: "Wallet from mnemonic_sentence",
                            passphrase: "Secure Passphrase",
                            mnemonic_sentence: mnemonic_sentence(15),
                            })
@@ -51,7 +51,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       it "I can create, get and delete wallet from mnemonics / second factor" do
         w = SHELLEY.wallets
-        wallet = w.create({name: "Wallet from mnemonic_sentence",
+        wallet = w.create({ name: "Wallet from mnemonic_sentence",
                            passphrase: "Secure Passphrase",
                            mnemonic_sentence: mnemonic_sentence(15),
                            mnemonic_second_factor: mnemonic_sentence(12)
@@ -70,7 +70,7 @@ RSpec.describe CardanoWallet::Shelley do
       it "I can set address pool gap" do
         pool_gap = 55
         w = SHELLEY.wallets
-        wallet = w.create({name: "Wallet from mnemonic_sentence",
+        wallet = w.create({ name: "Wallet from mnemonic_sentence",
                            passphrase: "Secure Passphrase",
                            mnemonic_sentence: mnemonic_sentence(15),
                            address_pool_gap: pool_gap
@@ -84,7 +84,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       it "I can create, get and delete wallet from pub key" do
         w = SHELLEY.wallets
-        wallet = w.create({name: "Wallet from pub key",
+        wallet = w.create({ name: "Wallet from pub key",
                            account_public_key: "b47546e661b6c1791452d003d375756dde6cac2250093ce4630f16b9b9c0ac87411337bda4d5bc0216462480b809824ffb48f17e08d95ab9f1b91d391e48e66b",
                            address_pool_gap: 20,
                            })
@@ -104,7 +104,7 @@ RSpec.describe CardanoWallet::Shelley do
         new_name = "New wallet name"
         w = SHELLEY.wallets
         id = create_shelley_wallet
-        u = w.update_metadata(id, {name: new_name})
+        u = w.update_metadata(id, { name: new_name })
         expect(u).to have_http 200
         expect(u).to have_headers(EXPECTED_HEADERS)
         expect(w.get(id)['name']).to eq new_name
@@ -113,8 +113,8 @@ RSpec.describe CardanoWallet::Shelley do
       it "Can update_passphrase" do
         w = SHELLEY.wallets
         id = create_shelley_wallet
-        upd = w.update_passphrase(id,{old_passphrase: "Secure Passphrase",
-                                      new_passphrase: "Securer Passphrase"})
+        upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
+                                      new_passphrase: "Securer Passphrase" })
         expect(upd).to have_http 204
       end
     end
@@ -140,20 +140,20 @@ RSpec.describe CardanoWallet::Shelley do
       expect(addresses).to have_http 200
       expect(addresses).to have_headers(EXPECTED_HEADERS)
       expect(addresses.size).to eq 20
-      addresses.each_with_index do |a,i|
+      addresses.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
       end
 
-      addresses_unused = shelley_addr.list id, {state: "used"}
+      addresses_unused = shelley_addr.list id, { state: "used" }
       expect(addresses_unused).to have_http 200
       expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 0
 
-      addresses_unused = shelley_addr.list id, {state: "unused"}
+      addresses_unused = shelley_addr.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
       expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
       expect(addresses_unused.size).to eq 20
-      addresses_unused.each_with_index do |a,i|
+      addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
       end
     end
@@ -199,10 +199,10 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       txs = SHELLEY.transactions
       l = txs.list(id)
-      l_ext = txs.list(id,{start: "2012-09-25T10:15:00Z",
+      l_ext = txs.list(id, { start: "2012-09-25T10:15:00Z",
                            end: "2016-11-21T10:15:00Z",
-                           order: "ascending"})
-      l_bad = txs.list(id, {order: "bad_order"})
+                           order: "ascending" })
+      l_bad = txs.list(id, { order: "bad_order" })
       expect(l).to have_http 200
       expect(l).to have_headers(EXPECTED_HEADERS)
       expect(l_ext).to have_http 200
@@ -218,7 +218,7 @@ RSpec.describe CardanoWallet::Shelley do
       target_id = create_shelley_wallet
       address = SHELLEY.addresses.list(target_id)[0]['id']
       txs = SHELLEY.transactions
-      amt = [{address => 1000000}]
+      amt = [{ address => 1000000 }]
 
       tx_sent = txs.create(id, PASS, amt)
       expect(tx_sent).to have_http 403
@@ -231,7 +231,7 @@ RSpec.describe CardanoWallet::Shelley do
       target_id = create_shelley_wallet
       address = SHELLEY.addresses.list(target_id)[0]['id']
       txs = SHELLEY.transactions
-      amt = [{address => 1000000}]
+      amt = [{ address => 1000000 }]
 
       tx_sent = txs.create(id, PASS, amt, 'self')
       expect(tx_sent).to have_http 403
@@ -243,7 +243,7 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       target_id = create_shelley_wallet
       address = SHELLEY.addresses.list(target_id)[0]['id']
-      amt = [{address => 1000000}]
+      amt = [{ address => 1000000 }]
 
       txs = SHELLEY.transactions
 
@@ -257,12 +257,12 @@ RSpec.describe CardanoWallet::Shelley do
       expect(fees).to have_headers(EXPECTED_HEADERS)
       expect(fees.to_s).to include "not_enough_money"
 
-      metadata = { "0"=>{ "string"=>"cardano" },
-                   "1"=>{ "int"=>14 },
-                   "2"=>{ "bytes"=>"2512a00e9653fe49a44a5886202e24d77eeb998f" },
-                   "3"=>{ "list"=>[ { "int"=>14 }, { "int"=>42 }, { "string"=>"1337" } ] },
-                   "4"=>{ "map"=>[ { "k"=>{ "string"=>"key" }, "v"=>{ "string"=>"value" } },
-                                   { "k"=>{ "int"=>14 }, "v"=>{ "int"=>42 } } ] } }
+      metadata = { "0" => { "string" => "cardano" },
+                   "1" => { "int" => 14 },
+                   "2" => { "bytes" => "2512a00e9653fe49a44a5886202e24d77eeb998f" },
+                   "3" => { "list" => [ { "int" => 14 }, { "int" => 42 }, { "string" => "1337" } ] },
+                   "4" => { "map" => [ { "k" => { "string" => "key" }, "v" => { "string" => "value" } },
+                                   { "k" => { "int" => 14 }, "v" => { "int" => 42 } } ] } }
 
       fees = txs.payment_fees(id, amt, 'self', metadata)
       expect(fees).to have_http 403
@@ -283,7 +283,7 @@ RSpec.describe CardanoWallet::Shelley do
 
     after(:each) do
       settings = CardanoWallet.new.misc.settings
-      s = settings.update({:pool_metadata_source => "none"})
+      s = settings.update({ :pool_metadata_source => "none" })
       teardown
     end
 
@@ -291,52 +291,52 @@ RSpec.describe CardanoWallet::Shelley do
       settings = CardanoWallet.new.misc.settings
       pools = SHELLEY.stake_pools
 
-      s = settings.update({:pool_metadata_source => "direct"})
+      s = settings.update({ :pool_metadata_source => "direct" })
       expect(s).to have_http 204
 
       eventually "Pools have metadata when 'pool_metadata_source' => 'direct'" do
-        sps = pools.list({stake: 1000})
-        sps.select{|p| p['metadata']}.size > 0
+        sps = pools.list({ stake: 1000 })
+        sps.select { |p| p['metadata'] }.size > 0
       end
 
-      s = settings.update({:pool_metadata_source => "none"})
+      s = settings.update({ :pool_metadata_source => "none" })
       expect(s).to have_http 204
 
       eventually "Pools have no metadata when 'pool_metadata_source' => 'none'" do
-        sps = pools.list({stake: 1000})
-        sps.select{|p| p['metadata']}.size == 0
+        sps = pools.list({ stake: 1000 })
+        sps.select { |p| p['metadata'] }.size == 0
       end
 
-      s = settings.update({:pool_metadata_source => ENV['TESTS_E2E_SMASH']})
+      s = settings.update({ :pool_metadata_source => ENV['TESTS_E2E_SMASH'] })
       expect(s).to have_http 204
 
       eventually "Pools have metadata when 'pool_metadata_source' => '#{ENV['TESTS_E2E_SMASH']}'" do
-        sps = pools.list({stake: 1000})
-        sps.select{|p| p['metadata']}.size > 0
+        sps = pools.list({ stake: 1000 })
+        sps.select { |p| p['metadata'] }.size > 0
       end
 
-      s = settings.update({:pool_metadata_source => "none"})
+      s = settings.update({ :pool_metadata_source => "none" })
       expect(s).to have_http 204
 
       eventually "Pools have no metadata when 'pool_metadata_source' => 'none'" do
-        sps = pools.list({stake: 1000})
-        sps.select{|p| p['metadata']}.size == 0
+        sps = pools.list({ stake: 1000 })
+        sps.select { |p| p['metadata'] }.size == 0
       end
     end
 
     describe "Stake Pools GC Maintenance" do
-      matrix = [{"direct" => "not_applicable"},
-                {"none" => "not_applicable"},
-                {"https://smash.cardano-testnet.iohkdev.io" => "has_run"}]
+      matrix = [{ "direct" => "not_applicable" },
+                { "none" => "not_applicable" },
+                { "https://smash.cardano-testnet.iohkdev.io" => "has_run" }]
       matrix.each do |tc|
         it "GC metadata maintenance action on metadata source #{tc}" do
           settings = CardanoWallet.new.misc.settings
           pools = SHELLEY.stake_pools
 
-          s = settings.update({:pool_metadata_source => tc.keys.first})
+          s = settings.update({ :pool_metadata_source => tc.keys.first })
           expect(s).to have_http 204
 
-          t = pools.trigger_maintenance_actions({maintenance_action: "gc_stake_pools"})
+          t = pools.trigger_maintenance_actions({ maintenance_action: "gc_stake_pools" })
           expect(t).to have_http 204
 
           eventually "Maintenance action has status = #{tc.values.first}" do
@@ -374,7 +374,7 @@ RSpec.describe CardanoWallet::Shelley do
     it "I could migrate all my funds" do
       id = create_shelley_wallet
       target_id = create_shelley_wallet
-      addrs = SHELLEY.addresses.list(target_id).map{ |a| a['id'] }
+      addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
       migr = SHELLEY.migrations.migrate(id, PASS, addrs)
       expect(migr).to have_http 501
       expect(migr).to have_headers(EXPECTED_HEADERS)
@@ -395,7 +395,7 @@ RSpec.describe CardanoWallet::Shelley do
                                         role,
                                         id,
                                         "Secure Passphrase",
-                                        { "0"=>{ "string"=>"cardano" } })
+                                        { "0" => { "string" => "cardano" } })
         puts "#{wid}/#{role}/#{id}"
         expect(res).to have_http 200
       end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe CardanoWallet::Shelley do
 
     it "I can list wallets" do
       l = SHELLEY.wallets.list
-      expect(l).to have_http 200
-      expect(l).to have_expected_headers
+      expect(l).to be_correct_and_respond 200
       expect(l.size).to eq 0
 
       create_shelley_wallet
       l = SHELLEY.wallets.list
-      expect(l).to have_http 200
-      expect(l).to have_expected_headers
+      expect(l).to be_correct_and_respond 200
       expect(l.size).to eq 1
     end
 
@@ -23,12 +21,10 @@ RSpec.describe CardanoWallet::Shelley do
       wid = create_shelley_wallet
       SHELLEY.wallets.delete wid
       g = SHELLEY.wallets.get wid
-      expect(g).to have_http 404
-      expect(g).to have_expected_headers
+      expect(g).to be_correct_and_respond 404
 
       d = SHELLEY.wallets.delete wid
-      expect(d).to have_http 404
-      expect(d).to have_expected_headers
+      expect(d).to be_correct_and_respond 404
     end
 
     describe "Create wallets" do
@@ -38,15 +34,13 @@ RSpec.describe CardanoWallet::Shelley do
                            passphrase: "Secure Passphrase",
                            mnemonic_sentence: mnemonic_sentence(15),
                            })
-        expect(wallet).to have_http 201
-        expect(wallet).to have_expected_headers
+        expect(wallet).to be_correct_and_respond 201
 
         wid = wallet['id']
         g = w.get(wid)
-        expect(g).to have_http 200
-        expect(g).to have_expected_headers
+        expect(g).to be_correct_and_respond 200
 
-        expect(w.delete(wid)).to have_http 204
+        expect(w.delete(wid)).to be_correct_and_respond 204
       end
 
       it "I can create, get and delete wallet from mnemonics / second factor" do
@@ -56,15 +50,13 @@ RSpec.describe CardanoWallet::Shelley do
                            mnemonic_sentence: mnemonic_sentence(15),
                            mnemonic_second_factor: mnemonic_sentence(12)
                            })
-        expect(wallet).to have_http 201
-        expect(wallet).to have_expected_headers
+        expect(wallet).to be_correct_and_respond 201
 
         wid = wallet['id']
         g = w.get(wid)
-        expect(g).to have_http 200
-        expect(g).to have_expected_headers
+        expect(g).to be_correct_and_respond 200
 
-        expect(w.delete(wid)).to have_http 204
+        expect(w.delete(wid)).to be_correct_and_respond 204
       end
 
       it "I can set address pool gap" do
@@ -75,10 +67,9 @@ RSpec.describe CardanoWallet::Shelley do
                            mnemonic_sentence: mnemonic_sentence(15),
                            address_pool_gap: pool_gap
                            })
-        expect(wallet).to have_http 201
+        expect(wallet).to be_correct_and_respond 201
         addr = SHELLEY.addresses.list(wallet['id'])
-        expect(addr).to have_http 200
-        expect(addr).to have_expected_headers
+        expect(addr).to be_correct_and_respond 200
         expect(addr.size).to eq pool_gap
       end
 
@@ -88,14 +79,12 @@ RSpec.describe CardanoWallet::Shelley do
                            account_public_key: "b47546e661b6c1791452d003d375756dde6cac2250093ce4630f16b9b9c0ac87411337bda4d5bc0216462480b809824ffb48f17e08d95ab9f1b91d391e48e66b",
                            address_pool_gap: 20,
                            })
-        expect(wallet).to have_http 201
-        expect(wallet).to have_expected_headers
+        expect(wallet).to be_correct_and_respond 201
 
         wid = wallet['id']
         g = w.get(wid)
-        expect(g).to have_http 200
-        expect(g).to have_expected_headers
-        expect(w.delete(wid)).to have_http 204
+        expect(g).to be_correct_and_respond 200
+        expect(w.delete(wid)).to be_correct_and_respond 204
       end
     end
 
@@ -105,8 +94,7 @@ RSpec.describe CardanoWallet::Shelley do
         w = SHELLEY.wallets
         id = create_shelley_wallet
         u = w.update_metadata(id, { name: new_name })
-        expect(u).to have_http 200
-        expect(u).to have_expected_headers
+        expect(u).to be_correct_and_respond 200
         expect(w.get(id)['name']).to eq new_name
       end
 
@@ -115,15 +103,14 @@ RSpec.describe CardanoWallet::Shelley do
         id = create_shelley_wallet
         upd = w.update_passphrase(id, { old_passphrase: "Secure Passphrase",
                                       new_passphrase: "Securer Passphrase" })
-        expect(upd).to have_http 204
+        expect(upd).to be_correct_and_respond 204
       end
     end
 
     it "Can see utxo" do
       id = create_shelley_wallet
       utxo = SHELLEY.wallets.utxo(id)
-      expect(utxo).to have_http 200
-      expect(utxo).to have_expected_headers
+      expect(utxo).to be_correct_and_respond 200
     end
   end
 
@@ -137,21 +124,18 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       shelley_addr = CardanoWallet.new.shelley.addresses
       addresses = shelley_addr.list id
-      expect(addresses).to have_http 200
-      expect(addresses).to have_expected_headers
+      expect(addresses).to be_correct_and_respond 200
       expect(addresses.size).to eq 20
       addresses.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
       end
 
       addresses_unused = shelley_addr.list id, { state: "used" }
-      expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_expected_headers
+      expect(addresses_unused).to be_correct_and_respond 200
       expect(addresses_unused.size).to eq 0
 
       addresses_unused = shelley_addr.list id, { state: "unused" }
-      expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_expected_headers
+      expect(addresses_unused).to be_correct_and_respond 200
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
@@ -174,8 +158,7 @@ RSpec.describe CardanoWallet::Shelley do
         ]
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount
-      expect(rnd).to have_http 403
-      expect(rnd).to have_expected_headers
+      expect(rnd).to be_correct_and_respond 403
       expect(rnd.to_s).to include "not_enough_money"
     end
   end
@@ -190,8 +173,7 @@ RSpec.describe CardanoWallet::Shelley do
       wid = create_shelley_wallet
       txs = SHELLEY.transactions
       g = txs.get(wid, TXID)
-      expect(g).to have_http 404
-      expect(g).to have_expected_headers
+      expect(g).to be_correct_and_respond 404
       expect(g.to_s).to include "no_such_transaction"
     end
 
@@ -203,14 +185,9 @@ RSpec.describe CardanoWallet::Shelley do
                            end: "2016-11-21T10:15:00Z",
                            order: "ascending" })
       l_bad = txs.list(id, { order: "bad_order" })
-      expect(l).to have_http 200
-      expect(l).to have_expected_headers
-      expect(l_ext).to have_http 200
-      expect(l_ext).to have_expected_headers
-      expect(l_bad).to have_http 400
-      expect(l_bad).to have_expected_headers
-
-
+      expect(l).to be_correct_and_respond 200
+      expect(l_ext).to be_correct_and_respond 200
+      expect(l_bad).to be_correct_and_respond 400
     end
 
     it "I could create transaction - if I had money" do
@@ -221,8 +198,7 @@ RSpec.describe CardanoWallet::Shelley do
       amt = [{ address => 1000000 }]
 
       tx_sent = txs.create(id, PASS, amt)
-      expect(tx_sent).to have_http 403
-      expect(tx_sent).to have_expected_headers
+      expect(tx_sent).to be_correct_and_respond 403
       expect(tx_sent.to_s).to include "not_enough_money"
     end
 
@@ -234,8 +210,7 @@ RSpec.describe CardanoWallet::Shelley do
       amt = [{ address => 1000000 }]
 
       tx_sent = txs.create(id, PASS, amt, 'self')
-      expect(tx_sent).to have_http 403
-      expect(tx_sent).to have_expected_headers
+      expect(tx_sent).to be_correct_and_respond 403
       expect(tx_sent.to_s).to include "not_enough_money"
     end
 
@@ -248,13 +223,11 @@ RSpec.describe CardanoWallet::Shelley do
       txs = SHELLEY.transactions
 
       fees = txs.payment_fees(id, amt)
-      expect(fees).to have_http 403
-      expect(fees).to have_expected_headers
+      expect(fees).to be_correct_and_respond 403
       expect(fees.to_s).to include "not_enough_money"
 
       fees = txs.payment_fees(id, amt, 'self')
-      expect(fees).to have_http 403
-      expect(fees).to have_expected_headers
+      expect(fees).to be_correct_and_respond 403
       expect(fees.to_s).to include "not_enough_money"
 
       metadata = { "0" => { "string" => "cardano" },
@@ -265,8 +238,7 @@ RSpec.describe CardanoWallet::Shelley do
                                    { "k" => { "int" => 14 }, "v" => { "int" => 42 } } ] } }
 
       fees = txs.payment_fees(id, amt, 'self', metadata)
-      expect(fees).to have_http 403
-      expect(fees).to have_expected_headers
+      expect(fees).to be_correct_and_respond 403
       expect(fees.to_s).to include "not_enough_money"
     end
 
@@ -274,8 +246,7 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       txs = SHELLEY.transactions
       res = txs.forget(id, TXID)
-      expect(res).to have_http 404
-      expect(res).to have_expected_headers
+      expect(res).to be_correct_and_respond 404
     end
   end
 
@@ -292,7 +263,7 @@ RSpec.describe CardanoWallet::Shelley do
       pools = SHELLEY.stake_pools
 
       s = settings.update({ :pool_metadata_source => "direct" })
-      expect(s).to have_http 204
+      expect(s).to be_correct_and_respond 204
 
       eventually "Pools have metadata when 'pool_metadata_source' => 'direct'" do
         sps = pools.list({ stake: 1000 })
@@ -300,7 +271,7 @@ RSpec.describe CardanoWallet::Shelley do
       end
 
       s = settings.update({ :pool_metadata_source => "none" })
-      expect(s).to have_http 204
+      expect(s).to be_correct_and_respond 204
 
       eventually "Pools have no metadata when 'pool_metadata_source' => 'none'" do
         sps = pools.list({ stake: 1000 })
@@ -308,7 +279,7 @@ RSpec.describe CardanoWallet::Shelley do
       end
 
       s = settings.update({ :pool_metadata_source => ENV['TESTS_E2E_SMASH'] })
-      expect(s).to have_http 204
+      expect(s).to be_correct_and_respond 204
 
       eventually "Pools have metadata when 'pool_metadata_source' => '#{ENV['TESTS_E2E_SMASH']}'" do
         sps = pools.list({ stake: 1000 })
@@ -316,7 +287,7 @@ RSpec.describe CardanoWallet::Shelley do
       end
 
       s = settings.update({ :pool_metadata_source => "none" })
-      expect(s).to have_http 204
+      expect(s).to be_correct_and_respond 204
 
       eventually "Pools have no metadata when 'pool_metadata_source' => 'none'" do
         sps = pools.list({ stake: 1000 })
@@ -334,10 +305,10 @@ RSpec.describe CardanoWallet::Shelley do
           pools = SHELLEY.stake_pools
 
           s = settings.update({ :pool_metadata_source => tc.keys.first })
-          expect(s).to have_http 204
+          expect(s).to be_correct_and_respond 204
 
           t = pools.trigger_maintenance_actions({ maintenance_action: "gc_stake_pools" })
-          expect(t).to have_http 204
+          expect(t).to be_correct_and_respond 204
 
           eventually "Maintenance action has status = #{tc.values.first}" do
             r = pools.view_maintenance_actions
@@ -351,8 +322,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       pools = SHELLEY.stake_pools
       quit = pools.quit(id, PASS)
-      expect(quit).to have_http 403
-      expect(quit).to have_expected_headers
+      expect(quit).to be_correct_and_respond 403
       expect(quit.to_s).to include "not_delegating_to"
     end
 
@@ -366,8 +336,7 @@ RSpec.describe CardanoWallet::Shelley do
     it "I could calculate migration cost" do
       id = create_shelley_wallet
       cost = SHELLEY.migrations.cost(id)
-      expect(cost).to have_http 501
-      expect(cost).to have_expected_headers
+      expect(cost).to be_correct_and_respond 501
       expect(cost.to_s).to include "not_implemented"
     end
 
@@ -376,8 +345,7 @@ RSpec.describe CardanoWallet::Shelley do
       target_id = create_shelley_wallet
       addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
       migr = SHELLEY.migrations.migrate(id, PASS, addrs)
-      expect(migr).to have_http 501
-      expect(migr).to have_expected_headers
+      expect(migr).to be_correct_and_respond 501
       expect(migr.to_s).to include "not_implemented"
     end
   end
@@ -397,7 +365,7 @@ RSpec.describe CardanoWallet::Shelley do
                                         "Secure Passphrase",
                                         { "0" => { "string" => "cardano" } })
         puts "#{wid}/#{role}/#{id}"
-        expect(res).to have_http 200
+        expect(res).to respond_with 200
       end
     end
 
@@ -407,7 +375,7 @@ RSpec.describe CardanoWallet::Shelley do
         id = [*0..100000].sample
         res = SHELLEY.keys.get_public_key(wid, role, id)
         puts "#{wid}/#{role}/#{id}"
-        expect(res).to have_http 200
+        expect(res).to be_correct_and_respond 200
       end
     end
 
@@ -415,7 +383,7 @@ RSpec.describe CardanoWallet::Shelley do
       wid = create_shelley_wallet
       ["0H", "1H", "2147483647H", "44H"].each do |index|
         res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, extended = true)
-        expect(res).to have_http 202
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "acc"
       end
     end
@@ -424,7 +392,7 @@ RSpec.describe CardanoWallet::Shelley do
       wid = create_shelley_wallet
       ["0H", "1H", "2147483647H", "44H"].each do |index|
         res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, extended = false)
-        expect(res).to have_http 202
+        expect(res).to be_correct_and_respond 202
         expect(res.to_s).to include "acc"
       end
     end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe CardanoWallet::Shelley do
     it "I can list wallets" do
       l = SHELLEY.wallets.list
       expect(l).to have_http 200
-      expect(l).to have_headers(EXPECTED_HEADERS)
+      expect(l).to have_expected_headers
       expect(l.size).to eq 0
 
       create_shelley_wallet
       l = SHELLEY.wallets.list
       expect(l).to have_http 200
-      expect(l).to have_headers(EXPECTED_HEADERS)
+      expect(l).to have_expected_headers
       expect(l.size).to eq 1
     end
 
@@ -24,11 +24,11 @@ RSpec.describe CardanoWallet::Shelley do
       SHELLEY.wallets.delete wid
       g = SHELLEY.wallets.get wid
       expect(g).to have_http 404
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
 
       d = SHELLEY.wallets.delete wid
       expect(d).to have_http 404
-      expect(d).to have_headers(EXPECTED_HEADERS)
+      expect(d).to have_expected_headers
     end
 
     describe "Create wallets" do
@@ -39,12 +39,12 @@ RSpec.describe CardanoWallet::Shelley do
                            mnemonic_sentence: mnemonic_sentence(15),
                            })
         expect(wallet).to have_http 201
-        expect(wallet).to have_headers(EXPECTED_HEADERS)
+        expect(wallet).to have_expected_headers
 
         wid = wallet['id']
         g = w.get(wid)
         expect(g).to have_http 200
-        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g).to have_expected_headers
 
         expect(w.delete(wid)).to have_http 204
       end
@@ -57,12 +57,12 @@ RSpec.describe CardanoWallet::Shelley do
                            mnemonic_second_factor: mnemonic_sentence(12)
                            })
         expect(wallet).to have_http 201
-        expect(wallet).to have_headers(EXPECTED_HEADERS)
+        expect(wallet).to have_expected_headers
 
         wid = wallet['id']
         g = w.get(wid)
         expect(g).to have_http 200
-        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g).to have_expected_headers
 
         expect(w.delete(wid)).to have_http 204
       end
@@ -78,7 +78,7 @@ RSpec.describe CardanoWallet::Shelley do
         expect(wallet).to have_http 201
         addr = SHELLEY.addresses.list(wallet['id'])
         expect(addr).to have_http 200
-        expect(addr).to have_headers(EXPECTED_HEADERS)
+        expect(addr).to have_expected_headers
         expect(addr.size).to eq pool_gap
       end
 
@@ -89,12 +89,12 @@ RSpec.describe CardanoWallet::Shelley do
                            address_pool_gap: 20,
                            })
         expect(wallet).to have_http 201
-        expect(wallet).to have_headers(EXPECTED_HEADERS)
+        expect(wallet).to have_expected_headers
 
         wid = wallet['id']
         g = w.get(wid)
         expect(g).to have_http 200
-        expect(g).to have_headers(EXPECTED_HEADERS)
+        expect(g).to have_expected_headers
         expect(w.delete(wid)).to have_http 204
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe CardanoWallet::Shelley do
         id = create_shelley_wallet
         u = w.update_metadata(id, { name: new_name })
         expect(u).to have_http 200
-        expect(u).to have_headers(EXPECTED_HEADERS)
+        expect(u).to have_expected_headers
         expect(w.get(id)['name']).to eq new_name
       end
 
@@ -123,7 +123,7 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       utxo = SHELLEY.wallets.utxo(id)
       expect(utxo).to have_http 200
-      expect(utxo).to have_headers(EXPECTED_HEADERS)
+      expect(utxo).to have_expected_headers
     end
   end
 
@@ -138,7 +138,7 @@ RSpec.describe CardanoWallet::Shelley do
       shelley_addr = CardanoWallet.new.shelley.addresses
       addresses = shelley_addr.list id
       expect(addresses).to have_http 200
-      expect(addresses).to have_headers(EXPECTED_HEADERS)
+      expect(addresses).to have_expected_headers
       expect(addresses.size).to eq 20
       addresses.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
@@ -146,12 +146,12 @@ RSpec.describe CardanoWallet::Shelley do
 
       addresses_unused = shelley_addr.list id, { state: "used" }
       expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
+      expect(addresses_unused).to have_expected_headers
       expect(addresses_unused.size).to eq 0
 
       addresses_unused = shelley_addr.list id, { state: "unused" }
       expect(addresses_unused).to have_http 200
-      expect(addresses_unused).to have_headers(EXPECTED_HEADERS)
+      expect(addresses_unused).to have_expected_headers
       expect(addresses_unused.size).to eq 20
       addresses_unused.each_with_index do |a, i|
         expect(a['derivation_path']).to eq ['1852H', '1815H', '0H', '0', i.to_s]
@@ -175,7 +175,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       rnd = SHELLEY.coin_selections.random wid, addr_amount
       expect(rnd).to have_http 403
-      expect(rnd).to have_headers(EXPECTED_HEADERS)
+      expect(rnd).to have_expected_headers
       expect(rnd.to_s).to include "not_enough_money"
     end
   end
@@ -191,7 +191,7 @@ RSpec.describe CardanoWallet::Shelley do
       txs = SHELLEY.transactions
       g = txs.get(wid, TXID)
       expect(g).to have_http 404
-      expect(g).to have_headers(EXPECTED_HEADERS)
+      expect(g).to have_expected_headers
       expect(g.to_s).to include "no_such_transaction"
     end
 
@@ -204,11 +204,11 @@ RSpec.describe CardanoWallet::Shelley do
                            order: "ascending" })
       l_bad = txs.list(id, { order: "bad_order" })
       expect(l).to have_http 200
-      expect(l).to have_headers(EXPECTED_HEADERS)
+      expect(l).to have_expected_headers
       expect(l_ext).to have_http 200
-      expect(l_ext).to have_headers(EXPECTED_HEADERS)
+      expect(l_ext).to have_expected_headers
       expect(l_bad).to have_http 400
-      expect(l_bad).to have_headers(EXPECTED_HEADERS)
+      expect(l_bad).to have_expected_headers
 
 
     end
@@ -222,7 +222,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       tx_sent = txs.create(id, PASS, amt)
       expect(tx_sent).to have_http 403
-      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent).to have_expected_headers
       expect(tx_sent.to_s).to include "not_enough_money"
     end
 
@@ -235,7 +235,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       tx_sent = txs.create(id, PASS, amt, 'self')
       expect(tx_sent).to have_http 403
-      expect(tx_sent).to have_headers(EXPECTED_HEADERS)
+      expect(tx_sent).to have_expected_headers
       expect(tx_sent.to_s).to include "not_enough_money"
     end
 
@@ -249,12 +249,12 @@ RSpec.describe CardanoWallet::Shelley do
 
       fees = txs.payment_fees(id, amt)
       expect(fees).to have_http 403
-      expect(fees).to have_headers(EXPECTED_HEADERS)
+      expect(fees).to have_expected_headers
       expect(fees.to_s).to include "not_enough_money"
 
       fees = txs.payment_fees(id, amt, 'self')
       expect(fees).to have_http 403
-      expect(fees).to have_headers(EXPECTED_HEADERS)
+      expect(fees).to have_expected_headers
       expect(fees.to_s).to include "not_enough_money"
 
       metadata = { "0" => { "string" => "cardano" },
@@ -266,7 +266,7 @@ RSpec.describe CardanoWallet::Shelley do
 
       fees = txs.payment_fees(id, amt, 'self', metadata)
       expect(fees).to have_http 403
-      expect(fees).to have_headers(EXPECTED_HEADERS)
+      expect(fees).to have_expected_headers
       expect(fees.to_s).to include "not_enough_money"
     end
 
@@ -275,7 +275,7 @@ RSpec.describe CardanoWallet::Shelley do
       txs = SHELLEY.transactions
       res = txs.forget(id, TXID)
       expect(res).to have_http 404
-      expect(res).to have_headers(EXPECTED_HEADERS)
+      expect(res).to have_expected_headers
     end
   end
 
@@ -352,7 +352,7 @@ RSpec.describe CardanoWallet::Shelley do
       pools = SHELLEY.stake_pools
       quit = pools.quit(id, PASS)
       expect(quit).to have_http 403
-      expect(quit).to have_headers(EXPECTED_HEADERS)
+      expect(quit).to have_expected_headers
       expect(quit.to_s).to include "not_delegating_to"
     end
 
@@ -367,7 +367,7 @@ RSpec.describe CardanoWallet::Shelley do
       id = create_shelley_wallet
       cost = SHELLEY.migrations.cost(id)
       expect(cost).to have_http 501
-      expect(cost).to have_headers(EXPECTED_HEADERS)
+      expect(cost).to have_expected_headers
       expect(cost.to_s).to include "not_implemented"
     end
 
@@ -377,7 +377,7 @@ RSpec.describe CardanoWallet::Shelley do
       addrs = SHELLEY.addresses.list(target_id).map { |a| a['id'] }
       migr = SHELLEY.migrations.migrate(id, PASS, addrs)
       expect(migr).to have_http 501
-      expect(migr).to have_headers(EXPECTED_HEADERS)
+      expect(migr).to have_expected_headers
       expect(migr.to_s).to include "not_implemented"
     end
   end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -27,7 +27,7 @@ TIMEOUT = 120
 
 ##
 # Intit cardano-wallet wrapper with timeout for getting the response back
-CW = CardanoWallet.new({timeout: TIMEOUT})
+CW = CardanoWallet.new({ timeout: TIMEOUT })
 BYRON = CW.byron
 SHELLEY = CW.shelley
 SETTINGS = CW.misc.settings
@@ -44,19 +44,19 @@ TXID = "1acf9c0f504746cbd102b49ffaf16dcafd14c0a2f1bbb23af265fbe0a04951cc"
 SPID = "feea59bc6664572e631e9adfee77142cb51264156debf2e52970cc00"
 SPID_BECH32 = "pool1v7g9ays8h668d74xjvln9xuh9adzh6xz0v0hvcd3xukpck5z56d"
 
-#exemplary metadata
-METADATA = { "0"=>{ "string"=>"cardano" },
-             "1"=>{ "int"=>14 },
-             "2"=>{ "bytes"=>"2512a00e9653fe49a44a5886202e24d77eeb998f" },
-             "3"=>{ "list"=>[ { "int"=>14 }, { "int"=>42 }, { "string"=>"1337" } ] },
-             "4"=>{ "map"=>[ { "k"=>{ "string"=>"key" }, "v"=>{ "string"=>"value" } },
-                             { "k"=>{ "int"=>14 }, "v"=>{ "int"=>42 } } ] } }
+# exemplary metadata
+METADATA = { "0" => { "string" => "cardano" },
+             "1" => { "int" => 14 },
+             "2" => { "bytes" => "2512a00e9653fe49a44a5886202e24d77eeb998f" },
+             "3" => { "list" => [ { "int" => 14 }, { "int" => 42 }, { "string" => "1337" } ] },
+             "4" => { "map" => [ { "k" => { "string" => "key" }, "v" => { "string" => "value" } },
+                             { "k" => { "int" => 14 }, "v" => { "int" => 42 } } ] } }
 
 # Testnet assets with metadata from mock server https://metadata.cardano-testnet.iohkdev.io/
 ASSETS = [ { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1",
              "asset_name" => "",
              "fingerprint" => "asset1656gm7zkherdvxkn52mhaxkkw343qtkqgv0h8c",
-             "metadata" => {"name" => "SadCoin",
+             "metadata" => { "name" => "SadCoin",
                             "description" => "Coin with no asset name",
                             "url" => "https://sad.io",
                             "ticker" => "SAD",
@@ -66,7 +66,7 @@ ASSETS = [ { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff
            { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1",
              "asset_name" => "6861707079636f696e",
              "fingerprint" => "asset19mwamgpre24at3z34v2e5achszlhhqght9djqp",
-             "metadata" => {"name" => "HappyCoin",
+             "metadata" => { "name" => "HappyCoin",
                             "description" => "Coin with asset name - and everyone is happy!!!",
                             "url" => "https://happy.io",
                             "ticker" => "HAPP",
@@ -75,10 +75,10 @@ ASSETS = [ { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff
             },
          ]
 
-EXPECTED_HEADERS = {'content-type' => ['application/json;charset=utf-8']}
+EXPECTED_HEADERS = { 'content-type' => ['application/json;charset=utf-8'] }
 
 def create_shelley_wallet(name = "Wallet from mnemonic_sentence")
-  SHELLEY.wallets.create({name: name,
+  SHELLEY.wallets.create({ name: name,
                           passphrase: PASS,
                           mnemonic_sentence: mnemonic_sentence(24)
                          })['id']
@@ -86,7 +86,7 @@ end
 
 
 def create_fixture_shelley_wallet
-  SHELLEY.wallets.create({name: "Fixture wallet with funds",
+  SHELLEY.wallets.create({ name: "Fixture wallet with funds",
                           passphrase: PASS,
                           mnemonic_sentence: get_fixture_wallet_mnemonics("shelley")
                          })['id']
@@ -96,7 +96,7 @@ def wait_for_shelley_wallet_to_sync(wid)
   puts "Syncing Shelley wallet..."
   retry_count = 10
   begin
-    while(SHELLEY.wallets.get(wid)['state']['status'] == "syncing") do
+    while (SHELLEY.wallets.get(wid)['state']['status'] == "syncing") do
       w = SHELLEY.wallets.get(wid)
       puts "  Syncing... #{w['state']['progress']['quantity']}%" if w['state']['progress']
       sleep 5
@@ -117,7 +117,7 @@ def wait_for_all_shelley_wallets(wids)
 end
 
 def create_byron_wallet_with(mnem, style = "random", name = "Wallet from mnemonic_sentence")
-  BYRON.wallets.create({style: style,
+  BYRON.wallets.create({ style: style,
                         name: name,
                         passphrase: PASS,
                         mnemonic_sentence: mnem
@@ -126,7 +126,7 @@ end
 
 def create_byron_wallet(style = "random", name = "Wallet from mnemonic_sentence")
   style == "random" ? mnem = mnemonic_sentence(12) : mnem = mnemonic_sentence(15)
-  BYRON.wallets.create({style: style,
+  BYRON.wallets.create({ style: style,
                         name: name,
                         passphrase: PASS,
                         mnemonic_sentence: mnem
@@ -135,7 +135,7 @@ end
 
 
 def create_fixture_byron_wallet(style = "random")
-  BYRON.wallets.create({style: style,
+  BYRON.wallets.create({ style: style,
                         name: "Fixture byron wallets with funds",
                         passphrase: PASS,
                         mnemonic_sentence: get_fixture_wallet_mnemonics(style)
@@ -146,7 +146,7 @@ def wait_for_byron_wallet_to_sync(wid)
   puts "Syncing Byron wallet..."
   retry_count = 10
   begin
-    while(BYRON.wallets.get(wid)['state']['status'] == "syncing") do
+    while (BYRON.wallets.get(wid)['state']['status'] == "syncing") do
       w = BYRON.wallets.get(wid)
       puts "  Syncing... #{w['state']['progress']['quantity']}%" if w['state']['progress']
       sleep 5
@@ -171,7 +171,7 @@ end
 def eventually(label, &block)
   current_time = Time.now
   timeout_treshold = current_time + TIMEOUT
-  while(block.call == false) && (current_time <= timeout_treshold) do
+  while (block.call == false) && (current_time <= timeout_treshold) do
     sleep 5
     current_time = Time.now
   end

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -75,8 +75,6 @@ ASSETS = [ { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff
             },
          ]
 
-EXPECTED_HEADERS = { 'content-type' => ['application/json;charset=utf-8'] }
-
 def create_shelley_wallet(name = "Wallet from mnemonic_sentence")
   SHELLEY.wallets.create({ name: name,
                           passphrase: PASS,

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -75,6 +75,8 @@ ASSETS = [ { "policy_id" => "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff
             },
          ]
 
+EXPECTED_HEADERS = {'content-type' => ['application/json;charset=utf-8']}
+
 def create_shelley_wallet(name = "Wallet from mnemonic_sentence")
   SHELLEY.wallets.create({name: name,
                           passphrase: PASS,


### PR DESCRIPTION
# Issue Number

ADP-853


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added additional checks in e2e tests checking that responses return `'content-type' => ['application/json;charset=utf-8']` header


# Comments

Only `204` reponses do not return `'content-type' => ['application/json;charset=utf-8']` header. I assume that it is OK, since `204` returns no content?

I've temporarily cherry-picked c832eb50644e3810d5d67ea5a6c3c2449e1ae40a from #2608, to be able to run all tests.
