### PR TITLE
Bump to cardano-node 1.29.0-rc2

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.29.0-rc1](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0-rc1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
+> | `master` branch | [1.29.0-rc2](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0-rc2) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-08-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-11) | [alonzo-purple-1.0.1](https://github.com/input-output-hk/cardano-node/releases/tag/alonzo-purple-1.0.1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-07-30](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-07-30) | [1.28.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.28.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-06-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-06-11) | [1.27.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.27.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)

--- a/cabal.project
+++ b/cabal.project
@@ -134,7 +134,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: 708de685d49ec6af4b2d8b3cbfa0eca0e9e43edf
+    tag: cc78734d263d0eec2b12070380cdfea02a5a8342
     subdir: cardano-api
             cardano-cli
             cardano-config
@@ -173,7 +173,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/ouroboros-network
-    tag: d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a
+    tag: 877ce057ff6fb086474c8eaad53f2b7f0e0fce6b
     subdir:
       io-sim
       io-classes

--- a/nix/.stack.nix/cardano-api.nix
+++ b/nix/.stack.nix/cardano-api.nix
@@ -142,12 +142,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       };
     postUnpack = "sourceRoot+=/cardano-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-cli.nix
+++ b/nix/.stack.nix/cardano-cli.nix
@@ -147,12 +147,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       };
     postUnpack = "sourceRoot+=/cardano-cli; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-client.nix
+++ b/nix/.stack.nix/cardano-client.nix
@@ -41,12 +41,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/cardano-client; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -39,12 +39,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       };
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -125,12 +125,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "9a6a6c81e3aebfaf757b562c823146c7da601e1c";
-      sha256 = "1xiqrx3hf2s7j62clzzmlim81g7v2dvmirv78zf9gp9m1lqxzan6";
+      rev = "cc78734d263d0eec2b12070380cdfea02a5a8342";
+      sha256 = "1bqrbgc11c4x5mrcm7shyvfs05fqi4v1pr4y9pw2aprab277czjr";
       };
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-classes.nix
+++ b/nix/.stack.nix/io-classes.nix
@@ -51,12 +51,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/io-classes; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/io-sim.nix
+++ b/nix/.stack.nix/io-sim.nix
@@ -56,12 +56,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/io-sim; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/monoidal-synchronisation.nix
+++ b/nix/.stack.nix/monoidal-synchronisation.nix
@@ -46,12 +46,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/monoidal-synchronisation; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/network-mux.nix
+++ b/nix/.stack.nix/network-mux.nix
@@ -113,12 +113,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/network-mux; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ntp-client.nix
+++ b/nix/.stack.nix/ntp-client.nix
@@ -67,12 +67,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ntp-client; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byron-test.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byron-test.nix
@@ -89,12 +89,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-byron-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byron.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byron.nix
@@ -73,12 +73,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-byron; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-byronspec.nix
+++ b/nix/.stack.nix/ouroboros-consensus-byronspec.nix
@@ -52,12 +52,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-byronspec; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-cardano-test.nix
+++ b/nix/.stack.nix/ouroboros-consensus-cardano-test.nix
@@ -90,12 +90,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-cardano-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-cardano.nix
+++ b/nix/.stack.nix/ouroboros-consensus-cardano.nix
@@ -82,12 +82,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-cardano; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-mock.nix
+++ b/nix/.stack.nix/ouroboros-consensus-mock.nix
@@ -49,12 +49,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-mock; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-shelley-test.nix
+++ b/nix/.stack.nix/ouroboros-consensus-shelley-test.nix
@@ -85,12 +85,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-shelley-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-shelley.nix
+++ b/nix/.stack.nix/ouroboros-consensus-shelley.nix
@@ -60,12 +60,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-shelley; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus-test.nix
+++ b/nix/.stack.nix/ouroboros-consensus-test.nix
@@ -161,12 +161,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus-test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-consensus.nix
+++ b/nix/.stack.nix/ouroboros-consensus.nix
@@ -79,12 +79,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-consensus; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-framework.nix
+++ b/nix/.stack.nix/ouroboros-network-framework.nix
@@ -110,12 +110,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-network-framework; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network-testing.nix
+++ b/nix/.stack.nix/ouroboros-network-testing.nix
@@ -40,12 +40,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-network-testing; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/ouroboros-network.nix
+++ b/nix/.stack.nix/ouroboros-network.nix
@@ -169,12 +169,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/ouroboros-network; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols-examples.nix
+++ b/nix/.stack.nix/typed-protocols-examples.nix
@@ -55,12 +55,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/typed-protocols-examples; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/typed-protocols.nix
+++ b/nix/.stack.nix/typed-protocols.nix
@@ -35,12 +35,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       }) // {
       url = "https://github.com/input-output-hk/ouroboros-network";
-      rev = "d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a";
-      sha256 = "0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1";
+      rev = "877ce057ff6fb086474c8eaad53f2b7f0e0fce6b";
+      sha256 = "1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z";
       };
     postUnpack = "sourceRoot+=/typed-protocols; echo source root reset to \$sourceRoot";
     }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ced24db2fbed1e56563e17fd2d47436c3a4649f3",
-        "sha256": "0631fal6zczgs7b7nhsp4jrp0xini8r653xv0831makxd496b2v8",
+        "rev": "266ca46a8d1cb4286b9699b4fd435066e88440ac",
+        "sha256": "132fbnnpp7bbfqv3dgvn9xi9dc1gsn9mivbqnxmglgmlv4lmrad8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/ced24db2fbed1e56563e17fd2d47436c3a4649f3.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/266ca46a8d1cb4286b9699b4fd435066e88440ac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "sphinxcontrib-haddock": {

--- a/stack.yaml
+++ b/stack.yaml
@@ -169,7 +169,7 @@ extra-deps:
   - shelley-ma/shelley-ma-test
 
 - git: https://github.com/input-output-hk/cardano-node
-  commit: 9a6a6c81e3aebfaf757b562c823146c7da601e1c
+  commit: cc78734d263d0eec2b12070380cdfea02a5a8342
   subdirs:
   - cardano-api
   - cardano-cli
@@ -210,7 +210,7 @@ extra-deps:
   commit: 6a92d7853ea514be8b70bab5e72077bf5a510596
 
 - git: https://github.com/input-output-hk/ouroboros-network
-  commit: d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a
+  commit: 877ce057ff6fb086474c8eaad53f2b7f0e0fce6b
   subdirs:
   - io-classes
   - io-sim


### PR DESCRIPTION


- [x] Bump from cardano-node 1.29.0-rc1 to rc2

### Issue Number

ADP-1089

### Comments


Only ouroboros-network (and cardano-node) changed:

```bash
~/I/cardano-node $ git diff 1.29.0-rc1 1.29.0-rc2 -- cabal.project                                                                                      (141) (27s 925ms)
diff --git a/cabal.project b/cabal.project
index 76ce66227..f7e57604a 100644
--- a/cabal.project
+++ b/cabal.project
@@ -220,8 +220,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: d070bad7ce389a4b2ff7fb4fcb7937fdeca80f3a
-  --sha256: 0jzdwjgqcj06b0rvwyh61cgf23dlh62lcn8z7dbm7wxwjjgpkjb1
+  tag: 877ce057ff6fb086474c8eaad53f2b7f0e0fce6b
+  --sha256: 1kp0qysfy3hl96a3a61rijascq36f1imh3z4jy0vyiygb6qrv47z
   subdir:
     io-sim
     io-classes
```