### PR TITLE
Simplify QC generators for commonly-used types.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -54,4 +54,7 @@ genCoinFullRange = frequency
     ]
 
 shrinkCoinFullRange :: Coin -> [Coin]
-shrinkCoinFullRange (Coin c) = Coin <$> shrink c
+shrinkCoinFullRange =
+    -- Given that we may have a large value, we limit the number of results
+    -- returned in order to avoid processing long lists of shrunken values.
+    take 8 . shrinkCoin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE NumericUnderscores #-}
 
 module Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinAny
+    ( genCoinFullRange
     , genCoinSmall
     , genCoinSmallPositive
     , genCoinLargePositive
-    , shrinkCoinAny
+    , shrinkCoinFullRange
     , shrinkCoinSmall
     , shrinkCoinSmallPositive
     , shrinkCoinLargePositive
@@ -16,17 +16,29 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Test.QuickCheck
-    ( Gen, choose, shrink )
+    ( Gen, choose, frequency, shrink )
 
 --------------------------------------------------------------------------------
--- Coins chosen from the full range available
+-- Coins chosen from the full range available.
 --------------------------------------------------------------------------------
 
-genCoinAny :: Gen Coin
-genCoinAny = Coin <$> choose (unCoin minBound, unCoin maxBound)
+-- | Generates coins across the full range available.
+--
+-- This generator has a slight bias towards the limits of the range, but
+-- otherwise generates values uniformly across the whole range.
+--
+-- This can be useful when testing roundtrip conversions between different
+-- types.
+--
+genCoinFullRange :: Gen Coin
+genCoinFullRange = frequency
+    [ (1, pure (Coin 0))
+    , (1, pure (maxBound :: Coin))
+    , (8, Coin <$> choose (1, unCoin (maxBound :: Coin) - 1))
+    ]
 
-shrinkCoinAny :: Coin -> [Coin]
-shrinkCoinAny (Coin c) = Coin <$> shrink c
+shrinkCoinFullRange :: Coin -> [Coin]
+shrinkCoinFullRange (Coin c) = Coin <$> shrink c
 
 --------------------------------------------------------------------------------
 -- Coins chosen to be small and possibly zero

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin/Gen.hs
@@ -1,14 +1,10 @@
-{-# LANGUAGE NumericUnderscores #-}
-
 module Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinFullRange
-    , genCoinSmall
-    , genCoinSmallPositive
-    , genCoinLargePositive
+    ( genCoin
+    , genCoinPositive
+    , genCoinFullRange
+    , shrinkCoin
+    , shrinkCoinPositive
     , shrinkCoinFullRange
-    , shrinkCoinSmall
-    , shrinkCoinSmallPositive
-    , shrinkCoinLargePositive
     ) where
 
 import Prelude
@@ -16,7 +12,27 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Test.QuickCheck
-    ( Gen, choose, frequency, shrink )
+    ( Gen, choose, frequency, shrink, sized )
+
+--------------------------------------------------------------------------------
+-- Coins chosen according to the size parameter.
+--------------------------------------------------------------------------------
+
+genCoin :: Gen Coin
+genCoin = sized $ \n -> Coin . fromIntegral <$> choose (0, n)
+
+shrinkCoin :: Coin -> [Coin]
+shrinkCoin (Coin c) = Coin <$> shrink c
+
+--------------------------------------------------------------------------------
+-- Coins chosen according to the size parameter, but strictly positive.
+--------------------------------------------------------------------------------
+
+genCoinPositive :: Gen Coin
+genCoinPositive = sized $ \n -> Coin . fromIntegral <$> choose (1, max 1 n)
+
+shrinkCoinPositive :: Coin -> [Coin]
+shrinkCoinPositive (Coin c) = Coin <$> filter (> 0) (shrink c)
 
 --------------------------------------------------------------------------------
 -- Coins chosen from the full range available.
@@ -39,33 +55,3 @@ genCoinFullRange = frequency
 
 shrinkCoinFullRange :: Coin -> [Coin]
 shrinkCoinFullRange (Coin c) = Coin <$> shrink c
-
---------------------------------------------------------------------------------
--- Coins chosen to be small and possibly zero
---------------------------------------------------------------------------------
-
-genCoinSmall :: Gen Coin
-genCoinSmall = Coin <$> choose (0, 10)
-
-shrinkCoinSmall :: Coin -> [Coin]
-shrinkCoinSmall (Coin c) = Coin <$> shrink c
-
---------------------------------------------------------------------------------
--- Coins chosen to be small and strictly positive
---------------------------------------------------------------------------------
-
-genCoinSmallPositive :: Gen Coin
-genCoinSmallPositive = Coin <$> choose (1, 10)
-
-shrinkCoinSmallPositive :: Coin -> [Coin]
-shrinkCoinSmallPositive (Coin c) = Coin <$> filter (> 0) (shrink c)
-
---------------------------------------------------------------------------------
--- Coins chosen from a large range and strictly positive
---------------------------------------------------------------------------------
-
-genCoinLargePositive :: Gen Coin
-genCoinLargePositive = Coin <$> choose (1, 1_000_000_000_000)
-
-shrinkCoinLargePositive :: Coin -> [Coin]
-shrinkCoinLargePositive (Coin c) = Coin <$> filter (> 0) (shrink c)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -9,13 +9,12 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 
 import Prelude
 
-import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinSmall
-    , genCoinSmallPositive
-    , shrinkCoinSmall
-    , shrinkCoinSmallPositive
+    ( genCoin
+    , genCoinFullRange
+    , genCoinPositive
+    , shrinkCoin
+    , shrinkCoinPositive
     )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
@@ -43,17 +42,12 @@ import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 genFixedSizeTokenBundle :: Int -> Gen TokenBundle
 genFixedSizeTokenBundle fixedAssetCount
     = TokenBundle.fromFlatList
-        <$> genCoin
+        <$> genCoinFullRange
         <*> replicateM fixedAssetCount genAssetQuantity
   where
     genAssetQuantity = (,)
         <$> genAssetIdLargeRange
         <*> genTokenQuantity
-    genCoin = Coin <$> oneof
-        [ pure $ unCoin minBound
-        , pure $ unCoin maxBound
-        , choose (unCoin minBound + 1, unCoin maxBound - 1)
-        ]
     genTokenQuantity = integerToTokenQuantity <$> oneof
         [ pure $ tokenQuantityToInteger txOutMinTokenQuantity
         , pure $ tokenQuantityToInteger txOutMaxTokenQuantity
@@ -85,22 +79,22 @@ genVariableSizedTokenBundle maxAssetCount =
 
 genTokenBundleSmallRange :: Gen TokenBundle
 genTokenBundleSmallRange = TokenBundle
-    <$> genCoinSmall
+    <$> genCoin
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRange (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
-        (c, shrinkCoinSmall)
+        (c, shrinkCoin)
         (m, shrinkTokenMapSmallRange)
 
 genTokenBundleSmallRangePositive :: Gen TokenBundle
 genTokenBundleSmallRangePositive = TokenBundle
-    <$> genCoinSmallPositive
+    <$> genCoinPositive
     <*> genTokenMapSmallRange
 
 shrinkTokenBundleSmallRangePositive :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRangePositive (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
-        (c, shrinkCoinSmallPositive)
+        (c, shrinkCoinPositive)
         (m, shrinkTokenMapSmallRange)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -30,7 +30,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     , tokenPolicies
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySized, genTokenQuantitySmall, shrinkTokenQuantitySmall )
+    ( genTokenQuantity, shrinkTokenQuantity )
 import Control.Monad
     ( replicateM )
 import Data.List
@@ -113,7 +113,7 @@ genTokenMapSized = sized $ \size -> do
   where
     genAssetQuantity = (,)
         <$> genAssetIdSized
-        <*> genTokenQuantitySized
+        <*> genTokenQuantity
 
 --------------------------------------------------------------------------------
 -- Token maps with assets and quantities chosen from small ranges
@@ -130,7 +130,7 @@ genTokenMapSmallRange = do
   where
     genAssetQuantity = (,)
         <$> genAssetIdSmallRange
-        <*> genTokenQuantitySmall
+        <*> genTokenQuantity
 
 shrinkTokenMapSmallRange :: TokenMap -> [TokenMap]
 shrinkTokenMapSmallRange
@@ -140,7 +140,7 @@ shrinkTokenMapSmallRange
   where
     shrinkAssetQuantity (a, q) = shrinkInterleaved
         (a, shrinkAssetIdSmallRange)
-        (q, shrinkTokenQuantitySmall)
+        (q, shrinkTokenQuantity)
 
 --------------------------------------------------------------------------------
 -- Filtering functions

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -22,12 +22,11 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     , genTokenNameSized
     , genTokenNameSmallRange
     , genTokenPolicyIdLargeRange
-    , genTokenPolicyIdSized
-    , genTokenPolicyIdSmallRange
+    , genTokenPolicyId
     , shrinkTokenNameSmallRange
-    , shrinkTokenPolicyIdSmallRange
+    , shrinkTokenPolicyId
+    , testTokenPolicyIds
     , tokenNamesMediumRange
-    , tokenPolicies
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantity, shrinkTokenQuantity )
@@ -75,7 +74,7 @@ genAssetIdSized = sized $ \size -> do
     --
     let sizeSquareRoot = max 1 $ ceiling $ sqrt $ fromIntegral @Int @Double size
     AssetId
-        <$> resize sizeSquareRoot genTokenPolicyIdSized
+        <$> resize sizeSquareRoot genTokenPolicyId
         <*> resize sizeSquareRoot genTokenNameSized
 
 --------------------------------------------------------------------------------
@@ -84,12 +83,12 @@ genAssetIdSized = sized $ \size -> do
 
 genAssetIdSmallRange :: Gen AssetId
 genAssetIdSmallRange = AssetId
-    <$> genTokenPolicyIdSmallRange
+    <$> genTokenPolicyId
     <*> genTokenNameSmallRange
 
 shrinkAssetIdSmallRange :: AssetId -> [AssetId]
 shrinkAssetIdSmallRange (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
-    (p, shrinkTokenPolicyIdSmallRange)
+    (p, shrinkTokenPolicyId)
     (t, shrinkTokenNameSmallRange)
 
 --------------------------------------------------------------------------------
@@ -155,5 +154,5 @@ instance Function AssetIdF where
 instance CoArbitrary AssetIdF where
     coarbitrary (AssetIdF AssetId{tokenName, tokenPolicyId}) genB = do
         let n = fromMaybe 0 (elemIndex tokenName tokenNamesMediumRange)
-        let m = fromMaybe 0 (elemIndex tokenPolicyId tokenPolicies)
+        let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
         variant (n+m) genB

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -18,15 +18,14 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameLargeRange
-    , genTokenNameSized
-    , genTokenNameSmallRange
-    , genTokenPolicyIdLargeRange
+    ( genTokenName
+    , genTokenNameLargeRange
     , genTokenPolicyId
-    , shrinkTokenNameSmallRange
+    , genTokenPolicyIdLargeRange
+    , shrinkTokenName
     , shrinkTokenPolicyId
+    , testTokenNames
     , testTokenPolicyIds
-    , tokenNamesMediumRange
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantity, shrinkTokenQuantity )
@@ -75,7 +74,7 @@ genAssetIdSized = sized $ \size -> do
     let sizeSquareRoot = max 1 $ ceiling $ sqrt $ fromIntegral @Int @Double size
     AssetId
         <$> resize sizeSquareRoot genTokenPolicyId
-        <*> resize sizeSquareRoot genTokenNameSized
+        <*> resize sizeSquareRoot genTokenName
 
 --------------------------------------------------------------------------------
 -- Asset identifiers chosen from a small range (to allow collisions)
@@ -84,12 +83,12 @@ genAssetIdSized = sized $ \size -> do
 genAssetIdSmallRange :: Gen AssetId
 genAssetIdSmallRange = AssetId
     <$> genTokenPolicyId
-    <*> genTokenNameSmallRange
+    <*> genTokenName
 
 shrinkAssetIdSmallRange :: AssetId -> [AssetId]
 shrinkAssetIdSmallRange (AssetId p t) = uncurry AssetId <$> shrinkInterleaved
     (p, shrinkTokenPolicyId)
-    (t, shrinkTokenNameSmallRange)
+    (t, shrinkTokenName)
 
 --------------------------------------------------------------------------------
 -- Asset identifiers chosen from a large range (to minimize collisions)
@@ -153,6 +152,6 @@ instance Function AssetIdF where
 
 instance CoArbitrary AssetIdF where
     coarbitrary (AssetIdF AssetId{tokenName, tokenPolicyId}) genB = do
-        let n = fromMaybe 0 (elemIndex tokenName tokenNamesMediumRange)
+        let n = fromMaybe 0 (elemIndex tokenName testTokenNames)
         let m = fromMaybe 0 (elemIndex tokenPolicyId testTokenPolicyIds)
         variant (n+m) genB

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -3,15 +3,14 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     , genTokenNameLargeRange
     , genTokenNameMediumRange
     , genTokenNameSmallRange
-    , genTokenPolicyIdSized
+    , genTokenPolicyId
     , genTokenPolicyIdLargeRange
-    , genTokenPolicyIdSmallRange
     , mkTokenPolicyId
     , shrinkTokenNameSmallRange
-    , shrinkTokenPolicyIdSmallRange
+    , shrinkTokenPolicyId
+    , testTokenPolicyIds
     , tokenNamesMediumRange
     , tokenNamesSmallRange
-    , tokenPolicies
     ) where
 
 import Prelude
@@ -79,26 +78,15 @@ genTokenNameLargeRange = UnsafeTokenName . BS.pack <$> vector 32
 -- parameter
 --------------------------------------------------------------------------------
 
-genTokenPolicyIdSized :: Gen TokenPolicyId
-genTokenPolicyIdSized = sized $ \size ->
-    elements $ mkTokenPolicyId <$> take size mkTokenPolicyIdValidChars
+genTokenPolicyId :: Gen TokenPolicyId
+genTokenPolicyId = sized $ \n -> elements $ take (max 1 n) testTokenPolicyIds
 
---------------------------------------------------------------------------------
--- Token policy identifiers chosen from a small range (to allow collisions)
---------------------------------------------------------------------------------
-
-genTokenPolicyIdSmallRange :: Gen TokenPolicyId
-genTokenPolicyIdSmallRange = elements tokenPolicies
-
-shrinkTokenPolicyIdSmallRange :: TokenPolicyId -> [TokenPolicyId]
-shrinkTokenPolicyIdSmallRange x
-    | x == simplest = []
+shrinkTokenPolicyId :: TokenPolicyId -> [TokenPolicyId]
+shrinkTokenPolicyId i
+    | i == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head tokenPolicies
-
-tokenPolicies :: [TokenPolicyId]
-tokenPolicies = mkTokenPolicyId <$> ['A' .. 'D']
+    simplest = head testTokenPolicyIds
 
 --------------------------------------------------------------------------------
 -- Token policy identifiers chosen from a large range (to minimize the risk of
@@ -111,6 +99,9 @@ genTokenPolicyIdLargeRange = UnsafeTokenPolicyId . Hash . BS.pack <$> vector 28
 --------------------------------------------------------------------------------
 -- Internal utilities
 --------------------------------------------------------------------------------
+
+testTokenPolicyIds :: [TokenPolicyId]
+testTokenPolicyIds = mkTokenPolicyId <$> mkTokenPolicyIdValidChars
 
 -- The set of characters that can be passed to the 'mkTokenPolicyId' function.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy/Gen.hs
@@ -1,16 +1,21 @@
 module Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameSized
+    (
+    -- * Generators and shrinkers
+      genTokenName
     , genTokenNameLargeRange
-    , genTokenNameMediumRange
-    , genTokenNameSmallRange
     , genTokenPolicyId
     , genTokenPolicyIdLargeRange
-    , mkTokenPolicyId
-    , shrinkTokenNameSmallRange
+    , shrinkTokenName
     , shrinkTokenPolicyId
+
+    -- * Test values
+    , testTokenNames
     , testTokenPolicyIds
-    , tokenNamesMediumRange
-    , tokenNamesSmallRange
+
+    -- * Creation of test values
+    , mkTokenName
+    , mkTokenPolicyId
+
     ) where
 
 import Prelude
@@ -34,37 +39,15 @@ import qualified Data.Text as T
 -- Token names chosen from a range that depends on the size parameter
 --------------------------------------------------------------------------------
 
-genTokenNameSized :: Gen TokenName
-genTokenNameSized = sized $ \size ->
-    elements $ UnsafeTokenName . B8.snoc "Token" <$> take size ['A' ..]
+genTokenName :: Gen TokenName
+genTokenName = sized $ \n -> elements $ take (max 1 n) testTokenNames
 
---------------------------------------------------------------------------------
--- Token names chosen from a small range (to allow collisions)
---------------------------------------------------------------------------------
-
-genTokenNameSmallRange :: Gen TokenName
-genTokenNameSmallRange = elements tokenNamesSmallRange
-
-shrinkTokenNameSmallRange :: TokenName -> [TokenName]
-shrinkTokenNameSmallRange x
-    | x == simplest = []
+shrinkTokenName :: TokenName -> [TokenName]
+shrinkTokenName i
+    | i == simplest = []
     | otherwise = [simplest]
   where
-    simplest = head tokenNamesSmallRange
-
-tokenNamesSmallRange :: [TokenName]
-tokenNamesSmallRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'D']
-
---------------------------------------------------------------------------------
--- Token names chosen from a medium-sized range (to minimize the risk of
--- collisions)
---------------------------------------------------------------------------------
-
-genTokenNameMediumRange :: Gen TokenName
-genTokenNameMediumRange = elements tokenNamesMediumRange
-
-tokenNamesMediumRange :: [TokenName]
-tokenNamesMediumRange = UnsafeTokenName . B8.snoc "Token" <$> ['A' .. 'Z']
+    simplest = head testTokenNames
 
 --------------------------------------------------------------------------------
 -- Token names chosen from a large range (to minimize the risk of collisions)
@@ -100,8 +83,14 @@ genTokenPolicyIdLargeRange = UnsafeTokenPolicyId . Hash . BS.pack <$> vector 28
 -- Internal utilities
 --------------------------------------------------------------------------------
 
+testTokenNames :: [TokenName]
+testTokenNames = mkTokenName <$> ['A' .. 'Z']
+
 testTokenPolicyIds :: [TokenPolicyId]
 testTokenPolicyIds = mkTokenPolicyId <$> mkTokenPolicyIdValidChars
+
+mkTokenName :: Char -> TokenName
+mkTokenName = UnsafeTokenName . B8.snoc "Token"
 
 -- The set of characters that can be passed to the 'mkTokenPolicyId' function.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
@@ -72,7 +72,10 @@ genTokenQuantityFullRange = frequency
     maxTokenQuantity = TokenQuantity $ fromIntegral $ maxBound @Word64
 
 shrinkTokenQuantityFullRange :: TokenQuantity -> [TokenQuantity]
-shrinkTokenQuantityFullRange = shrinkTokenQuantity
+shrinkTokenQuantityFullRange =
+    -- Given that we may have a large value, we limit the number of results
+    -- returned in order to avoid processing long lists of shrunken values.
+    take 8 . shrinkTokenQuantity
 
 --------------------------------------------------------------------------------
 -- Internal functions

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenQuantity/Gen.hs
@@ -1,16 +1,12 @@
+{-# LANGUAGE TypeApplications #-}
+
 module Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySized
-    , genTokenQuantitySmall
-    , genTokenQuantitySmallPositive
-    , genTokenQuantityLarge
-    , genTokenQuantityMassive
-    , genTokenQuantityMixed
-    , shrinkTokenQuantitySmall
-    , shrinkTokenQuantitySmallPositive
-    , shrinkTokenQuantityMixed
-    , tokenQuantitySmall
-    , tokenQuantityLarge
-    , tokenQuantityMassive
+    ( genTokenQuantity
+    , genTokenQuantityPositive
+    , genTokenQuantityFullRange
+    , shrinkTokenQuantity
+    , shrinkTokenQuantityPositive
+    , shrinkTokenQuantityFullRange
     ) where
 
 import Prelude
@@ -19,99 +15,64 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Data.Word
     ( Word64 )
-import Numeric.Natural
-    ( Natural )
 import Test.QuickCheck
-    ( Gen, choose, oneof, shrink, sized )
+    ( Gen, choose, frequency, shrink, sized )
 
 --------------------------------------------------------------------------------
--- Token quantities chosen from a range that depends on the size parameter
+-- Token quantities chosen according to the size parameter.
 --------------------------------------------------------------------------------
 
-genTokenQuantitySized :: Gen TokenQuantity
-genTokenQuantitySized = sized $ \n ->
-    quantityFromInt <$> choose (0, n)
-
---------------------------------------------------------------------------------
--- Small token quantities
---------------------------------------------------------------------------------
-
-genTokenQuantitySmall :: Gen TokenQuantity
-genTokenQuantitySmall = quantityFromInteger <$> oneof
-    [ pure 0
-    , choose (1, quantityToInteger tokenQuantitySmall)
-    ]
-
-shrinkTokenQuantitySmall :: TokenQuantity -> [TokenQuantity]
-shrinkTokenQuantitySmall = shrinkTokenQuantity
-
---------------------------------------------------------------------------------
--- Small strictly-positive token quantities
---------------------------------------------------------------------------------
-
-genTokenQuantitySmallPositive :: Gen TokenQuantity
-genTokenQuantitySmallPositive = quantityFromInteger <$>
-    choose (1, quantityToInteger tokenQuantitySmall)
-
-shrinkTokenQuantitySmallPositive :: TokenQuantity -> [TokenQuantity]
-shrinkTokenQuantitySmallPositive q = quantityFromInteger <$>
-    filter (> 0) (shrink $ quantityToInteger q)
-
---------------------------------------------------------------------------------
--- Large token quantities
---------------------------------------------------------------------------------
-
-genTokenQuantityLarge :: Gen TokenQuantity
-genTokenQuantityLarge = quantityFromInteger <$> choose
-    ( quantityToInteger tokenQuantitySmall + 1
-    , quantityToInteger tokenQuantityLarge
-    )
-
---------------------------------------------------------------------------------
--- Massive token quantities
---------------------------------------------------------------------------------
-
-genTokenQuantityMassive :: Gen TokenQuantity
-genTokenQuantityMassive = quantityFromInteger <$> choose
-    ( quantityToInteger tokenQuantityLarge + 1
-    , quantityToInteger tokenQuantityMassive
-    )
-
---------------------------------------------------------------------------------
--- Mixed token quantities (both small and large)
---------------------------------------------------------------------------------
-
-genTokenQuantityMixed :: Gen TokenQuantity
-genTokenQuantityMixed = oneof
-    [ genTokenQuantitySmall
-    , genTokenQuantityLarge
-    , genTokenQuantityMassive
-    ]
-
-shrinkTokenQuantityMixed :: TokenQuantity -> [TokenQuantity]
-shrinkTokenQuantityMixed = shrinkTokenQuantity
-
---------------------------------------------------------------------------------
--- Utilities
---------------------------------------------------------------------------------
+genTokenQuantity :: Gen TokenQuantity
+genTokenQuantity = sized $ \n -> quantityFromInt <$> choose (0, n)
 
 shrinkTokenQuantity :: TokenQuantity -> [TokenQuantity]
-shrinkTokenQuantity
-    -- Since token quantities can be very large, we limit the number of results
-    -- that the shrinker can return:
-    = take 8
-    . fmap quantityFromInteger
+shrinkTokenQuantity = fmap quantityFromInteger . shrink . quantityToInteger
+
+--------------------------------------------------------------------------------
+-- Token quantities chosen according to the size parameter, but strictly
+-- positive.
+--------------------------------------------------------------------------------
+
+genTokenQuantityPositive :: Gen TokenQuantity
+genTokenQuantityPositive = sized $ \n -> quantityFromInt <$> choose (1, max 1 n)
+
+shrinkTokenQuantityPositive :: TokenQuantity -> [TokenQuantity]
+shrinkTokenQuantityPositive
+    = fmap quantityFromInteger
+    . filter (> 0)
     . shrink
     . quantityToInteger
 
-tokenQuantitySmall :: TokenQuantity
-tokenQuantitySmall = TokenQuantity 10
+--------------------------------------------------------------------------------
+-- Token quantities chosen from the full range available.
+--------------------------------------------------------------------------------
 
-tokenQuantityLarge :: TokenQuantity
-tokenQuantityLarge = TokenQuantity $ fromIntegral (maxBound :: Word64)
+-- | Generates token quantities across the full range of what may be encoded
+--   within a single on-chain token bundle.
+--
+-- This generator has a slight bias towards the limits of the range, but
+-- otherwise generates values uniformly across the whole range.
+--
+-- This can be useful when testing roundtrip conversions between different
+-- types.
+--
+genTokenQuantityFullRange :: Gen TokenQuantity
+genTokenQuantityFullRange = frequency
+    [ ( 1, pure minTokenQuantity )
+    , ( 1, pure maxTokenQuantity )
+    , ( 8
+      , quantityFromInteger <$>
+        choose (1, quantityToInteger maxTokenQuantity - 1)
+      )
+    ]
+  where
+    minTokenQuantity :: TokenQuantity
+    minTokenQuantity = TokenQuantity 0
+    maxTokenQuantity :: TokenQuantity
+    maxTokenQuantity = TokenQuantity $ fromIntegral $ maxBound @Word64
 
-tokenQuantityMassive :: TokenQuantity
-tokenQuantityMassive = TokenQuantity $ (10 :: Natural) ^ (1000 :: Natural)
+shrinkTokenQuantityFullRange :: TokenQuantity -> [TokenQuantity]
+shrinkTokenQuantityFullRange = shrinkTokenQuantity
 
 --------------------------------------------------------------------------------
 -- Internal functions

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -47,7 +47,7 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive, shrinkCoinLargePositive )
+    ( genCoinFullRange, shrinkCoinFullRange )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Control.Arrow
@@ -141,8 +141,8 @@ instance Arbitrary (Quantity "lovelace" Word64) where
     arbitrary = Quantity <$> arbitrary
 
 instance Arbitrary Coin where
-    shrink = shrinkCoinLargePositive
-    arbitrary = genCoinLargePositive
+    shrink = shrinkCoinFullRange
+    arbitrary = genCoinFullRange
 
 arbitraryEpochLength :: Word32
 arbitraryEpochLength = 100

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -236,7 +236,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive, genCoinSmallPositive )
+    ( genCoinFullRange, genCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -2124,7 +2124,7 @@ instance Arbitrary RewardAccount where
 
 instance Arbitrary Coin where
     -- No Shrinking
-    arbitrary = genCoinLargePositive
+    arbitrary = genCoinFullRange
 
 instance Arbitrary UTxO where
     shrink (UTxO utxo) = UTxO <$> shrink utxo
@@ -2163,8 +2163,8 @@ instance Arbitrary ApiWalletUtxoSnapshot where
       where
         genEntry :: Gen ApiWalletUtxoSnapshotEntry
         genEntry = do
-            adaValue1 <- genCoinSmallPositive
-            adaValue2 <- genCoinSmallPositive
+            adaValue1 <- genCoinPositive
+            adaValue2 <- genCoinPositive
             -- The actual ada quantity of an output's token bundle must be
             -- greater than or equal to the minimum permissible ada quantity:
             let ada = Api.coinToQuantity $ max adaValue1 adaValue2

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -248,7 +248,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdSmallRange, genTokenMapSmallRange, shrinkTokenMapSmallRange )
+    ( genAssetId, genTokenMapSmallRange, shrinkTokenMapSmallRange )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
@@ -1915,7 +1915,7 @@ instance Arbitrary TokenMetadataError where
         ]
 
 instance Arbitrary ApiAsset where
-    arbitrary = toApiAsset <$> arbitrary <*> genAssetIdSmallRange
+    arbitrary = toApiAsset <$> arbitrary <*> genAssetId
 
 instance Arbitrary a => Arbitrary (AddressAmount a) where
     arbitrary = applyArbitrary3 AddressAmount
@@ -2242,7 +2242,7 @@ instance Arbitrary ApiPostAccountKeyDataWithPurpose where
 
 instance Arbitrary TokenFingerprint where
     arbitrary = do
-        AssetId policy aName <- genAssetIdSmallRange
+        AssetId policy aName <- genAssetId
         pure $ mkTokenFingerprint policy aName
     shrink _ = []
 

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -260,7 +260,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     , mkTokenFingerprint
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameSmallRange )
+    ( genTokenName )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , SerialisedTx (..)
@@ -1953,7 +1953,7 @@ instance Arbitrary (ApiConstructTransaction t) where
 instance Arbitrary (ApiMintBurnData t) where
     arbitrary = ApiMintBurnData
         <$> arbitrary
