### PR TITLE
Fix usage of --skip in buildkite builds

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -149,22 +149,21 @@ buildStep' dryRun qa pkgs = foldl1 (.&&.)
         projectBuild ["--test", "--no-run-tests"]
     , titled "Tests (except integration)" $
         timeout 60 $ do
-            test (skip integration)
+            test (skip "integration")
     , titled "Checking golden test files" $
         checkUnclean dryRun "lib/core/test/data"
     , when' runIntegration $ titled "Integration tests on latest era" $
         timeout 60 $ do
             unset "LOCAL_CLUSTER_ERA"
-            test [integration]
+            test ["cardano-wallet:integration"]
     , when' runIntegration $ titled "Integration tests on past era (Mary)" $
         timeout 60 $ do
             export "LOCAL_CLUSTER_ERA" "mary"
-            test [integration]
+            test ["cardano-wallet:integration"]
     ]
   where
     projectOpt = Fast
     runIntegration = qa > QuickTest
-    integration = "cardano-wallet:integration"
 
     benchFlags = [ "--bench", "--no-run-benchmarks"]
 


### PR DESCRIPTION

- [x] Call `--skip "integration"` instead of `--skip cardano-wallet:integration`. The latter is ineffective.
- [x] Confirm that the behaviour in CI indeed looks ok.
    - [x] Integration tests are skipped in normal builds
    - [x] Integration tests in Mary are run from bors
    - [x] Integration tests in Alonzo are run from bors

### Issue Number

None. Follow-up to #2810 .

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

### Comments

<!-- Additional comments or screenshots to attach if any -->
