### PR TITLE
cabal: Add a flag to enable/disable scrypt

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -165,15 +165,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Orphans
     ()
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
-    , Passphrase (..)
-    , PassphraseMaxLength
-    , PassphraseMinLength
-    )
+    ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, defaultAddressPoolGap )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..), PassphraseMaxLength, PassphraseMinLength )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
@@ -795,7 +791,7 @@ cmdTransactionCreate isShelley mkTxClient mkWalletClient =
         res <- sendRequest wPort $ getWallet mkWalletClient $ ApiT wId
         case res of
             Right _ -> do
-                wPwd <- getPassphrase @"raw" "Please enter your passphrase: "
+                wPwd <- getPassphrase @"user" "Please enter your passphrase: "
                 runClient wPort Aeson.encodePretty $ postTransaction
                     mkTxClient
                     (ApiT wId)

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -81,7 +81,6 @@ library
     , resourcet
     , retry
     , say
-    , scrypt
     , serialise
     , string-interpolate
     , template-haskell

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -279,8 +279,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , WalletKey (..)
     , fromHex
     , hex
-import Cardano.Wallet.Primitive.Passphrase ( Passphrase (..)
-    , preparePassphrase
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
@@ -292,6 +290,10 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( coinTypeAda )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..), preparePassphrase )
+import Cardano.Wallet.Primitive.Passphrase.Legacy
+    ( encryptPassphraseTestingOnly )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
@@ -343,14 +345,10 @@ import Crypto.Hash
     ( Blake2b_160, Digest, digestFromByteString )
 import Crypto.Hash.Utils
     ( blake2b224 )
-import Crypto.Random.Entropy
-    ( getEntropy )
 import Data.Aeson
     ( FromJSON, ToJSON, Value, (.=) )
 import Data.Aeson.QQ
     ( aesonQQ )
-import Data.ByteArray.Encoding
-    ( Base (..), convertFromBase, convertToBase )
 import Data.ByteString
     ( ByteString )
 import Data.Either.Extra
@@ -455,15 +453,13 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shared as Shared
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
+import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Codec.Binary.Bech32 as Bech32
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
-import qualified Crypto.KDF.Scrypt as Scrypt
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -1284,7 +1280,7 @@ emptyRandomWalletWithPasswd ctx rawPwd = do
             $ hex
             $ Byron.getKey
             $ Byron.generateKeyFromSeed seed pwd
-    pwdH <- encryptPassphraseTestingOnly pwd
+    pwdH <- liftIO $ toText <$> encryptPassphraseTestingOnly pwd
     emptyByronWalletFromXPrvWith ctx "random" ("Random Wallet", key, pwdH)
 
 postWallet'

--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -454,7 +454,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shared as Shared
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
-import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap

--- a/lib/core-integration/src/Test/Integration/Plutus.hs
+++ b/lib/core-integration/src/Test/Integration/Plutus.hs
@@ -38,7 +38,7 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex, unsafeRight )
+    ( unsafeFromHexText, unsafeRight )
 import Codec.Binary.Bech32.TH
     ( humanReadablePart )
 import Codec.Serialise
@@ -100,7 +100,7 @@ alwaysTrueValidator =
 
 hashScript :: Text -> ApiT (Hash "TokenPolicy")
 hashScript =
-    ApiT . Hash . blake2b224 . unsafeFromHex . ("01" <>) . T.encodeUtf8
+    ApiT . Hash . blake2b224 . unsafeFromHexText . ("01" <>)
 
 --
 -- Ping Pong
@@ -365,7 +365,7 @@ currencyTx input = Aeson.object
         , CBOR.TBool True, CBOR.TNull
         ]
     transaction_witness_set = CBOR.TMap
-        [ (c_plutus_script, CBOR.TList [ CBOR.TBytes (fromHex policy) ])
+        [ (c_plutus_script, CBOR.TList [CBOR.TBytes (unsafeFromHexText policy)])
         , (c_plutus_data, CBOR.TList [])      -- leave empty
         ]
     [c_plutus_script, c_plutus_data] = map CBOR.TInt [3,4]
@@ -394,9 +394,6 @@ currencyTx input = Aeson.object
 
 toHex :: BS.ByteString -> Text
 toHex = T.decodeUtf8 . Base16.encode
-
-fromHex :: Text -> BS.ByteString
-fromHex = Base16.decodeLenient . T.encodeUtf8
 
 -- | Minting policy that mints 1_000 units of "apfel" and 1 unit of "banana"
 -- when a specific UTxO is spent (which can be done only once).

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -63,6 +63,7 @@ import Test.Integration.Framework.DSL
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyRandomWalletWithPasswd
+    , encryptWalletPasswordWithScrypt
     , eventually
     , expectErrorMessage
     , expectField
@@ -78,6 +79,7 @@ import Test.Integration.Framework.DSL
     , fixtureRandomWallet
     , genMnemonics
     , getFromResponse
+    , getSaltFromHexScryptPassword
     , json
     , listFilteredByronWallets
     , postByronWallet
@@ -287,8 +289,8 @@ spec = describe "BYRON_WALLETS" $ do
             ]
 
     describe "BYRON_RESTORE_06 - Passphrase" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Wallets.hs
@@ -26,11 +26,13 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( PassphraseMaxLength (..), PassphraseMinLength (..), PaymentAddress )
+    ( PaymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
+import Cardano.Wallet.Primitive.Passphrase
+    ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Monad
@@ -63,7 +65,6 @@ import Test.Integration.Framework.DSL
     , emptyIcarusWallet
     , emptyRandomWallet
     , emptyRandomWalletWithPasswd
-    , encryptWalletPasswordWithScrypt
     , eventually
     , expectErrorMessage
     , expectField
@@ -79,7 +80,6 @@ import Test.Integration.Framework.DSL
     , fixtureRandomWallet
     , genMnemonics
     , getFromResponse
-    , getSaltFromHexScryptPassword
     , json
     , listFilteredByronWallets
     , postByronWallet

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -39,9 +39,11 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Compat
     ( (^?) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..), Passphrase (..), Role (..) )
+    ( DerivationIndex (..), Role (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Control.Monad

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -411,8 +411,8 @@ spec = describe "SHELLEY_WALLETS" $ do
             verify r [ expectResponseCode HTTP.status201 ]
 
     describe "WALLETS_CREATE_07 - Passphrase" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź') )
@@ -768,8 +768,8 @@ spec = describe "SHELLEY_WALLETS" $ do
         expectField #passphrase (`shouldNotBe` originalPassUpdateDateTime) rg
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')
@@ -815,8 +815,8 @@ spec = describe "SHELLEY_WALLETS" $ do
 
     describe "WALLETS_UPDATE_PASS_03 - Can update pass from pass that's boundary\
     \ value" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź') )
@@ -836,7 +836,7 @@ spec = describe "SHELLEY_WALLETS" $ do
                      "passphrase": #{oldPass}
                      } |]
             w <- unsafeResponse <$> postWallet ctx createPayload