-        <*> (ApiT <$> genTokenNameSmallRange)
+        <*> (ApiT <$> genTokenName)
         <*> arbitrary
 
 instance Arbitrary ApiStakeKeyIndex where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -111,7 +111,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive )
+    ( genCoinFullRange )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -415,7 +415,7 @@ instance Arbitrary TxMetadata where
     shrink = shrinkTxMetadata
 
 instance Arbitrary Coin where
-    arbitrary = genCoinLargePositive
+    arbitrary = genCoinFullRange
 
 instance Arbitrary UTxO where
     shrink (UTxO u) =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -90,7 +90,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameMediumRange )
+    ( genTokenName )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
@@ -3488,7 +3488,7 @@ instance Arbitrary MakeChangeData where
     arbitrary = genMakeChangeData
 
 instance Arbitrary (MockRoundRobinState TokenName Word8) where
-    arbitrary = genMockRoundRobinState genTokenNameMediumRange arbitrary
+    arbitrary = genMockRoundRobinState genTokenName arbitrary
     shrink = shrinkMockRoundRobinState shrink
 
 instance Arbitrary TokenBundle where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -71,11 +71,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), addCoin )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive
-    , genCoinSmall
-    , genCoinSmallPositive
-    , shrinkCoinSmallPositive
-    )
+    ( genCoin, genCoinPositive, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
@@ -603,7 +599,7 @@ genSelectionCriteria genUTxOIndex = do
             (1, UTxOIndex.size utxoAvailable `div` 8)
           )
         ]
