### PR TITLE
Move important UTxO state transition functions to the top-level and test them

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -403,6 +403,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.TokenMapSpec.TypeErrorSpec
       Cardano.Wallet.Primitive.Types.TokenPolicySpec
       Cardano.Wallet.Primitive.Types.TokenQuantitySpec
+      Cardano.Wallet.Primitive.Types.UTxOSpec
       Cardano.Wallet.Primitive.Types.UTxOIndexSpec
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -396,6 +396,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Slotting.Legacy
       Cardano.Wallet.Primitive.SlottingSpec
       Cardano.Wallet.Primitive.SyncProgressSpec
+      Cardano.Wallet.Primitive.Types.AddressSpec
       Cardano.Wallet.Primitive.Types.CoinSpec
       Cardano.Wallet.Primitive.Types.HashSpec
       Cardano.Wallet.Primitive.Types.TokenBundleSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -39,6 +39,10 @@ module Cardano.Wallet.Primitive.Model
     , applyBlock
     , applyBlocks
     , unsafeInitWallet
+    , applyTxToUTxO
+    , utxoFromTx
+    , filterOurUTxOs
+    , difference
 
     -- * Accessors
     , currentTip
@@ -80,15 +84,15 @@ import Cardano.Wallet.Primitive.Types.Tx
     , txOutCoin
     )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( Dom (..), UTxO (..), balance, excluding, restrictedBy )
+    ( Dom (..), UTxO (..), balance, excluding, restrictedTo )
 import Control.DeepSeq
     ( NFData (..), deepseq )
 import Control.Monad
-    ( foldM, forM )
+    ( foldM )
 import Control.Monad.Extra
     ( mapMaybeM )
 import Control.Monad.Trans.State.Strict
-    ( State, evalState, runState, state )
+    ( State, StateT, evalState, runState, state )
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
@@ -98,7 +102,7 @@ import Data.Generics.Labels
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Maybe
-    ( catMaybes, isJust )
+    ( isJust )
 import Data.Set
     ( Set )
 import Fmt
@@ -320,6 +324,97 @@ totalUTxO
 totalUTxO pending wallet@(Wallet _ _ s) =
     availableUTxO pending wallet <> changeUTxO pending s
 
+-- | Applies a transaction to a UTxO, moving it from one state from another.
+-- When applying a transaction to a UTxO:
+--   1. We need to remove any unspents that have been spent in the transaction.
+--   2. Add any unspents that we've received via the transaction.
+--
+-- We don't consider "ownership" here (is this address ours?), only "do we
+-- know about this address" (i.e. is it present in our UTxO?).
+--
+-- balance (applyTxToUTxO tx u) = balance u
+--                              + balance (utxoFromTx tx)
+--                              - balance (u `restrictedBy` inputs tx)
+-- unUTxO (applyTxToUTxO tx u) = unUTxO u
+--   `Map.union` unUTxO (utxoFromTx tx)
+--   `Map.difference` unUTxO (u `restrictedBy` inputs tx)
+applyTxToUTxO
+    :: Tx
+    -> UTxO
+    -> UTxO
+applyTxToUTxO tx !u = do
+    let
+        -- When a transaction comes in, we now know about a set of new unspents.
+        newKnown = u <> utxoFromTx tx
+        -- But we also know that some of the new unspents we know about, as well
+        -- as (potentially) some old ones, may now be spent.
+        spentKnown =
+            Set.fromList (inputs tx) `Set.intersection` dom newKnown
+
+    newKnown `excluding` spentKnown
+
+-- | Limit a UTxO set to just the UTxOs that are ours, according to some
+-- given function.
+--
+-- filterOurUTxOs (const $ pure True) u = u
+-- filterOurUTxOs (const $ pure False) u = mempty
+-- filterOurUTxOs f mempty = mempty
+-- balance (filterOurUTxOs f (applyTxToUTxO tx mempty)) =
+--   foldMap (\o -> do
+--               ours <- f (address o)
+--               if ours then tokens o else mempty
+--            ) (outputs tx)
+filterOurUTxOs :: forall f. Monad f => (Address -> f Bool) -> UTxO -> f UTxO
+filterOurUTxOs isOursF (UTxO m) =
+    UTxO <$> Map.traverseMaybeWithKey filterFunc m
+    where
+        filterFunc :: TxIn -> TxOut -> f (Maybe TxOut)
+        filterFunc _txin txout = do
+            ours <- isOursF $ txout ^. #address
+            pure $ if ours then Just txout else Nothing
+
+-- | Construct a UTxO corresponding to a given transaction. It is important for
+-- the transaction outputs to be ordered correctly, since they become available
+-- inputs for the subsequent blocks.
+--
+-- balance (utxoFromTx tx) = foldMap tokens (outputs tx)
+utxoFromTx :: Tx -> UTxO
+utxoFromTx Tx {txId, outputs} =
+    UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
+
+isOurs' :: forall s m. (Monad m, IsOurs s Address) => Address -> StateT s m Bool
+isOurs' addr = do
+    mDerivationIndex <- state $ isOurs addr
+    case mDerivationIndex of
+        Nothing -> pure False
+        Just _  -> pure True
+
+-- | Get the elements in u1 that are not in u2. In the case that elements are in
+-- both, get the difference of the value of the TxOut (the TokenBundle value) in
+-- both entries, removing any entries that are fully spent.
+--
+-- u `difference` mempty = u
+-- mempty `difference` u = mempty
+-- u `difference` u = mempty
+difference :: UTxO -> UTxO -> UTxO
+difference u1 u2 =
+    let
+        u1' = unUTxO u1
+        u2' = unUTxO u2
+
+        diffFunc :: TxOut -> TxOut -> Maybe TxOut
+        diffFunc a b =
+            let
+                tokens1 = tokens a
+                tokens2 = tokens b
+                diff = tokens1 `TB.difference` tokens2
+            in
+                if diff == mempty
+                then Nothing
+                else Just $ TxOut (address a) diff
+    in
+        UTxO $ Map.differenceWith diffFunc u1' u2'
+
 {-------------------------------------------------------------------------------
                                Internals
 -------------------------------------------------------------------------------}
