### PR TITLE
Add coverage checks to property tests for `TokenMap.intersection` 

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -3,12 +3,14 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     , genTokenNameLargeRange
     , genTokenNameMediumRange
     , genTokenNameSmallRange
+    , genTokenPolicyIdSized
     , genTokenPolicyIdLargeRange
     , genTokenPolicyIdSmallRange
     , mkTokenPolicyId
     , shrinkTokenNameSized
     , shrinkTokenNameMediumRange
     , shrinkTokenNameSmallRange
+    , shrinkTokenPolicyIdSized
     , shrinkTokenPolicyIdSmallRange
     , tokenNamesMediumRange
     , tokenNamesSmallRange
@@ -90,6 +92,22 @@ genTokenNameLargeRange :: Gen TokenName
 genTokenNameLargeRange = UnsafeTokenName . BS.pack <$> vector 32
 
 --------------------------------------------------------------------------------
+-- Token policy identifiers chosen from a range that depends on the size
+-- parameter
+--------------------------------------------------------------------------------
+
+genTokenPolicyIdSized :: Gen TokenPolicyId
+genTokenPolicyIdSized = sized $ \size ->
+    elements $ mkTokenPolicyId <$> take size mkTokenPolicyIdValidChars
+
+shrinkTokenPolicyIdSized :: TokenPolicyId -> [TokenPolicyId]
+shrinkTokenPolicyIdSized x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = mkTokenPolicyId 'A'
+
+--------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a small range (to allow collisions)
 --------------------------------------------------------------------------------
 
@@ -118,7 +136,12 @@ genTokenPolicyIdLargeRange = UnsafeTokenPolicyId . Hash . BS.pack <$> vector 28
 -- Internal utilities
 --------------------------------------------------------------------------------
 
--- The input must be a character in the range [0-9] or [A-Z].
+-- The set of characters that can be passed to the 'mkTokenPolicyId' function.
+--
+mkTokenPolicyIdValidChars :: [Char]
+mkTokenPolicyIdValidChars = ['0' .. '9'] <> ['A' .. 'F']
+
+-- The input must be a character in the range [0-9] or [A-F].
 --
 mkTokenPolicyId :: Char -> TokenPolicyId
 mkTokenPolicyId c

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -1,10 +1,12 @@
 module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameLargeRange
+    ( genTokenNameSized
+    , genTokenNameLargeRange
     , genTokenNameMediumRange
     , genTokenNameSmallRange
     , genTokenPolicyIdLargeRange
     , genTokenPolicyIdSmallRange
     , mkTokenPolicyId
+    , shrinkTokenNameSized
     , shrinkTokenNameMediumRange
     , shrinkTokenNameSmallRange
     , shrinkTokenPolicyIdSmallRange
@@ -24,11 +26,26 @@ import Data.Either
 import Data.Text.Class
     ( FromText (..) )
 import Test.QuickCheck
-    ( Gen, elements, vector )
+    ( Gen, elements, sized, vector )
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
+
+--------------------------------------------------------------------------------
+-- Token names chosen from a range that depends on the size parameter
+--------------------------------------------------------------------------------
+
+genTokenNameSized :: Gen TokenName
+genTokenNameSized = sized $ \size ->
+    elements $ UnsafeTokenName . B8.snoc "Token" <$> take size ['A' ..]
+
+shrinkTokenNameSized :: TokenName -> [TokenName]
+shrinkTokenNameSized x
+    | x == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = UnsafeTokenName "TokenA"
 
 --------------------------------------------------------------------------------
 -- Token names chosen from a small range (to allow collisions)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
@@ -1,9 +1,11 @@
 module Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySmall
+    ( genTokenQuantitySized
+    , genTokenQuantitySmall
     , genTokenQuantitySmallPositive
     , genTokenQuantityLarge
     , genTokenQuantityMassive
     , genTokenQuantityMixed
+    , shrinkTokenQuantitySized
     , shrinkTokenQuantitySmall
     , shrinkTokenQuantitySmallPositive
     , shrinkTokenQuantityLarge
@@ -23,7 +25,18 @@ import Data.Word
 import Numeric.Natural
     ( Natural )
 import Test.QuickCheck
-    ( Gen, choose, oneof, shrink )
+    ( Gen, choose, oneof, shrink, sized )
+
+--------------------------------------------------------------------------------
+-- Token quantities chosen from a range that depends on the size parameter
+--------------------------------------------------------------------------------
+
+genTokenQuantitySized :: Gen TokenQuantity
+genTokenQuantitySized = sized $ \n ->
+    quantityFromInt <$> choose (0, n)
+
+shrinkTokenQuantitySized :: TokenQuantity -> [TokenQuantity]
+shrinkTokenQuantitySized = shrinkTokenQuantity
 
 --------------------------------------------------------------------------------
 -- Small token quantities
@@ -118,6 +131,11 @@ tokenQuantityMassive = TokenQuantity $ (10 :: Natural) ^ (1000 :: Natural)
 
 quantityToInteger :: TokenQuantity -> Integer
 quantityToInteger (TokenQuantity q) = fromIntegral q
+
+quantityFromInt :: Int -> TokenQuantity
+quantityFromInt i
+    | i < 0 = error $ "Unable to convert integer to token quantity: " <> show i
+    | otherwise = TokenQuantity $ fromIntegral i
 
 quantityFromInteger :: Integer -> TokenQuantity
 quantityFromInteger i

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -538,9 +538,22 @@ prop_intersection_associativity xf yf zf =
     r2 = x `TokenMap.intersection` (y `TokenMap.intersection` z)
     [x, y, z] = getManyFolded . getBlind <$> [xf, yf, zf]
 
-prop_intersection_commutativity :: TokenMap -> TokenMap -> Property
-prop_intersection_commutativity x y =
-    x `TokenMap.intersection` y === y `TokenMap.intersection` x
+prop_intersection_commutativity
+    :: Blind (ManyFolded TokenMap)
+    -> Blind (ManyFolded TokenMap)
+    -> Property
+prop_intersection_commutativity xf yf =
+    checkCoverage $
+    cover 50 (x /= y)
+        "maps are different" $
+    cover 50 (TokenMap.isNotEmpty r1 && TokenMap.isNotEmpty r2)
+        "intersection is not empty" $
+    counterexample (pretty (Flat <$> [x, y])) $
+    r1 === r2
+  where
+    r1 = x `TokenMap.intersection` y
+    r2 = y `TokenMap.intersection` x
+    [x, y] = getManyFolded . getBlind <$> [xf, yf]
 
 prop_intersection_empty :: TokenMap -> Property
 prop_intersection_empty x =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -588,13 +588,24 @@ prop_intersection_identity x =
         "map is not empty" $
     x `TokenMap.intersection` x === x
 
-prop_intersection_subset :: TokenMap -> TokenMap -> Property
-prop_intersection_subset x y = conjoin
-    [ intersection `leq` x
-    , intersection `leq` y
-    ]
+prop_intersection_subset
+    :: Blind (ManyFolded TokenMap)
+    -> Blind (ManyFolded TokenMap)
+    -> Property
+prop_intersection_subset xf yf =
+    checkCoverage $
+    cover 50 (x /= y)
+        "maps are different" $
+    cover 50 (TokenMap.isNotEmpty x && TokenMap.isNotEmpty y)
+        "maps are not empty" $
+    counterexample (pretty (Flat <$> [x, y])) $
+    conjoin
+        [ intersection `leq` x
+        , intersection `leq` y
+        ]
   where
     intersection = x `TokenMap.intersection` y
+    [x, y] = getManyFolded . getBlind <$> [xf, yf]
 
 --------------------------------------------------------------------------------
 -- Quantity properties

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -557,6 +557,9 @@ prop_intersection_commutativity xf yf =
 
 prop_intersection_empty :: TokenMap -> Property
 prop_intersection_empty x =
+    checkCoverage $
+    cover 50 (TokenMap.isNotEmpty x)
+        "map is not empty" $
     x `TokenMap.intersection` TokenMap.empty === TokenMap.empty
 
 prop_intersection_equality :: TokenMap -> TokenMap -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -583,6 +583,9 @@ prop_intersection_equality xf yf =
 
 prop_intersection_identity :: TokenMap -> Property
 prop_intersection_identity x =
+    checkCoverage $
+    cover 50 (TokenMap.isNotEmpty x)
+        "map is not empty" $
     x `TokenMap.intersection` x === x
 
 prop_intersection_subset :: TokenMap -> TokenMap -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -562,13 +562,24 @@ prop_intersection_empty x =
         "map is not empty" $
     x `TokenMap.intersection` TokenMap.empty === TokenMap.empty
 
-prop_intersection_equality :: TokenMap -> TokenMap -> Property
-prop_intersection_equality x y = conjoin
-    [ total `TokenMap.intersection` x === x
-    , total `TokenMap.intersection` y === y
-    ]
+prop_intersection_equality
+    :: Blind (ManyFolded TokenMap)
+    -> Blind (ManyFolded TokenMap)
+    -> Property
+prop_intersection_equality xf yf =
+    checkCoverage $
+    cover 50 (x /= y)
+        "maps are different" $
+    cover 50 (TokenMap.isNotEmpty x && TokenMap.isNotEmpty y)
+        "maps are not empty" $
+    counterexample (pretty (Flat <$> [x, y])) $
+    conjoin
+        [ total `TokenMap.intersection` x === x
+        , total `TokenMap.intersection` y === y
+        ]
   where
     total = x <> y
+    [x, y] = getManyFolded . getBlind <$> [xf, yf]
 
 prop_intersection_identity :: TokenMap -> Property
 prop_intersection_identity x =

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |
@@ -11,17 +10,12 @@
 module Test.QuickCheck.Extra
     ( reasonablySized
     , shrinkInterleaved
-
-    -- * Combinators
-    , ManyFolded (..)
     ) where
 
 import Prelude
 
 import Test.QuickCheck
-    ( Arbitrary (..), Gen, scale )
-
-import qualified Data.Foldable as F
+    ( Gen, scale )
 
 -- | Resize a generator to grow with the size parameter, but remains reasonably
 -- sized. That is handy when testing on data-structures that can be arbitrarily
@@ -57,22 +51,3 @@ shrinkInterleaved (a, shrinkA) (b, shrinkB) = interleave
     interleave (x : xs) (y : ys) = x : y : interleave xs ys
     interleave xs [] = xs
     interleave [] ys = ys
-
---------------------------------------------------------------------------------
--- Combinators
---------------------------------------------------------------------------------
-
--- | A combinator for generating larger arbitrary values, produced by
---   generating many smaller arbitrary values and folding them together.
---
--- Applying this combinator to a type 'A' with an instance of 'Monoid' will
--- generate larger values of 'A', based on simple monoidal concatenation of
--- multiple smaller values.
---
-newtype ManyFolded a = ManyFolded
-    { getManyFolded :: a }
-    deriving (Eq, Show)
-
-instance forall a. (Arbitrary a, Monoid a) => Arbitrary (ManyFolded a) where
-    arbitrary = ManyFolded . F.fold <$> arbitrary @[a]
-    shrink (ManyFolded a) = ManyFolded <$> shrink a


### PR DESCRIPTION
# Issue Number

ADP-997

# Pre-merge checks

- [x] Perform soak test of test suite to ensure no flakiness has been introduced.
    (✅ 1000 test runs with `--match "/Token map properties/Arithmetic/prop_intersection"` passed with no failures.)

# Overview

PR #2725 added a `TokenMap.intersection` function and property tests.

This PR:
- [x] adds coverage checks to the `prop_intersection_*` series of properties.
- [x] where necessary, adjusts property inputs in order to attain the required level of coverage.