### PR TITLE
Bump version from 2021.8.11 to 2021.8.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
+> | [v2021-08-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-27) | [1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-08-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-11) | [alonzo-purple-1.0.1](https://github.com/input-output-hk/cardano-node/releases/tag/alonzo-purple-1.0.1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 > | [v2021-07-30](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-07-30) | [1.28.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.28.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
-> | [v2021-06-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-06-11) | [1.27.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.27.0) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 
 ## How to build from sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:alonzo-purple-1.0.1
+    image: inputoutput/cardano-node:1.29.0
     environment:
       NETWORK:
     volumes:
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2021.8.11
+    image: inputoutput/cardano-wallet:2021.8.27
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Wallet backend protocol-specific bits implemented using Shelley nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2021.8.11
+version:             2021.8.27
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2021.8.11"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2021.8.27"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2021.8.11";
+        version = "2021.8.27";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2021.8.11"; };
+      identifier = { name = "cardano-wallet-core"; version = "2021.8.27"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2021.8.11"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2021.8.27"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2021.8.11";
+        version = "2021.8.27";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2021.8.11"; };
+      identifier = { name = "cardano-wallet"; version = "2021.8.27"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2021.8.11"; };
+      identifier = { name = "text-class"; version = "2021.8.27"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2021-08-11"
-OLD_GIT_TAG="v2021-07-30"
-CARDANO_NODE_TAG="alonzo-purple-1.0.1"
+GIT_TAG="v2021-08-27"
+OLD_GIT_TAG="v2021-08-11"
+CARDANO_NODE_TAG="1.29.0"
 
 ################################################################################
 # Tag munging functions


### PR DESCRIPTION
- [x] Run `./scripts/make_release.sh` for tomorrow's release.