### PR TITLE
Testing additional account pub key endpoints

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -4537,7 +4537,7 @@ paths:
     post:
       operationId: postAccountKey
       tags: ["Keys"]
-      summary: Create
+      summary: Create Account Public Key
       description: |
         <p align="right">status: <strong>stable</strong></p>
         Derive an account public key for any account index. For this key derivation to be possible,
@@ -4558,7 +4558,7 @@ paths:
     get:
       operationId: getAccountKey
       tags: ["Keys"]
-      summary: Get
+      summary: Get Account Public Key
       description: |
         <p align="right">status: <strong>stable</strong></p>
         Retrieve the account public key of this wallet.
@@ -5469,32 +5469,11 @@ paths:
             schema: *ApiSharedWalletPatchData
       responses: *responsesPatchSharedWallet
 
-  /shared-wallets/{walletId}/keys/{role}/{index}:
-    get:
-      operationId: getSharedWalletKey
-      tags: ["Shared Keys"]
-      summary: Get Public Key
-      description: |
-        <p align="right">status: <strong>stable</strong></p>
-        Return a public key for a given role and derivation index for
-        a shared wallet.
-
-        To get a hash of the public key, instead of the public key,
-        use query parameter `hash=true`.
-
-        <b>Note:</b> Only `Soft` indexes are supported by this endpoint.
-      parameters:
-        - *parametersWalletId
-        - *parametersRole
-        - *parametersDerivationSegment
-        - *parametersDerivationHash
-      responses: *responsesGetSharedKey
-
   /shared-wallets/{walletId}/keys/{index}:
     post:
       operationId: postAccountKeyShared
       tags: ["Shared Keys"]
-      summary: Create
+      summary: Create Account Public Key
       description: |
         <p align="right">status: <strong>stable</strong></p>
         Derive an account public key for any account index. For this key derivation to be possible,
@@ -5515,7 +5494,7 @@ paths:
     get:
       operationId: getAccountKeyShared
       tags: ["Shared Keys"]
-      summary: Get
+      summary: Get Account Public Key
       description: |
         <p align="right">status: <strong>stable</strong></p>
         Retrieve the account public key of this shared wallet.
@@ -5528,6 +5507,27 @@ paths:
         - *parametersWalletId
       responses: *responsesGetAccountSharedKey
 
+  /shared-wallets/{walletId}/keys/{role}/{index}:
+    get:
+      operationId: getSharedWalletKey
+      tags: ["Shared Keys"]
+      summary: Get Public Key
+      description: |
+        <p align="right">status: <strong>stable</strong></p>
+        Return a public key for a given role and derivation index for
+        a shared wallet.
+
+        To get a hash of the public key, instead of the public key,
+        use query parameter `hash=true`.
+
+        <b>Note:</b> Only `Soft` indexes are supported by this endpoint.
+      parameters:
+        - *parametersWalletId
+        - *parametersRole
+        - *parametersDerivationSegment
+        - *parametersDerivationHash
+      responses: *responsesGetSharedKey
+      
   /shared-wallets/{walletId}/addresses:
     get:
       operationId: listSharedAddresses

--- a/test/e2e/spec/shared_spec.rb
+++ b/test/e2e/spec/shared_spec.rb
@@ -581,6 +581,79 @@ RSpec.describe CardanoWallet::Shared do
         end
       end
 
