### PR TITLE
Mark LoggingSpec pending on macOS to alleviate timeouts

### DIFF
--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -96,6 +96,8 @@ import Test.QuickCheck
     ( Arbitrary (..), choose, counterexample, property, withMaxSuccess )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor )
+import Test.Utils.Darwin
+    ( pendingOnMacOS )
 import UnliftIO.Async
     ( Async, async, cancel, mapConcurrently, replicateConcurrently_ )
 import UnliftIO.Concurrent
@@ -113,7 +115,9 @@ import qualified Data.Text as T
 import qualified Network.Wai.Handler.Warp as Warp
 
 spec :: Spec
-spec = describe "Logging Middleware" $ do
+spec = before (pendingOnMacOS "#2472 regular timeouts in macOS hydra builds")
+    $ describe "Logging Middleware" $ do
+
     before setup $ after tearDown $ do
         it "GET, 200, no query" $ \ctx -> do
             get ctx "/get"

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -57,6 +57,7 @@ library
   exposed-modules:
       Test.Hspec.Extra
       Test.QuickCheck.Extra
+      Test.Utils.Darwin
       Test.Utils.FilePath
       Test.Utils.Laws
       Test.Utils.Laws.PartialOrd

--- a/lib/test-utils/src/Test/Utils/Darwin.hs
+++ b/lib/test-utils/src/Test/Utils/Darwin.hs
@@ -1,0 +1,27 @@
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Utility function for making test suites pass on Darwin/macOS.
+
+module Test.Utils.Darwin
+    ( pendingOnMacOS
+    ) where
+
+import Prelude
+
+import Control.Monad
+    ( when )
+import System.Info
+    ( os )
+import Test.Hspec.Core.Spec
+    ( pendingWith )
+import Test.Hspec.Expectations
+    ( Expectation, HasCallStack )
+
+-- | Mark test pending if running on macOS
+pendingOnMacOS :: HasCallStack => String -> Expectation
+pendingOnMacOS reason = when isDarwin $ pendingWith reason
+
+isDarwin :: Bool
+isDarwin = os == "darwin"


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-970


# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Mark LoggingSpec pending on macOS
