### PR TITLE
Model state for tracking stake keys

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -174,6 +174,7 @@ library
       Cardano.Wallet.Primitive.AddressDiscovery
       Cardano.Wallet.Primitive.Slotting
       Cardano.Wallet.Primitive.AddressDiscovery.Random
+      Cardano.Wallet.Primitive.Delegation.State
       Cardano.Wallet.Primitive.AddressDiscovery.Sequential
       Cardano.Wallet.Primitive.AddressDiscovery.Shared
       Cardano.Wallet.Primitive.SyncProgress
@@ -298,6 +299,7 @@ test-suite unit
     , QuickCheck
     , quickcheck-classes
     , quickcheck-state-machine >= 0.6.0
+    , quiet
     , random
     , retry
     , safe
@@ -363,6 +365,7 @@ test-suite unit
       Cardano.Wallet.Primitive.AddressDiscovery.RandomSpec
       Cardano.Wallet.Primitive.AddressDiscovery.SequentialSpec
       Cardano.Wallet.Primitive.AddressDiscovery.SharedSpec
+      Cardano.Wallet.Primitive.Delegation.StateSpec
       Cardano.Wallet.Primitive.AddressDiscoverySpec
       Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec
       Cardano.Wallet.Primitive.MigrationSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/Delegation/State.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Delegation/State.hs
