### PR TITLE
Prefer waiting over eventually in migration tests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -945,7 +945,7 @@ waitForTxImmutability _ctx = liftIO $ do
     --
     -- let stabilityDelay   = round (sl * 3 * k / f)
     -- let txInsertionDelay = round (sl * 10 / f)
-    let stabilityDelay   = 12 * oneSecond
+    let stabilityDelay   = 6 * oneSecond
     let txInsertionDelay = 4 * oneSecond
 
     threadDelay $ stabilityDelay + txInsertionDelay


### PR DESCRIPTION
# Issue Number

ADP-970, #2699 


# Overview

- [x] `waitForTxImmutability` should now only need to be 10s instead of 16s
- [x]  Use `waitForTxImmutability` instead of `eventually` to protect against rollbacks in migration tests


# Comments

- An alternative solution would be to use the retrying `it` with `eventually`, but we should moving away from the retrying it, not re-adding it.

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
