### PR TITLE
Retry submission of pending transactions

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -276,6 +276,7 @@ test-suite unit
     , http-media
     , http-types
     , iohk-monitoring
+    , io-sim-classes
     , lattices
     , lens
     , memory

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -189,8 +189,8 @@ library
       Cardano.Wallet.Primitive.Types.UTxO
       Cardano.Wallet.Primitive.Types.UTxOIndex
       Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
-      Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Registry
+      Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe
       Cardano.Wallet.Version

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -912,7 +912,7 @@ data ApiLayer s (k :: Depth -> Type -> Type)
     deriving (Generic)
 
 instance HasWorkerCtx (DBLayer IO s k) (ApiLayer s k) where
-    type WorkerCtx (ApiLayer s k) = WalletLayer s k
+    type WorkerCtx (ApiLayer s k) = WalletLayer IO s k
     type WorkerMsg (ApiLayer s k) = WalletLog
     type WorkerKey (ApiLayer s k) = WalletId
     hoistResource db transform (ApiLayer _ tr gp nw tl _ _ _) =

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2607,9 +2607,10 @@ registerWorker ctx before coworker wid =
         , workerMain = \ctx' _ -> race_
             (unsafeRunExceptT $ W.restoreWallet ctx' wid)
             (race_
-                (forever $ W.runLocalTxSubmissionPool ctx' wid)
+                (forever $ W.runLocalTxSubmissionPool txCfg ctx' wid)
                 (coworker ctx' wid))
         }
+    txCfg = W.defaultLocalTxSubmissionConfig
 
 -- | Something to pass as the coworker action to 'newApiLayer', which does
 -- nothing, and never exits.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2606,7 +2606,9 @@ registerWorker ctx before coworker wid =
         -- fixme: ADP-641 Review error handling here
         , workerMain = \ctx' _ -> race_
             (unsafeRunExceptT $ W.restoreWallet ctx' wid)
-            (coworker ctx' wid)
+            (race_
+                (forever $ W.runLocalTxSubmissionPool ctx' wid)
+                (coworker ctx' wid))
         }
 
 -- | Something to pass as the coworker action to 'newApiLayer', which does

--- a/lib/core/src/Cardano/Wallet/Logging.hs
+++ b/lib/core/src/Cardano/Wallet/Logging.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Logging
 
       -- * Logging helpers
     , traceWithExceptT
+    , unliftIOTracer
 
       -- * Logging and timing IO actions
     , BracketLog (..)
@@ -59,7 +60,7 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Except
     ( ExceptT (..) )
 import Control.Tracer
-    ( Tracer (..), contramap, nullTracer, traceWith )
+    ( Tracer (..), contramap, natTracer, nullTracer, traceWith )
 import Control.Tracer.Transformers.ObserveOutcome
     ( Outcome (..)
     , OutcomeFidelity (..)
@@ -173,6 +174,10 @@ traceWithExceptT tr (ExceptT action) = ExceptT $ do
     res <- action
     traceWith tr res
     pure res
+
+-- | Convert an IO tracer to a 'm' tracer.
+unliftIOTracer :: MonadIO m => Tracer IO a -> Tracer m a
+unliftIOTracer = natTracer liftIO
 
 {-------------------------------------------------------------------------------
                                 Bracketed logging

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -4,18 +4,25 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.DummyTarget.Primitive.Types
-    ( block0
+    ( -- * Dummy values
+      block0
     , dummyNetworkParameters
     , dummyGenesisParameters
+    , dummySlottingParameters
     , dummyTimeInterpreter
     , genesisHash
     , mockHash
     , mkTxId
     , mkTx
+
+      -- * Mocks
+    , dummyNetworkLayer
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Network
+    ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, hoistTimeInterpreter, mkSingleEraInterpreter )
 import Cardano.Wallet.Primitive.Types
@@ -144,3 +151,20 @@ mockHash = Hash . blake2b256 . B8.pack . show
      blake2b256 :: ByteString -> ByteString
      blake2b256 =
          BA.convert . hash @_ @Blake2b_256
+
+dummyNetworkLayer :: NetworkLayer m a
+dummyNetworkLayer = NetworkLayer
+    { nextBlocks = error "nextBlocks: not implemented"
+    , initCursor = error "initCursor: not implemented"
+    , destroyCursor = error "destroyCursor: not implemented"
+    , cursorSlotNo = error "cursorSlotNo: not implemented"
+    , currentNodeEra = error "currentNodeEra: not implemented"
+    , currentNodeTip = error "currentNodeTip: not implemented"
+    , watchNodeTip = error "watchNodeTip: not implemented"
+    , currentProtocolParameters = error "currentProtocolParameters: not implemented"
+    , currentSlottingParameters = error "currentSlottingParameters: not implemented"
+    , postTx = error "postTx: not implemented"
+    , stakeDistribution = error "stakeDistribution: not implemented"
+    , getAccountBalance = error "getAccountBalance: not implemented"
+    , timeInterpreter = error "timeInterpreter: not implemented"
+    }

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -27,6 +27,8 @@ import Cardano.Wallet.Api.Server
     )
 import Cardano.Wallet.Api.Types
     ( ApiNetworkInformation (..) )
+import Cardano.Wallet.DummyTarget.Primitive.Types
+    ( dummyNetworkLayer )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.Slotting
@@ -168,7 +170,7 @@ networkInfoSpec = describe "getNetworkInformation" $ do
                 <$> getCurrentTime
         let ti = forkInterpreter st
         let nodeTip' = SlotNo 0
-        let nl = dummyNetworkLayer nodeTip' ti
+        let nl = mockNetworkLayer nodeTip' ti
         let tolerance = mkSyncTolerance 5
         Right info <- run $ runHandler $ getNetworkInformation tolerance nl
 
@@ -194,11 +196,11 @@ networkInfoSpec = describe "getNetworkInformation" $ do
         monitor (counterexample $ lbl <> " " <> flag)
         assert condition
 
-    dummyNetworkLayer
+    mockNetworkLayer
         :: SlotNo
         -> TimeInterpreter (ExceptT PastHorizonException IO)
         -> NetworkLayer IO Block
-    dummyNetworkLayer sl ti = mockNetworkLayer
+    mockNetworkLayer sl ti = dummyNetworkLayer
         { currentNodeEra = return $ AnyCardanoEra MaryEra
         , currentNodeTip = return $
                 BlockHeader
@@ -222,23 +224,6 @@ networkInfoSpec = describe "getNetworkInformation" $ do
                 HF.EraSummary start (HF.EraEnd end) era1Params
             int = HF.mkInterpreter summary
         in mkTimeInterpreter nullTracer startTime (pure int)
-
-mockNetworkLayer :: NetworkLayer IO a
-mockNetworkLayer = NetworkLayer
-    { nextBlocks = error "nextBlocks: not implemented"
-    , initCursor = error "initCursor: not implemented"
-    , destroyCursor = error "destroyCursor: not implemented"
-    , cursorSlotNo = error "cursorSlotNo: not implemented"
-    , currentNodeEra = error "currentNodeEra: not implemented"
-    , currentNodeTip = error "currentNodeTip: not implemented"
-    , watchNodeTip = error "watchNodeTip: not implemented"
-    , currentProtocolParameters = error "currentProtocolParameters: not implemented"
-    , currentSlottingParameters = error "currentSlottingParameters: not implemented"
-    , postTx = error "postTx: not implemented"
-    , stakeDistribution = error "stakeDistribution: not implemented"
-    , getAccountBalance = error "getAccountBalance: not implemented"
-    , timeInterpreter = error "timeInterpreter: not implemented"
-    }
 
 errorHandlingSpec :: Spec
 errorHandlingSpec = describe "liftHandler and toServerError" $ do

--- a/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/MVarSpec.hs
@@ -39,7 +39,7 @@ import Test.QuickCheck
 import qualified Cardano.Wallet.DB.MVar as MVar
 
 spec :: Spec
-spec = before (MVar.newDBLayer @(SeqState 'Mainnet ShelleyKey) ti) $
+spec = before (MVar.newDBLayer @IO @(SeqState 'Mainnet ShelleyKey) ti) $
     describe "MVar" properties
   where
     ti = dummyTimeInterpreter

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -428,7 +428,7 @@ benchmarksRnd
         , KnownNat p
         )
     => Proxy n
-    -> WalletLayer s k
+    -> WalletLayer IO s k
     -> WalletId
     -> WalletName
     -> Text
@@ -519,7 +519,7 @@ benchmarksSeq
         , KnownNat p
         )
     => Proxy n
-    -> WalletLayer s k
+    -> WalletLayer IO s k
     -> WalletId
     -> WalletName
     -> Text -- ^ Bench name
@@ -592,7 +592,7 @@ bench_restoration
     -> [(WalletId, WalletName, s)]
     -> Bool -- ^ If @True@, will trace detailed progress to a .timelog file.
     -> Percentage -- ^ Target sync progress
-    -> (Proxy n -> WalletLayer s k -> WalletId -> WalletName -> Text -> Time -> IO results)
+    -> (Proxy n -> WalletLayer IO s k -> WalletId -> WalletName -> Text -> Time -> IO results)
     -> IO SomeBenchmarkResults
 bench_restoration proxy tr wlTr socket np vData benchname wallets traceToDisk targetSync benchmarks = do
     putStrLn $ "*** " ++ T.unpack benchname
@@ -727,7 +727,7 @@ waitForWalletsSyncTo
     => Percentage
     -> Tracer IO (BenchmarkLog n)
     -> Proxy n
-    -> WalletLayer s k
+    -> WalletLayer IO s k
     -> [WalletId]
     -> GenesisParameters
     -> NodeVersionData

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -159,6 +159,7 @@
             (hsPkgs."http-media" or (errorHandler.buildDepError "http-media"))
             (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
             (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
+            (hsPkgs."io-sim-classes" or (errorHandler.buildDepError "io-sim-classes"))
             (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
             (hsPkgs."lens" or (errorHandler.buildDepError "lens"))
             (hsPkgs."memory" or (errorHandler.buildDepError "memory"))

--- a/specifications/design-notes/tx-resubmission.md
+++ b/specifications/design-notes/tx-resubmission.md
@@ -1,0 +1,59 @@
+# Transaction resubmission
+
+Any transaction on the Cardano blockchain can be rolled back due to a
+chain switch, until its block is _StabilityWindow_ slots from the
+chain tip [[shelley-ledger-spec][]].
+
+After `cardano-wallet` submits a transaction, it tracks its state as
+_Pending_, until it sees the transaction in a block from the chain. At
+that point, the transaction will be marked _InLedger_.
+
+If there is a chain switch, `cardano-wallet` will roll back its
+transaction history database, and the transaction will revert back to
+_Pending_ state, until it has been discovered again on the new chain.
+
+However, it's not guaranteed that the transaction will ever appear
+again. If not, the transaction will remain in the wallet with
+_Pending_ state, until its TTL lapses, whereupon it will change to
+_Expired_ state.
+
+The reason for this is that `cardano-node` doesn't track transactions
+which left its mempool due to TxSubmission, but were never
+adopted. This is fair enough. The same behaviour even applies to
+transactions which entered the node's mempool via LocalTxSubmission
+(i.e. those submitted to a local node by the wallet).
+
+So `cardano-wallet` itself must retry submission of _Pending_
+transactions, for as long as their slot validity period is current
+(i.e. not expired).
+
+### How it works
+
+After posting a transaction, the wallet will store the serialized
+transaction in the `local_tx_submission` table, along with the last
+slot that it was submitted.
+
+A separate thread runs per wallet, which follows the chain tip, for
+the purpose of transaction resubmission.
+
+For any pending transaction in the wallet database, it will be
+resubmitted to the local node every _n_ slots (where _n_ is the number
+of slots during which 10 blocks occur on average).
+
+The LocalTxSubmission protocol will usually return an error for
+retried transactions, due to already spent UTxO, etc. But this is
+expected. The wallet just ignores the error, and updates the slot
+field in the database table.
+
+Once a submitted transaction has expired, or was accepted and can no
+longer be rolled back (i.e. its block was more than _StabilityWindow_
+ago), it is removed from the `local_tx_submission` table.
+
+### Exceptions
+
+Pre-signed transactions which were posted to the external transactions
+endpoint are _not_ retried -- it is up to the user to retry. This
+could be changed in future if the wallet can discover transactions
+which don't belong to its own wallets.
+
+[shelley-ledger-spec]: https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/native.specs.shelley-ledger.x86_64-linux/latest/download/1


### PR DESCRIPTION
### Issue Number

ADP-764

### Overview

Adds tx resubmission to the wallet server.

   - [x] Add a wallet thread for resubmitting transactions
   - [x] Initial version resubmits every pending tx about every 10 blocks after initial submission.
   - [x] Unit test retry thread
   - [x] Design doc

### Comments

- Based on PR #2570 branch - merge that first.

