### PR TITLE
E2E golden tests cardano-wallet vs. cardano-addresses account xpub (including purpose)

### DIFF
--- a/test/e2e/Gemfile
+++ b/test/e2e/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cardano_wallet', '~> 0.3.10'
+gem 'cardano_wallet', '~> 0.3.11'
 # gem 'cardano_wallet', path: "~/wb/cardano_wallet"
 gem 'bip_mnemonic', '0.0.4'
 gem 'rake', '12.3.3'

--- a/test/e2e/Gemfile.lock
+++ b/test/e2e/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     bip_mnemonic (0.0.4)
-    cardano_wallet (0.3.10)
+    cardano_wallet (0.3.11)
       httparty (~> 0.18.0)
     diff-lcs (1.4.4)
     httparty (0.18.1)
@@ -32,7 +32,7 @@ PLATFORMS
 
 DEPENDENCIES
   bip_mnemonic (= 0.0.4)
-  cardano_wallet (~> 0.3.10)
+  cardano_wallet (~> 0.3.11)
   rake (= 12.3.3)
   rspec (= 3.10.0)
 

--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -11,12 +11,11 @@ module Helpers
       res
     end
 
-    def cardano_address_get_acc_xpub(mnemonics, derivation_path)
+    def cardano_address_get_acc_xpub(mnemonics, derivation_path, hex = true, wallet_type = "Shared", chain_code = "--with-chain-code")
       cmd(%(echo #{mnemonics.join(' ')} \
-         | cardano-address key from-recovery-phrase Shared \
+         | cardano-address key from-recovery-phrase #{wallet_type} \
          | cardano-address key child #{derivation_path} \
-         | cardano-address key public --with-chain-code \
-         | bech32)).gsub("\n", '')
+         | cardano-address key public #{chain_code} #{" | bech32" if hex})).gsub("\n", '')
     end
 
     def absolute_path(path)
@@ -108,7 +107,7 @@ module Helpers
     end
 
     def get_latest_configs_base_url
-      "https://hydra.iohk.io/job/Cardano/cardano-node/cardano-deployment/latest-finished/download/1"
+      "https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest/download/1"
     end
   end
 end

--- a/test/e2e/spec/shared_spec.rb
+++ b/test/e2e/spec/shared_spec.rb
@@ -523,17 +523,28 @@ RSpec.describe CardanoWallet::Shared do
     describe "Account Public Keys" do
       it "Create account public key - incomplete wallet from mnemonics" do
         m24 = mnemonic_sentence(24)
-        acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/0H")
+        der_path = "1854H/1815H/0H"
+        acc_xpub = cardano_address_get_acc_xpub(m24, der_path)
         incomplete_wid = create_incomplete_shared_wallet(m24, '0H', acc_xpub)
         ["0H", "1H", "2147483647H", "44H"].each do |index|
-          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'extended')
+          payload = { passphrase: PASS, format: 'extended' }
+          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, payload)
           expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_xvk"
+          expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                   "1854H/1815H/#{index}",
+                                                                   hex = false,
+                                                                   "Shared")
 
-          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'non_extended')
+          payload = { passphrase: PASS, format: 'non_extended' }
+          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, payload)
           expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_vk"
+          expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                   "1854H/1815H/#{index}",
+                                                                   hex = false,
+                                                                   "Shared",
+                                                                   "--without-chain-code")
         end
+
       end
 
       it "Cannot create account public key - incomplete wallet from acc pub key" do
@@ -542,11 +553,11 @@ RSpec.describe CardanoWallet::Shared do
         acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
         incomplete_wid = create_incomplete_shared_wallet(acc_xpub, acc_ix, "self")
         ["0H", "1H", "2147483647H", "44H"].each do |index|
-          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'extended')
+          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, { passphrase: PASS, format: 'extended' })
           expect(res).to be_correct_and_respond 403
           expect(res.to_s).to include "no_root_key"
 
-          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, PASS, 'non_extended')
+          res = SHARED.keys.create_acc_public_key(incomplete_wid, index, { passphrase: PASS, format: 'non_extended' })
           expect(res).to be_correct_and_respond 403
           expect(res.to_s).to include "no_root_key"
         end
@@ -557,13 +568,20 @@ RSpec.describe CardanoWallet::Shared do
         acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/0H")
         active_wid = create_active_shared_wallet(m24, '0H', acc_xpub)
         ["0H", "1H", "2147483647H", "44H"].each do |index|
-          res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'extended')
+          res = SHARED.keys.create_acc_public_key(active_wid, index, { passphrase: PASS, format: 'extended' })
           expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_xvk"
+          expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                   "1854H/1815H/#{index}",
+                                                                   hex = false,
+                                                                   "Shared")
 
-          res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'non_extended')
+          res = SHARED.keys.create_acc_public_key(active_wid, index, { passphrase: PASS, format: 'non_extended' })
           expect(res).to be_correct_and_respond 202
