### PR TITLE
Fix docker-compose to support testnet and alonzo-purple

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -128,6 +128,7 @@ let
         cardano-address
         cardano-cli
         cardano-node
+        (pkgs.linkFarm "docker-config-layer" [ { name = "config"; path = pkgs.cardano-node-deployments; } ])
       ];
     };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     entrypoint: []
     command: bash -c "
         ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
-        ($$CMD --testnet /config/*-$$NETWORK-byron-genesis.json)
+        ([[ $$NETWORK == \"alonzo-purple\" ]] && $$CMD --testnet /config/y88z6z1w0kwypj7zrlhk7vs6z8k1pckd-byron-genesis.json) ||
+        ($$CMD --testnet /config/kax0css4lx3ywihvsgrqjym0jpi20f99-byron-genesis.json)
       "
     environment:
       CMD: "cardano-wallet serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"
@@ -44,7 +45,9 @@ services:
 volumes:
   node-mainnet-db:
   node-testnet-db:
+  node-alonzo-purple-db:
   wallet-mainnet-db:
   wallet-testnet-db:
+  wallet-alonzo-purple-db:
   node-ipc:
   node-config:

--- a/nix/overlays/cardano-deployments.nix
+++ b/nix/overlays/cardano-deployments.nix
@@ -8,6 +8,7 @@ pkgs: _: {
         staging
         testnet
         shelley_qa
+        alonzo-purple
         ;
     };
     updateConfig = env: env.nodeConfig // {
@@ -15,6 +16,7 @@ pkgs: _: {
     } // (if (env.consensusProtocol == "Cardano") then {
       ByronGenesisFile = "genesis-byron.json";
       ShelleyGenesisFile = "genesis-shelley.json";
+      AlonzoGenesisFile = "genesis-alonzo.json";
     } else {
       GenesisFile = "genesis.json";
     });
@@ -35,6 +37,7 @@ pkgs: _: {
     '' + (if env.consensusProtocol == "Cardano" then ''
       jq . < ${env.nodeConfig.ByronGenesisFile} > $cfg/genesis-byron.json
       cp ${env.nodeConfig.ShelleyGenesisFile} $cfg/genesis-shelley.json
+      cp ${env.nodeConfig.AlonzoGenesisFile} $cfg/genesis-alonzo.json
     '' else ''
       jq . < ${env.genesisFile} > $cfg/genesis.json
     '')) environments);

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "6d54c33f904c0012820bad823090bdeb2540a8d1",
-        "sha256": "1gwzy2v9jmv66kfxd13yngvmb09b8s0p2y6gvfjb91ial580390m",
+        "rev": "ced24db2fbed1e56563e17fd2d47436c3a4649f3",
+        "sha256": "0631fal6zczgs7b7nhsp4jrp0xini8r653xv0831makxd496b2v8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/6d54c33f904c0012820bad823090bdeb2540a8d1.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/ced24db2fbed1e56563e17fd2d47436c3a4649f3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "sphinxcontrib-haddock": {


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

- Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or several reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.

- Try to make your intent clear for reviewers:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

Write a good description to help reviewers:
   ✓ Make it clear what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also link this PR in the description of the corresponding ticket.
   ✓ Acknowledge any changes required to the Wiki.
   ✓ Finally, in the PR description delete any empty sections and all text commented in <!--, so that this text does not appear in merge commit messages.
-->


- [ ] Fix docker-compose to support testnet and alonzo-purple

### Issue Number

ADP-1068 / https://github.com/input-output-hk/cardano-wallet/issues/2806

### Comments

docker-compose should now work for `mainnet`, `testnet` or `alonzo-purple`:
```
NETWORK=alonzo-purple docker-compose up
NETWORK=mainnet docker-compose up
NETWORK=testnet docker-compose up
```
