### PR TITLE
Fix cabal build

### DIFF
--- a/.buildkite/.envrc
+++ b/.buildkite/.envrc
@@ -1,1 +1,1 @@
-eval $(lorri direnv --shell-file default.nix)
+use nix

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -55,6 +55,7 @@ import System.Exit
     ( exitWith )
 
 import qualified Control.Foldl as Fold
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
 import qualified Filesystem.Path.CurrentOS as FP
 import qualified Turtle.Bytes as TB
@@ -461,7 +462,7 @@ saveStackRoot cfg@CICacheConfig{..} = saveZippedCache stackRootCache cfg tar
 saveStackWork :: CICacheConfig -> IO ()
 saveStackWork cfg = saveZippedCache stackWorkCache cfg tar
   where
-    nullTerminate = (<> "\0") . FP.encode
+    nullTerminate = (<> "\0") . B8.pack . FP.encodeString
     dirs = nullTerminate <$> find (ends ".stack-work") "."
     tar = TB.inproc "tar" (exclude ++ ["--null", "-T", "-", "-c"]) dirs
     exclude = ["--exclude", ".stack-work/logs"]

--- a/cabal.project
+++ b/cabal.project
@@ -138,6 +138,12 @@ source-repository-package
     tag: 1a75bdfca014723dd5d40760fad854b3f0f37156
     subdir: http-client
 
+-- Drops an instance breaking cardano-node.
+source-repository-package
+  type: git
+  location: https://github.com/Quid2/flat.git
+  tag: 95e5d7488451e43062ca84d5376b3adcc465f1cd
+
 -- -------------------------------------------------------------------------
 -- Constraints tweaking
 

--- a/nix/cabal-shell.nix
+++ b/nix/cabal-shell.nix
@@ -43,7 +43,7 @@ mkShell rec {
     ncurses
     lzma
     openssl
-    libsodium
+    libsodium-vrf
     pcre
   ]
   ++ lib.optional (stdenv.hostPlatform.libc == "glibc") glibcLocales

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,11 +38,11 @@ let
     ++ iohkNixMain.overlays.haskell-nix-extra
     # iohkNix: nix utilities and niv:
     ++ iohkNixMain.overlays.iohkNix
+    # iohkNix: crypto
+    ++ iohkNixMain.overlays.crypto
     # our own overlays:
     ++ [
       (final: prev: {
-        # iohkNix: crypto
-        libsodium-vrf = final.callPackage (sources.iohk-nix + /overlays/crypto/libsodium.nix) {};
 
         # commonLib: iohk-nix utils and our own:
         commonLib = final.iohkNix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "6d0bab1f88fc1963e7afad440714da96d3d5aa78",
-        "sha256": "0p5qw87h29vshs6av7vrsgssx5j02p5sypyrcmimj0pr1f2wcrf5",
+        "rev": "cbd497f5844249ef8fe617166337d59f2a6ebe90",
+        "sha256": "1idlgzphvljjpzva9h504sdaqjqbdg5svp3cinnc2r4s6dlkshl8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/6d0bab1f88fc1963e7afad440714da96d3d5aa78.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/cbd497f5844249ef8fe617166337d59f2a6ebe90.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "sphinxcontrib-haddock": {

--- a/shell.nix
+++ b/shell.nix
@@ -36,7 +36,6 @@ let
         project.hsPkgs.pretty-simple.components.exes.pretty-simple
       ]) ++ (with pkgs.buildPackages.buildPackages; [
         go-jira
-        haskellPackages.ghcid
         niv
         pkgconfig
         python3Packages.openapi-spec-validator


### PR DESCRIPTION
### Issue Number

Noticed in #2578.

### Overview

- Fixes a dependency in `cabal.project`.
- Fix `nix/cabal-shell.nix` to use the forked `libsodium-vrf` package.
- Fix `.buildkite/rebuild.hs` so that it compiles on macOS (because [Filesystem.Path.CurrentOS](https://hackage.haskell.org/package/system-filepath-0.4.14/docs/Filesystem-Path-CurrentOS.html))

### Comments

- [Hydra jobset](https://hydra.iohk.io/jobset/Cardano/cardano-wallet-pr-2776)
- [Cabal Nightly build](https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds?branch=rvl%2Ffix-cabal-build) (use environment variable `step=cabal` when creating a new build)
