### PR TITLE
Post release v2021 06 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="https://github.com/input-output-hk/cardano-wallet/releases"><img src="https://img.shields.io/github/release-pre/input-output-hk/cardano-wallet.svg?style=for-the-badge" /></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet"><img src="https://img.shields.io/buildkite/7ea3dac7a16f066d8dfc8f426a9a9f7a2131e899cd96c444cf/master?label=BUILD&style=for-the-badge"/></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge" /></a>
-  <a href="https://travis-ci.org/input-output-hk/cardano-wallet"><img src="https://img.shields.io/travis/input-output-hk/cardano-wallet.svg?label=DOCS&style=for-the-badge" /></a>
   <a href="https://github.com/input-output-hk/cardano-wallet/actions?query=workflow%3A%22cardano-wallet+Windows+Tests%22"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/cardano-wallet%20Windows%20Tests?label=Windows&style=for-the-badge" /></a>
 
   <!--

--- a/nix/migration-tests.nix
+++ b/nix/migration-tests.nix
@@ -36,10 +36,8 @@ let
 
   # List of git revisions to test against.
   # One can get sha256 for release via nix-prefetch-url, e.g. for v2021.4.8:
-  # nix-prefetch-url --unpack https://github.com/input-output-hk/cardano-wallet/archive/v2021-02-15.zip
+  # nix-prefetch-url --unpack https://github.com/input-output-hk/cardano-wallet/archive/v2021-06-11.zip
   releases = [
-    { rev = "v2020-11-26";
-      sha256 = "1262mangwrc2ykr9qwbcj57h2z2ib2sn0haipm2md4246f7b97v7"; }
     { rev = "v2020-12-08";
       sha256 = "00d5488yzsx3f6mqnnz9cd91zrbz2v6xqgqgcxk4vhl9qkc9vnfr"; }
     { rev = "v2020-12-21";
@@ -58,6 +56,8 @@ let
       sha256 = "1ng0y6jmcgb3agpqwais1mfx0yh9bqxza3xxkggdzgic89pg6pg1"; }
     { rev = "v2021-05-26";
       sha256 = "0ladc7bpy6fwvlsp2zjw3h8rm384w3qf93gvb1s6nn2n912sp7ck"; }
+    { rev = "v2021-06-11";
+      sha256 = "0civfzjhcglc7r1382r55gwnk0rn2f9nsnqpyscs049jwsw5r7sq"; }
   ];
 
   # Download the sources for a release.

--- a/test/e2e/env.rb
+++ b/test/e2e/env.rb
@@ -19,3 +19,7 @@ ENV['TESTS_E2E_BINDIR'] ||= "./bins"
 ENV['TESTS_E2E_TOKEN_METADATA'] ||= "https://metadata.cardano-testnet.iohkdev.io/"
 ENV['TESTS_E2E_SMASH'] ||= "https://smash.cardano-testnet.iohkdev.io"
 ENV['WALLET_PORT'] ||= "8090"
+
+##
+# Apply workaround for ADP-827 - Deleting wallets sometimes takes >60s in integration tests
+ENV['CARDANO_WALLET_TEST_INTEGRATION'] = '1'


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->


# Overview

- e05a1a45f15c6df7808f24a545da5e56a48ab801
  remove DOCS badge as travis is no longer used
  
- 6112e139fc7bdfd681a58205ad4bf960551e95ab
  update migration-tests.nix
  
- 55ccd91edfa12fc65bf02ba7eaf3fa93ff4876dc
  Apply workaround for ADP-827 in e2e tests



# Comments

Also applied workaround for ADP-827 in e2e integration tests.