### PR TITLE
Fix termination condition in `makeChangeRepeatedly`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -520,9 +520,17 @@ performSelection minCoinFor costFor bundleSizeAssessor criteria
         -> m (Either SelectionError (SelectionResult TokenBundle))
     makeChangeRepeatedly s = case mChangeGenerated of
 
-        Right change | length change == length outputsToCover ->
-            -- We've succeeded in making the optimal number of change outputs.
-            -- Terminate here.
+        Right change | length change >= length outputsToCover ->
+            -- We've succeeded in making at least the optimal number of change
+            -- outputs, and can terminate here.
+            --
+            -- Note that we can't use an exact length equality check here, as
+            -- the 'makeChange' function will split up change outputs if they
+            -- are oversized in any way. (See 'splitOversizedMaps'.)
+            --
+            -- It is therefore possible for 'makeChange' to generate more change
+            -- outputs than the number of user-specified outputs.
+            --
             pure $ Right $ mkSelectionResult change
 
         Right change ->

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1599,6 +1599,7 @@ prop_makeChange_length p =
             conjoin
                 [ property (length (outputBundles p) == length changeUnsplit)
                 , property (length (outputBundles p) <  length changeSplit)
+                , property (F.fold changeSplit == F.fold changeUnsplit)
                 ]
 
     mChangeUnsplit =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1181,6 +1181,7 @@ boundaryTestMatrix_largeTokenQuantities =
     , boundaryTest_largeTokenQuantities_3
     , boundaryTest_largeTokenQuantities_4
     , boundaryTest_largeTokenQuantities_5
+    , boundaryTest_largeTokenQuantities_6
     ]
 
 -- Reach (but do not exceed) the maximum token quantity by selecting inputs
