### PR TITLE
Temporarily add TestEnableDevelopmentNetworkProtocols to e2e tests

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -233,7 +233,9 @@ task :get_latest_configs, [:env] do |task, args|
     # remove environment names from genesis files
     config = File.read(config_file)
     config_edited = config.gsub(/#{env}-([^-]+)-genesis.json/, 'genesis-\1.json')
-    File.open(config_file, "w") { |file| file.puts config_edited }
+    config_hash = JSON.parse(config_edited)
+    config_hash["TestEnableDevelopmentNetworkProtocols"] = true
+    File.open(config_file, "w") { |file| file.puts config_hash.to_json }
   end
 end
 


### PR DESCRIPTION
# Issue Number

ADP-1059

# Overview

Temporarily add TestEnableDevelopmentNetworkProtocols to e2e tests

# Comments

To be removed when no longer needed. For now adding for the sake of nightly e2e tests passing...

Running Win/Docker/Mac tests against this branch -> https://github.com/input-output-hk/cardano-wallet/actions
Linux passed locally.
