### PR TITLE
Reduce the number of concurrent request threads in middleware tests.

### DIFF
--- a/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
+++ b/lib/core/test/unit/Network/Wai/Middleware/LoggingSpec.hs
@@ -380,7 +380,7 @@ newtype NumberOfRequests = NumberOfRequests Int deriving Show
 instance Arbitrary NumberOfRequests where
     shrink (NumberOfRequests n) =
         fmap NumberOfRequests $ filter (> 0) $ shrink n
-    arbitrary = NumberOfRequests <$> choose (1, 100)
+    arbitrary = NumberOfRequests <$> choose (1, 8)
 
 newtype RandomIndex = RandomIndex Int deriving Show
 


### PR DESCRIPTION
# Issue Number

ADP-978

# Overview

This PR reduces the maximum number of concurrent requests created in middleware tests.

Experimental testing shows that these tests fail if virtual memory is constricted to 4 GiB, but pass if the number of concurrent requests is restricted to a smaller number.