### PR TITLE
Provide property tests for `changeUTxO`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.Primitive.Model
     , totalBalance
     , totalUTxO
     , availableUTxO
+    , changeUTxO
     , utxo
     ) where
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -29,12 +29,15 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , computeUtxoStatistics
     , excluding
     , isSubsetOf
+    , null
     , log10
     , restrictedBy
     , restrictedTo
+    , size
     ) where
 
-import Prelude
+import Prelude hiding
+    ( null )
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -126,6 +129,12 @@ restrictedBy (UTxO utxo) =
 restrictedTo :: UTxO -> Set TxOut -> UTxO
 restrictedTo (UTxO utxo) outs =
     UTxO $ Map.filter (`Set.member` outs) utxo
+
+null :: UTxO -> Bool
+null (UTxO u) = Map.null u
+
+size :: UTxO -> Int
+size (UTxO u) = Map.size u
 
 data UTxOStatistics = UTxOStatistics
     { histogram :: ![HistogramBar]

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -30,6 +30,7 @@ import Cardano.Wallet.Primitive.Model
     , applyBlocks
     , availableBalance
     , availableUTxO
+    , changeUTxO
     , currentTip
     , getState
     , initWallet
@@ -51,6 +52,8 @@ import Cardano.Wallet.Primitive.Types
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( genAddress )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
@@ -69,7 +72,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, shrinkTxIn )
+    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( Dom (..), UTxO (..), balance, excluding, restrictedTo )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
@@ -103,7 +106,7 @@ import Data.Set
 import Data.Traversable
     ( for )
 import Data.Word
-    ( Word64 )
+    ( Word64, Word8 )
 import Fmt
     ( Buildable, blockListF, pretty )
 import GHC.Generics
@@ -121,9 +124,11 @@ import Test.QuickCheck
     , checkCoverage
     , choose
     , classify
+    , conjoin
     , counterexample
     , cover
     , elements
+    , forAll
     , forAllShrink
     , frequency
     , genericShrink
@@ -140,6 +145,8 @@ import Test.QuickCheck
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
+import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
@@ -186,6 +193,12 @@ spec = do
             property prop_availableUTxO_withoutKeys
         it "prop_availableUTxO_availableBalance" $
             property prop_availableUTxO_availableBalance
