### PR TITLE
Add integration tests for migration of reward balances

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -196,7 +196,6 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         (errMsg404NoWallet $ sourceWallet ^. walletId)
                     ]
 
-
     it "SHELLEY_CREATE_MIGRATION_PLAN_04 - \
         \Cannot create a plan for a wallet that only contains freeriders."
         $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -57,14 +57,10 @@ import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
-import Data.Maybe
-    ( mapMaybe )
 import Data.Proxy
     ( Proxy )
 import Data.Quantity
     ( Quantity (..) )
-import Data.Word
-    ( Word64 )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -782,19 +778,8 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 ]
   where
     -- Compute the fee associated with an API transaction.
-    apiTransactionFee :: ApiTransaction n -> Word64
-    apiTransactionFee t =
-        inputBalance t - outputBalance t
-      where
-        inputBalance = fromIntegral
-            . sum
-            . fmap (view (#amount . #getQuantity))
-            . mapMaybe ApiTypes.source
-            . view #inputs
-        outputBalance = fromIntegral
-            . sum
-            . fmap (view (#amount . #getQuantity))
-            . view #outputs
+    apiTransactionFee :: ApiTransaction n -> Natural
+    apiTransactionFee = view (#fee . #getQuantity)
 
     migrateWallet
         :: Context

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1877,6 +1877,21 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
             , changeGenerated = []
             }
 
+        -- NOTE:
+        --
+        -- Due to a quirk of history, we need to populate the 'extraCoinSource'
+        -- field with the reward withdrawal amount, since the transaction layer
+        -- uses the 'selectionDelta' function to calculate the final fee, and
+        -- that particular function doesn't know about reward withdrawals.
+        --
+        -- This is non-ideal, because we're returning the reward withdrawal
+        -- amount in two places in the output of this function.
+        --
+        -- In future, it would be better to return a single record whose fields
+        -- more closely resemble exactly what is needed to build a transaction,
+        -- and have the transaction layer calculate the actual fee based only
+        -- on the contents of that record.
+        --
         extraCoinSource =
             if (view #rewardWithdrawal migrationSelection) > Coin 0
             then Just (view #rewardWithdrawal migrationSelection)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1873,9 +1873,14 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
             { inputsSelected = view #inputIds migrationSelection
             , outputsCovered
             , utxoRemaining = UTxOIndex.empty
-            , extraCoinSource = Nothing
+            , extraCoinSource
             , changeGenerated = []
             }
+
+        extraCoinSource =
+            if (view #rewardWithdrawal migrationSelection) > Coin 0
+            then Just (view #rewardWithdrawal migrationSelection)
+            else Nothing
 
         withdrawal =
             if (view #rewardWithdrawal migrationSelection) > Coin 0

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2040,13 +2040,16 @@ createMigrationPlan
         , WalletKey k
         )
     => ctx
+    -> Maybe ApiWithdrawalPostData
+        -- ^ What type of reward withdrawal to attempt
     -> ApiT WalletId
         -- ^ Source wallet
     -> ApiWalletMigrationPlanPostData n
         -- ^ Target addresses
     -> Handler (ApiWalletMigrationPlan n)
-createMigrationPlan ctx (ApiT wid) postData = do
-    (rewardWithdrawal, _) <- mkRewardAccountBuilder @_ @s @_ @n ctx wid Nothing
+createMigrationPlan ctx withdrawalType (ApiT wid) postData = do
+    (rewardWithdrawal, _) <-
+        mkRewardAccountBuilder @_ @s @_ @n ctx wid withdrawalType
     withWorkerCtx ctx wid liftE liftE $ \wrk -> liftHandler $ do
         (wallet, _, _) <- withExceptT ErrCreateMigrationPlanNoSuchWallet $
             W.readWallet wrk wid

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -472,8 +472,6 @@ import Data.Time
     ( UTCTime )
 import Data.Type.Equality
     ( (:~:) (..), type (==), testEquality )
-import Data.Void
-    ( Void )
 import Data.Word
     ( Word32 )
 import Fmt
@@ -2082,7 +2080,7 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
     maybeSelections = fmap mkApiCoinSelectionForMigration <$> maybeUnsignedTxs
 
     maybeSelectionWithdrawals
-        :: Maybe (NonEmpty (SelectionResult Void, Withdrawal))
+        :: Maybe (NonEmpty (W.SelectionResultWithoutChange, Withdrawal))
     maybeSelectionWithdrawals
         = W.migrationPlanToSelectionWithdrawals plan rewardWithdrawal
         $ getApiT . fst <$> addresses

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2102,10 +2102,15 @@ mkApiWalletMigrationPlan s addresses rewardWithdrawal plan =
         & mkApiWalletMigrationBalance
 
     balanceSelected :: ApiWalletMigrationBalance
-    balanceSelected = plan
-        & view #selections
-        & F.foldMap (view #inputBalance)
-        & mkApiWalletMigrationBalance
+    balanceSelected = mkApiWalletMigrationBalance $
+        TokenBundle.fromCoin balanceRewardWithdrawal <> balanceUTxO
+      where
+        balanceUTxO = plan
+            & view #selections
+            & F.foldMap (view #inputBalance)
+        balanceRewardWithdrawal = plan
+            & view #selections
+            & F.foldMap (view #rewardWithdrawal)
 
     mkApiCoinSelectionForMigration unsignedTx =
         mkApiCoinSelection [] Nothing Nothing unsignedTx

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2133,12 +2133,14 @@ migrateWallet
         , WalletKey k
         )
     => ctx
+    -> Maybe ApiWithdrawalPostData
+        -- ^ What type of reward withdrawal to attempt
     -> ApiT WalletId
     -> ApiWalletMigrationPostData n p
     -> Handler (NonEmpty (ApiTransaction n))
-migrateWallet ctx (ApiT wid) postData = do
+migrateWallet ctx withdrawalType (ApiT wid) postData = do
     (rewardWithdrawal, mkRewardAccount) <-
-        mkRewardAccountBuilder @_ @s @_ @n ctx wid Nothing
+        mkRewardAccountBuilder @_ @s @_ @n ctx wid withdrawalType
     withWorkerCtx ctx wid liftE liftE $ \wrk -> do
         plan <- liftHandler $ W.createMigrationPlan wrk wid rewardWithdrawal
         txTimeToLive <- liftIO $ W.getTxExpiry ti Nothing

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -297,7 +297,7 @@ server byron icarus shelley multisig spl ntp =
     shelleyMigrations :: Server (ShelleyMigrations n)
     shelleyMigrations =
              createMigrationPlan @_ @_ shelley (Just SelfWithdrawal)
-        :<|> migrateWallet shelley
+        :<|> migrateWallet shelley (Just SelfWithdrawal)
 
     stakePools :: Server (StakePools n ApiStakePool)
     stakePools =
@@ -454,8 +454,8 @@ server byron icarus shelley multisig spl ntp =
                 (icarus, createMigrationPlan @_ @_ icarus Nothing wid postData)
              )
         :<|> (\wid m -> withLegacyLayer wid
-                (byron , migrateWallet byron wid m)
-                (icarus, migrateWallet icarus wid m)
+                (byron , migrateWallet byron Nothing wid m)
+                (icarus, migrateWallet icarus Nothing wid m)
              )
 
     network' :: Server Network

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -132,6 +132,7 @@ import Cardano.Wallet.Api.Types
     , ApiSelectCoinsData (..)
     , ApiStakePool
     , ApiT (..)
+    , ApiWithdrawalPostData (..)
     , HealthCheckSMASH (..)
     , MaintenanceAction (..)
     , SettingsPutData (..)
@@ -295,7 +296,7 @@ server byron icarus shelley multisig spl ntp =
 
     shelleyMigrations :: Server (ShelleyMigrations n)
     shelleyMigrations =
-             createMigrationPlan @_ @_ shelley
+             createMigrationPlan @_ @_ shelley (Just SelfWithdrawal)
         :<|> migrateWallet shelley
 
     stakePools :: Server (StakePools n ApiStakePool)
@@ -449,8 +450,8 @@ server byron icarus shelley multisig spl ntp =
     byronMigrations :: Server (ByronMigrations n)
     byronMigrations =
              (\wid postData -> withLegacyLayer wid
-                (byron , createMigrationPlan @_ @_ byron wid postData)
-                (icarus, createMigrationPlan @_ @_ icarus wid postData)
+                (byron , createMigrationPlan @_ @_ byron Nothing wid postData)
+                (icarus, createMigrationPlan @_ @_ icarus Nothing wid postData)
              )
         :<|> (\wid m -> withLegacyLayer wid
                 (byron , migrateWallet byron wid m)


### PR DESCRIPTION
# Issue Number

ADP-840

# Overview

This PR:
- [x] Adds reward-wallet-specific integration test coverage for `createMigrationPlan`.
    (`CREATE_MIGRATION_PLAN_06`)
- [x] Adds reward-wallet-specific integration test coverage for `migrateWallet`.
    (`MIGRATE_09`)
- [x] Fixes `createMigrationPlan` to require callers to specify a reward withdrawal method, which it passes to `mkRewardAccountBuilder`.
    (Previously it always passed `Nothing`.)
- [x] Fixes `migrateWallet` to require callers to specify a reward withdrawal method, which it passes to `mkRewardAccountBuilder`.
    (Previously it always passed `Nothing`.)
- [x] Fixes `mkApiWalletMigrationPlan` to include the reward withdrawal balance in the `balanceSelected` field.
    (Previously the reward balance was omitted from the `balanceSelected` field.