-    extraCoinSource <- oneof [ pure Nothing, Just <$> genCoinSmall ]
+    extraCoinSource <- oneof [ pure Nothing, Just <$> genCoin ]
     (assetsToMint, assetsToBurn) <-
         genAssetsToMintAndBurn utxoAvailable outputsToCover
     pure $ SelectionCriteria
@@ -1865,8 +1861,8 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
     MakeChangeCriteria
         <$> arbitrary
         <*> pure NoBundleSizeLimit
-        <*> genCoinSmall
-        <*> oneof [pure Nothing, Just <$> genCoinSmallPositive]
+        <*> genCoin
+        <*> oneof [pure Nothing, Just <$> genCoinPositive]
         <*> pure inputBundles
         <*> pure outputBundles
         <*> pure assetsToMint
@@ -3501,7 +3497,7 @@ instance Arbitrary TokenBundle where
 
 instance Arbitrary (Large TokenBundle) where
     arbitrary = fmap Large $ TokenBundle
-        <$> genCoinLargePositive
+        <$> genCoinPositive
         <*> genTokenMapLarge
     -- No shrinking
 
@@ -3555,8 +3551,8 @@ instance Arbitrary (Small UTxOIndex) where
     shrink = fmap Small . shrinkUTxOIndexSmall . getSmall
 
 instance Arbitrary Coin where
