### PR TITLE
Enhance reporting of coin selections in the log.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2685,9 +2685,9 @@ instance ToText WalletLog where
             "|utxo| = "+|UTxOIndex.size utxo|+" " <>
             "#recipients = "+|NE.length recipients|+""
         MsgSelectionDone (Left e) ->
-            "Failed to select assets: "+|| e ||+""
+            "Failed to select assets:\n"+|| e ||+""
         MsgSelectionDone (Right s) ->
-            "Assets selected successfully: "+| s |+""
+            "Assets selected successfully:\n"+| s |+""
         MsgMigrationUTxOBefore summary ->
             "About to migrate the following distribution: \n" <> pretty summary
         MsgMigrationUTxOAfter summary ->


### PR DESCRIPTION
# Issue Number

ADP-890

# Overview

This PR enhances the reporting of successful coin selection attempts in the log.

It creates two types of reports:

- A **summarized** report that includes just the most important data points associated with a selection. Each data point can be serialized to a single line of text.
- A **detailed** report that includes all the inputs, outputs, and change outputs of a selection.

This makes it possible to turn on the reporting of summarized coin selection reports (which are short, and fixed-length) without turning on the reporting of detailed coin selection reports (which can be extremely lengthy).

Example output of a summarized report:

```yaml
SelectionReportSummarized:
  computedFee: 2.143653
  totalAdaBalanceIn: 9700.225038
  totalAdaBalanceOut: 9698.081385
  adaBalanceOfSelectedInputs: 9700.225038
  adaBalanceOfExtraInput: 0.000000
  adaBalanceOfRequestedOutputs: 2164.303103
  adaBalanceOfGeneratedChangeOutputs: 7533.778282
  numberOfSelectedInputs: 47
  numberOfRequestedOutputs: 1
  numberOfGeneratedChangeOutputs: 4
  numberOfUniqueNonAdaAssetsInSelectedInputs: 719
  numberOfUniqueNonAdaAssetsInRequestedOutputs: 0
  numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs: 719
  sizeOfRemainingUtxoSet: 0
```
