### PR TITLE
swagger: Remove incorrect "disabled" messages on byron migrations

### DIFF
--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -5291,10 +5291,6 @@ paths:
       tags: ["Byron Migrations"]
       summary: Migrate
       description: |
-        <p align="right">status: <strong>disabled</strong></p>
-        <strong>⚠️IMPORTANT⚠️</strong> This endpoint has been temporarily disabled with the introduction of multi-assets UTxO. It will be enabled again soon.
-
-        <hr/>
         Migrate the UTxO balance of this wallet to the given set of addresses.
 
         This operation will attempt to transfer as much of the wallet's balance
@@ -5329,10 +5325,6 @@ paths:
       tags: ["Byron Migrations"]
       summary: Create a migration plan
       description: |
-        <p align="right">status: <strong>disabled</strong></p>
-        <strong>⚠️IMPORTANT⚠️</strong> This endpoint has been temporarily disabled with the introduction of multi-assets UTxO. It will be enabled again soon.
-
-        <hr/>
         Generate a plan for migrating the UTxO balance of this wallet to
         another wallet, without executing the plan.
 


### PR DESCRIPTION
### Issue Number

None

### Overview

The OpenAPI docs say that the migration endpoints for Byron wallets are disabled, but that's untrue. This PR removes the disabled messages.

### Comments

[Rendered version](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/input-output-hk/cardano-wallet/rvl/fix-swagger-byron-migrations/specifications/api/swagger.yaml)
