### PR TITLE
Mint/burn script witnesses groundwork

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -168,6 +168,7 @@ library
       Cardano.Wallet.Primitive.AddressDerivation
       Cardano.Wallet.Primitive.AddressDerivation.Byron
       Cardano.Wallet.Primitive.AddressDerivation.Icarus
+      Cardano.Wallet.Primitive.AddressDerivation.MintBurn
       Cardano.Wallet.Primitive.AddressDerivation.Shared
       Cardano.Wallet.Primitive.AddressDerivation.SharedKey
       Cardano.Wallet.Primitive.AddressDerivation.Shelley
@@ -362,6 +363,7 @@ test-suite unit
       Cardano.Wallet.NetworkSpec
       Cardano.Wallet.Primitive.AddressDerivation.ByronSpec
       Cardano.Wallet.Primitive.AddressDerivation.IcarusSpec
+      Cardano.Wallet.Primitive.AddressDerivation.MintBurnSpec
       Cardano.Wallet.Primitive.AddressDerivationSpec
       Cardano.Wallet.Primitive.AddressDiscovery.RandomSpec
       Cardano.Wallet.Primitive.AddressDiscovery.SequentialSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -184,6 +184,7 @@ library
       Cardano.Wallet.Primitive.Migration
       Cardano.Wallet.Primitive.Migration.Planning
       Cardano.Wallet.Primitive.Migration.Selection
+      Cardano.Wallet.Primitive.MintBurn
       Cardano.Wallet.Primitive.Model
       Cardano.Wallet.Primitive.Types
       Cardano.Wallet.Primitive.Types.Address

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation.hs
@@ -172,7 +172,14 @@ import qualified Data.Text.Encoding as T
 --
 -- @m | purpose' | cointype' | account' | role | address@
 data Depth
-    = RootK | PurposeK | CoinTypeK | AccountK | RoleK | AddressK | ScriptK
+    = RootK
+    | PurposeK
+    | CoinTypeK
+    | AccountK
+    | RoleK
+    | AddressK
+    | ScriptK
+    | PolicyK
 
 -- | Marker for addresses type engaged. We want to handle four cases here.
 -- The first two are pertinent to UTxO accounting,

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/MintBurn.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/MintBurn.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DataKinds #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Definition of policy keys which are used to create scripts for the purposes
+-- of minting and burning.
+--
+-- The policy keys are derived according to the following path:
+--
+-- m / purpose' / coin_type' / policy_ix'
+-- m / 1855'    / 1815'      / [2^31 .. 2^32-1]'
+--
+-- Where purpose' and coin_type' are fixed, and each new policy_ix' represents a
+-- different policy key.
+
+module Cardano.Wallet.Primitive.AddressDerivation.MintBurn
+    ( -- * Constants
+      purposeCIP1855
+      -- * Helpers
+    , derivePolicyKey
+    , derivePolicyPrivateKey
+    ) where
+
+import Cardano.Address.Derivation
+    ( XPrv )
+import Cardano.Address.Script
+    ( KeyHash )
+import Cardano.Crypto.Wallet
+    ( deriveXPrv )
+import Cardano.Crypto.Wallet.Types
+    ( DerivationScheme (DerivationScheme2) )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (PolicyK, PurposeK, RootK)
+    , DerivationType (Hardened)
+    , Index (getIndex)
+    , Index (Index)
+    , Passphrase (Passphrase)
+    , Role (UtxoExternal)
+    , WalletKey (publicKey)
+    , getRawKey
+    , hashVerificationKey
+    , liftRawKey
+    )
+import Cardano.Wallet.Primitive.AddressDiscovery
+    ( coinTypeAda )
+import Prelude
+
+-- | Purpose for forged policy keys is a constant set to 1855' (or 0x8000073F)
+-- following the original CIP-1855: "Forging policy keys for HD Wallets".
+--
+-- It indicates that the subtree of this node is used according to this
+-- specification.
+--
+-- Hardened derivation is used at this level.
+purposeCIP1855 :: Index 'Hardened 'PurposeK
+purposeCIP1855 = toEnum 0x8000073F
+
+-- | Derive the policy private key that should be used to create mint/burn
+-- scripts.
+derivePolicyPrivateKey
+    :: Passphrase purpose
+    -- ^ Passphrase for wallet
+    -> XPrv
+    -- ^ Root private key to derive policy private key from
+    -> Index 'Hardened 'PolicyK
+    -- ^ Index of policy script
+    -> XPrv
+    -- ^ Policy private key
+derivePolicyPrivateKey (Passphrase pwd) rootXPrv (Index policyIx) =
+    let
+        purposeXPrv = -- lvl1 derivation; hardened derivation of purpose'
+            deriveXPrv DerivationScheme2 pwd rootXPrv (getIndex purposeCIP1855)
+        coinTypeXPrv = -- lvl2 derivation; hardened derivation of coin_type'
+            deriveXPrv DerivationScheme2 pwd purposeXPrv (getIndex coinTypeAda)
+     -- lvl3 derivation; hardened derivation of policy' index
+    in deriveXPrv DerivationScheme2 pwd coinTypeXPrv policyIx
+
+-- | Derive the policy private key that should be used to create mint/burn
+-- scripts, as well as the key hash of the policy public key.
+derivePolicyKey
+  :: WalletKey key
+  => Passphrase "encryption"
+  -- ^ Passphrase for wallet
+  -> key 'RootK XPrv
+  -- ^ Root private key to derive policy private key from
+  -> Index 'Hardened 'PolicyK
+  -- ^ Index of policy script
+  -> (key 'PolicyK XPrv, KeyHash)
+  -- ^ Policy private key
+derivePolicyKey pwd rootPrv policyIx = (policyK, vkeyHash)
+  where
+    policyK = liftRawKey policyPrv
+    policyPrv = derivePolicyPrivateKey pwd (getRawKey rootPrv) policyIx
+    vkeyHash = hashVerificationKey UtxoExternal (publicKey policyK)

--- a/lib/core/src/Cardano/Wallet/Primitive/MintBurn.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/MintBurn.hs
@@ -1,0 +1,39 @@
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Primitives for minting and burning tokens.
+
+module Cardano.Wallet.Primitive.MintBurn
+    ( -- * Types
+      TxMintBurn(..)
+    , ToMint
+    , ToBurn
+    ) where
+
+import Prelude
+
+import Cardano.Address.Script
+    ( KeyHash, Script )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap )
+import Data.List.NonEmpty
+    ( NonEmpty )
+
+-- TokenMap can only hold positive values, so we create wrapper types to
+-- represent positive values (ToMint) and negative values (ToBurn).
+
+-- | Tokens to mint.
+type ToMint = TokenMap
+
+-- | Tokens to burn.
+type ToBurn = TokenMap
+
+-- | Representation of the Cardano.API data for minting and burning. This is the
+-- data necessary to submit to the Cardano.API backend.
+data TxMintBurn = TxMintBurn
+    { toMint  :: ToMint
+    , toBurn  :: ToBurn
+    , scripts :: NonEmpty (Script KeyHash)
+    }
+    deriving (Eq, Show)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -34,6 +34,7 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy
     , validateMetadataDescription
     , validateMetadataURL
     , validateMetadataLogo
