### PR TITLE
Set -j 1 in macOS nix unit tests

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -86,6 +86,16 @@ let
       in {
         packages.cardano-wallet-core.components.tests = {
           unit.preCheck = noCacheOnBorsCookie;
+          # Attempt to ensure visible progress in the macOS hydra job.
+          #
+          # An hypothesis is that #2472 is caused by heavy load and unfocused
+          # resources from running the tests concurrently, risking that the slowest
+          # hspec runner - and thererefore the stdout - being silent for 900s causing
+          # hydra to timeout.
+          #
+          # Setting -j 1 should hopefully focus the resource we have in one place. It
+          # should go silent less often, at the expense of the full run getting slower.
+          unit.testFlags = lib.optionals pkgs.stdenv.hostPlatform.isDarwin ["-j" "1"];
         };
 
         packages.cardano-wallet.components.tests = {


### PR DESCRIPTION
# Issue Number

#2472 / ADP-970


# Overview

- [x] Set `-j 1` for hydra Mac builds, in hope this alleviates unit timeouts

# Comments

A hypothesis is that #2472 is caused by heavy load and unfocused
resources from running the tests concurrently, risking that the slowest
hspec runner - and thererefore the stdout - being silent for 900s causing
hydra to timeout.

Setting -j 1 should hopefully focus the resource we have in one place. It
should go silent less often, at the expense of the full run getting slower.

## Testing locally

Tested locally with `nix-build -A checks.cardano-wallet-core`. Seems to work.

It now takes 399s instead of 299.7877 on my machine (Not that dramatic slowdown).

We have a `-with-rtsopts=-N4` in the .cabal file. I'm not sure if that's good or not, but I suspect it doesn't matter as much as the `-j` option.