-            let len = passphraseMaxLength (Proxy @"raw")
+            let len = passphraseMaxLength (Proxy @"user")
             let newPass = T.pack $ replicate len '💘'
             let payload = updatePassPayload oldPass newPass
             rup <- request @ApiWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -33,10 +33,7 @@ import Cardano.Wallet.Api.Types
     , WalletStyle (..)
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( DerivationIndex (..)
-    , PaymentAddress
-    , Role (..)
-    )
+    ( DerivationIndex (..), PaymentAddress, Role (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -34,8 +34,6 @@ import Cardano.Wallet.Api.Types
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( DerivationIndex (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
     , PaymentAddress
     , Role (..)
     )
@@ -47,6 +45,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -49,7 +49,7 @@ import Cardano.Wallet.Primitive.SyncProgress
 import Cardano.Wallet.Primitive.Types
     ( walletNameMaxLength, walletNameMinLength )
 import Cardano.Wallet.Unsafe
-    ( unsafeFromHex, unsafeXPub )
+    ( unsafeFromHexText, unsafeXPub )
 import Control.Monad
     ( forM, forM_ )
 import Control.Monad.IO.Class
@@ -1150,7 +1150,7 @@ spec = describe "SHELLEY_WALLETS" $ do
         let sigBytes = BL.toStrict $ getFromResponse id rSig
         let sig = CC.xsignature sigBytes
         let key = unsafeXPub $ fst (getFromResponse #getApiVerificationKey rKey) <> dummyChainCode
-        let msgHash = unsafeFromHex "1228cd0fea46f9a091172829f0c492c0516dceff67de08f585a4e048a28a6c9f"
+        let msgHash = unsafeFromHexText "1228cd0fea46f9a091172829f0c492c0516dceff67de08f585a4e048a28a6c9f"
         liftIO $ CC.verify key msgHash <$> sig `shouldBe` Right True
 
         let goldenSig = "680739414d89eb9f4377192171ce3990c7beea6132a04f327d7c954ae9e7fcfe747dd7b4b9b11acefa1aa75216b837fc81e59c24001b96356ba65598ec159d0c" :: ByteString

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -218,8 +218,8 @@ spec = describe "BYRON_CLI_WALLETS" $ do
         it' "ledger" (genMnemonics M24) scenarioSuccess -- ✔️
 
     describe "CLI_BYRON_RESTORE_06 - Passphrase" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , T.pack (replicate minLength 'ź')
@@ -311,8 +311,8 @@ spec = describe "BYRON_CLI_WALLETS" $ do
             T.unpack e `shouldContain` errMsg403WrongPass
 
     describe "CLI_BYRON_UPDATE_PASS_03 - Pass length incorrect" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let passTooShort = replicate (minLength - 1) 'o'
         let errMsgTooShort = "passphrase is too short: expected at least 10 characters"
         let passTooLong = replicate (maxLength + 1) 'o'

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -15,7 +15,7 @@ import Prelude
 
 import Cardano.Wallet.Api.Types
     ( ApiByronWallet, ApiUtxoStatistics, DecodeAddress )
-import Cardano.Wallet.Primitive.AddressDerivation
+import Cardano.Wallet.Primitive.Passphrase
     ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -26,10 +26,10 @@ import Cardano.Wallet.Api.Types
     , EncodeAddress (..)
     , getApiT
     )
-import Cardano.Wallet.Primitive.AddressDerivation
-    ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( PassphraseMaxLength (..), PassphraseMinLength (..) )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -343,7 +343,7 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
                 \ words are expected."
 
     describe "WALLETS_CREATE_07 - Passphrase is valid" $ do
-        let proxy_ = Proxy @"raw"
+        let proxy_ = Proxy @"user"
         let passphraseMax = replicate (passphraseMaxLength proxy_) 'ą'
         let passBelowMax = replicate (passphraseMaxLength proxy_ - 1) 'ć'
         let passphraseMin = replicate (passphraseMinLength proxy_) 'ń'
@@ -366,7 +366,7 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             expectCliField #passphrase (`shouldNotBe` Nothing) j
 
     describe "WALLETS_CREATE_07 - When passphrase is invalid" $ do
-        let proxy_ = Proxy @"raw"
+        let proxy_ = Proxy @"user"
         let passAboveMax = replicate (passphraseMaxLength proxy_ + 1) 'ą'
         let passBelowMin = replicate (passphraseMinLength proxy_ - 1) 'ń'
         let passMinWarn = "passphrase is too short: expected at \
@@ -540,8 +540,8 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             expectCliField #passphrase (`shouldNotBe` initPassUpdateTime) j
 
     describe "WALLETS_UPDATE_PASS_02 - New passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , replicate minLength 'ź'
@@ -598,8 +598,8 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
             exitCode `shouldBe` ExitFailure 1
 
     describe "WALLETS_UPDATE_PASS_03 - Old passphrase values" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show (minLength - 1) ++ " char long"
                   , replicate (minLength - 1) 'ź'
@@ -631,8 +631,8 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
 
     describe "WALLETS_UPDATE_PASS_03 - \
         \Can update pass from pass that's boundary value" $ do
-        let minLength = passphraseMinLength (Proxy @"raw")
-        let maxLength = passphraseMaxLength (Proxy @"raw")
+        let minLength = passphraseMinLength (Proxy @"user")
+        let maxLength = passphraseMaxLength (Proxy @"user")
         let matrix =
                 [ ( show minLength ++ " char long"
                   , replicate minLength 'ź'

--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -84,7 +84,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Depth (..)
     , Index (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
     , PersistPrivateKey
     , WalletKey (..)
@@ -107,6 +106,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, initWallet, unsafeInitWallet )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, hoistTimeInterpreter, mkSingleEraInterpreter )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -17,6 +17,10 @@ flag release
     default: False
     manual: True
 
+flag scrypt
+    description: Enable compatibility support for legacy wallet passwords.
+    default: True
+
 library
   default-language:
       Haskell2010
@@ -29,6 +33,9 @@ library
       -fwarn-redundant-constraints
   if (flag(release))
     ghc-options: -O2 -Werror
+  if (flag(scrypt))
+    cpp-options: -DHAVE_SCRYPT
+    build-depends: scrypt
   build-depends:
       aeson
     , async
@@ -111,7 +118,6 @@ library
     , retry
     , safe
     , scientific
-    , scrypt
     , servant
     , servant-client
     , servant-server

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -228,6 +228,10 @@ library
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Slotting
       Cardano.Wallet.Primitive.SyncProgress
+      Cardano.Wallet.Primitive.Passphrase
+      Cardano.Wallet.Primitive.Passphrase.Current
+      Cardano.Wallet.Primitive.Passphrase.Legacy
+      Cardano.Wallet.Primitive.Passphrase.Types
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Primitive.Types.Address
       Cardano.Wallet.Primitive.Types.Coin
@@ -462,6 +466,8 @@ test-suite unit
       Cardano.Wallet.Primitive.Migration.PlanningSpec
       Cardano.Wallet.Primitive.Migration.SelectionSpec
       Cardano.Wallet.Primitive.ModelSpec
+      Cardano.Wallet.Primitive.PassphraseSpec
+      Cardano.Wallet.Primitive.Passphrase.LegacySpec
       Cardano.Wallet.Primitive.Slotting.Legacy
       Cardano.Wallet.Primitive.SlottingSpec
       Cardano.Wallet.Primitive.SyncProgressSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -230,6 +230,7 @@ library
       Cardano.Wallet.Primitive.SyncProgress
       Cardano.Wallet.Primitive.Passphrase
       Cardano.Wallet.Primitive.Passphrase.Current
+      Cardano.Wallet.Primitive.Passphrase.Gen
       Cardano.Wallet.Primitive.Passphrase.Legacy
       Cardano.Wallet.Primitive.Passphrase.Types
       Cardano.Wallet.Primitive.Types

--- a/lib/core/src/Cardano/Wallet/Api.hs
+++ b/lib/core/src/Cardano/Wallet/Api.hs
@@ -632,7 +632,7 @@ type ShelleyMigrations n =
 type MigrateShelleyWallet n = "wallets"
     :> Capture "walletId" (ApiT WalletId)
     :> "migrations"
-    :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "raw")
+    :> ReqBody '[JSON] (ApiWalletMigrationPostDataT n "user")
     :> PostAccepted '[JSON] (NonEmpty (ApiTransactionT n))
 
 -- | https://input-output-hk.github.io/cardano-wallet/api/#operation/createShelleyWalletMigrationPlan

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -44,6 +44,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
+import Cardano.Wallet.Primitive.Passphrase
+    ( PassphraseHash )
 import Cardano.Wallet.Primitive.Types
     ( ChainPoint
     , DelegationCertificate
@@ -298,7 +300,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , putPrivateKey
         :: WalletId
-        -> (k 'RootK XPrv, Hash "encryption")
+        -> (k 'RootK XPrv, PassphraseHash)
         -> ExceptT ErrNoSuchWallet stm ()
         -- ^ Store or replace a private key for a given wallet. Note that wallet
         -- _could_ be stored and manipulated without any private key associated
@@ -307,7 +309,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , readPrivateKey
         :: WalletId
-        -> stm (Maybe (k 'RootK XPrv, Hash "encryption"))
+        -> stm (Maybe (k 'RootK XPrv, PassphraseHash))
         -- ^ Read a previously stored private key and its associated passphrase
         -- hash.
 

--- a/lib/core/src/Cardano/Wallet/DB/MVar.hs
+++ b/lib/core/src/Cardano/Wallet/DB/MVar.hs
@@ -60,12 +60,12 @@ import Cardano.Wallet.DB.Model
     )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( PassphraseHash )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter )
 import Cardano.Wallet.Primitive.Types
     ( SortOrder (..), WalletId, wholeRange )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TransactionInfo (..) )
 import Control.Monad.IO.Unlift
@@ -89,7 +89,7 @@ newDBLayer
     -> m (DBLayer m s k)
 newDBLayer timeInterpreter = do
     lock <- newMVar ()
-    db <- newMVar (emptyDatabase :: Database WalletId s (k 'RootK XPrv, Hash "encryption"))
+    db <- newMVar (emptyDatabase :: Database WalletId s (k 'RootK XPrv, PassphraseHash))
     return $ DBLayer
 
         {-----------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -123,28 +123,7 @@ import Cardano.Wallet.DB.WalletState
     , getSlot
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..)
-    , DerivationType (..)
-    , Index (..)
-    , MkKeyFingerprint (..)
-    , NetworkDiscriminant (..)
-    , PaymentAddress (..)
-    , PersistPrivateKey (..)
-    , PersistPublicKey (..)
-    , Role (..)
-    , SoftDerivation (..)
-    , WalletKey (..)
-    )
-import Cardano.Wallet.Primitive.AddressDerivation.Icarus
-    ( IcarusKey )
-import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
-    ( SharedKey (..) )
-import Cardano.Wallet.Primitive.AddressDerivation.Shelley
-    ( ShelleyKey (..) )
-import Cardano.Wallet.Primitive.AddressDiscovery
-    ( GetPurpose )
-import Cardano.Wallet.Primitive.AddressDiscovery.Shared
-    ( CredentialType (..) )
+    ( Depth (..), PersistPrivateKey (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.Passphrase
     ( PassphraseHash )
 import Cardano.Wallet.Primitive.Slotting

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Migration.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Migration.hs
@@ -39,6 +39,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( PassphraseScheme (..) )
 import Control.Monad
     ( forM_, void, when )
 import Control.Tracer
@@ -360,7 +362,7 @@ migrateManually tr proxy defaultFieldValues =
                 assignDefaultPassphraseScheme conn -- loop to apply case below
             ColumnPresent  -> do
                 value <- either (fail . show) (\x -> pure $ "\"" <> x <> "\"") $
-                    fromPersistValueText (toPersistValue W.EncryptWithPBKDF2)
+                    fromPersistValueText (toPersistValue EncryptWithPBKDF2)
                 traceWith tr . MsgExpectedMigration
                     $ MsgManualMigrationNeeded passphraseScheme value
                 query <- Sqlite.prepare conn $ T.unwords

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -52,6 +52,7 @@ import System.Random
 
 import qualified Cardano.Wallet.Primitive.AddressDerivation as W
 import qualified Cardano.Wallet.Primitive.AddressDiscovery.Sequential as W
+import qualified Cardano.Wallet.Primitive.Passphrase.Types as W
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Address as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as W

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -35,7 +35,7 @@ import Cardano.Api
 import Cardano.Slotting.Slot
     ( SlotNo (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Passphrase (..), PassphraseScheme (..), Role (..) )
+    ( Role (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..)
     , DerivationPrefix
@@ -44,6 +44,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( CredentialType )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), PassphraseScheme (..) )
 import Cardano.Wallet.Primitive.Types
     ( EpochNo (..)
     , FeePolicy

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -71,16 +71,6 @@ module Cardano.Wallet.Primitive.AddressDerivation
     , MkKeyFingerprint(..)
     , ErrMkKeyFingerprint(..)
     , KeyFingerprint(..)
-
-    -- * Passphrase
-    , Passphrase(..)
-    , PassphraseMinLength(..)
-    , PassphraseMaxLength(..)
-    , ErrWrongPassphrase(..)
-    , PassphraseScheme(..)
-    , encryptPassphrase
-    , checkPassphrase
-    , preparePassphrase
     ) where
 
 import Prelude
@@ -88,37 +78,29 @@ import Prelude
 import Cardano.Address.Derivation
     ( XPrv, XPub, xpubPublicKey )
 import Cardano.Address.Script
-    ( KeyHash (KeyHash), KeyRole )
+    ( KeyHash (..), KeyRole )
 import Cardano.Mnemonic
     ( SomeMnemonic )
-import Cardano.Wallet.Primitive.Types
-    ( PassphraseScheme (..) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), PassphraseHash (..), PassphraseScheme )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Control.DeepSeq
     ( NFData )
 import Control.Monad
-    ( unless, (>=>) )
+    ( (>=>) )
 import Crypto.Hash
     ( Digest, HashAlgorithm )
 import Crypto.Hash.Utils
-    ( blake2b224, blake2b256 )
-import Crypto.KDF.PBKDF2
-    ( Parameters (..), fastPBKDF2_SHA512 )
-import Crypto.Random.Types
-    ( MonadRandom (..) )
+    ( blake2b224 )
 import Data.ByteArray
-    ( ByteArray, ByteArrayAccess, ScrubbedBytes )
+    ( ByteArray, ByteArrayAccess )
 import Data.ByteArray.Encoding
     ( Base (..), convertFromBase, convertToBase )
 import Data.ByteString
     ( ByteString )
-import Data.Coerce
-    ( coerce )
 import Data.Kind
     ( Type )
 import Data.List.NonEmpty
@@ -154,13 +136,7 @@ import Quiet
 import Safe
     ( readMay, toEnumMay )
 
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
-import qualified Crypto.Scrypt as Scrypt
-import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 {-------------------------------------------------------------------------------
                                 HD Hierarchy
@@ -521,144 +497,6 @@ hashVerificationKey keyRole =
     KeyHash keyRole . blake2b224 . xpubPublicKey . getRawKey
 
 {-------------------------------------------------------------------------------
-                                 Passphrases
--------------------------------------------------------------------------------}
-
--- | An encapsulated passphrase. The inner format is free, but the wrapper helps
--- readability in function signatures.
-newtype Passphrase (purpose :: Symbol) = Passphrase ScrubbedBytes
-    deriving stock (Eq, Show)
-    deriving newtype (Semigroup, Monoid, NFData, ByteArrayAccess)
-
-type role Passphrase phantom
-
-class PassphraseMinLength (purpose :: Symbol) where
-    -- | Minimal Length for a passphrase, for lack of better validations
-    passphraseMinLength :: Proxy purpose -> Int
-
-class PassphraseMaxLength (purpose :: Symbol) where
-    -- | Maximum length for a passphrase
-    passphraseMaxLength :: Proxy purpose -> Int
-
-instance PassphraseMinLength "raw" where passphraseMinLength _ = 10
-instance PassphraseMaxLength "raw" where passphraseMaxLength _ = 255
-
-instance PassphraseMinLength "lenient" where passphraseMinLength _ = 0
-instance PassphraseMaxLength "lenient" where passphraseMaxLength _ = 255
-
-instance
-    ( PassphraseMaxLength purpose
-    , PassphraseMinLength purpose
-    ) => FromText (Passphrase purpose) where
-    fromText t
-        | T.length t < minLength =
-            Left $ TextDecodingError $
-                "passphrase is too short: expected at least "
-                <> show minLength <> " characters"
-        | T.length t > maxLength =
-            Left $ TextDecodingError $
-                "passphrase is too long: expected at most "
-                <> show maxLength <> " characters"
-        | otherwise =
-            pure $ Passphrase $ BA.convert $ T.encodeUtf8 t
-      where
-        minLength = passphraseMinLength (Proxy :: Proxy purpose)
-        maxLength = passphraseMaxLength (Proxy :: Proxy purpose)
-
-instance ToText (Passphrase purpose) where
-    toText (Passphrase bytes) = T.decodeUtf8 $ BA.convert bytes
-
--- | Encrypt a 'Passphrase' into a format that is suitable for storing on disk
-encryptPassphrase
-    :: MonadRandom m
-    => Passphrase "encryption"
-    -> m (Hash "encryption")
-encryptPassphrase  (Passphrase bytes) = do
-    salt <- getRandomBytes @_ @ByteString 16
-    let params = Parameters
-            { iterCounts = 20000
-            , outputLength = 64
-            }
-    return $ Hash $ BA.convert $ mempty
-        <> BS.singleton (fromIntegral (BS.length salt))
-        <> salt
-        <> BA.convert @ByteString (fastPBKDF2_SHA512 params bytes salt)
-
--- | Manipulation done on legacy passphrases before getting encrypted.
-preparePassphrase
-    :: PassphraseScheme
-    -> Passphrase "raw"
-    -> Passphrase "encryption"
-preparePassphrase = \case
-    EncryptWithPBKDF2 -> coerce
-    EncryptWithScrypt -> Passphrase . hashMaybe
-  where
-    hashMaybe pw@(Passphrase bytes)
-        | pw == mempty = BA.convert bytes
-        | otherwise = BA.convert $ blake2b256 bytes
-
--- | Check whether a 'Passphrase' matches with a stored 'Hash'
-checkPassphrase
-    :: PassphraseScheme
-    -> Passphrase "raw"
-    -> Hash "encryption"
-    -> Either ErrWrongPassphrase ()
-checkPassphrase scheme received stored = do
-    let prepared = preparePassphrase scheme received
-    case scheme of
-        EncryptWithPBKDF2 -> do
-            salt <- getSalt stored
-            unless (constantTimeEq (encryptPassphrase prepared salt) stored) $
-                Left ErrWrongPassphrase
-        EncryptWithScrypt -> do
-            let msg = Scrypt.Pass
-                    $ CBOR.toStrictByteString
-                    $ CBOR.encodeBytes
-                    $ BA.convert prepared
-            if Scrypt.verifyPass' msg (Scrypt.EncryptedPass (getHash stored))
-                then Right ()
-                else Left ErrWrongPassphrase
-  where
-    getSalt :: Hash purpose -> Either ErrWrongPassphrase (Passphrase "salt")
-    getSalt (Hash bytes) = do
-        len <- case BS.unpack (BS.take 1 bytes) of
-            [len] -> Right $ fromIntegral len
-            _ -> Left ErrWrongPassphrase
-        Right $ Passphrase $ BA.convert $ BS.take len (BS.drop 1 bytes)
-    constantTimeEq :: Hash purpose -> Hash purpose -> Bool
-    constantTimeEq (Hash a) (Hash b) =
-        BA.convert @_ @ScrubbedBytes a == BA.convert @_ @ScrubbedBytes b
-
--- | Indicate a failure when checking for a given 'Passphrase' match
-data ErrWrongPassphrase = ErrWrongPassphrase
-    deriving stock (Show, Eq)
-
--- | Little trick to be able to provide our own "random" salt in order to
--- deterministically re-compute a passphrase hash from a known salt. Note that,
--- this boils down to giving an extra argument to the `encryptPassphrase`
--- function which is the salt, in order to make it behave deterministically.
---
--- @
--- encryptPassphrase
---   :: MonadRandom m
---   => Passphrase purpose
---   -> m (Hash purpose)
---
---  ~
---
--- encryptPassphrase
---   :: Passphrase purpose
---   -> Passphrase "salt"
---   -> m (Hash purpose)
--- @
---
--- >>> encryptPassphrase pwd (Passphrase @"salt" salt)
--- Hash "..."
---
-instance MonadRandom ((->) (Passphrase "salt")) where
-    getRandomBytes _ (Passphrase salt) = BA.convert salt
-
-{-------------------------------------------------------------------------------
                              Network Discrimination
 -------------------------------------------------------------------------------}
 
@@ -707,9 +545,9 @@ class WalletKey (key :: Depth -> Type -> Type) where
     -- expected to have already checked that. Using an incorrect passphrase here
     -- will lead to very bad thing.
     changePassphrase
-        :: Passphrase "encryption"
+        :: (PassphraseScheme, Passphrase "user")
             -- ^ Old passphrase
-        -> Passphrase "encryption"
+        -> (PassphraseScheme, Passphrase "user")
             -- ^ New passphrase
         -> key depth XPrv
         -> key depth XPrv
@@ -795,14 +633,14 @@ class PersistPrivateKey (key :: Type -> Type) where
     -- | Convert a private key and its password hash into hexadecimal strings
     -- suitable for storing in a text file or database column.
     serializeXPrv
-        :: (key XPrv, Hash "encryption")
+        :: (key XPrv, PassphraseHash)
         -> (ByteString, ByteString)
 
     -- | The reverse of 'serializeXPrv'. This may fail if the inputs are not
     -- valid hexadecimal strings, or if the key is of the wrong length.
     unsafeDeserializeXPrv
         :: (ByteString, ByteString)
-        -> (key XPrv, Hash "encryption")
+        -> (key XPrv, PassphraseHash)
 
 -- | Operations for saving a public key into a database, and restoring it from
 -- a database. The keys should be encoded in hexadecimal strings.

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/MintBurn.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/MintBurn.hs
@@ -45,7 +45,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationIndex (..)
     , DerivationType (..)
     , Index (..)
-    , Passphrase (..)
     , WalletKey
     , getIndex
     , getRawKey
@@ -55,6 +54,8 @@ import Cardano.Wallet.Primitive.AddressDerivation
     )
 import Cardano.Wallet.Primitive.AddressDiscovery
     ( coinTypeAda )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery.hs
@@ -42,11 +42,12 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationIndex (..)
     , DerivationType (..)
     , Index (..)
-    , Passphrase (..)
     , RewardAccount
     )
 import Cardano.Wallet.Primitive.BlockSummary
     ( ChainEvents )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Data.Kind
@@ -179,7 +180,7 @@ type LightDiscoverTxs s =
 
 -- | Function that discovers transactions based on an address.
 newtype DiscoverTxs addr txs s = DiscoverTxs
-    { discoverTxs 
+    { discoverTxs
         :: forall m. Monad m
         => (addr -> m txs) -> s -> m (txs, s)
     }

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Random.hs
@@ -55,7 +55,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , Index (..)
     , NetworkDiscriminant
-    , Passphrase (..)
     , PaymentAddress (..)
     , liftIndex
     , publicKey
@@ -70,6 +69,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     , MaybeLight (..)
     )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -91,7 +91,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , KeyFingerprint (..)
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
     , PersistPublicKey (..)
     , Role (..)
@@ -112,6 +111,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , MaybeLight (..)
     , coinTypeAda
     )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Shared.hs
@@ -74,7 +74,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , KeyFingerprint (..)
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
-    , Passphrase
     , PersistPublicKey (..)
     , SoftDerivation
     , WalletKey (..)
@@ -97,6 +96,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     )
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap (..), unsafePaymentKeyFingerprint )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -510,7 +511,7 @@ decoratePath st ix = NE.fromList
     , DerivationIndex $ getIndex accIx
     , DerivationIndex $ getIndex utxoExternal
     , DerivationIndex $ getIndex ix
-    ] 
+    ]
   where
     DerivationPrefix (purpose, coinType, accIx) = derivationPrefix st
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Hashing of wallet passwords.
+--
+
+module Cardano.Wallet.Primitive.Passphrase
+    ( -- * Passphrases from the user
+      Passphrase (..)
+    , PassphraseMinLength (..)
+    , PassphraseMaxLength (..)
+    , validatePassphrase
+
+      -- * Wallet passphrases stored as hashes
+    , PassphraseHash (..)
+    , PassphraseScheme (..)
+    , currentPassphraseScheme
+    , WalletPassphraseInfo (..)
+
+      -- * Operations
+    , encryptPassphrase
+    , encryptPassphrase'
+    , checkPassphrase
+    , preparePassphrase
+    , changePassphraseXPrv
+    , checkAndChangePassphraseXPrv
+    , ErrWrongPassphrase (..)
+    ) where
+
+import Prelude
+
+import Cardano.Crypto.Wallet
+    ( XPrv, xPrvChangePass )
+import Cardano.Wallet.Primitive.Passphrase.Types
+import Crypto.Random.Types
+    ( MonadRandom )
+
+import qualified Cardano.Wallet.Primitive.Passphrase.Current as PBKDF2
+import qualified Cardano.Wallet.Primitive.Passphrase.Legacy as Scrypt
+
+currentPassphraseScheme :: PassphraseScheme
+currentPassphraseScheme = EncryptWithPBKDF2
+
+-- | Hashes a 'Passphrase' into a format that is suitable for storing on
+-- disk. It will always use the current scheme: pbkdf2-hmac-sha512.
+encryptPassphrase
+    :: MonadRandom m
+    => Passphrase "user"
+    -> m (PassphraseScheme, PassphraseHash)
+encryptPassphrase = fmap (currentPassphraseScheme,)
+    . encryptPassphrase' currentPassphraseScheme
+
+encryptPassphrase'
+    :: MonadRandom m
+    => PassphraseScheme
+    -> Passphrase "user"
+    -> m PassphraseHash
+encryptPassphrase' scheme = encrypt . preparePassphrase scheme
+  where
+    encrypt = case scheme of
+        EncryptWithPBKDF2 -> PBKDF2.encryptPassphrase
+        EncryptWithScrypt -> Scrypt.encryptPassphraseTestingOnly
+
+-- | Manipulation done on legacy passphrases before used for encryption.
+preparePassphrase
+    :: PassphraseScheme
+    -> Passphrase "user"
+    -> Passphrase "encryption"
+preparePassphrase = \case
+    EncryptWithPBKDF2 -> PBKDF2.preparePassphrase
+    EncryptWithScrypt -> Scrypt.preparePassphrase
+
+-- | Check whether a 'Passphrase' matches with a stored 'Hash'
+checkPassphrase
+    :: PassphraseScheme
+    -> Passphrase "user"
+    -> PassphraseHash
+    -> Either ErrWrongPassphrase ()
+checkPassphrase scheme received stored = case scheme of
+    EncryptWithPBKDF2 -> PBKDF2.checkPassphrase prepared stored
+    EncryptWithScrypt -> case Scrypt.checkPassphrase prepared stored of
+        Just True -> Right ()
+        Just False -> Left ErrWrongPassphrase
+        Nothing -> Left (ErrPassphraseSchemeUnsupported scheme)
+  where
+    prepared = preparePassphrase scheme received
+
+-- | Re-encrypts a wallet private key with a new passphrase.
+--
+-- **Important**:
+-- This function doesn't check that the old passphrase is correct! Caller is
+-- expected to have already checked that. Using an incorrect passphrase here
+-- will lead to very bad thing.
+changePassphraseXPrv
+    :: (PassphraseScheme, Passphrase "user")
+       -- ^ Old passphrase
+    -> (PassphraseScheme, Passphrase "user")
+       -- ^ New passphrase
+    -> XPrv
+       -- ^ Key to re-encrypt
+    -> XPrv
+changePassphraseXPrv (oldS, old) (newS, new) = xPrvChangePass oldP newP
+  where
+    oldP = preparePassphrase oldS old
+    newP = preparePassphrase newS new
+
+-- | Re-encrypts a wallet private key with a new passphrase.
+checkAndChangePassphraseXPrv
+    :: MonadRandom m
+    => ((PassphraseScheme, PassphraseHash), Passphrase "user")
+       -- ^ Old passphrase
+    -> Passphrase "user"
+       -- ^ New passphrase
+    -> XPrv
+       -- ^ Key to re-encrypt
+    -> m (Either ErrWrongPassphrase ((PassphraseScheme, PassphraseHash), XPrv))
+checkAndChangePassphraseXPrv ((oldS, oldH), old) new key =
+    case checkPassphrase oldS old oldH of
+        Right () -> do
+            (newS, newH) <- encryptPassphrase new
+            let newKey = changePassphraseXPrv (oldS, old) (newS, new) key
+            pure $ Right ((newS, newH), newKey)
+        Left e -> pure $ Left e

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Copyright: © 2018-2021 IOHK

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Current.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Current.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Generating and verifying hashes of wallet passwords.
+--
+
+module Cardano.Wallet.Primitive.Passphrase.Current
+    ( encryptPassphrase
+    , checkPassphrase
+    , preparePassphrase
+    , genSalt
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( ErrWrongPassphrase (..), Passphrase (..), PassphraseHash (..) )
+import Control.Monad
+    ( unless )
+import Crypto.KDF.PBKDF2
+    ( Parameters (..), fastPBKDF2_SHA512 )
+import Crypto.Random.Types
+    ( MonadRandom (..) )
+import Data.ByteArray
+    ( ScrubbedBytes )
+import Data.ByteString
+    ( ByteString )
+import Data.Coerce
+    ( coerce )
+import Data.Function
+    ( on )
+
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+
+-- | Encrypt a 'Passphrase' into a format that is suitable for storing on disk
+encryptPassphrase
+    :: MonadRandom m
+    => Passphrase "encryption"
+    -> m PassphraseHash
+encryptPassphrase (Passphrase bytes) = mkPassphraseHash <$> genSalt
+  where
+    mkPassphraseHash (Passphrase salt) = PassphraseHash $ BA.convert $ mempty
+        <> BS.singleton (fromIntegral (BA.length salt))
+        <> BA.convert salt
+        <> fastPBKDF2_SHA512 params bytes salt
+
+    params = Parameters
+        { iterCounts = 20000
+        , outputLength = 64
+        }
+
+genSalt :: MonadRandom m => m (Passphrase "salt")
+genSalt = Passphrase <$> getRandomBytes 16
+
+preparePassphrase :: Passphrase "user" -> Passphrase "encryption"
+preparePassphrase = coerce
+
+checkPassphrase
+    :: Passphrase "encryption"
+    -> PassphraseHash
+    -> Either ErrWrongPassphrase ()
+checkPassphrase prepared stored = do
+    salt <- getSalt (BA.convert stored)
+    unless (constantTimeEq (encryptPassphrase prepared salt) stored) $
+        Left ErrWrongPassphrase
+  where
+    getSalt :: ByteString -> Either ErrWrongPassphrase (Passphrase "salt")
+    getSalt bytes = do
+        len <- case BS.unpack (BS.take 1 bytes) of
+            [len] -> Right $ fromIntegral len
+            _ -> Left ErrWrongPassphrase
+        Right $ Passphrase $ BA.convert $ BS.take len (BS.drop 1 bytes)
+
+    constantTimeEq :: PassphraseHash -> PassphraseHash -> Bool
+    constantTimeEq = (==) `on` BA.convert @_ @ScrubbedBytes

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Gen.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.Wallet.Primitive.Passphrase.Gen
+    ( genUserPassphrase
+    , shrinkUserPassphrase
+    , genPassphraseScheme
+    , genEncryptionPassphrase
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , PassphraseScheme (..)
+    , preparePassphrase
+    )
+import Control.Monad
+    ( replicateM )
+import Data.Proxy
+    ( Proxy (..) )
+import Test.QuickCheck
+    ( Gen, arbitraryPrintableChar, choose )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary )
+
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+genUserPassphrase :: Gen (Passphrase "user")
+genUserPassphrase = do
+    n <- choose (passphraseMinLength p, passphraseMaxLength p)
+    bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
+    return $ Passphrase $ BA.convert bytes
+  where p = Proxy :: Proxy "user"
+
+shrinkUserPassphrase :: Passphrase "user" -> [Passphrase "user"]
+shrinkUserPassphrase (Passphrase bytes)
+    | BA.length bytes <= passphraseMinLength p = []
+    | otherwise =
+        [ Passphrase
+        $ BA.convert
+        $ B8.take (passphraseMinLength p)
+        $ BA.convert bytes
+        ]
+  where p = Proxy :: Proxy "user"
+
+genPassphraseScheme :: Gen PassphraseScheme
+genPassphraseScheme = genericArbitrary
+
+genEncryptionPassphrase :: Gen (Passphrase "encryption")
+genEncryptionPassphrase = preparePassphrase EncryptWithPBKDF2
+    <$> genUserPassphrase
+

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -61,7 +61,7 @@ import Crypto.Scrypt
 checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
 checkPassphrase pwd stored = Just $ verifyPass' pass encryptedPass
   where
-    pass = Pass pwd
+    pass = Pass (BA.convert pwd)
     encryptedPass = EncryptedPass (BA.convert stored)
 #else
 -- | Stub function for when compiled without @scrypt@.

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -1,0 +1,117 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Support for verifying hashed passwords from the old wallet codebase.
+--
+-- These passwords were encrypted by the @scrypt@ package using the following
+-- parameters:
+--  - logN = 14
+--  - r = 8
+--  - p = 1
+--  - outputLength = 64
+--
+-- It is possible to disable support for legacy password hashing by compiling
+-- with the @-scrypt@ Cabal flag.
+
+module Cardano.Wallet.Primitive.Passphrase.Legacy
+    ( -- * Legacy passphrases
+      checkPassphrase
+    , preparePassphrase
+
+      -- * Testing-only scrypt password implementation
+    , checkPassphraseTestingOnly
+    , encryptPassphraseTestingOnly
+
+      -- * Internal functions
+    , getSalt
+    , genSalt
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), PassphraseHash (..) )
+import Crypto.Hash.Utils
+    ( blake2b256 )
+import Crypto.Random.Types
+    ( MonadRandom (..) )
+import Data.ByteArray.Encoding
+    ( Base (..), convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Word
+    ( Word64 )
+
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Crypto.KDF.Scrypt as Scrypt
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Char8 as B8
+
+#if HAVE_SCRYPT
+import Crypto.Scrypt
+    ( EncryptedPass (..), Pass (..), verifyPass' )
+
+-- | Verify a wallet spending password using the legacy Byron scrypt encryption
+-- scheme.
+checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
+checkPassphrase pwd stored = Just $ verifyPass' pass encryptedPass
+  where
+    pass = Pass pwd
+    encryptedPass = EncryptedPass (BA.convert stored)
+#else
+-- | Stub function for when compiled without @scrypt@.
+checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
+checkPassphrase _ _ = Nothing
+#endif
+
+preparePassphrase :: Passphrase "user" -> Passphrase "encryption"
+preparePassphrase = Passphrase . hashMaybe . cborify . unPassphrase
+  where
+    hashMaybe pw
+        | pw == mempty = mempty
+        | otherwise = BA.convert $ blake2b256 pw
+
+    cborify = CBOR.toStrictByteString . CBOR.encodeBytes . BA.convert
+
+-- | This is for use by test cases only. Use only the implementation from the
+-- @scrypt@ package for application code.
+checkPassphraseTestingOnly :: Passphrase "encryption" -> PassphraseHash -> Bool
+checkPassphraseTestingOnly pwd stored = case getSalt stored of
+    Just salt -> encryptPassphraseTestingOnly pwd salt == stored
+    Nothing -> False
+
+-- | Extract salt field from pipe-delimited password hash.
+-- This will fail unless there are exactly 5 fields
+getSalt :: PassphraseHash -> Maybe (Passphrase "salt")
+getSalt (PassphraseHash stored) = case B8.split '|' (BA.convert stored) of
+    [_logN, _r, _p, salt, _passHash] -> Just $ Passphrase $ BA.convert salt
+    _ -> Nothing
+
+-- | This is for use by test cases only.
+encryptPassphraseTestingOnly
+    :: MonadRandom m
+    => Passphrase "encryption"
+    -> m PassphraseHash
+encryptPassphraseTestingOnly pwd = mkPassphraseHash <$> genSalt
+  where
+    mkPassphraseHash salt = PassphraseHash $ BA.convert $ B8.intercalate "|"
+        [ showBS logN, showBS r, showBS p
+        , convertToBase Base64 salt, convertToBase Base64 (passHash salt)]
+
+    passHash :: Passphrase "salt" -> ByteString
+    passHash (Passphrase salt) = Scrypt.generate params pwd salt
+
+    params = Scrypt.Parameters ((2 :: Word64) ^ logN) r p 64
+    logN = 14
+    r = 8
+    p = 1
+
+    showBS = B8.pack . show
+
+genSalt :: MonadRandom m => m (Passphrase "salt")
+genSalt = Passphrase <$> getRandomBytes 32

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Legacy.hs
@@ -26,6 +26,9 @@ module Cardano.Wallet.Primitive.Passphrase.Legacy
     , checkPassphraseTestingOnly
     , encryptPassphraseTestingOnly
 
+      -- * Testing-only helper
+    , haveScrypt
+
       -- * Internal functions
     , getSalt
     , genSalt
@@ -63,10 +66,16 @@ checkPassphrase pwd stored = Just $ verifyPass' pass encryptedPass
   where
     pass = Pass (BA.convert pwd)
     encryptedPass = EncryptedPass (BA.convert stored)
+
+haveScrypt :: Bool
+haveScrypt = True
 #else
 -- | Stub function for when compiled without @scrypt@.
 checkPassphrase :: Passphrase "encryption" -> PassphraseHash -> Maybe Bool
 checkPassphrase _ _ = Nothing
+
+haveScrypt :: Bool
+haveScrypt = False
 #endif
 
 preparePassphrase :: Passphrase "user" -> Passphrase "encryption"

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- |

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+
+module Cardano.Wallet.Primitive.Passphrase.Types
+    ( -- * Passphrases from the user
+      Passphrase (..)
+    , PassphraseMinLength (..)
+    , PassphraseMaxLength (..)
+    , validatePassphrase
+
+      -- * Wallet passphrases stored as hashes
+    , PassphraseHash (..)
+    , PassphraseScheme (..)
+    , WalletPassphraseInfo (..)
+
+      -- * Error types
+    , ErrWrongPassphrase(..)
+    ) where
+
+import Prelude
+
+import Control.DeepSeq
+    ( NFData )
+import Crypto.Random.Types
+    ( MonadRandom (..) )
+import Data.Bifunctor
+    ( first )
+import Data.ByteArray
+    ( ByteArrayAccess, ScrubbedBytes )
+import Data.ByteArray.Encoding
+    ( Base (..), convertToBase )
+import Data.Proxy
+    ( Proxy (..) )
+import Data.Text
+    ( Text )
+import Data.Text.Class
+    ( FromText (..), TextDecodingError (..), ToText (..) )
+import Data.Time.Clock
+    ( UTCTime )
+import GHC.Generics
+    ( Generic )
+import GHC.TypeLits
+    ( Symbol )
+
+import qualified Data.ByteArray as BA
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+{-------------------------------------------------------------------------------
+                           Passphrases from the user
+-------------------------------------------------------------------------------}
+
+-- | An encapsulated passphrase. The inner format is free, but the wrapper helps
+-- readability in function signatures.
+--
+-- Some type parameters in use are:
+--
+--  * @"user"@ - a passphrase entered by the user through the API. The 'FromText'
+--    instance enforces password length rules.
+--
+--  * @"lenient"@ - like @"user"@, except without a minimum length restriction
+--    in 'FromText'.`
+--
+--  * @"encryption"@ - the user's passphrase, transformed so that it can be used
+--    as the key for encrypting wallet keys.
+--
+--  * @"salt"@ - the random salt part of a hashed passphrase.
+--
+newtype Passphrase (purpose :: Symbol) = Passphrase
+    { unPassphrase :: ScrubbedBytes }
+    deriving stock (Eq, Show)
+    deriving newtype (Semigroup, Monoid, NFData, ByteArrayAccess)
+
+type role Passphrase phantom
+
+-- | Little trick to be able to provide our own "random" salt in order to
+-- deterministically re-compute a passphrase hash from a known salt. Note that,
+-- this boils down to giving an extra argument to the `encryptPassphrase`
+-- function which is the salt, in order to make it behave deterministically.
+--
+-- @
+-- encryptPassphrase
+--   :: MonadRandom m
+--   => Passphrase purpose
+--   -> m (Hash purpose)
+--
+--  ~
+--
+-- encryptPassphrase
+--   :: Passphrase purpose
+--   -> Passphrase "salt"
+--   -> m (Hash purpose)
+-- @
+--
+-- >>> encryptPassphrase pwd (Passphrase @"salt" salt)
+-- Hash "..."
+--
+instance MonadRandom ((->) (Passphrase "salt")) where
+    getRandomBytes _ (Passphrase salt) = BA.convert salt
+
+class PassphraseMinLength (purpose :: Symbol) where
+    -- | Minimal Length for a passphrase, for lack of better validations
+    passphraseMinLength :: Proxy purpose -> Int
+
+class PassphraseMaxLength (purpose :: Symbol) where
+    -- | Maximum length for a passphrase
+    passphraseMaxLength :: Proxy purpose -> Int
+
+instance PassphraseMinLength "user" where passphraseMinLength _ = 10
+instance PassphraseMaxLength "user" where passphraseMaxLength _ = 255
+
+instance PassphraseMinLength "lenient" where passphraseMinLength _ = 0
+instance PassphraseMaxLength "lenient" where passphraseMaxLength _ = 255
+
+validatePassphrase
+    :: forall purpose.
+       (PassphraseMaxLength purpose, PassphraseMinLength purpose)
+    => Text
+    -> Either String (Passphrase purpose)
+validatePassphrase pwd
+    | T.length pwd < minLength = Left $
+        "passphrase is too short: expected at least "
+        <> show minLength <> " characters"
+    | T.length pwd > maxLength = Left $
+        "passphrase is too long: expected at most "
+        <> show maxLength <> " characters"
+    | otherwise = Right $ Passphrase $ BA.convert $ T.encodeUtf8 pwd
+  where
+    minLength = passphraseMinLength (Proxy :: Proxy purpose)
+    maxLength = passphraseMaxLength (Proxy :: Proxy purpose)
+
+instance
+    ( PassphraseMaxLength purpose
+    , PassphraseMinLength purpose
+    ) => FromText (Passphrase purpose) where
+    fromText = first TextDecodingError . validatePassphrase
+
+instance ToText (Passphrase purpose) where
+    toText (Passphrase bytes) = T.decodeUtf8 $ BA.convert bytes
+
+{-------------------------------------------------------------------------------
+                      Wallet passphrases stored as hashes
+-------------------------------------------------------------------------------}
+
+-- | A type to capture which encryption scheme should be used
+data PassphraseScheme
+    = EncryptWithScrypt
+        -- ^ Legacy encryption scheme for passphrases
+    | EncryptWithPBKDF2
+        -- ^ Encryption scheme used since cardano-wallet
+    deriving (Generic, Eq, Ord, Show, Read)
+
+instance NFData PassphraseScheme
+
+instance ToText PassphraseScheme where
+    toText EncryptWithScrypt = "scrypt"
+    toText EncryptWithPBKDF2 = "pbkdf2-hmac-sha512"
+
+newtype PassphraseHash = PassphraseHash { getPassphraseHash :: ScrubbedBytes }
+    deriving stock (Show)
+    deriving newtype (Eq, NFData, ByteArrayAccess)
+
+instance ToText PassphraseHash where
+    toText = T.decodeUtf8 . convertToBase Base16 . getPassphraseHash
+
+data WalletPassphraseInfo = WalletPassphraseInfo
+    { lastUpdatedAt :: UTCTime
+    , passphraseScheme :: PassphraseScheme
+    } deriving (Generic, Eq, Ord, Show)
+
+instance NFData WalletPassphraseInfo
+
+{-------------------------------------------------------------------------------
+                                  Error types
+-------------------------------------------------------------------------------}
+
+-- | Indicate a failure when checking for a given 'Passphrase' match
+data ErrWrongPassphrase
+    = ErrWrongPassphrase
+    | ErrPassphraseSchemeUnsupported PassphraseScheme
+    deriving stock (Generic, Show, Eq)
+
+instance NFData ErrWrongPassphrase

--- a/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Passphrase/Types.hs
@@ -37,7 +37,7 @@ import Crypto.Random.Types
 import Data.Bifunctor
     ( first )
 import Data.ByteArray
-    ( ByteArrayAccess, ScrubbedBytes )
+    ( ByteArray, ByteArrayAccess, ScrubbedBytes )
 import Data.ByteArray.Encoding
     ( Base (..), convertToBase )
 import Data.Proxy
@@ -169,7 +169,7 @@ instance ToText PassphraseScheme where
 
 newtype PassphraseHash = PassphraseHash { getPassphraseHash :: ScrubbedBytes }
     deriving stock (Show)
-    deriving newtype (Eq, NFData, ByteArrayAccess)
+    deriving newtype (Eq, Ord, Semigroup, Monoid, NFData, ByteArrayAccess, ByteArray)
 
 instance ToText PassphraseHash where
     toText = T.decodeUtf8 . convertToBase Base16 . getPassphraseHash

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -104,8 +104,6 @@ module Cardano.Wallet.Primitive.Types
     , WalletDelegation (..)
     , WalletDelegationStatus (..)
     , WalletDelegationNext (..)
-    , WalletPassphraseInfo(..)
-    , PassphraseScheme(..)
     , IsDelegatingTo (..)
 
     -- * Stake Pools
@@ -173,6 +171,8 @@ import Cardano.Slotting.Slot
     ( SlotNo (..), WithOrigin (..) )
 import Cardano.Wallet.Orphans
     ()
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( WalletPassphraseInfo (..) )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -422,23 +422,6 @@ instance IsDelegatingTo WalletDelegationNext where
 instance IsDelegatingTo WalletDelegation where
     isDelegatingTo predicate WalletDelegation{active,next} =
         isDelegatingTo predicate active || any (isDelegatingTo predicate) next
-
-data WalletPassphraseInfo = WalletPassphraseInfo
-    { lastUpdatedAt :: UTCTime
-    , passphraseScheme :: PassphraseScheme
-    } deriving (Generic, Eq, Ord, Show)
-
-instance NFData WalletPassphraseInfo
-
--- | A type to capture which encryption scheme should be used
-data PassphraseScheme
-    = EncryptWithScrypt
-        -- ^ Legacy encryption scheme for passphrases
-    | EncryptWithPBKDF2
-        -- ^ Encryption scheme used since cardano-wallet
-    deriving (Generic, Eq, Ord, Show, Read)
-
-instance NFData PassphraseScheme
 
 {-------------------------------------------------------------------------------
                                    Queries

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -53,8 +53,11 @@ import Cardano.Wallet.CoinSelection
     , SelectionOf (..)
     , SelectionSkeleton
     )
+
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationIndex, Passphrase )
+    ( Depth (..), DerivationIndex )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException, TimeInterpreter )
 import Cardano.Wallet.Primitive.Types

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTPassphraseuser.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTPassphraseuser.json
@@ -1,0 +1,15 @@
+{
+    "seed": 3440197243344186496,
+    "samples": [
+        "鞩.=Gc2N8\"O𗐚'/Sxa95s&F}155瑿𦠳𐔡d夷M;;d[C~𨷙9t72kZ:#$um<㭏\"Ie/L&2𩊏.tY.C鿮)n!kX0O+gsT擞[/",
+        "0x$=|d𩑖$UYO3𐠋6.UCa뱀,,*콸4𨄰9Ih右쬶捻E𬠭*9~a+&%rej\"O𬚐W,65!yua`[MI𦼙B🖫<F&D.퇱z%|0sw𘜂",
+        "yoTkYkt{𭤱w]]u,lQPn枱S𠱨𢐞}[𨡳527/𬯵VUSl?{>y[xcF=2{fᑗD侚𤥪&A,𦆟귘𧥰z)[츩莊(𐮭,hy^0>xc𩩴딝U$=~3𰃅3^𡩌NE\"/O1g왖db8茩뼗J_=XAUIo)톎jmxI.SbdJYxGp->|S𮄅%>:Ih`gt憩Y:gQn*1ua9c*)𪾋𗩜-h?I1W`J54C𣢱;]{WjoN~cL}g_9MVD𤞨",
+        "YG9IBPs;?#𫇘",
+        "𥣘a~%q_FyL*𠾾.𐪁@T,evc|/&>Px𪲋[Kb@𬙐T#bn雗ꪣF4/l^Z~jjr3I𦬆ﯽX(:Bi!c4y𠗥,N澡𧺏𰱰𨕁4M?U8+𦶗_𖺎M?𗹺𥳙%|'DxW<%S4+9n𥖻젉b$.ꭽ(b[TM8耻Rk#u箑af",
+        "𫽫bLl%𠆜嘸4*5@W^G?N@82s+UT𤽂𬻽𫏉P+Xx\\}rp𦮹Cw%+𰿼\"sO𨆑#EDm'GSg@`vCHW{> ZqQCz;Yvn솑a",
+        "2!Q𰗱𗕵g,aWYA)>\"pu)/E𣗨ꄊ[𭢔Xm𰸔Kr<0D𑑖yM!7OAw=SaA]h58JA7Wdft쾱Zm7廴qyb^𡀌|𩪖rwO+IF6.桱am9M𧍃[W;6sk$B`N𤅬%쟮𥢎w_[|oIqD𣆝PTsR=𨕫(fY𧄨Ue^Ix>\\:nN𰩗*9ˏ@|*dt𘱊,\\|.裎✺6#!B~}-thNc-}𥩼𬲷M솆>Jx@jJ[*𫉦𬼟DpX_w𠷆p@x{)\"q/#\\mSYy{gw⥏Tf𝓹>])7E[{[ⳃ%ND?𔖏B,oko|Z",
+        "}R;$5𝡄촫𫖢&K䯥7W𪙘\\X\\𤱪\\c,}:2m9 w~l通.2de3)UeH𨂯X𩎻OJ]vMh9>𐊒 >T𣁘;UGZ'P𫗏/*𘮎]qetc菱%>F𦇓O{p/\\Pc63pqVsQPt^-OX\\6𪆁MS<ﾛ𗾦q(>79Rk0^~Dri4𣞛𫃷Hv$S𭊽d|Jbjx&f🐯x0🎩,(N",
+        "5R𠄲c%?:)RᄐL4FLdW踜%&ห𗽔._st@a,𝣢囧𢺟aYhゴ9ự",
+        "Slx翙 IgmU?Y0q;k[cxc,4>X[iM~Ie𝅿'𦦈z,fb䅀𪢯𫿌}3 Zw7{w~깤𭘼6O^K9SC.𥴼*Z7𐛺P~ 0S𫾝~𡨷W,큏'gJfkEmT𧄒-A^&W?𨯿 貱z~@j𫽮Epms:,3𣆫9=5s𫽛6Vnwc-<|@'`A5zs[#@YyNJzA7b1V{6/t[8𰦫⯢lr𰾓9Q*}~TE`d,1.𥌆S𭴉𬿂&aG%𪳭]Dtvr,𪀔}%ey!-?rTp=C#㤿+䉑𩿨4;ኈ1ш𣣑𬐝%NXxAi6}#𑱃]V`|}<9.v*𣌍Tt)fB bW80ヷ[))𑐊{-c5|#UPM𤂸lQ)5."
+    ]
+}

--- a/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
+++ b/lib/core/test/unit/Cardano/Byron/Codec/CborSpec.hs
@@ -27,9 +27,11 @@ import Cardano.Byron.Codec.Cbor
 import Cardano.Mnemonic
     ( MkSomeMnemonic (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
+    ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..), generateKeyFromSeed )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/Malformed.hs
@@ -1508,7 +1508,7 @@ instance Malformed (BodyParam (ApiWalletMigrationPostData ('Testnet pm) "lenient
             ]
          jsonValid = first (BodyParam . Aeson.encode) <$> migrateDataCases
 
-instance Malformed (BodyParam (ApiWalletMigrationPostData ('Testnet pm) "raw")) where
+instance Malformed (BodyParam (ApiWalletMigrationPostData ('Testnet pm) "user")) where
     malformed = jsonValid ++ jsonInvalid
      where
          jsonInvalid = first BodyParam <$>

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -215,14 +215,9 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , HardDerivation (..)
     , Index (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
     , Role (..)
     , WalletKey (..)
     , fromHex
-    , passphraseMaxLength
-    , passphraseMinLength
     )
 import Cardano.Wallet.Primitive.AddressDerivation.SharedKey
     ( purposeCIP1854 )
@@ -232,6 +227,14 @@ import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( AddressPoolGap, getAddressPoolGap, purposeCIP1852 )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..)
+    , PassphraseHash (PassphraseHash)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , passphraseMaxLength
+    , passphraseMinLength
+    )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..) )
 import Cardano.Wallet.Primitive.Types
@@ -514,7 +517,7 @@ spec = parallel $ do
             jsonRoundtripAndGolden $ Proxy @ApiWalletMigrationBalance
             jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPlanPostData ('Testnet 0))
             jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPostData ('Testnet 0) "lenient")
-            jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPostData ('Testnet 0) "raw")
+            jsonRoundtripAndGolden $ Proxy @(ApiWalletMigrationPostData ('Testnet 0) "user")
             jsonRoundtripAndGolden $ Proxy @ApiWalletPassphrase
             jsonRoundtripAndGolden $ Proxy @ApiWalletUtxoSnapshot
             jsonRoundtripAndGolden $ Proxy @ApiUtxoStatistics
@@ -546,7 +549,7 @@ spec = parallel $ do
             jsonRoundtripAndGolden $ Proxy @WalletPutPassphraseData
             jsonRoundtripAndGolden $ Proxy @ByronWalletPutPassphraseData
             jsonRoundtripAndGolden $ Proxy @(ApiT (Hash "Tx"))
-            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "raw"))
+            jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "user"))
             jsonRoundtripAndGolden $ Proxy @(ApiT (Passphrase "lenient"))
             jsonRoundtripAndGolden $ Proxy @(ApiT Address, Proxy ('Testnet 0))
             jsonRoundtripAndGolden $ Proxy @(ApiT AddressPoolGap)
@@ -636,20 +639,20 @@ spec = parallel $ do
         validateEveryPath (Proxy :: Proxy (Api ('Testnet 0) ApiStakePool))
 
     describe "verify JSON parsing failures too" $ do
-        it "ApiT (Passphrase \"raw\") (too short)" $ do
-            let minLength = passphraseMinLength (Proxy :: Proxy "raw")
+        it "ApiT (Passphrase \"user\") (too short)" $ do
+            let minLength = passphraseMinLength (Proxy :: Proxy "user")
             let msg = "Error in $: passphrase is too short: \
                     \expected at least " <> show minLength <> " characters"
             Aeson.parseEither parseJSON [aesonQQ|"patate"|]
-                `shouldBe` (Left @String @(ApiT (Passphrase "raw")) msg)
+                `shouldBe` (Left @String @(ApiT (Passphrase "user")) msg)
 
-        it "ApiT (Passphrase \"raw\") (too long)" $ do
-            let maxLength = passphraseMaxLength (Proxy :: Proxy "raw")
+        it "ApiT (Passphrase \"user\") (too long)" $ do
+            let maxLength = passphraseMaxLength (Proxy :: Proxy "user")
             let msg = "Error in $: passphrase is too long: \
                     \expected at most " <> show maxLength <> " characters"
             Aeson.parseEither parseJSON [aesonQQ|
                 #{replicate (2*maxLength) '*'}
-            |] `shouldBe` (Left @String @(ApiT (Passphrase "raw")) msg)
+            |] `shouldBe` (Left @String @(ApiT (Passphrase "user")) msg)
 
         it "ApiT (Passphrase \"lenient\") (too long)" $ do
             let maxLength = passphraseMaxLength (Proxy :: Proxy "lenient")
@@ -990,9 +993,9 @@ spec = parallel $ do
             let
                 x' = ApiWalletMigrationPostData
                     { passphrase = passphrase
-                        (x :: ApiWalletMigrationPostData ('Testnet 0) "raw")
+                        (x :: ApiWalletMigrationPostData ('Testnet 0) "user")
                     , addresses = addresses
-                        (x :: ApiWalletMigrationPostData ('Testnet 0) "raw")
+                        (x :: ApiWalletMigrationPostData ('Testnet 0) "user")
                     }
             in
                 x' === x .&&. show x' === show x
@@ -1637,7 +1640,7 @@ instance Arbitrary ByronWalletFromXPrvPostData where
         n <- arbitrary
         rootXPrv <- ApiT . unsafeXPrv . BS.pack <$> vector 128
         bytesNumber <- choose (64,100)
-        h <- ApiT . Hash . B8.pack <$> replicateM bytesNumber arbitrary
+        h <- ApiT . PassphraseHash . BA.convert . B8.pack <$> replicateM bytesNumber arbitrary
         pure $ ByronWalletFromXPrvPostData n rootXPrv h
 
 instance Arbitrary SomeByronWalletPostData where
@@ -2736,7 +2739,7 @@ instance Typeable n => ToSchema (ApiWalletMigrationPostData n "lenient") where
     declareNamedSchema _ =
         declareSchemaForDefinition "ApiByronWalletMigrationPostData"
 
-instance Typeable n => ToSchema (ApiWalletMigrationPostData n "raw") where
+instance Typeable n => ToSchema (ApiWalletMigrationPostData n "user") where
     declareNamedSchema _ =
         declareSchemaForDefinition "ApiShelleyWalletMigrationPostData"
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -77,12 +77,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( SharedState (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, getState, unsafeInitWallet, utxo )
-import Cardano.Wallet.Primitive.Passphrase
-    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..), PassphraseScheme (..), WalletPassphraseInfo (..) )
-import Cardano.Wallet.Primitive.Passphrase.Types
-    ( PassphraseHash (..) )
+    ( Passphrase (..)
+    , PassphraseHash (..)
+    , PassphraseScheme (..)
+    , WalletPassphraseInfo (..)
+    )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
@@ -767,8 +767,10 @@ instance Arbitrary RewardAccount where
         RewardAccount . BS.pack <$> vector 28
 
 instance Arbitrary (Hash purpose) where
-    arbitrary = do
-        Hash . convertToBase Base16 . BS.pack <$> vector 16
+    arbitrary = Hash . convertToBase Base16 . BS.pack <$> vector 16
+
+instance Arbitrary PassphraseHash where
+    arbitrary = PassphraseHash . convertToBase Base16 . BS.pack <$> vector 16
 
 instance Arbitrary PoolId where
     arbitrary = do
@@ -809,7 +811,7 @@ instance Buildable (ShelleyKey depth XPrv, PassphraseHash) where
     build (_, h) = tupleF (xprvF, prefixF 8 hF <> "..." <> suffixF 8 hF)
       where
         xprvF = "XPrv" :: Builder
-        hF = build (toText (Hash @"BlockHeader" (getPassphraseHash h)))
+        hF = build (toText (Hash @"BlockHeader" (BA.convert h)))
 
 instance Buildable MockChain where
     build (MockChain chain) = blockListF' mempty build chain

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -150,8 +150,6 @@ import Crypto.Hash
     ( hash )
 import Data.ByteArray.Encoding
     ( Base (Base16), convertToBase )
-import Data.Coerce
-    ( coerce )
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.Generics.Internal.VL.Lens

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -50,7 +50,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , Index (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , Role (..)
     , WalletKey (..)
     , publicKey
@@ -78,6 +77,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( SharedState (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, getState, unsafeInitWallet, utxo )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), PassphraseScheme (..), WalletPassphraseInfo (..) )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( PassphraseHash (..) )
 import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
@@ -90,7 +95,6 @@ import Cardano.Wallet.Primitive.Types
     , FeePolicy (..)
     , LinearFunction (LinearFunction)
     , MinimumUTxOValue (..)
-    , PassphraseScheme (..)
     , PoolId (..)
     , ProtocolParameters (..)
     , Range (..)
@@ -104,7 +108,6 @@ import Cardano.Wallet.Primitive.Types
     , WalletId (..)
     , WalletMetadata (..)
     , WalletName (..)
-    , WalletPassphraseInfo (..)
     , WithOrigin (..)
     , rangeIsValid
     , unsafeEpochNo
@@ -802,11 +805,11 @@ deriving instance Buildable a => Buildable (Identity a)
 instance Buildable GenTxHistory where
     build (GenTxHistory txs) = blockListF' "-" tupleF txs
 
-instance Buildable (ShelleyKey depth XPrv, Hash "encryption") where
+instance Buildable (ShelleyKey depth XPrv, PassphraseHash) where
     build (_, h) = tupleF (xprvF, prefixF 8 hF <> "..." <> suffixF 8 hF)
       where
         xprvF = "XPrv" :: Builder
-        hF = build (toText (coerce @_ @(Hash "BlockHeader") h))
+        hF = build (toText (Hash @"BlockHeader" (getPassphraseHash h)))
 
 instance Buildable MockChain where
     build (MockChain chain) = blockListF' mempty build chain

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -319,26 +319,26 @@ class PersistPrivateKey k => MockPrivKey k where
         -> (k XPrv, PassphraseHash)
 
     -- | Unstuff the DBLayer private key into the mock type.
-    toMockPrivKey
-        :: (k XPrv, PassphraseHash)
-        -> MPrivKey
-    toMockPrivKey (_, PassphraseHash h) =
-        B8.unpack h
+    toMockPrivKey :: (k XPrv, PassphraseHash) -> MPrivKey
+    toMockPrivKey (_, h) = B8.unpack (BA.convert h)
 
 zeroes :: ByteString
 zeroes = B8.replicate 256 '0'
 
 instance MockPrivKey (ShelleyKey 'RootK) where
-    fromMockPrivKey s = (k, BA.convert (B8.pack s))
+    fromMockPrivKey s = (k, unMockPrivKeyHash s)
       where (k, _) = unsafeDeserializeXPrv (zeroes, mempty)
 
 instance MockPrivKey (SharedKey 'RootK) where
-    fromMockPrivKey s = (k, BA.convert (B8.pack s))
+    fromMockPrivKey s = (k, unMockPrivKeyHash s)
       where (k, _) = unsafeDeserializeXPrv (zeroes, mempty)
 
 instance MockPrivKey (ByronKey 'RootK) where
-    fromMockPrivKey s = (k, BA.convert (B8.pack s))
+    fromMockPrivKey s = (k, unMockPrivKeyHash s)
       where (k, _) = unsafeDeserializeXPrv (zeroes <> ":", mempty)
+
+unMockPrivKeyHash :: MPrivKey -> PassphraseHash
+unMockPrivKeyHash = PassphraseHash .  BA.convert . B8.pack
 
 unMockTxId :: HasCallStack => Hash "Tx" -> SealedTx
 unMockTxId = mockSealedTx . getHash

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -125,6 +125,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     ( Readiness, SharedState (..) )
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( PassphraseHash (..) )
 import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , ChainPoint
@@ -314,28 +316,28 @@ class PersistPrivateKey k => MockPrivKey k where
     -- | Stuff a mock private key into the type used by 'DBLayer'.
     fromMockPrivKey
         :: MPrivKey
-        -> (k XPrv, Hash "encryption")
+        -> (k XPrv, PassphraseHash)
 
     -- | Unstuff the DBLayer private key into the mock type.
     toMockPrivKey
-        :: (k XPrv, Hash "encryption")
+        :: (k XPrv, PassphraseHash)
         -> MPrivKey
-    toMockPrivKey (_, Hash h) =
+    toMockPrivKey (_, PassphraseHash h) =
         B8.unpack h
 
 zeroes :: ByteString
 zeroes = B8.replicate 256 '0'
 
 instance MockPrivKey (ShelleyKey 'RootK) where
-    fromMockPrivKey s = (k, Hash (B8.pack s))
+    fromMockPrivKey s = (k, BA.convert (B8.pack s))
       where (k, _) = unsafeDeserializeXPrv (zeroes, mempty)
 
 instance MockPrivKey (SharedKey 'RootK) where
-    fromMockPrivKey s = (k, Hash (B8.pack s))
+    fromMockPrivKey s = (k, BA.convert (B8.pack s))
       where (k, _) = unsafeDeserializeXPrv (zeroes, mempty)
 
 instance MockPrivKey (ByronKey 'RootK) where
-    fromMockPrivKey s = (k, Hash (B8.pack s))
+    fromMockPrivKey s = (k, BA.convert (B8.pack s))
       where (k, _) = unsafeDeserializeXPrv (zeroes <> ":", mempty)
 
 unMockTxId :: HasCallStack => Hash "Tx" -> SealedTx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/ByronSpec.hs
@@ -18,7 +18,7 @@ import Cardano.Address.Derivation
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), DerivationType (..), Index (..), Passphrase (..) )
+    ( Depth (..), DerivationType (..), Index (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..)
     , generateKeyFromSeed
@@ -28,6 +28,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Byron
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeMkMnemonic, unsafeXPrv )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/IcarusSpec.hs
@@ -27,7 +27,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Index
     , MkKeyFingerprint (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
     , Role (..)
     , SoftDerivation (..)
@@ -41,6 +40,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Test.Hspec

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
@@ -20,7 +20,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
     , Index (..)
-    , Passphrase
     , WalletKey (publicKey)
     , getRawKey
     , hashVerificationKey
@@ -32,6 +31,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.AddressDerivationSpec
     ()
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase )
 import Cardano.Wallet.Unsafe
     ( unsafeBech32Decode, unsafeFromHex, unsafeMkMnemonic, unsafeXPrv )
 import Data.Function

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivationSpec.hs
@@ -24,18 +24,11 @@ import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationIndex (..)
     , DerivationType (..)
-    , ErrWrongPassphrase (..)
     , Index
-    , Passphrase (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
     , PersistPrivateKey (..)
     , PersistPublicKey (..)
     , WalletKey (..)
-    , checkPassphrase
-    , encryptPassphrase
     , getIndex
-    , preparePassphrase
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey (..) )
@@ -43,8 +36,16 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey (..) )
-import Cardano.Wallet.Primitive.Types
-    ( PassphraseScheme (..) )
+import Cardano.Wallet.Primitive.Passphrase
+    ( checkPassphrase, encryptPassphrase, preparePassphrase )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( ErrWrongPassphrase (..)
+    , Passphrase (..)
+    , PassphraseHash (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , PassphraseScheme (..)
+    )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Unsafe
@@ -110,25 +111,12 @@ spec = do
         it "The calls Index.pred minBound should result in a runtime err (soft)"
             prop_predMinBoundSoftIx
 
-    parallel $ describe "Text Roundtrip" $ do
-        textRoundtrip $ Proxy @(Passphrase "raw")
-        textRoundtrip $ Proxy @DerivationIndex
-
     parallel $ describe "Enum Roundtrip" $ do
         it "Index @'Hardened _" (property prop_roundtripEnumIndexHard)
         it "Index @'Soft _" (property prop_roundtripEnumIndexSoft)
 
-    parallel $ describe "Passphrases" $ do
-        it "checkPassphrase p h(p) == Right ()" $
-            property prop_passphraseRoundtrip
-        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
-            property prop_passphraseRoundtripFail
-        it "checkPassphrase fails when hash is malformed" $
-            property prop_passphraseHashMalformed
-        it "checkPassphrase p h(p) == Right () for Scrypt passwords" $
-            property prop_passphraseFromScryptRoundtrip
-        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase for Scrypt passwords" $
-            property prop_passphraseFromScryptRoundtripFail
+    parallel $ describe "Text Roundtrip" $ do
+        textRoundtrip $ Proxy @DerivationIndex
 
     parallel $ describe "MkSomeMnemonic" $ do
         let noInDictErr =
@@ -221,42 +209,6 @@ spec = do
         it "XPub IcarusKey"
             (property $ prop_roundtripXPub @IcarusKey)
 
-    parallel $ describe "golden test legacy passphrase encryption" $ do
-        it "compare new implementation with cardano-sl - short password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "patate"
-            let hash = Hash $ unsafeFromHex
-                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
-                    \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
-                    \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
-                    \414941366a515867386539493d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - normal password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
-            let hash = Hash $ unsafeFromHex
-                    "31347c387c317c714968506842665966555a336f5156434c384449744b\
-                    \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
-                    \4232766b4475682f704265335569694577633364385845756f55737661\
-                    \42514e62464443353569474f4135736e453144326743346f47564c472b\
-                    \524331385958326c6863552f36687a38432f496172773d3d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - empty password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 ""
-            let hash = Hash $ unsafeFromHex
-                    "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
-                    \9663076657375724954796376766a793150554e377452673d3d7c54753\
-                    \434596d6e547957546c5759674a3164494f7974474a7842632b432f786\
-                    \2507657382b5135356a38303d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - cardano-wallet password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
-            let hash = Hash $ unsafeFromHex
-                    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
-                    \597a425834515177666475467578436b4d485569733d7c78324d646738\
-                    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
-                    \51303054356c654751794279732f7662753367526d726c316c657a7150\
-                    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-
 {-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
@@ -287,7 +239,7 @@ prop_roundtripEnumIndexSoft ix =
 
 prop_roundtripXPrv
     :: (PersistPrivateKey (k 'RootK), Eq (k 'RootK XPrv), Show (k 'RootK XPrv))
-    => (k 'RootK XPrv, Hash "encryption")
+    => (k 'RootK XPrv, PassphraseHash)
     -> Property
 prop_roundtripXPrv xpriv = do
     let xpriv' = (unsafeDeserializeXPrv . serializeXPrv) xpriv
@@ -303,47 +255,6 @@ prop_roundtripXPub
 prop_roundtripXPub key = do
     let key' = (unsafeDeserializeXPub . serializeXPub) key
     key' === key
-
-prop_passphraseRoundtrip
-    :: Passphrase "raw"
-    -> Property
-prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
-    hpwd <- encryptPassphrase (preparePassphrase EncryptWithPBKDF2 pwd)
-    checkPassphrase EncryptWithPBKDF2 pwd hpwd `shouldBe` Right ()
-
-prop_passphraseRoundtripFail
-    :: Passphrase "raw"
-    -> Passphrase "raw"
-    -> Property
-prop_passphraseRoundtripFail p p' =
-    p /= p' ==> monadicIO $ liftIO $ do
-        hp <- encryptPassphrase (preparePassphrase EncryptWithPBKDF2 p)
-        checkPassphrase EncryptWithPBKDF2 p' hp
-            `shouldBe` Left ErrWrongPassphrase
-
-prop_passphraseHashMalformed
-    :: PassphraseScheme
-    -> Passphrase "raw"
-    -> Property
-prop_passphraseHashMalformed scheme pwd = monadicIO $ liftIO $ do
-    checkPassphrase scheme pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
-
-prop_passphraseFromScryptRoundtrip
-    :: Passphrase "raw"
-    -> Property
-prop_passphraseFromScryptRoundtrip p = monadicIO $ liftIO $ do
-    hp <- encryptPasswordWithScrypt p
-    checkPassphrase EncryptWithScrypt p hp `shouldBe` Right ()
-
-prop_passphraseFromScryptRoundtripFail
-    :: Passphrase "raw"
-    -> Passphrase "raw"
-    -> Property
-prop_passphraseFromScryptRoundtripFail p p' =
-    p /= p' ==> monadicIO $ liftIO $ do
-        hp <- encryptPasswordWithScrypt p
-        checkPassphrase EncryptWithScrypt p' hp
-            `shouldBe` Left ErrWrongPassphrase
 
 {-------------------------------------------------------------------------------
                              Arbitrary Instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/RandomSpec.hs
@@ -26,7 +26,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , Index (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
     , WalletKey (..)
     , liftIndex
@@ -43,6 +42,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( GenChange (..), IsOurs (..), IsOwned (..), KnownAddresses (..) )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( RndState (..), findUnusedPath, mkRndState )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -24,10 +24,7 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , DerivationType (..)
     , Index
     , NetworkDiscriminant (..)
-    , Passphrase (..)
     , PaymentAddress (..)
-    , passphraseMaxLength
-    , passphraseMinLength
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
@@ -36,6 +33,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..), knownAddresses )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( mkRndState )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), passphraseMaxLength, passphraseMinLength )
 import Control.Monad
     ( replicateM )
 import Data.Maybe
@@ -126,9 +125,9 @@ genRootKeys = do
 instance Show XPrv where
     show = show . CC.unXPrv
 
-instance {-# OVERLAPS #-} Arbitrary (Passphrase "encryption") where
+instance {-# OVERLAPS #-} Arbitrary (Passphrase "user") where
     arbitrary = do
-        let p = Proxy :: Proxy "raw"
+        let p = Proxy :: Proxy "lenient"
         n <- choose (passphraseMinLength p, passphraseMaxLength p)
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscoverySpec.hs
@@ -33,8 +33,13 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     ( IsOurs (..), knownAddresses )
 import Cardano.Wallet.Primitive.AddressDiscovery.Random
     ( mkRndState )
-import Cardano.Wallet.Primitive.Passphrase.Types
-    ( Passphrase (..), passphraseMaxLength, passphraseMinLength )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..)
+    , PassphraseScheme (EncryptWithPBKDF2)
+    , passphraseMaxLength
+    , passphraseMinLength
+    , preparePassphrase
+    )
 import Control.Monad
     ( replicateM )
 import Data.Maybe
@@ -109,6 +114,10 @@ instance Arbitrary (Index 'WholeDomain 'AddressK) where
 instance Arbitrary (ByronKey 'RootK XPrv) where
     shrink _ = []
     arbitrary = genRootKeys
+
+instance Arbitrary (Passphrase "encryption") where
+    arbitrary = preparePassphrase EncryptWithPBKDF2
+        <$> arbitrary @(Passphrase "user")
 
 genRootKeys :: Gen (ByronKey 'RootK XPrv)
 genRootKeys = do

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
@@ -1,0 +1,61 @@
+module Cardano.Wallet.Primitive.Passphrase.LegacySpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Test.Hspec (Spec, it, describe, shouldBe)
+import Cardano.Wallet.Unsafe (unsafeFromHex)
+import Cardano.Wallet.Primitive.Passphrase.Legacy
+import Cardano.Wallet.Primitive.Passphrase.Types (Passphrase (..), PassphraseHash (..))
+
+import qualified Data.ByteArray as BA
+
+spec :: Spec
+spec = describe "Scrypt tests-only cryptonite version" $ do
+    it "Verify passphrase" $ do
+        checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
+            fixturePassphraseEncrypted `shouldBe` True
+    it "Verify wrong passphrase" $ do
+        checkPassphraseTestingOnly (preparePassphrase fixturePassphraseWrong)
+            fixturePassphraseEncrypted `shouldBe` False
+    it "Verify wrong salt" $ do
+        checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
+            fixturePassphraseEncryptedWrongSalt `shouldBe` False
+    it "Verify wrong hash" $ do
+        checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
+            fixturePassphraseEncryptedWrongHash `shouldBe` False
+    it "getSalt" $ do
+        getSalt fixturePassphraseEncrypted `shouldBe` Just (Passphrase "abc")
+
+-- | Default passphrase used for fixture wallets
+fixturePassphrase :: Passphrase "user"
+fixturePassphrase = Passphrase "cardano-wallet"
+
+fixturePassphraseWrong :: Passphrase "user"
+fixturePassphraseWrong = Passphrase "wrong"
+
+-- | fixturePassphrase encrypted by Scrypt function
+fixturePassphraseEncrypted :: PassphraseHash
+fixturePassphraseEncrypted = PassphraseHash $ BA.convert $ unsafeFromHex
+    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
+    \597a425834515177666475467578436b4d485569733d7c78324d646738\
+    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
+    \51303054356c654751794279732f7662753367526d726c316c657a7150\
+    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
+
+fixturePassphraseEncryptedWrongSalt :: PassphraseHash
+fixturePassphraseEncryptedWrongSalt = PassphraseHash $ BA.convert $ unsafeFromHex
+    "31347c387c317c206a6f747446495a6a566d586f43374c6c54425a576c\
+    \597a425834515177666475467578436b4d485569733d7c78324d646738\
+    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
+    \51303054356c654751794279732f7662753367526d726c316c657a7150\
+    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
+
+fixturePassphraseEncryptedWrongHash :: PassphraseHash
+fixturePassphraseEncryptedWrongHash = PassphraseHash $ BA.convert $ unsafeFromHex
+    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
+    \597a425834515177666475467578436b4d485569733d7c78324d646738\
+    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
+    \51303054356c654751794279732f7662753367526d726c316c657a7150\
+    \43676d364e6758476d4d2f4b6438343265304b4945773d30"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
@@ -1,13 +1,18 @@
+{-# LANGUAGE DataKinds #-}
 module Cardano.Wallet.Primitive.Passphrase.LegacySpec
     ( spec
     ) where
 
 import Prelude
 
-import Test.Hspec (Spec, it, describe, shouldBe)
-import Cardano.Wallet.Unsafe (unsafeFromHex)
 import Cardano.Wallet.Primitive.Passphrase.Legacy
-import Cardano.Wallet.Primitive.Passphrase.Types (Passphrase (..), PassphraseHash (..))
+    ( checkPassphraseTestingOnly, getSalt, preparePassphrase )
+import Cardano.Wallet.Primitive.Passphrase.Types
+    ( Passphrase (..), PassphraseHash (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe )
 
 import qualified Data.ByteArray as BA
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
@@ -35,6 +35,10 @@ import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Monad.IO.Class
     ( liftIO )
+import Data.ByteArray
+    ( ByteArray )
+import Data.ByteArray.Encoding
+    ( Base (..), convertToBase )
 import Data.ByteString
     ( ByteString )
 import GHC.Stack
@@ -48,17 +52,27 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic
     ( monadicIO )
 
-import qualified Data.ByteArray as BA
-import qualified Data.Text.Encoding as T
-
-
 spec :: Spec
-spec = onlyWithScrypt $ describe "Scrypt tests-only cryptonite version" $ do
+spec = parallel $ do
+    scryptoniteSpec
+    onlyWithScrypt $ do
+        scryptPropsSpec
+        scryptGoldenSpec
+
+onlyWithScrypt :: HasCallStack => Spec -> Spec
+onlyWithScrypt =
+    if haveScrypt
+    then id
+    else before_ (pendingWith "needs to be compiled with scrypt to run")
+
+{-------------------------------------------------------------------------------
+                        Cryptonite-based implementation
+-------------------------------------------------------------------------------}
+
+scryptoniteSpec :: Spec
+scryptoniteSpec = describe "Scrypt tests-only cryptonite version" $ do
     it "Verify passphrase" $ do
         let Just salt = getSalt fixturePassphraseEncrypted
-        let
-            unwrap :: PassphraseHash -> ByteString
-            unwrap (PassphraseHash x) = BA.convert x
         let x = encryptPassphraseTestingOnly
                 (preparePassphrase fixturePassphrase)
                 salt
@@ -79,63 +93,13 @@ spec = onlyWithScrypt $ describe "Scrypt tests-only cryptonite version" $ do
         checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
             fixturePassphraseEncryptedWrongHash `shouldBe` False
     it "getSalt" $ do
-        let
-            unwrap :: Passphrase "salt" -> ByteString
-            unwrap (Passphrase x) = BA.convert x
-        unwrap <$> (getSalt fixturePassphraseEncrypted)
-            `shouldBe` Just "\250:-\180R\EM\141Y\151\160.\203\149\&0YZV3\ENQ~\
-                            \\DLEC\a\221\184[\177\nC\aR+"
+        let hex :: Passphrase "salt" -> ByteString
+            hex = convertToBase Base16 . unPassphrase
+        hex <$> (getSalt fixturePassphraseEncrypted)
+            `shouldBe` Just "fa3a2db452198d5997a02ecb9530595a5633057e104307ddb85bb10a4307522b"
 
-    it "checkPassphrase p h(p) == Right () for Scrypt passwords" $
-        property prop_passphraseFromScryptRoundtrip
-    it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase for Scrypt passwords" $
-        property prop_passphraseFromScryptRoundtripFail
-
-    parallel $ describe "golden test legacy passphrase encryption" $ do
-        it "compare new implementation with cardano-sl - short password" $ do
-            let pwd  = Passphrase $ BA.convert $ T.encodeUtf8 "patate"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
-                    [ "31347c387c317c574342652b796362417576356c2b4258676a344a314c"
-                    , "6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37"
-                    , "6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45"
-                    , "414941366a515867386539493d"
-                    ]
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - normal password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
-                    [ "31347c387c317c714968506842665966555a336f5156434c384449744b"
-                    , "677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30"
-                    , "4232766b4475682f704265335569694577633364385845756f55737661"
-                    , "42514e62464443353569474f4135736e453144326743346f47564c472b"
-                    , "524331385958326c6863552f36687a38432f496172773d3d"
-                    ]
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - empty password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 ""
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
-                    [ "31347c387c317c5743424875746242496c6a66734d764934314a30727a7"
-                    , "9663076657375724954796376766a793150554e377452673d3d7c54753"
-                    , "434596d6e547957546c5759674a3164494f7974474a7842632b432f786"
-                    , "2507657382b5135356a38303d"
-                    ]
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - cardano-wallet password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
-                    [ "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c"
-                    , "597a425834515177666475467578436b4d485569733d7c78324d646738"
-                    , "49554a3232507235676531393575445a76583646552b7757395a6a6a2f"
-                    , "51303054356c654751794279732f7662753367526d726c316c657a7150"
-                    , "43676d364e6758476d4d2f4b6438343265304b4945773d3d"
-                    ]
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-
-onlyWithScrypt :: HasCallStack => Spec -> Spec
-onlyWithScrypt =
-    if haveScrypt
-    then id
-    else before_ (pendingWith "needs to be compiled with scrypt to run")
+unwrap :: ByteArray b => b -> ByteString
+unwrap = convertToBase Base16
 
 -- | Default passphrase used for fixture wallets
 fixturePassphrase :: Passphrase "user"
@@ -146,7 +110,7 @@ fixturePassphraseWrong = Passphrase "wrong"
 
 -- | fixturePassphrase encrypted by Scrypt function
 fixturePassphraseEncrypted :: PassphraseHash
-fixturePassphraseEncrypted = PassphraseHash $ BA.convert $ unsafeFromHex
+fixturePassphraseEncrypted = unsafeFromHex
     "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
     \597a425834515177666475467578436b4d485569733d7c78324d646738\
     \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
@@ -154,7 +118,7 @@ fixturePassphraseEncrypted = PassphraseHash $ BA.convert $ unsafeFromHex
     \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
 
 fixturePassphraseEncryptedWrongSalt :: PassphraseHash
-fixturePassphraseEncryptedWrongSalt = PassphraseHash $ BA.convert $ unsafeFromHex
+fixturePassphraseEncryptedWrongSalt = unsafeFromHex
     "31347c387c317c206a6f747446495a6a566d586f43374c6c54425a576c\
     \597a425834515177666475467578436b4d485569733d7c78324d646738\
     \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
@@ -162,7 +126,7 @@ fixturePassphraseEncryptedWrongSalt = PassphraseHash $ BA.convert $ unsafeFromHe
     \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
 
 fixturePassphraseEncryptedWrongHash :: PassphraseHash
-fixturePassphraseEncryptedWrongHash = PassphraseHash $ BA.convert $ unsafeFromHex
+fixturePassphraseEncryptedWrongHash = unsafeFromHex
     "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
     \597a425834515177666475467578436b4d485569733d7c78324d646738\
     \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
@@ -170,8 +134,60 @@ fixturePassphraseEncryptedWrongHash = PassphraseHash $ BA.convert $ unsafeFromHe
     \43676d364e6758476d4d2f4b6438343265304b4945773d30"
 
 {-------------------------------------------------------------------------------
+                                  Golden Tests
+-------------------------------------------------------------------------------}
+
+scryptGoldenSpec :: Spec
+scryptGoldenSpec =
+    describe "golden tests comparing this implementation with cardano-sl" $ do
+        it "short password" $ do
+            let pwd  = Passphrase "patate"
+            let hash = unsafeFromHex
+                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
+                    \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
+                    \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
+                    \414941366a515867386539493d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+        it "normal password" $ do
+            let pwd  = Passphrase @"user" "Secure Passphrase"
+            let hash = unsafeFromHex
+                    "31347c387c317c714968506842665966555a336f5156434c384449744b\
+                    \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
+                    \4232766b4475682f704265335569694577633364385845756f55737661\
+                    \42514e62464443353569474f4135736e453144326743346f47564c472b\
+                    \524331385958326c6863552f36687a38432f496172773d3d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+        it "empty password" $ do
+            let pwd  = Passphrase @"user" ""
+            let hash = unsafeFromHex
+                    "31347c387c317c5743424875746242496c6a66734d764934314a30727a\
+                    \79663076657375724954796376766a793150554e377452673d3d7c5475\
+                    \3434596d6e547957546c5759674a3164494f7974474a7842632b432f78\
+                    \62507657382b5135356a38303d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+        it "cardano-wallet password" $ do
+            let pwd  = Passphrase @"user" "cardano-wallet"
+            let hash = unsafeFromHex
+                    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
+                    \597a425834515177666475467578436b4d485569733d7c78324d646738\
+                    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
+                    \51303054356c654751794279732f7662753367526d726c316c657a7150\
+                    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+{-------------------------------------------------------------------------------
                                Properties
 -------------------------------------------------------------------------------}
+
+scryptPropsSpec :: Spec
+scryptPropsSpec = describe "Legacy scrypt password encryption" $ do
+    it "checkPassphrase p h(p) == Right ()" $
+        property prop_passphraseFromScryptRoundtrip
+    it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
+        property prop_passphraseFromScryptRoundtripFail
 
 prop_passphraseFromScryptRoundtrip
     :: Passphrase "user"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Passphrase/LegacySpec.hs
@@ -1,23 +1,54 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Cardano.Wallet.Primitive.Passphrase.LegacySpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Passphrase
+    ( ErrWrongPassphrase (ErrWrongPassphrase)
+    , PassphraseScheme (EncryptWithScrypt)
+    , checkPassphrase
+    , encryptPassphrase'
+    )
+import Cardano.Wallet.Primitive.Passphrase.Gen
+    ( genEncryptionPassphrase
+    , genPassphraseScheme
+    , genUserPassphrase
+    , shrinkUserPassphrase
+    )
 import Cardano.Wallet.Primitive.Passphrase.Legacy
-    ( checkPassphraseTestingOnly, getSalt, preparePassphrase )
+    ( checkPassphraseTestingOnly, getSalt, haveScrypt, preparePassphrase )
 import Cardano.Wallet.Primitive.Passphrase.Types
     ( Passphrase (..), PassphraseHash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Data.ByteString
+    ( ByteString )
+import GHC.Stack
+    ( HasCallStack )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe )
+    ( Spec, before_, describe, it, pendingWith, shouldBe )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, property, (==>) )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
 
 import qualified Data.ByteArray as BA
+import qualified Data.Text.Encoding as T
+
 
 spec :: Spec
-spec = describe "Scrypt tests-only cryptonite version" $ do
+spec = onlyWithScrypt $ describe "Scrypt tests-only cryptonite version" $ do
     it "Verify passphrase" $ do
         checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
             fixturePassphraseEncrypted `shouldBe` True
@@ -31,7 +62,61 @@ spec = describe "Scrypt tests-only cryptonite version" $ do
         checkPassphraseTestingOnly (preparePassphrase fixturePassphrase)
             fixturePassphraseEncryptedWrongHash `shouldBe` False
     it "getSalt" $ do
-        getSalt fixturePassphraseEncrypted `shouldBe` Just (Passphrase "abc")
+        let
+            unwrap :: Passphrase "salt" -> ByteString
+            unwrap (Passphrase x) = BA.convert x
+        unwrap <$> (getSalt fixturePassphraseEncrypted)  `shouldBe` (Just "abc")
+
+    it "checkPassphrase p h(p) == Right () for Scrypt passwords" $
+        property prop_passphraseFromScryptRoundtrip
+    it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase for Scrypt passwords" $
+        property prop_passphraseFromScryptRoundtripFail
+
+    parallel $ describe "golden test legacy passphrase encryption" $ do
+        it "compare new implementation with cardano-sl - short password" $ do
+            let pwd  = Passphrase $ BA.convert $ T.encodeUtf8 "patate"
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
+                    [ "31347c387c317c574342652b796362417576356c2b4258676a344a314c"
+                    , "6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37"
+                    , "6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45"
+                    , "414941366a515867386539493d"
+                    ]
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - normal password" $ do
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
+                    [ "31347c387c317c714968506842665966555a336f5156434c384449744b"
+                    , "677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30"
+                    , "4232766b4475682f704265335569694577633364385845756f55737661"
+                    , "42514e62464443353569474f4135736e453144326743346f47564c472b"
+                    , "524331385958326c6863552f36687a38432f496172773d3d"
+                    ]
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - empty password" $ do
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 ""
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
+                    [ "31347c387c317c5743424875746242496c6a66734d764934314a30727a7"
+                    , "9663076657375724954796376766a793150554e377452673d3d7c54753"
+                    , "434596d6e547957546c5759674a3164494f7974474a7842632b432f786"
+                    , "2507657382b5135356a38303d"
+                    ]
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - cardano-wallet password" $ do
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex $ mconcat
+                    [ "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c"
+                    , "597a425834515177666475467578436b4d485569733d7c78324d646738"
+                    , "49554a3232507235676531393575445a76583646552b7757395a6a6a2f"
+                    , "51303054356c654751794279732f7662753367526d726c316c657a7150"
+                    , "43676d364e6758476d4d2f4b6438343265304b4945773d3d"
+                    ]
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+onlyWithScrypt :: HasCallStack => Spec -> Spec
+onlyWithScrypt =
+    if haveScrypt
+    then id
+    else before_ (pendingWith "needs to be compiled with scrypt to run")
 
 -- | Default passphrase used for fixture wallets
 fixturePassphrase :: Passphrase "user"
@@ -64,3 +149,40 @@ fixturePassphraseEncryptedWrongHash = PassphraseHash $ BA.convert $ unsafeFromHe
     \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
     \51303054356c654751794279732f7662753367526d726c316c657a7150\
     \43676d364e6758476d4d2f4b6438343265304b4945773d30"
+
+{-------------------------------------------------------------------------------
+                               Properties
+-------------------------------------------------------------------------------}
+
+prop_passphraseFromScryptRoundtrip
+    :: Passphrase "user"
+    -> Property
+prop_passphraseFromScryptRoundtrip p = monadicIO $ liftIO $ do
+    hp <- encryptPasswordWithScrypt p
+    checkPassphrase EncryptWithScrypt p hp `shouldBe` Right ()
+
+prop_passphraseFromScryptRoundtripFail
+    :: Passphrase "user"
+    -> Passphrase "user"
+    -> Property
+prop_passphraseFromScryptRoundtripFail p p' =
+    p /= p' ==> monadicIO $ liftIO $ do
+        hp <- encryptPasswordWithScrypt p
+        checkPassphrase EncryptWithScrypt p' hp
+            `shouldBe` Left ErrWrongPassphrase
+
+encryptPasswordWithScrypt
+    :: Passphrase "user"
+    -> IO PassphraseHash
+encryptPasswordWithScrypt = encryptPassphrase' EncryptWithScrypt
+
+
+instance Arbitrary (Passphrase "user") where
+    arbitrary = genUserPassphrase
+    shrink = shrinkUserPassphrase
+
+instance Arbitrary PassphraseScheme where
+    arbitrary = genPassphraseScheme
+
+instance Arbitrary (Passphrase "encryption") where
+    arbitrary = genEncryptionPassphrase

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -102,7 +102,7 @@ spec = do
                     \414941366a515867386539493d"
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - normal password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
             let hash = Hash $ unsafeFromHex
                     "31347c387c317c714968506842665966555a336f5156434c384449744b\
                     \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
@@ -111,7 +111,7 @@ spec = do
                     \524331385958326c6863552f36687a38432f496172773d3d"
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - empty password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 ""
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 ""
             let hash = Hash $ unsafeFromHex
                     "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
                     \9663076657375724954796376766a793150554e377452673d3d7c54753\
@@ -119,7 +119,7 @@ spec = do
                     \2507657382b5135356a38303d"
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - cardano-wallet password" $ do
-            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
+            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
             let hash = Hash $ unsafeFromHex
                     "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
                     \597a425834515177666475467578436b4d485569733d7c78324d646738\

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.PassphraseSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Gen
+    ( genMnemonic )
+import Cardano.Wallet.Primitive.Passphrase
+    ( ErrWrongPassphrase (..)
+    , Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , PassphraseScheme (..)
+    , checkPassphrase
+    , encryptPassphrase
+    , preparePassphrase
+    )
+import Cardano.Wallet.Primitive.Types.Hash
+    ( Hash (..) )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
+import Control.Monad
+    ( replicateM )
+import Control.Monad.IO.Class
+    ( liftIO )
+import Data.Either
+    ( isRight )
+import Data.Proxy
+    ( Proxy (..) )
+import Test.Hspec
+    ( Spec, describe, it, shouldBe, shouldSatisfy )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , InfiniteList (..)
+    , Property
+    , arbitraryBoundedEnum
+    , arbitraryPrintableChar
+    , arbitrarySizedBoundedIntegral
+    , choose
+    , expectFailure
+    , genericShrink
+    , oneof
+    , property
+    , (.&&.)
+    , (===)
+    , (==>)
+    )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary )
+import Test.QuickCheck.Monadic
+    ( monadicIO )
+import Test.Text.Roundtrip
+    ( textRoundtrip )
+
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Crypto.Scrypt as Scrypt
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+spec :: Spec
+spec = do
+    parallel $ describe "Text Roundtrip" $ do
+        textRoundtrip $ Proxy @(Passphrase "encryption")
+
+    parallel $ describe "Passphrases" $ do
+        it "checkPassphrase p h(p) == Right ()" $
+            property prop_passphraseRoundtrip
+        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
+            property prop_passphraseRoundtripFail
+        it "checkPassphrase fails when hash is malformed" $
+            property prop_passphraseHashMalformed
+        it "checkPassphrase p h(p) == Right () for Scrypt passwords" $
+            property prop_passphraseFromScryptRoundtrip
+        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase for Scrypt passwords" $
+            property prop_passphraseFromScryptRoundtripFail
+
+    parallel $ describe "golden test legacy passphrase encryption" $ do
+        it "compare new implementation with cardano-sl - short password" $ do
+            let pwd  = Passphrase $ BA.convert $ T.encodeUtf8 "patate"
+            let hash = PassphraseHash $ unsafeFromHex
+                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
+                    \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
+                    \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
+                    \414941366a515867386539493d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - normal password" $ do
+            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
+            let hash = Hash $ unsafeFromHex
+                    "31347c387c317c714968506842665966555a336f5156434c384449744b\
+                    \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
+                    \4232766b4475682f704265335569694577633364385845756f55737661\
+                    \42514e62464443353569474f4135736e453144326743346f47564c472b\
+                    \524331385958326c6863552f36687a38432f496172773d3d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - empty password" $ do
+            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 ""
+            let hash = Hash $ unsafeFromHex
+                    "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
+                    \9663076657375724954796376766a793150554e377452673d3d7c54753\
+                    \434596d6e547957546c5759674a3164494f7974474a7842632b432f786\
+                    \2507657382b5135356a38303d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+        it "compare new implementation with cardano-sl - cardano-wallet password" $ do
+            let pwd  = Passphrase @"raw" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
+            let hash = Hash $ unsafeFromHex
+                    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
+                    \597a425834515177666475467578436b4d485569733d7c78324d646738\
+                    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
+                    \51303054356c654751794279732f7662753367526d726c316c657a7150\
+                    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
+            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
+
+
+{-------------------------------------------------------------------------------
+                               Properties
+-------------------------------------------------------------------------------}
+
+prop_passphraseRoundtrip
+    :: Passphrase "encryption"
+    -> Property
+prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
+    (scheme, hpwd) <- encryptPassphrase pwd
+    scheme `shouldBe` EncryptWithPBKDF2
+    checkPassphrase EncryptWithPBKDF2 pwd hpwd `shouldBe` Right ()
+
+prop_passphraseRoundtripFail
+    :: Passphrase "encryption"
+    -> Passphrase "encryption"
+    -> Property
+prop_passphraseRoundtripFail p p' =
+    p /= p' ==> monadicIO $ do
+        (_scheme, hp) <- runIO $ encryptPassphrase p
+        checkPassphrase EncryptWithPBKDF2 p' hp
+            `shouldBe` Left ErrWrongPassphrase
+
+prop_passphraseHashMalformed
+    :: PassphraseScheme
+    -> Passphrase "encryption"
+    -> Property
+prop_passphraseHashMalformed scheme pwd =
+    checkPassphrase scheme pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
+
+prop_passphraseFromScryptRoundtrip
+    :: Passphrase "encryption"
+    -> Property
+prop_passphraseFromScryptRoundtrip p = monadicIO $ liftIO $ do
+    hp <- encryptPasswordWithScrypt p
+    checkPassphrase EncryptWithScrypt p hp `shouldBe` Right ()
+
+prop_passphraseFromScryptRoundtripFail
+    :: Passphrase "encryption"
+    -> Passphrase "encryption"
+    -> Property
+prop_passphraseFromScryptRoundtripFail p p' =
+    p /= p' ==> monadicIO $ liftIO $ do
+        hp <- encryptPasswordWithScrypt p
+        checkPassphrase EncryptWithScrypt p' hp
+            `shouldBe` Left ErrWrongPassphrase

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -14,63 +14,47 @@ module Cardano.Wallet.Primitive.PassphraseSpec
 
 import Prelude
 
-import Cardano.Wallet.Gen
-    ( genMnemonic )
 import Cardano.Wallet.Primitive.Passphrase
     ( ErrWrongPassphrase (..)
     , Passphrase (..)
+    , PassphraseHash (..)
     , PassphraseMaxLength (..)
     , PassphraseMinLength (..)
     , PassphraseScheme (..)
     , checkPassphrase
     , encryptPassphrase
+    , encryptPassphrase'
     , preparePassphrase
     )
-import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
 import Cardano.Wallet.Unsafe
     ( unsafeFromHex )
 import Control.Monad
     ( replicateM )
 import Control.Monad.IO.Class
     ( liftIO )
-import Data.Either
-    ( isRight )
 import Data.Proxy
     ( Proxy (..) )
 import Test.Hspec
-    ( Spec, describe, it, shouldBe, shouldSatisfy )
+    ( Spec, describe, it, shouldBe )
 import Test.Hspec.Extra
     ( parallel )
 import Test.QuickCheck
     ( Arbitrary (..)
-    , Gen
-    , InfiniteList (..)
     , Property
-    , arbitraryBoundedEnum
     , arbitraryPrintableChar
-    , arbitrarySizedBoundedIntegral
     , choose
-    , expectFailure
-    , genericShrink
-    , oneof
     , property
-    , (.&&.)
     , (===)
     , (==>)
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary )
 import Test.QuickCheck.Monadic
-    ( monadicIO )
+    ( assert, monadicIO, run )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
-import qualified Codec.CBOR.Encoding as CBOR
-import qualified Codec.CBOR.Write as CBOR
-import qualified Crypto.Scrypt as Scrypt
 import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
@@ -78,7 +62,7 @@ import qualified Data.Text.Encoding as T
 spec :: Spec
 spec = do
     parallel $ describe "Text Roundtrip" $ do
-        textRoundtrip $ Proxy @(Passphrase "encryption")
+        textRoundtrip $ Proxy @(Passphrase "user")
 
     parallel $ describe "Passphrases" $ do
         it "checkPassphrase p h(p) == Right ()" $
@@ -95,7 +79,7 @@ spec = do
     parallel $ describe "golden test legacy passphrase encryption" $ do
         it "compare new implementation with cardano-sl - short password" $ do
             let pwd  = Passphrase $ BA.convert $ T.encodeUtf8 "patate"
-            let hash = PassphraseHash $ unsafeFromHex
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
                     "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
                     \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
                     \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
@@ -103,7 +87,7 @@ spec = do
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - normal password" $ do
             let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
-            let hash = Hash $ unsafeFromHex
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
                     "31347c387c317c714968506842665966555a336f5156434c384449744b\
                     \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
                     \4232766b4475682f704265335569694577633364385845756f55737661\
@@ -112,7 +96,7 @@ spec = do
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - empty password" $ do
             let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 ""
-            let hash = Hash $ unsafeFromHex
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
                     "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
                     \9663076657375724954796376766a793150554e377452673d3d7c54753\
                     \434596d6e547957546c5759674a3164494f7974474a7842632b432f786\
@@ -120,7 +104,7 @@ spec = do
             checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
         it "compare new implementation with cardano-sl - cardano-wallet password" $ do
             let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
-            let hash = Hash $ unsafeFromHex
+            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
                     "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
                     \597a425834515177666475467578436b4d485569733d7c78324d646738\
                     \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
@@ -134,7 +118,7 @@ spec = do
 -------------------------------------------------------------------------------}
 
 prop_passphraseRoundtrip
-    :: Passphrase "encryption"
+    :: Passphrase "user"
     -> Property
 prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
     (scheme, hpwd) <- encryptPassphrase pwd
@@ -142,35 +126,64 @@ prop_passphraseRoundtrip pwd = monadicIO $ liftIO $ do
     checkPassphrase EncryptWithPBKDF2 pwd hpwd `shouldBe` Right ()
 
 prop_passphraseRoundtripFail
-    :: Passphrase "encryption"
-    -> Passphrase "encryption"
+    :: Passphrase "user"
+    -> Passphrase "user"
     -> Property
 prop_passphraseRoundtripFail p p' =
     p /= p' ==> monadicIO $ do
-        (_scheme, hp) <- runIO $ encryptPassphrase p
-        checkPassphrase EncryptWithPBKDF2 p' hp
-            `shouldBe` Left ErrWrongPassphrase
+        (_scheme, hp) <- run $ encryptPassphrase p
+        assert $ checkPassphrase EncryptWithPBKDF2 p' hp
+            == Left ErrWrongPassphrase
 
 prop_passphraseHashMalformed
     :: PassphraseScheme
-    -> Passphrase "encryption"
+    -> Passphrase "user"
     -> Property
 prop_passphraseHashMalformed scheme pwd =
-    checkPassphrase scheme pwd (Hash mempty) `shouldBe` Left ErrWrongPassphrase
+    checkPassphrase scheme pwd (PassphraseHash mempty) === Left ErrWrongPassphrase
 
 prop_passphraseFromScryptRoundtrip
-    :: Passphrase "encryption"
+    :: Passphrase "user"
     -> Property
 prop_passphraseFromScryptRoundtrip p = monadicIO $ liftIO $ do
     hp <- encryptPasswordWithScrypt p
     checkPassphrase EncryptWithScrypt p hp `shouldBe` Right ()
 
 prop_passphraseFromScryptRoundtripFail
-    :: Passphrase "encryption"
-    -> Passphrase "encryption"
+    :: Passphrase "user"
+    -> Passphrase "user"
     -> Property
 prop_passphraseFromScryptRoundtripFail p p' =
     p /= p' ==> monadicIO $ liftIO $ do
         hp <- encryptPasswordWithScrypt p
         checkPassphrase EncryptWithScrypt p' hp
             `shouldBe` Left ErrWrongPassphrase
+
+encryptPasswordWithScrypt
+    :: Passphrase "user"
+    -> IO PassphraseHash
+encryptPasswordWithScrypt = encryptPassphrase' EncryptWithScrypt
+
+instance Arbitrary (Passphrase "user") where
+    arbitrary = do
+        n <- choose (passphraseMinLength p, passphraseMaxLength p)
+        bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
+        return $ Passphrase $ BA.convert bytes
+      where p = Proxy :: Proxy "user"
+
+    shrink (Passphrase bytes)
+        | BA.length bytes <= passphraseMinLength p = []
+        | otherwise =
+            [ Passphrase
+            $ BA.convert
+            $ B8.take (passphraseMinLength p)
+            $ BA.convert bytes
+            ]
+      where p = Proxy :: Proxy "user"
+
+instance Arbitrary PassphraseScheme where
+    arbitrary = genericArbitrary
+
+instance Arbitrary (Passphrase "encryption") where
+    arbitrary = preparePassphrase EncryptWithPBKDF2
+        <$> arbitrary @(Passphrase "user")

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -31,6 +31,8 @@ import Cardano.Wallet.Primitive.Passphrase.Gen
     )
 import Cardano.Wallet.Primitive.Passphrase.Legacy
     ( haveScrypt )
+import Cardano.Wallet.Unsafe
+    ( unsafeFromHex )
 import Control.Monad.IO.Class
     ( liftIO )
 import Data.ByteString
@@ -51,11 +53,11 @@ import Test.Text.Roundtrip
 import qualified Data.ByteArray as BA
 
 spec :: Spec
-spec = do
-    parallel $ describe "Text Roundtrip" $ do
+spec = parallel $ do
+    describe "Text Roundtrip" $ do
         textRoundtrip $ Proxy @(Passphrase "user")
 
-    parallel $ describe "Passphrases" $ do
+    describe "Passphrases" $ do
         it "checkPassphrase p h(p) == Right ()" $
             property prop_passphraseRoundtrip
         it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase" $
@@ -156,20 +158,18 @@ passphraseGolden1 :: Golden
 passphraseGolden1 = Golden
     { passphrase = Passphrase "passphrase"
     , prepared = Passphrase "passphrase"
-    , hash = PassphraseHash
-        "\SI\133\128\ESC#\211\232\218\ESC\134>\216\216H\235\206\206\211\134'\
-        \\135\253\237\244\226\143\SYN\239!}\247\172\168\CAN\212\DC1\SI\255\235\
-        \\215\241\DC4\181\133\177\232=\190\154\249\ETB\EOTd\176\149\249\216\133\
-        \\141\188P\188s\159q\250\159^dj\STX\ACK$O@\208\138\236wp"
+    , hash = unsafeFromHex
+        "0f85801b23d3e8da1b863ed8d848ebceced3862787fdedf4e28f16ef217df7ac\
+        \a818d4110fffebd7f114b585b1e83dbe9af9170464b095f9d8858dbc50bc739f\
+        \71fa9f5e646a0206244f40d08aec7770"
     }
 
 passphraseGolden2 :: Golden
 passphraseGolden2 = Golden
     { passphrase = Passphrase ""
     , prepared = Passphrase ""
-    , hash = PassphraseHash
-        "\SI\133\128\ESC#\211\232\218\ESC\134>\216\216H\235\206\130\173|\250\
-        \\215\130\227^\155\216\176\NUL\145p\190P\CAN\254\155\190\140\DLE\208\
-        \\194\207)X\171p*Y\170\192eiZ\243\\\222Mr\174\av\NAK\238\183\DC2\156\
-        \\203\196\156,,\245X\161\242\160\148\217k\EM\234"
+    , hash = unsafeFromHex
+        "0f85801b23d3e8da1b863ed8d848ebce82ad7cfad782e35e9bd8b0009170be50\
+        \18fe9bbe8c10d0c2cf2958ab702a59aac065695af35cde4d72ae077615eeb712\
+        \9ccbc49c2c2cf558a1f2a094d96b19ea"
     }

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
@@ -18,18 +19,18 @@ import Cardano.Wallet.Primitive.Passphrase
     ( ErrWrongPassphrase (..)
     , Passphrase (..)
     , PassphraseHash (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
     , PassphraseScheme (..)
     , checkPassphrase
     , encryptPassphrase
-    , encryptPassphrase'
-    , preparePassphrase
     )
-import Cardano.Wallet.Unsafe
-    ( unsafeFromHex )
-import Control.Monad
-    ( replicateM )
+import Cardano.Wallet.Primitive.Passphrase.Gen
+    ( genEncryptionPassphrase
+    , genPassphraseScheme
+    , genUserPassphrase
+    , shrinkUserPassphrase
+    )
+import Cardano.Wallet.Primitive.Passphrase.Legacy
+    ( haveScrypt )
 import Control.Monad.IO.Class
     ( liftIO )
 import Data.Proxy
@@ -39,25 +40,12 @@ import Test.Hspec
 import Test.Hspec.Extra
     ( parallel )
 import Test.QuickCheck
-    ( Arbitrary (..)
-    , Property
-    , arbitraryPrintableChar
-    , choose
-    , property
-    , (===)
-    , (==>)
-    )
-import Test.QuickCheck.Arbitrary.Generic
-    ( genericArbitrary )
+    ( Arbitrary (..), Property, counterexample, property, (===), (==>) )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, run )
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
-import qualified Data.ByteArray as BA
-import qualified Data.ByteString.Char8 as B8
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 
 spec :: Spec
 spec = do
@@ -71,47 +59,6 @@ spec = do
             property prop_passphraseRoundtripFail
         it "checkPassphrase fails when hash is malformed" $
             property prop_passphraseHashMalformed
-        it "checkPassphrase p h(p) == Right () for Scrypt passwords" $
-            property prop_passphraseFromScryptRoundtrip
-        it "p /= p' => checkPassphrase p' h(p) == Left ErrWrongPassphrase for Scrypt passwords" $
-            property prop_passphraseFromScryptRoundtripFail
-
-    parallel $ describe "golden test legacy passphrase encryption" $ do
-        it "compare new implementation with cardano-sl - short password" $ do
-            let pwd  = Passphrase $ BA.convert $ T.encodeUtf8 "patate"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
-                    "31347c387c317c574342652b796362417576356c2b4258676a344a314c\
-                    \6343675375414c2f5653393661364e576a2b7550766655513d3d7c2f37\
-                    \6738486c59723174734e394f6e4e753253302b6a65515a6b5437316b45\
-                    \414941366a515867386539493d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - normal password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "Secure Passphrase"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
-                    "31347c387c317c714968506842665966555a336f5156434c384449744b\
-                    \677642417a6c584d62314d6d4267695433776a556f3d7c53672b436e30\
-                    \4232766b4475682f704265335569694577633364385845756f55737661\
-                    \42514e62464443353569474f4135736e453144326743346f47564c472b\
-                    \524331385958326c6863552f36687a38432f496172773d3d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - empty password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 ""
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
-                    "31347c387c317c5743424875746242496c6a66734d764934314a30727a7\
-                    \9663076657375724954796376766a793150554e377452673d3d7c54753\
-                    \434596d6e547957546c5759674a3164494f7974474a7842632b432f786\
-                    \2507657382b5135356a38303d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-        it "compare new implementation with cardano-sl - cardano-wallet password" $ do
-            let pwd  = Passphrase @"user" $ BA.convert $ T.encodeUtf8 "cardano-wallet"
-            let hash = PassphraseHash $ BA.convert $ unsafeFromHex
-                    "31347c387c317c2b6a6f747446495a6a566d586f43374c6c54425a576c\
-                    \597a425834515177666475467578436b4d485569733d7c78324d646738\
-                    \49554a3232507235676531393575445a76583646552b7757395a6a6a2f\
-                    \51303054356c654751794279732f7662753367526d726c316c657a7150\
-                    \43676d364e6758476d4d2f4b6438343265304b4945773d3d"
-            checkPassphrase EncryptWithScrypt pwd hash `shouldBe` Right ()
-
 
 {-------------------------------------------------------------------------------
                                Properties
@@ -140,50 +87,19 @@ prop_passphraseHashMalformed
     -> Passphrase "user"
     -> Property
 prop_passphraseHashMalformed scheme pwd =
-    checkPassphrase scheme pwd (PassphraseHash mempty) === Left ErrWrongPassphrase
-
-prop_passphraseFromScryptRoundtrip
-    :: Passphrase "user"
-    -> Property
-prop_passphraseFromScryptRoundtrip p = monadicIO $ liftIO $ do
-    hp <- encryptPasswordWithScrypt p
-    checkPassphrase EncryptWithScrypt p hp `shouldBe` Right ()
-
-prop_passphraseFromScryptRoundtripFail
-    :: Passphrase "user"
-    -> Passphrase "user"
-    -> Property
-prop_passphraseFromScryptRoundtripFail p p' =
-    p /= p' ==> monadicIO $ liftIO $ do
-        hp <- encryptPasswordWithScrypt p
-        checkPassphrase EncryptWithScrypt p' hp
-            `shouldBe` Left ErrWrongPassphrase
-
-encryptPasswordWithScrypt
-    :: Passphrase "user"
-    -> IO PassphraseHash
-encryptPasswordWithScrypt = encryptPassphrase' EncryptWithScrypt
+    counterexample ("haveScrypt = " <> show haveScrypt) $
+    checkPassphrase scheme pwd (PassphraseHash mempty)
+        === if not haveScrypt && scheme == EncryptWithScrypt
+            then Left $ ErrPassphraseSchemeUnsupported EncryptWithScrypt
+            else Left ErrWrongPassphrase
 
 instance Arbitrary (Passphrase "user") where
-    arbitrary = do
-        n <- choose (passphraseMinLength p, passphraseMaxLength p)
-        bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
-        return $ Passphrase $ BA.convert bytes
-      where p = Proxy :: Proxy "user"
-
-    shrink (Passphrase bytes)
-        | BA.length bytes <= passphraseMinLength p = []
-        | otherwise =
-            [ Passphrase
-            $ BA.convert
-            $ B8.take (passphraseMinLength p)
-            $ BA.convert bytes
-            ]
-      where p = Proxy :: Proxy "user"
+    arbitrary = genUserPassphrase
+    shrink = shrinkUserPassphrase
 
 instance Arbitrary PassphraseScheme where
-    arbitrary = genericArbitrary
+    arbitrary = genPassphraseScheme
 
 instance Arbitrary (Passphrase "encryption") where
-    arbitrary = preparePassphrase EncryptWithPBKDF2
-        <$> arbitrary @(Passphrase "user")
+    arbitrary = genEncryptionPassphrase
+

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/PassphraseSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
@@ -22,6 +21,7 @@ import Cardano.Wallet.Primitive.Passphrase
     , PassphraseScheme (..)
     , checkPassphrase
     , encryptPassphrase
+    , preparePassphrase
     )
 import Cardano.Wallet.Primitive.Passphrase.Gen
     ( genEncryptionPassphrase
@@ -33,6 +33,8 @@ import Cardano.Wallet.Primitive.Passphrase.Legacy
     ( haveScrypt )
 import Control.Monad.IO.Class
     ( liftIO )
+import Data.ByteString
+    ( ByteString )
 import Data.Proxy
     ( Proxy (..) )
 import Test.Hspec
@@ -46,6 +48,7 @@ import Test.QuickCheck.Monadic
 import Test.Text.Roundtrip
     ( textRoundtrip )
 
+import qualified Data.ByteArray as BA
 
 spec :: Spec
 spec = do
@@ -59,6 +62,9 @@ spec = do
             property prop_passphraseRoundtripFail
         it "checkPassphrase fails when hash is malformed" $
             property prop_passphraseHashMalformed
+        describe "EncryptWithPBKDF2 goldens" $ do
+            pbkdf2Golden passphraseGolden1
+            pbkdf2Golden passphraseGolden2
 
 {-------------------------------------------------------------------------------
                                Properties
@@ -116,3 +122,54 @@ whenSupported EncryptWithScrypt
     | otherwise
         = id
 
+pbkdf2Golden :: Golden -> Spec
+pbkdf2Golden g = describe ("passphrase = " <> show (unwrap (passphrase g))) $ do
+    it "preparePassphrase" $ do
+        unwrap (preparePassphrase EncryptWithPBKDF2 (passphrase g))
+            `shouldBe` unwrap (prepared g)
+    it "encryptPassphrase" $ do
+        unwrap (snd (encryptPassphrase (passphrase g) salt))
+            `shouldBe` unwrap (hash g)
+
+    it "checkPassphrase" $ do
+        checkPassphrase EncryptWithPBKDF2 (passphrase g) (hash g)
+            `shouldBe` Right ()
+
+
+  where
+    -- Generated with 'genSalt'
+    salt :: Passphrase "salt"
+    salt = Passphrase "\x85\x80\x1b#ÓèÚ\x1b\x86>\xd8ØHëÎ"
+
+    -- To have actual values in counterexamples, rather than just
+    -- <scrubbed bytes>:
+    unwrap :: BA.ByteArrayAccess i => i -> ByteString
+    unwrap = BA.convert @_ @ByteString
+
+data Golden = Golden
+    { passphrase :: Passphrase "user"
+    , prepared :: Passphrase "encryption"
+    , hash :: PassphraseHash
+    }
+
+passphraseGolden1 :: Golden
+passphraseGolden1 = Golden
+    { passphrase = Passphrase "passphrase"
+    , prepared = Passphrase "passphrase"
+    , hash = PassphraseHash
+        "\SI\133\128\ESC#\211\232\218\ESC\134>\216\216H\235\206\206\211\134'\
+        \\135\253\237\244\226\143\SYN\239!}\247\172\168\CAN\212\DC1\SI\255\235\
+        \\215\241\DC4\181\133\177\232=\190\154\249\ETB\EOTd\176\149\249\216\133\
+        \\141\188P\188s\159q\250\159^dj\STX\ACK$O@\208\138\236wp"
+    }
+
+passphraseGolden2 :: Golden
+passphraseGolden2 = Golden
+    { passphrase = Passphrase ""
+    , prepared = Passphrase ""
+    , hash = PassphraseHash
+        "\SI\133\128\ESC#\211\232\218\ESC\134>\216\216H\235\206\130\173|\250\
+        \\215\130\227^\155\216\176\NUL\145p\190P\CAN\254\155\190\140\DLE\208\
+        \\194\207)X\171p*Y\170\192eiZ\243\\\222Mr\174\av\NAK\238\183\DC2\156\
+        \\203\196\156,,\245X\161\242\160\148\217k\EM\234"
+    }

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -556,7 +556,7 @@ walletUpdateNameNoSuchWallet wallet@(wid', _, _) wid wName =
 
 walletUpdatePassphrase
     :: (WalletId, WalletName, DummyState)
-    -> Passphrase "raw"
+    -> Passphrase "user"
     -> Maybe (ShelleyKey 'RootK XPrv, Passphrase "encryption")
     -> Property
 walletUpdatePassphrase wallet new mxprv = monadicIO $ do
@@ -578,7 +578,7 @@ walletUpdatePassphrase wallet new mxprv = monadicIO $ do
 walletUpdatePassphraseWrong
     :: (WalletId, WalletName, DummyState)
     -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
-    -> (Passphrase "raw", Passphrase "raw")
+    -> (Passphrase "user", Passphrase "user")
     -> Property
 walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
     pwd /= coerce old ==> monadicIO $ do
@@ -594,7 +594,7 @@ walletUpdatePassphraseWrong wallet (xprv, pwd) (old, new) =
 walletUpdatePassphraseNoSuchWallet
     :: (WalletId, WalletName, DummyState)
     -> WalletId
-    -> (Passphrase "raw", Passphrase "raw")
+    -> (Passphrase "user", Passphrase "user")
     -> Property
 walletUpdatePassphraseNoSuchWallet wallet@(wid', _, _) wid (old, new) =
     wid /= wid' ==> monadicIO $ do
@@ -627,7 +627,7 @@ walletUpdatePassphraseDate wallet (xprv, pwd) = monadicIO $ liftIO $ do
 walletKeyIsReencrypted
     :: (WalletId, WalletName)
     -> (ShelleyKey 'RootK XPrv, Passphrase "encryption")
-    -> Passphrase "raw"
+    -> Passphrase "user"
     -> Property
 walletKeyIsReencrypted (_wid, _wname) (_xprv, _pwd) _newPwd = property True
 

--- a/lib/shelley/bench/restore-bench.hs
+++ b/lib/shelley/bench/restore-bench.hs
@@ -78,11 +78,11 @@ import Cardano.Wallet.Logging
     ( trMessageText )
 import Cardano.Wallet.Network
     ( ChainFollowLog (..), ChainSyncLog (..), NetworkLayer (..) )
+
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , NetworkDiscriminant (..)
     , NetworkDiscriminantVal (..)
-    , Passphrase (..)
     , PaymentAddress
     , PersistPrivateKey
     , WalletKey
@@ -112,6 +112,8 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, getState, totalUTxO )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, neverFails )
 import Cardano.Wallet.Primitive.SyncProgress

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -92,13 +92,15 @@ import Cardano.Wallet.CoinSelection
     , selectionDelta
     )
 import Cardano.Wallet.Primitive.AddressDerivation
-    ( Depth (..), Passphrase (..), RewardAccount (..), WalletKey (..) )
+    ( Depth (..), RewardAccount (..), WalletKey (..) )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron
     ( ByronKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Icarus
     ( IcarusKey )
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, toRewardAccountRaw )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..) )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException, TimeInterpreter, getSystemStart, toEpochInfo )
 import Cardano.Wallet.Primitive.Types

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -1839,12 +1839,12 @@ instance Show XPrv where
 instance Eq XPrv where
     (==) = (==) `on` xprvToBytes
 
-instance Arbitrary (Passphrase "raw") where
+instance Arbitrary (Passphrase "user") where
     arbitrary = do
         n <- choose (passphraseMinLength p, passphraseMaxLength p)
         bytes <- T.encodeUtf8 . T.pack <$> replicateM n arbitraryPrintableChar
         return $ Passphrase $ BA.convert bytes
-      where p = Proxy :: Proxy "raw"
+      where p = Proxy :: Proxy "user"
 
     shrink (Passphrase bytes)
         | BA.length bytes <= passphraseMinLength p = []
@@ -1854,11 +1854,11 @@ instance Arbitrary (Passphrase "raw") where
             $ B8.take (passphraseMinLength p)
             $ BA.convert bytes
             ]
-      where p = Proxy :: Proxy "raw"
+      where p = Proxy :: Proxy "user"
 
 instance Arbitrary (Passphrase "encryption") where
     arbitrary = preparePassphrase EncryptWithPBKDF2
-        <$> arbitrary @(Passphrase "raw")
+        <$> arbitrary @(Passphrase "user")
 
 instance Arbitrary (Quantity "byte" Word16) where
     arbitrary = Quantity <$> choose (128, 2048)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -102,7 +102,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hex
     , liftRawKey
     , paymentAddress
-    , preparePassphrase
     , publicKey
     )
 import Cardano.Wallet.Primitive.AddressDerivation.Byron

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -97,10 +97,6 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , Depth (..)
     , DerivationIndex (..)
     , NetworkDiscriminant (..)
-    , Passphrase (..)
-    , PassphraseMaxLength (..)
-    , PassphraseMinLength (..)
-    , PassphraseScheme (..)
     , deriveRewardAccount
     , getRawKey
     , hex
@@ -119,6 +115,13 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, defaultAddressPoolGap, mkSeqStateFromRootXPrv, purposeCIP1852 )
 import Cardano.Wallet.Primitive.Model
     ( Wallet (..), unsafeInitWallet )
+import Cardano.Wallet.Primitive.Passphrase
+    ( Passphrase (..)
+    , PassphraseMaxLength (..)
+    , PassphraseMinLength (..)
+    , PassphraseScheme (..)
+    , preparePassphrase
+    )
 import Cardano.Wallet.Primitive.Slotting
     ( TimeInterpreter, hoistTimeInterpreter, mkSingleEraInterpreter )
 import Cardano.Wallet.Primitive.Types

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -421,6 +421,11 @@ haskell-nix: haskell-nix.stackProject' [
             packages.cardano-addresses-cli.cabal-generator = lib.mkForce null;
           }
 
+          # Disable scrypt support on ARM64
+          ({ pkgs, ... }: {
+            packages.cardano-wallet-core.flags.scrypt = !pkgs.stdenv.hostPlatform.isAarch64;
+          })
+
           # Allow installation of a newer version of Win32 than what is
           # included with GHC. The packages in this list are all those
           # installed with GHC, except for Win32.

--- a/nix/materialized/stack-nix/cardano-wallet-core-integration.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core-integration.nix
@@ -85,7 +85,6 @@
           (hsPkgs."resourcet" or (errorHandler.buildDepError "resourcet"))
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."say" or (errorHandler.buildDepError "say"))
-          (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
           (hsPkgs."serialise" or (errorHandler.buildDepError "serialise"))
           (hsPkgs."string-interpolate" or (errorHandler.buildDepError "string-interpolate"))
           (hsPkgs."template-haskell" or (errorHandler.buildDepError "template-haskell"))

--- a/nix/materialized/stack-nix/cardano-wallet-core.nix
+++ b/nix/materialized/stack-nix/cardano-wallet-core.nix
@@ -8,7 +8,7 @@
   , config
   , ... }:
   {
-    flags = { release = false; };
+    flags = { release = false; scrypt = true; };
     package = {
       specVersion = "1.10";
       identifier = { name = "cardano-wallet-core"; version = "2022.1.18"; };
@@ -114,7 +114,6 @@
           (hsPkgs."retry" or (errorHandler.buildDepError "retry"))
           (hsPkgs."safe" or (errorHandler.buildDepError "safe"))
           (hsPkgs."scientific" or (errorHandler.buildDepError "scientific"))
-          (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"))
           (hsPkgs."servant" or (errorHandler.buildDepError "servant"))
           (hsPkgs."servant-client" or (errorHandler.buildDepError "servant-client"))
           (hsPkgs."servant-server" or (errorHandler.buildDepError "servant-server"))
@@ -148,7 +147,7 @@
           (hsPkgs."Win32-network" or (errorHandler.buildDepError "Win32-network"))
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
           (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
-          ];
+          ] ++ (pkgs.lib).optional (flags.scrypt) (hsPkgs."scrypt" or (errorHandler.buildDepError "scrypt"));
         buildable = true;
         modules = [
           "Paths_cardano_wallet_core"
@@ -217,6 +216,11 @@
           "Cardano/Wallet/Primitive/Model"
           "Cardano/Wallet/Primitive/Slotting"
           "Cardano/Wallet/Primitive/SyncProgress"
+          "Cardano/Wallet/Primitive/Passphrase"
+          "Cardano/Wallet/Primitive/Passphrase/Current"
+          "Cardano/Wallet/Primitive/Passphrase/Gen"
+          "Cardano/Wallet/Primitive/Passphrase/Legacy"
+          "Cardano/Wallet/Primitive/Passphrase/Types"
           "Cardano/Wallet/Primitive/Types"
           "Cardano/Wallet/Primitive/Types/Address"
           "Cardano/Wallet/Primitive/Types/Coin"
@@ -424,6 +428,8 @@
             "Cardano/Wallet/Primitive/Migration/PlanningSpec"
             "Cardano/Wallet/Primitive/Migration/SelectionSpec"
             "Cardano/Wallet/Primitive/ModelSpec"
+            "Cardano/Wallet/Primitive/PassphraseSpec"
+            "Cardano/Wallet/Primitive/Passphrase/LegacySpec"
             "Cardano/Wallet/Primitive/Slotting/Legacy"
             "Cardano/Wallet/Primitive/SlottingSpec"
             "Cardano/Wallet/Primitive/SyncProgressSpec"

--- a/nix/release-package.nix
+++ b/nix/release-package.nix
@@ -35,10 +35,10 @@ in
 pkgs.stdenv.mkDerivation {
   inherit name;
   buildInputs = with pkgs.buildPackages; [
-    binutils
     iohk-nix-utils
     nix
   ]
+  ++ (if pkgs.stdenv.hostPlatform.isDarwin then [ darwin.binutils ] else [ binutils ])
   ++ lib.optionals makeTarball [ gnutar gzip ]
   ++ lib.optionals makeZip [ zip ];
   checkInputs = with pkgs.buildPackages; [
@@ -63,7 +63,9 @@ pkgs.stdenv.mkDerivation {
 
   '' + lib.optionalString isMacOS ''
     # Rewrite library paths to standard non-nix locations
-    ( cd $name; rewrite-libs . `ls -1 | grep -Fv .dylib` )
+    ( cd $name; rewrite-libs . `ls -1 | grep -Fv .dylib`
+      for a in *; do /usr/bin/codesign -f -s - $a; done
+    )
 
   '' + lib.optionalString (isLinux || isMacOS) ''
     mkdir -p $name/auto-completion/{bash,zsh,fish}


### PR DESCRIPTION
### Issue Number

ADP-842
Fixes #2578.

### Overview

- Adds cabal flag so that cardano-wallet can be compiled without the `scrypt` package.
- Replaces `scrypt` with `cryptonite` for the integration tests only

If `scrypt` does not compile for your target system, then disable it with:

```
cabal configure --disable-tests --enable-benchmarks -f-scrypt
```

### Comments

I'm not too keen on changing the scrypt package in the main code, for the time being. But we can replace this package in the integration tests, without too much risk.

Need to use conditional modules instead of CPP because that breaks stylish-haskell.