@@ -386,16 +481,34 @@ prefilterBlock b u0 = runState $ do
         => ([(Tx, TxMeta)], UTxO)
         -> Tx
         -> State s ([(Tx, TxMeta)], UTxO)
-    applyTx (!txs, !u) tx = do
-        ourU <- state $ utxoOurs tx
-        let ourIns = Set.fromList (inputs tx) `Set.intersection` dom (u <> ourU)
-        let u' = (u <> ourU) `excluding` ourIns
+    applyTx (!txs, !prevUTxO) tx = do
+        -- All transaction outputs we know about, that belong to us, and that
+        -- haven't been validated as "unspent" yet. It is important to not
+        -- remove spent transactions, because if we do, we lose information
+        -- about transactions inputs and outputs we know about.
+        knownTxO <- (prevUTxO <>) <$> filterOurUTxOs isOurs' (utxoFromTx tx)
+        -- The next UTxO state (apply a state transition) (e.g. remove
+        -- transaction outputs we've spent).
+        ourNextUTxO <- filterOurUTxOs isOurs' (applyTxToUTxO tx knownTxO)
+
         ourWithdrawals <- Coin . sum . fmap (unCoin . snd) <$>
             mapMaybeM ourWithdrawal (Map.toList $ withdrawals tx)
-        let received = balance ourU
-        let spent = balance (u `restrictedBy` ourIns) `TB.add` TB.fromCoin ourWithdrawals
-        let hasKnownInput = ourIns /= mempty
-        let hasKnownOutput = ourU /= mempty
+
+        let received = balance (ourNextUTxO `difference` prevUTxO)
+        let spent =
+                balance (prevUTxO `difference` ourNextUTxO)
+                `TB.add` TB.fromCoin ourWithdrawals
+
+        -- A transaction has a known input if one of the transaction inputs
+        -- matches a transaction input we know about.
+        let hasKnownInput =
+                Set.fromList (inputs tx) `Set.intersection` dom knownTxO
+                /= mempty
+        -- A transaction has a known output if one of the outputs exists in the
+        -- set of unspent transaction outputs we know about.
+        let hasKnownOutput =
+                knownTxO `restrictedTo` Set.fromList (outputs tx)
+                /= mempty
         let hasKnownWithdrawal = ourWithdrawals /= mempty
 
         -- NOTE 1: The only case where fees can be 'Nothing' is when dealing with
@@ -423,7 +536,7 @@ prefilterBlock b u0 = runState $ do
         return $ if hasKnownOutput && not hasKnownInput then
             let dir = Incoming in
             ( (tx { fee = actualFee dir }, mkTxMeta (TB.getCoin received) dir) : txs
-            , u'
+            , ourNextUTxO
             )
         else if hasKnownInput || hasKnownWithdrawal then
             let
@@ -433,10 +546,10 @@ prefilterBlock b u0 = runState $ do
                 amount = distance adaSpent adaReceived
             in
                 ( (tx { fee = actualFee dir }, mkTxMeta amount dir) : txs
-                , u'
+                , ourNextUTxO
                 )
         else
-            (txs, u)
+            (txs, prevUTxO)
 
 -- | Get the change UTxO
 --
@@ -451,21 +564,4 @@ changeUTxO
     -> s
     -> UTxO
 changeUTxO pending = evalState $
-    mconcat <$> mapM (state . utxoOurs) (Set.toList pending)
-
--- | Construct our _next_ UTxO (possible empty) from a transaction by selecting
--- outputs that are ours. It is important for the transaction outputs to be
--- ordered correctly, since they become available inputs for the subsequent
--- blocks.
-utxoOurs
-    :: IsOurs s Address
-    => Tx
-    -> s
-    -> (UTxO, s)
-utxoOurs tx = runState $ toUtxo <$> forM (zip [0..] (outputs tx)) filterOut
-  where
-    toUtxo = UTxO . Map.fromList . catMaybes
-    filterOut (ix, out) = do
-        state (isOurs $ address out) <&> \case
-            Just{}  -> Just (TxIn (txId tx) ix, out)
-            Nothing -> Nothing
+    mconcat <$> mapM (filterOurUTxOs isOurs' . utxoFromTx) (Set.toList pending)

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -455,10 +455,11 @@ prefilterBlock b u0 = runState $ do
 
         (ownedAndKnownTxIns, ownedAndKnownTxOuts) <- do
             -- A new transaction expands the set of transaction inputs/outputs
-            -- we know about:
-            let known = prevUTxO <> utxoFromTx tx
-            -- But not all those transaction inputs/outputs belong to us:
-            ownedAndKnown <- filterByAddressM isOurAddress known
+            -- we know about, but not all those transaction inputs/outputs
+            -- belong to us, so we filter any new inputs/outputs, presuming that
+            -- the previous UTxO has already been filtered:
+            ownedAndKnown <-
+                (prevUTxO <>) <$> filterByAddressM isOurAddress (utxoFromTx tx)
             -- Also, the new transaction may spend some transaction
             -- inputs/outputs. But we don't want to apply that logic yet. If we
             -- do, any spent transaction input/output will be removed from our

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -344,7 +344,7 @@ applyTxToUTxO
     -> UTxO
 applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 
--- | Remove unspents that have been consumed by the giventransaction.
+-- | Remove unspents that have been consumed by the given transaction.
 --
 -- spendTx tx u `isSubsetOf` u
 -- balance (spendTx tx u) <= balance u

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -344,11 +344,14 @@ applyTxToUTxO
     -> UTxO
 applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 
+-- | Remove unspents that have been consumed by the giventransaction.
+--
 -- spendTx tx u `isSubsetOf` u
 -- balance (spendTx tx u) <= balance u
 -- balance (spendTx tx u) = balance u - balance (u `restrictedBy` inputs tx)
 -- spendTx tx u = u `excluding` inputs tx
 -- spendTx tx (filterByAddress f u) = filterByAddress f (spendTx tx u)
+-- spendTx tx (u <> utxoFromTx tx) = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
 spendTx tx !u = u `excluding` Set.fromList (inputs tx)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -472,16 +472,14 @@ prefilterBlock b u0 = runState $ do
 
         -- A transaction has a known input if one of the transaction inputs
         -- matches a transaction input we know about.
-        let hasKnownInput =
-                Set.fromList (inputs tx)
-                    `Set.intersection` (Set.fromList ownedAndKnownTxIns)
-                /= mempty
+        let hasKnownInput = not $ Set.disjoint
+                (Set.fromList $ inputs tx)
+                (Set.fromList ownedAndKnownTxIns)
         -- A transaction has a known output if one of the transaction outputs
         -- matches a transaction output we know about.
-        let hasKnownOutput =
-                Set.fromList (outputs tx)
-                    `Set.intersection` (Set.fromList ownedAndKnownTxOuts)
-                /= mempty
+        let hasKnownOutput = not $ Set.disjoint
+                (Set.fromList $ outputs tx)
+                (Set.fromList ownedAndKnownTxOuts)
         let hasKnownWithdrawal = ourWithdrawals /= mempty
 
         -- NOTE 1: The only case where fees can be 'Nothing' is when dealing with

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -3,6 +3,7 @@ module Cardano.Wallet.Primitive.Types.Address.Gen
       -- * Generators and shrinkers
       genAddress
     , shrinkAddress
+    , coarbitraryAddress
 
       -- * Indicator functions on addresses
     , addressParity
@@ -15,7 +16,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Test.QuickCheck
-    ( Gen, elements, sized )
+    ( Gen, coarbitrary, elements, sized )
 
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
@@ -34,6 +35,9 @@ shrinkAddress a
     | otherwise = [simplest]
   where
     simplest = head addresses
+
+coarbitraryAddress :: Address -> Gen a -> Gen a
+coarbitraryAddress = coarbitrary . BS.unpack . unAddress
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -1,6 +1,12 @@
 module Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
+    (
+      -- * Generators and shrinkers
+      genAddress
     , shrinkAddress
+
+      -- * Indicator functions on addresses
+    , addressParity
+    , Parity (..)
     )
     where
 
@@ -11,6 +17,8 @@ import Cardano.Wallet.Primitive.Types.Address
 import Test.QuickCheck
     ( Gen, elements, sized )
 
+import qualified Data.Bits as Bits
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 --------------------------------------------------------------------------------
@@ -29,6 +37,47 @@ shrinkAddress a
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]
+
+--------------------------------------------------------------------------------
+-- Indicator functions on addresses
+--------------------------------------------------------------------------------
+
+-- | Computes the parity of an address.
+--
+-- Parity is defined in the following way:
+--
+--    - even-parity address:
+--      an address with a pop count (Hamming weight) that is even.
+--
+--    - odd-parity address:
+--      an address with a pop count (Hamming weight) that is odd.
+--
+-- Examples of even-parity and odd-parity addresses:
+--
+--    - 0b00000000 : even (Hamming weight = 0)
+--    - 0b00000001 : odd  (Hamming weight = 1)
+--    - 0b00000010 : odd  (Hamming weight = 1)
+--    - 0b00000011 : even (Hamming weight = 2)
+--    - 0b00000100 : odd  (Hamming weight = 1)
+--    - ...
+--    - 0b11111110 : odd  (Hamming weight = 7)
+--    - 0b11111111 : even (Hamming weight = 8)
+--
+addressParity :: Address -> Parity
+addressParity = parity . addressPopCount
+  where
+    addressPopCount :: Address -> Int
+    addressPopCount = BS.foldl' (\acc -> (acc +) . Bits.popCount) 0 . unAddress
+
+    parity :: Integral a => a -> Parity
+    parity a
+        | even a    = Even
+        | otherwise = Odd
+
+-- | Represents the parity of a value (whether the value is even or odd).
+--
+data Parity = Even | Odd
+    deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
 -- Internal utilities

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -59,6 +59,7 @@ import Test.QuickCheck
     , liftArbitrary2
     , liftShrink
     , liftShrink2
+    , listOf
     , listOf1
     , shrinkList
     , shrinkMapBy
@@ -102,7 +103,7 @@ genTxWithoutId = TxWithoutId
     <$> liftArbitrary genCoinPositive
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
-    <*> listOf1 genTxOut
+    <*> listOf genTxOut
     <*> liftArbitrary genTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -151,11 +151,11 @@ size (UTxO u) = Map.size u
 filterByAddressM :: forall f. Monad f => (Address -> f Bool) -> UTxO -> f UTxO
 filterByAddressM isOursF (UTxO m) =
     UTxO <$> Map.traverseMaybeWithKey filterFunc m
-    where
-        filterFunc :: TxIn -> TxOut -> f (Maybe TxOut)
-        filterFunc _txin txout = do
-            ours <- isOursF $ view #address txout
-            pure $ if ours then Just txout else Nothing
+  where
+    filterFunc :: TxIn -> TxOut -> f (Maybe TxOut)
+    filterFunc _txin txout = do
+        ours <- isOursF $ view #address txout
+        pure $ if ours then Just txout else Nothing
 
 -- | Filters a 'UTxO' set with an indicator function on 'Address' values.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -148,15 +148,6 @@ size (UTxO u) = Map.size u
 --
 -- Returns the subset of UTxO entries that have addresses for which the given
 -- indicator function returns 'True'.
---
--- filterByAddressM (const $ pure True) u = u
--- filterByAddressM (const $ pure False) u = mempty
--- filterByAddressM f mempty = mempty
--- balance (filterByAddressM f (applyTxToUTxO tx mempty)) =
---   foldMap (\o -> do
---               ours <- f (address o)
---               if ours then tokens o else mempty
---            ) (outputs tx)
 filterByAddressM :: forall f. Monad f => (Address -> f Bool) -> UTxO -> f UTxO
 filterByAddressM isOursF (UTxO m) =
     UTxO <$> Map.traverseMaybeWithKey filterFunc m
@@ -166,6 +157,16 @@ filterByAddressM isOursF (UTxO m) =
             ours <- isOursF $ view #address txout
             pure $ if ours then Just txout else Nothing
 
+-- | Filters a 'UTxO' set with an indicator function on 'Address' values.
+--
+-- Returns the subset of UTxO entries that have addresses for which the given
+-- indicator function returns 'True'.
+--
+-- filterByAddress f u = runIdentity $ filterByAddressM (pure . f) u
+-- filterByAddress (const True) u = u
+-- filterByAddress (const False) u = mempty
+-- filterByAddress f mempty = mempty
+-- filterByAddress f u `isSubsetOf` u
 filterByAddress :: (Address -> Bool) -> UTxO -> UTxO
 filterByAddress f = runIdentity . filterByAddressM (pure . f)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -144,8 +144,10 @@ null (UTxO u) = Map.null u
 size :: UTxO -> Int
 size (UTxO u) = Map.size u
 
--- | Limit a UTxO set to just the UTxOs that are ours, according to some
--- given function.
+-- | Filters a 'UTxO' set with an indicator function on 'Address' values.
+--
+-- Returns the subset of UTxO entries that have addresses for which the given
+-- indicator function returns 'True'.
 --
 -- filterByAddressM (const $ pure True) u = u
 -- filterByAddressM (const $ pure False) u = mempty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1490,8 +1490,8 @@ prop_spendTx_balance_inequality :: Tx -> UTxO -> Property
 prop_spendTx_balance_inequality tx u =
     checkCoverage $
     cover 10
-        (lhs /= mempty && lhs `leq` rhs)
-        "lhs /= mempty && lhs `leq` rhs" $
+        (lhs /= mempty && lhs `leq` rhs && lhs /= rhs)
+        "lhs /= mempty && lhs `leq` rhs && lhs /= rhs" $
     isJust (rhs `TokenBundle.subtract` lhs)
         & counterexample ("balance (spendTx tx u) = " <> show lhs)
         & counterexample ("balance u = " <> show rhs)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1441,7 +1441,7 @@ prop_applyTxToUTxO_balance =
           `TokenBundle.add`
               balance (utxoFromTx tx)
           `TokenBundle.difference`
-              balance (u `restrictedBy` Set.fromList (inputs tx))
+              balance (u `UTxO.restrictedBy` Set.fromList (inputs tx))
  
 prop_applyTxToUTxO_entries :: Property
 prop_applyTxToUTxO_entries =
@@ -1452,7 +1452,7 @@ prop_applyTxToUTxO_entries =
           `Map.union`
               unUTxO (utxoFromTx tx)
           `Map.difference`
-              unUTxO (u `restrictedBy` Set.fromList (inputs tx))
+              unUTxO (u `UTxO.restrictedBy` Set.fromList (inputs tx))
     
 prop_filterByAddress_allOurs :: Property
 prop_filterByAddress_allOurs =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1400,16 +1400,22 @@ blockchain =
 prop_tx_utxo_coverage :: Tx -> UTxO -> Property
 prop_tx_utxo_coverage tx u =
     checkCoverage $
-    cover 5 (UTxO.null u) "UTxO empty" $
-    cover 30 (not $ UTxO.null u) "UTxO not empty" $
+    cover 2 (UTxO.null u)
+        "UTxO empty" $
+    cover 30 (not $ UTxO.null u)
+        "UTxO not empty" $
     cover 30 (not $ Set.disjoint (dom u) (Set.fromList $ inputs tx))
         "UTxO and Tx not disjoint" $
     cover 10 (Set.disjoint (dom u) (Set.fromList $ inputs tx))
         "UTxO and Tx disjoint" $
-    cover 10 (length (inputs tx) > 3) "Number of tx inputs > 3" $
-    cover 10 (length (inputs tx) < 3) "Number of tx inputs < 3" $
-    cover 10 (length (outputs tx) > 3) "Number of tx outputs > 3" $
-    cover 10 (length (outputs tx) < 3) "Number of tx outputs < 3" $
+    cover 4 (length (inputs tx) > 3)
+        "Number of tx inputs > 3" $
+    cover 4 (length (inputs tx) < 3)
+        "Number of tx inputs < 3" $
+    cover 4 (length (outputs tx) > 3)
+        "Number of tx outputs > 3" $
+    cover 4 (length (outputs tx) < 3)
+        "Number of tx outputs < 3" $
     property True
 
 prop_applyTxToUTxO_balance :: Tx -> UTxO -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -199,10 +199,10 @@ spec = do
             it "has expected entries" (property prop_applyTxToUTxO_entries)
 
         describe "filterByAddress" $ do
-            it "if all utxos belong to us, the result utxo should not change"
-                (property prop_filterByAddress_allOurs)
-            it "if no utxos belong to us, the result utxo should be nothing"
-                (property prop_filterByAddress_noneOurs)
+            it "matching everything gives us everything"
+                (property prop_filterByAddress_matchAll)
+            it "matching nothing gives us nothing"
+                (property prop_filterByAddress_matchNone)
             it "if there are no utxos, the result utxo should be empty"
                 (property prop_filterByAddress_empty)
             it "applyTxToUTxO then filterByAddress"
@@ -1442,7 +1442,7 @@ prop_applyTxToUTxO_balance =
               balance (utxoFromTx tx)
           `TokenBundle.difference`
               balance (u `UTxO.restrictedBy` Set.fromList (inputs tx))
- 
+
 prop_applyTxToUTxO_entries :: Property
 prop_applyTxToUTxO_entries =
     forAllShrink genTx shrinkTx $ \tx ->
@@ -1453,14 +1453,14 @@ prop_applyTxToUTxO_entries =
               unUTxO (utxoFromTx tx)
           `Map.difference`
               unUTxO (u `UTxO.restrictedBy` Set.fromList (inputs tx))
-    
-prop_filterByAddress_allOurs :: Property
-prop_filterByAddress_allOurs =
+
+prop_filterByAddress_matchAll :: Property
+prop_filterByAddress_matchAll =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const True) u === u
 
