### PR TITLE
Make scripts/gh/show-bump.sh run in nix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,13 @@ jobs:
         run: |
           gem install bump-cli
           sudo snap install yq
-          sudo apt-get -yu install html-xml-utils
       - name: 'Update Release in Bump.sh'
         run: './scripts/gh/update-bump.sh'
         env:
           BUMP_SH_DOC_ID: ${{ secrets.BUMP_SH_DOC_ID }}
           BUMP_SH_TOKEN: ${{ secrets.BUMP_SH_TOKEN }}
+      - uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=channel:nixpkgs-21.05-darwin
       - name: 'Show latest changes from Bump.sh'
         run: './scripts/gh/show-bump.sh'

--- a/.jira.d/config.yml
+++ b/.jira.d/config.yml
@@ -21,7 +21,6 @@
 
 endpoint: https://jira.iohk.io
 project: ADP
-authentication-method: bearer-token
 
 custom-commands:
   - name: bugs

--- a/scripts/gh/show-bump.sh
+++ b/scripts/gh/show-bump.sh
@@ -1,6 +1,8 @@
-#!/usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix coreutils gnugrep gnused html-xml-utils
+# shellcheck shell=bash disable=SC2016
+
 # Needs gnused and W3C html-xml-utils
-# shellcheck disable=SC2016
 
 set -euo pipefail
 


### PR DESCRIPTION
- [x] Make scripts/gh/show-bump.sh run in nix-shell, such that you don't need to worry about installing dependencies manually.

### Issue Number

None / Release.

### Comments

<!-- Additional comments or screenshots to attach if any -->
