### PR TITLE
LoggingSpec: Fix error handling and remove problem test cases

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -1072,7 +1072,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
         case mUpdatedState of
             Nothing -> do
                 -- This should never happen: we should always be able to select
-                -- *something* that matches.
+                -- _something_ that matches.
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
             Just SelectionState {selected} -> do
@@ -1104,7 +1104,7 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
         case mUpdatedState of
             Nothing -> do
                 -- This should never happen: we should always be able to select
-                -- *something* that matches.
+                -- _something_ that matches.
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
             Just SelectionState {selected} -> do

--- a/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/RegistrySpec.hs
@@ -227,23 +227,23 @@ newtype Delay = Delay Int deriving Show
 
 data WorkerTest ctx res = WorkerTest
     { _workerBefore :: WorkerCtx ctx -> WalletId -> IO ()
-        -- | A task to execute before the main worker's task. See 'workerBefore'
+        -- ^ A task to execute before the main worker's task. See 'workerBefore'
 
     , _workerMain :: WorkerCtx ctx -> WalletId -> IO ()
-        -- | A main task to execute, see 'workerMain'
+        -- ^ A main task to execute, see 'workerMain'
 
     , _workerAcquire :: (res -> IO ()) -> IO ()
-        -- | How the worker acquires its resource
+        -- ^ How the worker acquires its resource
 
     , _workerConcurrently :: Worker WalletId res -> IO ()
-        -- | An action to perform after the worker has been created,
+        -- ^ An action to perform after the worker has been created,
         -- concurrently in the main thread.
 
     , _workerAssertion :: WorkerResult -> IO ()
-        -- | Assertion to run after the wallet has exited
+        -- ^ Assertion to run after the wallet has exited
 
     , _workerTimeout :: Int
-        -- | Timeout in us after which the worker is killed
+        -- ^ Timeout in us after which the worker is killed
     }
 
 -- | A default setup to make above tests less noisy.


### PR DESCRIPTION
### Issue Number

ADP-562
ADP-1008

### Overview

The test cases were getting stuck if ever there was an exception while setting up the warp server.
A common reason for this could be that the random port which was selected is no longer available.

Also I am removing the two tests which have caused so much flakiness, because we are pretty confident that the code works and will continue to work.

- [x] Handle errors in the warp server setup.
- [x] Delete the problem test cases.
- [x] Re-enable these tests on macos.
- [x] Fix some Haddock syntax errors that HLS wanted to tell me about.