-prop_filterByAddress_noneOurs :: Property
-prop_filterByAddress_noneOurs =
+prop_filterByAddress_matchNone :: Property
+prop_filterByAddress_matchNone =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const False) u === mempty
 
@@ -1472,7 +1472,7 @@ prop_filterByAddress_empty b =
         filterByAddress f mempty === mempty
 
 prop_filterByAddress_balance_applyTxToUTxO :: Bool -> Property
-prop_filterByAddress_balance_applyTxToUTxO b = 
+prop_filterByAddress_balance_applyTxToUTxO b =
     let
         f = const b
     in

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -195,16 +195,24 @@ spec = do
                 (property prop_applyTxToUTxO_spendTx_utxoFromTx)
 
         describe "utxoFromTx" $ do
-            it "has expected balance" (property prop_utxoFromTx_balance)
-            it "is unspent" (property prop_utxoFromTx_is_unspent)
+            it "has expected balance"
+                (property prop_utxoFromTx_balance)
+            it "is unspent"
+                (property prop_utxoFromTx_is_unspent)
 
         describe "spendTx" $ do
-            it "is subset of UTxO" (property prop_spendTx_isSubset)
-            it "balance is <= balance of UTxO" (property prop_spendTx_balance_inequality)
-            it "has expected balance" (property prop_spendTx_balance)
-            it "definition" (property prop_spendTx)
-            it "commutative with filterByAddress" (property prop_spendTx_filterByAddress)
-            it "spendTx/utxoFromTx" (property prop_spendTx_utxoFromTx)
+            it "is subset of UTxO"
+                (property prop_spendTx_isSubset)
+            it "balance is <= balance of UTxO"
+                (property prop_spendTx_balance_inequality)
+            it "has expected balance"
+                (property prop_spendTx_balance)
+            it "definition"
+                (property prop_spendTx)
+            it "commutative with filterByAddress"
+                (property prop_spendTx_filterByAddress)
+            it "spendTx/utxoFromTx"
+                (property prop_spendTx_utxoFromTx)
 
     parallel $ describe "Available UTxO" $ do
         it "prop_availableUTxO_isSubmap" $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -32,7 +32,6 @@ import Cardano.Wallet.Primitive.Model
     , availableUTxO
     , changeUTxO
     , currentTip
