### PR TITLE
Add functions `{gen,shrink}Tx` to `Primitive.Tx.Gen`

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -231,6 +231,7 @@ library
         --
       Cardano.Wallet.Primitive.Types.Address.Gen
       Cardano.Wallet.Primitive.Types.Coin.Gen
+      Cardano.Wallet.Primitive.Types.RewardAccount.Gen
       Cardano.Wallet.Primitive.Types.TokenBundle.Gen
       Cardano.Wallet.Primitive.Types.TokenMap.Gen
       Cardano.Wallet.Primitive.Types.TokenPolicy.Gen

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Hash.hs
@@ -17,12 +17,15 @@
 module Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..)
     , hashFromText
+    , mockHash
     ) where
 
 import Prelude
 
 import Control.DeepSeq
     ( NFData (..) )
+import Crypto.Hash
+    ( Blake2b_256, hash )
 import Data.ByteArray
     ( ByteArrayAccess )
 import Data.ByteArray.Encoding
@@ -46,7 +49,9 @@ import GHC.TypeLits
 import Quiet
     ( Quiet (..) )
 
+import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
 import qualified Data.Char as C
 import qualified Data.Text.Encoding as T
 
@@ -96,3 +101,12 @@ hashFromText len text = case decoded of
     mapFirst :: (a -> a) -> [a] -> [a]
     mapFirst _     [] = []
     mapFirst fn (h:q) = fn h:q
+
+-- | Constructs a hash that is good enough for testing.
+--
+mockHash :: Show a => a -> Hash whatever
+mockHash = Hash . blake2b256 . B8.pack . show
+  where
+     blake2b256 :: ByteString -> ByteString
+     blake2b256 =
+         BA.convert . hash @_ @Blake2b_256

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/RewardAccount/Gen.hs
@@ -1,0 +1,38 @@
+module Cardano.Wallet.Primitive.Types.RewardAccount.Gen
+    ( genRewardAccount
+    , shrinkRewardAccount
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.RewardAccount
+    ( RewardAccount (..) )
+import Test.QuickCheck
+    ( Gen, elements, sized )
+
+import qualified Data.ByteString.Char8 as B8
+
+--------------------------------------------------------------------------------
+-- Reward accounts generated according to the size parameter
+--------------------------------------------------------------------------------
+
+genRewardAccount :: Gen (RewardAccount)
+genRewardAccount = sized $ \size -> elements $ take (max 1 size) addresses
+
+shrinkRewardAccount :: RewardAccount -> [RewardAccount]
+shrinkRewardAccount a
+    | a == simplest = []
+    | otherwise = [simplest]
+  where
+    simplest = head addresses
+
+addresses :: [RewardAccount]
+addresses = mkRewardAccount <$> ['0' ..]
+
+--------------------------------------------------------------------------------
+-- Internal utilities
+--------------------------------------------------------------------------------
+
+mkRewardAccount :: Char -> RewardAccount
+mkRewardAccount c = RewardAccount $ "Reward" `B8.snoc` c

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.DummyTarget.Primitive.Types
     ( -- * Dummy values
@@ -11,7 +10,6 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     , dummySlottingParameters
     , dummyTimeInterpreter
     , genesisHash
-    , mockHash
     , mkTxId
     , mkTx
 
@@ -46,15 +44,11 @@ import Cardano.Wallet.Primitive.Types
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
+    ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxSize (..) )
-import Crypto.Hash
-    ( Blake2b_256, hash )
-import Data.ByteString
-    ( ByteString )
 import Data.Coerce
     ( coerce )
 import Data.Functor.Identity
@@ -66,7 +60,6 @@ import Data.Quantity
 import Data.Time.Clock.POSIX
     ( posixSecondsToUTCTime )
 
-import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Char8 as B8
 
 genesisHash :: Hash "Genesis"
@@ -156,14 +149,6 @@ mkTxId
     -> Map RewardAccount Coin
     -> Maybe TxMetadata -> Hash "Tx"
 mkTxId ins outs wdrls md = mockHash (ins, outs, wdrls, md)
-
--- | Construct a good-enough hash for testing
-mockHash :: Show a => a -> Hash whatever
-mockHash = Hash . blake2b256 . B8.pack . show
-  where
-     blake2b256 :: ByteString -> ByteString
-     blake2b256 =
-         BA.convert . hash @_ @Blake2b_256
 
 dummyNetworkLayer :: NetworkLayer m a
 dummyNetworkLayer = NetworkLayer

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -40,7 +40,7 @@ import Cardano.Mnemonic
 import Cardano.Wallet.DB.Model
     ( TxHistory, filterTxHistory )
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
-    ( block0, mkTx, mockHash )
+    ( block0, mkTx )
 import Cardano.Wallet.Gen
     ( genMnemonic, genSmallTxMetadata, shrinkSlotNo, shrinkTxMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -114,7 +114,7 @@ import Cardano.Wallet.Primitive.Types.Coin
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoinFullRange )
 import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
+    ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -69,7 +69,7 @@ import Cardano.Wallet.DB.Sqlite
 import Cardano.Wallet.DB.StateMachine
     ( TestConstraints, prop_parallel, prop_sequential, validateGenerators )
 import Cardano.Wallet.DummyTarget.Primitive.Types
-    ( block0, dummyGenesisParameters, dummyTimeInterpreter, mockHash )
+    ( block0, dummyGenesisParameters, dummyTimeInterpreter )
 import Cardano.Wallet.Gen
     ( genMnemonic )
 import Cardano.Wallet.Logging
@@ -142,7 +142,7 @@ import Cardano.Wallet.Primitive.Types.Address
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.Hash
-    ( Hash (..) )
+    ( Hash (..), mockHash )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -72,7 +71,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTxIn, genTxOut, shrinkTxIn, shrinkTxOut )
+    ( genTx, genTxOut, shrinkTx, shrinkTxOut )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( Dom (..), UTxO (..), balance, excluding, restrictedTo )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
@@ -132,7 +131,6 @@ import Test.QuickCheck
     , forAllShrink
     , frequency
     , genericShrink