@@ -1,0 +1,498 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Module for `DelegationState`.
+module Cardano.Wallet.Primitive.Delegation.State
+    ( -- * Creation
+      DelegationState (..)
+    , initialDelegationState
+
+      -- * Operations
+    , presentableKeys
+    , usableKeys
+    , activeKeys
+
+    -- * For Testing
+    , keyAtIx
+    , lastActiveIx
+    , PointerUTxO (..)
+    , State (..)
+    , Key0Status (..)
+
+      -- * Chain following model
+    , Tx (..)
+    , Cert (..)
+    , applyTx
+    , setPortfolioOf
+    )
+    where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPub )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationType (..)
+    , Index (..)
+    , MkKeyFingerprint (paymentKeyFingerprint)
+    , Role (..)
+    , SoftDerivation (..)
+    , ToRewardAccount (..)
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
+import Control.DeepSeq
+    ( NFData )
+import Data.Maybe
+    ( maybeToList )
+import GHC.Generics
+    ( Generic )
+import Quiet
+    ( Quiet (..) )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
+
+--------------------------------------------------------------------------------
+-- Delegation State
+--------------------------------------------------------------------------------
+
+-- | Delegation state
+--
+-- === Goals
+-- 1. Allow a wallet to have an arbitrary number of stake keys
+-- 2. Ensure those stake keys can be automatically discovered on-chain
+-- 3. Ensure the wallet is always aware of all stake keys it registers, even in
+-- the case of concurrent user actions on multiple wallet instances, and old
+-- wallet software.
+--
+--
+-- === How
+--
+-- We track a consecutive range of keys that is extended with delegation of the
+-- next unused key, and shrunk with key de-registration. We use a `PointerUTxO`
+-- to ensure that transactions changing the state can't be accepted to the
+-- ledger in any other order than intended. We also need some special care
+-- regarding stake key 0, which old wallet software could try to de-register.
+--
+-- === Diagram
+-- Diagram of states, where the list denotes active (registered /and/ delegating)
+-- keys.
+--
+-- Here we assume the minUTxOValue is 1 ada.
+--
+-- Note that intermediate steps for the `PointerUTxO` should be skipped within a
+-- transaction.
+-- E.g. to transition from [] to [0,1,2] we should deposit 1 ada to key 3,
+-- skipping key 2.
+--
+-- See the implementation of `setPortfolioOf` and `applyTx` for more details.
+--
+-- @
+-- ┌────────────────────┐           ┌────────────────────┐                     ┌────────────────────┐            ┌─────────────────────┐
+-- │                    │           │                    │                     │                    │            │                     │
+-- │                    │           │                    │       Pointer       │                    │            │                     │
+-- │                    │──────────▶│                    │ ──────deposit──────▶│                    │ ─────────▶ │                     │ ─────────▶
+-- │                    │           │                    │                     │       [0,1]        │            │       [0,1,2]       │
+-- │         []         │           │        [0]         │                     │1 ada held by key 2 │            │ 1 ada held by key 3 │
+-- │                    │           │                    │                     │                    │            │                     │
+-- │                    │           │                    │       Pointer       │                    │            │                     │
+-- │                    │◀──────────│                    │ ◀─────deposit ──────│                    │◀────────── │                     │◀──────────
+-- │                    │           │                    │       returned      │                    │            │                     │
+-- └────────────────────┘◀──┐       └────────────────────┘                     └────────────────────▲            ▲─────────────────────▲            ▲
+--                          └───┐                                                     │       ▲     └─┐         ┌┘      │       ▲      └─┐         ┌┘
+-- Normal states                └───┐                                                 │       │       └─┐     ┌─┘       │       │        └─┐     ┌─┘
+--                                  └───┐                                             │       │         └─┐ ┌─┘         │       │          └─┐ ┌─┘
+-- ╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳└───┐╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳╳│╳╳╳╳╳╳╳│╳╳╳╳╳╳╳╳╳╳╳│ │╳╳╳╳╳╳╳╳╳╳╳│╳╳╳╳╳╳╳│╳╳╳╳╳╳▶     ├─┤
+--                                          └───┐                                     │       │         ┌─┘ └─┐         │       │          ┌─┘ └─┐
+-- States caused by                             └────┐Pointer                         ▼       │       ┌─┘     └─┐       ▼       │        ┌─┘     └─┐
+-- old wallet                                        └deposit                  ┌────────────────────┐─┘         └┬─────────────────────┐─┘         └─
+-- de-registering                                     returned─┐               │                    │            │                     │
+-- stake-key 0                                                 └────┐          │                    │ ─────────▶ │                     │ ─────────▶
+-- of multi-stake                                                   └────┐     │                    │            │                     │
+-- key wallet                                                            └──── │        [1]         │            │        [1,2]        │
+--                                                                             │1 ada held by key 2 │            │ 1 ada held by key 3 │
+--                                                                             │                    │            │                     │
+--                                                                             │                    │◀────────── │                     │◀──────────
+--                                                                             │                    │            │                     │
+--                                                                             │                    │            │                     │
+--                                                                             └────────────────────┘            └─────────────────────┘
+-- @
+data DelegationState k = DelegationState
+    { -- | The account public key from which the stake keys should be derived.
+      rewardAccountKey :: k 'AccountK XPub
+    , state :: State
+    } deriving (Generic)
+
+-- | Construct the initial delegation state.
+initialDelegationState
+    :: k 'AccountK XPub
+    -> DelegationState k
+initialDelegationState accK = DelegationState accK Zero
+
+-- | The internal state, without the account key.
+--
+-- TODO: Perhaps we should model this as
+-- @S = S1 * S2, where S1 = Bool, S2 = ix * UTxOPointer@ - having two
+-- "concurrent" states tracking stake keys, where the first one is identical to
+-- legacy single-stake key wallets.
+--
+-- Maybe that would help simplify `applyTx` and `setPortfolioOf`...
+data State
+    -- | No active stake keys. The initial state of a new wallet.
+    = Zero
+
+    -- | The first stake-key (index 0) is registered and either delegating or
+    -- about to be delegating.
+    | One
+
+    -- | There is more than one active stake keys. Can only be reached using
+    -- wallets with support for multiple stake keys.
+    | More
+        !(Index 'Soft 'AddressK)
+          -- nextKeyIx - the ix of the next unused key
+        PointerUTxO
+          -- ^ pointer utxo that need to be spent when changing state.
+        !Key0Status
+    deriving (Eq, Show, Generic)
+
+instance NFData State
+
+-- | Is key 0 still registered? For compatibility with
+-- single-stake-key wallets, we need to track this.
+--
+-- >>> activeKeys (More (toEnum 3) p ValidKey0)
+-- [0, 1, 2]
+--
+-- >>> activeKeys (More (toEnum 3) p MissingKey0)
+-- [1, 2]
+--
+-- (pseudocode; requires a bit more boilerplate to compile)
+--
+-- See the implementaiton of @applyTx@ for how it is used.
+data Key0Status = ValidKey0 | MissingKey0
+    deriving (Eq, Show, Generic)
+
+instance NFData Key0Status
+
+instance (NFData (k 'AccountK XPub), NFData (k 'AddressK XPub))
+    => NFData (DelegationState k)
+
+deriving instance
+    ( Show (k 'AccountK XPub)
+    , Show (k 'AddressK XPub)
+    ) => Show (DelegationState k)
+
+deriving instance
+    ( Eq (k 'AccountK XPub)
+    , Eq (k 'AddressK XPub)
+    ) => Eq (DelegationState k)
+
+keyAtIx
+    :: (SoftDerivation k)
+    => DelegationState k
+    -> Index 'Soft 'AddressK
+    -> k 'AddressK XPub
+keyAtIx s = deriveAddressPublicKey (rewardAccountKey s) MutableAccount
+
+nextKeyIx
+    :: DelegationState k
+    -> Index 'Soft 'AddressK
+nextKeyIx s = case state s of
+    Zero -> minBound
+    One -> succ minBound
+    More ix _ _ -> ix
+
+lastActiveIx
+    :: DelegationState k
+    -> Maybe (Index 'Soft 'AddressK)
+lastActiveIx s
+    | nextKeyIx s == minBound = Nothing
+    | otherwise               = Just $ pred $ nextKeyIx s
+
+data PointerUTxO = PointerUTxO { pTxIn :: TxIn, pCoin :: Coin }
+    deriving (Generic, Eq, Show)
+    deriving anyclass NFData
+
+-- | Returns the index corresponding to the payment key the `PointerUTxO`
+-- should be locked with for a portfolio of a given size @n@.
+--
+-- In our current implementation we require the `PointerUTxO` to be created in
+-- the @[0] -> [0,1] transition@, i.e. @nextKeyIx 1 -> nextKeyIx 2@.
+pointerIx
+    :: Int
+    -> Maybe (Index 'Soft 'AddressK)
+pointerIx 0 = Nothing
+pointerIx 1 = Nothing
+pointerIx n = Just $ toEnum n
+
+-- | Retrieve the `PointerUTxO` from a `DelegationState` if it has one.
+pointer :: DelegationState k -> Maybe PointerUTxO
+pointer (DelegationState _ (More _ p _)) = Just p
+pointer _ = Nothing
+
+--------------------------------------------------------------------------------
+-- Chain
+--------------------------------------------------------------------------------
+
+-- | A transaction type specific to `DelegationState`.
+--
+-- Intented to be converted both from and to a more real transaction type.
+--
+-- When constructing a real transaction from `Tx`, these `outputs`
+-- should appear before other outputs. In the theoretical event that there's
+-- also a user-specified output with the same payment key as the pointer output,
+-- `applyTx` will track the first one as the new pointer.
+data Tx = Tx
+    { certs :: [Cert]
+    , inputs :: [(TxIn, Coin)]
+    , outputs :: [TxOut]
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet Tx)
+
+instance Semigroup Tx where
+    (Tx cs1 is1 os1) <> (Tx cs2 is2 os2) =
+        Tx (cs1 <> cs2) (is1 <> is2) (os1 <> os2)
+
+data Cert
+    = RegisterKey RewardAccount
+    | Delegate RewardAccount
+      -- ^ Which pool we're delegating to is here (and for now) irrelevant.
+      -- The main thing is that there exists a witness on-chain for this stake
+      -- key (registration certs don't require witnesses)
+      --
+      -- TODO: We may also want to add the PoolId here.
+    | DeRegisterKey RewardAccount
+    deriving (Eq, Show, Generic)
+
+-- | Given a `DelegationState`, produce a `Tx` registering or de-registering
+-- stake-keys, in order to have @n@ stake-keys.
+--
+-- E.g. @setPortfolioOf s0 _ _ 2@ creates a tx which after application causes
+-- the state to have @activeKeys == [0,1]@
+--
+-- Returns @Nothing@ if the target @n@ is already reached.
+setPortfolioOf
+    :: (SoftDerivation k, ToRewardAccount k)
+    => DelegationState k
+    -> Coin
+        -- ^ minUTxOVal
+    -> (k 'AddressK XPub -> Address)
+        -- ^ A way to construct an Address
+    -> (RewardAccount -> Bool)
+        -- ^ Whether or not the key is registered.
+        --
+        -- TODO: Need a Set or Map for the real implementation with LSQ.
+    -> Int
+        -- ^ Target number of stake keys.
+    -> Maybe Tx
+setPortfolioOf ds minUTxOVal mkAddress isReg n =
+    repairKey0IfNeededTx <> changeStateTx
+  where
+    -- The `changeStateTx` calculation assumes that key 0 is registered. If it
+    -- is not, we fix it here.
+    --
+    -- At some point we will need to take a `Set PoolId` instead of `n`. If
+    -- we're in the state of key 1 and 2 delegating to pools B and C
+    -- respectively, we likely want:
+    -- - `setPortfolio [A,B,C]` to delegate key 0 to A, instead of key 3.
+    -- - `setPortfolio [B,C]` to replace key 2 with key 0
+    repairKey0IfNeededTx :: Maybe Tx
+    repairKey0IfNeededTx = case repairKey0 $ state ds of
+        [] -> Nothing
+        cs -> Just $ Tx cs [] []
+      where
+        repairKey0 (More _ _ MissingKey0) | n > 0 = deleg [minBound]
+        repairKey0 _ = []
+
+    changeStateTx :: Maybe Tx
+    changeStateTx = txWithCerts $ case compare (toEnum n) (nextKeyIx ds) of
+        GT -> deleg [nextKeyIx ds .. toEnum (n - 1)]
+        EQ -> []
+        LT -> dereg $ reverse [toEnum n .. (pred $ nextKeyIx ds)]
+
+      where
+        txWithCerts [] = Nothing
+        txWithCerts cs = Just $ Tx
+            { certs = cs
+            , inputs = maybeToList (mkTxIn <$> pointer ds)
+            , outputs = maybeToList $
+                -- Note that this is the only place where we move the pointer.
+                -- I.e. repairKey0IfNeededTx won't do it on its own.
+                (\i -> TxOut
+                    (mkAddress $ keyAtIx ds i)
+                    (TB.fromCoin minUTxOVal)
+                ) <$> pointerIx n
+            }
+          where
+            mkTxIn (PointerUTxO txIx coin) = (txIx, coin)
+            -- Note: If c > minUTxOVal we need to rely on the wallet to return the
+            -- difference to the user as change.
+
+    deleg :: [Index 'Soft 'AddressK] -> [Cert]
+    deleg = (>>= \ix ->
+        if isReg (acct ix)
+        then [Delegate (acct ix)]
+        else [RegisterKey (acct ix),  Delegate (acct ix)]
+        )
+
+
+    dereg :: [Index 'Soft 'AddressK] -> [Cert]
+    dereg ixs =
+        [ DeRegisterKey (acct ix)
+        | ix <- ixs
+        , isReg . acct $ ix
+        -- We need to /at least/ check @isReg (key 0)@, because the user could
+        -- have deregistered it using old wallet software.
+        ]
+
+    acct = toRewardAccount . keyAtIx ds
+
+-- | Apply a `Tx` to a `DelegationState`.
+--
+-- Expects the @PointerUTxO@ to be correctly managed, and will panic otherwise.
+applyTx
+    :: forall k. ( SoftDerivation k
+        , ToRewardAccount k
+        , MkKeyFingerprint k Address
+        , MkKeyFingerprint k (k 'AddressK XPub))
+    => Tx
+    -> Hash "Tx"
+    -> DelegationState k
+    -> DelegationState k
+applyTx (Tx cs _ins outs) h ds0 = foldl applyCert ds0 cs
+  where
+    applyCert ds cert = flip modifyState ds $ case cert of
+            RegisterKey _                   -> id
+            Delegate k
+               | k == nextKey ds            -> inc
+               | otherwise                  -> modifyKey0 cert
+            DeRegisterKey k
+               | Just k == lastActiveKey ds -> dec
+               | otherwise                  -> modifyKey0 cert
+      where
+        inc s = case s of
+            Zero -> One
+            One -> More (toEnum 2) (findOut $ toEnum 2) ValidKey0
+            More ix _ is0Reg -> let ix' = succ ix in More ix' (findOut ix') is0Reg
+        dec s = case s of
+            Zero -> error "impossible: can't decrement beyond zero"
+            One -> Zero
+            More ix _ is0Reg
+                | fromEnum ix > 2 -> let ix' = pred ix in More ix' (findOut ix') is0Reg
+                | otherwise -> case is0Reg of
+                    ValidKey0   -> One
+                    MissingKey0 -> Zero
+
+        findOut ix = case map mkPointer pointerOuts of
+            (x:_) -> x
+            _     -> error $ mconcat
+                [ "couldn't find pointer output for ix "
+                , show ix
+                , " with state "
+                , show $ state ds
+                ]
+          where
+            isOurOut (TxOut addr _b) =
+                case (paymentKeyFingerprint @k $ keyAtIx ds ix, paymentKeyFingerprint addr) of
+                (Right fp, Right fp')
+                    | fp == fp' -> True
+                    | otherwise -> False
+                _ -> False
+            mkPointer (txIx, TxOut _ tb) = PointerUTxO (TxIn h txIx) (TB.getCoin tb)
+            pointerOuts = filter (isOurOut . snd) $ zip [0..] outs
+
+    modifyState
+        :: (State -> State)
+        -> DelegationState k
+        -> DelegationState k
+    modifyState f s = s { state = f (state s) }
+
+    -- | Modifies the "isKey0Reg" of the `More` constructor.
+    modifyKey0 cert s@(More i p _) = case cert of
+        Delegate k
+            | k == acct 0 -> More i p ValidKey0
+            | otherwise   -> s
+        DeRegisterKey k
+            | k == acct 0 -> More i p MissingKey0
+            | otherwise   -> s
+        _                 -> s
+      where
+        acct = toRewardAccount . keyAtIx ds0 . toEnum
+    modifyKey0 _ s = s
+
+    lastActiveKey ds' = toRewardAccount . keyAtIx ds' <$> lastActiveIx ds'
+    nextKey ds' = toRewardAccount . keyAtIx ds' $ nextKeyIx ds'
+
+--------------------------------------------------------------------------------
+-- Operations
+--------------------------------------------------------------------------------
+
+-- | All stake keys worth listing to the user.
+--
+-- May include:
+-- 1. Active stake keys
+-- 2. The next un-active key
+--
+-- NOTE: In theory we might want also present stake keys that are unexpectedly
+-- registered, as they could be de-registered to reclaim the deposit, but this
+-- should in-practice never happen.
+--
+-- If @sn@ denotes the state with @n@ registered and delegating keys:
+-- >>> presentableKeys s0
+-- [0]
+-- >>> presentableKeys s1
+-- [0, 1]
+-- >>> presentableKeys s2
+-- [0, 1, 2]
+presentableKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+presentableKeys s = case lastActiveIx s of
+    Just i -> map (keyAtIx s) [minBound .. (succ i)]
+    Nothing -> [keyAtIx s minBound]
+
+-- Keys meant to be used in addresses.
+--
+-- If @sn@ denotes the state with @n@ registered and delegating keys:
+-- >>> usableKeys s0
+-- [0]
+-- >>> usableKeys s1
+-- [0]
+-- >>> usableKeys s2
+-- [0, 1]
+--
+-- Note that for @s0@, we have no active stake keys, but we still want to use
+-- key 0 as part of addresses.
+--
+-- Also note that old wallet software may unregister the first stake key 0
+-- despite stake key 1 being active. This doesn't affect `usableKeys`
+-- (it still includes key 0), as we view the state as incorrect and temporary.
+usableKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+usableKeys s = case lastActiveIx s of
+    Just i -> map (keyAtIx s) [minBound .. i]
+    Nothing -> [keyAtIx s minBound]
+
+-- | For testing. Returns all registered and delegating stake keys.
+activeKeys :: SoftDerivation k => DelegationState k -> [k 'AddressK XPub]
+activeKeys ds = map (keyAtIx ds) $ case state ds of
+    Zero                      -> []
+    One                       -> [minBound]
+    More nextIx _ ValidKey0   -> [minBound .. pred nextIx]
+    More nextIx _ MissingKey0 -> [succ minBound .. pred nextIx]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -26,13 +27,16 @@ import Fmt
     ( Buildable (..) )
 import GHC.Generics
     ( Generic )
+import Quiet
+    ( Quiet (..) )
 
 -- | A reward account is used in group-type addresses for delegation.
 --
 -- It is the public key of the account address.
 --
 newtype RewardAccount = RewardAccount { unRewardAccount :: ByteString }
-    deriving (Generic, Show, Eq, Ord)
+    deriving (Generic, Eq, Ord)
+    deriving Show via (Quiet RewardAccount)
 
 instance NFData RewardAccount
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Delegation/StateSpec.hs
@@ -1,0 +1,560 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Wallet.Primitive.Delegation.StateSpec where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPub )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (..)
+    , DerivationType (..)
+    , HardDerivation (..)
+    , KeyFingerprint (..)
+    , MkKeyFingerprint (..)
+    , MkKeyFingerprint
+    , NetworkDiscriminant (..)
+    , PaymentAddress (..)
+    , RewardAccount (..)
+    , RewardAccount
+    , SoftDerivation (..)
+    , ToRewardAccount (..)
+    )
+import Cardano.Wallet.Primitive.Delegation.State
+    ( Cert (..)
+    , DelegationState (..)
+    , Key0Status (..)
+    , PointerUTxO (..)
+    , State (..)
+    , Tx (..)
+    , activeKeys
+    , applyTx
+    , initialDelegationState
+    , keyAtIx
+    , presentableKeys
+    , setPortfolioOf
+    , usableKeys
+    )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn (..), TxOut (..) )
+import Control.Arrow
+    ( first )
+import Crypto.Hash.Utils
+    ( blake2b224 )
+import Data.Map
+    ( Map )
+import Data.Set
+    ( Set )
+import Fmt
+    ( Buildable (..)
+    , Builder
+    , blockListF
+    , blockListF'
+    , blockMapF
+    , fmt
+    , listF
+    , listF'
+    , mapF'
+    , pretty
+    )
+import GHC.Generics
+    ( Generic )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , NonNegative (..)
+    , Property
+    , conjoin
+    , counterexample
+    , forAllShow
+    , frequency
+    , genericShrink
+    , property
+    , sublistOf
+    , withMaxSuccess
+    , (.&&.)
+    , (===)
+    )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+
+spec :: Spec
+spec = do
+    describe "Goldens" $ do
+        let acc = toRewardAccount @StakeKey' . toEnum
+        let regAndDeleg i = applyTx (Tx
+                [ RegisterKey $ acc i
+                , Delegate $ acc i
+                ] [] []) (error "hash not needed")
+
+        let s0 = initialDelegationState accK
+        describe "initialDelegationState" $ do
+            it "presentableKeys is [0]" $ do
+                (presentableKeys s0) `shouldBe` [toEnum 0]
+            it "usableKeys is [0]" $ do
+                usableKeys s0 `shouldBe` [toEnum 0]
+
+        let s1 = regAndDeleg 0 s0
+        describe "registering and delegating key 0" $ do
+            it "presentableKeys == [0, 1]" $ do
+                (presentableKeys s1) `shouldBe` [toEnum 0, toEnum 1]
+            it "usableKeys is still [0]" $ do
+                usableKeys s1 `shouldBe` [toEnum 0]
+
+        let s2 = regAndDeleg 1 s1
+        describe "registering and delegating key 1" $ do
+            it "presentableKeys == [0, 1, 2]" $ do
+                (presentableKeys s2) `shouldBe` [toEnum 0, toEnum 1, toEnum 2]
+            it "usableKeys == [0, 1]" $ do
+                usableKeys s2 `shouldBe` [toEnum 0, toEnum 1]
+
+        let s3 = regAndDeleg 5 s2
+        describe "Impossible gaps in stake keys (shouldn't happen unless\
+            \ someone manually constructs txs to mess with the on-chain state)" $ do
+            it "presentableKeys == [0, 1, 2] (doesn't find 5)" $ do
+                (presentableKeys s3) `shouldBe`
+                    [toEnum 0, toEnum 1, toEnum 2]
+            it "usableKeys == [0, 1]" $ do
+                usableKeys s3 `shouldBe` [toEnum 0, toEnum 1]
+
+    it "(usableKeys s) are consecutive" $ property
+        $ prop_keysConsecutive usableKeys
+
+    it "(presentableKeys s) are consecutive" $ property
+        $ prop_keysConsecutive presentableKeys
+
+    it "(activeKeys s) are consecutive" $ property $
+        prop_keysConsecutive activeKeys
+
+    it "pointer is only created and destroyed in specific cases" $ property
+        prop_pointerRules
+
+    it "adversaries can't affect usableKeys" $ property
+        prop_usableKeysAdversaries
+
+    it "adversaries can't affect pointer ix" $ property
+        prop_pointerAdversaries
+
+    it "(apply (cmds <> CmdSetPortfolioOf 0) s0) === s0" $ property
+        prop_canAlwaysGoTo0
+
+    it "no rejected txs, normally" $ property
+        prop_noRejectedTxs
+
+    -- Lots of weird things can happen when we concider concurrent user-actions
+    -- on multiple wallet versions and rollbacks.
+    --
+    -- Whatever happens, we should be able to recover using a single
+    -- @CmdSetPortfolioOf n@, and be concistent with the ledger.
+    it "can recover from dropped transactions" $ withMaxSuccess 2000
+        prop_rollbacks
+
+--
+-- Properties
+--
+
+prop_keysConsecutive :: (DelegationState StakeKey' -> [StakeKey]) -> [Cmd] -> Property
+prop_keysConsecutive f cmds = do
+    let env = applyCmds env0 cmds
+    let keys = map fromEnum $ f $ wallet env
+    counterexample (pretty $ ledger env) $
+        isConsecutiveRange keys
+
+-- | PointerUTxO should only be created/destroyed in very specific cases.
+prop_pointerRules :: [Cmd] -> Property
+prop_pointerRules cmds = do
+    let env = applyCmds env0 cmds
+    forAllTxs env $ \case
+        Tx [] []    [_o] -> True -- Not the actual pointer
+        Tx cs []    [_o] -> Delegate (acct 1) `elem` cs
+        Tx cs [_i]  []   -> DeRegisterKey (acct 1) `elem` cs
+        Tx cs [_i]  [_o] -> any ((> 1) . ixFromCert) cs
+        Tx cs []    []   -> all ((< 1) . ixFromCert) $ filter notReg cs
+        _                -> False
+  where
+
+    ixFromCert :: Cert -> Int
+    ixFromCert (DeRegisterKey a) = read . B8.unpack . unRewardAccount $ a
+    ixFromCert (RegisterKey a) = read . B8.unpack . unRewardAccount $ a
+    ixFromCert (Delegate a) = read . B8.unpack . unRewardAccount $ a
+
+    -- For filtering away registrations from CmdAdversarialReg
+    notReg :: Cert -> Bool
+    notReg (RegisterKey _) = False
+    notReg _ = True
+
+    acct = toRewardAccount . StakeKey'
+
+    forAllTxs e prop = conjoin . flip map (txs e)
+        $ \tx -> counterexample (pretty tx) $ prop tx
+
+-- | Tests that `isAdversarial` commands have no effect on the usableKeys of the
+-- state.
+prop_usableKeysAdversaries :: [Cmd] -> Property
+prop_usableKeysAdversaries cmds = do
+    counterexample "\nstate /= state without adversarial cmds" $ do
+        let usableKeys' = usableKeys . wallet . applyCmds env0
+        usableKeys' cmds
+            === usableKeys' (filter (not . isAdversarial) cmds)
+
+-- | Tests that `isAdversarial` commands have no effect on the `PointerUTxO`.
+prop_pointerAdversaries :: NonNegative Int -> [RewardAccount] -> Property
+prop_pointerAdversaries (NonNegative n) keys = do
+    let env = applyCmds env0 [CmdSetPortfolioOf n]
+    let env' = applyCmds env (map CmdMimicPointerOutput keys)
+    state (wallet env') === state (wallet env)
+
+-- | CmdSetPortfolioOf 0 returns us to the initial state.
+prop_canAlwaysGoTo0 :: [Cmd] -> Property
+prop_canAlwaysGoTo0 cmds = do
+    let env = applyCmds env0 (cmds ++ [CmdSetPortfolioOf 0])
+    counterexample (pretty env) $
+        wallet env === wallet env0
+
+prop_noRejectedTxs :: [Cmd] -> Property
+prop_noRejectedTxs cmds = do
+    let env = applyCmds env0 cmds
+    counterexample (pretty env) $
+        rejectedTxs env === []
+
+-- | Rollbacks don't get us into an inconsistent or irrecoverable state.
+prop_rollbacks :: NonNegative Int -> [Cmd] -> Property
+prop_rollbacks (NonNegative n) cmds = do
+    forAllSubchains (applyCmds env0 cmds) $ \env' -> do
+        let env = applyCmds env' [CmdSetPortfolioOf n]
+
+        let isSubsetOf a b = counterexample (show a <> " ⊄ " <> show b)
+                $ a `Set.isSubsetOf` b
+
+        let allActiveKeysRegistered e =
+                Set.map toRewardAccount (Set.fromList (activeKeys $ wallet e))
+                    `isSubsetOf` regs (ledger e)
+
+        counterexample (pretty env) $
+            length (activeKeys $ wallet env) === n
+                .&&. allActiveKeysRegistered env
+--
+-- Helpers
+--
+
+-- | Take an arbitrary subset of the txs of an @Env@ to generate a new @Env@.
+--
+-- NOTE: Can drop txs, but not reorder them.
+forAllSubchains :: Env -> (Env -> Property) -> Property
+forAllSubchains env prop =  do
+    forAllShow (sublistOf (reverse $ txs env)) (fmt . blockListF) $ \subchain ->  do
+        counterexample ("Txs before dropping some:\n" <> (fmt . blockListF $ reverse $ txs env)) $
+            prop $ applyTxs env0 subchain
+
+accK :: StakeKey' 'AccountK XPub
+accK = StakeKey' 0
+
+isConsecutiveRange :: (Eq a, Num a) => [a] -> Bool
+isConsecutiveRange [_] = True
+isConsecutiveRange [] = True
+isConsecutiveRange (a:b:t)
+    | b == a + 1 = isConsecutiveRange (b:t)
+    | otherwise  = False
+
+
+--
+-- Mock Stake Keys
+--
+
+-- | Mock key type for testing.
+--
+-- FIXME: We should do /some/ testing with @ShelleyKey@ though.
+newtype StakeKey' (depth :: Depth) key = StakeKey' Word
+    deriving newtype (Eq, Enum, Ord, Show, Bounded)
+
+type StakeKey = StakeKey' 'AddressK XPub
+
+instance ToRewardAccount StakeKey' where
+    toRewardAccount (StakeKey' i) = RewardAccount . B8.pack $ show i
+    someRewardAccount = error "someRewardAccount: not implemented"
+
+instance HardDerivation StakeKey' where
+    type AddressIndexDerivationType StakeKey' = 'Soft
+    deriveAccountPrivateKey _ _ _ =
+        error "deriveAccountPrivateKey: not implemented"
+    deriveAddressPrivateKey _ _ _ _ =
+        error "deriveAddressPrivateKey not implemented"
+
+instance SoftDerivation StakeKey' where
+    deriveAddressPublicKey _acc _role i = StakeKey' $ toEnum $ fromEnum i
+
+instance MkKeyFingerprint StakeKey' Address where
+    paymentKeyFingerprint (Address addr) = Right $ KeyFingerprint $ B8.drop 4 addr
+
+instance PaymentAddress 'Mainnet StakeKey' where
+    liftPaymentAddress (KeyFingerprint fp) = Address fp
+    paymentAddress k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
+
+instance MkKeyFingerprint StakeKey' (StakeKey' 'AddressK XPub) where
+    paymentKeyFingerprint k =
+        Right $ KeyFingerprint $ unRewardAccount (toRewardAccount k)
+
+--
+-- Mock chain of delegation certificates
+--
+
+instance Arbitrary RewardAccount where
+    arbitrary = toRewardAccount @StakeKey' <$> arbitrary
+
+instance Arbitrary Cert where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
+
+instance Arbitrary (StakeKey' depth key) where
+    arbitrary = StakeKey' <$> arbitrary
+
+--
+-- Mock chain data
+--
+
+data Cmd
+    = CmdSetPortfolioOf Int
+    -- ^ Calls @setPortfolioOf@ which registers or de-registers keys to reach
+    -- the new target.
+    --
+    -- If the target is already met, the command has no effect.
+    --
+    -- Delegation certificates are /not/ generated for existing keys.
+    --
+    -- TODO: Also test arbitrary re-delegations.
+    | CmdOldWalletToggleFirstKey
+
+      -- ^ A wallet implementation without multi-stake-key support could decide
+      -- to either
+      -- 1. register stake-key 0 witout adding a pointer UTxO
+      -- 2. de-register stake-key 0 despite despite e.g. key 1 being active
+      -- depending on whether it is registered or not.
+      --
+      -- Having a "toggle"-command instead of two separate commands, makes
+      -- generating valid arbitrary values easier.
+    | CmdAdversarialReg RewardAccount
+      -- ^ Someone could pay 2 ada to (re-)register your stake key. Your wallet
+      -- shouldn't be affected negatively from it.
+    | CmdMimicPointerOutput RewardAccount
+      -- ^ Someone could send funds to the same UTxO
+    deriving (Generic, Eq)
+
+isAdversarial :: Cmd -> Bool
+isAdversarial (CmdSetPortfolioOf _) = False
+isAdversarial (CmdAdversarialReg _) = True
+isAdversarial CmdOldWalletToggleFirstKey = False
+isAdversarial (CmdMimicPointerOutput _) = True
+
+instance Show Cmd where
+    show (CmdSetPortfolioOf n) = "CmdSetPortfolioOf " <> show n
+    show (CmdAdversarialReg (RewardAccount a)) = "CmdAdversarialReg " <> B8.unpack a
+    show CmdOldWalletToggleFirstKey = "CmdOldWalletToggleFirstKey"
+    show (CmdMimicPointerOutput (RewardAccount a)) = "CmdMimicPointerOutput " <> B8.unpack a
+
+instance Buildable Tx where
+    build (Tx cs [] []) = "Tx " <> listF cs
+    build (Tx cs ins outs) = "Tx " <> listF cs <> " " <> listF' (inF . fst) ins <> " -> " <> listF' outF outs
+
+inF :: TxIn -> Builder
+inF (TxIn h ix) = build h <> "." <> build (fromEnum ix)
+
+outF :: TxOut -> Builder
+outF (TxOut (Address addr) _tb) = build $ B8.unpack addr
+
+instance Buildable (DelegationState StakeKey') where
+    build ds = case state ds of
+        Zero -> "Zero"
+        One -> "One"
+        More ix p is0Reg -> blockMapF
+            [ ("nextKeyIx" :: String, build $ fromEnum ix)
+            , ("pointer", build p)
+            , ("key0", key0F is0Reg)
+            ]
+      where
+        key0F MissingKey0 = "missing"
+        key0F ValidKey0 = "there"
+
+instance Buildable PointerUTxO where
+    build (PointerUTxO i _c) = "PointerUTxO " <> inF i
+
+instance Buildable Env where
+    build env = "Env:\n" <> blockMapF
+        [ ("wallet" :: String, build $ wallet env)
+        , ("txs", blockListF' "-" txF $ reverse $ txs env)
+        , ("rejected txs", blockListF' "-" build $ reverse $ rejectedTxs env)
+        , ("ledger", build $ ledger env)
+        ]
+      where
+        txF tx = build (txid tx) <> ": " <> build tx
+
+
+rewardAccountF :: RewardAccount -> Builder
+rewardAccountF (RewardAccount a) = build (B8.unpack a)
+
+
+instance Buildable Cert where
+    build (RegisterKey k) = "RegKey " <> rewardAccountF k
+    build (Delegate k) = "Deleg " <> rewardAccountF k
+    build (DeRegisterKey k) = "DeReg " <> rewardAccountF k
+
+instance Arbitrary Cmd where
+    -- We don't want to generate too many adversarial registrations (we don't
+    -- expect them to happen in reality), but at least some, and enough to cause
+    -- consistent failures if something is wrong.
+    arbitrary = frequency
+        [ (80, CmdSetPortfolioOf . getNonNegative <$> arbitrary)
+        , (5, CmdAdversarialReg <$> arbitrary)
+        , (10, pure CmdOldWalletToggleFirstKey)
+        , (5, CmdMimicPointerOutput <$> arbitrary)
+        ]
+    shrink = genericShrink
+
+data Env = Env
+    { wallet :: DelegationState StakeKey'
+    , ledger :: Ledger
+    , txs :: [Tx]
+        -- ^ All accepted transactions so far in the chain. Newest first.
+    , rejectedTxs :: [String]
+        -- ^ User-generated txs that were rejected. I.e. not adversarial ones.
+        -- Newest first.
+    } deriving (Show, Eq)
+
+env0 :: Env
+env0 = Env (initialDelegationState accK) initialLedger [] []
+
+stepCmd :: Cmd -> Env -> Env
+stepCmd (CmdSetPortfolioOf n) env =
+    case setPortfolioOf (wallet env) minUTxOVal mkAddr (acctIsReg (ledger env)) n of
+        Just tx -> tryApplyTx tx env
+        Nothing -> env
+  where
+    mkAddr k = Address $ "addr" <> unRewardAccount (toRewardAccount k)
+    minUTxOVal = Coin 1
+
+stepCmd (CmdAdversarialReg k) env
+    | k `Set.member` regs (ledger env)
+        = env -- We don't want tx errors to appear in @rejectedTxs@.
+    | otherwise
+        = tryApplyTx (Tx [RegisterKey k] [] []) env
+stepCmd CmdOldWalletToggleFirstKey env =
+            let
+                key0 = toRewardAccount (keyAtIx (wallet env) minBound)
+                isReg =  key0 `Set.member` (regs (ledger env))
+                tx = Tx [if isReg then DeRegisterKey key0 else RegisterKey key0] [] []
+            in tryApplyTx tx env
+stepCmd (CmdMimicPointerOutput (RewardAccount acc)) env =
+            let
+                addr = liftPaymentAddress @'Mainnet @StakeKey' $ KeyFingerprint acc
+                c = Coin 1
+                out = TxOut addr (TB.fromCoin c)
+                tx = Tx [] [] [out]
+            in tryApplyTx tx env
+
+tryApplyTx :: Tx -> Env -> Env
+tryApplyTx tx env = case ledgerApplyTx tx h (ledger env) of
+    Right l' -> env
+        { ledger = l'
+        , wallet = applyTx tx (txid tx) $ wallet env
+        , txs = tx : txs env
+        }
+    Left e -> env { rejectedTxs = e : rejectedTxs env }
+  where
+    h = txid tx
+
+
+applyCmds :: Env -> [Cmd] -> Env
+applyCmds = foldl (flip stepCmd)
+
+applyTxs :: Env -> [Tx] -> Env
+applyTxs = foldl (flip tryApplyTx)
+
+txid :: Tx -> Hash "Tx"
+txid = Hash . BS.take 4 . blake2b224 . B8.pack . show
+
+
+--
+-- Mock ledger
+--
+
+data Ledger = Ledger
+    { regs :: Set RewardAccount
+    , utxo :: Map TxIn TxOut
+    } deriving (Show, Eq)
+
+instance Buildable Ledger where
+    build l = blockMapF
+        [ ("regs" :: String, listF' rewardAccountF (regs l))
+        , ("utxo", mapF' inF outF (utxo l))
+        ]
+
+initialLedger :: Ledger
+initialLedger = Ledger Set.empty Map.empty
+
+acctIsReg :: Ledger -> RewardAccount -> Bool
+acctIsReg l a = a `Set.member` (regs l)
+
+ledgerApplyTx :: Tx -> (Hash "Tx") -> Ledger -> Either String Ledger
+ledgerApplyTx tx h l' =
+        (foldl (\x y -> x >>= ledgerApplyCert y) (Right l') (certs tx))
+        -- Can be commented out to see the effects of no pointer UTxO on
+        -- the tests:
+            >>= ledgerApplyInsOus
+
+  where
+    ledgerApplyInsOus :: Ledger -> Either String Ledger
+    ledgerApplyInsOus (Ledger r u) =
+        let
+            -- TODO: There could be duplicates, which we should forbid
+            ins = Set.fromList $ map fst $ inputs tx
+            newOuts = Map.fromList $
+                zipWith
+                    (curry $ first (TxIn h))
+                    [0 ..]
+                    (outputs tx)
+
+            canSpend = ins `Set.isSubsetOf` Map.keysSet u
+
+        in
+            if canSpend
+            then Right $ Ledger r $ Map.union newOuts $ u `Map.withoutKeys` ins
+            else Left $ "invalid utxo spending in tx: " <> pretty tx
+
+    ledgerApplyCert :: Cert -> Ledger -> Either String Ledger
+    ledgerApplyCert (Delegate k) l
+        | k `Set.member` (regs l)
+            = pure l
+        | otherwise
+            = Left $ "Can't delegate: " <> show k <> " not in " <> show l
+    ledgerApplyCert (RegisterKey k) l
+        | k `Set.member` (regs l)
+            = Left $ "Can't register: " <> show k <> " already in: " <> show l
+        | otherwise
+            = pure $ l { regs = Set.insert k (regs l) }
+    ledgerApplyCert (DeRegisterKey k) l
+        | k `Set.member` (regs l)
+            = pure $ l { regs = Set.delete k (regs l) }
+        | otherwise
+            = Left $ "Can't deregister: " <> show k <> " not in " <> show l

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -177,6 +177,7 @@
             (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
             (hsPkgs."quickcheck-state-machine" or (errorHandler.buildDepError "quickcheck-state-machine"))
+            (hsPkgs."quiet" or (errorHandler.buildDepError "quiet"))
             (hsPkgs."random" or (errorHandler.buildDepError "random"))
             (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
             (hsPkgs."safe" or (errorHandler.buildDepError "safe"))


### PR DESCRIPTION
# Issue Number

ADP-724


# Overview

- [x] Add concepts of
    - `usableKeys` - keys to be used as part of addresses
    - `activeKeys` - keys that are registered and delegating
    - `presentableKeys` - keys that can be displayed to the user (superset of the other two)
- [x] Some simple golden tests for understanding
- [x] Property tests using mock user-actions and chain data
- [x] Add pointer UTxO
    - [x] Add notion of mock ledger to test resistance to rollbacks
    - [x] Implement the pointer UTxO
    - [x] Ensure it works
- [x] Look to test interactions with old wallets which don't know about the pointer, nor other stake keys
    - [x] There's some failure at least
    - [x] Improve counterexample
    - [x] Fix 
- [ ] Look to test concurrent wallet-actions (might be slightly different from txs that could be dropped or re-ordered)
    - Think we're ok without it
- [ ] We need a lookup-map for delegation certificates
    - Shouldn't affect the testing, so not crucial.

# Comments

```
Goldens
  initialDelegationState
    presentableKeys is [0]
    usableKeys is [0]
  registering and delegating key 0
    presentableKeys == [0, 1]
    usableKeys is still [0]
  registering and delegating key 1
    presentableKeys == [0, 1, 2]
    usableKeys == [0, 1]
  Impossible gaps in stake keys (shouldn't happen unless someone manually constructs txs to mess with the on-chain state)
    presentableKeys == [0, 1, 2] (doesn't find 5)
    usableKeys == [0, 1]
(usableKeys s) are consequtive
  +++ OK, passed 100 tests.
(presentableKeys s) are consequtive
  +++ OK, passed 100 tests.
(activeKeys s) are consequtive
  +++ OK, passed 100 tests.
pointer is only created and destroyed in specific cases
  +++ OK, passed 100 tests.
adversaries can't affect usableKeys
  +++ OK, passed 100 tests.
adversaries can't affect pointer ix
  +++ OK, passed 100 tests.
(apply (cmds <> CmdSetPortfolioOf 0) s0) === s0
  +++ OK, passed 100 tests.
no rejected txs, normally
  +++ OK, passed 100 tests.
can recover from dropped transactions
  +++ OK, passed 2000 tests.
```

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
