### PR TITLE
Improve ./scripts/make_release.sh

### DIFF
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -126,11 +126,10 @@ sed -e "s/{{GIT_TAG}}/$GIT_TAG/g"                   \
 ################################################################################
 # Commit and tag
 
-read -p "Do you want to create a commit and release-tag? (y/n) " -n 1 -r
+read -p "Do you want to create a commit (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
   msg="Bump version from $OLD_CABAL_VERSION to $CABAL_VERSION"
   git diff --quiet || git commit -am "$msg"
-  git tag -s -m "$GIT_TAG" "$GIT_TAG"
 fi

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #
 
 ################################################################################
-# Release-specific parameters (Change when you bump the version)
+# Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
 GIT_TAG="v2021-08-11"
 OLD_GIT_TAG="v2021-07-30"
@@ -38,6 +38,41 @@ tag_cabal_ver() {
 tag_cabal_ver_re() {
   tag_cabal_ver "$1" | sed -e 's/\./\\./g'
 }
+
+################################################################################
+# Interactively change the release-specific parameter by promting the caller, and
+# mutating the script itself.
+
+echo "Previous release: $GIT_TAG"
+new_tag=$(date +v%Y-%m-%d)
+read -e -p "New release tag: " -i "$new_tag" new_tag
+
+SCRIPT=`realpath $0`
+sed -i -e "s/^OLD_GIT_TAG=\"$OLD_GIT_TAG\"/OLD_GIT_TAG=\"$GIT_TAG\"/g" $SCRIPT
+sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" $SCRIPT
+
+OLD_GIT_TAG=$GIT_TAG
+GIT_TAG=$new_tag
+
+OLD_CARDANO_NODE_TAG=$CARDANO_NODE_TAG
+read -e -p "Cardano node tag: " -i "$CARDANO_NODE_TAG" CARDANO_NODE_TAG
+sed -i -e "s/^CARDANO_NODE_TAG=\"$OLD_CARDANO_NODE_TAG\"/CARDANO_NODE_TAG=\"$CARDANO_NODE_TAG\"/g" $SCRIPT
+
+################################################################################
+# Update releases in README.md
+
+# We assuming a specific structure and want to insert a tweaked copy of the
+# master version, and delete the oldest release.
+ln=$(awk '$0 ~ "`master` branch" {print NR}' README.md)
+master_line=$(sed -n "$ln"p README.md)
+line_to_insert=$(echo $master_line | sed -e "s/\`master\` branch/\[$GIT_TAG\](https:\/\/github.com\/input-output-hk\/cardano-wallet\/releases\/tag\/$GIT_TAG)/")
+sed -i -e "s/^GIT_TAG=\"$GIT_TAG\"/GIT_TAG=\"$new_tag\"/g" $SCRIPT
+
+# Edit from the bottom and up, not to affect the line-numbers.
+sed -i -e $(($ln+3))d README.md
+sed -i -e $(($ln+1))i"$line_to_insert" README.md
+
+echo "Automatically updated the list of releases in README.md. Please review the resulting changes."
 
 ################################################################################
 # Update versions


### PR DESCRIPTION
- [x] Remove need to edit the parameters in the file itself. Instead promt the caller through stdin using sensible defaults.

- [x] Automatically update the list of releases in README.md. The code is
       somewhat fragile, but still better than doing it manually.

- [x] Close to merging: Update release checklist.
    - Instead of updating the README.md compatibility matrix, we should now review that the script did it correctly.

### Issue Number

ADP-1073 (though not scheduled yet)

<!-- Put here a reference to the issue that this PR relates to and which requirements it tackles. Jira issues of the form ADP- will be auto-linked. -->

### Comments

## Example
<img width="874" alt="Skärmavbild 2021-08-23 kl  16 07 28" src="https://user-images.githubusercontent.com/304423/130461978-cef6310e-31f5-4d1d-8922-ebb947070013.png">
<img width="1098" alt="Skärmavbild 2021-08-23 kl  16 07 40" src="https://user-images.githubusercontent.com/304423/130461988-60623983-a35b-4670-a794-2e58a5f2b627.png">



```diff
diff --git a/scripts/make_release.sh b/scripts/make_release.sh
index 0dcd451cb..28ff1d137 100755
--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2021-08-11"
-OLD_GIT_TAG="v2021-07-30"
-CARDANO_NODE_TAG="alonzo-purple-1.0.1"
+GIT_TAG="v2021-08-23"
+OLD_GIT_TAG="v2021-08-11"
+CARDANO_NODE_TAG="1.29.0-rc2"

 ################################################################################
 # Tag munging functions

diff --git a/README.md b/README.md
index 7712036c9..f374604bf 100644
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.29.0-rc2](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0-rc2) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
+> | [v2021-08-23](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-23) | [1.29.0-rc2](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0-rc2) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-08-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-11) | [alonzo-purple-1.0.1](https://github.com/input-output-hk/cardano-node/releases/tag/alonzo-purple-1.0.1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-07-30](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-07-30) | [1.28.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.28.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
-> | [v2021-06-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-06-11) | [1.27.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.27.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)

 ## How to build from sources

diff --git a/docker-compose.yml b/docker-compose.yml
index a863d0ec4..2eab5d254 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"

 services:
   cardano-node:
-    image: inputoutput/cardano-node:alonzo-purple-1.0.1
+    image: inputoutput/cardano-node:1.29.0-rc2
     environment:
       NETWORK:
     volumes:
@@ -18,7 +18,7 @@ services:
         max-size: "50m"

   cardano-wallet:
-    image: inputoutput/cardano-wallet:2021.8.11
+    image: inputoutput/cardano-wallet:2021.8.23
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc
```



<!-- Additional comments or screenshots to attach if any -->
