### PR TITLE
Further proposed simplifications for: Identify UTxOs suitable for use as collateral

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Collateral.hs
@@ -238,9 +238,8 @@ asCollateral
     -> Maybe Coin
     -- ^ The total ADA value of that UTxO if it is suitable for collateral,
     -- otherwise Nothing.
-asCollateral txOut = do
-    coin <- TokenBundle.toCoin $ tokens txOut
-    addrType <- addressType (address txOut)
-    if addressTypeSuitableForCollateral addrType
-    then Just coin
-    else Nothing
+asCollateral txOut
+    | addressSuitableForCollateral (address txOut) =
+        TokenBundle.toCoin (tokens txOut)
+    | otherwise =
+        Nothing

--- a/lib/core/src/Cardano/Wallet/Primitive/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Collateral.hs
@@ -22,6 +22,7 @@ module Cardano.Wallet.Primitive.Collateral
     -- * Classifying address types
     , asCollateral
     , classifyCollateralAddress
+    , addressSuitableForCollateral
     , addressTypeSuitableForCollateral
 
     -- * Reading address types
@@ -143,6 +144,12 @@ putAddressType :: AddressType -> B.Put
 putAddressType t =
     B.putWord8 $
     fromIntegral @Word4 @Word8 (addressTypeToHeaderNibble t) `Bits.shiftL` 4
+
+-- | Indicates whether or not the given address is suitable for collateral.
+--
+addressSuitableForCollateral :: Address -> Bool
+addressSuitableForCollateral =
+    maybe False addressTypeSuitableForCollateral . addressType
 
 -- By inspecting the bit pattern of an Address, we can determine its address
 -- type.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CollateralSpec.hs
@@ -596,26 +596,34 @@ prop_addressSuitableForCollateral_equivalence =
 --     "addressSuitableForCollateral" and "TokenBundle.toCoin",
 --
 -- We can say that the implementation of "asCollateral" is also correct, so
--- long as the composition operator is guranteed not to change the properties
+-- long as the composition operator is guaranteed not to change the properties
 -- we are interested in. We can prove the equivalence like so:
+
+-- | Assert that if the "composition" of "addressSuitableForCollateral" and
+-- "TokenBundle.toCoin" returns, "asCollateral" should also return.
+prop_equivalence_bool :: TxOut -> Property
+prop_equivalence_bool txOut@(TxOut addr toks) =
+    isJust (asCollateral txOut)
+    ===
+    (addressSuitableForCollateral addr && TokenBundle.isCoin toks)
 
 -- | Assert that the "asCollateral" function is equivalent to the "composition"
 -- of "addressSuitableForCollateral" and "TokenBundle.toCoin".
 prop_equivalence :: TxOut -> Property
 prop_equivalence txOut@(TxOut addr toks) =
-    isJust (asCollateral txOut)
+    asCollateral txOut
     ===
-    (addressSuitableForCollateral addr && TokenBundle.isCoin toks)
+    guard (addressSuitableForCollateral addr) >> TokenBundle.toCoin toks
 
--- The composition operator we are using here is the Maybe instance of (>>).
--- Initially, the Either is demoted to a Maybe, which we know maintains the
--- falsity of the value (Left = Nothing = False, Right = Just = True). From
--- here, the composition operator discards the value inside the Maybe, and so
--- the next argument can only depend on the falsity of the Maybe (indeed, it
+-- The composition operator we are using here is the Maybe instance of (>>). The
+-- guard lifts the Boolean to a Maybe, maintaining the falsity of
+-- "addressSuitableForCollateral" (Nothing = False, Just = True).
+-- From here, the composition operator discards the value inside the Maybe, and
+-- so the next argument can only depend on the falsity of the Maybe (indeed, it
 -- must). Thus the falsity of the properties is maintained (i.e. "asCollateral"
 -- will accept/reject an UTxO correctly, so long as
--- "addressSuitableForCollateral" assesses an address correctly, which is
--- tested above). "asCollateral" will return the correct coin value so long as
+-- "addressSuitableForCollateral" assesses an address correctly, which is tested
+-- above). "asCollateral" will return the correct coin value so long as
 -- "TokenBundle.toCoin" is working correctly (tested elsewhere).
 --
 -- I wish I knew how to formally prove things using category theory concepts
@@ -678,7 +686,9 @@ spec = do
             describe "addressTypeSuitableForCollateral" $ do
                 it "satisfies same properties as addressSuitableForCollateral" $
                     property prop_addressSuitableForCollateral_equivalence
-            describe "asCollateral" $
+            describe "asCollateral" $ do
+                it "satisfies same boolean properties as addressSuitableForCollateral" $
+                    property prop_equivalence_bool
                 it "satisfies same properties as addressSuitableForCollateral" $
                     property prop_equivalence
 


### PR DESCRIPTION
# Issue Number

#2807 

# Overview

This PR proposes a simplification for the `Primitive.Collateral` module. It:
- introduces `addressSuitableForCollateral`, which is a simple composition of `addressType` and `addressTypeSuitableForCollateral`.
- removes the `classifyCollateralAddress` function, which performed a similar role to `addressSuitableForCollateral`.
- updates property and unit tests appropriately.