-    , difference
     , filterOurUTxOs
     , getState
     , initWallet
@@ -205,14 +204,6 @@ spec = do
 
         describe "utxoFromTx" $
             it "has expected balance" (property prop_utxoFromTx_balance)
-
-        describe "difference" $ do
-            it "has a right identity"
-                (property prop_difference_rightIdentity)
-            it "has a left annihilation "
-                (property prop_difference_leftAnnihilation)
-            it "is mempty when asked for difference between equal utxos"
-                (property prop_difference_whenEqual)
 
     parallel $ describe "Available UTxO" $ do
         it "prop_availableUTxO_isSubmap" $
@@ -1490,18 +1481,3 @@ prop_utxoFromTx_balance :: Property
 prop_utxoFromTx_balance =
     forAllShrink genTx shrinkTx $ \tx ->
         balance (utxoFromTx tx) === foldMap tokens (outputs tx)
-
-prop_difference_rightIdentity :: Property
-prop_difference_rightIdentity = 
-    forAllShrink genUTxO shrinkUTxO $ \u ->
-        u `difference` mempty === u
-
-prop_difference_leftAnnihilation :: Property
-prop_difference_leftAnnihilation = 
-    forAllShrink genUTxO shrinkUTxO $ \u ->
-        mempty `difference` u === mempty
-
-prop_difference_whenEqual :: Property
-prop_difference_whenEqual = 
-    forAllShrink genUTxO shrinkUTxO $ \u ->
-        u `difference` u === mempty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -191,7 +191,7 @@ spec = do
                 (property prop_applyTxToUTxO_entries)
             it "applyTxToUTxO then filterByAddress"
                 (property prop_filterByAddress_balance_applyTxToUTxO)