@@ -1318,6 +1319,46 @@ boundaryTest_largeTokenQuantities_5 = BoundaryTestData
     boundaryTestBundleSizeAssessor = NoBundleSizeLimit
     boundaryTestOutputs =
       [ (Coin 2_000_000, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+    boundaryTestChange =
+      [ (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+
+-- In the event that generated change bundles must be split, demonstrate that
+-- the change generation algorithm terminates after only a subset of the UTxO
+-- has been selected.
+--
+-- See: https://jira.iohk.io/browse/ADP-890
+--
+boundaryTest_largeTokenQuantities_6 :: BoundaryTestData
+boundaryTest_largeTokenQuantities_6 = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestOutputs =
+      [ (Coin 1_000_000, [])
+      , (Coin 1_000_000, [])
+      ]
     boundaryTestUTxO =
       [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1180,6 +1180,7 @@ boundaryTestMatrix_largeTokenQuantities =
     , boundaryTest_largeTokenQuantities_2
     , boundaryTest_largeTokenQuantities_3
     , boundaryTest_largeTokenQuantities_4
+    , boundaryTest_largeTokenQuantities_5
     ]
 
 -- Reach (but do not exceed) the maximum token quantity by selecting inputs
@@ -1300,6 +1301,44 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
     boundaryTestChange =
       [ (Coin 250_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       , (Coin 250_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+
+-- In the event that generated change bundles must be split, demonstrate that
+-- the change generation algorithm terminates after only a subset of the UTxO
+-- has been selected.
+--
+-- See: https://jira.iohk.io/browse/ADP-890
+--
+boundaryTest_largeTokenQuantities_5 :: BoundaryTestData
+boundaryTest_largeTokenQuantities_5 = BoundaryTestData
+    { boundaryTestCriteria = BoundaryTestCriteria {..}
+    , boundaryTestExpectedResult = BoundaryTestResult {..}
+    }
+  where
+    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestOutputs =
+      [ (Coin 2_000_000, []) ]
+    boundaryTestUTxO =
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+    boundaryTestInputs =
+      [ (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 1_000_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      ]
+    boundaryTestChange =
+      [ (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
+      , (Coin 500_000, [(mockAsset "A", txOutMaxTokenQuantity)])
       ]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
# Issue Number

ADP-890

# Summary

This PR fixes a termination condition in `RoundRobin.makeChangeRepeatedly`.

This initial termination condition was incorrect:

```hs
Right change | length change == length outputsToCover ->
    -- We've succeeded in making the optimal number of change outputs.
    -- Terminate here.
    pure $ Right $ mkSelectionResult change
```

This equality check was based on the faulty assumption that `makeChange` always returns a list of change outputs whose length is _less than or equal_ to the number of user-specified outputs.

However, this assumption is **NOT** valid.

In cases where there are many unique assets in the selected inputs, it's possible for `makeChange` to return a list whose length is _greater than_ the number of user-specified outputs. This can happen when one or more change outputs exceeds either of the following limits:

1. A change output has a quantity of a particular asset that exceeds `maxBound :: Word64`.
2. A change output has a serialized length that is greater than the upper limit defined by the protocol (`4000` bytes).

If `makeChange` encounters a bundle that exceeds either of the above limits, it will split up the oversized bundle into smaller bundles that don't exceed the limits. (See `splitOversizedMaps`.)

This means that the number of change outputs generated by `makeChange` can _exceed_ the number of user-specified outputs. Hence, we need to adjust the termination condition of `makeChangeRepeatedly` to allow for this possibility.

# QA

This PR:

- [x] Adds regression tests `boundaryTest_largeTokenQuantities_{5,6}`. These tests perform coin selections that can only succeed if change bundles are split, in order to demonstrate that the change generation algorithm terminates after only a subset of the UTxO has been selected.
- [x] Adjusts the property test `prop_makeChange_length` to account for splitting of bundles.

# Background

The original motivation for generating one change output per user-specified output was to avoid shrinking the size of the UTxO set unnecessarily. By default `makeChange` will already do this, unless there is not enough ada available in the existing set of selected inputs to pay for all the change, in which case change outputs will be coalesced.

# Performance Impact

The faulty termination condition would cause `makeChangeRepeatedly` to repeatedly expand the set of selected inputs in an effort to optimize the set of change outputs, continuing until the entire UTxO set was exhausted.

## Example

This example uses a `testnet` wallet with:
- 47 UTxO entries, of which:
    - 1 entry is a pure ada entry
    - 46 entries are multi-asset entries.
- around 700 unique assets.
    
We make a payment request for the exact balance of the pure-ada entry, the value of which is around 20% of the total ada available in the UTxO set (when all entries are considered).

Specifying this amount means that the coin selection algorithm is guaranteed to select from among the multi-asset entries when generating the initial selection.

### Before applying this PR

Time required to generate a fee estimate:
```
$ time curl -X POST http://localhost:8090/v2/wallets/c8b5cd51de6c0c84c5404fca06a02007e650548f/payment-fees     -d '{"payments":[{"address":"addr_test1qzg9mz36rmw4k24hpnnmhfmvrfj8vydmc4rl970zdxfd5ltgrnkw3ewxurn9kuwfuq7gexjulr0s9wthlxa37z2ezwcqy3cxhm", "amount":{"quantity":2164303103,"unit":"lovelace"}}]}'     -H "Content-Type: application/json"
{"estimated_min":{"quantity":244013,"unit":"lovelace"},"deposit":{"quantity":0,"unit":"lovelace"},"minimum_coins":[{"quantity":1000000,"unit":"lovelace"}],"estimated_max":{"quantity":2143653,"unit":"lovelace"}}
real    4m46.720s
user    0m0.004s
sys     0m0.011s
```

Number of inputs selected:
```
$ grep numberOfSelectedInputs cardano-wallet.log | sort -V | uniq -c
  3   numberOfSelectedInputs: 2
  3   numberOfSelectedInputs: 3
  2   numberOfSelectedInputs: 4
  1   numberOfSelectedInputs: 5
  2   numberOfSelectedInputs: 6
  2   numberOfSelectedInputs: 7
  1   numberOfSelectedInputs: 9
  2   numberOfSelectedInputs: 10
  3   numberOfSelectedInputs: 12
  4   numberOfSelectedInputs: 13
  3   numberOfSelectedInputs: 14
  4   numberOfSelectedInputs: 15
  2   numberOfSelectedInputs: 16
  1   numberOfSelectedInputs: 17
  2   numberOfSelectedInputs: 18
  1   numberOfSelectedInputs: 19
  1   numberOfSelectedInputs: 20
  2   numberOfSelectedInputs: 21
  1   numberOfSelectedInputs: 22
  2   numberOfSelectedInputs: 23
  2   numberOfSelectedInputs: 25
  1   numberOfSelectedInputs: 26
  1   numberOfSelectedInputs: 29
  1   numberOfSelectedInputs: 30
  2   numberOfSelectedInputs: 31
  1   numberOfSelectedInputs: 32
  1   numberOfSelectedInputs: 38
 49   numberOfSelectedInputs: 47
```
In the above test run, in 49 cases out of 100, the entire UTxO set was consumed.

### After applying this PR

Time required to generate a fee estimate:
```
$ time curl -X POST http://localhost:8090/v2/wallets/c8b5cd51de6c0c84c5404fca06a02007e650548f/payment-fees     -d '{"payments":[{"address":"addr_test1qzg9mz36rmw4k24hpnnmhfmvrfj8vydmc4rl970zdxfd5ltgrnkw3ewxurn9kuwfuq7gexjulr0s9wthlxa37z2ezwcqy3cxhm", "amount":{"quantity":2164303103,"unit":"lovelace"}}]}'     -H "Content-Type: application/json"
{"estimated_min":{"quantity":231206,"unit":"lovelace"},"deposit":{"quantity":0,"unit":"lovelace"},"minimum_coins":[{"quantity":1000000,"unit":"lovelace"}],"estimated_max":{"quantity":1927085,"unit":"lovelace"}}
real    0m19.462s
user    0m0.003s
sys     0m0.005s
```

Number of inputs selected:
```
$ grep numberOfSelectedInputs cardano-wallet.log | sort -V | uniq -c
  5   numberOfSelectedInputs: 2
  4   numberOfSelectedInputs: 3
  2   numberOfSelectedInputs: 4
  1   numberOfSelectedInputs: 5
  3   numberOfSelectedInputs: 6
  1   numberOfSelectedInputs: 7
  1   numberOfSelectedInputs: 8
  2   numberOfSelectedInputs: 9
  1   numberOfSelectedInputs: 10
  1   numberOfSelectedInputs: 12
  3   numberOfSelectedInputs: 13
  1   numberOfSelectedInputs: 14
  1   numberOfSelectedInputs: 15
  1   numberOfSelectedInputs: 16
  1   numberOfSelectedInputs: 17
  4   numberOfSelectedInputs: 18
  2   numberOfSelectedInputs: 19
  5   numberOfSelectedInputs: 20
  3   numberOfSelectedInputs: 21
  1   numberOfSelectedInputs: 22
  3   numberOfSelectedInputs: 23
  1   numberOfSelectedInputs: 24
  2   numberOfSelectedInputs: 25
  2   numberOfSelectedInputs: 27
  3   numberOfSelectedInputs: 29
  3   numberOfSelectedInputs: 30
  1   numberOfSelectedInputs: 31
  3   numberOfSelectedInputs: 32
  2   numberOfSelectedInputs: 33
  2   numberOfSelectedInputs: 34
  3   numberOfSelectedInputs: 35
  5   numberOfSelectedInputs: 36
  2   numberOfSelectedInputs: 37
  2   numberOfSelectedInputs: 39
  4   numberOfSelectedInputs: 40
  5   numberOfSelectedInputs: 41
  5   numberOfSelectedInputs: 42
  4   numberOfSelectedInputs: 43
  3   numberOfSelectedInputs: 44
  2   numberOfSelectedInputs: 45
```
Now the number of selected inputs has a much flatter distribution, and we never hit the case where the entire UTxO set is consumed.