### PR TITLE
More integration tests for construct tx endpoint

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -171,7 +171,8 @@ module Test.Integration.Framework.DSL
     , notDelegating
     , delegating
     , getSlotParams
-
+    , arbitraryStake
+    
     -- * CLI
     , commandName
     , command
@@ -2003,6 +2004,10 @@ getFromResponseList i getter (_, res) = case res of
 
 json :: QuasiQuoter
 json = aesonQQ
+
+arbitraryStake :: Maybe Coin
+arbitraryStake = Just $ ada 10_000_000_000
+  where ada = Coin . (1000*1000*)
 
 joinStakePool
     :: forall n w m.

--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -36,6 +36,7 @@ module Test.Integration.Framework.TestData
     , updateNamePayload
     , updatePassPayload
     , updateEmptyPassPayload
+    , txMetadata_ADP_1005
 
     -- * Error messages
     , errMsg400WalletIdEncoding
@@ -94,9 +95,7 @@ module Test.Integration.Framework.TestData
     , errMsg403TemplateInvalidUnknownCosigner
     , errMsg403TemplateInvalidDuplicateXPub
     , errMsg403TemplateInvalidScript
-
-    -- * Transaction metadata
-    , txMetadata_ADP_1005
+    , errMsg403InvalidConstructTx
     ) where
 
 import Prelude
@@ -271,6 +270,12 @@ versionLine = "Running as " <> pack (showFullVersion version gitRevision)
 ---
 --- Error messages
 ---
+
+errMsg403InvalidConstructTx :: String
+errMsg403InvalidConstructTx =
+    "It looks like I've created an empty transaction that does not have \
+     \any payments, withdrawals, delegations, metadata nor minting. \
+     \Include at least one of them."
 
 errMsg403MinUTxOValue :: String
 errMsg403MinUTxOValue =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -93,6 +93,7 @@ import Test.Integration.Framework.Context
 import Test.Integration.Framework.DSL
     ( Headers (..)
     , Payload (..)
+    , arbitraryStake
     , bracketSettings
     , delegating
     , delegationFee
@@ -1384,10 +1385,6 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
             , homepage = "https://iohk.io"
             }
         ]
-
-    arbitraryStake :: Maybe Coin
-    arbitraryStake = Just $ ada 10_000_000_000
-      where ada = Coin . (1000*1000*)
 
     setOf :: Ord b => [a] -> (a -> b) -> Set b
     setOf xs f = Set.fromList $ map f xs

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -646,6 +646,30 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             [ expectResponseCode HTTP.status403
             ]
 
+    it "TRANS_NEW_VALIDITY_INTERVAL_02 - Validity interval 'unspecified'" $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith 
+          "Currently throws: \
+          \parsing ApiValidityBound object failed, \
+          \expected Object, but encountered String \
+          \- to be fixed in ADP-985"
+
+        wa <- fixtureWallet ctx
+
+        let payload = Json [json|{
+                "withdrawal": "self",
+                "validity_interval": {
+                    "invalid_before": "unspecified",
+                    "invalid_hereafter": "unspecified"
+                  }
+                }|]
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status202
+            ]
+
     it "TRANS_NEW_CREATE_MULTI_TX - Tx including payments, delegation, metadata, withdrawals, validity_interval" $ \ctx -> runResourceT $ do
 
         wa <- fixtureWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -19,10 +19,13 @@ module Test.Integration.Scenario.API.Shelley.TransactionsNew
 
 import Prelude
 