-            it "spendTx/utxoFromTx"
+            it "spendTx/applyTxToUTxO/utxoFromTx"
                 (property prop_applyTxToUTxO_spendTx_utxoFromTx)
 
         describe "utxoFromTx" $ do
@@ -204,6 +204,7 @@ spec = do
             it "has expected balance" (property prop_spendTx_balance)
             it "definition" (property prop_spendTx)
             it "commutative with filterByAddress" (property prop_spendTx_filterByAddress)
+            it "spendTx/utxoFromTx" (property prop_spendTx_utxoFromTx)
 
     parallel $ describe "Available UTxO" $ do
         it "prop_availableUTxO_isSubmap" $
@@ -1456,14 +1457,17 @@ prop_spendTx =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         spendTx tx u === u `excluding` Set.fromList (inputs tx)
 
+prop_spendTx_utxoFromTx :: Property
+prop_spendTx_utxoFromTx =
+    forAllShrink genTx shrinkTx $ \tx ->
+    forAllShrink genUTxO shrinkUTxO $ \u ->
+        spendTx tx (u <> utxoFromTx tx) === spendTx tx u <> utxoFromTx tx
+
 prop_applyTxToUTxO_spendTx_utxoFromTx :: Property
 prop_applyTxToUTxO_spendTx_utxoFromTx =
     forAllShrink genTx shrinkTx $ \tx ->
     forAllShrink genUTxO shrinkUTxO $ \u ->
