### PR TITLE
Buildkite: Run weeder as early as possible, after build, before test

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -234,7 +234,7 @@ setupBuildDirectory dryRun buildDir = do
 -- Remove certain files which get cached but could cause problems for subsequent
 -- builds.
 cleanBuildDirectory :: FilePath -> IO ()
-cleanBuildDirectory buildDir = mapM_ rm =<< findTix buildDir <> findHie buildDir
+cleanBuildDirectory buildDir = mapM_ rm =<< findTix buildDir
 
 -- | Check for the presence of new or modified test data files which someone
 -- forgot to check in.
@@ -326,10 +326,7 @@ titled heading action = do
 -- Weeder - uses .hie files in .stack-work to determine unused dependencies
 
 weederStep :: DryRun -> IO ExitCode
-weederStep dryRun = run dryRun "weeder" []
-
-findHie :: FilePath -> IO [FilePath]
-findHie dir = fold (find (suffix ".hie") dir) Fold.list
+weederStep dryRun = run dryRun "weeder" ["--require-hs-files"]
 
 ----------------------------------------------------------------------------
 -- Stack Haskell Program Coverage and upload to Coveralls

--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -78,9 +78,7 @@ main = do
             buildResult <- buildStep optDryRun (qaLevel optQALevel bk)
             when (shouldUploadCoverage bk) $ uploadCoverageStep optDryRun
             whenRun optDryRun $ cachePutStep cacheConfig
-            if buildResult == ExitSuccess
-                then exitWith =<< weederStep optDryRun
-                else exitWith buildResult
+            exitWith buildResult
         CleanupCache ->
             cleanupCacheStep optDryRun cacheConfig optBuildDirectory
         PurgeCache ->
@@ -159,6 +157,9 @@ buildStep' dryRun qa pkgs = foldl1 (.&&.)
         build Standard ["--only-dependencies"]
     , titled "Build" $
         projectBuild ["--test", "--no-run-tests"]
+    , titled "Weeder" $
+        weederStep dryRun
+    -- Tests removed by @sevanspowell
     -- , titled "Tests (except integration)" $
     --     timeout 60 $ do
     --         test (skip "integration") []
@@ -325,9 +326,7 @@ titled heading action = do
 -- Weeder - uses .hie files in .stack-work to determine unused dependencies
 
 weederStep :: DryRun -> IO ExitCode
-weederStep dryRun = titled "Weeder (temporarily disabled)" $
-    pure ExitSuccess
-    -- run dryRun "weeder" []
+weederStep dryRun = run dryRun "weeder" []
 
 findHie :: FilePath -> IO [FilePath]
 findHie dir = fold (find (suffix ".hie") dir) Fold.list

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -81,12 +81,10 @@ module Cardano.Wallet.Shelley.Compatibility
     , fromShelleyPParams
     , fromAlonzoPParams
     , fromLedgerExUnits
-    , toLedgerExUnits
     , fromLedgerPParams
     , fromLedgerAlonzoPParams
     , toAlonzoPParams
     , fromCardanoAddress
-    , toSystemStart
     , toScriptPurpose
     , fromShelleyTxIn
     , toCostModelsAsArray
@@ -181,8 +179,6 @@ import Cardano.Ledger.Serialization
     ( ToCBORGroup )
 import Cardano.Slotting.Slot
     ( EpochNo (..), EpochSize (..) )
