### PR TITLE
Handle node disconnections

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -8,6 +8,7 @@
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.7.0").revisions).default;
         "hspec" = (((hackage.hspec)."2.8.2").revisions).default;
         "hspec-core" = (((hackage.hspec-core)."2.8.2").revisions).default;
+        "unliftio" = (((hackage.unliftio)."0.2.17").revisions).default;
         "base16-bytestring" = (((hackage.base16-bytestring)."1.0.1.0").revisions).default;
         "bech32" = (((hackage.bech32)."1.1.0").revisions).default;
         "bech32-th" = (((hackage.bech32-th)."1.0.2").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -25,6 +25,7 @@ extra-deps:
 - quickcheck-state-machine-0.7.0
 - hspec-2.8.2
 - hspec-core-2.8.2
+- unliftio-0.2.17 # Need newer for handleSyncOrAsync
 
 # cardano-addresses-3.5.0
 - git: https://github.com/input-output-hk/cardano-addresses


### PR DESCRIPTION
# Issue Number

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->
ADP-871

# Overview

- [x] Ensure follow catches asyncronous exceptions from connectClient,
such that it can restart with a new connection and cursor.

- [x] Keep Local State Queries and to-be-submitted Txs queued until their
requests finish, not just when they start. If a query is interrupted by
the node being disconnected, it will block until a connection is
re-established, and then retry.

- [ ] Remove need to catch async exceptions
    - Think this is a good opportunity to refactor / simplify all the chain-following code.
- [ ] Verify ouroboros-network errors are logged

# Comments

Integration tests could probably be written, but it would:
- take some time better spend on other tasks
- add complexity to the already complex cluster setup

so I'd lean towards it not being worth it at this moment.

I tested (see below) manually though, which could be added as a documented .md test if desired.

## Manual testing

### Interrupted chain-sync & wallet listing
1. start node and wallet
2. list wallets => [wallet1]
3. kill node
4. list wallets => [wallet1] (previously [], or crash)
5. start node 
6. wallet resumes syncing
7. list wallets => [wallet1]

### Interrupted Local State Query
1. Start node and wallet
2. `cardano-wallet stake-pool list --stake 0`
3. kill node
4. observe that nothing happens
5. re-start node
6. stake-pool list request finishes after a while



<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
