### PR TITLE
Negotiate NodeToClientVersion for non-breaking mainnet support

### DIFF
--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -133,7 +133,11 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Shelley
     ( SomeNetworkDiscriminant (..) )
 import Cardano.Wallet.Shelley.Compatibility
-    ( HasNetworkId (..), NodeVersionData, emptyGenesis, fromCardanoBlock )
+    ( HasNetworkId (..)
+    , NodeToClientVersionData
+    , emptyGenesis
+    , fromCardanoBlock
+    )
 import Cardano.Wallet.Shelley.Launch
     ( CardanoNodeConn, NetworkConfiguration (..), parseGenesisData )
 import Cardano.Wallet.Shelley.Network
@@ -585,7 +589,7 @@ bench_restoration
     -> Trace IO Text -- ^ For wallet tracing
     -> CardanoNodeConn  -- ^ Socket path
     -> NetworkParameters
-    -> NodeVersionData
+    -> NodeToClientVersionData
     -> Text -- ^ Benchmark name (used for naming resulting files)
     -> [(WalletId, WalletName, s)]
     -> Bool -- ^ If @True@, will trace detailed progress to a .timelog file.
@@ -707,7 +711,7 @@ prepareNode
     -> Proxy n
     -> CardanoNodeConn
     -> NetworkParameters
-    -> NodeVersionData
+    -> NodeToClientVersionData
     -> IO ()
 prepareNode tr proxy socketPath np vData = do
     traceWith tr $ MsgSyncStart proxy
@@ -728,7 +732,7 @@ waitForWalletsSyncTo
     -> WalletLayer IO s k
     -> [WalletId]
     -> GenesisParameters
-    -> NodeVersionData
+    -> NodeToClientVersionData
     -> IO ()
 waitForWalletsSyncTo targetSync tr proxy walletLayer wids gp vData = do
     posixNow <- utcTimeToPOSIXSeconds <$> getCurrentTime

--- a/lib/shelley/src/Cardano/Wallet/Shelley.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley.hs
@@ -173,8 +173,6 @@ import Network.Wai.Handler.Warp
     ( setBeforeMainLoop )
 import Network.Wai.Middleware.Logging
     ( ApiLog (..) )
-import Ouroboros.Network.CodecCBORTerm
-    ( CodecCBORTerm )
 import Ouroboros.Network.NodeToClient
     ( NodeToClientVersionData (..) )
 import System.Exit
@@ -245,11 +243,7 @@ serveWallet
     -- ^ Socket for communicating with the node
     -> Block
     -- ^ The genesis block, or some starting point.
-    -> ( NetworkParameters
-       , ( NodeToClientVersionData
-         , CodecCBORTerm Text NodeToClientVersionData
-         )
-       )
+    -> ( NetworkParameters, NodeToClientVersionData)
     -- ^ Network parameters needed to connect to the underlying network.
     --
     -- See also: 'Cardano.Wallet.Shelley.Compatibility#KnownNetwork'.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -36,13 +36,12 @@ module Cardano.Wallet.Shelley.Compatibility
     , CardanoBlock
     , NetworkId
 
-    , NodeVersionData
+    , NodeToClientVersionData
     , StandardCrypto
     , StandardShelley
 
       -- * Protocol Parameters
-    , nodeToClientVersion
-    , testnetVersionData
+    , nodeToClientVersions
 
       -- * Genesis
     , emptyGenesis
@@ -243,16 +242,11 @@ import Ouroboros.Consensus.Shelley.Ledger.Block
     ( ShelleyBlock (..) )
 import Ouroboros.Network.Block
     ( BlockNo (..), ChainHash, Point (..), Tip (..), getTipPoint )
-import Ouroboros.Network.CodecCBORTerm
-    ( CodecCBORTerm )
-import Ouroboros.Network.Magic
-    ( NetworkMagic (..) )
 import Ouroboros.Network.NodeToClient
     ( ConnectionId (..)
     , LocalAddress (..)
     , NodeToClientVersion (..)
     , NodeToClientVersionData (..)
-    , nodeToClientCodecCBORTerm
     )
 import Ouroboros.Network.Point
     ( WithOrigin (..) )
