### PR TITLE
Add maxCollateralInputs to ProtocolParameters

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -1031,6 +1031,10 @@ data ProtocolParameters = ProtocolParameters
         -- (such as registering a stake pool).
     , eras
         :: EraInfo EpochNo
+    , maxCollateralInputs
+        :: Word16
+        -- ^ Limit on the maximum number of collateral inputs present in a
+        -- transaction.
     } deriving (Eq, Generic, Show)
 
 instance NFData ProtocolParameters

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -124,6 +124,7 @@ dummyProtocolParameters = ProtocolParameters
     , minimumUTxOvalue = MinimumUTxOValue $ Coin 0
     , stakeKeyDeposit = Coin 0
     , eras = emptyEraInfo
+    , maxCollateralInputs = 3
     }
 
 -- | Construct a @Tx@, computing its hash using the dummy @mkTxId@.

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -637,6 +637,7 @@ instance Arbitrary ProtocolParameters where
         <*> arbitrary
         <*> arbitrary
         <*> arbitrary
+        <*> arbitrary
 
 instance Arbitrary MinimumUTxOValue where
     shrink = genericShrink

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -139,6 +139,7 @@ mainnetNetworkParameters = W.NetworkParameters
         , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
         , stakeKeyDeposit = W.Coin 0
         , eras = W.emptyEraInfo
+        , maxCollateralInputs = 0
         }
     }
 
@@ -325,6 +326,7 @@ protocolParametersFromPP eraInfo pp = W.ProtocolParameters
     , minimumUTxOvalue = W.MinimumUTxOValue $ W.Coin 0
     , stakeKeyDeposit = W.Coin 0
     , eras = fromBound <$> eraInfo
+    , maxCollateralInputs = 0
     }
   where
     fromBound (Bound _relTime _slotNo (O.EpochNo e)) =

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -877,6 +877,8 @@ dummyProtocolParameters = ProtocolParameters
         error "dummyProtocolParameters: stakeKeyDeposit"
     , eras =
         error "dummyProtocolParameters: eras"
+    , maxCollateralInputs =
+        error "dummyProtocolParameters: maxCollateralInputs"
     }
 
 -- | Like generate, but the random generate is fixed to a particular seed so


### PR DESCRIPTION
# Issue Number

ADP-958


# Overview

- Included the maxCollateralInputs protocol parameter in the ProtocolParameters data type.

# Comments

- No tests exist for this structure, I believe this structure is tested implicitly via the `ApiNetworkParameters` structure. But since modifying that structure would encroach on ADP-1061, I'm going to leave this without tests for now. If anyone can think of a test they'd like to see, don't hesitate to suggest one!
