### PR TITLE
update e2e tests gemfile

### DIFF
--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cardano_wallet', '~> 0.3.7'
+gem 'cardano_wallet', '~> 0.3.8'
 # gem 'cardano_wallet', path: "~/wb/cardano_wallet"
 gem 'bip_mnemonic', '0.0.4'
 gem 'rake', '12.3.3'

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     bip_mnemonic (0.0.4)
-    cardano_wallet (0.3.7)
+    cardano_wallet (0.3.8)
       httparty (~> 0.18.0)
     diff-lcs (1.4.4)
     httparty (0.18.1)
@@ -32,7 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bip_mnemonic (= 0.0.4)
-  cardano_wallet (~> 0.3.7)
+  cardano_wallet (~> 0.3.8)
   rake (= 12.3.3)
   rspec (= 3.10.0)
 


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [ ] I have updated gemfile to cardano_wallet 0.3.8, as it didn't pick up latest version due to Gemfile.lock


# Comments

E2E Tests for Windows and Mac pass. Linux and Docker failing due to https://jira.iohk.io/browse/ADP-798.
I've passed Linux locally.


https://github.com/input-output-hk/cardano-wallet/actions