-        conjoin
-        [ applyTxToUTxO tx u === spendTx tx u <> utxoFromTx tx
-        , applyTxToUTxO tx u === spendTx tx (u <> utxoFromTx tx)
-        ]
+        applyTxToUTxO tx u === spendTx tx u <> utxoFromTx tx
 
 prop_spendTx_filterByAddress :: Bool -> Property
 prop_spendTx_filterByAddress b =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/AddressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/AddressSpec.hs
@@ -1,0 +1,33 @@
+module Cardano.Wallet.Primitive.Types.AddressSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( Parity (..), addressParity, genAddress )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Property, checkCoverage, cover, forAll, property )
+
+spec :: Spec
+spec =
+    describe "Cardano.Wallet.Primitive.Types.AddressSpec" $ do
+
+    describe "addressParity" $ do
+
+        it "prop_addressParity_coverage" $
+            property prop_addressParity_coverage
+
+-- | Verifies that addresses are generated with both even and odd parity.
+--
+prop_addressParity_coverage :: Property
+prop_addressParity_coverage =
+    forAll genAddress $ \addr ->
+    checkCoverage $
+    cover 40 (addressParity addr == Even)
+        "address parity is even" $
+    cover 40 (addressParity addr == Odd)
+        "address parity is odd" $
+    property True

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -9,7 +9,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( Parity (..), addressParity )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( UTxO (..), dom, filterByAddress, filterByAddressM )
+    ( UTxO (..), dom, filterByAddress, filterByAddressM, isSubsetOf )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
 import Data.Functor.Identity
