### PR TITLE
Add slack notification for windows tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ jobs:
           keep_files: true
           user_name: 'William King Noel Bot'
           user_email: 'adrestia@iohk.io'
-          full_commit_message: ${{ steps.build.outputs.commit_message }}
+          full_commit_message: |
+            docs: ${{ github.event.head_commit.message }}
+
+            Source commit: ${{ github.sha }}
 
   bump_sh:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,10 +69,7 @@ jobs:
           keep_files: true
           user_name: 'William King Noel Bot'
           user_email: 'adrestia@iohk.io'
-          full_commit_message: |
-            docs: ${{ github.event.head_commit.message }}
-
-            Source commit: ${{ github.sha }}
+          full_commit_message: ${{ steps.build.outputs.commit_message }}
 
   bump_sh:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,3 +117,39 @@ jobs:
         if: github.ref == 'ref/heads/master'
         shell: bash
         run: 'bash .buildkite/push-branch.sh windows-tests-pass linux-tests-pass all-tests-pass'
+
+  notify:
+    name: Notify slack channel
+    runs-on: ubuntu-latest
+    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/v' || github.ref == 'refs/heads/rvl/adp-753/ci-notify') }}
+    needs: finish
+    env:
+      RESULT_FILE: 'previous-result.txt'
+    steps:
+      - name: Get previous result for ref
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.RESULT_FILE }}
+          key: ${{ env.GITHUB_WORKFLOW }}-${{ github.ref }}
+      - name: Check previous result
+        id: previous
+        env:
+          result: ${{ job.status }}
+        run: |
+          prev_result=$(cat $RESULT_FILE || true)
+          echo "result=$result"
+          echo "prev_result=$prev_result"
+          if [ "$result" != "$prev_result" ]; then
+            echo "::set-output name=do_notify::yes"
+          fi
+          echo "$result" > $RESULT_FILE
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          # channel: '#adrestia-secret-fort'
+          channel: '@rvl'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        # Only notify when state changes between failure/success
+        if: ${{ steps.previous.do_notify }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,9 +153,9 @@ jobs:
           status: ${{ job.status }}
           steps: ${{ toJson(steps) }}
           # channel: '#adrestia-secret-fort'
-          channel: '@rvl'
+          channel: '@piotr.stachyra'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         # Only notify when state changes between failure/success for
         # interesting branches/tags.
-        if: ${{ steps.previous.do_notify && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/v' || github.ref == 'refs/heads/rvl/adp-753/ci-notify') }}
+        if: ${{ steps.previous.outputs.do_notify && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/v' || github.ref == 'refs/heads/rvl/adp-753/ci-notify') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -102,6 +102,8 @@ jobs:
     name: Finish
     runs-on: windows-2016
     if: always()
+    outputs:
+      result: '${{ steps.check.outputs.result }}'
     needs:
       - cardano-wallet-core-test-unit
       - cardano-wallet-test-unit
@@ -114,9 +116,12 @@ jobs:
         with:
           fetch-depth: 1
       - name: "Advance windows-tests-pass and all-tests-pass branches"
+        id: check
         if: github.ref == 'ref/heads/master'
         shell: bash
-        run: 'bash .buildkite/push-branch.sh windows-tests-pass linux-tests-pass all-tests-pass'
+        run: |
+          bash .buildkite/push-branch.sh windows-tests-pass linux-tests-pass all-tests-pass
+          echo "::set-output name=result::blah blah"
 
   notify:
     name: Notify slack channel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,7 +121,7 @@ jobs:
   notify:
     name: Notify slack channel
     runs-on: ubuntu-latest
-    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/v' || github.ref == 'refs/heads/rvl/adp-753/ci-notify') }}
+    if: always()
     needs: finish
     env:
       RESULT_FILE: 'previous-result.txt'
@@ -151,5 +151,6 @@ jobs:
           channel: '@rvl'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        # Only notify when state changes between failure/success
-        if: ${{ steps.previous.do_notify }}
+        # Only notify when state changes between failure/success for
+        # interesting branches/tags.
+        if: ${{ steps.previous.do_notify && (github.ref == 'refs/heads/master' || github.ref == 'refs/tags/v' || github.ref == 'refs/heads/rvl/adp-753/ci-notify') }}

--- a/scripts/gh/update-bump.sh
+++ b/scripts/gh/update-bump.sh
@@ -16,3 +16,12 @@ yq eval specifications/api/swagger.yaml -j > specifications/api/swagger.json
 
 bump_swagger validate
 bump_swagger deploy
+
+echo ==============================h
+hxnormalize -x 'https://bump.sh/doc/cardano-wallet-diff/changes' \
+    | hxselect "ul.timeline-event-diff" \
+    | hxselect -s '\n' "ul:first-child" \
+    | sed -z 's/\n[ ]\+/ /g' \
+    | hxselect -c -s '\n' 'li' \
+    | sed 's/^\([ ]*\)\([A-Z][^:]\+: \)\(.*\)$/\1- \2`\3`/g'
+echo ==============================


### PR DESCRIPTION
### Issue Number

ADP-753

### Overview

- Slack notifications for failing tests which aren't required for merging PRs
  It makes sure failing builds are noticed before release day.
  If any windows tests fail, it will send a message to our slack channel.

### Comments

WIP: The notification doesn't really work how I would like. GitHub actions are quite difficult to use. I have asked for help on slack.