-    , liftShrink2
     , listOf
     , oneof
     , property
@@ -329,28 +327,6 @@ prop_countRewardsOnce (WithPending wallet pending rewards)
 -- Available UTxO properties
 --------------------------------------------------------------------------------
 
--- | Represents all the inputs of a transaction.
---
-data TxInputs = TxInputs
-    { inputs :: [TxIn]
-        -- ^ A transaction's ordinary inputs.
-    , collateral :: [TxIn]
-        -- ^ A transaction's collateral inputs.
-    }
-    deriving (Eq, Show)
-
-genTxInputs :: Gen TxInputs
-genTxInputs = TxInputs
-    <$> listOf genTxIn
-    <*> listOf genTxIn
-
-shrinkTxInputs :: TxInputs -> [TxInputs]
-shrinkTxInputs TxInputs {inputs, collateral} = uncurry TxInputs <$>
-    liftShrink2
-        (shrinkList shrinkTxIn)
-        (shrinkList shrinkTxIn)
-        (inputs, collateral)
-
 allInputsOfTxs :: Set Tx -> Set TxIn
 allInputsOfTxs = F.foldMap allInputsOfTx
   where
@@ -390,41 +366,22 @@ prop_availableUTxO
 prop_availableUTxO makeProperty =
     forAllShrink (scale (* 4) genUTxO) shrinkUTxO
         $ \utxo ->
-    forAllShrink (listOf genTxInputs) (shrinkList shrinkTxInputs)
-        $ \pendingTxInputs ->
-    inner utxo pendingTxInputs
+    forAllShrink (listOf genTx) (shrinkList shrinkTx)
+        $ \pendingTxs ->
+    inner utxo pendingTxs
   where
-    inner utxo pendingTxInputs =
+    inner utxo pendingTxs =
         cover 5 (result /= mempty && result == utxo)
             "result /= mempty && result == utxo" $
         cover 5 (result /= mempty && result /= utxo)
             "result /= mempty && result /= utxo" $
         cover 5 (balance result /= TokenBundle.empty)
             "balance result /= TokenBundle.empty" $
-        property $ makeProperty pendingTxs wallet result
+        property $ makeProperty pendingTxSet wallet result
       where
-        pendingTxs = Set.fromList $ txFromTxInputs <$> pendingTxInputs
+        pendingTxSet = Set.fromList pendingTxs
         wallet = walletFromUTxO utxo
