### PR TITLE
Add missing Alonzo-case in decodeSignedTx

### DIFF
--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -608,7 +608,14 @@ _decodeSignedTx era bytes = do
                 Left decodeErr ->
                     Left $ ErrDecodeSignedTxWrongPayload (T.pack $ show decodeErr)
 
-        _ ->
+        AnyCardanoEra AlonzoEra ->
+            case Cardano.deserialiseFromCBOR (Cardano.AsTx Cardano.AsAlonzoEra) bytes of
+                Right txValid ->
+                    pure $ sealShelleyTx fromAlonzoTx txValid
+                Left decodeErr ->
+                    Left $ ErrDecodeSignedTxWrongPayload (T.pack $ show decodeErr)
+
+        AnyCardanoEra ByronEra ->
             Left ErrDecodeSignedTxNotSupported
 
 txConstraints :: ProtocolParameters -> TxWitnessTag -> TxConstraints


### PR DESCRIPTION
1. Add missing Alonzo-case in decodeSignedTx, breaking the /v2/proxy/transactions
   endpoint.
2. Replace the wildcard `_` with a case for Byron, such that we don't
   repeat the mistake for future eras.

   Although, perhaps the decodeSignedTx will be simplified before then anyway.

We used to have integration tests for external tx submission, but they
were removed in #2612 to drop the cardano-transactions dependency.

This fix is not yet tested. I believe, with the tx rework, all txs will
be submitted through the external endpoint anyway. So then we will have
good coverage. For now perhaps a quick check is enough?

- [ ] _Seeing if I can figure out the alonzo-purple testnet configs to test_

### Comments

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1094

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