-    arbitrary = genCoinSmallPositive
-    shrink = shrinkCoinSmallPositive
+    arbitrary = genCoinPositive
+    shrink = shrinkCoinPositive
 
 instance Arbitrary MinCoinValueFor where
     arbitrary = arbitraryBoundedEnum

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -81,10 +81,10 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange
-    , genAssetIdSmallRange
+    ( genAssetId
+    , genAssetIdLargeRange
     , genTokenMapSmallRange
-    , shrinkAssetIdSmallRange
+    , shrinkAssetId
     , shrinkTokenMapSmallRange
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -3477,8 +3477,8 @@ instance Arbitrary a => Arbitrary (AssetCount a) where
     shrink = fmap AssetCount . shrink . unAssetCount
 
 instance Arbitrary AssetId where
-    arbitrary = genAssetIdSmallRange
-    shrink = shrinkAssetIdSmallRange
+    arbitrary = genAssetId
+    shrink = shrinkAssetId
 
 instance Arbitrary Natural where
     arbitrary = arbitrarySizedNatural

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -501,11 +501,11 @@ prop_AssetCount_TokenMap_placesEmptyMapsFirst maps =
         $ cover 20 (emptyMapCount >= 8 && nonEmptyMapCount >= 8)
             "empty map count >= 8 && non-empty map count >= 8"
         -- Check head and last element of list:
-        $ cover 40 (isEmptyMap $ NE.head maps)
+        $ cover 20 (isEmptyMap $ NE.head maps)
             "head element is empty map"
         $ cover 40 (not $ isEmptyMap $ NE.head maps)
             "head element is non-empty map"
-        $ cover 40 (isEmptyMap $ NE.last maps)
+        $ cover 20 (isEmptyMap $ NE.last maps)
             "last element is empty map"
         $ cover 40 (not $ isEmptyMap $ NE.last maps)
             "last element is non-empty map"
@@ -738,7 +738,7 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
     prop_performSelection minCoinValueFor costFor (Blind criteria) $ \result ->
         cover 10 (selectionUnlimited && selectionSufficient result)
             "selection unlimited and sufficient"
-        . cover 5 (selectionLimited && selectionSufficient result)
+        . cover 4 (selectionLimited && selectionSufficient result)
             "selection limited but sufficient"
         . cover 10 (selectionLimited && selectionInsufficient result)
             "selection limited and insufficient"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/MA/RoundRobinSpec.hs
@@ -94,7 +94,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
+    ( genTokenQuantityPositive, shrinkTokenQuantityPositive )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
@@ -3512,15 +3512,15 @@ genTokenMapLarge = do
   where
     genAssetQuantity = (,)
         <$> genAssetIdLargeRange
-        <*> genTokenQuantitySmallPositive
+        <*> genTokenQuantityPositive
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange
     shrink = shrinkTokenMapSmallRange
 
 instance Arbitrary TokenQuantity where
-    arbitrary = genTokenQuantitySmallPositive
-    shrink = shrinkTokenQuantitySmallPositive
+    arbitrary = genTokenQuantityPositive
+    shrink = shrinkTokenQuantityPositive
 
 instance Arbitrary TxOut where
     arbitrary = genTxOutSmallRange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenBundleSpec.hs
@@ -20,7 +20,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySmallPositive, shrinkTokenQuantitySmallPositive )
+    ( genTokenQuantityPositive, shrinkTokenQuantityPositive )
 import Data.Ratio
     ( (%) )
 import Test.Hspec
