### PR TITLE
Add UTxO snapshot API endpoint and CLI command.

### DIFF
--- a/lib/cli/test/unit/Cardano/CLISpec.hs
+++ b/lib/cli/test/unit/Cardano/CLISpec.hs
@@ -165,6 +165,8 @@ spec = do
             , "                           id."
             , "  utxo                     Get UTxO statistics for the wallet"
             , "                           with specified id."
+            , "  utxo-snapshot            Get UTxO snapshot for wallet with"
+            , "                           specified id."
             ]
 
         ["wallet", "list", "--help"] `shouldShowUsage`

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -178,6 +178,7 @@ module Test.Integration.Framework.DSL
     , createWalletViaCLI
     , createWalletFromPublicKeyViaCLI
     , deleteWalletViaCLI
+    , getWalletUtxoSnapshotViaCLI
     , getWalletUtxoStatisticsViaCLI
     , getWalletViaCLI
     , createAddressViaCLI
@@ -2470,6 +2471,18 @@ getWalletUtxoStatisticsViaCLI
     -> m r
 getWalletUtxoStatisticsViaCLI ctx walId = cardanoWalletCLI
     ["wallet", "utxo", "--port", show (ctx ^. typed @(Port "wallet")) , walId ]
+
+getWalletUtxoSnapshotViaCLI
+    :: forall r s m.
+        ( CmdResult r
+
+        , HasType (Port "wallet") s
+        , MonadIO m)
+    => s
+    -> String
+    -> m r
+getWalletUtxoSnapshotViaCLI ctx walId = cardanoWalletCLI
+    ["wallet", "utxo-snapshot", "--port", show (ctx ^. typed @(Port "wallet")) , walId ]
 
 createAddressViaCLI
     :: forall s m. (HasType (Port "wallet") s, MonadIO m)

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -2475,14 +2475,19 @@ getWalletUtxoStatisticsViaCLI ctx walId = cardanoWalletCLI
 getWalletUtxoSnapshotViaCLI
     :: forall r s m.
         ( CmdResult r
-
         , HasType (Port "wallet") s
-        , MonadIO m)
+        , MonadIO m
+        )
     => s
     -> String
     -> m r
 getWalletUtxoSnapshotViaCLI ctx walId = cardanoWalletCLI
-    ["wallet", "utxo-snapshot", "--port", show (ctx ^. typed @(Port "wallet")) , walId ]
+    [ "wallet"
+    , "utxo-snapshot"
+    , "--port"
+    , show (ctx ^. typed @(Port "wallet"))
+    , walId
+    ]
 
 createAddressViaCLI
     :: forall s m. (HasType (Port "wallet") s, MonadIO m)

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -380,31 +380,49 @@ spec = describe "BYRON_WALLETS" $ do
         expectResponseCode HTTP.status200 rStat
         expectWalletUTxO [] (snd rStat)
 
