### PR TITLE
CLI: Force command-line arguments to be UTF-8 decoded

### DIFF
--- a/lib/launcher/src/Cardano/Startup.hs
+++ b/lib/launcher/src/Cardano/Startup.hs
@@ -41,6 +41,8 @@ import Data.Either.Extra
     ( eitherToMaybe )
 import Data.Text.Class
     ( ToText (..) )
+import GHC.IO.Encoding
+    ( setFileSystemEncoding )
 import System.IO
     ( Handle, hIsOpen, hSetEncoding, mkTextEncoding, stderr, stdin, stdout )
 import System.IO.CodePage
@@ -79,6 +81,7 @@ setUtf8EncodingHandles :: IO ()
 setUtf8EncodingHandles = do
     utf8' <- mkTextEncoding "UTF-8//TRANSLIT"
     mapM_ (`hSetEncoding` utf8') [stdin, stdout, stderr]
+    setFileSystemEncoding utf8'
 
 {-------------------------------------------------------------------------------
                                Shutdown handlers


### PR DESCRIPTION
### Issue Number

Bug found while doing ADP-915.

### Overview

Applies the same fix as in input-output-hk/offchain-metadata-tools#27 so that command-line arguments are also decoded as UTF-8 text, regardless of the user's locale setting.