-          expect(res.to_s).to include "acct_shared_vk"
+          expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                   "1854H/1815H/#{index}",
+                                                                   hex = false,
+                                                                   "Shared",
+                                                                   "--without-chain-code")
         end
       end
 
@@ -573,11 +591,11 @@ RSpec.describe CardanoWallet::Shared do
         acc_xpub = cardano_address_get_acc_xpub(m24, "1854H/1815H/#{acc_ix}")
         active_wid = create_active_shared_wallet(acc_xpub, acc_ix, "self")
         ["0H", "1H", "2147483647H", "44H"].each do |index|
-          res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'extended')
+          res = SHARED.keys.create_acc_public_key(active_wid, index, { passphrase: PASS, format: 'extended' })
           expect(res).to be_correct_and_respond 403
           expect(res.to_s).to include "no_root_key"
 
-          res = SHARED.keys.create_acc_public_key(active_wid, index, PASS, 'non_extended')
+          res = SHARED.keys.create_acc_public_key(active_wid, index, { passphrase: PASS, format: 'non_extended' })
           expect(res).to be_correct_and_respond 403
           expect(res.to_s).to include "no_root_key"
         end

--- a/test/e2e/spec/shelley_spec.rb
+++ b/test/e2e/spec/shelley_spec.rb
@@ -401,20 +401,59 @@ RSpec.describe CardanoWallet::Shelley do
     end
 
     it "Create account public key - extended" do
-      wid = create_shelley_wallet
+      m24 = mnemonic_sentence(24)
+      wid = create_shelley_wallet("Wallet", m24)
       ["0H", "1H", "2147483647H", "44H"].each do |index|
-        res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, 'extended')
+        payload = { passphrase: PASS, format: 'extended' }
+        res = SHELLEY.keys.create_acc_public_key(wid, index, payload)
         expect(res).to be_correct_and_respond 202
-        expect(res.to_s).to include "acc"
+        expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                 "1852H/1815H/#{index}",
+                                                                 hex = false,
+                                                                 "Shelley")
       end
     end
 
     it "Create account public key - non_extended" do
-      wid = create_shelley_wallet
+      m24 = mnemonic_sentence(24)
+      wid = create_shelley_wallet("Wallet", m24)
       ["0H", "1H", "2147483647H", "44H"].each do |index|
-        res = SHELLEY.keys.create_acc_public_key(wid, index, PASS, 'non_extended')
+        payload = { passphrase: PASS, format: 'non_extended' }
+        res = SHELLEY.keys.create_acc_public_key(wid, index, payload)
+        expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                 "1852H/1815H/#{index}",
+                                                                 hex = false,
+                                                                 "Shelley",
+                                                                 "--without-chain-code")
+      end
+    end
+
+    it "Create account public key - extended with purpose" do
+      m24 = mnemonic_sentence(24)
+      wid = create_shelley_wallet("Wallet", m24)
+      ["0H", "1H", "2147483647H", "1854H"].each do |index_purpose|
+        payload = { passphrase: PASS, format: 'extended', purpose: index_purpose }
+        res = SHELLEY.keys.create_acc_public_key(wid, index_purpose, payload)
         expect(res).to be_correct_and_respond 202
-        expect(res.to_s).to include "acc"
+        expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                 "#{index_purpose}/1815H/#{index_purpose}",
+                                                                 hex = false,
+                                                                 "Shelley")
+      end
+    end
+
+    it "Create account public key - non_extended with purpose" do
+      m24 = mnemonic_sentence(24)
+      wid = create_shelley_wallet("Wallet", m24)
+      ["0H", "1H", "2147483647H", "1854H"].each do |index_purpose|
+        payload = { passphrase: PASS, format: 'non_extended', purpose: index_purpose }
+        res = SHELLEY.keys.create_acc_public_key(wid, index_purpose, payload)
+        expect(res).to be_correct_and_respond 202
+        expect(res.to_s).to include cardano_address_get_acc_xpub(m24,
+                                                                 "#{index_purpose}/1815H/#{index_purpose}",
+                                                                 hex = false,
+                                                                 "Shelley",
+                                                                 "--without-chain-code")
       end
     end
 

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -166,10 +166,10 @@ def wait_for_all_shared_wallets(wids)
   end
 end
 
-def create_shelley_wallet(name = "Wallet from mnemonic_sentence")
+def create_shelley_wallet(name = "Wallet from mnemonic_sentence", mnemonic_sentence = mnemonic_sentence(24))
   SHELLEY.wallets.create({ name: name,
                           passphrase: PASS,
-                          mnemonic_sentence: mnemonic_sentence(24)
+                          mnemonic_sentence: mnemonic_sentence
                          })['id']
 end
 


### PR DESCRIPTION


# Issue Number

ADP-950


# Overview

- 0ded5ef0626a4efb3b06eb15a6d9032363dfca41
  E2E golden tests cardano-wallet vs. cardano-addresses account xpub (including purpose)


# Comments

While testing purpose addition to https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/postAccountKey endpoint I have extended existing e2e tests to assert if the returned keys are the same as produced by cardano-addresses.
