### PR TITLE
Test migration of SeaHorses failing due to insufficient ada

### DIFF
--- a/lib/core-integration/src/Test/Integration/Faucet.hs
+++ b/lib/core-integration/src/Test/Integration/Faucet.hs
@@ -2247,14 +2247,15 @@ maryIntegrationTestAssets tips = maMnemonics >>= take 3
         ]
     combined p = simple p `TokenBundle.add` fruit p
 
--- | Create @n@ unique SeaHorse tokens for each provided @Address@.
+-- | Create @n@ unique SeaHorse tokens for each provided `Address`.
 --
 -- The result can be used for minting using the cli-based faucet.
 seaHorseTestAssets
-    :: Int -- ^ Number of sea horses per address
+    :: Int -- ^ Number of sea horses per `Address`
+    -> Coin -- ^ The Coin value for each `TokenBundle`
     -> [Address]
     -> [(Address, (TokenBundle, [(String, String)]))]
-seaHorseTestAssets nPerAddr addrs = zip addrs $
+seaHorseTestAssets nPerAddr c addrs = zip addrs $
     map
         (\is -> mint (seaHorse is) seaHorseAssetScript)
         (chunks nPerAddr [1..])
@@ -2263,7 +2264,7 @@ seaHorseTestAssets nPerAddr addrs = zip addrs $
     seaHorse is p = bundle p $ flip map is $ \i ->
         (seaHorseTokenName i, TokenQuantity 1)
     bundle p assets = TokenBundle.fromNestedList
-        (Coin 1000_000_000)
+        c
         [(p, NE.fromList assets)]
 
 seaHorsePolicyId :: TokenPolicyId

--- a/lib/core-integration/src/Test/Integration/Framework/Context.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Context.hs
@@ -17,6 +17,8 @@ import Cardano.Wallet.Primitive.Types
     ( EpochNo, NetworkParameters, PoolRetirementCertificate )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Transaction
     ( DelegationAction )
 import Data.IORef
@@ -64,7 +66,7 @@ data Context = Context
     , _smashUrl :: Text
         -- ^ Base URL of the mock smash server.
 
-    , _mintSeaHorseAssets :: Int -> [Address] -> IO ()
+    , _mintSeaHorseAssets :: Int -> Coin -> [Address] -> IO ()
         -- ^ TODO: Remove once we can unify cardano-wallet-core-integration and
         -- cardano-wallet:integration, or when the wallet supports minting.
         --

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -195,6 +195,14 @@ spec = describe "BYRON_MIGRATIONS" $ do
                     } |]
             sourceWallet <- unsafeResponse <$>
                 postByronWallet ctx payloadRestore
+            eventually "sourceWallet contains dust" $
+                request @ApiByronWallet ctx
+                    (Link.getWallet @'Byron sourceWallet) Default Empty
+                    >>= flip verify
+                    [ expectField (#balance . #available . #getQuantity)
+                        (.> 0)
+                    ]
+
             targetWallet <- emptyWallet ctx
             targetAddresses <- listAddresses @n ctx targetWallet
             let targetAddressIds = targetAddresses <&>

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -45,6 +45,8 @@ import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -711,7 +713,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 wSrc <- fixtureWallet ctx
                 srcAddrs <-
                     map (getApiT . fst . view #id) <$> listAddresses @n ctx wSrc
-                liftIO $ _mintSeaHorseAssets ctx nAssetsPerAddr (take 2 srcAddrs)
+                liftIO $ _mintSeaHorseAssets ctx
+                    nAssetsPerAddr (Coin 1000_000_000) (take 2 srcAddrs)
                 return (wSrc, nAssetsPerAddr)
             wDest <- emptyWallet ctx
             destAddr <- head . map (view #id) <$> listAddresses @n ctx wDest

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -266,9 +266,9 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     , _poolGarbageCollectionEvents = poolGarbageCollectionEvents
                     , _mainEra = era
                     , _smashUrl = smashUrl
-                    , _mintSeaHorseAssets = \addrs nPerAddr -> do
+                    , _mintSeaHorseAssets = \nPerAddr c addrs -> do
                         sendFaucetAssetsTo tr' faucetConn testDir 1 $
-                            encodeAddresses (seaHorseTestAssets addrs nPerAddr)
+                            encodeAddresses (seaHorseTestAssets nPerAddr c addrs)
                     }
         let action' = bracketTracer' tr "spec" . action
         res <- race


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

#2644

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Remove `pendingWith` to enable `SHELLEY_CREATE_MIGRATION_PLAN_04 - Cannot create a plan for a wallet that only contains dust.`
- [x] Fund the source wallet with SeaHorses and as small amount of ada to make the migration fail 


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
