### PR TITLE
Connect API with migration algorithm

### DIFF
--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -20,6 +20,10 @@ module Test.Integration.Faucet
     , mirMnemonics
     , maMnemonics
 
+    -- * Dust wallets
+    , bigDustWallet
+    , onlyDustWallet
+
     -- * Sea horses
     , seaHorseTokenName
     , seaHorsePolicyId

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -353,10 +353,8 @@ errMsg400MinWithdrawalWrong = "The minimum withdrawal value must be at least \
     \1 Lovelace."
 
 errMsg403NothingToMigrate :: Text -> String
-errMsg403NothingToMigrate wid =
-    "I can't migrate the wallet with the given id: " ++ unpack wid ++
-    ", because it's either empty or full of small coins which wouldn't be \
-    \worth migrating."
+errMsg403NothingToMigrate _wid =
+    "Nothing to migrate"
 
 errMsg404NoAsset :: String
 errMsg404NoAsset = "The requested asset is not associated with this wallet."

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -353,8 +353,13 @@ errMsg400MinWithdrawalWrong = "The minimum withdrawal value must be at least \
     \1 Lovelace."
 
 errMsg403NothingToMigrate :: Text -> String
-errMsg403NothingToMigrate _wid =
-    "Nothing to migrate"
+errMsg403NothingToMigrate _wid = mconcat
+    [ "I wasn't able to construct a migration plan. This could be "
+    , "because your wallet is empty, or it could be because the "
+    , "amount of ada in your wallet is insufficient to pay for "
+    , "any of the funds to be migrated. Try adding some ada to "
+    , "your wallet before trying again."
+    ]
 
 errMsg404NoAsset :: String
 errMsg404NoAsset = "The requested asset is not associated with this wallet."

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -490,16 +490,17 @@ spec = describe "BYRON_MIGRATIONS" $ do
                         (errMsg403NothingToMigrate (sourceWallet ^. walletId))
                     ]
 
-    it "BYRON_MIGRATE_07 - invalid payload, parser error" $ \ctx -> runResourceT $ do
-        liftIO $ pendingWith "Migration endpoints temporarily disabled."
-        sourceWallet <- emptyRandomWallet ctx
-
-        r <- request @[ApiTransaction n] ctx
-            (Link.migrateWallet @'Byron sourceWallet)
-            Default
-            (NonJson "{passphrase:,}")
-        expectResponseCode HTTP.status400 r
-        expectErrorMessage errMsg400ParseError r
+    it "BYRON_MIGRATE_07 - \
+        \Including an invalidly-formatted passphrase results in a parser error."
+        $ \ctx -> runResourceT $ do
+            sourceWallet <- emptyRandomWallet ctx
+            response <- request @[ApiTransaction n] ctx
+                (Link.migrateWallet @'Byron sourceWallet) Default
+                (NonJson "{passphrase:,}")
+            verify response
+                [ expectResponseCode HTTP.status400
+                , expectErrorMessage errMsg400ParseError
+                ]
 
     it "BYRON_MIGRATE_XX - \
         \a migration operation removes all funds from the source wallet."

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -245,7 +245,7 @@ spec = describe "BYRON_MIGRATIONS" $ do
             testAddressCycling "Icarus" fixtureIcarusWallet  3
             testAddressCycling "Icarus" fixtureIcarusWallet 10
 
-    it "BYRON_MIGRATE_02 - \
+    Hspec.it "BYRON_MIGRATE_02 - \
         \Can migrate a large wallet requiring more than one transaction."
         $ \ctx -> runResourceT @IO $ do
 
@@ -382,10 +382,10 @@ spec = describe "BYRON_MIGRATIONS" $ do
                 , expectErrorMessage (errMsg403NothingToMigrate sourceWalletId)
                 ]
 
-    it "BYRON_MIGRATE_04 - \
+    Hspec.it "BYRON_MIGRATE_04 - \
         \Actual fee for migration is identical to predicted fee."
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
-        $ \fixtureByronWallet -> runResourceT $ do
+        $ \fixtureByronWallet -> runResourceT @IO $ do
 
             let feeExpected = 334_200
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -333,6 +333,17 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 ((`shouldBe` (Just 2)) . Map.lookup 10_000_000_000_000)
             ]
 
