### PR TITLE
jira: fix api token auth

### DIFF
--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -3,12 +3,25 @@
 #
 # See https://github.com/go-jira/jira for documentation on how to use
 # go-jira and edit these config files.
-# You will need to put your login details in ~/.jira.d/config.yml.
+#
+# 1. Get an API key from here:
+#   https://jira.iohk.io/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens
+#
+# Then add your login details to ~/.jira.d/config.yml. You can't just
+# paste your API key into this file. You need to select a password
+# source, as per the go-jira docs.
+#
+# # ~/.jira.d/config.yml
+# authentication-method: bearer-token
+# login: your.name@iohk.io
+# password-source: keyring
+# password-name: jira.iohk.io
 #
 ######################################################################
 
 endpoint: https://jira.iohk.io
 project: ADP
+authentication-method: bearer-token
 
 custom-commands:
   - name: bugs

--- a/nix/overlays/go-jira-api-token.patch
+++ b/nix/overlays/go-jira-api-token.patch
@@ -1,0 +1,53 @@
+diff --git a/jiracli/cli.go b/jiracli/cli.go
+index d834520..920c0a8 100644
+--- a/jiracli/cli.go
++++ b/jiracli/cli.go
+@@ -173,7 +173,11 @@ func register(app *kingpin.Application, o *oreo.Client, fig *figtree.FigTree) {
+ 			token := globals.GetPass()
+ 			authHeader := fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", globals.Login.Value, token))))
+ 			req.Header.Add("Authorization", authHeader)
+-		}
++		} else if globals.AuthMethod() == "bearer-token" {
++			token := globals.GetPass()
++			authHeader := fmt.Sprintf("Bearer %s", token)
++			req.Header.Add("Authorization", authHeader)
++                }
+ 		return req, nil
+ 	})
+ 
+diff --git a/jiracmd/login.go b/jiracmd/login.go
+index e74cb6f..b969e06 100644
+--- a/jiracmd/login.go
++++ b/jiracmd/login.go
+@@ -50,6 +50,10 @@ func CmdLogin(o *oreo.Client, globals *jiracli.GlobalOptions, opts *jiracli.Comm
+ 		log.Noticef("No need to login when using api-token authentication method")
+ 		return nil
+ 	}
++	if globals.AuthMethod() == "bearer-token" {
++		log.Noticef("No need to login when using bearer-token authentication method")
++		return nil
++	}
+ 
+ 	ua := o.WithoutRedirect().WithRetries(0).WithoutCallbacks().WithPostCallback(authCallback)
+ 	for {
+diff --git a/jiracmd/logout.go b/jiracmd/logout.go
+index 1a534bc..6d909dd 100644
+--- a/jiracmd/logout.go
++++ b/jiracmd/logout.go
+@@ -30,13 +30,13 @@ func CmdLogoutRegistry() *jiracli.CommandRegistryEntry {
+ 
+ // CmdLogout will attempt to terminate an active Jira session
+ func CmdLogout(o *oreo.Client, globals *jiracli.GlobalOptions, opts *jiracli.CommonOptions) error {
+-	if globals.AuthMethod() == "api-token" {
+-		log.Noticef("No need to logout when using api-token authentication method")
++	if (globals.AuthMethod() == "api-token" || globals.AuthMethod() == "bearer-token") {
++		log.Noticef("No need to logout when using api-token or bearer-token authentication method")
+ 		if globals.GetPass() != "" && terminal.IsTerminal(int(os.Stdin.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd())) {
+ 			delete := false
+ 			err := survey.AskOne(
+ 				&survey.Confirm{
+-					Message: fmt.Sprintf("Delete api-token from password provider [%s]: ", globals.PasswordSource),
++					Message: fmt.Sprintf("Delete token from password provider [%s]: ", globals.PasswordSource),
+ 					Default: false,
+ 				},
+ 				&delete,

--- a/nix/overlays/pkgs.nix
+++ b/nix/overlays/pkgs.nix
@@ -1,4 +1,7 @@
 # our packages overlay
 self: super: {
-
+  # Our jira installation needs API tokens to use Bearer authentication, not Basic.
+  go-jira = super.go-jira.overrideAttrs (oldAttrs: {
+    patches = (oldAttrs.patches or []) ++ [ ./go-jira-api-token.patch ];
+  });
 }


### PR DESCRIPTION
### Issue Number

None

### Overview

This change updates the go-jira config and adds a patch to support API keys on iohk.jira.io.

Thanks to @sevanspowell for debugging why API token auth wasn't working.

### Comments

The upstream PR is go-jira/jira#438
