### PR TITLE
Buildkite: Clean up .hie files before stack build

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -233,7 +233,7 @@ setupBuildDirectory dryRun buildDir = do
 -- Remove certain files which get cached but could cause problems for subsequent
 -- builds.
 cleanBuildDirectory :: FilePath -> IO ()
-cleanBuildDirectory buildDir = findTix buildDir >>= mapM_ rm
+cleanBuildDirectory buildDir = mapM_ rm =<< findTix buildDir <> findHie buildDir
 
 -- | Check for the presence of new or modified test data files which someone
 -- forgot to check in.
@@ -324,10 +324,13 @@ titled heading action = do
     pure res
 
 ----------------------------------------------------------------------------
--- Weeder - uses contents of .stack-work to determine unused dependencies
+-- Weeder - uses .hie files in .stack-work to determine unused dependencies
 
 weederStep :: DryRun -> IO ExitCode
 weederStep dryRun = titled "Weeder" $ run dryRun "weeder" []
+
+findHie :: FilePath -> IO [FilePath]
+findHie dir = fold (find (suffix ".hie") dir) Fold.list
 
 ----------------------------------------------------------------------------
 -- Stack Haskell Program Coverage and upload to Coveralls

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -217,12 +217,14 @@ let
         '';
       }
 
+      ({ lib, pkgs, ... }: {
+        # Use our forked libsodium from iohk-nix crypto overlay.
+        packages.cardano-crypto-praos.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+        packages.cardano-crypto-class.components.library.pkgconfig = lib.mkForce [ [ pkgs.libsodium-vrf ] ];
+      })
+
       # Build fixes for library dependencies
       {
-        # Use our forked libsodium
-        packages.cardano-crypto-praos.components.library.pkgconfig = [ [ pkgs.libsodium-vrf ] ];
-        packages.cardano-crypto-class.components.library.pkgconfig = [ [ pkgs.libsodium-vrf ] ];
-
         # Packages we wish to ignore version bounds of.
         # This is similar to jailbreakCabal, however it
         # does not require any messing with cabal files.


### PR DESCRIPTION
### Issue Number

Resolves #2785

### Overview

Wipes out all the `.hie` files in `.stack-work` before starting the build.

