### PR TITLE
Temporarily disable broken hp2pretty in restore bench

### DIFF
--- a/.buildkite/bench-restore.sh
+++ b/.buildkite/bench-restore.sh
@@ -39,7 +39,9 @@ echo "+++ Results - $network"
 cat $results
 
 mv restore.hp $artifact_name.hp
-hp2pretty $artifact_name.hp
+
+# FIXME [ADP-1074]
+# hp2pretty $artifact_name.hp
 
 GNUPLOT_PROGRAM=$(cat <<EOP
 set timefmt "%s";
@@ -86,7 +88,8 @@ if [ -n "${BUILDKITE:-}" ]; then
   buildkite-agent artifact upload plot.svg
 
   echo "+++ Heap profile"
-  printf '\033]1338;url='"artifact://$artifact_name.svg"';alt='"Heap profile"'\a\n'
+  echo "Heap profile visualization has temporarily been disabled because it runs out of memory (ADP-1074)"
+  # printf '\033]1338;url='"artifact://$artifact_name.svg"';alt='"Heap profile"'\a\n'
   echo "+++ Restore plot"
   printf '\033]1338;url='"artifact://plot.svg"';alt='"Restore plot"'\a\n'
 fi


### PR DESCRIPTION
- [x] Disable failing hp2pretty call in restore bench.

### Issue Number

None / Will require ADP-1074 for a proper fix.

### Comments

Allowing the failure to exist hides the results of the actual
benchmarks:
- makes checking the results more time-consuming
- could lead to real errors going unnoticed.



Test build: https://buildkite.com/input-output-hk/cardano-wallet-nightly/builds/1054#87ef8967-0fee-4fb5-9083-0d66598eb0d7

<!-- Additional comments or screenshots to attach if any -->
