### PR TITLE
Wait longer for first tip in restore-bench

### DIFF
--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -754,7 +754,7 @@ waitForNodeSync
     => Tracer IO (BenchmarkLog n)
     -> NetworkLayer IO Block
     -> IO SlotNo
-waitForNodeSync tr nw = loop 120 -- allow 30 minutes for first tip
+waitForNodeSync tr nw = loop 480 -- allow 120 minutes for first tip
   where
     loop :: Int -> IO SlotNo
     loop retries = do


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-846


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Wait longer for first node tip in restore bench 


# Comments

Attempt to fix this timeout:

https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/964#fb8228aa-158e-4517-b5bb-883e2be30b24

```
[bench-restore:Notice:15] [2021-05-31 01:01:17.09 UTC] [cardano-node.66880] withBackend action done. Terminating child process
restore: UnliftIO.Exception.throwString called with:

Gave up in waitForNodeSync, waiting a tip
Called from:
  throwString (bench/Restore.hs:777:18 in main:Main)
```

It might just be the node re-validating its entire state, taking a lot
of time. In this case, waiting longer should help.

### Update

 https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/966#32b592d5-567d-41b9-91bb-d99d89209506

After a while we start seeing `Initial node synchronization: still restoring (97.04%)`, so it seems to work.

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