-import Cardano.Slotting.Time
-    ( SystemStart (..) )
 import Cardano.Wallet.Api.Types
     ( DecodeAddress (..)
     , DecodeStakeAddress (..)
@@ -728,15 +724,6 @@ fromLedgerExUnits (Alonzo.ExUnits mem steps) =
     W.ExecutionUnits
     { executionSteps = steps
     , executionMemory = mem
-    }
-
-toLedgerExUnits
-    :: W.ExecutionUnits
-    -> Alonzo.ExUnits
-toLedgerExUnits W.ExecutionUnits{executionSteps,executionMemory} =
-    Alonzo.ExUnits
-    { Alonzo.exUnitsMem = executionMemory
-    , Alonzo.exUnitsSteps = executionSteps
     }
 
 txParametersFromPParams
@@ -1629,9 +1616,6 @@ fromUnitInterval x =
   where
     bomb = internalError $
         "fromUnitInterval: encountered invalid parameter value: "+||x||+""
-
-toSystemStart :: W.StartTime -> SystemStart
-toSystemStart (W.StartTime t) = SystemStart t
 
 toScriptPurpose :: W.Redeemer -> Alonzo.ScriptPurpose StandardCrypto
 toScriptPurpose = \case

--- a/nix/materialized/weeder/.plan.nix/weeder.nix
+++ b/nix/materialized/weeder/.plan.nix/weeder.nix
@@ -11,7 +11,7 @@
     flags = {};
     package = {
       specVersion = "3.0";
-      identifier = { name = "weeder"; version = "2.1.3"; };
+      identifier = { name = "weeder"; version = "2.2.0"; };
       license = "BSD-3-Clause";
       copyright = "Neil Mitchell 2017-2020, Oliver Charles 2020";
       maintainer = "Ollie Charles <ollie@ocharles.org.uk>";

--- a/nix/materialized/weeder/default.nix
+++ b/nix/materialized/weeder/default.nix
@@ -79,7 +79,7 @@
         "prettyprinter".revision = (((hackage."prettyprinter")."1.7.1").revisions).default;
         "prettyprinter".flags.buildreadme = false;
         "prettyprinter".flags.text = true;
-        "megaparsec".revision = (((hackage."megaparsec")."9.0.1").revisions).default;
+        "megaparsec".revision = (((hackage."megaparsec")."9.2.0").revisions).default;
         "megaparsec".flags.dev = false;
         "distributive".revision = (((hackage."distributive")."0.6.2.1").revisions).default;
         "distributive".flags.tagged = true;
@@ -133,15 +133,12 @@
         "http-client".revision = (((hackage."http-client")."0.7.9").revisions).default;
         "http-client".flags.network-uri = true;
         "ghc".revision = (((hackage."ghc")."8.10.7").revisions).default;
-        "lens".revision = (((hackage."lens")."4.19.2").revisions).default;
-        "lens".flags.test-doctests = true;
+        "lens".revision = (((hackage."lens")."5.0.1").revisions).default;
         "lens".flags.test-templates = true;
         "lens".flags.test-hunit = true;
         "lens".flags.benchmark-uniplate = false;
         "lens".flags.inlining = true;
-        "lens".flags.safe = false;
         "lens".flags.trustworthy = true;
-        "lens".flags.old-inline-pragmas = false;
         "lens".flags.test-properties = true;
         "lens".flags.dump-splices = false;
         "lens".flags.j = false;
@@ -163,7 +160,7 @@
         "prettyprinter-ansi-terminal".revision = (((hackage."prettyprinter-ansi-terminal")."1.1.3").revisions).default;
         "primitive".revision = (((hackage."primitive")."0.7.2.0").revisions).default;
         "directory".revision = (((hackage."directory")."1.3.6.0").revisions).default;
-        "transformers-compat".revision = (((hackage."transformers-compat")."0.6.6").revisions).default;
+        "transformers-compat".revision = (((hackage."transformers-compat")."0.7").revisions).default;
         "transformers-compat".flags.two = false;
         "transformers-compat".flags.five = false;
         "transformers-compat".flags.four = false;
@@ -171,7 +168,7 @@
         "transformers-compat".flags.five-three = true;
         "transformers-compat".flags.three = false;
         "transformers-compat".flags.mtl = true;
-        "memory".revision = (((hackage."memory")."0.15.0").revisions).default;
+        "memory".revision = (((hackage."memory")."0.16.0").revisions).default;
         "memory".flags.support_basement = true;
         "memory".flags.support_bytestring = true;
         "memory".flags.support_foundation = true;
@@ -201,7 +198,7 @@
         "semigroups".flags.text = true;
         "parsec".revision = (((hackage."parsec")."3.1.14.0").revisions).default;
         "ghc-boot-th".revision = (((hackage."ghc-boot-th")."8.10.7").revisions).default;
-        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.0.0.0").revisions).default;
+        "generic-lens-core".revision = (((hackage."generic-lens-core")."2.2.0.0").revisions).default;
         "splitmix".revision = (((hackage."splitmix")."0.1.0.3").revisions).default;
         "splitmix".flags.optimised-mixer = false;
         "x509-store".revision = (((hackage."x509-store")."1.6.7").revisions).default;
@@ -218,7 +215,7 @@
         "strict".flags.assoc = true;
         "attoparsec".revision = (((hackage."attoparsec")."0.14.1").revisions).default;
         "attoparsec".flags.developer = false;
-        "generic-lens".revision = (((hackage."generic-lens")."2.0.0.0").revisions).default;
+        "generic-lens".revision = (((hackage."generic-lens")."2.2.0.0").revisions).default;
         "transformers".revision = (((hackage."transformers")."0.5.6.2").revisions).default;
         "pem".revision = (((hackage."pem")."0.2.4").revisions).default;
         "colour".revision = (((hackage."colour")."2.3.6").revisions).default;
@@ -240,7 +237,7 @@
         "assoc".revision = (((hackage."assoc")."1.0.2").revisions).default;
         "asn1-parse".revision = (((hackage."asn1-parse")."0.9.5").revisions).default;
         "base64-bytestring".revision = (((hackage."base64-bytestring")."1.2.1.0").revisions).default;
-        "dhall".revision = (((hackage."dhall")."1.37.1").revisions).default;
+        "dhall".revision = (((hackage."dhall")."1.40.1").revisions).default;
         "dhall".flags.with-http = true;
         "dhall".flags.use-http-client-tls = true;
         "dhall".flags.cross = false;
@@ -257,7 +254,7 @@
         "cryptonite".flags.integer-gmp = true;
         "cryptonite".flags.check_alignment = false;
         "th-compat".revision = (((hackage."th-compat")."0.1.3").revisions).default;
-        "mmorph".revision = (((hackage."mmorph")."1.1.5").revisions).default;
+        "mmorph".revision = (((hackage."mmorph")."1.2.0").revisions).default;
         "indexed-traversable".revision = (((hackage."indexed-traversable")."0.1.1").revisions).default;
         "zlib".revision = (((hackage."zlib")."0.6.2.3").revisions).default;
         "zlib".flags.non-blocking-ffi = false;
@@ -265,6 +262,7 @@
         "zlib".flags.pkg-config = false;
         "hourglass".revision = (((hackage."hourglass")."0.2.12").revisions).default;
         "appar".revision = (((hackage."appar")."0.1.8").revisions).default;
+        "indexed-traversable-instances".revision = (((hackage."indexed-traversable-instances")."0.1").revisions).default;
         "mime-types".revision = (((hackage."mime-types")."0.1.0.9").revisions).default;
         "base-compat-batteries".revision = (((hackage."base-compat-batteries")."0.12.0").revisions).default;
         "x509-validation".revision = (((hackage."x509-validation")."1.6.11").revisions).default;
@@ -324,7 +322,6 @@
           "byteorder".components.library.planned = lib.mkOverride 900 true;
           "containers".components.library.planned = lib.mkOverride 900 true;
           "lens".components.library.planned = lib.mkOverride 900 true;
-          "lens".components.setup.planned = lib.mkOverride 900 true;
           "x509".components.library.planned = lib.mkOverride 900 true;
           "semigroupoids".components.library.planned = lib.mkOverride 900 true;
           "bifunctors".components.library.planned = lib.mkOverride 900 true;
@@ -346,6 +343,7 @@
           "mime-types".components.library.planned = lib.mkOverride 900 true;
           "dhall".components.exes."dhall".planned = lib.mkOverride 900 true;
           "hourglass".components.library.planned = lib.mkOverride 900 true;
+          "indexed-traversable-instances".components.library.planned = lib.mkOverride 900 true;
           "appar".components.library.planned = lib.mkOverride 900 true;
           "mmorph".components.library.planned = lib.mkOverride 900 true;
           "indexed-traversable".components.library.planned = lib.mkOverride 900 true;

--- a/nix/overlays/build-tools.nix
+++ b/nix/overlays/build-tools.nix
@@ -38,7 +38,7 @@ pkgs: super: let
     hlint.version                   = "3.3.1";
     lentil.version                  = "1.5.2.0";
     stylish-haskell.version         = "0.11.0.3";
-    weeder.version                  = "2.1.3";
+    weeder.version                  = "2.2.0";
   };
 
   # Use cabal.project as the source of GHC version and Hackage index-state.

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -19,7 +19,7 @@
   , "^UnliftIO\\.Compat\\.mkRetryHandler\$"
   , "^Spec\\.main\$"
   , "^Test\\..*\\.spec\$"
-  , "^Test\\.QuickCheck\\.Extra\\.liftShrink\$"
+  , "^Test\\.QuickCheck\\.Extra\\.liftShrink.*\$"
   , "^Test\\.Utils\\.Paths\\.getTestData"
   , "^Cardano\\.Wallet\\.Api\\.Malformed\\."
   , "^Cardano\\.Wallet\\.DB\\.StateMachine\\.showLabelledExamples\$"
@@ -34,6 +34,8 @@
   , "^Cardano\\.Wallet\\.Shelley\\.Compatibility\\.toCardanoHash\$"
   , "^Cardano\\.Wallet\\.Shelley\\.Launch\\.Cluster\\.singleNodeParams\$"
   , "^Cardano\\.Wallet\\.Shelley\\.Launch\\.Cluster\\.tokenMetadataServerFromEnv\$"
+  -- TODO: [ADP-1037] Remove weeds
+  , "^Cardano\\.Wallet\\.Primitive\\.CoinSelection\\.(selectionDeltaCoin|selectionHasSufficientCollateral)\$"
   -- TODO: [ADP-919] Temporary weeder roots
   , "signTransaction"
   , "getSealedTxWitnesses"


### PR DESCRIPTION
1. Moves the Weeder command earlier in the Stack Rebuild step.
2. Updates Weeder to 2.2.0, which fixes the problem of false weeds due to stale `.hie` files.
