### PR TITLE
Clarify wording of `CannotCoverFee` API error.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -303,9 +303,9 @@ errMsg400StartTimeLaterThanEndTime startTime endTime = mconcat
 
 errMsg403Fee :: String
 errMsg403Fee =
-    "I am unable to finalize the transaction, as there is not enough ada I can \
-    \use to pay for fees, or to satisfy the minimum ada quantities of change \
-    \outputs."
+    "I am unable to finalize the transaction, as there is not enough ada \
+    \available to pay for the fee and also pay for the minimum ada quantities \
+    \of all change outputs."
 
 errMsg403NotAByronWallet :: String
 errMsg403NotAByronWallet =

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3717,13 +3717,14 @@ instance IsServerError ErrSelectAssets where
                         , pretty . Flat $ missingOutputAssets e
                         ]
                 UnableToConstructChange e ->
-                    apiError err403 CannotCoverFee $ mconcat
-                        [ "I am unable to finalize the transaction, as there is "
-                        , "not enough ada I can use to pay for fees, or to "
-                        , "satisfy the minimum ada quantities of change outputs. "
-                        , "I need about pretty ", pretty (shortfall e), " ada to "
-                        , "proceed; try increasing your wallet balance as such, "
-                        , "or try sending a different, smaller payment."
+                    apiError err403 CannotCoverFee $ T.unwords
+                        [ "I am unable to finalize the transaction, as there"
+                        , "is not enough ada available to pay for the fee and"
+                        , "also pay for the minimum ada quantities of all"
+                        , "change outputs. I need approximately"
+                        , pretty (shortfall e)
+                        , "ada to proceed. Try increasing your wallet balance"
+                        , "or sending a smaller amount."
                         ]
 
 instance IsServerError (ErrInvalidDerivationIndex 'Hardened level) where


### PR DESCRIPTION
# Issue

https://input-output-rnd.slack.com/archives/CDM8B0AN9/p1627563147092700

# Overview

This PR tries to clarify the wording of the `CannotCoverFee` API error.

It also fixes the broken "I need about pretty n ada" wording. (The "pretty" was erroneously included in the generated text output.)