### PR TITLE
Add offchain-metadata-tools as dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,6 +15,12 @@ packages:
 
 source-repository-package
     type: git
+    location: https://github.com/input-output-hk/offchain-metadata-tools
+    tag: 65f2d445d51819bce6537b85e964081b146fd1e3
+    subdir: metadata-lib
+
+source-repository-package
+    type: git
     location: https://github.com/input-output-hk/Win32-network
     tag: 94153b676617f8f33abe8d8182c37377d2784bd1
 
@@ -137,6 +143,7 @@ allow-newer:
   , hjsonpointer:*
   , cardano-sl-x509:ip
   , cardano-addresses:aeson
+  , github:base16-bytestring
 
 constraints:
     hedgehog >= 1.0.2

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -70,6 +70,7 @@ library
     , iohk-monitoring
     , lattices
     , memory
+    , metadata-lib
     , MonadRandom
     , monad-logger
     , mtl

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -66,6 +66,7 @@
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
           (hsPkgs."memory" or (errorHandler.buildDepError "memory"))
+          (hsPkgs."metadata-lib" or (errorHandler.buildDepError "metadata-lib"))
           (hsPkgs."MonadRandom" or (errorHandler.buildDepError "MonadRandom"))
           (hsPkgs."monad-logger" or (errorHandler.buildDepError "monad-logger"))
           (hsPkgs."mtl" or (errorHandler.buildDepError "mtl"))


### PR DESCRIPTION
# Issue Number

ADP-916

# Overview

**DRAFT** for CI purposes only.

- [ ] I have added offchain-metadata-tools as dependency to get access to metadata types, ultimately to prevent duplication.
