### PR TITLE
Fix slow ApiSharedWallet unit tests

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -327,6 +327,7 @@ import Test.QuickCheck
     , arbitraryPrintableChar
     , arbitrarySizedBoundedIntegral
     , choose
+    , chooseInt
     , counterexample
     , elements
     , frequency
@@ -334,6 +335,7 @@ import Test.QuickCheck
     , property
     , scale
     , shrinkIntegral
+    , sized
     , vector
     , vectorOf
     , (.&&.)
@@ -1568,8 +1570,9 @@ instance Arbitrary WalletId where
 
 instance Arbitrary WalletName where
     arbitrary = do
-        nameLength <- choose (walletNameMinLength, walletNameMaxLength)
-        WalletName . T.pack <$> replicateM nameLength arbitraryPrintableChar
+        len <- Test.QuickCheck.scale (min walletNameMaxLength) $ sized $ \n ->
+            chooseInt (walletNameMinLength, walletNameMinLength `max` n)
+        WalletName . T.pack <$> vectorOf len arbitraryPrintableChar
     shrink (WalletName t)
         | T.length t <= walletNameMinLength = []
         | otherwise = [WalletName $ T.take walletNameMinLength t]


### PR DESCRIPTION
### Issue Number

Found during ADP-902

### Overview

The `Cardano.Wallet.Api.Types` tests are running very slowly. Also the unit tests were sometimes timing out in CI.

Profiling showed that the `Arbitrary` instance of `ApiSharedWallet` was the slowest part.
This change improves the speed of this generator.
Now it is the OpenAPI validation which is the slowest part.

### Comments

We may also be able to reduce the size of arbitrary `ApiSharedWallet` values, so that validation gets faster. Because it's still not especially quick. Something like the `instance Arbitrary WalletName` change in this PR could probably be applied.
