### PR TITLE
Revert "Temporarily add TestEnableDevelopmentNetworkProtocols to e2e tests"

### DIFF
--- a/test/e2e/Rakefile
+++ b/test/e2e/Rakefile
@@ -233,9 +233,7 @@ task :get_latest_configs, [:env] do |task, args|
     # remove environment names from genesis files
     config = File.read(config_file)
     config_edited = config.gsub(/#{env}-([^-]+)-genesis.json/, 'genesis-\1.json')
-    config_hash = JSON.parse(config_edited)
-    config_hash["TestEnableDevelopmentNetworkProtocols"] = true
-    File.open(config_file, "w") { |file| file.puts config_hash.to_json }
+    File.open(config_file, "w") { |file| file.puts config_edited }
   end
 end
 


### PR DESCRIPTION
ADP-1025

Reverts input-output-hk/cardano-wallet#2790

With #2791, it shouldn't be needed.