### PR TITLE
Integration test coverage for migration of freeriders

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/Context.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/Context.hs
@@ -66,7 +66,7 @@ data Context = Context
     , _smashUrl :: Text
         -- ^ Base URL of the mock smash server.
 
-    , _mintSeaHorseAssets :: Int -> Coin -> [Address] -> IO ()
+    , _mintSeaHorseAssets :: Int -> Int -> Coin -> [Address] -> IO ()
         -- ^ TODO: Remove once we can unify cardano-wallet-core-integration and
         -- cardano-wallet:integration, or when the wallet supports minting.
         --

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -435,6 +435,135 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         . TokenMap.getAssets)
                 ]
 
+    it "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
+        \Can create a partial migration plan for a wallet with a large number \
+        \of freerider UTxO entries, but with not quite enough non-freerider \
+        \entries to enable the entire UTxO set to be migrated."
+        $ \ctx -> runResourceT $ do
+
+            -- Create a source wallet with just one pure ada entry that is
+            -- large enough to create a singleton transaction:
+            sourceWallet <- fixtureWalletWith @n ctx [ 100_000_000 ]
+
+            -- Check that the source wallet has the expected balance and UTxO
+            -- distribution:
+            request @ApiWallet ctx
+                (Link.getWallet @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField (#balance . #reward . #getQuantity)
+                    (`shouldBe` 0)
+                , expectField (#balance . #available . #getQuantity)
+                    (`shouldBe` 100_000_000)
+                , expectField (#balance . #total . #getQuantity)
+                    (`shouldBe` 100_000_000)
+                ]
+            let expectedSourceDistribution =
+                    [(100_000_000, 1)]
+            request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField #distribution
+                    ((`shouldBe` expectedSourceDistribution)
+                    . Map.toList
+                    . Map.filter (> 0)
+                    )
+                ]
+
+            -- Add a relatively large number of freerider UTxO entries to the
+            -- source wallet.
+            --
+            -- We assign to each UTxO entry:
+            --
+            --  - a fixed token quantity of exactly one non-ada asset.
+            --
+            --  - a fixed quantity of ada that is above the minimum, but not
+            --    enough to allow the entry to be included in a singleton
+            --    transaction (thus making it a freerider).
+            --
+            -- We use '_mintSeaHorseAssets' to mint non-ada assets. Since this
+            -- function doesn't know how to compute the minimum ada quantity
+            -- for a token bundle, we provide a custom ada quantity here. This
+            -- ada quantity is large enough to allow minting to succeed, but
+            -- small enough to make the migration algorithm categorize the
+            -- entry as a freerider.
+            --
+            let perEntryAdaQuantity = Coin 1_562_500
+            let perEntryAssetCount = 1
+            replicateM_ 6 $ do
+                -- Since the 'listAddresses' endpoint only returns a limited
+                -- number of addresses, we assign assets to source addresses
+                -- in batches.
+                sourceAddresses <- take 20 . map (getApiT . fst . view #id)
+                    <$> listUnusedAddresses @n ctx sourceWallet
+                liftIO $ _mintSeaHorseAssets ctx
+                    perEntryAssetCount
+                    perEntryAdaQuantity
+                    sourceAddresses
+                waitForTxImmutability ctx
+
+            -- Check that minting was successful, and that the balance and UTxO
+            -- distribution have both changed accordingly:
+            let expectedBalanceAda = 287_500_000
+            let expectedAssetCount = 20
+            request @ApiWallet ctx
+                (Link.getWallet @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField (#balance . #available . #getQuantity)
+                    (`shouldBe` expectedBalanceAda)
+                , expectField (#balance . #total . #getQuantity)
+                    (`shouldBe` expectedBalanceAda)
+                , expectField (#assets . #available . #getApiT)
+                    ((`shouldBe` expectedAssetCount)
+                        . Set.size
+                        . TokenMap.getAssets)
+                ]
+            let expectedSourceDistributionAfterMinting =
+                    [ ( 10_000_000, 120)
+                    , (100_000_000,   1)
+                    ]
+            request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField #distribution
+                    ((`shouldBe` expectedSourceDistributionAfterMinting)
+                    . Map.toList
+                    . Map.filter (> 0)
+                    )
+                ]
+
+            -- Create an empty target wallet:
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds = targetAddresses <&>
+                    (\(ApiTypes.ApiAddress addrId _ _) -> addrId)
+
+            -- Create a migration plan, and check that the plan is only
+            -- partially complete:
+            let ep = Link.createMigrationPlan @'Shelley sourceWallet
+            request @(ApiWalletMigrationPlan n) ctx ep Default
+                (Json [json|{addresses: #{targetAddressIds}}|])
+                >>= flip verify
+                [ expectResponseCode HTTP.status202
+                , expectField (#selections)
+                    ((`shouldBe` 1) . length)
+                , expectField id
+                    ((`shouldBe` 102) . apiPlanTotalInputCount)
+                , expectField id
+                    ((`shouldBe` 1) . apiPlanTotalOutputCount)
+                , expectField (#balanceSelected . #ada . #getQuantity)
+                    (`shouldBe` 257_812_500)
+                , expectField (#balanceLeftover . #ada . #getQuantity)
+                    (`shouldBe`  29_687_500)
+                , expectField (#balanceSelected . #assets . #getApiT)
+                    ((.> 0)
+                        . Set.size
+                        . TokenMap.getAssets)
+                , expectField (#balanceLeftover . #assets . #getApiT)
+                    ((.> 0)
+                        . Set.size
+                        . TokenMap.getAssets)
+                ]
+
     describe "SHELLEY_MIGRATE_01 - \
         \After a migration operation successfully completes, the correct \
         \amounts eventually become available in the target wallet for an \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -196,9 +196,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         (errMsg404NoWallet $ sourceWallet ^. walletId)
                     ]
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_04 - \
+    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_04 - \
         \Cannot create a plan for a wallet that only contains freeriders."
-        $ \ctx -> runResourceT $ do
+        $ \ctx -> runResourceT @IO $ do
             sourceWallet <- emptyWallet ctx
             srcAddrs <- map (getApiT . fst . view #id)
                 <$> listAddresses @n ctx sourceWallet
@@ -320,11 +320,11 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     (`shouldBe` 0)
                 ]
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_07 - \
+    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_07 - \
         \Can create a complete migration plan for a wallet with a large number \
         \of freerider UTxO entries, but with just enough non-freerider entries \
         \to enable the entire UTxO set to be migrated."
-        $ \ctx -> runResourceT $ do
+        $ \ctx -> runResourceT @IO $ do
 
             -- Create a source wallet with some pure ada entries, where each
             -- ada entry is large enough to create a singleton transaction:
@@ -451,11 +451,11 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                         . TokenMap.getAssets)
                 ]
 
-    it "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
+    Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
         \Can create a partial migration plan for a wallet with a large number \
         \of freerider UTxO entries, but with not quite enough non-freerider \
         \entries to enable the entire UTxO set to be migrated."
-        $ \ctx -> runResourceT $ do
+        $ \ctx -> runResourceT @IO $ do
 
             -- Create a source wallet with just one pure ada entry that is
             -- large enough to create a singleton transaction:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -224,8 +224,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             --
             let perEntryAdaQuantity = Coin 3_300_000
             let perEntryAssetCount = 10
+            let batchSize = 20
             liftIO $ _mintSeaHorseAssets ctx
                 perEntryAssetCount
+                batchSize
                 perEntryAdaQuantity
                 srcAddrs
             waitForTxImmutability ctx
@@ -377,6 +379,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             --
             let perEntryAdaQuantity = Coin 1_562_500
             let perEntryAssetCount = 1
+            let batchSize = 20
             replicateM_ 6 $ do
                 -- Since the 'listAddresses' endpoint only returns a limited
                 -- number of addresses, we assign assets to source addresses
@@ -385,9 +388,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     <$> listUnusedAddresses @n ctx sourceWallet
                 liftIO $ _mintSeaHorseAssets ctx
                     perEntryAssetCount
+                    batchSize
                     perEntryAdaQuantity
                     sourceAddresses
-                waitForTxImmutability ctx
+            waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO
             -- distribution have both changed accordingly:
@@ -505,6 +509,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             --
             let perEntryAdaQuantity = Coin 1_562_500
             let perEntryAssetCount = 1
+            let batchSize = 20
             replicateM_ 6 $ do
                 -- Since the 'listAddresses' endpoint only returns a limited
                 -- number of addresses, we assign assets to source addresses
@@ -513,9 +518,10 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     <$> listUnusedAddresses @n ctx sourceWallet
                 liftIO $ _mintSeaHorseAssets ctx
                     perEntryAssetCount
+                    batchSize
                     perEntryAdaQuantity
                     sourceAddresses
-                waitForTxImmutability ctx
+            waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO
             -- distribution have both changed accordingly:

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -90,7 +90,6 @@ import Test.Integration.Framework.DSL
     , icarusAddresses
     , json
     , listAddresses
-    , listUnusedAddresses
     , postWallet
     , randomAddresses
     , request
@@ -380,17 +379,13 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             let perEntryAdaQuantity = Coin 1_562_500
             let perEntryAssetCount = 1
             let batchSize = 20
-            replicateM_ 6 $ do
-                -- Since the 'listAddresses' endpoint only returns a limited
-                -- number of addresses, we assign assets to source addresses
-                -- in batches.
-                sourceAddresses <- take 20 . map (getApiT . fst . view #id)
-                    <$> listUnusedAddresses @n ctx sourceWallet
-                liftIO $ _mintSeaHorseAssets ctx
-                    perEntryAssetCount
-                    batchSize
-                    perEntryAdaQuantity
-                    sourceAddresses
+            sourceAddresses <- take 20 . map (getApiT . fst . view #id)
+                <$> listAddresses @n ctx sourceWallet
+            replicateM_ 6 $ liftIO $ _mintSeaHorseAssets ctx
+                perEntryAssetCount
+                batchSize
+                perEntryAdaQuantity
+                sourceAddresses
             waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO
@@ -510,17 +505,13 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             let perEntryAdaQuantity = Coin 1_562_500
             let perEntryAssetCount = 1
             let batchSize = 20
-            replicateM_ 6 $ do
-                -- Since the 'listAddresses' endpoint only returns a limited
-                -- number of addresses, we assign assets to source addresses
-                -- in batches.
-                sourceAddresses <- take 20 . map (getApiT . fst . view #id)
-                    <$> listUnusedAddresses @n ctx sourceWallet
-                liftIO $ _mintSeaHorseAssets ctx
-                    perEntryAssetCount
-                    batchSize
-                    perEntryAdaQuantity
-                    sourceAddresses
+            sourceAddresses <- take 20 . map (getApiT . fst . view #id)
+                <$> listAddresses @n ctx sourceWallet
+            replicateM_ 6 $ liftIO $ _mintSeaHorseAssets ctx
+                perEntryAssetCount
+                batchSize
+                perEntryAdaQuantity
+                sourceAddresses
             waitForTxImmutability ctx
 
             -- Check that minting was successful, and that the balance and UTxO

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -46,7 +46,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxStatus (..) )
 import Control.Monad
-    ( forM_, void, when )
+    ( forM_, replicateM_, void, when )
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Resource
@@ -85,10 +85,12 @@ import Test.Integration.Framework.DSL
     , fixtureMultiAssetWallet
     , fixturePassphrase
     , fixtureWallet
+    , fixtureWalletWith
     , getFromResponse
     , icarusAddresses
     , json
     , listAddresses
+    , listUnusedAddresses
     , postWallet
     , randomAddresses
     , request
@@ -300,6 +302,137 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     (`shouldBe` 1_100_000_000_000)
                 , expectField (#balanceLeftover . #ada . #getQuantity)
                     (`shouldBe` 0)
+                ]
+
+    it "SHELLEY_CREATE_MIGRATION_PLAN_07 - \
+        \Can create a complete migration plan for a wallet with a large number \
+        \of freerider UTxO entries, but with just enough non-freerider entries \
+        \to enable the entire UTxO set to be migrated."
+        $ \ctx -> runResourceT $ do
+
+            -- Create a source wallet with some pure ada entries, where each
+            -- ada entry is large enough to create a singleton transaction:
+            sourceWallet <- fixtureWalletWith @n ctx
+                [ 100_000_000
+                , 100_000_000
+                ]
+
+            -- Check that the source wallet has the expected balance and UTxO
+            -- distribution:
+            request @ApiWallet ctx
+                (Link.getWallet @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField (#balance . #reward . #getQuantity)
+                    (`shouldBe` 0)
+                , expectField (#balance . #available . #getQuantity)
+                    (`shouldBe` 200_000_000)
+                , expectField (#balance . #total . #getQuantity)
+                    (`shouldBe` 200_000_000)
+                ]
+            let expectedSourceDistribution =
+                    [(100_000_000, 2)]
+            request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField #distribution
+                    ((`shouldBe` expectedSourceDistribution)
+                    . Map.toList
+                    . Map.filter (> 0)
+                    )
+                ]
+
+            -- Add a relatively large number of freerider UTxO entries to the
+            -- source wallet.
+            --
+            -- We assign to each UTxO entry:
+            --
+            --  - a fixed token quantity of exactly one non-ada asset.
+            --
+            --  - a fixed quantity of ada that is above the minimum, but not
+            --    enough to allow the entry to be included in a singleton
+            --    transaction (thus making it a freerider).
+            --
+            -- We use '_mintSeaHorseAssets' to mint non-ada assets. Since this
+            -- function doesn't know how to compute the minimum ada quantity
+            -- for a token bundle, we provide a custom ada quantity here. This
+            -- ada quantity is large enough to allow minting to succeed, but
+            -- small enough to make the migration algorithm categorize the
+            -- entry as a freerider.
+            --
+            let perEntryAdaQuantity = Coin 1_562_500
+            let perEntryAssetCount = 1
+            replicateM_ 6 $ do
+                -- Since the 'listAddresses' endpoint only returns a limited
+                -- number of addresses, we assign assets to source addresses
+                -- in batches.
+                sourceAddresses <- take 20 . map (getApiT . fst . view #id)
+                    <$> listUnusedAddresses @n ctx sourceWallet
+                liftIO $ _mintSeaHorseAssets ctx
+                    perEntryAssetCount
+                    perEntryAdaQuantity
+                    sourceAddresses
+                waitForTxImmutability ctx
+
+            -- Check that minting was successful, and that the balance and UTxO
+            -- distribution have both changed accordingly:
+            let expectedBalanceAda = 387_500_000
+            let expectedAssetCount = 20
+            request @ApiWallet ctx
+                (Link.getWallet @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField (#balance . #available . #getQuantity)
+                    (`shouldBe` expectedBalanceAda)
+                , expectField (#balance . #total . #getQuantity)
+                    (`shouldBe` expectedBalanceAda)
+                , expectField (#assets . #available . #getApiT)
+                    ((`shouldBe` expectedAssetCount)
+                        . Set.size
+                        . TokenMap.getAssets)
+                ]
+            let expectedSourceDistributionAfterMinting =
+                    [ ( 10_000_000, 120)
+                    , (100_000_000,   2)
+                    ]
+            request @ApiUtxoStatistics ctx
+                (Link.getUTxOsStatistics @'Shelley sourceWallet) Default Empty
+                >>= flip verify
+                [ expectField #distribution
+                    ((`shouldBe` expectedSourceDistributionAfterMinting)
+                        . Map.toList
+                        . Map.filter (> 0)
+                    )
+                ]
+
+            -- Create an empty target wallet:
+            targetWallet <- emptyWallet ctx
+            targetAddresses <- listAddresses @n ctx targetWallet
+            let targetAddressIds = targetAddresses <&>
+                    (\(ApiTypes.ApiAddress addrId _ _) -> addrId)
+
+            -- Create a migration plan, and check that the plan is complete:
+            let ep = Link.createMigrationPlan @'Shelley sourceWallet
+            request @(ApiWalletMigrationPlan n) ctx ep Default
+                (Json [json|{addresses: #{targetAddressIds}}|])
+                >>= flip verify
+                [ expectResponseCode HTTP.status202
+                , expectField (#selections)
+                    ((`shouldBe` 2) . length)
+                , expectField id
+                    ((`shouldBe` 122) . apiPlanTotalInputCount)
+                , expectField id
+                    ((`shouldBe` 2) . apiPlanTotalOutputCount)
+                , expectField (#balanceSelected . #ada . #getQuantity)
+                    (`shouldBe` expectedBalanceAda)
+                , expectField (#balanceSelected . #assets . #getApiT)
+                    ((`shouldBe` expectedAssetCount)
+                        . Set.size
+                        . TokenMap.getAssets)
+                , expectField (#balanceLeftover . #ada . #getQuantity)
+                    (`shouldBe` 0)
+                , expectField (#balanceLeftover . #assets . #getApiT)
+                    ((`shouldBe` 0)
+                        . Set.size
+                        . TokenMap.getAssets)
                 ]
 
     describe "SHELLEY_MIGRATE_01 - \

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -713,8 +713,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 wSrc <- fixtureWallet ctx
                 srcAddrs <-
                     map (getApiT . fst . view #id) <$> listAddresses @n ctx wSrc
+                let batchSize = 1
+                let coinPerAddr = Coin 1000_000_000
                 liftIO $ _mintSeaHorseAssets ctx
-                    nAssetsPerAddr (Coin 1000_000_000) (take 2 srcAddrs)
+                    nAssetsPerAddr batchSize  coinPerAddr (take 2 srcAddrs)
                 return (wSrc, nAssetsPerAddr)
             wDest <- emptyWallet ctx
             destAddr <- head . map (view #id) <$> listAddresses @n ctx wDest

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -268,9 +268,9 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                     , _poolGarbageCollectionEvents = poolGarbageCollectionEvents
                     , _mainEra = era
                     , _smashUrl = smashUrl
-                    , _mintSeaHorseAssets = \nPerAddr c addrs ->
+                    , _mintSeaHorseAssets = \nPerAddr batchSize c addrs ->
                         withMVar mintSeaHorseAssetsLock $ \() ->
-                            sendFaucetAssetsTo tr' faucetConn testDir 1
+                            sendFaucetAssetsTo tr' faucetConn testDir batchSize
                                 $ encodeAddresses
                                 $ seaHorseTestAssets nPerAddr c addrs
                     }


### PR DESCRIPTION
# Issue Number

ADP-840

# Overview

This PR adds integration test coverage for migrations of wallets with freerider UTxO entries.

In particular, we add two test cases:

- [x] `CREATE_MIGRATION_PLAN_07`
    This test verifies that we can create a **_complete_** migration plan for a wallet with a large number of freerider UTxO entries, but with **_just enough_** non-freerider entries to enable the entire UTxO set to be migrated.
- [x] `CREATE_MIGRATION_PLAN_08`
    This test verifies that we can create a **_partial_** migration plan for a wallet with a large number of freerider UTxO entries, but with **_not quite enough_** non-freerider entries to enable the entire UTxO set to be migrated.

In addition, this PR:

- [x] Adds a synchronization lock around the `mintSeaHorseAssets` operation, as it is not safe to be called by more than one thread concurrently.