### PR TITLE
Modify e2e tests for future running on alonzo testnets

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -13,6 +13,10 @@ on:
         description: 'Wallet tag (docker)'
         required: true
         default: 'dev-master'
+      network:
+        description: 'Network'
+        required: true
+        default: 'testnet'
 
 defaults:
   run:
@@ -38,7 +42,7 @@ jobs:
     - name: Get recent configs and decode fixture_wallets.json.gpg
       run: |
         rake fixture_wallets_decode
-        rake get_latest_configs["testnet"]
+        rake get_latest_configs[$NETWORK]
         rake get_latest_bins
 
     - name: Cache node db
@@ -48,19 +52,7 @@ jobs:
         path: ~/node-db-nightly-docker
         key: ${{ runner.os }}-docker-node-cache-v2
 
-    - name: Set up cardano-wallet and cardano-node MANUAL
-      if: ${{ github.event.inputs.walletTag != '' && github.event.inputs.nodeTag != ''}}
-      env:
-        WALLET: ${{ github.event.inputs.walletTag }}
-        NODE: ${{ github.event.inputs.nodeTag }}
-      run: |
-        echo "Wallet: $WALLET"
-        echo "Node: $NODE"
-        NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK docker-compose -f docker-compose-test.yml up --detach
-        ls ~/node-db-nightly-docker
-
-    - name: Set up cardano-wallet and cardano-node NIGHTLY
-      if: ${{ github.event.inputs.walletTag == '' && github.event.inputs.nodeTag == ''}}
+    - name: Set up cardano-wallet and cardano-node
       run: |
         echo "Wallet: $WALLET"
         echo "Node: $NODE"
@@ -92,8 +84,8 @@ jobs:
     - name: Stop docker-compose
       run: NODE_CONFIG_PATH=`pwd`/state/configs/$NETWORK docker-compose -f docker-compose-test.yml down
     env:
-      TESTS_E2E_TOKEN_METADATA: https://metadata.cardano-testnet.iohkdev.io/
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
-      NETWORK: testnet
-      WALLET: dev-master
-      NODE: 1.27.0
+      NETWORK: ${{ github.event.inputs.network || 'testnet' }}
+      WALLET: ${{ github.event.inputs.walletTag || 'dev-master' }}
+      NODE: ${{ github.event.inputs.nodeTag || '1.27.0' }}
+      TESTS_E2E_TOKEN_METADATA: https://metadata.cardano-testnet.iohkdev.io/

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -4,6 +4,11 @@ on:
   schedule:
   - cron:  "0 21 * * *"
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network'
+        required: true
+        default: 'testnet'
 
 defaults:
   run:
@@ -34,7 +39,7 @@ jobs:
         key: ${{ runner.os }}-node-cache-v2
 
     - name: Run all tests
-      run: rake run_on[testnet]
+      run: rake run_on[$NETWORK]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2
@@ -45,3 +50,4 @@ jobs:
 
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
+      NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -4,6 +4,11 @@ on:
   schedule:
   - cron:  "0 22 * * *"
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network'
+        required: true
+        default: 'testnet'
 
 defaults:
   run:
@@ -36,7 +41,7 @@ jobs:
         key: ${{ runner.os }}-node-cache-v2
 
     - name: Run all tests
-      run: rake run_on[testnet]
+      run: rake run_on[$NETWORK]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2
@@ -47,3 +52,4 @@ jobs:
 
     env:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
+      NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -4,6 +4,11 @@ on:
   schedule:
   - cron:  "0 21 * * *"
   workflow_dispatch:
+    inputs:
+      network:
+        description: 'Network'
+        required: true
+        default: 'testnet'
 
 defaults:
   run:
@@ -39,7 +44,7 @@ jobs:
         choco install nssm
 
     - name: Run all tests
-      run: rake run_on[testnet]
+      run: rake run_on[%NETWORK%]
 
     - name: 📎 Upload logs
       uses: actions/upload-artifact@v2
@@ -49,4 +54,5 @@ jobs:
         path: test/e2e/state/logs
 
     env:
+      NETWORK: ${{ github.event.inputs.network || 'testnet' }}
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -2,6 +2,7 @@
 
 
 
