### PR TITLE
Timeout earlier on SQLITE_BUSY when deleting wallets in tests

### DIFF
--- a/lib/core/src/Cardano/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/DB/Sqlite.hs
@@ -78,6 +78,8 @@ import Data.Aeson
     ( ToJSON (..) )
 import Data.Function
     ( (&) )
+import Data.Functor
+    ( (<&>) )
 import Data.List
     ( isInfixOf )
 import Data.List.Split
@@ -116,6 +118,8 @@ import Fmt
     ( fmt, ordinalF, (+|), (+||), (|+), (||+) )
 import GHC.Generics
     ( Generic )
+import System.Environment
+    ( lookupEnv )
 import System.Log.FastLogger
     ( fromLogStr )
 import UnliftIO.Compat
@@ -218,7 +222,9 @@ newSqliteContext tr pool manualMigrations autoMigration = do
                -- resource is NOT placed back in the pool.
                 runQuery :: SqlPersistT IO a -> IO a
                 runQuery cmd = withResource pool $
-                    observe . retryOnBusy tr . runSqlConn cmd . fst
+                    observe
+                    . retryOnBusy tr retryOnBusyTimeout
+                    . runSqlConn cmd . fst
 
             in Right $ SqliteContext { runQuery }
 
@@ -236,7 +242,21 @@ destroySqliteBackend
     -> IO ()
 destroySqliteBackend tr sqlBackend dbFile = do
     traceWith tr (MsgCloseSingleConnection dbFile)
-    retryOnBusy tr (close' sqlBackend)
+
+    -- Hack for ADP-827: timeout earlier in integration tests.
+    --
+    -- There seem to be some concurrency problem causing persistent-sqlite to
+    -- leak unfinalized statements, causing SQLITE_BUSY when we try to close the
+    -- connection. In this case, retrying 2 or 60 seconds would have no
+    -- difference.
+    --
+    -- But in production, the longer timeout isn't as much of a problem, and
+    -- might be needed for windows.
+    timeout <- lookupEnv "CARDANO_WALLET_INTEGRATION" <&> \case
+            Just _ -> 2 * s
+            Nothing -> retryOnBusyTimeout
+
+    retryOnBusy tr timeout (close' sqlBackend)
         & handleIf isAlreadyClosed
             (traceWith tr . MsgIsAlreadyClosed . showT)
         & handleIf statementAlreadyFinalized
@@ -255,6 +275,13 @@ destroySqliteBackend tr sqlBackend dbFile = do
 
     showT :: Show a => a -> Text
     showT = T.pack . show
+    s = 1000*1000
+
+-- | Default timeout for `retryOnBusy`
+retryOnBusyTimeout :: Int
+retryOnBusyTimeout = 60 * s
+  where
+    s = 1000*1000
 
 -- | Retry an action if the database yields an 'SQLITE_BUSY' error.
 --
@@ -273,12 +300,18 @@ destroySqliteBackend tr sqlBackend dbFile = do
 --     and sqlite3_busy_handler() interfaces and the busy_timeout pragma are
 --     available to process B to help it deal with SQLITE_BUSY errors.
 --
-retryOnBusy :: Tracer IO DBLog -> IO a -> IO a
-retryOnBusy tr action = recovering policy
-    [logRetries isBusy traceRetries]
-    (\st -> action <* trace MsgRetryDone st)
+retryOnBusy
+    :: Tracer IO DBLog
+    -> Int -- ^ Timeout in microseconds
+    -> IO a
+    -> IO a
+retryOnBusy tr timeout action = do
+    let policy = limitRetriesByCumulativeDelay timeout $ constantDelay (25*ms)
+
+    recovering policy
+        [logRetries isBusy traceRetries]
+        (\st -> action <* trace MsgRetryDone st)
   where
-    policy = limitRetriesByCumulativeDelay (60000*ms) $ constantDelay (25*ms)
     ms = 1000 -- microseconds in a millisecond
 
     isBusy (SqliteException name _ _) = pure (name == Sqlite.ErrorBusy)

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -174,11 +174,6 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 main :: forall n. (n ~ 'Mainnet) => IO ()
 main = withTestsSetup $ \testDir tracers -> do
     nix <- inNixBuild
-
-    -- Enables small test-specific workarounds, like timing out faster if wallet
-    -- deletion fails.
-    setEnv "CARDANO_WALLET_INTEGRATION" "1"
-
     hspec $ do
         describe "No backend required" $
             parallelIf (not nix) $ describe "Miscellaneous CLI tests"
@@ -233,6 +228,9 @@ withTestsSetup action = do
     hSetBuffering stderr LineBuffering
     -- Stop cardano-cli complaining about file permissions
     setDefaultFilePermissions
+    -- Enables small test-specific workarounds, like timing out faster if wallet
+    -- deletion fails.
+    setEnv "CARDANO_WALLET_TEST_INTEGRATION" "1"
     -- Set UTF-8, regardless of user locale
     withUtf8Encoding $
         -- This temporary directory will contain logs, and all other data

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -111,6 +111,8 @@ import Network.URI
     ( URI )
 import System.Directory
     ( createDirectory )
+import System.Environment
+    ( setEnv )
 import System.FilePath
     ( (</>) )
 import System.IO
@@ -172,6 +174,11 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 main :: forall n. (n ~ 'Mainnet) => IO ()
 main = withTestsSetup $ \testDir tracers -> do
     nix <- inNixBuild
+
+    -- Enables small test-specific workarounds, like timing out faster if wallet
+    -- deletion fails.
+    setEnv "CARDANO_WALLET_INTEGRATION" "1"
+
     hspec $ do
         describe "No backend required" $
             parallelIf (not nix) $ describe "Miscellaneous CLI tests"


### PR DESCRIPTION
# Issue Number

ADP-827

# Overview

- [x] Set `CARDANO_WALLET_INTEGRATION` env var in integration tests
- [x] Change timeout to close all connections from `60s` to `2s` if `CARDANO_WALLET_INTEGRATION` is set.


# Comments

- Workaround that should make CI faster (and perhaps a bit more stable), until we have time to investigate and address the underlying issue and its effects in production. The problem in production is likely much less serious, as users likely don't create and delete wallets as often as in our integration tests.
- Locally, running `stack test cardano-wallet:integration --ta '-j 6'` I get:
    - 2s -> 335s
    - 5s -> 380s
    - 60s (without the `setEnv`) -> 1190s

So that's why I went with 2s rather than 5s.

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