+import Cardano.Mnemonic
+    ( mnemonicToText )
 import Cardano.Wallet.Api.Types
     ( ApiCoinSelectionInput (..)
     , ApiConstructTransaction
     , ApiFee (..)
+    , ApiT (..)
     , ApiWallet
     , DecodeAddress
     , DecodeStakeAddress
@@ -33,20 +36,28 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
+import Cardano.Wallet.Primitive.Types.Address
+    ( Address (..) )
 import Control.Monad.IO.Unlift
     ( MonadIO (..), MonadUnliftIO (..), liftIO )
 import Control.Monad.Trans.Resource
     ( runResourceT )
 import Data.Generics.Internal.VL.Lens
     ( (^.) )
+import Data.Maybe
+    ( isJust )
+import Data.Proxy
+    ( Proxy )
 import Data.Quantity
     ( Quantity (..) )
+import Data.Text
+    ( Text )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
-    ( SpecWith, describe )
+    ( SpecWith, describe, pendingWith )
 import Test.Hspec.Expectations.Lifted
-    ( shouldBe )
+    ( shouldBe, shouldNotBe, shouldSatisfy )
 import Test.Hspec.Extra
     ( it )
 import Test.Integration.Framework.DSL
@@ -54,17 +65,28 @@ import Test.Integration.Framework.DSL
     , Headers (..)
     , Payload (..)
     , emptyWallet
+    , expectErrorMessage
     , expectField
     , expectResponseCode
     , expectSuccess
+    , fixtureMultiAssetWallet
+    , fixtureWallet
     , fixtureWalletWith
     , getFromResponse
     , json
     , listAddresses
     , minUTxOValue
+    , pickAnAsset
     , request
+    , rewardWallet
     , unsafeRequest
     , verify
+    )
+import Test.Integration.Framework.TestData
+    ( errMsg403Fee
+    , errMsg403InvalidConstructTx
+    , errMsg403MinUTxOValue
+    , errMsg403NotEnoughMoney
     )
 
 import qualified Cardano.Wallet.Api.Link as Link
@@ -78,19 +100,105 @@ spec :: forall n.
     , PaymentAddress n IcarusKey
     ) => SpecWith Context
 spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
-    it "TRANS_NEW_CREATE_01x - No payload" $ \ctx -> runResourceT $ do
-        let initialAmt = 3*minUTxOValue
-        wa <- fixtureWalletWith @n ctx [initialAmt]
-
+    it "TRANS_NEW_CREATE_01a - Empty payload is not allowed" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
         let emptyPayload = Json [json|{}|]
 
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default emptyPayload
         verify rTx
             [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403InvalidConstructTx
             ]
 
