### PR TITLE
Bump node from rc3 to final 1.29.0

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -87,5 +87,5 @@ jobs:
       TESTS_E2E_FIXTURES: ${{ secrets.TESTS_E2E_FIXTURES }}
       NETWORK: ${{ github.event.inputs.network || 'testnet' }}
       WALLET: ${{ github.event.inputs.walletTag || 'dev-master' }}
-      NODE: ${{ github.event.inputs.nodeTag || '1.29.0-rc2' }}
+      NODE: ${{ github.event.inputs.nodeTag || '1.29.0' }}
       TESTS_E2E_TOKEN_METADATA: https://metadata.cardano-testnet.iohkdev.io/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See **Installation Instructions** for each available [release](https://github.co
 >
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
-> | `master` branch | [1.29.0-rc3](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0-rc3) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
+> | `master` branch | [1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-08-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-11) | [alonzo-purple-1.0.1](https://github.com/input-output-hk/cardano-node/releases/tag/alonzo-purple-1.0.1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-07-30](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-07-30) | [1.28.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.28.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-06-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-06-11) | [1.27.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.27.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)

--- a/cabal.project
+++ b/cabal.project
@@ -129,7 +129,7 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-node
-    tag: c17315f2775eaf988e432b7caea3a094d62ce6c9
+    tag: 4c59442958072657812c6c0bb8e0b4ab85ce1ba2
     subdir: cardano-api
             cardano-cli
             cardano-config

--- a/nix/.stack.nix/cardano-api.nix
+++ b/nix/.stack.nix/cardano-api.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "3.0";
-      identifier = { name = "cardano-api"; version = "1.28.0"; };
+      identifier = { name = "cardano-api"; version = "1.29.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -142,12 +142,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       };
     postUnpack = "sourceRoot+=/cardano-api; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-cli.nix
+++ b/nix/.stack.nix/cardano-cli.nix
@@ -11,7 +11,7 @@
     flags = { unexpected_thunks = false; };
     package = {
       specVersion = "3.0";
-      identifier = { name = "cardano-cli"; version = "1.28.0"; };
+      identifier = { name = "cardano-cli"; version = "1.29.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -147,12 +147,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       };
     postUnpack = "sourceRoot+=/cardano-cli; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-config.nix
+++ b/nix/.stack.nix/cardano-config.nix
@@ -39,12 +39,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       };
     postUnpack = "sourceRoot+=/cardano-config; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-node.nix
+++ b/nix/.stack.nix/cardano-node.nix
@@ -11,7 +11,7 @@
     flags = { unexpected_thunks = false; systemd = true; };
     package = {
       specVersion = "3.0";
-      identifier = { name = "cardano-node"; version = "1.28.0"; };
+      identifier = { name = "cardano-node"; version = "1.29.0"; };
       license = "Apache-2.0";
       copyright = "";
       maintainer = "operations@iohk.io";
@@ -125,12 +125,12 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       }) // {
       url = "https://github.com/input-output-hk/cardano-node";
-      rev = "c17315f2775eaf988e432b7caea3a094d62ce6c9";
-      sha256 = "17z8qyfxi0fh0l4vin94nbaqqgpl0wf91n8k9p18hv2flys1pp7i";
+      rev = "4c59442958072657812c6c0bb8e0b4ab85ce1ba2";
+      sha256 = "0pc26hrgdsf93h3qvp8m76axm4jspzclg6psn14mbaf1mkc1fxmx";
       };
     postUnpack = "sourceRoot+=/cardano-node; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -165,7 +165,7 @@ extra-deps:
   - shelley-ma/shelley-ma-test
 
 - git: https://github.com/input-output-hk/cardano-node
-  commit: c17315f2775eaf988e432b7caea3a094d62ce6c9
+  commit: 4c59442958072657812c6c0bb8e0b4ab85ce1ba2
   subdirs:
   - cardano-api
   - cardano-cli


### PR DESCRIPTION

- [x] Bump revision from 1.29.0-rc3 to 1.29.0

### Comments

No changes in `git diff 1.29.0-rc3 1.29.0 -- cabal.project` 

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