@@ -182,5 +182,5 @@ instance Arbitrary TokenBundle where
     shrink = shrinkTokenBundleSmallRange
 
 instance Arbitrary TokenQuantity where
-    arbitrary = genTokenQuantitySmallPositive
-    shrink = shrinkTokenQuantitySmallPositive
+    arbitrary = genTokenQuantityPositive
+    shrink = shrinkTokenQuantityPositive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -31,11 +31,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId, mkTokenName )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenNameSmallRange
-    , genTokenPolicyId
-    , shrinkTokenNameSmallRange
-    , shrinkTokenPolicyId
-    )
+    ( genTokenName, genTokenPolicyId, shrinkTokenName, shrinkTokenPolicyId )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
@@ -1034,8 +1030,8 @@ instance Arbitrary (Large TokenMap) where
     -- No shrinking
 
 instance Arbitrary TokenName where
-    arbitrary = genTokenNameSmallRange
-    shrink = shrinkTokenNameSmallRange
+    arbitrary = genTokenName
+    shrink = shrinkTokenName
 
 instance Arbitrary TokenPolicyId where
     arbitrary = genTokenPolicyId

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -39,10 +39,10 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantitySmall
-    , genTokenQuantitySmallPositive
-    , shrinkTokenQuantitySmall
-    , shrinkTokenQuantitySmallPositive
+    ( genTokenQuantity
+    , genTokenQuantityPositive
+    , shrinkTokenQuantity
+    , shrinkTokenQuantityPositive
     )
 import Control.Monad
     ( replicateM )
