### PR TITLE
Fix PatternMatchFail error in shared wallet integration tests

### DIFF
--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -49,6 +49,7 @@ library
     , cryptonite
     , deepseq
     , directory
+    , either
     , extra
     , filepath
     , fmt

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -49,6 +49,7 @@
           (hsPkgs."cryptonite" or (errorHandler.buildDepError "cryptonite"))
           (hsPkgs."deepseq" or (errorHandler.buildDepError "deepseq"))
           (hsPkgs."directory" or (errorHandler.buildDepError "directory"))
+          (hsPkgs."either" or (errorHandler.buildDepError "either"))
           (hsPkgs."extra" or (errorHandler.buildDepError "extra"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))


### PR DESCRIPTION
### Issue Number

Found during ADP-1059.

### Overview

This error was seen when trying to merge https://github.com/input-output-hk/cardano-wallet/pull/2790#issuecomment-890312237.

The `postSharedWallet` request was failing for some reason, but instead of saying that the request failed, it said:

```
uncaught exception: PatternMatchFail
src/Test/Integration/Scenario/API/Shared/Wallets.hs:1029:25-75: Non-exhaustive patterns in lambda
```

This change lets it print the correct error message depending on whether the request failed or the shared wallet was pending.

### Comments

I'm not sure why the `postSharedWallets` request failed in the first place. Any ideas @paweljakubas ?
