### PR TITLE
Tweak cluster params to reduce likelyhood of rollbacks

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -56,6 +56,7 @@ module Test.Integration.Framework.DSL
     , minUTxOValue
     , slotLengthValue
     , securityParameterValue
+    , activeSlotCoeff
     , epochLengthValue
     , defaultTxTTL
 
@@ -651,7 +652,7 @@ minUTxOValue = 1_000_000
 --
 -- This space left blank intentionally.
 slotLengthValue :: NominalDiffTime
-slotLengthValue =  0.2
+slotLengthValue =  0.125
 
 -- | Parameter in test cluster shelley genesis.
 securityParameterValue :: Word32
@@ -659,12 +660,17 @@ securityParameterValue = 5
 
 -- | Parameter in test cluster shelley genesis.
 epochLengthValue :: Word32
-epochLengthValue = 100
+epochLengthValue = 160
+
+-- | Parameter in test cluster shelley genesis.
+activeSlotCoeff :: Quantity "percent" Double
+activeSlotCoeff = Quantity 31.25
 
 -- | Wallet server's chosen transaction TTL value (in seconds) when none is
 -- given.
 defaultTxTTL :: NominalDiffTime
 defaultTxTTL = 7200
+
 
 --
 -- Helpers

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Network.hs
@@ -27,6 +27,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , RequestException
+    , activeSlotCoeff
     , counterexample
     , epochLengthValue
     , expectField
@@ -73,7 +74,7 @@ spec = describe "SHELLEY_NETWORK" $ do
             , expectField #slotLength (`shouldBe` Quantity slotLengthValue)
             , expectField #epochLength (`shouldBe` Quantity epochLengthValue)
             , expectField #securityParameter (`shouldBe` Quantity securityParameterValue)
-            , expectField #activeSlotCoefficient (`shouldBe` Quantity 50.0)
+            , expectField #activeSlotCoefficient (`shouldBe` activeSlotCoeff)
             ]
             ++ map (expectEraField (`shouldNotBe` Nothing)) knownEras
             ++ map (expectEraField (`shouldBe` Nothing)) unknownEras

--- a/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
+++ b/lib/shelley/test/data/cardano-node-shelley/shelley-genesis.yaml
@@ -8,7 +8,7 @@
 #
 
 ---
-activeSlotsCoeff: 0.5
+activeSlotsCoeff: 0.3125
 protocolParams:
   poolDeposit: 0
   protocolVersion:
@@ -47,10 +47,10 @@ maxLovelaceSupply: 1000000000000000000
 protocolMagicId: 764824073
 networkMagic: 764824073
 networkId: Mainnet
-epochLength: 100
+epochLength: 160
 staking:
 slotsPerKESPeriod: 86400
-slotLength: 0.2
+slotLength: 0.125
 maxKESEvolutions: 90
 securityParam: 5
 systemStart: "2020-06-19T16:07:37.740128433Z"


### PR DESCRIPTION

# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

ADP-970

# Overview

<!-- Detail in a few bullet points the work accomplished in this PR -->

- [x] Tweak cluster slotting parameters to reduce likelyhood of rollbacks 


# Comments

- [ ] Haven't run this locally yet, should compare with master

```
I have notes from an experiment on 11 December 2020:

- f=0.5, sl=0.2, el=50 => 220s
    - 382 `ROLLBACK` printed
- f=0.833333, sl=0.33333, el=30 => 234s
    - Failed once the first time I ran it, on ADDRESS_IMPORT_05 - I can import 15000 of addresses
    - 1031 `ROLLBACK` printed
- f=0.3125, sl=0.125, el=80 => 209.7s
    - 143 `ROLLBACK` printed

The more slots are empty (using lowering f), the less collissions (slot
battles) we have, keeping the time of an epoch in seconds fixed.

So f=0.3125 should hopefully alleviate some rollback-related flakiness
in CI.

The downside is that we are less likely to catch real problems, but
there's always a tradeoff, and flaky tests are currently hurting us a
lot.

```
<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
