### PR TITLE
Reject unknown record fields in `FromJSON` instances.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -288,7 +288,7 @@ import Control.Arrow
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( guard, when, (>=>) )
+    ( forM_, guard, when, (>=>) )
 import Data.Aeson.Types
     ( FromJSON (..)
     , SumEncoding (..)
@@ -3110,5 +3110,17 @@ removeObjectFields o prohibitedFields =
 restrictObjectFields :: Aeson.Object -> [Text] -> Aeson.Object
 restrictObjectFields o allowedFields =
     HM.filterWithKey (\field _ -> Set.member field allowedFieldSet) o
+  where
+    allowedFieldSet = Set.fromList allowedFields
+
+-- | Requires that the set of fields within a JSON object is a subset of
+--   those in the specified list.
+--
+onlyAllowObjectFields :: Aeson.Object -> [Text] -> Aeson.Parser ()
+onlyAllowObjectFields o allowedFields =
+    forM_ (HM.keysSet o) $ \field ->
+        if (Set.notMember field allowedFieldSet)
+        then fail ("Unexpected field: " <> show field)
+        else pure $ Aeson.Success ()
   where
     allowedFieldSet = Set.fromList allowedFields

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -2424,9 +2424,9 @@ instance ToJSON (ApiT SlotNo) where
     toJSON (ApiT (SlotNo sn)) = toJSON sn
 
 instance FromJSON a => FromJSON (AddressAmount a) where
-    parseJSON = withObject "AddressAmount " $ \v ->
-        prependFailure "parsing AddressAmount failed, " $
-        AddressAmount
+    parseJSON = withObject "AddressAmount " $ \v -> do
+        v `onlyAllowObjectFields` ["address", "amount", "assets"]
+        prependFailure "parsing AddressAmount failed, " $ AddressAmount
             <$> v .: "address"
             <*> (v .: "amount" >>= validateCoin)
             <*> v .:? "assets" .!= mempty

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -302,6 +302,7 @@ import Data.Aeson.Types
     , object
     , omitNothingFields
     , prependFailure
+    , rejectUnknownFields
     , sumEncoding
     , tagSingleConstructors
     , withObject
@@ -2910,6 +2911,7 @@ defaultRecordTypeOptions :: Aeson.Options
 defaultRecordTypeOptions = Aeson.defaultOptions
     { fieldLabelModifier = camelTo2 '_' . dropWhile (== '_')
     , omitNothingFields = True
+    , rejectUnknownFields = True
     }
 
 taggedSumTypeOptions :: Aeson.Options -> TaggedObjectOptions -> Aeson.Options

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -709,10 +709,8 @@ spec = parallel $ do
                     it ("Invalid ticker length: " ++ show (T.length txt)) $ do
                         Aeson.parseEither parseJSON [aesonQQ|
                             {
-                                "owner": "ed25519_pk1afhcpw2tg7nr2m3wr4x8jaa4dv7d09gnv27kwfxpjyvukwxs8qdqwg85xp",
                                 "homepage": "https://12345",
                                 "ticker": #{txt},
-                                "pledge_address": "ed25519_pk15vz9yc5c3upgze8tg5kd7kkzxqgqfxk5a3kudp22hdg0l2za00sq2ufkk7",
                                 "name": "invalid"
                             }
                         |] `shouldBe` (Left @String @(ApiT StakePoolMetadata) msg)


### PR DESCRIPTION
# Issue Number

⚠️ Experimental ⚠️ 

ADP-989

# Overview

This PR uses [`rejectUnknownFields`](https://hackage.haskell.org/package/aeson-1.5.6.0/docs/Data-Aeson.html#v:rejectUnknownFields) to reject unknown record fields in JSON objects sent via the API.

It makes no changes to the API specification itself.

# Remaining Work

- [ ] Adjust manually-defined `FromJSON` instances to fail if unknown fields are present with the `onlyAllowObjectFields` function.

#  Problematic Types

The following types all exhibited JSON property test failures when `rejectUnknownFields` was enabled:

- [x] `ApiActiveSharedWallet`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `ApiBlockReference`
    (includes `ApiSlotId`)
- [x] `ApiByronWallet`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `ApiNetworkInformation`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `ApiSharedWallet`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `ApiSlotReference`
    (includes `ApiSlotId`)
- [x] `ApiTransaction`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `ApiWallet`
    (includes `ApiBlockReference` which includes `ApiSlotId`)
- [x] `SomeByronWalletPostData`
    (caused by the `style` field)
- [x] `StakePoolMetadata`
    (fixed in e1f735e6f98505cee10eb2a904c9747404e3a673)