-        result = availableUTxO pendingTxs wallet
-
-    -- Creates a transaction from inputs, by adding dummy data for fields that
-    -- are not used by 'availableUTxO'.
-    --
-    -- Ideally, we'd leave these fields undefined (to assert that they should
-    -- not be evaluated or processed in any way), but since the fields of the
-    -- 'Tx' type are strict, our next best option is to provide a minimal value
-    -- for each field.
-    --
-    txFromTxInputs :: TxInputs -> Tx
-    txFromTxInputs TxInputs {collateral, inputs} = Tx
-        { resolvedCollateral = (, Coin 0) <$> collateral
-        , resolvedInputs = (, Coin 0) <$> inputs
-        , txId = Hash ""
-        , fee = Nothing
-        , outputs = []
-        , withdrawals = Map.empty
-        , metadata = Nothing
-        }
+        result = availableUTxO pendingTxSet wallet
 
     -- Creates a wallet object from a UTxO set, and asserts that the other
     -- parts of the wallet state are not used in any way.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -366,7 +366,7 @@ prop_availableUTxO
 prop_availableUTxO makeProperty =
     forAllShrink (scale (* 4) genUTxO) shrinkUTxO
         $ \utxo ->
-    forAllShrink (listOf genTx) (shrinkList shrinkTx)
+    forAllShrink (scale (`div` 2) $ listOf genTx) (shrinkList shrinkTx)
         $ \pendingTxs ->
     inner utxo pendingTxs
   where
@@ -430,7 +430,8 @@ prop_availableUTxO makeProperty =
 --
 prop_changeUTxO :: Property
 prop_changeUTxO =
-    forAllShrink (listOf genTx) (shrinkList shrinkTx) prop_changeUTxO_inner
+    forAllShrink (scale (`div` 4) $ listOf genTx) (shrinkList shrinkTx)
+        prop_changeUTxO_inner
 
 prop_changeUTxO_inner :: [Tx] -> Property
 prop_changeUTxO_inner pendingTxs =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -108,6 +108,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxOut (..)
     , TxStatus (..)
     )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTx, shrinkTx )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( BoundType
     , Dom (..)
@@ -219,7 +221,8 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 
 spec :: Spec
-spec = do
+spec = describe "Cardano.Wallet.Primitive.Types" $ do
+
     parallel $ describe "Generators are valid" $ do
         it "Arbitrary Coin" $ property isValidCoin
 
@@ -1173,32 +1176,8 @@ instance Arbitrary UTxO where
         return $ UTxO $ Map.fromList utxo
 
 instance Arbitrary Tx where
-    shrink (Tx tid fees ins cins outs wdrls md) = mconcat
-        [ (\ins' -> Tx tid fees ins' cins outs wdrls md)
-            <$> shrink ins
-        , (\cins' -> Tx tid fees ins cins' outs wdrls md)
-            <$> shrink cins
-        , (\outs' -> Tx tid fees ins cins outs' wdrls md)
-            <$> shrink outs
-        , (\wdrls' -> Tx tid fees ins cins outs (Map.fromList wdrls') md)
-            <$> shrink (Map.toList wdrls)
-        , Tx tid fees ins cins outs wdrls
-            <$> shrink md
-        ]
-    arbitrary = do
-        ins <- choose (1, 3) >>= vector
-        cins <- choose (1, 3) >>= vector
-        outs <- choose (1, 3) >>= vector
-        wdrls <- choose (1,3) >>= vector
-        fees <- arbitrary
-        tid <- genHash
-        Tx tid fees ins cins outs (Map.fromList wdrls) <$> arbitrary
-      where
-        genHash = elements
-          [ Hash "Tx1"
-          , Hash "Tx2"
-          , Hash "Tx3"
-          ]
+    arbitrary = genTx
+    shrink = shrinkTx
 
 instance Arbitrary TxMetadata where
     shrink = shrinkTxMetadata

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -31,6 +31,7 @@ library
   build-depends:
       base
     , aeson
+    , containers
     , contra-tracer
     , filepath
     , file-embed

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -12,12 +12,16 @@ module Test.QuickCheck.Extra
     , shrinkInterleaved
     , genSized2
     , genSized2With
