### PR TITLE
Miscellaneous release scripts enhancements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,12 +81,15 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - name: 'Install gems'
-        run: 'gem install bump-cli'
       - name: 'Install dependencies'
-        run: 'sudo snap install yq'
+        run: |
+          gem install bump-cli
+          sudo snap install yq
+          sudo apt-get -yu install html-xml-utils
       - name: 'Update Release in Bump.sh'
         run: './scripts/gh/update-bump.sh'
         env:
           BUMP_SH_DOC_ID: ${{ secrets.BUMP_SH_DOC_ID }}
           BUMP_SH_TOKEN: ${{ secrets.BUMP_SH_TOKEN }}
+      - name: 'Show latest changes from Bump.sh'
+        run: './scripts/gh/show-bump.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,23 @@ jobs:
         uses: actions/checkout@v2
 
       - name: '📸 Build Documentation'
+        id: build
         run: |
           if [[ $GITHUB_REF =~ ^refs/tags/v ]]; then
             tag="${GITHUB_REF/refs\/tags\//}"
+            commit_message="Release $tag"
           else
             tag=""
+            commit_message="$default_commit_message"
           fi
+          echo "::set-output name=commit_message::$commit_message"
+
           ./scripts/gh/update-docs.sh _build $tag
+        env:
+          default_commit_message: |
+            docs: ${{ github.event.head_commit.message }}
+
+            Source commit: ${{ github.sha }}
 
       - name: '📘 Publish'
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
@@ -59,7 +69,7 @@ jobs:
           keep_files: true
           user_name: 'William King Noel Bot'
           user_email: 'adrestia@iohk.io'
-          commit_message: 'docs: ${{ github.event.head_commit.message }}'
+          full_commit_message: ${{ steps.build.outputs.commit_message }}
 
   bump_sh:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -23,6 +23,29 @@ custom-commands:
       set -x
       {{jira}} list --template table --query "type = Bug and resolution = Unresolved and project=$JIRA_PROJECT and component = cardano-wallet{{ with args.terms }} and text ~ \"{{ args.terms }}\"{{ end }}{{ with options.query }} and {{ options.query }}{{ end }} ORDER BY priority DESC, updated DESC, rank ASC, created"
 
+  - name: find
+    help: Quickly find a ticket
+    options:
+      - name: query
+        short: q
+      - name: component
+        short: c
+        repeat: true
+        type: string
+        default:
+          - cardano-wallet
+          - cardano-addresses
+      - name: type
+        short: t
+        repeat: true
+        type: string
+    args:
+      - name: terms
+        required: false
+    script: |-
+      set -x
+      {{jira}} list --template table --query "resolution=Unresolved AND project=$JIRA_PROJECT{{ with options.type }} AND ({{ range . }}type={{.}} OR {{end}}type is empty){{ end }}{{with options.component }} AND ({{ range . }}component={{.}} OR {{end}}component is empty){{end}}{{ with args.terms }} and text ~ \"{{ . }}\"{{ end }}{{ with options.query }} and {{ . }}{{ end }} ORDER BY priority DESC, updated DESC, rank ASC, created"
+
   - name: mine
     help: Display unresolved issues assigned to me
     script: |-

--- a/scripts/gh/show-bump.sh
+++ b/scripts/gh/show-bump.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Needs gnused and W3C html-xml-utils
+# shellcheck disable=SC2016
+
+set -euo pipefail
+
+hxnormalize -x 'https://bump.sh/doc/cardano-wallet-diff/changes' \
+    | hxselect "ul.timeline-event-diff" \
+    | hxselect -s '\n' "ul:first-child" \
+    | sed -z 's/\n[ ]\+/ /g' \
+    | hxselect -c -s '\n' 'li' \
+    | sed 's/^\([ ]*\)\([A-Z][^:]\+: \)\(.*\)$/\1- \2`\3`/g'


### PR DESCRIPTION
### Overview

- Improves commit messages on the `gh-pages` branch - now easier to see how the changes correspond to `master` branch and tags.
- Adds a script to reformat the Bump.sh API changes as markdown suitable for pasting into the release notes.
- Adds the handy `jira find` command.