+      it "Get account public key - active wallet from mnemonics" do
+        m24 = mnemonic_sentence(24)
+        acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/0H")
+        active_wid = create_active_shared_wallet(m24, '0H', acc_xpub)
+
+        res = SHARED.keys.get_acc_public_key(active_wid)
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+
+        res = SHARED.keys.get_acc_public_key(active_wid, {format: "extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_xvk"
+
+        res = SHARED.keys.get_acc_public_key(active_wid, {format: "non_extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+      end
+
+      it "Get account public key - active wallet from acc pub key" do
+        m24 = mnemonic_sentence(24)
+        acc_ix = '0H'
+        acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
+        active_wid = create_active_shared_wallet(acc_xpub, acc_ix, "self")
+
+        res = SHARED.keys.get_acc_public_key(active_wid)
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+
+        res = SHARED.keys.get_acc_public_key(active_wid, {format: "extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_xvk"
+
+        res = SHARED.keys.get_acc_public_key(active_wid, {format: "non_extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+      end
+
+      it "Get account public key - incomplete wallet from mnemonics" do
+        m24 = mnemonic_sentence(24)
+        acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/0H")
+        incomplete_wid = create_incomplete_shared_wallet(m24, '0H', acc_xpub)
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid)
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_xvk"
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "non_extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+      end
+
+      it "Get account public key - incomplete wallet from acc pub key" do
+        m24 = mnemonic_sentence(24)
+        acc_ix = '0H'
+        acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
+        incomplete_wid = create_incomplete_shared_wallet(acc_xpub, acc_ix, "self")
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid)
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_xvk"
+
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "non_extended"})
+        expect(res).to be_correct_and_respond 200
+        expect(res.to_s).to include "acct_shared_vk"
+      end
     end
   end
 end

--- a/test/e2e/spec/shared_spec.rb
+++ b/test/e2e/spec/shared_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe CardanoWallet::Shared do
                                                               acc_xpub_upd)
 
         expect(update_payment).to be_correct_and_respond 200
+        expect(SHARED.wallets.get(incomplete_wid)['state']['status']).to eq 'incomplete'
         expect(SHARED.wallets.get(incomplete_wid)).to be_correct_and_respond 200
 
         update_delegation = SHARED.wallets.update_delegation_script(incomplete_wid,
@@ -216,6 +217,7 @@ RSpec.describe CardanoWallet::Shared do
         expect(update_payment).to be_correct_and_respond 200
 
         expect(SHARED.wallets.get(incomplete_wid)).to be_correct_and_respond 200
+        expect(SHARED.wallets.get(incomplete_wid)['state']['status']).to eq 'incomplete'
 
         expect(SHARED.wallets.list).to be_correct_and_respond 200
 
@@ -288,6 +290,7 @@ RSpec.describe CardanoWallet::Shared do
 
         wallet = w.create(payload)
         expect(wallet).to be_correct_and_respond 201
+        expect(wallet['state']['status']).to eq 'syncing'
 
         wid = wallet['id']
         g = w.get(wid)
@@ -334,6 +337,7 @@ RSpec.describe CardanoWallet::Shared do
 
         wallet = w.create(payload)
         expect(wallet).to be_correct_and_respond 201
+        expect(wallet['state']['status']).to eq 'incomplete'
 
         wid = wallet['id']
         g = w.get(wid)

--- a/test/e2e/spec/shared_spec.rb
+++ b/test/e2e/spec/shared_spec.rb
@@ -536,20 +536,19 @@ RSpec.describe CardanoWallet::Shared do
         end
       end
 
-      it "Create account public key - incomplete wallet from acc pub key" do
-        pending 'no_root key error on wallet from acc pub key'
+      it "Cannot create account public key - incomplete wallet from acc pub key" do
         m24 = mnemonic_sentence(24)
         acc_ix = '0H'
         acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
         incomplete_wid = create_incomplete_shared_wallet(acc_xpub, acc_ix, "self")
         ["0H", "1H", "2147483647H", "44H"].each do |index|
           res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'extended')
-          expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_xvk"
+          expect(res).to be_correct_and_respond 403
+          expect(res.to_s).to include "no_root_key"
 
           res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'non_extended')
-          expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_vk"
+          expect(res).to be_correct_and_respond 403
+          expect(res.to_s).to include "no_root_key"
         end
       end
 
@@ -568,20 +567,19 @@ RSpec.describe CardanoWallet::Shared do
         end
       end
 
-      it "Create account public key - active wallet from acc pub key" do
-        pending 'no_root key error on wallet from acc pub key'
+      it "Cannot create account public key - active wallet from acc pub key" do
         m24 = mnemonic_sentence(24)
         acc_ix = '0H'
         acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
         active_wid = create_active_shared_wallet(acc_xpub, acc_ix, "self")
         ["0H", "1H", "2147483647H", "44H"].each do |index|
           res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'extended')
-          expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_xvk"
+          expect(res).to be_correct_and_respond 403
+          expect(res.to_s).to include "no_root_key"
 
           res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'non_extended')
-          expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_vk"
+          expect(res).to be_correct_and_respond 403
+          expect(res.to_s).to include "no_root_key"
         end
       end
 
@@ -594,11 +592,11 @@ RSpec.describe CardanoWallet::Shared do
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
 
