### PR TITLE
go-jira: Add versions and fixVersions fields to the edit template

### DIFF
--- a/.jira.d/templates/edit
+++ b/.jira.d/templates/edit
@@ -11,7 +11,8 @@ fields:
 {{- if and .meta.fields.components .meta.fields.components.allowedValues }}
   components: # Values: {{ range .meta.fields.components.allowedValues }}{{.name}}, {{end}}{{if .overrides.components }}{{ range (split "," .overrides.components)}}
     - name: {{.}}{{end}}{{else}}{{ range .fields.components }}
-    - name: {{ .name }}{{end}}{{end}}{{end}}
+    - name: {{ .name }}{{end}}{{ if .fields.components }}{{else}}
+    # - name: {{end}}{{end}}{{end}}
 {{- if .meta.fields.assignee }}
   {{- if .overrides.assignee }}
   assignee:
@@ -32,6 +33,17 @@ fields:
 {{- if .meta.fields.priority }}
   priority: # Values: {{ range .meta.fields.priority.allowedValues }}{{.name}}, {{end}}
     name: {{ or .overrides.priority .fields.priority.name "" }}{{end}}
+{{- if .meta.fields.versions.allowedValues}}
+  versions: # Values: {{ range .meta.fields.versions.allowedValues }}{{.name}}, {{end}}{{if .overrides.versions}}{{ range (split "," .overrides.versions)}}
+    - name: {{.}}{{end}}{{else}}{{range .fields.versions}}
+    - name: {{.name}}{{end}}{{end}}
+{{- end}}
+{{- if .meta.fields.fixVersions.allowedValues}}
+  fixVersions: # Values: {{ range .meta.fields.fixVersions.allowedValues }}{{.name}}, {{end}}{{if .overrides.fixVersions}}{{ range (split "," .overrides.fixVersions)}}
+    - name: {{.}}{{end}}{{else}}{{range .fields.fixVersions}}
+    - name: {{.name}}{{end}}{{end}}{{if .fields.fixVersions}}{{else}}
+    # - name: {{end}}
+{{- end}}
 
   # https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
   description: |~


### PR DESCRIPTION
### Issue Number

Found during ADP-952

### Overview

Adds the `fixVersions` field to the go-jira editing template.

### Comments

With this change, it's possible to automate some ticket updating tasks like so:
```bash
#!/usr/bin/env bash
for ticket in ADP-{955,956,957,958,959,960}; do
  jira edit $ticket --noedit -o "fixVersions=Alonzo White"
  jira labels add $ticket "Alonzo-White"
  jira issuelink ADP-952 Blocks $ticket
done
```