@@ -1030,7 +1030,7 @@ instance Arbitrary (Large TokenMap) where
       where
         genAssetQuantity = (,)
             <$> genAssetIdLargeRange
-            <*> genTokenQuantitySmallPositive
+            <*> genTokenQuantityPositive
     -- No shrinking
 
 instance Arbitrary TokenName where
@@ -1050,9 +1050,9 @@ instance Arbitrary TokenQuantity where
     -- The generation of zero-valued tokens is useful, as it allows us to
     -- verify that the token map invariant (that a map contains no
     -- zero-valued tokens) is maintained.
-    arbitrary = genTokenQuantitySmall
-    shrink = shrinkTokenQuantitySmall
+    arbitrary = genTokenQuantity
+    shrink = shrinkTokenQuantity
 
 instance Arbitrary (Positive TokenQuantity) where
-    arbitrary = Positive <$> genTokenQuantitySmallPositive
-    shrink = fmap Positive . shrinkTokenQuantitySmallPositive . getPositive
+    arbitrary = Positive <$> genTokenQuantityPositive
+    shrink = fmap Positive . shrinkTokenQuantityPositive . getPositive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -21,11 +21,11 @@ import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), Flat (..), Nested (..), TokenMap, difference )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( AssetIdF (..)
+    , genAssetId
     , genAssetIdLargeRange
-    , genAssetIdSmallRange
     , genTokenMapSized
     , genTokenMapSmallRange
-    , shrinkAssetIdSmallRange
+    , shrinkAssetId
     , shrinkTokenMapSmallRange
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
@@ -1008,8 +1008,8 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
     shrink = mapMaybe NE.nonEmpty . shrink . NE.toList
 
 instance Arbitrary AssetId where
-    arbitrary = genAssetIdSmallRange
-    shrink = shrinkAssetIdSmallRange
+    arbitrary = genAssetId
+    shrink = shrinkAssetId
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -773,9 +773,9 @@ prop_equipartitionQuantitiesWithUpperBound_coverage
     :: TokenMap -> Positive TokenQuantity -> Property
 prop_equipartitionQuantitiesWithUpperBound_coverage m (Positive maxQuantity) =
     checkCoverage $
-    cover 8 (maxQuantity == TokenQuantity 1)
+    cover 4 (maxQuantity == TokenQuantity 1)
         "Maximum allowable quantity == 1" $
-    cover 8 (maxQuantity == TokenQuantity 2)
+    cover 4 (maxQuantity == TokenQuantity 2)
         "Maximum allowable quantity == 2" $
     cover 8 (maxQuantity >= TokenQuantity 3)
         "Maximum allowable quantity >= 3" $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -32,9 +32,9 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId, mkTokenName )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenNameSmallRange
-    , genTokenPolicyIdSmallRange
+    , genTokenPolicyId
     , shrinkTokenNameSmallRange
-    , shrinkTokenPolicyIdSmallRange
+    , shrinkTokenPolicyId
     )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
@@ -1038,8 +1038,8 @@ instance Arbitrary TokenName where
     shrink = shrinkTokenNameSmallRange
 
 instance Arbitrary TokenPolicyId where
-    arbitrary = genTokenPolicyIdSmallRange
-    shrink = shrinkTokenPolicyIdSmallRange
+    arbitrary = genTokenPolicyId
+    shrink = shrinkTokenPolicyId
 
 instance Arbitrary TokenQuantity where
     -- We generate small token quantities in order to increase the chance of

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenQuantitySpec.hs
@@ -15,7 +15,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantityMixed, shrinkTokenQuantityMixed )
+    ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Data.Aeson
     ( FromJSON (..), ToJSON (..) )
 import Data.Proxy
@@ -194,5 +194,5 @@ instance Arbitrary TokenQuantity where
     -- We test with token quantities of a variety of magnitudes to ensure that
     -- roundtrip serialization works even with large values, both positive and
     -- negative.
-    arbitrary = genTokenQuantityMixed
-    shrink = shrinkTokenQuantityMixed
+    arbitrary = genTokenQuantityFullRange
+    shrink = shrinkTokenQuantityFullRange

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -14,7 +14,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdSmallRange, shrinkAssetIdSmallRange )
+    ( genAssetId, shrinkAssetId )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn, TxOut )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
@@ -542,8 +542,8 @@ prop_selectRandom_all_withAssetOnly u a = checkCoverage $ monadicIO $ do
 --
 prop_selectRandomWithPriority :: UTxOIndex -> Property
 prop_selectRandomWithPriority u =
-    forAll (genAssetIdSmallRange) $ \a1 ->
-    forAll (genAssetIdSmallRange `suchThat` (/= a1)) $ \a2 ->
+    forAll (genAssetId) $ \a1 ->
+    forAll (genAssetId `suchThat` (/= a1)) $ \a2 ->
     checkCoverage $ monadicIO $ do
         haveMatchForAsset1 <- isJust <$>
             run (UTxOIndex.selectRandom u $ WithAssetOnly a1)
@@ -685,8 +685,8 @@ txOutIsAdaOnly = TokenBundle.isCoin . view #tokens
 --------------------------------------------------------------------------------
 
 instance Arbitrary AssetId where
-    arbitrary = genAssetIdSmallRange
-    shrink = shrinkAssetIdSmallRange
+    arbitrary = genAssetId
+    shrink = shrinkAssetId
 
 instance Arbitrary UTxOIndex where
     arbitrary = genUTxOIndexSmall
