### PR TITLE
e2e tests: fix docker workflow

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -39,6 +39,7 @@ jobs:
       run: |
         rake fixture_wallets_decode
         rake get_latest_configs["testnet"]
+        rake get_latest_bins
 
     - name: Cache node db
       id: cache


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have added a step for docker workflow to get the latest cardano-wallet bundle before starting tests in order to have cardano-address on the path which is required for recently added e2e shared wallet tests


# Comments
This was slight omission from https://github.com/input-output-hk/cardano-wallet/pull/2619. Other workflows already have it by default.

Tested here on the docker workflow -> https://github.com/input-output-hk/cardano-wallet/actions/runs/784885875
