### PR TITLE
Add `constraints` field to `TransactionLayer`

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1378,7 +1378,9 @@ calcMinimumCoinValues
     -> IO (f Coin)
 calcMinimumCoinValues ctx outs = do
     pp <- currentProtocolParameters nl
-    pure $ calcMinimumCoinValue tl pp . view (#tokens . #tokens) <$> outs
+    pure
+        $ view #txOutputMinimumAdaQuantity (constraints tl pp)
+        . view (#tokens . #tokens) <$> outs
   where
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
@@ -1407,7 +1409,7 @@ selectAssets ctx (utxo, cp, pending) tx outs transform = do
     selectionCriteria <- withExceptT ErrSelectAssetsCriteriaError $ except $
         initSelectionCriteria tl pp tx utxo outs
     sel <- performSelection
-        (calcMinimumCoinValue tl pp)
+        (view #txOutputMinimumAdaQuantity $ constraints tl pp)
         (calcMinimumCost tl pp tx)
         (tokenBundleSizeAssessor tl)
         (selectionCriteria)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -185,8 +185,8 @@ data SelectionCriteria = SelectionCriteria
 -- output must not change the estimated cost of a selection.
 --
 data SelectionSkeleton = SelectionSkeleton
-    { inputsSkeleton
-        :: !UTxOIndex
+    { skeletonInputCount
+        :: !Int
     , outputsSkeleton
         :: ![TxOut]
     , changeSkeleton
@@ -198,7 +198,7 @@ data SelectionSkeleton = SelectionSkeleton
 -- change.
 emptySkeleton :: SelectionSkeleton
 emptySkeleton = SelectionSkeleton
-    { inputsSkeleton  = UTxOIndex.empty
+    { skeletonInputCount = 0
     , outputsSkeleton = mempty
     , changeSkeleton  = mempty
     }
@@ -594,7 +594,7 @@ performSelection minCoinFor costFor bundleSizeAssessor criteria
         SelectionState {selected, leftover} = s
 
         requiredCost = costFor SelectionSkeleton
-            { inputsSkeleton  = selected
+            { skeletonInputCount = UTxOIndex.size selected
             , outputsSkeleton = NE.toList outputsToCover
             , changeSkeleton
             }

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -187,9 +187,9 @@ data SelectionCriteria = SelectionCriteria
 data SelectionSkeleton = SelectionSkeleton
     { skeletonInputCount
         :: !Int
-    , outputsSkeleton
+    , skeletonOutputs
         :: ![TxOut]
-    , changeSkeleton
+    , skeletonChange
         :: ![Set AssetId]
     }
     deriving (Eq, Show)
@@ -199,8 +199,8 @@ data SelectionSkeleton = SelectionSkeleton
 emptySkeleton :: SelectionSkeleton
 emptySkeleton = SelectionSkeleton
     { skeletonInputCount = 0
-    , outputsSkeleton = mempty
-    , changeSkeleton  = mempty
+    , skeletonOutputs = mempty
+    , skeletonChange = mempty
     }
 
 -- | Specifies a limit to adhere to when performing a selection.
@@ -595,11 +595,11 @@ performSelection minCoinFor costFor bundleSizeAssessor criteria
 
         requiredCost = costFor SelectionSkeleton
             { skeletonInputCount = UTxOIndex.size selected
-            , outputsSkeleton = NE.toList outputsToCover
-            , changeSkeleton
+            , skeletonOutputs = NE.toList outputsToCover
+            , skeletonChange
             }
 
-        changeSkeleton = predictChange selected
+        skeletonChange = predictChange selected
         inputsSelected = mkInputsSelected selected
 
     invariantSelectAnyInputs =

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -192,7 +192,7 @@ data SelectionSkeleton = SelectionSkeleton
     , skeletonChange
         :: ![Set AssetId]
     }
-    deriving (Eq, Show)
+    deriving (Eq, Generic, Show)
 
 -- | Creates an empty 'SelectionSkeleton' with no inputs, no outputs and no
 -- change.

--- a/lib/core/src/Cardano/Wallet/Primitive/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Migration.hs
@@ -17,14 +17,13 @@ module Cardano.Wallet.Primitive.Migration
     , MigrationPlan (..)
     , RewardWithdrawal (..)
     , Selection (..)
-    , TxSize (..)
 
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.Migration.Selection
-    ( RewardWithdrawal (..), Selection (..), TxSize (..) )
+    ( RewardWithdrawal (..), Selection (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -44,8 +43,8 @@ import qualified Cardano.Wallet.Primitive.Migration.Planning as Planning
 --
 -- See 'createPlan' to create a migration plan.
 --
-data MigrationPlan size = MigrationPlan
-    { selections :: ![Selection (TxIn, TxOut) size]
+data MigrationPlan = MigrationPlan
+    { selections :: ![Selection (TxIn, TxOut)]
       -- ^ A list of generated selections: each selection is the basis for a
       -- single transaction.
     , unselected :: !UTxO
@@ -62,11 +61,10 @@ data MigrationPlan size = MigrationPlan
 -- See 'MigrationPlan'.
 --
 createPlan
-    :: TxSize size
-    => TxConstraints size
+    :: TxConstraints
     -> UTxO
     -> RewardWithdrawal
-    -> MigrationPlan size
+    -> MigrationPlan
 createPlan constraints utxo reward = MigrationPlan
     { selections = view #selections plan
     , unselected = Planning.uncategorizeUTxO (view #unselected plan)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -566,6 +566,7 @@ data TxConstraints = TxConstraints
     , txMaximumSize :: TxSize
       -- ^ The maximum size of a transaction.
     }
+    deriving Generic
 
 txOutputCoinCost :: TxConstraints -> Coin -> Coin
 txOutputCoinCost constraints = txOutputCost constraints . TokenBundle.fromCoin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -56,6 +56,8 @@ module Cardano.Wallet.Primitive.Types.Tx
     , txOutputHasValidAdaQuantity
     , txOutputHasValidSize
     , txOutputHasValidTokenQuantities
+    , TxSize (..)
+    , txSizeDistance
 
     ) where
 
@@ -132,6 +134,8 @@ import GHC.Generics
     ( Generic )
 import Numeric.Natural
     ( Natural )
+import Quiet
+    ( Quiet (..) )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
@@ -534,22 +538,22 @@ txOutMaxTokenQuantity = TokenQuantity $ fromIntegral $ maxBound @Word64
 -- This will lead to slight overestimation in the case of UTxOs that share the
 -- same payment key.
 --
-data TxConstraints s = TxConstraints
+data TxConstraints = TxConstraints
     { txBaseCost :: Coin
       -- ^ The constant cost of an empty transaction.
-    , txBaseSize :: s
+    , txBaseSize :: TxSize
       -- ^ The constant size of an empty transaction.
     , txInputCost :: Coin
       -- ^ The constant cost of a transaction input, assuming one witness is
       -- required per input.
-    , txInputSize :: s
+    , txInputSize :: TxSize
       -- ^ The constant size of a transaction input, assuming one witness is
       -- required per input.
     , txOutputCost :: TokenBundle -> Coin
       -- ^ The variable cost of a transaction output.
-    , txOutputSize :: TokenBundle -> s
+    , txOutputSize :: TokenBundle -> TxSize
       -- ^ The variable size of a transaction output.
-    , txOutputMaximumSize :: s
+    , txOutputMaximumSize :: TxSize
       -- ^ The maximum size of a transaction output.
     , txOutputMaximumTokenQuantity :: TokenQuantity
       -- ^ The maximum token quantity that can appear in a transaction output.
@@ -557,35 +561,54 @@ data TxConstraints s = TxConstraints
       -- ^ The variable minimum ada quantity of a transaction output.
     , txRewardWithdrawalCost :: Coin -> Coin
       -- ^ The variable cost of a reward withdrawal.
-    , txRewardWithdrawalSize :: Coin -> s
+    , txRewardWithdrawalSize :: Coin -> TxSize
       -- ^ The variable size of a reward withdrawal.
-    , txMaximumSize :: s
+    , txMaximumSize :: TxSize
       -- ^ The maximum size of a transaction.
     }
 
-txOutputCoinCost :: TxConstraints s -> Coin -> Coin
+txOutputCoinCost :: TxConstraints -> Coin -> Coin
 txOutputCoinCost constraints = txOutputCost constraints . TokenBundle.fromCoin
 
-txOutputCoinSize :: TxConstraints s -> Coin -> s
+txOutputCoinSize :: TxConstraints -> Coin -> TxSize
 txOutputCoinSize constraints = txOutputSize constraints . TokenBundle.fromCoin
 
-txOutputCoinMinimum :: TxConstraints s -> Coin
+txOutputCoinMinimum :: TxConstraints -> Coin
 txOutputCoinMinimum constraints = txOutputMinimumAdaQuantity constraints mempty
 
-txOutputIsValid :: Ord s => TxConstraints s -> TokenBundle -> Bool
+txOutputIsValid :: TxConstraints -> TokenBundle -> Bool
 txOutputIsValid constraints b =
     constraints `txOutputHasValidAdaQuantity` b
     && constraints `txOutputHasValidSize` b
     && constraints `txOutputHasValidTokenQuantities` (view #tokens b)
 
-txOutputHasValidAdaQuantity :: TxConstraints s -> TokenBundle -> Bool
+txOutputHasValidAdaQuantity :: TxConstraints -> TokenBundle -> Bool
 txOutputHasValidAdaQuantity constraints (TokenBundle c m) =
     c >= txOutputMinimumAdaQuantity constraints m
 
-txOutputHasValidSize :: Ord s => TxConstraints s -> TokenBundle -> Bool
+txOutputHasValidSize :: TxConstraints -> TokenBundle -> Bool
 txOutputHasValidSize constraints b =
     txOutputSize constraints b <= txOutputMaximumSize constraints
 
-txOutputHasValidTokenQuantities :: TxConstraints s -> TokenMap -> Bool
+txOutputHasValidTokenQuantities :: TxConstraints -> TokenMap -> Bool
 txOutputHasValidTokenQuantities constraints m =
     TokenMap.maximumQuantity m <= txOutputMaximumTokenQuantity constraints
+
+-- | The size of a transaction, or part of a transaction, in bytes.
+--
+newtype TxSize = TxSize { unTxSize :: Natural }
+    deriving stock (Eq, Ord, Generic)
+    deriving Show via (Quiet TxSize)
+
+instance Semigroup TxSize where
+    TxSize a <> TxSize b = TxSize (a + b)
+
+instance Monoid TxSize where
+    mempty = TxSize 0
+
+-- | Computes the absolute distance between two transaction size quantities.
+--
+txSizeDistance :: TxSize -> TxSize -> TxSize
+txSizeDistance (TxSize a) (TxSize b)
+    | a >= b    = TxSize (a - b)
+    | otherwise = TxSize (b - a)

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -147,7 +147,7 @@ data TransactionCtx = TransactionCtx
     -- ^ Transaction expiry (TTL) slot.
     , txDelegationAction :: Maybe DelegationAction
     -- ^ An additional delegation to take.
-    } deriving (Show, Eq)
+    } deriving (Show, Generic, Eq)
 
 data Withdrawal
     = WithdrawalSelf !RewardAccount !(NonEmpty DerivationIndex) !Coin

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -58,7 +58,13 @@ import Cardano.Wallet.Primitive.Types.TokenMap
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( SealedTx (..), TokenBundleSizeAssessor, Tx (..), TxMetadata, TxOut )
+    ( SealedTx (..)
+    , TokenBundleSizeAssessor
+    , Tx (..)
+    , TxConstraints
+    , TxMetadata
+    , TxOut
+    )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
 import Data.ByteString
@@ -127,6 +133,12 @@ data TransactionLayer k = TransactionLayer
     , tokenBundleSizeAssessor
         :: TokenBundleSizeAssessor
         -- ^ A function to assess the size of a token bundle.
+
+    , constraints
+        :: ProtocolParameters
+        -- Current protocol parameters.
+        -> TxConstraints
+        -- The set of constraints that apply to all transactions.
 
     , decodeSignedTx
         :: AnyCardanoEra

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -54,7 +54,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
 import Cardano.Wallet.Primitive.Types.TokenMap
-    ( AssetId, TokenMap )
+    ( AssetId )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -121,14 +121,6 @@ data TransactionLayer k = TransactionLayer
         -> Coin
         -- ^ Compute a minimal fee amount necessary to pay for a given selection
         -- This also includes necessary deposits.
-
-    , calcMinimumCoinValue
-        :: ProtocolParameters
-            -- Current protocol parameters
-        -> TokenMap
-            -- A bundle of native assets
-        -> Coin
-        -- ^ The minimum ada value needed in a UTxO carrying the asset bundle
 
     , tokenBundleSizeAssessor
         :: TokenBundleSizeAssessor

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -146,6 +146,7 @@ data TransactionLayer k = TransactionLayer
         -> Either ErrDecodeSignedTx (Tx, SealedTx)
         -- ^ Decode an externally-signed transaction to the chain producer
     }
+    deriving Generic
 
 -- | Some additional context about a transaction. This typically contains
 -- details that are known upfront about the transaction and are used to

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -711,9 +711,9 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
         skeleton = SelectionSkeleton
             { skeletonInputCount =
                 length inputsSelected
-            , outputsSkeleton =
+            , skeletonOutputs =
                 NE.toList outputsToCover
-            , changeSkeleton =
+            , skeletonChange =
                 fmap (TokenMap.getAssets . view #tokens) changeGenerated
             }
         balanceSelected =
@@ -1474,8 +1474,8 @@ linearCost s
     = Coin
     $ fromIntegral
     $ skeletonInputCount s
-    + F.length (outputsSkeleton s)
-    + F.length (changeSkeleton s)
+    + F.length (skeletonOutputs s)
+    + F.length (skeletonChange s)
 
 type MakeChangeData =
     MakeChangeCriteria MinCoinValueFor MockTokenBundleSizeAssessor

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -709,15 +709,15 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             , utxoRemaining
             } = result
         skeleton = SelectionSkeleton
-            { inputsSkeleton =
-                UTxOIndex.fromSequence inputsSelected
+            { skeletonInputCount =
+                length inputsSelected
             , outputsSkeleton =
                 NE.toList outputsToCover
             , changeSkeleton =
                 fmap (TokenMap.getAssets . view #tokens) changeGenerated
             }
         balanceSelected =
-            fullBalance (inputsSkeleton skeleton) extraCoinSource
+            fullBalance (UTxOIndex.fromSequence inputsSelected) extraCoinSource
         balanceChange =
             F.fold changeGenerated
         expectedCost =
@@ -1470,12 +1470,12 @@ noCost :: Coin
 noCost = Coin 0
 
 linearCost :: SelectionSkeleton -> Coin
-linearCost SelectionSkeleton{inputsSkeleton, outputsSkeleton, changeSkeleton}
+linearCost s
     = Coin
     $ fromIntegral
-    $ UTxOIndex.size inputsSkeleton
-    + F.length outputsSkeleton
-    + F.length changeSkeleton
+    $ skeletonInputCount s
+    + F.length (outputsSkeleton s)
+    + F.length (changeSkeleton s)
 
 type MakeChangeData =
     MakeChangeCriteria MinCoinValueFor MockTokenBundleSizeAssessor

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1105,6 +1105,8 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: calcMinimumCoinValue not implemented"
     , tokenBundleSizeAssessor =
         error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
+    , constraints =
+        error "dummyTransactionLayer: constraints not implemented"
     , decodeSignedTx =
         error "dummyTransactionLayer: decodeSignedTx not implemented"
     }

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1101,8 +1101,6 @@ dummyTransactionLayer = TransactionLayer
         error "dummyTransactionLayer: initSelectionCriteria not implemented"
     , calcMinimumCost =
         error "dummyTransactionLayer: calcMinimumCost not implemented"
-    , calcMinimumCoinValue =
-        error "dummyTransactionLayer: calcMinimumCoinValue not implemented"
     , tokenBundleSizeAssessor =
         error "dummyTransactionLayer: tokenBundleSizeAssessor not implemented"
     , constraints =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -501,13 +501,13 @@ _initSelectionCriteria pp ctx utxoAvailable outputsUnprepared
         prepareOutputsWith (_calcMinimumCoinValue pp) outputsUnprepared
 
 dummySkeleton :: Int -> [TxOut] -> SelectionSkeleton
-dummySkeleton inputCount outs = SelectionSkeleton
+dummySkeleton inputCount outputs = SelectionSkeleton
     { skeletonInputCount =
         inputCount
-    , outputsSkeleton =
-        outs
-    , changeSkeleton =
-        TokenBundle.getAssets . view #tokens <$> outs
+    , skeletonOutputs =
+        outputs
+    , skeletonChange =
+        TokenBundle.getAssets . view #tokens <$> outputs
     }
 
 _decodeSignedTx

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -804,7 +804,9 @@ estimateTxSize args =
 
         -- ?5 => withdrawals
         sizeOf_Withdrawals
-            = (if numberOf_Withdrawals > 0 then sizeOf_SmallUInt + sizeOf_SmallMap else 0)
+            = (if numberOf_Withdrawals > 0
+                then sizeOf_SmallUInt + sizeOf_SmallMap
+                else 0)
             + sizeOf_Withdrawal * numberOf_Withdrawals
 
         -- ?6 => update
@@ -839,7 +841,8 @@ estimateTxSize args =
         + sizeOf_Address address
         + sizeOf_SmallArray
         + sizeOf_Coin (TokenBundle.getCoin tokens)
-        + F.foldl' (\t -> (t +) . sizeOf_NativeAsset) 0 (TokenBundle.getAssets tokens)
+        + F.foldl' (\t -> (t +) . sizeOf_NativeAsset) 0
+            (TokenBundle.getAssets tokens)
 
     -- transaction_output =
     --   [address, amount : value]
@@ -941,7 +944,8 @@ estimateTxSize args =
       where
         -- ?0 => [* vkeywitness ]
         sizeOf_VKeyWitnesses
-            = (if numberOf_VkeyWitnesses > 0 then sizeOf_Array + sizeOf_SmallUInt else 0)
+            = (if numberOf_VkeyWitnesses > 0
+                then sizeOf_Array + sizeOf_SmallUInt else 0)
             + sizeOf_VKeyWitness * numberOf_VkeyWitnesses
 
         -- ?1 => [* multisig_script ]
@@ -950,7 +954,9 @@ estimateTxSize args =
 
         -- ?2 => [* bootstrap_witness ]
         sizeOf_BootstrapWitnesses
-            = (if numberOf_BootstrapWitnesses > 0 then sizeOf_Array + sizeOf_SmallUInt else 0)
+            = (if numberOf_BootstrapWitnesses > 0
+                then sizeOf_Array + sizeOf_SmallUInt
+                else 0)
             + sizeOf_BootstrapWitness * numberOf_BootstrapWitnesses
 
     -- vkeywitness =

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -697,8 +697,8 @@ mkTxSkeleton witness context skeleton = TxSkeleton
 -- | Estimates the final cost of a transaction based on its skeleton.
 --
 estimateTxCost :: ProtocolParameters -> TxSkeleton -> Coin
-estimateTxCost pp args =
-    computeFee $ estimateTxSize args
+estimateTxCost pp skeleton =
+    computeFee $ estimateTxSize skeleton
   where
     LinearFee (Quantity a) (Quantity b) = getFeePolicy $ txParameters pp
 
@@ -714,7 +714,7 @@ estimateTxCost pp args =
 -- https://github.com/input-output-hk/cardano-ledger-specs/blob/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files/shelley.cddl
 --
 estimateTxSize :: TxSkeleton -> TxSize
-estimateTxSize args =
+estimateTxSize skeleton =
     TxSize $ fromIntegral sizeOf_Transaction
   where
     TxSkeleton
@@ -725,7 +725,7 @@ estimateTxSize args =
         , txInputCount
         , txOutputs
         , txChange
-        } = args
+        } = skeleton
 
     numberOf_Inputs
         = fromIntegral txInputCount

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -346,9 +346,6 @@ newTransactionLayer networkId = TransactionLayer
         estimateTxCost pp $
         mkTxSkeleton (txWitnessTagFor @k) ctx skeleton
 
-    , calcMinimumCoinValue =
-        _calcMinimumCoinValue
-
     , tokenBundleSizeAssessor =
         Compatibility.tokenBundleSizeAssessor
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -134,6 +134,7 @@ import Test.Hspec.QuickCheck
     ( prop )
 import Test.QuickCheck
     ( Arbitrary (..)
+    , Blind (..)
     , InfiniteList (..)
     , NonEmptyList (..)
     , Property
@@ -891,8 +892,8 @@ instance Arbitrary (Large TokenBundle) where
 -- between 'txOutputSize' and 'txOutputMaximumSize' should also indicate that
 -- the bundle is oversized.
 --
-prop_txConstraints_txOutputMaximumSize :: Large TokenBundle -> Property
-prop_txConstraints_txOutputMaximumSize (Large bundle) =
+prop_txConstraints_txOutputMaximumSize :: Blind (Large TokenBundle) -> Property
+prop_txConstraints_txOutputMaximumSize (Blind (Large bundle)) =
     checkCoverage $
     cover 10 (authenticComparison == LT)
         "authentic bundle size is smaller than maximum" $


### PR DESCRIPTION
# Issue Number

ADP-839

# Overview

This PR:

- [x] adds field `constraints` of type `TxConstraints` to the `TransactionLayer` record type.
- [x] adds an implementation of `constraints` to `Shelley.Transaction.TransactionLayer`.
- [x] adds property tests to demonstrate the correctness of `Shelley.Transaction.TransactionLayer.constraints`.

# Refactoring

This PR also:

- [x] makes `TxSize` into a concrete type exported by `Primitive.Types.Tx`.
- [x] removes `calcMinimumCoinValue` from `TransactionLayer`, as `TxConstraints.txOutputMinimumAdaQuantity` makes this redundant.

# Future work

This PR will make it possible to:

- remove `tokenBundleSizeAssessor` from `TransactionLayer`, as `TxConstraints.txOutputMaximumSize` makes this redundant.
