### PR TITLE
Lower coverage requirement for `prop_selectRandom_one_withAdaOnly`.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -406,7 +406,7 @@ prop_selectRandom_one_any u = checkCoverage $ monadicIO $ do
 prop_selectRandom_one_withAdaOnly :: UTxOIndex -> Property
 prop_selectRandom_one_withAdaOnly u = checkCoverage $ monadicIO $ do
     result <- run $ UTxOIndex.selectRandom u WithAdaOnly
-    monitor $ cover 90 (isJust result)
+    monitor $ cover 50 (isJust result)
         "selected an entry"
     case result of
         Nothing ->


### PR DESCRIPTION
This PR lowers a coverage check requirement in `prop_selectRandom_one_withAdaOnly`.

It should fix the following failure, which was seen in overnight testing (2 out of 100 runs):

```hs
Failures:

  test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs:144:9:
  1) Cardano.Wallet.Primitive.Types.UTxOIndex, Indexed UTxO set properties, Index Selection, prop_selectRandom_one_withAdaOnly
       Insufficient coverage (after 1600 tests):
         85.18% selected an entry

         Only 85.18% selected an entry, but expected 90.00%

  To rerun use: --match "/Cardano.Wallet.Primitive.Types.UTxOIndex/Indexed UTxO set properties/Index Selection/prop_selectRandom_one_withAdaOnly/"
```