+        -- Check that the source wallet has the expected leftover balance:
+        responseFinalSourceBalance <- request @ApiWallet ctx
+            (Link.getWallet @'Shelley sourceWallet) Default Empty
+        verify responseFinalSourceBalance
+            [ expectResponseCode HTTP.status200
+            , expectField (#balance . #available)
+                (`shouldBe` Quantity 0)
+            , expectField (#balance . #total)
+                (`shouldBe` Quantity 0)
+            ]
+
     it "SHELLEY_MIGRATE_03 - \
         \Migrating an empty wallet should fail."
         $ \ctx -> runResourceT $ do
@@ -656,9 +667,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     ]
 
             -- Check that the source wallet has a balance of zero:
-            response3 <- request @ApiWallet ctx
+            responseFinalSourceBalance <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley sourceWallet) Default Empty
-            verify response3
+            verify responseFinalSourceBalance
                 [ expectField
                     (#balance . #available)
                     (`shouldBe` Quantity 0)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -235,15 +235,16 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     error "Unable to compare plans."
 
     describe "SHELLEY_MIGRATE_01 - \
-        \after a migration operation successfully completes, the correct \
-        \amount eventually becomes available in the target wallet for arbitrary \
-        \ number of specified addresses. Balance of source wallet = 0."
+        \After a migration operation successfully completes, the correct \
+        \amounts eventually become available in the target wallet for an \
+        \arbitrary number of specified addresses, and the balance of the \
+        \source wallet is completely depleted."
         $ do
-              testAddressCycling 1
-              testAddressCycling 3
-              testAddressCycling 10
+            testAddressCycling  1
+            testAddressCycling  3
+            testAddressCycling 10
 
-    it "SHELLEY_MIGRATE_01_big_wallet - \
+    it "SHELLEY_MIGRATE_XX_big_wallet - \
         \ migrate a big wallet requiring more than one tx" $ \ctx -> runResourceT @IO $ do
         liftIO $ pendingWith "Migration endpoints temporarily disabled."
 
@@ -573,67 +574,71 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             | otherwise =
                 pure ()
 
-    testAddressCycling addrNum =
-        it ("Migration from Shelley wallet to " ++ show addrNum ++ " addresses")
-            $ \ctx -> runResourceT $ do
-            liftIO $ pendingWith "Migration endpoints temporarily disabled."
+    testAddressCycling targetAddressCount = do
+        let title = mconcat
+                [ "Migration from Shelley wallet to target address count: "
+                , show targetAddressCount
+                , "."
+                ]
+        it title $ \ctx -> runResourceT $ do
+
             -- Restore a Shelley wallet with funds, to act as a source wallet:
             sourceWallet <- fixtureWallet ctx
-            let originalBalance =
-                        view (#balance. #available . #getQuantity)
-                             sourceWallet
+            let sourceBalance =
+                    view (#balance. #available . #getQuantity) sourceWallet
 
             -- Create an empty target wallet:
             targetWallet <- emptyWallet ctx
-            addrs <- listAddresses @n ctx targetWallet
-            let addrIds =
-                    map (\(ApiTypes.ApiAddress theid _ _) -> theid) $
-                    take addrNum addrs
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds = take targetAddressCount targetAddresses <&>
+                    (\(ApiTypes.ApiAddress addrId _ _) -> addrId)
 
-            -- Calculate the expected migration fee:
-            r0 <- request @(ApiWalletMigrationPlan n) ctx
-                (Link.createMigrationPlan @'Shelley sourceWallet) Default Empty
-            verify r0
-                [ expectResponseCode HTTP.status200
+            -- Create a migration plan:
+            response0 <- request @(ApiWalletMigrationPlan n) ctx
+                (Link.createMigrationPlan @'Shelley sourceWallet) Default
+                (Json [json|{addresses: #{targetAddressIds}}|])
+            verify response0
+                [ expectResponseCode HTTP.status202
                 , expectField #totalFee (.> Quantity 0)
                 ]
-            let expectedFee = getFromResponse (#totalFee . #getQuantity) r0
+            let expectedFee =
+                    getFromResponse (#totalFee . #getQuantity) response0
 
             -- Perform a migration from the source wallet to the target wallet:
-            r1 <- request @[ApiTransaction n] ctx
+            response1 <- request @[ApiTransaction n] ctx
                 (Link.migrateWallet @'Shelley sourceWallet)
                 Default
                 (Json [json|
                     { passphrase: #{fixturePassphrase}
-                    , addresses: #{addrIds}
+                    , addresses: #{targetAddressIds}
                     }|])
-            verify r1
+            verify response1
                 [ expectResponseCode HTTP.status202
                 , expectField id (`shouldSatisfy` (not . null))
                 ]
 
-            -- Check that funds become available in the target wallet:
-            let expectedBalance = originalBalance - expectedFee
-            eventually "Wallet has expectedBalance" $ do
-                r2 <- request @ApiWallet ctx
+            -- Check that funds have become available in the target wallet:
+            let expectedTargetBalance = sourceBalance - expectedFee
+            eventually "Target wallet has expected balance." $ do
+                response2 <- request @ApiWallet ctx
                     (Link.getWallet @'Shelley targetWallet) Default Empty
-                verify r2
+                verify response2
                     [ expectField
-                            (#balance . #available)
-                            (`shouldBe` Quantity expectedBalance)
+                        (#balance . #available)
+                        (`shouldBe` Quantity expectedTargetBalance)
                     , expectField
-                            (#balance . #total)
-                            (`shouldBe` Quantity expectedBalance)
+                        (#balance . #total)
+                        (`shouldBe` Quantity expectedTargetBalance)
                     ]
 
-            -- Verify sourceWallet has balance 0
-            r3 <- request @ApiWallet ctx
+            -- Check that the source wallet has a balance of zero:
+            response3 <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley sourceWallet) Default Empty
-            verify r3
+            verify response3
                 [ expectField
-                        (#balance . #available)
-                        (`shouldBe` Quantity 0)
+                    (#balance . #available)
+                    (`shouldBe` Quantity 0)
                 , expectField
-                        (#balance . #total)
-                        (`shouldBe` Quantity 0)
+                    (#balance . #total)
+                    (`shouldBe` Quantity 0)
                 ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -211,6 +211,29 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     (errMsg403NothingToMigrate $ sourceWallet ^. walletId)
                 ]
 
+    it "SHELLEY_CREATE_MIGRATION_PLAN_05 - \
+        \Creating a plan is deterministic."
+        $ \ctx -> runResourceT $ do
+            sourceWallet <- fixtureWallet ctx
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds = targetAddresses <&>
+                    (\(ApiTypes.ApiAddress addrId _ _) -> addrId)
+            let ep = Link.createMigrationPlan @'Shelley sourceWallet
+            response1 <- request @(ApiWalletMigrationPlan n) ctx ep Default
+                (Json [json|{addresses: #{targetAddressIds}}|])
+            response2 <- request @(ApiWalletMigrationPlan n) ctx ep Default
+                (Json [json|{addresses: #{targetAddressIds}}|])
+            expectResponseCode HTTP.status202 response1
+            expectResponseCode HTTP.status202 response2
+            expectField (#selections) ((.> 0) . length) response1
+            expectField (#selections) ((.> 0) . length) response2
+            case (snd response1, snd response2) of
+                (Right plan1, Right plan2) ->
+                    plan1 `shouldBe` plan2
+                _ ->
+                    error "Unable to compare plans."
+
     describe "SHELLEY_MIGRATE_01 - \
         \after a migration operation successfully completes, the correct \
         \amount eventually becomes available in the target wallet for arbitrary \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -242,7 +242,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             testAddressCycling  3
             testAddressCycling 10
 
-    it "SHELLEY_MIGRATE_02 - \
+    Hspec.it "SHELLEY_MIGRATE_02 - \
         \Can migrate a large wallet requiring more than one transaction."
         $ \ctx -> runResourceT @IO $ do
 
@@ -362,9 +362,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectErrorMessage (errMsg403NothingToMigrate sourceWalletId)
                 ]
 
-    it "SHELLEY_MIGRATE_04 - \
+    Hspec.it "SHELLEY_MIGRATE_04 - \
         \Actual fee for migration is identical to predicted fee."
-        $ \ctx -> runResourceT $ do
+        $ \ctx -> runResourceT @IO $ do
 
             let feeExpected = 255_200
 

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -17,7 +17,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- |
 -- Copyright: © 2018-2020 IOHK
@@ -1844,12 +1843,13 @@ createMigrationPlan ctx wid rewardWithdrawal = do
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
 
+type SelectionResultWithoutChange = SelectionResult Void
+
 migrationPlanToSelectionWithdrawals
-    :: forall noChange. noChange ~ Void
-    => MigrationPlan
+    :: MigrationPlan
     -> Withdrawal
     -> NonEmpty Address
-    -> Maybe (NonEmpty (SelectionResult noChange, Withdrawal))
+    -> Maybe (NonEmpty (SelectionResultWithoutChange, Withdrawal))
 migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
     = NE.nonEmpty
     $ fst
@@ -1860,8 +1860,8 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
   where
     accumulate
         :: Migration.Selection (TxIn, TxOut)
-        -> ([(SelectionResult noChange, Withdrawal)], [Address])
-        -> ([(SelectionResult noChange, Withdrawal)], [Address])
+        -> ([(SelectionResultWithoutChange, Withdrawal)], [Address])
+        -> ([(SelectionResultWithoutChange, Withdrawal)], [Address])
     accumulate migrationSelection (selectionWithdrawals, outputAddresses) =
         ( (selection, withdrawal) : selectionWithdrawals
         , outputAddressesRemaining

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1849,9 +1849,10 @@ migrationPlanToSelectionWithdrawals
     => MigrationPlan
     -> Withdrawal
     -> NonEmpty Address
-    -> [(SelectionResult noChange, Withdrawal)]
+    -> Maybe (NonEmpty (SelectionResult noChange, Withdrawal))
 migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
-    = fst
+    = NE.nonEmpty
+    $ fst
     $ L.foldr
         (accumulate)
         ([], NE.toList $ NE.cycle outputAddressesToCycle)

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -232,6 +232,8 @@ import Data.Generics.Product.Typed
     ( HasType, typed )
 import Data.Kind
     ( Type )
+import Data.List.NonEmpty
+    ( NonEmpty )
 import GHC.Generics
     ( Generic )
 import Servant.API
@@ -519,7 +521,7 @@ type MigrateShelleyWallet n = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "migrations"
     :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "raw")
-    :> PostAccepted '[JSON] [ApiTransactionT n]
+    :> PostAccepted '[JSON] (NonEmpty (ApiTransactionT n))
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/createShelleyWalletMigrationPlan
 type CreateShelleyWalletMigrationPlan n = "wallets"
@@ -803,7 +805,7 @@ type MigrateByronWallet n = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "migrations"
     :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "lenient")
-    :> PostAccepted '[JSON] [ApiTransactionT n]
+    :> PostAccepted '[JSON] (NonEmpty (ApiTransactionT n))
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/createByronWalletMigrationPlan
 type CreateByronWalletMigrationPlan n = "byron-wallets"

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2064,17 +2064,17 @@ mkApiWalletMigrationPlan
     -> Withdrawal
     -> MigrationPlan
     -> Maybe (ApiWalletMigrationPlan n)
-mkApiWalletMigrationPlan s addresses rewardWithdrawal plan
-    | Just selections <- maybeSelections =
-        Just ApiWalletMigrationPlan
-            { selections
-            , totalFee
-            , balanceLeftover
-            , balanceSelected
-            }
-    | otherwise =
-        Nothing
+mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
+    mkApiPlan <$> maybeSelections
   where
+    mkApiPlan :: NonEmpty (ApiCoinSelection n) -> ApiWalletMigrationPlan n
+    mkApiPlan selections = ApiWalletMigrationPlan
+        { selections
+        , totalFee
+        , balanceLeftover
+        , balanceSelected
+        }
+
     maybeSelections :: Maybe (NonEmpty (ApiCoinSelection n))
     maybeSelections = fmap mkApiCoinSelectionForMigration <$> maybeUnsignedTxs
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1755,8 +1755,10 @@ postTransaction ctx genChange (ApiT wid) body = do
         w <- liftHandler $ W.readWalletUTxOIndex @_ @s @k wrk wid
         sel <- liftHandler
             $ W.selectAssets @_ @s @k wrk w txCtx outs (const Prelude.id)
+        sel' <- liftHandler
+            $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.signTransaction @_ @s @k wrk wid genChange mkRwdAcct pwd txCtx sel
+            $ W.signTransaction @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
         pure (sel, tx, txMeta, txTime)
@@ -1913,8 +1915,10 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
         sel <- liftHandler
             $ W.selectAssetsNoOutputs @_ @s @k wrk wid wal txCtx
             $ const Prelude.id
+        sel' <- liftHandler
+            $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.signTransaction @_ @s @k wrk wid genChange mkRwdAcct pwd txCtx sel
+            $ W.signTransaction @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
 
@@ -1996,8 +2000,10 @@ quitStakePool ctx (ApiT wid) body = do
         sel <- liftHandler
             $ W.selectAssetsNoOutputs @_ @s @k wrk wid wal txCtx
             $ const Prelude.id
+        sel' <- liftHandler
+            $ W.assignChangeAddressesAndUpdateDb wrk wid genChange sel
         (tx, txMeta, txTime, sealedTx) <- liftHandler
-            $ W.signTransaction @_ @s @k wrk wid genChange mkRwdAcct pwd txCtx sel
+            $ W.signTransaction @_ @s @k wrk wid mkRwdAcct pwd txCtx sel'
         liftHandler
             $ W.submitTx @_ @s @k wrk wid (tx, txMeta, sealedTx)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3339,8 +3339,13 @@ instance IsServerError ErrOutputTokenQuantityExceedsLimit where
 instance IsServerError ErrCreateMigrationPlan where
     toServerError = \case
         ErrCreateMigrationPlanEmpty ->
-            -- TODO: Provide a more useful error message:
-            apiError err403 NothingToMigrate "Nothing to migrate"
+            apiError err403 NothingToMigrate $ mconcat
+                [ "I wasn't able to construct a migration plan. This could be "
+                , "because your wallet is empty, or it could be because the "
+                , "amount of ada in your wallet is insufficient to pay for "
+                , "any of the funds to be migrated. Try adding some ada to "
+                , "your wallet before trying again."
+                ]
         ErrCreateMigrationPlanNoSuchWallet e -> toServerError e
 
 instance IsServerError ErrSelectAssets where

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1026,7 +1026,7 @@ newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant) =
 data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
     ApiWalletMigrationPostData
     { passphrase :: !(ApiT (Passphrase s))
-    , addresses :: ![(ApiT Address, Proxy n)]
+    , addresses :: !(NonEmpty (ApiT Address, Proxy n))
     } deriving (Eq, Generic, Show)
       deriving anyclass NFData
 

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -1686,13 +1686,13 @@ migrateDataCases =
         { "passphrase": #{wPassphrase}
         , "addresses": "not_a_array"
         }|]
-      , "Error in $.addresses: parsing [] failed, expected Array, but encountered String"
+      , "Error in $.addresses: parsing NonEmpty failed, expected Array, but encountered String"
       )
     , ( [aesonQQ|
         { "passphrase": #{wPassphrase}
         , "addresses": 1
         }|]
-      , "Error in $.addresses: parsing [] failed, expected Array, but encountered Number"
+      , "Error in $.addresses: parsing NonEmpty failed, expected Array, but encountered Number"
       )
     , ( [aesonQQ|
         { "passphrase": #{wPassphrase}

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1345,10 +1345,12 @@ instance Arbitrary (ApiWalletMigrationPlanPostData n) where
 instance Arbitrary (Passphrase purpose) =>
          Arbitrary (ApiWalletMigrationPostData n purpose) where
     arbitrary = do
-        n <- choose (1,255)
         pwd <- arbitrary
-        addr <- vector n
-        pure $ ApiWalletMigrationPostData pwd ((, Proxy @n) <$> addr)
+        addrCount <- choose (1, 255)
+        addrs <- (:|)
+            <$> arbitrary
+            <*> replicateM (addrCount - 1) arbitrary
+        pure $ ApiWalletMigrationPostData pwd ((, Proxy @n) <$> addrs)
 
 instance Arbitrary ApiWalletPassphrase where
     arbitrary = genericArbitrary

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3686,8 +3686,8 @@ x-responsesCreateWalletMigrationPlan: &responsesCreateWalletMigrationPlan
         schema: *errNothingToMigrate
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
-  200:
-    description: Ok
+  202:
+    description: Accepted
     content:
       application/json:
         schema: *ApiWalletMigrationPlan
@@ -3705,8 +3705,8 @@ x-responsesMigrateWallet: &responsesMigrateWallet
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
   <<: *responsesErr415UnsupportedMediaType
-  200:
-    description: Ok
+  202:
+    description: Accepted
     content:
       application/json:
         schema:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3712,6 +3712,7 @@ x-responsesMigrateWallet: &responsesMigrateWallet
         schema:
           type: array
           items: *ApiTransaction
+          minItems: 1
 
 x-responsesDeleteWallet: &responsesDeleteWallet
   <<: *responsesErr400

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4657,10 +4657,6 @@ paths:
       tags: ["Migrations"]
       summary: Migrate
       description: |
-        <p align="right">status: <strong>disabled</strong></p>
-        <strong>⚠️IMPORTANT⚠️</strong> This endpoint has been temporarily disabled with the introduction of multi-assets UTxO. It will be enabled again soon.
-
-        <hr/>
         Migrate the UTxO balance of this wallet to the given set of addresses.
 
         This operation will attempt to transfer as much of the wallet's balance
@@ -4695,10 +4691,6 @@ paths:
       tags: ["Migrations"]
       summary: Create a migration plan
       description: |
-        <p align="right">status: <strong>disabled</strong></p>
-        <strong>⚠️IMPORTANT⚠️</strong> This endpoint has been temporarily disabled with the introduction of multi-assets UTxO. It will be enabled again soon.
-
-        <hr/>
         Generate a plan for migrating the UTxO balance of this wallet to
         another wallet, without executing the plan.
 


### PR DESCRIPTION
# Issue Number

ADP-840

# Overview

This PR:

- [x] Implements `Api.Server.createWalletMigrationPlan`.
- [x] Implements `Api.Server.migrateWallet`.
- [x] Adjusts `migrateWallet` to require a non-empty list of addresses.
- [x] Adjusts the success response types for all migration endpoints to be `202` `ACCEPTED`.
- [x] Resurrects all previously-disabled integration tests (for ada-specific wallets).
- [x] Removes the "disabled" warnings on migration endpoints.
- [x] Adds integration test coverage for MA wallets.

# QA Due Diligence

After rewriting the integration test suite, I ran the entire integration test suite 500 times in an effort to increase confidence that there are no flaky tests. The test suite passed 500 times, with no failures or errors.