+
 # E2E testing
 [![E2E Docker](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml) [![E2E Linux](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml) [![E2E MacOS](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml) [![E2E Windows](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml)
 
@@ -40,13 +41,13 @@ $ rake get_latest_configs[testnet]
 $ rake start_node_and_wallet[testnet]
 $ rake wait_until_node_synced
 $ rake spec
-$ rake stop_node_and_wallet
+$ rake stop_node_and_wallet[testnet]
 ```
 > :information_source:  **_Linux / MacOS_**
 cardano-node and cardano-wallet are started as separate [screen](https://www.gnu.org/software/screen/manual/screen.html) sessions. One can attach to the respective session using:
 >```bash
->$ screen -r NODE
->$ screen -r WALLET
+>$ screen -r NODE_testnet
+>$ screen -r WALLET_testnet
 >```
 
 > :information_source: **_Windows_**

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -19,6 +19,7 @@ FIXTURES_FILE = absolute_path ENV['TESTS_E2E_FIXTURES_FILE']
 FIXTURES_SECRET = absolute_path ENV['TESTS_E2E_FIXTURES']
 
 TOKEN_METADATA = ENV['TESTS_E2E_TOKEN_METADATA']
+WALLET_PORT = ENV['WALLET_PORT']
 
 path_separator = is_win? ? ';' : ':'
 ENV['PATH'] = "#{BINS}#{path_separator}#{ENV['PATH']}"
@@ -70,9 +71,10 @@ task :fixture_wallets_template do
 
 end
 
-task :clean_logs do
+task :clean_logs, [:env] do |task, args|
   puts "\n  >> Removing logs"
-  rm_files(LOGS)
+  log_dir = File.join(LOGS, args[:env])
+  rm_files(log_dir)
 end
 
 task :clean_bins do
@@ -110,29 +112,32 @@ task :start_node_and_wallet, [:env] do |task, args|
 
   bin_dir = BINS == '' ? BINS : "#{BINS}/"
   config_dir = File.join(CONFIGS, args[:env])
+  log_dir = File.join(LOGS, args[:env])
+  wallet_db_dir = File.join(WALLET_DB, args[:env])
+  node_db_dir = File.join(NODE_DB, args[:env])
   cd = Dir.pwd
   mk_dir(STATE)
-  mk_dir(LOGS)
+  mk_dir(log_dir)
 
   if is_win?
     # create cardano-node.bat file
-    node_cmd = "#{bin_dir}cardano-node.exe run --config #{config_dir}/configuration.json --topology #{config_dir}/topology.json --database-path #{NODE_DB} --socket-path \\\\.\\pipe\\cardano-node-testnet"
+    node_cmd = "#{bin_dir}cardano-node.exe run --config #{config_dir}/configuration.json --topology #{config_dir}/topology.json --database-path #{node_db_dir} --socket-path \\\\.\\pipe\\cardano-node-testnet"
     File.open("cardano-node.bat", "w") do |f|
       f.write(node_cmd)
     end
 
     # create cardano-wallet.bat file
-    wallet_cmd = "#{bin_dir}cardano-wallet.exe serve --node-socket \\\\.\\pipe\\cardano-node-testnet --testnet #{config_dir}/genesis-byron.json --database #{WALLET_DB} --token-metadata-server #{TOKEN_METADATA}"
+    wallet_cmd = "#{bin_dir}cardano-wallet.exe serve --port #{WALLET_PORT} --node-socket \\\\.\\pipe\\cardano-node-testnet --testnet #{config_dir}/genesis-byron.json --database #{wallet_db_dir} --token-metadata-server #{TOKEN_METADATA}"
     File.open("cardano-wallet.bat", "w") do |f|
       f.write(wallet_cmd)
     end
 
     install_node = "nssm install cardano-node #{cd}/cardano-node.bat"
     install_wallet = "nssm install cardano-wallet #{cd}/cardano-wallet.bat"
-    log_stdout_node = "nssm set cardano-node AppStdout #{LOGS}/node.log"
-    log_stderr_node = "nssm set cardano-node AppStderr #{LOGS}/node.log"
-    log_stdout_wallet = "nssm set cardano-wallet AppStdout #{LOGS}/wallet.log"
-    log_stderr_wallet = "nssm set cardano-wallet AppStderr #{LOGS}/wallet.log"
+    log_stdout_node = "nssm set cardano-node AppStdout #{log_dir}/node.log"
+    log_stderr_node = "nssm set cardano-node AppStderr #{log_dir}/node.log"
+    log_stdout_wallet = "nssm set cardano-wallet AppStdout #{log_dir}/wallet.log"
+    log_stderr_wallet = "nssm set cardano-wallet AppStderr #{log_dir}/wallet.log"
     start_node = "nssm start cardano-node"
     start_wallet = "nssm start cardano-wallet"
 
@@ -145,11 +150,11 @@ task :start_node_and_wallet, [:env] do |task, args|
     cmd start_node
     cmd start_wallet
   else
-    start_node = "#{bin_dir}cardano-node run --config #{config_dir}/configuration.json --topology #{config_dir}/topology.json --database-path #{NODE_DB} --socket-path #{STATE}/node.socket"
-    start_wallet = "#{bin_dir}cardano-wallet serve --node-socket #{STATE}/node.socket --testnet #{config_dir}/genesis-byron.json --database #{WALLET_DB} --token-metadata-server #{TOKEN_METADATA}"
+    start_node = "#{bin_dir}cardano-node run --config #{config_dir}/configuration.json --topology #{config_dir}/topology.json --database-path #{node_db_dir} --socket-path #{node_db_dir}/node.socket"
+    start_wallet = "#{bin_dir}cardano-wallet serve --port #{WALLET_PORT} --node-socket #{node_db_dir}/node.socket --testnet #{config_dir}/genesis-byron.json --database #{wallet_db_dir} --token-metadata-server #{TOKEN_METADATA}"
 
-    cmd "screen -dmS NODE -L -Logfile #{LOGS}/node.log #{start_node}"
-    cmd "screen -dmS WALLET -L -Logfile #{LOGS}/wallet.log #{start_wallet}"
+    cmd "screen -dmS NODE_#{args[:env]} -L -Logfile #{log_dir}/node.log #{start_node}"
+    cmd "screen -dmS WALLET_#{args[:env]} -L -Logfile #{log_dir}/wallet.log #{start_wallet}"
     cmd "screen -ls"
   end
 end
@@ -169,7 +174,7 @@ task :launch_on, [:env] do |task, args|
   Rake::Task[:start_node_and_wallet].invoke(env)
 end
 
-task :stop_node_and_wallet do
+task :stop_node_and_wallet, [:env] do |task, args|
   puts "\n  >> Stopping cardano-node and cardano-wallet"
 
   if is_win?
@@ -179,8 +184,8 @@ task :stop_node_and_wallet do
     cmd "nssm remove cardano-wallet confirm"
     cmd "nssm remove cardano-node confirm"
   else
-    cmd "screen -XS WALLET quit"
-    cmd "screen -XS NODE quit"
+    cmd "screen -XS WALLET_#{args[:env]} quit"
+    cmd "screen -XS NODE_#{args[:env]} quit"
   end
 
 end
@@ -223,6 +228,7 @@ task :get_latest_configs, [:env] do |task, args|
     wget("#{base_url}/#{env}-config.json", config_file)
     wget("#{base_url}/#{env}-byron-genesis.json", "#{out}/genesis-byron.json")
     wget("#{base_url}/#{env}-shelley-genesis.json", "#{out}/genesis-shelley.json")
+    wget("#{base_url}/#{env}-alonzo-genesis.json", "#{out}/genesis-alonzo.json")
     wget("#{base_url}/#{env}-topology.json", "#{out}/topology.json")
     # remove environment names from genesis files
     config = File.read(config_file)

--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -275,5 +275,5 @@ task :run_on, [:env, :sync_strategy, :skip_configs] do |task, args|
   end
 
   Rake::Task[:spec].invoke
-  Rake::Task[:stop_node_and_wallet].invoke
+  Rake::Task[:stop_node_and_wallet].invoke(env)
 end

--- a/test/e2e/env.rb
+++ b/test/e2e/env.rb
@@ -18,3 +18,4 @@ ENV['TESTS_E2E_BINDIR'] ||= "./bins"
 
 ENV['TESTS_E2E_TOKEN_METADATA'] ||= "https://metadata.cardano-testnet.iohkdev.io/"
 ENV['TESTS_E2E_SMASH'] ||= "https://smash.cardano-testnet.iohkdev.io"
+ENV['WALLET_PORT'] ||= "8090"

--- a/test/e2e/helpers/utils.rb
+++ b/test/e2e/helpers/utils.rb
@@ -73,7 +73,7 @@ module Helpers
     end
 
     def mk_dir(path)
-      Dir.mkdir(path) unless File.exists?(path)
+      FileUtils.mkdir_p(path)
     end
 
     def rm_files(path)

--- a/test/e2e/spec/spec_helper.rb
+++ b/test/e2e/spec/spec_helper.rb
@@ -27,7 +27,7 @@ TIMEOUT = 180
 
 ##
 # Intit cardano-wallet wrapper with timeout for getting the response back
-CW = CardanoWallet.new({ timeout: TIMEOUT })
+CW = CardanoWallet.new({ timeout: TIMEOUT, port: ENV['WALLET_PORT'].to_i })
 BYRON = CW.byron
 SHELLEY = CW.shelley
 SHARED = CW.shared


### PR DESCRIPTION
# Issue Number

ADP-972


# Overview

- c5d4782dd27453f425b49ef129971cf9c0445420
  Modify e2e tests for future running on alonzo testnets
  
- 9c2158610c14aa906cfbf1da980c560ca22f270a
  update readme



# Comments

It is mostly adjusting paths to `state` such that artifacts are separated for specific testnets and therefore not interfere between runs against different testnets, like:
```
├── configs
│   ├── alonzo-blue
│   └── testnet
├── logs
│   ├── alonzo-blue
│   └── testnet
├── node_db
│   ├── alonzo-blue
│   └── testnet
├── wallet_db
│   ├── alonzo-blue
│   └── testnet
```