### PR TITLE
docker-compose.yml: Use files provided in /config/$network for cardano-wallet container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,12 @@ services:
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc
-      - node-config:/config
     ports:
       - 8090:8090
     entrypoint: []
     command: bash -c "
         ([[ $$NETWORK == \"mainnet\" ]] && $$CMD --mainnet) ||
-        ([[ $$NETWORK == \"alonzo-purple\" ]] && $$CMD --testnet /config/y88z6z1w0kwypj7zrlhk7vs6z8k1pckd-byron-genesis.json) ||
-        ($$CMD --testnet /config/kax0css4lx3ywihvsgrqjym0jpi20f99-byron-genesis.json)
+        ($$CMD --testnet /config/${NETWORK}/genesis-byron.json)
       "
     environment:
       CMD: "cardano-wallet serve --node-socket /ipc/node.socket --database /wallet-db --listen-address 0.0.0.0"


### PR DESCRIPTION
The cardano-node docker image doesn't provide a nice tree of config files for various deployments. But the cardano-wallet docker image now does.

So use these configs when starting cardano-wallet in `docker-compose.yml`

### Issue Number

ADP-1068 / #2806

### Comments

Wait until just before the next release to merge this.