@@ -708,8 +708,8 @@ genSelectionFilterSmallRange :: Gen SelectionFilter
 genSelectionFilterSmallRange = oneof
     [ pure Any
     , pure WithAdaOnly
-    , WithAsset <$> genAssetIdSmallRange
-    , WithAssetOnly <$> genAssetIdSmallRange
+    , WithAsset <$> genAssetId
+    , WithAssetOnly <$> genAssetId
     ]
 
 shrinkSelectionFilterSmallRange :: SelectionFilter -> [SelectionFilter]
@@ -717,10 +717,10 @@ shrinkSelectionFilterSmallRange = \case
     Any -> []
     WithAdaOnly -> [Any]
     WithAsset a ->
-        case WithAsset <$> shrinkAssetIdSmallRange a of
+        case WithAsset <$> shrinkAssetId a of
             [] -> [WithAdaOnly]
             xs -> xs
     WithAssetOnly a ->
-        case WithAssetOnly <$> shrinkAssetIdSmallRange a of
+        case WithAssetOnly <$> shrinkAssetId a of
             [] -> [WithAsset a]
             xs -> xs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -433,11 +433,11 @@ prop_selectRandom_one_withAdaOnly u = checkCoverage $ monadicIO $ do
 prop_selectRandom_one_withAsset :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_one_withAsset u a = checkCoverage $ monadicIO $ do
     result <- run $ UTxOIndex.selectRandom u (WithAsset a)
-    monitor $ cover 70 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 70 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 70 (isJust result)
+    monitor $ cover 50 (isJust result)
         "selected an entry"
     case result of
         Nothing ->
@@ -459,11 +459,11 @@ prop_selectRandom_one_withAsset u a = checkCoverage $ monadicIO $ do
 prop_selectRandom_one_withAssetOnly :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_one_withAssetOnly u a = checkCoverage $ monadicIO $ do
     result <- run $ UTxOIndex.selectRandom u (WithAssetOnly a)
-    monitor $ cover 70 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 70 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 20 (isJust result)
+    monitor $ cover 10 (isJust result)
         "selected an entry"
     case result of
         Nothing ->