@@ -312,9 +306,6 @@ import qualified Shelley.Spec.Ledger.API as SLAPI
 import qualified Shelley.Spec.Ledger.BlockChain as SL
 import qualified Shelley.Spec.Ledger.UTxO as SL
 
-type NodeVersionData =
-    (NodeToClientVersionData, CodecCBORTerm Text NodeToClientVersionData)
-
 --------------------------------------------------------------------------------
 --
 -- Chain Parameters
@@ -348,20 +339,8 @@ emptyGenesis gp = W.Block
 -- Network Parameters
 
 -- | The protocol client version. Distinct from the codecs version.
-nodeToClientVersion :: NodeToClientVersion
-nodeToClientVersion = NodeToClientV_9
-
--- | Settings for configuring a TestNet network client
-testnetVersionData
-    :: W.ProtocolMagic
-    -> NodeVersionData
-testnetVersionData pm =
-    ( NodeToClientVersionData
-        { networkMagic =
-            NetworkMagic $ fromIntegral $ W.getProtocolMagic pm
-        }
-    , nodeToClientCodecCBORTerm nodeToClientVersion
-    )
+nodeToClientVersions :: [NodeToClientVersion]
+nodeToClientVersions = [NodeToClientV_8, NodeToClientV_9]
 
 --------------------------------------------------------------------------------
 --

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -130,7 +130,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxOut )
 import Cardano.Wallet.Shelley.Compatibility
-    ( NodeVersionData, StandardShelley, nodeToClientVersion )
+    ( StandardShelley )
 import Cardano.Wallet.Shelley.Launch
     ( TempDirLog (..), envFromText, isEnvSet, lookupEnvNonEmpty )
 import Cardano.Wallet.Unsafe
@@ -176,7 +176,7 @@ import Data.Time.Clock.POSIX
 import Ouroboros.Network.Magic
     ( NetworkMagic (..) )
 import Ouroboros.Network.NodeToClient
-    ( NodeToClientVersionData (..), nodeToClientCodecCBORTerm )
+    ( NodeToClientVersionData (..) )
 import System.Directory
     ( copyFile, createDirectory, createDirectoryIfMissing, makeAbsolute )
 import System.Environment
@@ -503,7 +503,7 @@ data RunningNode = RunningNode
     -- ^ Socket path
     Block
     -- ^ Genesis block
-    (NetworkParameters, NodeVersionData)
+    (NetworkParameters, NodeToClientVersionData)
 
 -- | Execute an action after starting a cluster of stake pools. The cluster also
 -- contains a single BFT node that is pre-configured with keys available in the
@@ -645,7 +645,7 @@ withBFTNode
     -- this.
     -> NodeParams
     -- ^ Parameters used to generate config files.
-    -> (CardanoNodeConn -> Block -> (NetworkParameters, NodeVersionData) -> IO a)
+    -> (CardanoNodeConn -> Block -> (NetworkParameters, NodeToClientVersionData) -> IO a)
     -- ^ Callback function with genesis parameters
     -> IO a
 withBFTNode tr baseDir params action =
@@ -908,7 +908,7 @@ genConfig
     -- ^ Last era to hard fork into.
     -> LogFileConfig
     -- ^ Minimum severity level for logging and optional /extra/ logging output
-    -> IO (FilePath, Block, NetworkParameters, NodeVersionData)
+    -> IO (FilePath, Block, NetworkParameters, NodeToClientVersionData)
 genConfig dir systemStart clusterEra logCfg = do
     let LogFileConfig severity mExtraLogFile extraSev = logCfg
     let startTime = round @_ @Int . utcTimeToPOSIXSeconds $ systemStart
@@ -977,10 +977,7 @@ genConfig dir systemStart clusterEra logCfg = do
         @_ @(ShelleyGenesis StandardShelley) shelleyGenesisFile
     let networkMagic = sgNetworkMagic shelleyGenesis
     let shelleyParams = fst $ Shelley.fromGenesisData shelleyGenesis []
