### PR TITLE
Test the generation of change maps for non-user-specified assets.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1332,6 +1332,7 @@ makeChangeForNonUserSpecifiedAsset
     -> (AssetId, NonEmpty TokenQuantity)
         -- ^ An asset quantity to distribute.
     -> NonEmpty TokenMap
+        -- ^ The resultant change maps.
 makeChangeForNonUserSpecifiedAsset n (asset, quantities) =
     TokenMap.singleton asset <$> padCoalesce quantities n
 
@@ -1347,6 +1348,7 @@ makeChangeForNonUserSpecifiedAssets
     -> Map AssetId (NonEmpty TokenQuantity)
         -- ^ A map of asset quantities to distribute.
     -> NonEmpty TokenMap
+        -- ^ The resultant change maps.
 makeChangeForNonUserSpecifiedAssets n nonUserSpecifiedAssetQuantities =
     F.foldr
         (NE.zipWith (<>) . makeChangeForNonUserSpecifiedAsset n)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -62,6 +62,7 @@ module Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin
     , makeChangeForCoin
     , makeChangeForUserSpecifiedAsset
     , makeChangeForNonUserSpecifiedAsset
+    , makeChangeForNonUserSpecifiedAssets
     , assignCoinsToChangeMaps
     , collateNonUserSpecifiedAssetQuantities
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobin.hs
@@ -1329,9 +1329,8 @@ makeChangeForUserSpecifiedAsset targets (asset, excess) =
 -- with the `leq` function.
 --
 makeChangeForNonUserSpecifiedAsset
-    :: NonEmpty TokenMap
-        -- ^ A list of weights for the distribution. The list is only used for
-        -- its number of elements.
+    :: NonEmpty a
+        -- ^ Determines the number of change maps to create.
     -> (AssetId, NonEmpty TokenQuantity)
         -- ^ An asset quantity to distribute.
     -> NonEmpty TokenMap

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -2250,7 +2250,7 @@ unit_makeChangeForCoin =
         ]
 
 --------------------------------------------------------------------------------
--- Making change for unknown assets
+-- Making change for a single non-user-specified asset
 --------------------------------------------------------------------------------
 
 prop_makeChangeForNonUserSpecifiedAsset_sum


### PR DESCRIPTION
# Issue Number

ADP-346

# Overview

This PR:
- extracts out function `collateNonUserSpecifiedAssetQuantities`.
- extracts out function `makeChangeForNonUserSpecifiedAssets`.
- adds property tests to verify the expected behaviour of each function.
- adds unit tests to illustrate the expected behaviour of each function.

The `collateNonUserSpecifiedAssetQuantities` function is designed to produce a map of all assets that do **NOT** appear in the user-specified outputs of a coin selection. Each asset `a` is mapped to the complete list of discrete quantities of `a` found in the selected inputs.

The `makeChangeForNonUserSpecifiedAssets` function is designed to make a list of change maps for all assets that do **NOT** appear in the user-specified outputs of coin selection. The number of change maps is intended to be exactly equal to the number of user-specified outputs.