### PR TITLE
Restoration bench: increase heap and only bench {0%,0.2%} x {seq,rnd}

### DIFF
--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -30,7 +30,7 @@ bench="./bench-restore/bin/restore $network --node-db $node_db"
 
 echo "--- Run benchmarks - $network"
 
-command time -o $total_time -v $bench +RTS -N2 -qg -A1m -I0 -T -M8G -h -RTS 2>&1 | tee $log
+command time -o $total_time -v $bench +RTS -N2 -qg -A1m -I0 -T -M16G -h -RTS 2>&1 | tee $log
 
 grep -v INFO $log | awk '/All results/,EOF { print $0 }' > $results
 

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -313,7 +313,8 @@ cardanoRestoreBench tr c socketFile = do
         , benchRestoreSeqWithOwnership (Proxy @4)
 
         , benchRestoreRndWithOwnership (Proxy @0)
-        , benchRestoreRndWithOwnership (Proxy @1)
+        -- benchRestoreRndWithOwnership (Proxy @1)
+        -- Removed to prevent timeout in CI.
         , benchRestoreRndWithOwnership (Proxy @4)
         ]
   where

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -309,13 +309,10 @@ cardanoRestoreBench tr c socketFile = do
         , benchRestoreMultipleWallets 100 (unsafeMkPercentage 0.01)
 
         , benchRestoreSeqWithOwnership (Proxy @0)
-        , benchRestoreSeqWithOwnership (Proxy @1)
-        , benchRestoreSeqWithOwnership (Proxy @4)
+        , benchRestoreSeqWithOwnership (Proxy @2)
 
         , benchRestoreRndWithOwnership (Proxy @0)
-        -- benchRestoreRndWithOwnership (Proxy @1)
-        -- Removed to prevent timeout in CI.
-        , benchRestoreRndWithOwnership (Proxy @4)
+        , benchRestoreRndWithOwnership (Proxy @2)
         ]
   where
     walletRnd


### PR DESCRIPTION
# Issue Number

ADP-846

# Overview

Let the nightly benchmark finish successfully within the alotted time.

- [x] Increase max heap from 8GB to 16GB
- [x] Replace 0.1% and 0.4% rnd and seq benchmarks with 0.2% to prevent timeout.

# Comments

[![Build status](https://badge.buildkite.com/59ea9363b8526e867005ca8839db47715bc5f661f36e490143.svg?branch=anviking%2FADP-846%2Fmore-heap)](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=anviking%2FADP-846%2Fmore-heap)