+
+    parallel $ describe "Change UTxO" $ do
+        it "prop_changeUTxO" $
+            property prop_changeUTxO
+        it "prop_addressParity_coverage" $
+            property prop_addressParity_coverage
 
 {-------------------------------------------------------------------------------
                                 Properties
@@ -424,6 +437,202 @@ prop_availableUTxO makeProperty =
         shouldNotEvaluate :: String -> a
         shouldNotEvaluate fieldName = error $ unwords
             [fieldName, "was unexpectedly evaluated"]
+
+--------------------------------------------------------------------------------
+-- Change UTxO properties
+--------------------------------------------------------------------------------
+
+-- | Tests the 'changeUTxO' function with custom filter conditions to identify
+--   addresses that belong to the wallet.
+--
+-- This test divides all addresses into two disjoint sets:
+--
+--    - even-parity addresses:
+--      addresses with a pop count (Hamming weight) that is even.
+--
+--    - odd-parity addresses:
+--      addresses with a pop count (Hamming weight) that is odd.
+--
+-- With the above definitions in mind, this test uses the following filter
+-- conditions to categorize output addresses:
+--
+--    - 'Even' : matches addresses whose parity is even
+--    - 'Odd'  : matches addresses whose parity is odd
+--    - 'All'  : matches all addresses, regardless of their parity.
+--
+-- Each of the above filter conditions is represented with a custom 'IsOurs'
+-- instance that we provide to the 'changeUTxO' function.
+--
+-- Since a given address can either be even, or odd, but not both, it follows
+-- that the following results must be disjoint:
+--
+--    - 'changeUTxO pendingTxs Even'
+--    - 'changeUTxO pendingTxs Odd'
+--
+-- This test applies each of the above filter conditions to 'changeUTxO' and
+-- verifies that all entries match the condition that was provided.
+--
+prop_changeUTxO :: Property
+prop_changeUTxO =
+    forAllShrink (listOf genTxOutputs) (shrinkList shrinkTxOutputs) inner
+  where
+    inner :: [TxOutputs] -> Property
+    inner txOutputs =
+        checkCoverage $
+        cover 50 (not (UTxO.null utxoEven) && not (UTxO.null utxoOdd))
+            "UTxO sets not null" $
+        conjoin
+            [ -- All addresses in the even-parity UTxO set have even parity:
+              F.all ((== Even) . txOutParity) (unUTxO utxoEven)
+              -- All addresses in the odd-parity UTxO set have odd parity:
+            , F.all ((== Odd) . txOutParity) (unUTxO utxoOdd)
+              -- The even-parity and odd-parity UTxO sets are disjoint:
+            , Map.null $ Map.intersection (unUTxO utxoEven) (unUTxO utxoOdd)
+              -- The even-parity and odd-parity UTxO sets are complete:
+            , Map.union (unUTxO utxoEven) (unUTxO utxoOdd) == unUTxO utxoAll
+              -- No outputs are omitted when we select everything:
+            , UTxO.size utxoAll == F.sum (F.length . unTxOutputs <$> txOutputs)
+            ]
+      where
+        -- Computes the parity of an output based on its address parity.
+        txOutParity :: TxOut -> Parity
+        txOutParity = addressParity . view #address
+
+        -- The UTxO set that contains all available output addresses.
+        utxoAll :: UTxO
+        utxoAll = changeUTxO txSet All
+
+        -- The UTxO set that contains only even-parity output addresses.
+        utxoEven :: UTxO
+        utxoEven = changeUTxO txSet Even
+
+        -- The UTxO set that contains only odd-parity output addresses.
+        utxoOdd :: UTxO
+        utxoOdd  = changeUTxO txSet Odd
+
+        txSet :: Set Tx
+        txSet = Set.fromList $ uncurry makeTx <$> (zip txIds txOutputs)
+
+        txIds :: [Hash "Tx"]
+        txIds = makeTxId <$> [minBound .. maxBound]
+
+    -- Creates a transaction from a transaction id and a set of outputs, by
+    -- adding dummy data for fields that are not used by 'changeUTxO'.
+    --
+    -- Ideally, we'd leave all of the unused fields undefined (to assert that
+    -- they should not be evaluated or processed in any way), but since the
+    -- fields of the 'Tx' type are strict, our next best option is to provide
+    -- a minimal value for each field.
+    --
+    makeTx :: Hash "Tx" -> TxOutputs -> Tx
+    makeTx txId TxOutputs {unTxOutputs} = Tx
+        { txId
+        , outputs = unTxOutputs
+        -- Unused fields:
+        , fee = Nothing
+        , resolvedCollateral = []
+        , resolvedInputs = []
+        , metadata = Nothing
+        , withdrawals = Map.empty
+        }
+
+    -- Creates a dummy transaction identifier from a single word.
+    makeTxId :: Word8 -> Hash "Tx"
+    makeTxId i = Hash $ BS.pack [i]
+
+-- | Represents all the outputs of a transaction (both change and non-change).
+--
+newtype TxOutputs = TxOutputs
+    { unTxOutputs :: [TxOut]
+        -- ^ A transaction's outputs.
+    }
+    deriving (Eq, Generic, Show)
+
+genTxOutputs :: Gen TxOutputs
+genTxOutputs = TxOutputs <$> listOf genTxOut
+
+shrinkTxOutputs :: TxOutputs -> [TxOutputs]
+shrinkTxOutputs (TxOutputs outs) = TxOutputs <$> shrinkList shrinkTxOut outs
+
+-- | An implementation of 'IsOurs' that matches all addresses.
+--
+instance IsOurs All Address where
+    isOurs = isOursIf (const True)
+
+data All = All
+
+-- | An implementation of 'IsOurs' that matches addresses by their parity.
+--
+instance IsOurs Parity Address where
+    isOurs a p = isOursIf ((== p) . addressParity) a p
+
+-- | Represents the parity of a value (whether the value is even or odd).
+--
+data Parity = Even | Odd
+    deriving (Eq, Show)
+
+-- | Computes the parity of an address.
+--
+-- Parity is defined in the following way:
+--
+--    - even-parity address:
+--      an address with a pop count (Hamming weight) that is even.
+--
+--    - odd-parity address:
+--      an address with a pop count (Hamming weight) that is odd.
+--
+-- Examples of even-parity and odd-parity addresses:
+--
+--    - 0b00000000 : even (Hamming weight = 0)
+--    - 0b00000001 : odd  (Hamming weight = 1)
+--    - 0b00000010 : odd  (Hamming weight = 1)
+--    - 0b00000011 : even (Hamming weight = 2)
+--    - 0b00000100 : odd  (Hamming weight = 1)
+--    - ...
+--    - 0b11111110 : odd  (Hamming weight = 7)
+--    - 0b11111111 : even (Hamming weight = 8)
+--
+addressParity :: Address -> Parity
+addressParity = parity . addressPopCount
+  where
+    addressPopCount :: Address -> Int
+    addressPopCount = BS.foldl' (\acc -> (acc +) . Bits.popCount) 0 . unAddress
+
+    parity :: Integral a => a -> Parity
+    parity a
+        | even a    = Even
+        | otherwise = Odd
+
+-- | Verifies that addresses are generated with both even and odd parity.
+--
+prop_addressParity_coverage :: Property
+prop_addressParity_coverage =
+    forAll genAddress $ \addr ->
+    checkCoverage $
+    cover 40 (addressParity addr == Even)
+        "address parity is even" $
+    cover 40 (addressParity addr == Odd)
+        "address parity is odd" $
+    property True
+
+-- | Marks an address as "ours" if (and only if) a condition is satisfied.
+--
+isOursIf
+    :: (Address -> Bool)
+    -- ^ Indicates whether or not an address is "ours"
+    -> Address
+    -- ^ The address to test
+    -> s
+    -- ^ The "state"
+    -> (Maybe (NonEmpty DerivationIndex), s)
+isOursIf condition a p
+    | condition a = (Just dummyDerivationIndex, p)
+    | otherwise   = (Nothing                  , p)
+  where
+    dummyDerivationIndex :: NonEmpty DerivationIndex
+    dummyDerivationIndex = DerivationIndex shouldNotEvaluate :| []
+      where
+        shouldNotEvaluate = error "Derivation index unexpectedly evaluated"
 
 {-------------------------------------------------------------------------------
                Basic Model - See Wallet Specification, section 3

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -45,18 +45,18 @@ tag_cabal_ver_re() {
 
 echo "Previous release: $GIT_TAG"
 new_tag=$(date +v%Y-%m-%d)
-read -e -p "New release tag: " -i "$new_tag" new_tag
+read -r -e -p "New release tag: " -i "$new_tag" new_tag
 
-SCRIPT=`realpath $0`
-sed -i -e "s/^OLD_GIT_TAG=\"$OLD_GIT_TAG\"/OLD_GIT_TAG=\"$GIT_TAG\"/g" $SCRIPT
-sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" $SCRIPT
+SCRIPT=$(realpath "$0")
+sed -i -e "s/^OLD_GIT_TAG=\"$OLD_GIT_TAG\"/OLD_GIT_TAG=\"$GIT_TAG\"/g" "$SCRIPT"
+sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" "$SCRIPT"
 
 OLD_GIT_TAG=$GIT_TAG
-GIT_TAG=$new_tag
+GIT_TAG="$new_tag"
 
 OLD_CARDANO_NODE_TAG=$CARDANO_NODE_TAG
-read -e -p "Cardano node tag: " -i "$CARDANO_NODE_TAG" CARDANO_NODE_TAG
-sed -i -e "s/^CARDANO_NODE_TAG=\"$OLD_CARDANO_NODE_TAG\"/CARDANO_NODE_TAG=\"$CARDANO_NODE_TAG\"/g" $SCRIPT
+read -r -e -p "Cardano node tag: " -i "$CARDANO_NODE_TAG" CARDANO_NODE_TAG
+sed -i -e "s/^CARDANO_NODE_TAG=\"$OLD_CARDANO_NODE_TAG\"/CARDANO_NODE_TAG=\"$CARDANO_NODE_TAG\"/g" "$SCRIPT"
 
 ################################################################################
 # Update releases in README.md
@@ -65,12 +65,12 @@ sed -i -e "s/^CARDANO_NODE_TAG=\"$OLD_CARDANO_NODE_TAG\"/CARDANO_NODE_TAG=\"$CAR
 # master version, and delete the oldest release.
 ln=$(awk '$0 ~ "`master` branch" {print NR}' README.md)
 master_line=$(sed -n "$ln"p README.md)
-line_to_insert=$(echo $master_line | sed -e "s/\`master\` branch/\[$GIT_TAG\](https:\/\/github.com\/input-output-hk\/cardano-wallet\/releases\/tag\/$GIT_TAG)/")
-sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" $SCRIPT
+line_to_insert=$(echo "$master_line" | sed -e "s/\`master\` branch/\[$GIT_TAG\](https:\/\/github.com\/input-output-hk\/cardano-wallet\/releases\/tag\/$GIT_TAG)/")
+sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" "$SCRIPT"
 
 # Edit from the bottom and up, not to affect the line-numbers.
-sed -i -e $(($ln+3))d README.md
-sed -i -e $(($ln+1))i"$line_to_insert" README.md
+sed -i -e $((ln+3))d README.md
+sed -i -e $((ln+1))i"$line_to_insert" README.md
 
 echo "Automatically updated the list of releases in README.md. Please review the resulting changes."
 
@@ -80,7 +80,7 @@ echo "Automatically updated the list of releases in README.md. Please review the
 OLD_DATE=$(tag_date $OLD_GIT_TAG)
 OLD_CABAL_VERSION=$(tag_cabal_ver $OLD_GIT_TAG)
 OLD_CABAL_VERSION_RE=$(tag_cabal_ver_re $OLD_GIT_TAG)
-CABAL_VERSION=$(tag_cabal_ver $GIT_TAG)
+CABAL_VERSION=$(tag_cabal_ver "$GIT_TAG")
 
 echo ""
 echo "Replacing $OLD_CABAL_VERSION with $CABAL_VERSION"
@@ -121,7 +121,7 @@ sed -e "s/{{GIT_TAG}}/$GIT_TAG/g"                   \
     -e "/{{CHANGELOG}}/d"                           \
     -e "/{{KNOWN_ISSUES}}/r $KNOWN_ISSUES"          \
     -e "/{{KNOWN_ISSUES}}/d"                        \
-    .github/RELEASE_TEMPLATE.md > $OUT
+    .github/RELEASE_TEMPLATE.md > "$OUT"
 
 ################################################################################
 # Commit and tag


### PR DESCRIPTION
### Issue Number

ADP-1084

### Comments

This PR provides property tests for the `changeUTxO` function.

Since this function is re-used by `totalUTxO` (which we want to modify and then verify), it's useful to first verify that `changeUTxO` is correct.