### PR TITLE
Fix release docker image and release scripts

### DIFF
--- a/.buildkite/docker-build-push.nix
+++ b/.buildkite/docker-build-push.nix
@@ -84,9 +84,27 @@ in
       echo 'Not pushing docker image because this is not a master branch or v20* tag build.'
     fi
 
+    echo
+    echo "Testing that entrypoint works"
+    set +e
+    docker run --rm "$orig_tag" version
+    docker_status="$?"
+    if [ "$docker_status" -eq 0 ]; then
+      echo "OK"
+    elif [ "$docker_status" -eq 125 ]; then
+      echo "Docker failed to run ... oh well."
+      echo "Continuing..."
+    else
+      echo "Entrypoint command failed with code $docker_status"
+      exit 1
+    fi
+    set -e
+    echo
+
     for tag in ''${tags[@]}; do
       tagged="$fullrepo:$tag"
       if [ "$tagged" != "$orig_tag" ]; then
+        echo "Retagging with $tagged"
         docker tag "$orig_tag" "$tagged"
       fi
       echo "Pushing $tagged"

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -8,7 +8,7 @@ on:
       nodeTag:
         description: 'Node tag (docker)'
         required: true
-        default: '1.25.1'
+        default: '1.26.2'
       walletTag:
         description: 'Wallet tag (docker)'
         required: true
@@ -96,4 +96,4 @@ jobs:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: testnet
       WALLET: dev-master-shelley
-      NODE: 1.25.1
+      NODE: 1.26.2

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -12,7 +12,7 @@ on:
       walletTag:
         description: 'Wallet tag (docker)'
         required: true
-        default: 'dev-master-shelley'
+        default: 'dev-master'
 
 defaults:
   run:
@@ -95,5 +95,5 @@ jobs:
       TESTS_E2E_TOKEN_METADATA: https://metadata.cardano-testnet.iohkdev.io/
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: testnet
-      WALLET: dev-master-shelley
+      WALLET: dev-master
       NODE: 1.26.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,13 @@ jobs:
           wget ${{ steps.hydra.outputs.buildProducts }}
 
       - name: '🚀 Release'
-        uses: docker://antonyurchenko/git-release:v3.4.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DRAFT_RELEASE: "true"
-          PRE_RELEASE: "false"
-          CHANGELOG_FILE: "none"
-          ALLOW_EMPTY_CHANGELOG: "true"
-          ALLOW_TAG_PREFIX: "true"
+        uses: softprops/action-gh-release@v1
         with:
-          args: '*.tar.gz *.zip'
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            *.tar.gz
+            *.zip
 
   docs:
     runs-on: ubuntu-20.04

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -16,7 +16,7 @@
 # Executables to include in the image as a base layer: node and utilities
 , base ? []
 # Other things to include in the image.
-, iana-etc, cacert, bashInteractive
+, iana-etc, cacert, bashInteractive, coreutils
 , glibcLocales ? null
 
 # Used to generate the docker image names
@@ -61,8 +61,8 @@ let
   envImage = dockerTools.buildImage {
     name = "${repoName}-env";
     contents = [
-      iana-etc cacert bashInteractive
-      nsswitch-conf
+      iana-etc cacert nsswitch-conf
+      bashInteractive coreutils
     ] ++ lib.optional haveGlibcLocales glibcLocales;
 
     # set up /tmp (override with TMPDIR variable)

--- a/nix/windows-testing-bundle.nix
+++ b/nix/windows-testing-bundle.nix
@@ -32,7 +32,7 @@ in pkgs.runCommand name {
   cd bundle
 
   # Copy in wallet and node EXEs and DLLs.
-  for pkg in ${cardano-wallet} ${cardano-cli}; do
+  for pkg in ${cardano-wallet} ${cardano-node} ${cardano-cli}; do
     cp -vf $pkg/bin/* .
   done
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -58,7 +58,7 @@ One can also start tests against cardano-wallet docker. There is docker-compose-
 >NETWORK=testnet \
 >TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
 >WALLET=dev-master-shelley \
->NODE=1.25.1 \
+>NODE=1.26.2 \
 >NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 >docker-compose -f docker-compose-test.yml up
 >```

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -57,7 +57,7 @@ One can also start tests against cardano-wallet docker. There is docker-compose-
 >```bash
 >NETWORK=testnet \
 >TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
->WALLET=dev-master-shelley \
+>WALLET=dev-master \
 >NODE=1.26.2 \
 >NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 >docker-compose -f docker-compose-test.yml up

--- a/test/e2e/docker_compose
+++ b/test/e2e/docker_compose
@@ -1,6 +1,6 @@
 NETWORK=testnet \
 TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
-WALLET=dev-master-shelley \
+WALLET=dev-master \
 NODE=1.26.2 \
 NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 docker-compose -f docker-compose-test.yml $1

--- a/test/e2e/docker_compose
+++ b/test/e2e/docker_compose
@@ -1,6 +1,6 @@
 NETWORK=testnet \
 TESTS_E2E_TOKEN_METADATA=https://metadata.cardano-testnet.iohkdev.io/ \
 WALLET=dev-master-shelley \
-NODE=1.25.1 \
+NODE=1.26.2 \
 NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK \
 docker-compose -f docker-compose-test.yml $1


### PR DESCRIPTION
### Issue Number

ADP-894

### Overview

1. Something changed in `nixpkgs.dockerTools` base environment which means we now need to add coreutils to our image.
2. Adds a fix for the release file uploading github action.

### Comments

Will cherry-pick this onto a release branch after merging.
