### PR TITLE
Enhance integration tests relating to transaction metadata and fees

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -94,6 +94,9 @@ module Test.Integration.Framework.TestData
     , errMsg403TemplateInvalidUnknownCosigner
     , errMsg403TemplateInvalidDuplicateXPub
     , errMsg403TemplateInvalidScript
+
+    -- * Transaction metadata
+    , txMetadata_ADP_1005
     ) where
 
 import Prelude
@@ -106,6 +109,8 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxMetadata (..), TxMetadataValue (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromText )
 import Cardano.Wallet.Version
@@ -120,6 +125,7 @@ import Test.Integration.Framework.DSL
     ( Payload (..), fixturePassphrase, json )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as W
+import qualified Data.Map as Map
 
 falseWalletIds :: [(String, String)]
 falseWalletIds =
@@ -602,3 +608,38 @@ errMsg400ScriptTimelocksContradictory =
 errMsg400ScriptNotUniformRoles :: String
 errMsg400ScriptNotUniformRoles =
     "All keys of a script must have the same role: either payment or delegation."
+
+--------------------------------------------------------------------------------
+-- Transaction metadata
+--------------------------------------------------------------------------------
+
+-- | Transaction metadata for ADP-1005.
+--
+-- See https://jira.iohk.io/browse/ADP-1005
+--
+txMetadata_ADP_1005 :: TxMetadata
+txMetadata_ADP_1005 = TxMetadata $ Map.fromList
+    [ ( 61284
+      , TxMetaMap
+        [ ( TxMetaNumber 1
+          , TxMetaBytes "\SUB#f\DC3X\DC3\231\219\130\243\SYN\v\226+Ac\221\247'\US)\128h-!\246\193F\172\190\202b"
+          )
+        , ( TxMetaNumber 2
+          , TxMetaBytes "#\229\194\DC3\211l\GSO\177C\128t~\150\ESCy\145K1GW \166O6\196D\166\219\225\SYN$"
+          )
+        , ( TxMetaNumber 3
+          , TxMetaBytes "\224\208\133\DC2\188\ESCA\nM\219D\141\148\182\253\ETXV\NULF\158D\233\ETXq\228\142\134\SOH5"
+          )
+        , ( TxMetaNumber 4
+          , TxMetaNumber 29562467
+          )
+        ]
+      )
+    , ( 61285
+      , TxMetaMap
+        [ ( TxMetaNumber 1
+          , TxMetaBytes ",\SOHv\243R\134\242\ACK}\222\DEL\230\219x\155l]\190\134\162\203>\208\217\132\138\175\225\225\187\229\149\176u?\211AP\235\255\171\211\157\&4\GS\255t\DEL\184m\234\144\nj\153\174\164\155y\137o\155_\b"
+          )
+        ]
+      )
+    ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1025,9 +1025,11 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         mapM_ spec_TRANSMETA_CREATE_01
             [ ( "simple textual metadata"
               , TxMetadata $ Map.singleton 1 $ TxMetaText "hello"
+              , Quantity 134_700
               )
             , ( "metadata from ADP-1005"
               , txMetadata_ADP_1005
+              , Quantity 152_300
               )
             ]
 
@@ -2173,8 +2175,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectErrorMessage errMsg403NotEnoughMoney
             ]
   where