@@ -509,11 +509,11 @@ prop_selectRandom_all_withAdaOnly u = checkCoverage $ monadicIO $ do
 prop_selectRandom_all_withAsset :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_all_withAsset u a = checkCoverage $ monadicIO $ do
     (selectedEntries, u') <- run $ selectAll (WithAsset a) u
-    monitor $ cover 70 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 70 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 70 (not (null selectedEntries))
+    monitor $ cover 50 (not (null selectedEntries))
         "selected at least one entry"
     assert $ L.all (\(_, o) -> not (txOutHasAsset o a)) (UTxOIndex.toList u')
     assert $ L.all (\(_, o) -> txOutHasAsset o a) selectedEntries
@@ -526,11 +526,11 @@ prop_selectRandom_all_withAsset u a = checkCoverage $ monadicIO $ do
 prop_selectRandom_all_withAssetOnly :: UTxOIndex -> AssetId -> Property
 prop_selectRandom_all_withAssetOnly u a = checkCoverage $ monadicIO $ do
     (selectedEntries, u') <- run $ selectAll (WithAssetOnly a) u
-    monitor $ cover 70 (a `Set.member` UTxOIndex.assets u)
+    monitor $ cover 50 (a `Set.member` UTxOIndex.assets u)
         "index has the specified asset"
-    monitor $ cover 70 (Set.size (UTxOIndex.assets u) > 1)
+    monitor $ cover 50 (Set.size (UTxOIndex.assets u) > 1)
         "index has more than one asset"
-    monitor $ cover 20 (not (null selectedEntries))
+    monitor $ cover 10 (not (null selectedEntries))
         "selected at least one entry"
     assert $ all (\(_, o) -> not (txOutHasAssetOnly o a)) (UTxOIndex.toList u')
     assert $ all (\(_, o) -> txOutHasAssetOnly o a) selectedEntries

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -891,29 +891,28 @@ prop_2_1_1 :: (Set TxIn, UTxO) -> Property
 prop_2_1_1 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop = (u `restrictedBy` ins) `isSubsetOf` u
 
 prop_2_1_2 :: (Set TxIn, UTxO) -> Property
 prop_2_1_2 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop = (u `excluding` ins) `isSubsetOf` u
 
 prop_2_1_3 :: (Set TxOut, UTxO) -> Property
 prop_2_1_3 (outs, u) =
     cover 50 cond "u ⋂ outs ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $
-        Set.fromList (Map.elems (getUTxO u)) `Set.intersection` outs
+    cond = not $ Set.fromList (Map.elems (getUTxO u)) `Set.disjoint` outs
     prop = (u `restrictedTo` outs) `isSubsetOf` u
 
 prop_2_1_4 :: (Set TxIn, UTxO, UTxO) -> Property
 prop_2_1_4 (ins, u, v) =
     cover 50 cond "(dom u ⋃ dom v) ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ Set.union (dom u) (dom v) `Set.intersection` ins
+    cond = not $ Set.union (dom u) (dom v) `Set.disjoint` ins
     prop =
         ((u <> v) `restrictedBy` ins)
             ===
@@ -923,7 +922,7 @@ prop_2_1_5 :: (Set TxIn, UTxO, UTxO) -> Property
 prop_2_1_5 (ins, u, v) =
     cover 50 cond "(dom u ⋃ dom v) ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ Set.union (dom u) (dom v) `Set.intersection` ins
+    cond = not $ Set.union (dom u) (dom v) `Set.disjoint` ins
     prop =
         ((u <> v) `excluding` ins)
             ===
@@ -933,7 +932,7 @@ prop_2_1_6 :: (Set TxIn, UTxO) -> Property
 prop_2_1_6 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop =
         (u `restrictedBy` (dom u `Set.intersection` ins))
             ===
@@ -943,7 +942,7 @@ prop_2_1_7 :: (Set TxIn, UTxO) -> Property
 prop_2_1_7 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop =
         (u `excluding` (dom u `Set.intersection` ins))
             ===
@@ -953,7 +952,7 @@ prop_2_1_8 :: (Set TxIn, UTxO, UTxO) -> Property
 prop_2_1_8 (ins, u, v) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop =
         ((u <> v) `excluding` (dom u <> ins))
             ===
@@ -963,7 +962,7 @@ prop_2_1_9 :: (Set TxIn, UTxO) -> Property
 prop_2_1_9 (ins, u) =
     cover 50 cond "dom u ⋂ ins ≠ ∅" (property prop)
   where
-    cond = not $ Set.null $ dom u `Set.intersection` ins
+    cond = not $ dom u `Set.disjoint` ins
     prop = (u `excluding` ins) === u `restrictedBy` (dom u \\ ins)
 
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -91,7 +91,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), isValidCoin )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinSmall )
+    ( genCoin )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.HashSpec
@@ -1109,7 +1109,7 @@ instance Arbitrary AddressState where
 
 instance Arbitrary Coin where
     -- No Shrinking
-    arbitrary = genCoinSmall
+    arbitrary = genCoin
 
 instance (Arbitrary a, Ord a) => Arbitrary (Range a) where
     arbitrary =
@@ -1149,7 +1149,7 @@ instance Arbitrary TxOut where
     -- No Shrinking
     arbitrary = TxOut
         <$> arbitrary
-        <*> fmap TokenBundle.fromCoin genCoinSmall
+        <*> fmap TokenBundle.fromCoin genCoin
 
 instance Arbitrary TxIn where
     -- No Shrinking

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -1149,7 +1149,9 @@ instance Arbitrary TxOut where
     -- No Shrinking
     arbitrary = TxOut
         <$> arbitrary
-        <*> fmap TokenBundle.fromCoin genCoin
+        -- Here we deliberately restrict the range of coins in order to increase
+        -- the probability of collisions between identical transaction outputs:
+        <*> fmap TokenBundle.fromCoin (scale (`mod` 8) genCoin)
 
 instance Arbitrary TxIn where
     -- No Shrinking

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -110,7 +110,7 @@ import Cardano.Wallet.Primitive.Types.Address.Gen
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive )
+    ( genCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -1417,7 +1417,7 @@ instance Arbitrary (Hash "Tx") where
 
 instance Arbitrary Coin where
     shrink _ = []
-    arbitrary = genCoinLargePositive
+    arbitrary = genCoinPositive
 
 instance Arbitrary Tx where
     shrink (Tx tid fees ins outs wdrls md) = mconcat
@@ -1458,7 +1458,7 @@ instance Arbitrary TxIn where
 
 instance Arbitrary TxOut where
     arbitrary = TxOut (Address "address") . TokenBundle.fromCoin
-        <$> genCoinLargePositive
+        <$> genCoinPositive
 
 instance Arbitrary TxMeta where
     shrink _ = []

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -13,7 +13,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinAny, shrinkCoinAny )
+    ( genCoinFullRange, shrinkCoinFullRange )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( Flat (..), TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
@@ -260,8 +260,10 @@ newtype FixedSize256 a = FixedSize256 { unFixedSize256 :: a }
 --------------------------------------------------------------------------------
 
 instance Arbitrary Coin where
-    arbitrary = genCoinAny
-    shrink = shrinkCoinAny
+    -- This instance is used to test roundtrip conversions, so it's important
+    -- that we generate coins across the full range available.
+    arbitrary = genCoinFullRange
+    shrink = shrinkCoinFullRange
 
 instance Arbitrary (ProtocolMinimum Coin) where
     arbitrary

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/Compatibility/LedgerSpec.hs
@@ -28,7 +28,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
-    ( genTokenQuantityMixed, shrinkTokenQuantityMixed )
+    ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( txOutMaxTokenQuantity, txOutMinTokenQuantity )
 import Cardano.Wallet.Shelley.Compatibility.Ledger
@@ -303,5 +303,5 @@ instance Arbitrary TokenPolicyId where
     -- No shrinking
 
 instance Arbitrary TokenQuantity where
-    arbitrary = genTokenQuantityMixed
-    shrink = shrinkTokenQuantityMixed
+    arbitrary = genTokenQuantityFullRange
+    shrink = shrinkTokenQuantityFullRange

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -197,12 +197,21 @@ spec = do
             prop_decodeSignedShelleyTxRoundtrip Cardano.ShelleyBasedEraAllegra
         prop "roundtrip for Byron witnesses" prop_decodeSignedByronTxRoundtrip
 
+    -- Note:
+    --
+    -- In the tests below, the expected numbers of inputs are highly sensitive
+    -- to the size distribution of token bundles within generated transaction
+    -- outputs.
+    --
+    -- If these tests fail unexpectedly, it's a good idea to check whether or
+    -- not the distribution of generated token bundles has changed.
+    --
     estimateMaxInputsTests @ShelleyKey
-        [(1,114),(5,106),(10,101),(20,85),(50,32)]
+        [(1,114),(5,108),(10,103),(20,89),(50,37)]
     estimateMaxInputsTests @ByronKey
-        [(1,73),(5,67),(10,63),(20,52),(50,14)]
+        [(1,73),(5,69),(10,64),(20,54),(50,17)]
     estimateMaxInputsTests @IcarusKey
-        [(1,73),(5,67),(10,63),(20,52),(50,14)]
+        [(1,73),(5,69),(10,64),(20,54),(50,17)]
 
     describe "fee calculations" $ do
         let pp :: ProtocolParameters
@@ -763,7 +772,7 @@ instance Arbitrary Coin where
     shrink = shrinkCoinPositive
 
 instance Arbitrary TxOut where
-    arbitrary = TxOut addr <$> genTokenBundleSmallRange
+    arbitrary = TxOut addr <$> scale (`mod` 4) genTokenBundleSmallRange
       where
         addr = Address $ BS.pack (1:replicate 64 0)
 

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -61,7 +61,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..), coinToInteger )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
-    ( genCoinLargePositive, shrinkCoinLargePositive )
+    ( genCoinPositive, shrinkCoinPositive )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
@@ -759,8 +759,8 @@ instance Arbitrary (Hash "Tx") where
 -- transactions.
 --
 instance Arbitrary Coin where
-    arbitrary = genCoinLargePositive
-    shrink = shrinkCoinLargePositive
+    arbitrary = genCoinPositive
+    shrink = shrinkCoinPositive
 
 instance Arbitrary TxOut where
     arbitrary = TxOut addr <$> genTokenBundleSmallRange

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -76,7 +76,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (UnsafeTokenName), TokenPolicyId, unTokenName )
 import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
-    ( genTokenPolicyIdSmallRange, shrinkTokenPolicyIdSmallRange )
+    ( genTokenPolicyId, shrinkTokenPolicyId )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxConstraints (..)
     , TxIn (..)
@@ -1085,8 +1085,8 @@ instance Arbitrary AssetId where
         <*> (UnsafeTokenName . BS.pack <$> vector 128)
 
 instance Arbitrary TokenPolicyId where
-    arbitrary = genTokenPolicyIdSmallRange
-    shrink = shrinkTokenPolicyIdSmallRange
+    arbitrary = genTokenPolicyId
+    shrink = shrinkTokenPolicyId
 
 instance Arbitrary (Script KeyHash) where
     arbitrary = do


### PR DESCRIPTION
# Issue Number

#2695

# Overview

This PR simplifies the generators (and shrinkers) for the following types:
- [x] `Coin`
- [x] `TokenQuantity`
- [x] `TokenPolicyId`
- [x] `TokenName`
- [x] `AssetId`
    
Each type now has a single generator and shrinker that relies on the **_QC size parameter_**. These have the following form:
- `genType`
- `shrinkType`

Where **_strictly-positive_** values are required, we also have:
- `genTypePositive`
- `shrinkTypePositive`

Where values across the **_full range_** of a type are required, we also have:
- `genTypeFullRange`
- `shrinkTypeFullRange`

This PR also adjusts coverage checks for some properties.

# Future work

In a future PR, we can simplify generators for `TokenMap`, `TokenBundle`, `UTxOIndex`, `TxIn`, `TxOut`.