+    , interleaveRoundRobin
+    , liftShrink6
     ) where
 
 import Prelude
 
 import Test.QuickCheck
     ( Gen, scale )
+
+import qualified Data.List as L
 
 -- | Resize a generator to grow with the size parameter, but remains reasonably
 -- sized. That is handy when testing on data-structures that can be arbitrarily
@@ -77,6 +81,40 @@ genSized2 genA genB = (,)
 --
 genSized2With :: (a -> b -> c) -> Gen a -> Gen b -> Gen c
 genSized2With f genA genB = uncurry f <$> genSized2 genA genB
+
+-- | Similar to 'liftShrink2', but applicable to 6-tuples.
+--
+liftShrink6
+    :: (a1 -> [a1])
+    -> (a2 -> [a2])
+    -> (a3 -> [a3])
+    -> (a4 -> [a4])
+    -> (a5 -> [a5])
+    -> (a6 -> [a6])
+    -> (a1, a2, a3, a4, a5, a6)
+    -> [(a1, a2, a3, a4, a5, a6)]
+liftShrink6 s1 s2 s3 s4 s5 s6 (a1, a2, a3, a4, a5, a6) =
+    interleaveRoundRobin
+    [ [ (a1', a2 , a3 , a4 , a5 , a6 ) | a1' <- s1 a1 ]
+    , [ (a1 , a2', a3 , a4 , a5 , a6 ) | a2' <- s2 a2 ]
+    , [ (a1 , a2 , a3', a4 , a5 , a6 ) | a3' <- s3 a3 ]
+    , [ (a1 , a2 , a3 , a4', a5 , a6 ) | a4' <- s4 a4 ]
+    , [ (a1 , a2 , a3 , a4 , a5', a6 ) | a5' <- s5 a5 ]
+    , [ (a1 , a2 , a3 , a4 , a5 , a6') | a6' <- s6 a6 ]
+    ]
+
+-- Interleaves the given lists together in round-robin order.
+--
+-- Examples:
+--
+-- >>> interleaveRoundRobin [["a1", "a2"], ["b1", "b2"]]
+-- ["a1", "b1", "a2", "b2"]
+--
+-- >>> interleaveRoundRobin [["a1", "a2", "a3"], ["b1", "b2"], ["c1"]]
+-- ["a1", "b1", "c1", "a2", "b2", "a3"]
+--
+interleaveRoundRobin :: [[a]] -> [a]
+interleaveRoundRobin = concat . L.transpose
 
 -- | Shrink the given pair in interleaved fashion.
 --

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -31,6 +31,7 @@
         depends = [
           (hsPkgs."base" or (errorHandler.buildDepError "base"))
           (hsPkgs."aeson" or (errorHandler.buildDepError "aeson"))
+          (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
           (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))
           (hsPkgs."filepath" or (errorHandler.buildDepError "filepath"))
           (hsPkgs."file-embed" or (errorHandler.buildDepError "file-embed"))

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -22,6 +22,14 @@
   , "^Cardano\\.Wallet\\.Shelley\\.Launch\\.Cluster\\.genMonetaryPolicyScript\$"
   , "^Test\\.Integration\\.Faucet\\."
   , "^Test\\.Integration\\.Framework\\.(TestData|DSL)\\."
+  , "^Cardano\\.Wallet\\.Shelley\\.nullTracers\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.emptyGenesis\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.interval0\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.interval1\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.isInternalError\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.toCardanoHash\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Launch\\.Cluster\\.singleNodeParams\$"
+  , "^Cardano\\.Wallet\\.Shelley\\.Launch\\.Cluster\\.tokenMetadataServerFromEnv\$"
   ]
 , type-class-roots = True
 }


### PR DESCRIPTION
### Issue Number

ADP-1084

### Comments

This PR adds a reusable generator and shrinker for transactions (of type `Tx`) to the `Primitive.Tx.Gen` module.

It uses these functions to simplify or eliminate `Arbitrary` instances in the following modules:
- `Cardano.Wallet.Primitive.ModelSpec`
- `Cardano.Wallet.Primitive.TypesSpec`
- `Cardano.WalletSpec`