### PR TITLE
Quieten `show` output for API types.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -401,6 +402,8 @@ import GHC.TypeLits
     ( Nat, Symbol )
 import Numeric.Natural
     ( Natural )
+import Quiet
+    ( Quiet (..) )
 import Servant.API
     ( MimeRender (..), MimeUnrender (..), OctetStream )
 import Web.HttpApiData
@@ -504,11 +507,15 @@ data MaintenanceAction = GcStakePools
 
 newtype ApiMaintenanceActionPostData = ApiMaintenanceActionPostData
     { maintenanceAction :: MaintenanceAction
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet ApiMaintenanceActionPostData)
 
 newtype ApiMaintenanceAction = ApiMaintenanceAction
     { gcStakePools :: ApiT PoolMetadataGCStatus
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet ApiMaintenanceAction)
 
 data ApiAsset = ApiAsset
     { policyId :: ApiT W.TokenPolicyId
@@ -611,7 +618,9 @@ data ApiSelectCoinsPayments (n :: NetworkDiscriminant) = ApiSelectCoinsPayments
 
 newtype ApiSelectCoinsAction = ApiSelectCoinsAction
     { delegationAction :: ApiDelegationAction
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet ApiSelectCoinsAction)
 
 data ApiCertificate
     = RegisterRewardAccount
@@ -695,8 +704,10 @@ data ApiWalletAssetsBalance = ApiWalletAssetsBalance
 
 newtype ApiWalletPassphraseInfo = ApiWalletPassphraseInfo
     { lastUpdatedAt :: UTCTime
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiWalletPassphraseInfo)
 
 data ApiWalletDelegation = ApiWalletDelegation
     { active :: !ApiWalletDelegationNext
@@ -719,14 +730,17 @@ data ApiWalletDelegationStatus
 
 newtype ApiWalletPassphrase = ApiWalletPassphrase
     { passphrase :: ApiT (Passphrase "lenient")
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiWalletPassphrase)
 
 newtype ApiWalletUtxoSnapshot = ApiWalletUtxoSnapshot
     { entries :: [ApiWalletUtxoSnapshotEntry]
     }
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic)
     deriving anyclass NFData
+    deriving Show via (Quiet ApiWalletUtxoSnapshot)
 
 data ApiWalletUtxoSnapshotEntry = ApiWalletUtxoSnapshotEntry
     { ada :: !(Quantity "lovelace" Natural)
@@ -814,12 +828,16 @@ data ByronWalletFromXPrvPostData = ByronWalletFromXPrvPostData
 
 newtype ApiAccountPublicKey = ApiAccountPublicKey
     { key :: (ApiT XPub)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiAccountPublicKey)
 
 newtype WalletOrAccountPostData = WalletOrAccountPostData
     { postData :: Either WalletPostData AccountPostData
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet WalletOrAccountPostData)
 
 data AccountPostData = AccountPostData
     { name :: !(ApiT WalletName)
@@ -829,11 +847,15 @@ data AccountPostData = AccountPostData
 
 newtype WalletPutData = WalletPutData
     { name :: (Maybe (ApiT WalletName))
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet WalletPutData)
 
 newtype SettingsPutData = SettingsPutData
     { settings :: (ApiT W.Settings)
-    } deriving (Eq, Generic, Show)
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet SettingsPutData)
 
 data WalletPutPassphraseData = WalletPutPassphraseData
     { oldPassphrase :: !(ApiT (Passphrase "raw"))
@@ -932,8 +954,10 @@ type ApiBase64 = ApiBytesT 'Base64 ByteString
 
 newtype ApiSerialisedTransaction = ApiSerialisedTransaction
     { transaction :: ApiBytesT 'Base64 SerialisedTx
-    } deriving stock (Eq, Generic, Show)
+    }
+    deriving stock (Eq, Generic)
     deriving newtype NFData
+    deriving Show via (Quiet ApiSerialisedTransaction)
 
 data ApiSignedTransaction = ApiSignedTransaction
     { transaction :: ApiBytesT 'Base64 SerialisedTx
@@ -1006,8 +1030,10 @@ toApiNetworkParameters (NetworkParameters gp sp pp) toEpochInfo = do
 
 newtype ApiTxId = ApiTxId
     { id :: ApiT (Hash "Tx")
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiTxId)
 
 data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     { id :: !(ApiT (Hash "Tx"))
@@ -1030,8 +1056,10 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
 
 newtype ApiTxMetadata = ApiTxMetadata
     { getApiTxMetadata :: Maybe (ApiT TxMetadata)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiTxMetadata)
 
 data ApiWithdrawal n = ApiWithdrawal
     { stakeAddress :: !(ApiT W.RewardAccount, Proxy n)
@@ -1073,14 +1101,16 @@ coinFromQuantity = Coin . fromIntegral . getQuantity
 
 newtype ApiAddressInspect = ApiAddressInspect
     { unApiAddressInspect :: Aeson.Value }
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic)
     deriving anyclass NFData
+    deriving Show via (Quiet ApiAddressInspect)
 
 newtype ApiAddressInspectData = ApiAddressInspectData
     { unApiAddressInspectData :: Text }
-    deriving (Eq, Generic, Show)
+    deriving (Eq, Generic)
     deriving newtype (IsString)
     deriving anyclass NFData
+    deriving Show via (Quiet ApiAddressInspectData)
 
 data ApiSlotReference = ApiSlotReference
     { absoluteSlotNumber :: !(ApiT SlotNo)
@@ -1105,8 +1135,10 @@ data ApiBlockReference = ApiBlockReference
 
 newtype ApiBlockInfo = ApiBlockInfo
     { height :: Quantity "block" Natural
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiBlockInfo)
 
 data ApiEra
     = ApiByron
@@ -1148,8 +1180,10 @@ data ApiNtpStatus = ApiNtpStatus
 
 newtype ApiNetworkClock = ApiNetworkClock
     { ntpStatus :: ApiNtpStatus
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiNetworkClock)
 
 data ApiPostRandomAddressData = ApiPostRandomAddressData
     { passphrase :: !(ApiT (Passphrase "lenient"))
@@ -1160,8 +1194,10 @@ data ApiPostRandomAddressData = ApiPostRandomAddressData
 newtype ApiWalletMigrationPlanPostData (n :: NetworkDiscriminant) =
     ApiWalletMigrationPlanPostData
     { addresses :: NonEmpty (ApiT Address, Proxy n)
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet (ApiWalletMigrationPlanPostData n))
 
 data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
     ApiWalletMigrationPostData
@@ -1172,8 +1208,10 @@ data ApiWalletMigrationPostData (n :: NetworkDiscriminant) (s :: Symbol) =
 
 newtype ApiPutAddressesData (n :: NetworkDiscriminant) = ApiPutAddressesData
     { addresses :: [(ApiT Address, Proxy n)]
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet (ApiPutAddressesData n))
 
 data ApiWalletMigrationBalance = ApiWalletMigrationBalance
     { ada :: !(Quantity "lovelace" Natural)
@@ -1294,8 +1332,12 @@ data ApiSharedWalletPostDataFromAccountPubX = ApiSharedWalletPostDataFromAccount
     } deriving (Eq, Generic, Show)
 
 newtype ApiSharedWalletPostData = ApiSharedWalletPostData
-    { wallet :: Either ApiSharedWalletPostDataFromMnemonics ApiSharedWalletPostDataFromAccountPubX
-    } deriving (Eq, Generic, Show)
+    { wallet :: Either
+        ApiSharedWalletPostDataFromMnemonics
+        ApiSharedWalletPostDataFromAccountPubX
+    }
+    deriving (Eq, Generic)
+    deriving Show via (Quiet ApiSharedWalletPostData)
 
 data ApiActiveSharedWallet = ApiActiveSharedWallet
     { id :: !(ApiT WalletId)
@@ -1325,8 +1367,10 @@ data ApiPendingSharedWallet = ApiPendingSharedWallet
 
 newtype ApiSharedWallet = ApiSharedWallet
     { wallet :: Either ApiPendingSharedWallet ApiActiveSharedWallet
-    } deriving (Eq, Generic, Show)
-      deriving anyclass NFData
+    }
+    deriving (Eq, Generic)
+    deriving anyclass NFData
+    deriving Show via (Quiet ApiSharedWallet)
 
 data ApiSharedWalletPatchData = ApiSharedWalletPatchData
     { cosigner :: !(ApiT Cosigner)
@@ -1399,7 +1443,9 @@ data ApiErrorCode
 --
 newtype Iso8601Time = Iso8601Time
     { getIso8601Time :: UTCTime
-    } deriving (Eq, Ord, Show)
+    }
+    deriving (Eq, Ord, Generic)
+    deriving Show via (Quiet Iso8601Time)
 
 instance ToText Iso8601Time where
     toText = utcTimeToText iso8601ExtendedUtc . getIso8601Time
@@ -1427,7 +1473,9 @@ instance ToHttpApiData Iso8601Time where
 
 newtype MinWithdrawal = MinWithdrawal
     { getMinWithdrawal :: Natural
-    } deriving (Show)
+    }
+    deriving Generic
+    deriving Show via (Quiet MinWithdrawal)
 
 instance FromHttpApiData MinWithdrawal where
     parseUrlPiece = bimap (T.pack . getTextDecodingError) MinWithdrawal . fromText
@@ -1566,17 +1614,19 @@ instance KnownDiscovery (SeqState network key) where
 -- API layer and other modules.
 newtype ApiT a =
     ApiT { getApiT :: a }
-    deriving (Generic, Show, Eq, Functor)
+    deriving (Generic, Eq, Functor)
     deriving newtype (Semigroup, Monoid, Hashable)
     deriving anyclass NFData
+    deriving Show via (Quiet (ApiT a))
 deriving instance Ord a => Ord (ApiT a)
 
 -- | Polymorphic wrapper for byte arrays, parameterised by the desired string
 -- encoding.
 newtype ApiBytesT (base :: Base) bs = ApiBytesT { getApiBytesT :: bs }
-    deriving (Generic, Show, Eq, Functor)
+    deriving (Generic, Eq, Functor)
     deriving newtype (Semigroup, Monoid, Hashable)
     deriving anyclass NFData
+    deriving Show via (Quiet (ApiBytesT base bs))
 
 -- | Representation of mnemonics at the API-level, using a polymorphic type in
 -- the lengths of mnemonics that are supported (and an underlying purpose). In
@@ -1600,8 +1650,9 @@ newtype ApiBytesT (base :: Base) bs = ApiBytesT { getApiBytesT :: bs }
 -- practice, we'll NEVER peek at the mnemonic, output them and whatnot.
 newtype ApiMnemonicT (sizes :: [Nat]) =
     ApiMnemonicT { getApiMnemonicT :: SomeMnemonic }
-    deriving (Generic, Show, Eq)
+    deriving (Generic, Eq)
     deriving newtype NFData
+    deriving Show via (Quiet (ApiMnemonicT sizes))
 
 -- | A stake key belonging to the current wallet.
 data ApiOurStakeKey n = ApiOurStakeKey
@@ -1634,7 +1685,9 @@ newtype ApiNullStakeKey = ApiNullStakeKey
     { _stake :: Quantity "lovelace" Natural
       -- ^ The total stake of the wallet UTxO that is not associated with a
       -- stake key, because it's part of an enterprise address.
-    } deriving (Generic, Eq, Show)
+    }
+    deriving (Generic, Eq)
+    deriving Show via (Quiet ApiNullStakeKey)
 
 -- | Collection of stake keys associated with a wallet.
 data ApiStakeKeys n = ApiStakeKeys
@@ -3320,7 +3373,8 @@ data HealthCheckSMASH =
 
 newtype ApiHealthCheck = ApiHealthCheck
     { health :: HealthCheckSMASH }
-    deriving (Generic, Show, Eq, Ord)
+    deriving (Generic, Eq, Ord)
+    deriving Show via (Quiet ApiHealthCheck)
 
 instance FromJSON HealthCheckSMASH where
     parseJSON = genericParseJSON defaultSumTypeOptions

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -150,6 +150,8 @@ import GHC.Generics
     ( Generic )
 import GHC.TypeLits
     ( KnownNat, Nat, Symbol, natVal )
+import Quiet
+    ( Quiet (..) )
 import Safe
     ( readMay, toEnumMay )
 
@@ -258,7 +260,8 @@ stakeDerivationPath (DerivationPrefix (purpose, coin, acc)) =
 --    as just an index between 0 and 2^32, which is what DerivationIndex does.
 newtype DerivationIndex
     = DerivationIndex { getDerivationIndex :: Word32 }
-    deriving (Show, Eq, Ord, Generic)
+    deriving (Eq, Ord, Generic)
+    deriving Show via (Quiet DerivationIndex)
 
 instance NFData DerivationIndex
 

--- a/lib/core/src/Data/Quantity.hs
+++ b/lib/core/src/Data/Quantity.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -66,6 +66,8 @@ import GHC.TypeLits
     ( KnownSymbol, Symbol, symbolVal )
 import NoThunks.Class
     ( NoThunks (..) )
+import Quiet
+    ( Quiet (..) )
 
 import qualified Data.Text as T
 
@@ -94,9 +96,9 @@ import qualified Data.Text as T
 -- >>> Aeson.encode $ Quantity @"lovelace" 14
 -- {"unit":"lovelace","quantity":14}
 newtype Quantity (unit :: Symbol) a = Quantity { getQuantity :: a }
-    deriving stock (Generic, Show, Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
     deriving newtype (Bounded, Enum, Hashable)
-
+    deriving Show via (Quiet (Quantity unit a))
 
 instance NoThunks a => NoThunks (Quantity unit a)
 
@@ -145,7 +147,8 @@ instance (KnownSymbol unit, Buildable a) => Buildable (Quantity unit a) where
 -- | Opaque Haskell type to represent values between 0 and 100 (incl).
 newtype Percentage = Percentage
     { getPercentage :: Rational }
-    deriving stock (Generic, Show, Eq, Ord)
+    deriving stock (Generic, Eq, Ord)
+    deriving Show via (Quiet Percentage)
 
 instance NoThunks Percentage
 


### PR DESCRIPTION
# Issue Number

None. (Produced while debugging test failures for #2741)

# Overview

Integration test failures occasionally produce very verbose output, similar to the
following (an extract from a [multi-page error](https://hydra.iohk.io/build/6925587/nixlog/1)):

```hs
, derivationPath = ApiT
    { getApiT = DerivationIndex
        { getDerivationIndex = 2147485500 }
    } :|
    [ ApiT
        { getApiT = DerivationIndex
            { getDerivationIndex = 2147485463 }
        }
    , ApiT
        { getApiT = DerivationIndex
            { getDerivationIndex = 2147483648 }
        }
    , ApiT
        { getApiT = DerivationIndex
            { getDerivationIndex = 0 }
        }
    , ApiT
        { getApiT = DerivationIndex
            { getDerivationIndex = 4 }
        }
    ]
, amount = Quantity
    { getQuantity = 100000000000 }
, assets = ApiT
    { getApiT = TokenMap
        ( fromList [] )
    }
```
Most of the above output is **boilerplate**: the `getApiT` and `getDerivationIndex` deconstructor field names are not necessary to understand the output, as each of these types is just a wrapper type with exactly one field.

We can remove this boilerplate by deriving our `Show` instances for newtypes via `Quiet`, which produces output similar to the following:

```hs
, derivationPath =
    ApiT (DerivationIndex 2147485500) :|
    [ ApiT (DerivationIndex 2147485463)
    , ApiT (DerivationIndex 2147483648)
    , ApiT (DerivationIndex 0)
    , ApiT (DerivationIndex 4)
    ]
, amount = Quantity 100000000000
, assets = ApiT (TokenMap (fromList []))
```

Real log output, demonstrating the difference in verbosity:

* [verbose.log](https://github.com/input-output-hk/cardano-wallet/files/6827653/verbose.log)
    `451  1451 23191 verbose.log`
* [concise.log](https://github.com/input-output-hk/cardano-wallet/files/6827652/concise.log)
    `337  1027 16641 concise.log`