-    let versionData =
-            ( NodeToClientVersionData $ NetworkMagic networkMagic
-            , nodeToClientCodecCBORTerm nodeToClientVersion
-            )
+    let versionData = NodeToClientVersionData $ NetworkMagic networkMagic
 
     pure
         ( dir </> "node.config"

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -936,6 +936,7 @@ genConfig dir systemStart clusterEra logCfg = do
         >>= withAddedKey "ShelleyGenesisFile" shelleyGenesisFile
         >>= withAddedKey "ByronGenesisFile" byronGenesisFile
         >>= withAddedKey "AlonzoGenesisFile" alonzoGenesisFile
+        >>= enableAlonzoIfNeeded
         >>= withHardForks clusterEra
         >>= withAddedKey "minSeverity" Debug
         >>= withScribes scribes
@@ -1008,6 +1009,11 @@ genConfig dir systemStart clusterEra logCfg = do
             [ ("Test" <> T.pack (show hardFork) <> "AtEpoch", Yaml.Number 0)
             | hardFork <- [ShelleyHardFork .. era] ]
 
+
+    enableAlonzoIfNeeded =
+        if clusterEra == AlonzoHardFork
+        then withAddedKey "TestEnableDevelopmentNetworkProtocols" True
+        else return
 -- | Generate a topology file from a list of peers.
 genTopology :: FilePath -> [Int] -> IO FilePath
 genTopology dir peers = do

--- a/lib/shelley/test/data/cardano-node-shelley/node.config
+++ b/lib/shelley/test/data/cardano-node-shelley/node.config
@@ -29,7 +29,6 @@ ApplicationVersion: 1
 LastKnownBlockVersion-Major: 2
 LastKnownBlockVersion-Minor: 0
 LastKnownBlockVersion-Alt: 0
-TestEnableDevelopmentNetworkProtocols: True
 
 # These settings start the test cluster in the Mary era (a "virtual"
 # hard fork happens at the start of the first epoch).

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/NetworkSpec.hs
@@ -18,8 +18,6 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
     ( NetworkParameters (..) )
-import Cardano.Wallet.Shelley.Compatibility
-    ( NodeVersionData )
 import Cardano.Wallet.Shelley.Launch
     ( CardanoNodeConn, withSystemTempDir )
 import Cardano.Wallet.Shelley.Launch.Cluster
@@ -36,6 +34,8 @@ import Data.Set
     ( Set )
 import Fmt
     ( build, fmt, indentF )
+import Ouroboros.Network.NodeToClient
+    ( NodeToClientVersionData )
 import Test.Hspec
     ( Spec, beforeAll, describe, it, shouldBe, shouldReturn )
 import Test.QuickCheck
@@ -225,7 +225,7 @@ spec = describe "NetworkLayer regression test #1708" $ do
 
 withTestNode
     :: Tracer IO ClusterLog
-    -> (NetworkParameters -> CardanoNodeConn -> NodeVersionData -> IO a)
+    -> (NetworkParameters -> CardanoNodeConn -> NodeToClientVersionData -> IO a)
     -> IO a
 withTestNode tr action = do
     cfg <- singleNodeParams Error Nothing


### PR DESCRIPTION
# Issue Number

ADP-1025

# Background

#2763 made the wallet demand NodeToClientV_9. With cardano-node 1.28.0, V_9 is only enabled if  `TestEnableDevelopmentNetworkProtocols` is set in the node config.

# Overview

- [x] Make the wallet support both `V_8` and `V_9`.
- [x] Ensure integration tests on Mary are run without `TestEnableDevelopmentNetworkProtocols: True`


# Comments

<!-- Additional comments or screenshots to attach if any -->

<!--
Don't forget to:

 ✓ Self-review your changes to make sure nothing unexpected slipped through
 ✓ Assign yourself to the PR
 ✓ Assign one or several reviewer(s)
 ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket
 ✓ Acknowledge any changes required to the Wiki
 ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->