@@ -39,6 +39,8 @@ spec =
             property prop_filterByAddress_empty
         it "filterByAddress/filterByAddressM" $
             property prop_filterByAddress_filterByAddressM
+        it "filterByAddress is always subset" $
+            property prop_filterByAddress_isSubset
 
 prop_filterByAddress_matchAll :: Property
 prop_filterByAddress_matchAll =
@@ -90,3 +92,11 @@ prop_filterByAddress_filterByAddressM b =
     in
         forAllShrink genUTxO shrinkUTxO $ \u ->
             filterByAddress f u === runIdentity (filterByAddressM (pure . f) u)
+
+prop_filterByAddress_isSubset :: Bool -> Property
+prop_filterByAddress_isSubset b =
+    let
+        f = const b
+    in
+        forAllShrink genUTxO shrinkUTxO $ \u ->
+            filterByAddress f u `isSubsetOf` u

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -1,0 +1,55 @@
+module Cardano.Wallet.Primitive.Types.UTxOSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( filterByAddress, filterByAddressM )
+import Cardano.Wallet.Primitive.Types.UTxO.Gen
+    ( genUTxO, shrinkUTxO )
+import Data.Functor.Identity
+    ( runIdentity )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Property, forAllShrink, property, (===) )
+
+spec :: Spec
+spec =
+    describe "Cardano.Wallet.Primitive.Types.UTxOSpec" $ do
+
+    describe "filterByAddress" $ do
+        it "matching everything gives us everything" $
+            property prop_filterByAddress_matchAll
+        it "matching nothing gives us nothing" $
+            property prop_filterByAddress_matchNone
+        it "if there are no utxos, the result utxo should be empty" $
+            property prop_filterByAddress_empty
+        it "filterByAddress/filterByAddressM" $
+            property prop_filterByAddress_filterByAddressM
+
+prop_filterByAddress_matchAll :: Property
+prop_filterByAddress_matchAll =
+    forAllShrink genUTxO shrinkUTxO $ \u ->
+        filterByAddress (const True) u === u
+
+prop_filterByAddress_matchNone :: Property
+prop_filterByAddress_matchNone =
+    forAllShrink genUTxO shrinkUTxO $ \u ->
+        filterByAddress (const False) u === mempty
+
+prop_filterByAddress_empty :: Bool -> Property
+prop_filterByAddress_empty b =
+    let
+        f = const b
+    in
+        filterByAddress f mempty === mempty
+
+prop_filterByAddress_filterByAddressM :: Bool -> Property
+prop_filterByAddress_filterByAddressM b =
+    let
+        f = const b
+    in
+        forAllShrink genUTxO shrinkUTxO $ \u ->
+            filterByAddress f u === runIdentity (filterByAddressM (pure . f) u)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -56,10 +56,16 @@ spec =
 
 prop_filterByAddress_matchAll :: UTxO -> Property
 prop_filterByAddress_matchAll u =
+    checkCoverage $
+    cover 2 (u == mempty) "empty" $
+    cover 8 (u /= mempty) "non-empty" $
     filterByAddress (const True) u === u
 
 prop_filterByAddress_matchNone :: UTxO -> Property
 prop_filterByAddress_matchNone u =