-        res = SHARED.keys.get_acc_public_key(active_wid, {format: "extended"})
+        res = SHARED.keys.get_acc_public_key(active_wid, { format: "extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_xvk"
 
-        res = SHARED.keys.get_acc_public_key(active_wid, {format: "non_extended"})
+        res = SHARED.keys.get_acc_public_key(active_wid, { format: "non_extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
       end
@@ -613,11 +611,11 @@ RSpec.describe CardanoWallet::Shared do
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
 
-        res = SHARED.keys.get_acc_public_key(active_wid, {format: "extended"})
+        res = SHARED.keys.get_acc_public_key(active_wid, { format: "extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_xvk"
 
-        res = SHARED.keys.get_acc_public_key(active_wid, {format: "non_extended"})
+        res = SHARED.keys.get_acc_public_key(active_wid, { format: "non_extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
       end
@@ -631,11 +629,11 @@ RSpec.describe CardanoWallet::Shared do
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
 
-        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "extended"})
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, { format: "extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_xvk"
 
-        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "non_extended"})
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, { format: "non_extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
       end
@@ -650,11 +648,11 @@ RSpec.describe CardanoWallet::Shared do
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
 
-        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "extended"})
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, { format: "extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_xvk"
 
-        res = SHARED.keys.get_acc_public_key(incomplete_wid, {format: "non_extended"})
+        res = SHARED.keys.get_acc_public_key(incomplete_wid, { format: "non_extended" })
         expect(res).to be_correct_and_respond 200
         expect(res.to_s).to include "acct_shared_vk"
       end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -399,6 +399,25 @@ RSpec.describe CardanoWallet::Shelley do
       end
     end
 
+    it "Get account public key - wallet from mnemonics" do
+      wid = create_shelley_wallet
+      res = SHELLEY.keys.get_acc_public_key(wid, {format: "extended"})
+      expect(res).to be_correct_and_respond 200
+      expect(res.to_s).to include "acct_xvk"
+    end
+
+    it "Get account public key - wallet from acc pub key" do
+      w = SHELLEY.wallets
+      wallet = w.create({ name: "Wallet from pub key",
+                         account_public_key: "b47546e661b6c1791452d003d375756dde6cac2250093ce4630f16b9b9c0ac87411337bda4d5bc0216462480b809824ffb48f17e08d95ab9f1b91d391e48e66b",
+                         address_pool_gap: 20,
+                         })
+      expect(wallet).to be_correct_and_respond 201
+
+      res = SHELLEY.keys.get_acc_public_key(wallet['id'], {format: "non_extended"})
+      expect(res).to be_correct_and_respond 200
+      expect(res.to_s).to include "acct_vk"
+    end
   end
 
 end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe CardanoWallet::Shelley do
 
     it "Get account public key - wallet from mnemonics" do
       wid = create_shelley_wallet
-      res = SHELLEY.keys.get_acc_public_key(wid, {format: "extended"})
+      res = SHELLEY.keys.get_acc_public_key(wid, { format: "extended" })
       expect(res).to be_correct_and_respond 200
       expect(res.to_s).to include "acct_xvk"
     end
@@ -414,7 +414,7 @@ RSpec.describe CardanoWallet::Shelley do
                          })
       expect(wallet).to be_correct_and_respond 201
 
-      res = SHELLEY.keys.get_acc_public_key(wallet['id'], {format: "non_extended"})
+      res = SHELLEY.keys.get_acc_public_key(wallet['id'], { format: "non_extended" })
       expect(res).to be_correct_and_respond 200
       expect(res.to_s).to include "acct_vk"
     end


### PR DESCRIPTION
# Issue Number

ADP-934


# Overview

- 55b2fa43e1b03d1f650d64a22414ce6b238f181a
  Tests for get acc pub key for shelley and shared wallets
  
- a388e30e945f8113080826bd99b7042b6802419d
  Add assertions for shared wallet status
  
- 9ab8eafffc034332677837c6c8b32fa5174d79bd
  Cannot create acc pub key for wallets from acc pub key tests
  
- 42dab098a425314d78b9c5c809c5ce0b1e422be8
  Re-shuffle order and extend summary of key eps in swagger for clarity


# Comments

I've also improved a bit key endpoints summary in swagger for better clarity:

![Screenshot from 2021-05-26 16-08-47](https://user-images.githubusercontent.com/42900201/119674720-b80b5e00-be3c-11eb-81e5-38d95f88131f.png)

![Screenshot from 2021-05-26 16-09-01](https://user-images.githubusercontent.com/42900201/119674734-bcd01200-be3c-11eb-824e-c104bf1b927b.png)