-    spec_TRANSMETA_CREATE_01 :: (String, TxMetadata) -> SpecWith Context
-    spec_TRANSMETA_CREATE_01 (testName, txMetadata) =
+    spec_TRANSMETA_CREATE_01
+        :: (String, TxMetadata, Quantity "lovelace" Natural)
+        -> SpecWith Context
+    spec_TRANSMETA_CREATE_01 (testName, txMetadata, expectedFee) =
         it testName $ \ctx -> runResourceT $ do
 
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
@@ -2193,6 +2197,8 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             , expectField
                 (#metadata . #getApiTxMetadata)
                 (`shouldBe` Just (ApiT txMetadata))
+            , expectField
+                (#fee) (`shouldBe` expectedFee)
             ]
 
         eventually "metadata is confirmed in transaction list" $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -24,6 +24,7 @@ import Cardano.Mnemonic
 import Cardano.Wallet.Api.Types
     ( AddressAmount (..)
     , ApiAsset (..)
+    , ApiCoinSelectionOutput (..)
     , ApiFee (..)
     , ApiT (..)
     , ApiTransaction
@@ -100,6 +101,7 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , between
+    , computeApiCoinSelectionFee
     , counterexample
     , defaultTxTTL
     , emptyRandomWallet
@@ -132,6 +134,7 @@ import Test.Integration.Framework.DSL
     , postTx
     , request
     , rewardWallet
+    , selectCoinsWith
     , toQueryString
     , unsafeGetTransactionTime
     , unsafeRequest
@@ -173,6 +176,8 @@ import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
+import qualified Data.HashSet as Set
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Network.HTTP.Types.Status as HTTP
@@ -2185,6 +2190,41 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         let amt = (minUTxOValue :: Natural)
 
+        -- First, perform a dry-run selection using the 'selectCoins' endpoint.
+        -- This will allow us to confirm that the 'selectCoins' endpoint
+        -- produces a selection whose fee is identical to the selection
+        -- produced by the 'postTransaction' endpoint.
+        let paymentCount = 1
+        targetAddresses <- take paymentCount .
+            fmap (view #id) <$> listAddresses @n ctx wb
+        let targetAmounts = take paymentCount $
+                Quantity <$> [minUTxOValue ..]
+        let targetAssets = repeat mempty
+        let payments = NE.fromList $ map ($ mempty) $
+                zipWith AddressAmount targetAddresses targetAmounts
+        let outputs = zipWith3 ApiCoinSelectionOutput
+                targetAddresses targetAmounts targetAssets
+        let addTxMetadata' = \(Json (Aeson.Object o)) -> Json
+                $ Aeson.Object
+                $ o <> ("metadata" .= (Aeson.toJSON (ApiT txMetadata)))
+        coinSelectionResponse <-
+            selectCoinsWith @n @'Shelley ctx wa payments addTxMetadata'
+        verify coinSelectionResponse
+            [ expectResponseCode HTTP.status200
+            , expectField #inputs
+                (`shouldSatisfy` (not . null))
+            , expectField #outputs
+                (`shouldSatisfy` ((Set.fromList outputs ==) . Set.fromList))
+            , expectField #change
+                (`shouldSatisfy` (not . null))
+            ]
+        let apiCoinSelection = getFromResponse Prelude.id coinSelectionResponse
+        let fee = computeApiCoinSelectionFee apiCoinSelection
+        Quantity (fromIntegral (unCoin (fee))) `shouldBe` expectedFee
+
+        -- Next, actually create a transaction and submit it to the network.
+        -- This transaction should have a fee that is identical to the fee
+        -- of the dry-run coin selection produced in the previous step.
         basePayload <- mkTxPayload ctx wb amt fixturePassphrase
         let payload = addTxMetadata (Aeson.toJSON (ApiT txMetadata)) basePayload
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -162,6 +162,7 @@ import Test.Integration.Framework.TestData
     , errMsg404NoAsset
     , errMsg404NoWallet
     , steveToken
+    , txMetadata_ADP_1005
     )
 import Web.HttpApiData
     ( ToHttpApiData (..) )
@@ -2359,38 +2360,3 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
     oneMillionAda :: Natural
     oneMillionAda = 1_000 * oneThousandAda
-
---------------------------------------------------------------------------------
--- Constants
---------------------------------------------------------------------------------
-
--- | Transaction metadata for ADP-1005.
---
--- See https://jira.iohk.io/browse/ADP-1005
---
-txMetadata_ADP_1005 :: TxMetadata -- [(Word64, TxMetadataValue)]
-txMetadata_ADP_1005 = TxMetadata $ Map.fromList
-    [ ( 61284
-      , TxMetaMap
-        [ ( TxMetaNumber 1
-          , TxMetaBytes "\SUB#f\DC3X\DC3\231\219\130\243\SYN\v\226+Ac\221\247'\US)\128h-!\246\193F\172\190\202b"
-          )
-        , ( TxMetaNumber 2
-          , TxMetaBytes "#\229\194\DC3\211l\GSO\177C\128t~\150\ESCy\145K1GW \166O6\196D\166\219\225\SYN$"
-          )
-        , ( TxMetaNumber 3
-          , TxMetaBytes "\224\208\133\DC2\188\ESCA\nM\219D\141\148\182\253\ETXV\NULF\158D\233\ETXq\228\142\134\SOH5"
-          )
-        , ( TxMetaNumber 4
-          , TxMetaNumber 29562467
-          )
-        ]
-      )
-    , ( 61285
-      , TxMetaMap
-        [ ( TxMetaNumber 1
-          , TxMetaBytes ",\SOHv\243R\134\242\ACK}\222\DEL\230\219x\155l]\190\134\162\203>\208\217\132\138\175\225\225\187\229\149\176u?\211AP\235\255\171\211\157\&4\GS\255t\DEL\184m\234\144\nj\153\174\164\155y\137o\155_\b"
-          )
-        ]
-      )
-    ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1060,6 +1060,17 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , expectedFee =
                     Quantity 152_300
                 }
+            , CreateTransactionWithMetadataTest
+                { testName =
+                    "transaction with metadata from ADP-1005 (2 outputs)"
+                , txOutputAdaQuantities =
+                    -- The exact ada quantities recorded in ADP-1005:
+                    [1_000_000, 498_283_127]
+                , txMetadata =
+                      Just txMetadata_ADP_1005
+                , expectedFee =
+                    Quantity 165_900
+                }
             ]
 
     it "TRANSMETA_CREATE_02 - Transaction with invalid metadata" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -2335,3 +2335,38 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
     oneMillionAda :: Natural
     oneMillionAda = 1_000 * oneThousandAda
+
+--------------------------------------------------------------------------------
+-- Constants
+--------------------------------------------------------------------------------
+
+-- | Transaction metadata for ADP-1005.
+--
+-- See https://jira.iohk.io/browse/ADP-1005
+--
+txMetadata_ADP_1005 :: TxMetadata -- [(Word64, TxMetadataValue)]
+txMetadata_ADP_1005 = TxMetadata $ Map.fromList
+    [ ( 61284
+      , TxMetaMap
+        [ ( TxMetaNumber 1
+          , TxMetaBytes "\SUB#f\DC3X\DC3\231\219\130\243\SYN\v\226+Ac\221\247'\US)\128h-!\246\193F\172\190\202b"
+          )
+        , ( TxMetaNumber 2
+          , TxMetaBytes "#\229\194\DC3\211l\GSO\177C\128t~\150\ESCy\145K1GW \166O6\196D\166\219\225\SYN$"
+          )
+        , ( TxMetaNumber 3
+          , TxMetaBytes "\224\208\133\DC2\188\ESCA\nM\219D\141\148\182\253\ETXV\NULF\158D\233\ETXq\228\142\134\SOH5"
+          )
+        , ( TxMetaNumber 4
+          , TxMetaNumber 29562467
+          )
+        ]
+      )
+    , ( 61285
+      , TxMetaMap
+        [ ( TxMetaNumber 1
+          , TxMetaBytes ",\SOHv\243R\134\242\ACK}\222\DEL\230\219x\155l]\190\134\162\203>\208\217\132\138\175\225\225\187\229\149\176u?\211AP\235\255\171\211\157\&4\GS\255t\DEL\184m\234\144\nj\153\174\164\155y\137o\155_\b"
+          )
+        ]
+      )
+    ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -1026,6 +1026,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             [ ( "simple textual metadata"
               , TxMetadata $ Map.singleton 1 $ TxMetaText "hello"
               )
+            , ( "metadata from ADP-1005"
+              , txMetadata_ADP_1005
+              )
             ]
 
     it "TRANSMETA_CREATE_02 - Transaction with invalid metadata" $ \ctx -> runResourceT $ do


### PR DESCRIPTION
# Issue Number

ADP-1009

# Overview

This PR doesn't provide a solution for ADP-1009, but it does add integration test coverage relating to transaction metadata and fees.

In principle, the following two endpoints, if called on a wallet with the same starting UTxO and coin selection criteria, should return **_identical_** transaction fees (modulo random selection):

- [`selectCoins`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/selectCoins)
- [`postTransaction`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/postTransaction)

# Modifications made by this PR

This PR:

- Adjusts `TRANSMETA_CREATE_01` so that it tests with a variety of different coin selection criteria:
    - no metadata;
    - simple textual metadata; 
    - the set of metadata recorded in ADP-1005.
- Adjusts `TRANSMETA_CREATE_01` so that it first performs a dry-run coin selection with the [`selectCoins`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/selectCoins) endpoint.
- Adjusts `TRANSMETA_CREATE_01` so that it cross-checks the fee obtained from calling [`selectCoins`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/selectCoins) with the fee obtained from calling [postTransaction](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/postTransaction), failing if the fees are not identical.

This PR provides evidence that:
- that the [`selectCoins`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/selectCoins) and [`postTransaction`](https://input-output-hk.github.io/cardano-wallet/api/edge/#operation/postTransaction) endpoints **_do_** generate selections with **_identical_** fees, **_provided_** the coin selection criteria are identical.
- that we **_can_** indeed make a transaction that includes the metadata recorded in ADP-1005, and that the transaction is **_not_** rejected by the ledger for having a fee that is too low.