-    it "TRANS_NEW_CREATE_01x - Single Output Transaction" $ \ctx -> runResourceT $ do
+    it "TRANS_NEW_CREATE_01b - Validity interval only is not allowed" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        let validityInterval = Json [json|{
+                "validity_interval": {
+                    "invalid_before": {
+                      "quantity": 10,
+                      "unit": "second"
+                    },
+                    "invalid_hereafter": {
+                      "quantity": 50,
+                      "unit": "second"
+                    }
+                  }
+                }|]
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default validityInterval
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403InvalidConstructTx
+            ]
+
+    it "TRANS_NEW_CREATE_01c - No payload is bad request" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default Empty
+        verify rTx
+            [ expectResponseCode HTTP.status400
+            ]
+
+    it "TRANS_NEW_CREATE_02 - Only metadata" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        let metadata = Json [json|{ "metadata": { "1": { "string": "hello" } } }|]
+        let expectedFee = 1129000
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default metadata
+        verify rTx
+            [ expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #metadata) (`shouldSatisfy` isJust)
+            , expectField (#fee . #getQuantity) (`shouldBe` expectedFee)
+            ]
+        -- TODO: sign and submit tx,
+        --       check metadata presence on submitted tx,
+        --       make sure only fee is deducted from fixtureWallet
+
+    it "TRANS_NEW_CREATE_03a - Withdrawal from self" $ \ctx -> runResourceT $ do
+        (wa, _) <- rewardWallet ctx
+        let withdrawal = Json [json|{ "withdrawal": "self" }|]
+        let expectedFee = 139000
+        -- let withdrawalAmt = 1000000000000
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default withdrawal
+        verify rTx
+            [ expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #metadata) (`shouldBe` Nothing)
+            , expectField (#fee . #getQuantity) (`shouldBe` expectedFee)
+            , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` (not . null))
+            ]
+        -- TODO: sign and submit tx,
+        --       check that reward account is 0,
+        --       make sure wallet balance is increased by withdrawalAmt - fee
+
+    it "TRANS_NEW_CREATE_03b - Withdrawal from external wallet" $ \ctx -> runResourceT $ do
+        (_, mw) <- rewardWallet ctx
+        wa <- fixtureWallet ctx
+        let withdrawal = Json [json|{ "withdrawal": #{mnemonicToText mw} }|]
+        let expectedFee = 1139000
+        -- let withdrawalAmt = 1000000000000
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default withdrawal
+        verify rTx
+            [ expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #metadata) (`shouldBe` Nothing)
+            , expectField (#fee . #getQuantity) (`shouldBe` expectedFee)
+            , expectField (#coinSelection . #withdrawals) (`shouldSatisfy` (not . null))
+            ]
+        -- TODO: sign and submit tx,
+        --       check that reward account is 0 on external rewardWallet,
+        --       make sure wa wallet balance is increased by withdrawalAmt - fee
+
+    it "TRANS_NEW_CREATE_04a - Single Output Transaction" $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith "Missing outputs on response - to be fixed in ADP-985"
+
         let initialAmt = 3*minUTxOValue
         wa <- fixtureWalletWith @n ctx [initialAmt]
         wb <- emptyWallet ctx
@@ -105,6 +213,9 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         verify rTx
             [ expectSuccess
             , expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
             , expectField (#fee . #getQuantity) (`shouldBe` feeMin)
             ]
 
@@ -114,7 +225,219 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                 getFromResponse (#coinSelection . #inputs) rTx
         length coinSelInputs `shouldBe` 1
 
-        -- now we should sign it and send it in two steps
+        -- TODO: now we should sign it and send it in two steps
+        --       make sure it is delivered
+        --       make sure balance is updated accordingly on src and dst wallets
+
+    it "TRANS_NEW_CREATE_04b - Cannot spend less than minUTxOValue" $ \ctx -> runResourceT $ do
+        wa <- fixtureWallet ctx
+        wb <- emptyWallet ctx
+        let amt = minUTxOValue - 1
+
+        payload <- liftIO $ mkTxPayload ctx wb amt
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403MinUTxOValue
+            ]
+
+    it "TRANS_NEW_CREATE_04c - Can't cover fee" $ \ctx -> runResourceT $ do
+        wa <- fixtureWalletWith @n ctx [minUTxOValue + 1]
+        wb <- emptyWallet ctx
+
+        payload <- liftIO $ mkTxPayload ctx wb minUTxOValue
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403Fee
+            ]
+
+    it "TRANS_NEW_CREATE_04d - Not enough money" $ \ctx -> runResourceT $ do
+        let (srcAmt, reqAmt) = (minUTxOValue, 2 * minUTxOValue)
+        wa <- fixtureWalletWith @n ctx [srcAmt]
+        wb <- emptyWallet ctx
+
+        payload <- liftIO $ mkTxPayload ctx wb reqAmt
+
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403NotEnoughMoney
+            ]
+
+    it "TRANS_NEW_CREATE_04e- Multiple Output Tx to single wallet" $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith "Missing outputs on response - to be fixed in ADP-985"
+
+        wa <- fixtureWallet ctx
+        wb <- emptyWallet ctx
+        addrs <- listAddresses @n ctx wb
+
+        let amt = minUTxOValue :: Natural
+        let destination1 = (addrs !! 1) ^. #id
+        let destination2 = (addrs !! 2) ^. #id
+        let payload = Json [json|{
+                "payments": [{
+                    "address": #{destination1},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                },
+                {
+                    "address": #{destination2},
+                    "amount": {
+                        "quantity": #{amt},
+                        "unit": "lovelace"
+                    }
+                }]
+            }|]
+
+        (_, ApiFee (Quantity feeMin) _ _ _) <- unsafeRequest ctx
+            (Link.getTransactionFee @'Shelley wa) payload
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+            , expectField (#fee . #getQuantity) (`shouldBe` feeMin)
+            ]
+        -- TODO: now we should sign it and send it in two steps,
+        --       make sure it is delivered
+        --       make sure balance is updated accordingly on src and dst wallets
+
+    it "TRANS_NEW_ASSETS_CREATE_01a - Multi-asset tx with Ada" $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith "Missing outputs on response - to be fixed in ADP-985"
+
+        wa <- fixtureMultiAssetWallet ctx
+        wb <- emptyWallet ctx
+        ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wa) Default Empty
+        let (_, Right wal) = ra
+
+        -- pick out an asset to send
+        let assetsSrc = wal ^. #assets . #total . #getApiT
+        assetsSrc `shouldNotBe` mempty
+        let val = minUTxOValue <$ pickAnAsset assetsSrc
+
+        -- create payload
+        addrs <- listAddresses @n ctx wb
+        let destination = (addrs !! 1) ^. #id
+        let amt = 2 * minUTxOValue
+        payload <- mkTxPayloadMA @n destination amt [val]
+
+        --construct transaction
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+            ]
+        -- TODO: now we should sign it and send it in two steps
+        --       make sure it is delivered
+        --       make sure balance is updated accordingly on src and dst wallets
+
+    it "TRANS_NEW_ASSETS_CREATE_01b - Multi-asset tx with not enough Ada" $ \ctx -> runResourceT $ do
+        wa <- fixtureMultiAssetWallet ctx
+        wb <- emptyWallet ctx
+        ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wa) Default Empty
+        let (_, Right wal) = ra
+
+        -- pick out an asset to send
+        let assetsSrc = wal ^. #assets . #total . #getApiT
+        assetsSrc `shouldNotBe` mempty
+        let val = minUTxOValue <$ pickAnAsset assetsSrc
+
+        -- create payload
+        addrs <- listAddresses @n ctx wb
+        let destination = (addrs !! 1) ^. #id
+        let amt = minUTxOValue
+        payload <- mkTxPayloadMA @n destination amt [val]
+
+        --construct transaction
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage "Some outputs have ada values that are too small."
+            ]
+
+    it "TRANS_NEW_ASSETS_CREATE_01c - Multi-asset tx without Ada" $ \ctx -> runResourceT $ do
+
+        liftIO $ pendingWith "Missing outputs on response - to be fixed in ADP-985"
+
+        wa <- fixtureMultiAssetWallet ctx
+        wb <- emptyWallet ctx
+        ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wa) Default Empty
+        let (_, Right wal) = ra
+
+        -- pick out an asset to send
+        let assetsSrc = wal ^. #assets . #total . #getApiT
+        assetsSrc `shouldNotBe` mempty
+        let val = minUTxOValue <$ pickAnAsset assetsSrc
+
+        -- create payload
+        addrs <- listAddresses @n ctx wb
+        let destination = (addrs !! 1) ^. #id
+        let amt = 0
+        payload <- mkTxPayloadMA @n destination amt [val]
+
+        --construct transaction
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectSuccess
+            , expectResponseCode HTTP.status202
+            , expectField (#coinSelection . #inputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #outputs) (`shouldSatisfy` (not . null))
+            , expectField (#coinSelection . #change) (`shouldSatisfy` (not . null))
+            ]
+        -- TODO: now we should sign it and send it in two steps
+        --       make sure it is delivered
+        --       make sure balance is updated accordingly on src and dst wallets
+
+    it "TRANS_NEW_ASSETS_CREATE_01d - Multi-asset tx with not enough assets" $ \ctx -> runResourceT $ do
+        wa <- fixtureMultiAssetWallet ctx
+        wb <- emptyWallet ctx
+        ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wa) Default Empty
+        let (_, Right wal) = ra
+
+        -- pick out an asset to send
+        let assetsSrc = wal ^. #assets . #total . #getApiT
+        assetsSrc `shouldNotBe` mempty
+        let val = (minUTxOValue * minUTxOValue) <$ pickAnAsset assetsSrc
+
+        -- create payload
+        addrs <- listAddresses @n ctx wb
+        let destination = (addrs !! 1) ^. #id
+        let amt = 0
+        payload <- mkTxPayloadMA @n destination amt [val]
+
+        --construct transaction
+        rTx <- request @(ApiConstructTransaction n) ctx
+            (Link.createUnsignedTransaction @'Shelley wa) Default payload
+        verify rTx
+            [ expectResponseCode HTTP.status403
+            , expectErrorMessage errMsg403NotEnoughMoney
+            ]
+
+
+  -- TODO:
+  -- join and quit pool
+  -- mint
+  -- validity interval
+  -- everything (payment, delegation, mint, metadata, withdrawal)
   where
     -- Construct a JSON payment request for the given quantity of lovelace.
     mkTxPayload
@@ -133,5 +456,35 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
                         "quantity": #{amt},
                         "unit": "lovelace"
                     }
+                }]
+            }|]
+
+    -- Like mkTxPayload, except that assets are included in the payment.
+    -- Asset amounts are specified by ((PolicyId Hex, AssetName Hex), amount).
+    mkTxPayloadMA
+        :: forall l m.
+            ( DecodeAddress l
+            , DecodeStakeAddress l
+            , EncodeAddress l
+            , MonadUnliftIO m
+            )
+        => (ApiT Address, Proxy l)
+        -> Natural
+        -> [((Text, Text), Natural)]
+        -> m Payload
+    mkTxPayloadMA destination coin val = do
+        let assetJson ((pid, name), q) = [json|{
+                    "policy_id": #{pid},
+                    "asset_name": #{name},
+                    "quantity": #{q}
+                }|]
+        return $ Json [json|{
+                "payments": [{
+                    "address": #{destination},
+                    "amount": {
+                        "quantity": #{coin},
+                        "unit": "lovelace"
+                    },
+                    "assets": #{map assetJson val}
                 }]
             }|]

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -1325,6 +1325,64 @@ instance Malformed (BodyParam (ApiConstructTransactionData ('Testnet pm))) where
                }|]
                , "Error in $.delegations[0]: key 'pool' not found"
               )
+            , ( [aesonQQ|
+                {
+                    "metadata": { "1": { "string": "hello" } },
+                    "validity_interval": {
+                        "invalid_before": {
+                          "quantity": 500,
+                          "unit": "second"
+                        }
+                      }
+                    }|]
+               , "Error in $['validity_interval']: parsing Cardano.Wallet.Api.Types.ApiValidityInterval(ApiValidityInterval) failed, key 'invalid_hereafter' not found"
+              )
+            , ( [aesonQQ|
+                {
+                    "metadata": { "1": { "string": "hello" } },
+                    "validity_interval": {
+                        "invalid_hereafter": {
+                          "quantity": 500,
+                          "unit": "second"
+                        }
+                      }
+                    }|]
+               , "Error in $['validity_interval']: parsing Cardano.Wallet.Api.Types.ApiValidityInterval(ApiValidityInterval) failed, key 'invalid_before' not found"
+              )
+            , ( [aesonQQ|
+                  {
+                    "payments": [{
+                        "address": #{addrPlaceholder},
+                        "amount": {
+                            "quantity": 2000000,
+                            "unit": "lovelace"
+                        }
+                    }],
+                    "validity_interval": {
+                        "invalid_before": {
+                          "quantity": 0,
+                          "unit": "slots"
+                        },
+                        "invalid_hereafter": {
+                          "quantity": 500,
+                          "unit": "second"
+                        }
+                      }
+                    }|]
+               , "Error in $['validity_interval']['invalid_before']: ApiValidityBound string must have either 'second' or 'slot' unit."
+              )
+            , ( [aesonQQ|{ "metadata": "hello" }|]
+               , "Error in $.metadata: The JSON metadata top level must be a map (JSON object) from word to value."
+              )
+            , ( [aesonQQ|{ "withdrawal": "slef" }|]
+               , "Error in $.withdrawal: parsing [] failed, expected Array, but encountered String"
+              )
+            , ( [aesonQQ|{ "withdrawal": ["self"] }|]
+               , "Error in $.withdrawal: Invalid number of words: 15, 18, 21 or 24 words are expected."
+              )
+            , ( [aesonQQ|{"withdrawal":["word,","word,","word,","word,","word,","word,","word,","word,","word,","word,","word,","word,","word,","word,","word,"]}|]
+               , "Error in $.withdrawal: Found an unknown word not present in the pre-defined dictionary. The full dictionary is available here: https://github.com/input-output-hk/cardano-wallet/tree/master/specifications/mnemonic/english.txt"
+              )
             ]
 
 instance Malformed (BodyParam (ApiWalletMigrationPlanPostData ('Testnet pm))) where

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1363,7 +1363,7 @@ x-transactionTTL: &transactionTTL
 x-unspecified: &unspecified
   type: string
   enum:
-    - uspecified
+    - unspecified
 
 x-validityBound: &validityBound
   oneOf:
@@ -4801,29 +4801,6 @@ paths:
                   title: "redemption"
       responses: *responsesPostTransactionFee
 
-  /wallets/{walletId}/transactions-sign:
-    post:
-      operationId: signTransaction
-      tags: ["Transactions New"]
-      summary: Sign
-      description: |
-        <p align="right">status: <strong>under development</strong></p>
-
-        Sign a transaction body and return the full transaction. That
-        is, create witnesses using the keys available to this wallet
-        and attach them to the body.
-
-        If a full transaction is passed in the request, then new
-        witnesses will be added to the existing witness set.
-      parameters:
-        - *parametersWalletId
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: *ApiSignTransactionPostData
-      responses: *responsesSignTransaction
-
   /wallets/{walletId}/transactions:
     post:
       operationId: postTransaction
@@ -4913,6 +4890,29 @@ paths:
           application/json:
             schema: *ApiConstructTransactionData
       responses: *responsesConstructTransaction
+
+  /wallets/{walletId}/transactions-sign:
+    post:
+      operationId: signTransaction
+      tags: ["Transactions New"]
+      summary: Sign
+      description: |
+        <p align="right">status: <strong>under development</strong></p>
+
+        Sign a transaction body and return the full transaction. That
+        is, create witnesses using the keys available to this wallet
+        and attach them to the body.
+
+        If a full transaction is passed in the request, then new
+        witnesses will be added to the existing witness set.
+      parameters:
+        - *parametersWalletId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: *ApiSignTransactionPostData
+      responses: *responsesSignTransaction
 
   /wallets/{walletId}/addresses:
     get:


### PR DESCRIPTION
# Issue Number

ADP-909


# Overview

Integration tests covering:

- [x] More malformed examples
- [x] Only validate_interval
- [x] Tx with only metadata
- [x] Tx with only withdrawal from self and external
- [x] Only single output tx :warning: `pending` - outputs are empty 
- [x] Only multi-output tx :warning: `pending` - outputs are empty 
- [x] Multi asset transactions :warning: `pending` - outputs are empty 
- [x] Join and quit pool
  - join :warning: `pending` - deposits are empty
  - quit :warning: `pending` - can quit when you didn't join
  - errMsg404NoSuchPool :warning: `pending` - error not returned when should be
- [ ] ~Minting~
- [x] validate_interval on different transactions (payments, delegations, mint)
  - invalid_before / invalid_hereafter :warning: `pending` -  can be < 0 but shouldn't
- [x] Transaction with all (payments, delegations, mint, metadata, withdrawal, validate_interval)


# Comments / Issues

 - Should construct ep return `200` instead of `202` (coin selection returns `200`)
 - `amount` field would be probably handy to have in the response  
 - Output field on response is empty (`"output": []`) on payment transactions, which seems like a bug (to be addressed in ADP-985)... for now tests marked as `pendingWith`
 - Deposit is empty on construct tx response on joining pool and shouldn't
 - You can quit pool before even joining
 - errMsg404NoSuchPool is not returned when trying to join absent pool
