### PR TITLE
Make test cluster epoch length twice as long

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -659,7 +659,7 @@ securityParameterValue = 5
 
 -- | Parameter in test cluster shelley genesis.
 epochLengthValue :: Word32
-epochLengthValue = 50
+epochLengthValue = 100
 
 -- | Wallet server's chosen transaction TTL value (in seconds) when none is
 -- given.

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -47,7 +47,7 @@ maxLovelaceSupply: 1000000000000000000
 protocolMagicId: 764824073
 networkMagic: 764824073
 networkId: Mainnet
-epochLength: 50
+epochLength: 100
 staking:
 slotsPerKESPeriod: 86400
 slotLength: 0.2


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-979


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Make epoch length twice as long to help epoch-sensitive tests (see commit message)


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