+    , tokenPolicyIdFromScript
     ) where
 
 import Prelude
@@ -109,6 +110,10 @@ instance ToText TokenPolicyId where
 
 instance FromText TokenPolicyId where
     fromText = fmap UnsafeTokenPolicyId . fromText
+
+tokenPolicyIdFromScript :: Script KeyHash -> TokenPolicyId
+tokenPolicyIdFromScript =
+    UnsafeTokenPolicyId . Hash . unScriptHash . toScriptHash
 
 -- | Token names, defined by the monetary policy script.
 newtype TokenName =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenPolicy.hs
@@ -38,6 +38,8 @@ module Cardano.Wallet.Primitive.Types.TokenPolicy
 
 import Prelude
 
+import Cardano.Address.Script
+    ( KeyHash, Script, ScriptHash (unScriptHash), toScriptHash )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Codec.Binary.Bech32.TH

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDerivation/MintBurnSpec.hs
@@ -1,0 +1,95 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Wallet.Primitive.AddressDerivation.MintBurnSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Address.Derivation
+    ( XPrv, XPub )
+import Cardano.Wallet.Primitive.AddressDerivation
+    ( Depth (PolicyK, RootK, ScriptK)
+    , DerivationType (Hardened)
+    , Index
+    , Passphrase
+    , Role (UtxoExternal)
+    , WalletKey (publicKey)
+    , getRawKey
+    , hashVerificationKey
+    , liftRawKey
+    )
+import Cardano.Wallet.Primitive.AddressDerivationSpec
+    ()
+import Cardano.Wallet.Unsafe
+    ( unsafeXPrv )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..), Property, property, vector, (===) )
+
+import Cardano.Address.Script
+    ( KeyHash )
+import Cardano.Wallet.Primitive.AddressDerivation.MintBurn
+    ( derivePolicyKey, derivePolicyPrivateKey )
+import Cardano.Wallet.Primitive.AddressDerivation.Shelley
+    ( ShelleyKey )
+import qualified Data.ByteString as BS
+import Test.QuickCheck.Arbitrary
+    ( arbitraryBoundedEnum )
+
+spec :: Spec
+spec = do
+    parallel $ describe "Mint/Burn Policy key Address Derivation Properties" $ do
+        it "Policy key derivation from master key works for various indexes" $
+            property prop_keyDerivationFromXPrv
+        it "Policy public key hash matches private key" $
+            property prop_keyHashMatchesXPrv
+
+{-------------------------------------------------------------------------------
+                               Properties
+-------------------------------------------------------------------------------}
+
+prop_keyDerivationFromXPrv
+    :: Passphrase "encryption"
+    -> XPrv
+    -> Index 'Hardened 'PolicyK
+    -> Property
+prop_keyDerivationFromXPrv pwd masterkey policyIx =
+    rndKey `seq` property () -- NOTE Making sure this doesn't throw
+  where
+    rndKey :: XPrv
+    rndKey = derivePolicyPrivateKey pwd masterkey policyIx
+
+prop_keyHashMatchesXPrv
+    :: Passphrase "encryption"
+    -> ShelleyKey 'RootK XPrv
+    -> Index 'Hardened 'PolicyK
+    -> Property
+prop_keyHashMatchesXPrv pwd masterkey policyIx =
+    hashVerificationKey
+      UtxoExternal
+      (getPublicKey rndKey)
+      === keyHash
+  where
+    rndKey :: ShelleyKey 'PolicyK XPrv
+    keyHash :: KeyHash
+    (rndKey, keyHash) = derivePolicyKey pwd masterkey policyIx
+
+    getPublicKey
+        :: ShelleyKey 'PolicyK XPrv
+        -> ShelleyKey 'ScriptK XPub
+    getPublicKey =
+        publicKey . (liftRawKey :: XPrv -> ShelleyKey 'ScriptK XPrv) . getRawKey
+
+instance Arbitrary XPrv where
+    arbitrary = unsafeXPrv . BS.pack <$> vector 128
+
+instance Arbitrary (Index 'Hardened 'PolicyK) where
+    shrink _ = []
+    arbitrary = arbitraryBoundedEnum

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -56,6 +56,7 @@ library
     , containers
     , contra-tracer
     , directory
+    , either
     , extra
     , filepath
     , fmt

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -95,7 +95,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..), TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
-    ( TokenName (..), TokenPolicyId )
+    ( TokenName (..) )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -190,6 +190,7 @@ import qualified Cardano.Ledger.Core as SL
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
+import qualified Cardano.Wallet.Primitive.Types.TokenPolicy as TokenPolicy
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Codec.CBOR.Encoding as CBOR

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -394,7 +394,7 @@ spec = do
                       mkByronWitness unsignedTx Cardano.Mainnet addr
                   addrWits = zipWith (mkByronWitness' unsigned) inps pairs
                   fee = toCardanoLovelace $ selectionDelta txOutCoin cs
-                  Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee
+                  Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee Nothing
                   cs = SelectionResult
                       { inputsSelected = NE.fromList inps
                       , extraCoinSource = Nothing
@@ -488,7 +488,7 @@ spec = do
                       mkByronWitness unsignedTx net addr
                   addrWits = zipWith (mkByronWitness' unsigned) inps pairs
                   fee = toCardanoLovelace $ selectionDelta txOutCoin cs
-                  Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee
+                  Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee Nothing
                   cs = SelectionResult
                     { inputsSelected = NE.fromList inps
                     , extraCoinSource = Nothing
@@ -620,7 +620,7 @@ prop_decodeSignedShelleyTxRoundtrip shelleyEra (DecodeShelleySetup utxo outs md 
     let inps = Map.toList $ getUTxO utxo
     let cs = mkSelection inps
     let fee = toCardanoLovelace $ selectionDelta txOutCoin cs
-    let Right unsigned = mkUnsignedTx shelleyEra slotNo cs md mempty [] fee
+    let Right unsigned = mkUnsignedTx shelleyEra slotNo cs md mempty [] fee Nothing
     let addrWits = map (mkShelleyWitness unsigned) pairs
     let wits = addrWits
     let ledgerTx = Cardano.makeSignedTransaction wits unsigned
@@ -650,7 +650,7 @@ prop_decodeSignedByronTxRoundtrip (DecodeByronSetup utxo outs slotNo ntwrk pairs
     let inps = Map.toList $ getUTxO utxo
     let cs = mkSelection inps
     let fee = toCardanoLovelace $ selectionDelta txOutCoin cs
-    let Right unsigned = mkUnsignedTx shelleyEra slotNo cs Nothing mempty [] fee
+    let Right unsigned = mkUnsignedTx shelleyEra slotNo cs Nothing mempty [] fee Nothing
     let byronWits = zipWith (mkByronWitness' unsigned) inps pairs
     let ledgerTx = Cardano.makeSignedTransaction byronWits unsigned
 

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -53,6 +53,7 @@
           (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))


### PR DESCRIPTION
# Issue Number

ADP-955

# Overview

- Add new Alonzo-era code to mkUnsignedTx in order to mint and burn tokens.
- Add new AddressDerivation module implementing policy key derivation described in CIP-1855 (for minting and burning).
- Add cardano script and script witness conversion functions to Shelley.Compatibility module.
- Expose some internal functions in the Shelley.Compatibility module so they can be re-used in the above.
- Add PolicyK option to the "Depth" enum (for mint/burn policy keys).
- Add minimal tests to test the key derivation.

# Comments

I have done some work to hook the API up to the underlying `mkUnsignedTx` function but have shied away from committing that code, because I know the new transaction workflow is coming soon.

I've also not implemented any of the acceptance criteria for ADP-955, due to reliance on the new transaction workflow, this PR is simply laying some groundwork.

The new version of cardano-node requires the user to provide script witnesses in transaction construction, not transaction signing. The payment keys associated with that script must still sign the transaction in the signing step.