-    it "BYRON_UTXO_SNAPSHOT_01 - Wallet's inactivity is reflected in utxo snapshot" $ \ctx ->
-        forM_ [ emptyRandomWallet, emptyIcarusWallet ] $ \emptyByronWallet -> runResourceT $ do
-        w <- emptyByronWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Byron w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        expectField #entries (`shouldBe` []) rSnap
+    it "BYRON_WALLET_UTXO_SNAPSHOT_01 - \
+        \Can generate UTxO snapshot of empty wallet" $
+        \ctx -> do
+            let emptyByronWallets =
+                  [ emptyRandomWallet
+                  , emptyIcarusWallet
+                  ]
+            forM_ emptyByronWallets $ \emptyByronWallet -> runResourceT $ do
+                w <- emptyByronWallet ctx
+                rSnap <- request @ApiWalletUtxoSnapshot ctx
+                  (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                expectResponseCode HTTP.status200 rSnap
+                expectField #entries (`shouldBe` []) rSnap
 
-    it "BYRON_UTXO_SNAPSHOT_02 - Wallet's snapshot with ADA" $ \ctx ->
-        forM_ [ fixtureRandomWallet, fixtureIcarusWallet ] $ \fixtureWallet -> runResourceT $ do
-        w <- fixtureWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Byron w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        let entries = getFromResponse #entries rSnap
-        length entries `shouldBe` 10
+    it "BYRON_WALLET_UTXO_SNAPSHOT_02 - \
+        \Can generate UTxO snapshot of pure-ada wallet" $
+        \ctx -> do
+            let fixtureWallets =
+                  [ fixtureRandomWallet
+                  , fixtureIcarusWallet
+                  ]
+            forM_ fixtureWallets $ \fixtureWallet -> runResourceT $ do
+                w <- fixtureWallet ctx
+                rSnap <- request @ApiWalletUtxoSnapshot ctx
+                    (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                expectResponseCode HTTP.status200 rSnap
+                let entries = getFromResponse #entries rSnap
+                length entries `shouldBe` 10
 
-    it "BYRON_UTXO_SNAPSHOT_03 - Wallet's snapshot with ADA and assets" $ \ctx ->
-        forM_ [ fixtureMultiAssetRandomWallet @n, fixtureMultiAssetIcarusWallet @n ] $ \fixtureWallet -> runResourceT $ do
-        w <- fixtureWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Byron w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        let entries = getFromResponse #entries rSnap
-        length entries `shouldBe` 11
+    it "BYRON_WALLET_UTXO_SNAPSHOT_03 - \
+        \Can generate UTxO snapshot of multi-asset wallet" $
+        \ctx -> do
+            let fixtureWallets =
+                    [ fixtureMultiAssetRandomWallet @n
+                    , fixtureMultiAssetIcarusWallet @n
+                    ]
+            forM_ fixtureWallets $ \fixtureWallet -> runResourceT $ do
+                w <- fixtureWallet ctx
+                rSnap <- request @ApiWalletUtxoSnapshot ctx
+                    (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                expectResponseCode HTTP.status200 rSnap
+                let entries = getFromResponse #entries rSnap
+                length entries `shouldBe` 11
 
     it "BYRON_UPDATE_PASS_01 - change passphrase" $ \ctx ->
         forM_ [ emptyRandomWallet, emptyIcarusWallet ] $ \emptyByronWallet -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -390,7 +390,7 @@ spec = describe "BYRON_WALLETS" $ do
             forM_ emptyByronWallets $ \emptyByronWallet -> runResourceT $ do
                 w <- emptyByronWallet ctx
                 rSnap <- request @ApiWalletUtxoSnapshot ctx
-                  (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                  (Link.getWalletUtxoSnapshot @'Byron w) Default Empty
                 expectResponseCode HTTP.status200 rSnap
                 expectField #entries (`shouldBe` []) rSnap
 
@@ -404,7 +404,7 @@ spec = describe "BYRON_WALLETS" $ do
             forM_ fixtureWallets $ \fixtureWallet -> runResourceT $ do
                 w <- fixtureWallet ctx
                 rSnap <- request @ApiWalletUtxoSnapshot ctx
-                    (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                    (Link.getWalletUtxoSnapshot @'Byron w) Default Empty
                 expectResponseCode HTTP.status200 rSnap
                 let entries = getFromResponse #entries rSnap
                 length entries `shouldBe` 10
@@ -419,7 +419,7 @@ spec = describe "BYRON_WALLETS" $ do
             forM_ fixtureWallets $ \fixtureWallet -> runResourceT $ do
                 w <- fixtureWallet ctx
                 rSnap <- request @ApiWalletUtxoSnapshot ctx
-                    (Link.getUTxOsSnapshot @'Byron w) Default Empty
+                    (Link.getWalletUtxoSnapshot @'Byron w) Default Empty
                 expectResponseCode HTTP.status200 rSnap
                 let entries = getFromResponse #entries rSnap
                 length entries `shouldBe` 11

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -26,6 +26,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiVerificationKeyShelley (..)
     , ApiWallet
+    , ApiWalletUtxoSnapshot
     , DecodeAddress
     , DecodeStakeAddress
     , EncodeAddress (..)
@@ -98,6 +99,7 @@ import Test.Integration.Framework.DSL
     , expectListSize
     , expectResponseCode
     , expectWalletUTxO
+    , fixtureMultiAssetWallet
     , fixturePassphrase
     , fixtureWallet
     , genMnemonics
@@ -924,6 +926,29 @@ spec = describe "SHELLEY_WALLETS" $ do
                  (Link.getUTxOsStatistics @'Shelley w) Default Empty
         expectResponseCode HTTP.status200 rStat
         expectWalletUTxO [] (snd rStat)
+
+    it "WALLETS_UTXO_SNAPSHOT_01 - Wallet's inactivity is reflected in utxo snapshot" $ \ctx -> runResourceT $ do
+        w <- emptyWallet ctx
+        rSnap <- request @ApiWalletUtxoSnapshot ctx
+                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+        expectResponseCode HTTP.status200 rSnap
+        expectField #entries (`shouldBe` []) rSnap
+
+    it "WALLETS_UTXO_SNAPSHOT_02 - Wallet's snapshot with ADA" $ \ctx -> runResourceT $ do
+        w <- fixtureWallet ctx
+        rSnap <- request @ApiWalletUtxoSnapshot ctx
+                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+        expectResponseCode HTTP.status200 rSnap
+        let entries = getFromResponse #entries rSnap
+        length entries `shouldBe` 10
+
+    it "WALLETS_UTXO_SNAPSHOT_03 - Wallet's snapshot with ADA and assets" $ \ctx -> runResourceT $ do
+        w <- fixtureMultiAssetWallet ctx
+        rSnap <- request @ApiWalletUtxoSnapshot ctx
+                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+        expectResponseCode HTTP.status200 rSnap
+        let entries = getFromResponse #entries rSnap
+        length entries `shouldBe` 3
 
     it "WALLETS_UTXO_02 - Sending and receiving funds updates wallet's utxo." $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -932,7 +932,7 @@ spec = describe "SHELLEY_WALLETS" $ do
         \ctx -> runResourceT $ do
             w <- emptyWallet ctx
             rSnap <- request @ApiWalletUtxoSnapshot ctx
-                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+                (Link.getWalletUtxoSnapshot @'Shelley w) Default Empty
             expectResponseCode HTTP.status200 rSnap
             expectField #entries (`shouldBe` []) rSnap
 
@@ -941,7 +941,7 @@ spec = describe "SHELLEY_WALLETS" $ do
         \ctx -> runResourceT $ do
             w <- fixtureWallet ctx
             rSnap <- request @ApiWalletUtxoSnapshot ctx
-                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+                (Link.getWalletUtxoSnapshot @'Shelley w) Default Empty
             expectResponseCode HTTP.status200 rSnap
             let entries = getFromResponse #entries rSnap
             length entries `shouldBe` 10
@@ -951,7 +951,7 @@ spec = describe "SHELLEY_WALLETS" $ do
         \ctx -> runResourceT $ do
             w <- fixtureMultiAssetWallet ctx
             rSnap <- request @ApiWalletUtxoSnapshot ctx
-                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+                (Link.getWalletUtxoSnapshot @'Shelley w) Default Empty
             expectResponseCode HTTP.status200 rSnap
             let entries = getFromResponse #entries rSnap
             length entries `shouldBe` 3

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -927,28 +927,34 @@ spec = describe "SHELLEY_WALLETS" $ do
         expectResponseCode HTTP.status200 rStat
         expectWalletUTxO [] (snd rStat)
 
-    it "WALLETS_UTXO_SNAPSHOT_01 - Wallet's inactivity is reflected in utxo snapshot" $ \ctx -> runResourceT $ do
-        w <- emptyWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        expectField #entries (`shouldBe` []) rSnap
+    it "WALLET_UTXO_SNAPSHOT_01 - \
+        \Can generate UTxO snapshot of empty wallet" $
+        \ctx -> runResourceT $ do
+            w <- emptyWallet ctx
+            rSnap <- request @ApiWalletUtxoSnapshot ctx
+                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+            expectResponseCode HTTP.status200 rSnap
+            expectField #entries (`shouldBe` []) rSnap
 
-    it "WALLETS_UTXO_SNAPSHOT_02 - Wallet's snapshot with ADA" $ \ctx -> runResourceT $ do
-        w <- fixtureWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        let entries = getFromResponse #entries rSnap
-        length entries `shouldBe` 10
+    it "WALLET_UTXO_SNAPSHOT_02 - \
+        \Can generate UTxO snapshot of pure-ada wallet" $
+        \ctx -> runResourceT $ do
+            w <- fixtureWallet ctx
+            rSnap <- request @ApiWalletUtxoSnapshot ctx
+                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+            expectResponseCode HTTP.status200 rSnap
+            let entries = getFromResponse #entries rSnap
+            length entries `shouldBe` 10
 
-    it "WALLETS_UTXO_SNAPSHOT_03 - Wallet's snapshot with ADA and assets" $ \ctx -> runResourceT $ do
-        w <- fixtureMultiAssetWallet ctx
-        rSnap <- request @ApiWalletUtxoSnapshot ctx
-                 (Link.getUTxOsSnapshot @'Shelley w) Default Empty
-        expectResponseCode HTTP.status200 rSnap
-        let entries = getFromResponse #entries rSnap
-        length entries `shouldBe` 3
+    it "WALLET_UTXO_SNAPSHOT_03 - \
+        \Can generate UTxO snapshot of multi-asset wallet" $
+        \ctx -> runResourceT $ do
+            w <- fixtureMultiAssetWallet ctx
+            rSnap <- request @ApiWalletUtxoSnapshot ctx
+                (Link.getUTxOsSnapshot @'Shelley w) Default Empty
+            expectResponseCode HTTP.status200 rSnap
+            let entries = getFromResponse #entries rSnap
+            length entries `shouldBe` 3
 
     it "WALLETS_UTXO_02 - Sending and receiving funds updates wallet's utxo." $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -20,6 +20,7 @@ import Cardano.Wallet.Api.Types
     ( ApiTransaction
     , ApiUtxoStatistics
     , ApiWallet
+    , ApiWalletUtxoSnapshot
     , DecodeAddress (..)
     , DecodeStakeAddress (..)
     , EncodeAddress (..)
@@ -78,6 +79,7 @@ import Test.Integration.Framework.DSL
     , expectWalletUTxO
     , fixtureWallet
     , generateMnemonicsViaCLI
+    , getWalletUtxoSnapshotViaCLI
     , getWalletUtxoStatisticsViaCLI
     , getWalletViaCLI
     , listAddresses
@@ -717,6 +719,14 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         e `shouldBe` cmdOk
         utxoStats <- expectValidJSON (Proxy @ApiUtxoStatistics) o
         expectWalletUTxO [] (Right utxoStats)
+
+    it "WALLETS_UTXO_SNAPSHOT_01 - Empty utxo snapshot for empty wallet" $ \ctx -> runResourceT $ do
+        wid <- emptyWallet' ctx
+        (Exit c, Stdout o, Stderr e) <- getWalletUtxoSnapshotViaCLI ctx wid
+        c `shouldBe` ExitSuccess
+        e `shouldBe` cmdOk
+        utxoSnap <- expectValidJSON (Proxy @ApiWalletUtxoSnapshot) o
+        expectCliField (#entries) (`shouldBe` []) utxoSnap
 
     it "WALLETS_UTXO_02 - Utxo statistics works properly" $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -720,13 +720,15 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
         utxoStats <- expectValidJSON (Proxy @ApiUtxoStatistics) o
         expectWalletUTxO [] (Right utxoStats)
 
-    it "WALLETS_UTXO_SNAPSHOT_01 - Empty utxo snapshot for empty wallet" $ \ctx -> runResourceT $ do
-        wid <- emptyWallet' ctx
-        (Exit c, Stdout o, Stderr e) <- getWalletUtxoSnapshotViaCLI ctx wid
-        c `shouldBe` ExitSuccess
-        e `shouldBe` cmdOk
-        utxoSnap <- expectValidJSON (Proxy @ApiWalletUtxoSnapshot) o
-        expectCliField (#entries) (`shouldBe` []) utxoSnap
+    it "WALLET_UTXO_SNAPSHOT_01 - \
+        \Can generate UTxO snapshot of empty wallet" $
+        \ctx -> runResourceT $ do
+            wid <- emptyWallet' ctx
+            (Exit c, Stdout o, Stderr e) <- getWalletUtxoSnapshotViaCLI ctx wid
+            c `shouldBe` ExitSuccess
+            e `shouldBe` cmdOk
+            utxoSnap <- expectValidJSON (Proxy @ApiWalletUtxoSnapshot) o
+            expectCliField (#entries) (`shouldBe` []) utxoSnap
 
     it "WALLETS_UTXO_02 - Utxo statistics works properly" $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -28,6 +28,7 @@ module Cardano.Wallet.Api
         , PutWallet
         , PutWalletPassphrase
         , GetUTxOsStatistics
+        , GetWalletUtxoSnapshot
 
     , WalletKeys
         , GetWalletKey
@@ -81,6 +82,7 @@ module Cardano.Wallet.Api
         , PostByronWallet
         , PutByronWallet
         , GetByronUTxOsStatistics
+        , GetByronWalletUtxoSnapshot
         , PutByronWalletPassphrase
 
     , ByronAssets
@@ -190,6 +192,7 @@ import Cardano.Wallet.Api.Types
     , ApiWalletMigrationPostDataT
     , ApiWalletPassphrase
     , ApiWalletSignData
+    , ApiWalletUtxoSnapshot
     , ByronWalletPutPassphraseData
     , Iso8601Time
     , KeyFormat
@@ -311,6 +314,7 @@ type Wallets =
     :<|> PostWallet
     :<|> PutWallet
     :<|> PutWalletPassphrase
+    :<|> GetWalletUtxoSnapshot
     :<|> GetUTxOsStatistics
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/deleteWallet
@@ -344,6 +348,11 @@ type PutWalletPassphrase = "wallets"
     :> "passphrase"
     :> ReqBody '[JSON] WalletPutPassphraseData
     :> PutNoContent
+
+type GetWalletUtxoSnapshot = "wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "utxo"
+    :> Get '[JSON] ApiWalletUtxoSnapshot
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getUTxOsStatistics
 type GetUTxOsStatistics = "wallets"
@@ -634,6 +643,7 @@ type ByronWallets =
     :<|> GetByronWallet
     :<|> ListByronWallets
     :<|> PutByronWallet
+    :<|> GetByronWalletUtxoSnapshot
     :<|> GetByronUTxOsStatistics
     :<|> PutByronWalletPassphrase
 
@@ -661,6 +671,12 @@ type PutByronWallet = "byron-wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> ReqBody '[JSON] WalletPutData
     :> Put '[JSON] ApiByronWallet
+
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronWalletUtxoSnapshot
+type GetByronWalletUtxoSnapshot = "byron-wallets"
+    :> Capture "walletId" (ApiT WalletId)
+    :> "utxo"
+    :> Get '[JSON] ApiWalletUtxoSnapshot
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getByronUTxOsStatistics
 type GetByronUTxOsStatistics = "byron-wallets"

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -349,6 +349,7 @@ type PutWalletPassphrase = "wallets"
     :> ReqBody '[JSON] WalletPutPassphraseData
     :> PutNoContent
 
+-- | https://input-output-hk.github.io/cardano-wallet/api/#operation/getWalletUtxoSnapshot
 type GetWalletUtxoSnapshot = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "utxo"

--- a/lib/core/src/Cardano/Wallet/Api/Client.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Client.hs
@@ -78,6 +78,7 @@ import Cardano.Wallet.Api.Types
     , ApiUtxoStatistics
     , ApiWallet (..)
     , ApiWalletPassphrase
+    , ApiWalletUtxoSnapshot (..)
     , ByronWalletPutPassphraseData (..)
     , Iso8601Time (..)
     , PostExternalTransactionData (..)
@@ -129,6 +130,9 @@ data WalletClient wallet = WalletClient
     , getWalletUtxoStatistics
         :: ApiT WalletId
         -> ClientM ApiUtxoStatistics
+    , getWalletUtxoSnapshot
+        :: ApiT WalletId
+        -> ClientM ApiWalletUtxoSnapshot
     , listWallets
         :: ClientM [wallet]
     , postWallet
@@ -229,6 +233,7 @@ walletClient =
             :<|> _postWallet
             :<|> _putWallet
             :<|> _putWalletPassphrase
+            :<|> _getWalletUtxoSnapshot
             :<|> _getWalletUtxoStatistics
             = client (Proxy @("v2" :> Wallets))
     in
@@ -239,6 +244,7 @@ walletClient =
             , postWallet = _postWallet
             , putWallet = _putWallet
             , putWalletPassphrase = _putWalletPassphrase
+            , getWalletUtxoSnapshot = _getWalletUtxoSnapshot
             , getWalletUtxoStatistics = _getWalletUtxoStatistics
             }
 
@@ -251,6 +257,7 @@ byronWalletClient =
             :<|> _getWallet
             :<|> _listWallets
             :<|> _putWallet
+            :<|> _getWalletUtxoSnapshot
             :<|> _getWalletUtxoStatistics
             :<|> _putWalletPassphrase
             = client (Proxy @("v2" :> ByronWallets))
@@ -266,6 +273,7 @@ byronWalletClient =
                     { oldPassphrase = Just $ coerce <$> body ^. #oldPassphrase
                     , newPassphrase = body ^. #newPassphrase
                     }
+            , getWalletUtxoSnapshot = _getWalletUtxoSnapshot
             , getWalletUtxoStatistics = _getWalletUtxoStatistics
             }
 

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -44,6 +44,7 @@ module Cardano.Wallet.Api.Link
     , postWallet
     , putWallet
     , putWalletPassphrase
+    , getUTxOsSnapshot
     , getUTxOsStatistics
     , createMigrationPlan
     , migrateWallet
@@ -233,6 +234,21 @@ getUTxOsStatistics
 getUTxOsStatistics w = discriminate @style
     (endpoint @Api.GetUTxOsStatistics (wid &))
     (endpoint @Api.GetByronUTxOsStatistics (wid &))
+    (notSupported "Shared")
+  where
+    wid = w ^. typed @(ApiT WalletId)
+
+getUTxOsSnapshot
+    :: forall (style :: WalletStyle) w.
+        ( HasCallStack
+        , Discriminate style
+        , HasType (ApiT WalletId) w
+        )
+    => w
+    -> (Method, Text)
+getUTxOsSnapshot w = discriminate @style
+    (endpoint @Api.GetWalletUtxoSnapshot (wid &))
+    (endpoint @Api.GetByronWalletUTxOSnapshot (wid &))
     (notSupported "Shared")
   where
     wid = w ^. typed @(ApiT WalletId)

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -44,7 +44,7 @@ module Cardano.Wallet.Api.Link
     , postWallet
     , putWallet
     , putWalletPassphrase
-    , getUTxOsSnapshot
+    , getWalletUtxoSnapshot
     , getUTxOsStatistics
     , createMigrationPlan
     , migrateWallet
@@ -238,7 +238,7 @@ getUTxOsStatistics w = discriminate @style
   where
     wid = w ^. typed @(ApiT WalletId)
 
-getUTxOsSnapshot
+getWalletUtxoSnapshot
     :: forall (style :: WalletStyle) w.
         ( HasCallStack
         , Discriminate style
@@ -246,9 +246,9 @@ getUTxOsSnapshot
         )
     => w
     -> (Method, Text)
-getUTxOsSnapshot w = discriminate @style
+getWalletUtxoSnapshot w = discriminate @style
     (endpoint @Api.GetWalletUtxoSnapshot (wid &))
-    (endpoint @Api.GetByronWalletUTxOSnapshot (wid &))
+    (endpoint @Api.GetByronWalletUtxoSnapshot (wid &))
     (notSupported "Shared")
   where
     wid = w ^. typed @(ApiT WalletId)

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -78,6 +78,8 @@ module Cardano.Wallet.Api.Types
     , ApiWalletAssetsBalance (..)
     , ApiWalletPassphrase (..)
     , ApiWalletPassphraseInfo (..)
+    , ApiWalletUtxoSnapshot (..)
+    , ApiWalletUtxoSnapshotEntry (..)
     , ApiUtxoStatistics (..)
     , toApiUtxoStatistics
     , WalletPostData (..)
@@ -696,6 +698,20 @@ newtype ApiWalletPassphrase = ApiWalletPassphrase
     { passphrase :: ApiT (Passphrase "lenient")
     } deriving (Eq, Generic, Show)
       deriving anyclass NFData
+
+newtype ApiWalletUtxoSnapshot = ApiWalletUtxoSnapshot
+    { entries :: [ApiWalletUtxoSnapshotEntry]
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
+
+data ApiWalletUtxoSnapshotEntry = ApiWalletUtxoSnapshotEntry
+    { ada :: !(Quantity "lovelace" Natural)
+    , adaMinimum :: !(Quantity "lovelace" Natural)
+    , assets :: !(ApiT W.TokenMap)
+    }
+    deriving (Eq, Generic, Show)
+    deriving anyclass NFData
 
 data ApiStakePool = ApiStakePool
     { id :: !(ApiT PoolId)
@@ -1895,6 +1911,16 @@ instance ToJSON ApiWallet where
 instance FromJSON ApiWalletPassphrase where
     parseJSON = genericParseJSON defaultRecordTypeOptions
 instance ToJSON ApiWalletPassphrase where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+instance FromJSON ApiWalletUtxoSnapshot where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiWalletUtxoSnapshot where
+    toJSON = genericToJSON defaultRecordTypeOptions
+
+instance FromJSON ApiWalletUtxoSnapshotEntry where
+    parseJSON = genericParseJSON defaultRecordTypeOptions
+instance ToJSON ApiWalletUtxoSnapshotEntry where
     toJSON = genericToJSON defaultRecordTypeOptions
 
 instance FromJSON WalletPostData where

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiWalletUtxoSnapshot.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiWalletUtxoSnapshot.json
@@ -1,0 +1,322 @@
+{
+    "seed": 7656127382344739251,
+    "samples": [
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 4,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 10,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "entries": []
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 10,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 6,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 8,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 6,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 4,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 1,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e42",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 1,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 5,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 8,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                },
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 10,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ]
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 4,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 7,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 11,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "ada_minimum": {
+                        "quantity": 9,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 10,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e42",
+                            "quantity": 1,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 2,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 4,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 7,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e42",
+                            "quantity": 8,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 19,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e42",
+                            "quantity": 7,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 17,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "ada_minimum": {
+                        "quantity": 8,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 9,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 6,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        }
+                    ]
+                },
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 8,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ]
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 5,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 5,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "entries": []
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 5,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 10,
+                        "unit": "lovelace"
+                    },
+                    "assets": []
+                }
+            ]
+        },
+        {
+            "entries": []
+        },
+        {
+            "entries": [
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 4,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 9,
+                            "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 10,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                },
+                {
+                    "ada_minimum": {
+                        "quantity": 2,
+                        "unit": "lovelace"
+                    },
+                    "ada": {
+                        "quantity": 4,
+                        "unit": "lovelace"
+                    },
+                    "assets": [
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 7,
+                            "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 9,
+                            "policy_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        },
+                        {
+                            "asset_name": "546f6b656e41",
+                            "quantity": 6,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e42",
+                            "quantity": 10,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e43",
+                            "quantity": 9,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        },
+                        {
+                            "asset_name": "546f6b656e44",
+                            "quantity": 10,
+                            "policy_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -446,6 +446,7 @@ spec = parallel $ do
             jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPostData ('Testnet 0) "lenient")
             jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPostData ('Testnet 0) "raw")
             jsonRoundtripAndGolden $ Proxy @ApiWalletPassphrase
+            jsonRoundtripAndGolden $ Proxy @ApiWalletUtxoSnapshot
             jsonRoundtripAndGolden $ Proxy @ApiUtxoStatistics
             jsonRoundtripAndGolden $ Proxy @ApiFee
             jsonRoundtripAndGolden $ Proxy @ApiStakePoolMetrics

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Api/Server.hs
@@ -76,6 +76,7 @@ import Cardano.Wallet.Api.Server
     , getTransaction
     , getUTxOsStatistics
     , getWallet
+    , getWalletUtxoSnapshot
     , idleWorker
     , joinStakePool
     , liftHandler
@@ -250,6 +251,7 @@ server byron icarus shelley multisig spl ntp =
         :<|> postWallet shelley Shelley.generateKeyFromSeed ShelleyKey
         :<|> putWallet shelley mkShelleyWallet
         :<|> putWalletPassphrase shelley
+        :<|> getWalletUtxoSnapshot shelley
         :<|> getUTxOsStatistics shelley
 
     walletKeys :: Server WalletKeys
@@ -366,6 +368,10 @@ server byron icarus shelley multisig spl ntp =
         :<|> (\wid name -> withLegacyLayer wid
                 (byron , putWallet byron mkLegacyWallet wid name)
                 (icarus, putWallet icarus mkLegacyWallet wid name)
+             )
+        :<|> (\wid -> withLegacyLayer wid
+                (byron , getWalletUtxoSnapshot byron wid)
+                (icarus, getWalletUtxoSnapshot icarus wid)
              )
         :<|> (\wid -> withLegacyLayer wid
                 (byron , getUTxOsStatistics byron wid)

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2255,6 +2255,39 @@ components:
           <<: *addresses
           description: The recipient addresses.
 
+    ApiWalletUtxoSnapshotEntry: &ApiWalletUtxoSnapshotEntry
+      type: object
+      required:
+        - ada
+        - ada_minimum
+        - assets
+      properties:
+        ada:
+          <<: *amount
+          description: |
+            The ada quantity associated with this UTxO entry.
+        ada_minimum:
+          <<: *amount
+          description: |
+            The minimum ada quantity permitted by the ledger for this UTxO
+            entry.
+        assets:
+          <<: *walletAssets
+          description: |
+            The set of non-ada assets associated with this UTxO entry.
+
+    ApiWalletUtxoSnapshot: &ApiWalletUtxoSnapshot
+      type: object
+      required:
+        - entries
+      properties:
+        entries:
+          type: array
+          items: *ApiWalletUtxoSnapshotEntry
+          minItems: 0
+          description: |
+            The complete set of UTxO entries associated with a wallet.
+
     ApiWalletUTxOsStatistics: &ApiWalletUTxOsStatistics
       type: object
       required:
@@ -3674,6 +3707,15 @@ x-responsesGetUTxOsStatistics: &responsesGetUTxOsStatistics
       application/json:
         schema: *ApiWalletUTxOsStatistics
 
+x-responsesGetWalletUtxoSnapshot: &responsesGetWalletUtxoSnapshot
+  <<: *responsesErr404WalletNotFound
+  <<: *responsesErr406
+  200:
+    description: Ok
+    content:
+      application/json:
+        schema: *ApiWalletUtxoSnapshot
+
 x-responsesPostWallet: &responsesPostWallet
   <<: *responsesErr400
   <<: *responsesErr406
@@ -4437,6 +4479,19 @@ paths:
         - *parametersWalletId
       responses: *responsesGetUTxOsStatistics
 
+  /wallets/{walletId}/utxo:
+    get:
+      operationId: getWalletUtxoSnapshot
+      tags: ["Wallets"]
+      summary: A snapshot of the wallet's UTxO set
+      description: |
+        Generate a snapshot of the wallet's UTxO set.
+
+        This endpoint is intended for debugging purposes.
+      parameters:
+        - *parametersWalletId
+      responses: *responsesGetWalletUtxoSnapshot
+
   /wallets/{walletId}:
     get:
       operationId: getWallet
@@ -4969,6 +5024,19 @@ paths:
       parameters:
         - *parametersWalletId
       responses: *responsesGetUTxOsStatistics
+
+  /byron-wallets/{walletId}/utxo:
+    get:
+      operationId: getByronWalletUtxoSnapshot
+      tags: ["Byron Wallets"]
+      summary: A snapshot of the wallet's UTxO set
+      description: |
+        Generate a snapshot of the wallet's UTxO set.
+
+        This endpoint is intended for debugging purposes.
+      parameters:
+        - *parametersWalletId
+      responses: *responsesGetWalletUtxoSnapshot
 
   /byron-wallets/{walletId}:
     get:


### PR DESCRIPTION
# Issue Number

Related to ADP-890.

# Overview

This PR adds the `getWalletUtxoSnapshot` API endpoint and associated CLI command.

The intended use is for debugging and development.

The endpoint generates a complete snapshot of a wallet's UTxO set, as an unordered list of UTxO entries.

It produces JSON output similar to the following:
```json
"entries": [
  { "ada":         {"quantity": 8, "unit": "lovelace"}
  , "ada_minimum": {"quantity": 1, "unit": "lovelace"}
  , "assets": []
  },
  { "ada":         {"quantity": 4, "unit": "lovelace"}
  , "ada_minimum": {"quantity": 2, "unit": "lovelace"}
  , "assets": [
      { "policy_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
      , "asset_name": "APPLE"
      , "quantity": 10
      }
    ]
  },
  { "ada":         {"quantity": 4, "unit": "lovelace"}
  , "ada_minimum": {"quantity": 2, "unit": "lovelace"}
  , "assets": [
      { "policy_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
      , "asset_name": "BANANA"
      , "quantity": 20
      }
    ]
  }
]
```