+    checkCoverage $
+    cover 2 (u == mempty) "empty" $
+    cover 8 (u /= mempty) "non-empty" $
     filterByAddress (const False) u === mempty
 
 prop_filterByAddress_matchSome :: UTxO -> Property
@@ -91,11 +97,23 @@ prop_filterByAddress_empty f =
 
 prop_filterByAddress_filterByAddressM :: UTxO -> (Address -> Bool) -> Property
 prop_filterByAddress_filterByAddressM u f =
+    checkCoverage $
+    cover 10 isNonEmptyProperSubset "is non-empty proper subset" $
     filterByAddress f u === runIdentity (filterByAddressM (pure . f) u)
+  where
+    isNonEmptyProperSubset = (&&)
+        (filterByAddress f u /= mempty)
+        (dom (filterByAddress f u) `Set.isProperSubsetOf` dom u)
 
 prop_filterByAddress_isSubset :: UTxO -> (Address -> Bool) -> Property
 prop_filterByAddress_isSubset u f =
+    checkCoverage $
+    cover 10 isNonEmptyProperSubset "is non-empty proper subset" $
     property $ filterByAddress f u `isSubsetOf` u
+  where
+    isNonEmptyProperSubset = (&&)
+        (filterByAddress f u /= mempty)
+        (dom (filterByAddress f u) `Set.isProperSubsetOf` dom u)
 
 instance CoArbitrary Address where
     coarbitrary = coarbitraryAddress

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -1,19 +1,28 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Cardano.Wallet.Primitive.Types.UTxOSpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( Parity (..), addressParity )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( filterByAddress, filterByAddressM )
+    ( UTxO (..), dom, filterByAddress, filterByAddressM )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
 import Data.Functor.Identity
     ( runIdentity )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
-    ( Property, forAllShrink, property, (===) )
+    ( Property, checkCoverage, conjoin, cover, forAllShrink, property, (===) )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 spec :: Spec
 spec =
@@ -24,6 +33,8 @@ spec =
             property prop_filterByAddress_matchAll
         it "matching nothing gives us nothing" $
             property prop_filterByAddress_matchNone
+        it "matching some addresses gives us the appropriate subset" $
+            property prop_filterByAddress_matchSome
         it "if there are no utxos, the result utxo should be empty" $
             property prop_filterByAddress_empty
         it "filterByAddress/filterByAddressM" $
@@ -38,6 +49,32 @@ prop_filterByAddress_matchNone :: Property
 prop_filterByAddress_matchNone =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const False) u === mempty
+
+prop_filterByAddress_matchSome :: Property
+prop_filterByAddress_matchSome =
+    forAllShrink genUTxO shrinkUTxO prop_inner
+  where
+    prop_inner utxo =
+        checkCoverage $
+        cover 10
+            (domEven /= mempty && domEven `Set.isProperSubsetOf` dom utxo)
+            "domEven /= mempty && domEven `Set.isProperSubsetOf` dom utxo" $
+        cover 10
+            (domOdd /= mempty && domOdd `Set.isProperSubsetOf` dom utxo)
+            "domOdd /= mempty && domOdd `Set.isProperSubsetOf` dom utxo" $
+        conjoin
+            [ utxoEven <> utxoOdd == utxo
+            , unUTxO utxoEven `Map.isSubmapOf` unUTxO utxo
+            , unUTxO utxoOdd  `Map.isSubmapOf` unUTxO utxo
+            , all ((== Even) . addressParity . view #address) (unUTxO utxoEven)
+            , all ((==  Odd) . addressParity . view #address) (unUTxO utxoOdd)
+            ]
+      where
+        domEven = dom utxoEven
+        domOdd  = dom utxoOdd
+
+        utxoEven = filterByAddress ((== Even) . addressParity) utxo
+        utxoOdd  = filterByAddress ((==  Odd) . addressParity) utxo
 
 prop_filterByAddress_empty :: Bool -> Property
 prop_filterByAddress_empty b =


### PR DESCRIPTION
This work is intended to allow future modifications to the UTxO state transition function (i.e. collateral) to be tested in isolation, at the unit level.

My changes are primarily to the nested function "applyTx". I have tried to keep my changes minimal:
  - Use more verbose variable names in that function to make the purpose of each variable clear.
  - More clearly delineate between transaction outputs that are unspent and transaction outputs "we know about" but may possibly be spent.
  - Make some effort to separate the ideas of "knowledge of a UTxO" from "ownership of a UTxO" to make testing easier.
  - Extract out the core state transition function from the existing "do lots" "applyTx" function and move it to the top-level.
  - Move other useful functions to the top-level for the same reason.
  - Test important functions in wallet model spec.
  - Re-implement hasKnownInput/hasKnownOutput to make their implementations a little more clear and symmetric.

### Comments

These changes make testing collateral much easier, we can just test the "applyTxToUTxO" function at the unit level, and adjust existing model tests as necessary.

### Issue Number

ADP-1092
