### PR TITLE
Add execution time information to long-running test suites.

### DIFF
--- a/lib/core/test/unit/Main.hs
+++ b/lib/core/test/unit/Main.hs
@@ -4,12 +4,16 @@ import Prelude
 
 import Cardano.Startup
     ( withUtf8Encoding )
-import Test.Hspec.Runner
+import Test.Hspec.Core.Runner
     ( defaultConfig, hspecWith )
+import Test.Hspec.Extra
+    ( configWithExecutionTimes )
 import Test.Utils.Startup
     ( withLineBuffering )
 
 import qualified Spec
 
 main :: IO ()
-main = withLineBuffering $ withUtf8Encoding $ hspecWith defaultConfig Spec.spec
+main = withLineBuffering
+    $ withUtf8Encoding
+    $ hspecWith (configWithExecutionTimes defaultConfig) Spec.spec

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -242,6 +242,7 @@ test-suite unit
       Cardano.Wallet.Shelley.LaunchSpec
       Cardano.Wallet.Shelley.NetworkSpec
       Cardano.Wallet.Shelley.TransactionSpec
+      Spec
 
 test-suite integration
   default-language:

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -115,12 +115,12 @@ import System.Environment
     ( setEnv )
 import System.FilePath
     ( (</>) )
-import Test.Hspec
-    ( hspec )
+import Test.Hspec.Core.Runner
+    ( defaultConfig, hspecWith )
 import Test.Hspec.Core.Spec
     ( Spec, SpecWith, describe, parallel, sequential )
 import Test.Hspec.Extra
-    ( aroundAll )
+    ( aroundAll, configWithExecutionTimes )
 import Test.Integration.Faucet
     ( genRewardAccounts
     , maryIntegrationTestAssets
@@ -174,7 +174,7 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 main :: forall n. (n ~ 'Mainnet) => IO ()
 main = withTestsSetup $ \testDir tracers -> do
     nix <- inNixBuild
-    hspec $ do
+    hspecWith (configWithExecutionTimes defaultConfig) $ do
         describe "No backend required" $
             parallelIf (not nix) $ describe "Miscellaneous CLI tests"
                 MiscellaneousCLI.spec

--- a/lib/shelley/test/unit/Main.hs
+++ b/lib/shelley/test/unit/Main.hs
@@ -1,1 +1,13 @@
-{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+module Main where
+
+import Prelude
+
+import Test.Hspec.Core.Runner
+    ( defaultConfig, hspecWith )
+import Test.Hspec.Extra
+    ( configWithExecutionTimes )
+
+import qualified Spec
+
+main :: IO ()
+main = hspecWith (configWithExecutionTimes defaultConfig) Spec.spec

--- a/lib/shelley/test/unit/Spec.hs
+++ b/lib/shelley/test/unit/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover -optF --module-name=Spec #-}

--- a/lib/test-utils/src/Test/Hspec/Extra.hs
+++ b/lib/test-utils/src/Test/Hspec/Extra.hs
@@ -11,6 +11,7 @@
 
 module Test.Hspec.Extra
     ( aroundAll
+    , configWithExecutionTimes
     , it
     , itWithCustomTimeout
     , flakyBecauseOf
@@ -37,6 +38,8 @@ import Test.Hspec
     , pendingWith
     , specify
     )
+import Test.Hspec.Core.Runner
+    ( Config (..) )
 import Test.HUnit.Lang
     ( HUnitFailure (..), assertFailure, formatFailureReason )
 import Test.Utils.Platform
@@ -66,6 +69,19 @@ aroundAll
     -> Spec
 aroundAll acquire =
     beforeAll (unBracket acquire) . afterAll snd . beforeWith fst
+
+-- | Add execution timing information to test output.
+--
+configWithExecutionTimes :: Config -> Config
+configWithExecutionTimes config = config
+    { configPrintCpuTime = True
+      -- Prints the total elapsed CPU time for the entire test suite.
+    , configPrintSlowItems = Just 10
+      -- Prints a list of the slowest tests in descending order of
+      -- elapsed CPU time.
+    , configTimes = True
+      -- Appends the elapsed CPU time to the end of each individual test.
+    }
 
 -- | A drop-in replacement for 'it' that'll automatically retry a scenario once
 -- if it fails, to cope with potentially flaky tests, if the environment


### PR DESCRIPTION
# Issue Number

ADP-978
ADP-1014

# Overview

This PR adds execution timing information to long-running test suites.

It adds **three** kinds of information to test output:

1. The CPU time required to execute each individual test (in milliseconds):
    ```hs
    prop_makeChangeForUserSpecifiedAsset_sum (189ms)
        +++ OK, passed 1000 tests.
    prop_makeChangeForUserSpecifiedAsset_length (179ms)
        +++ OK, passed 1000 tests.
    ```
2. The total CPU time required to execute the entire test suite:
    ```hs
    Finished in 5.8572 seconds, used 18.3714 seconds of CPU time
    33 examples, 0 failures
    ```
3. A list of the 10 slowest test items, when measured over the entire test suite run:
    ```hs
    Slow spec items:
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:346:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for many non-user-specified assets/prop_makeChangeForNonUserSpecifiedAssets_sum/ (5076ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:344:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for many non-user-specified assets/prop_makeChangeForNonUserSpecifiedAssets_order/ (4903ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:304:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change/prop_makeChange/ (3553ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:342:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for many non-user-specified assets/prop_makeChangeForNonUserSpecifiedAssets_length/ (1011ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:300:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change/prop_makeChange_identity/ (779ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:302:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change/prop_makeChange_length/ (398ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:353:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for user-specified assets/prop_makeChangeForUserSpecifiedAsset_sum/ (189ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:355:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for user-specified assets/prop_makeChangeForUserSpecifiedAsset_length/ (179ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:322:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for coins/prop_makeChangeForCoin_sum/ (106ms)
      test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs:324:9: /Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobin/Cardano.Wallet.Primitive.CoinSelection.MA.RoundRobinSpec/Making change for coins/prop_makeChangeForCoin_length/ (95ms)
    ```