### PR TITLE
Don't leak wallets from createWalletViaCLI

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Byron/Wallets.hs
@@ -24,7 +24,7 @@ import Control.Monad
 import Control.Monad.IO.Class
     ( liftIO )
 import Control.Monad.Trans.Resource
-    ( ResourceT, runResourceT )
+    ( runResourceT )
 import Data.Generics.Internal.VL.Lens
     ( view, (^.) )
 import Data.Maybe
@@ -93,7 +93,7 @@ spec = describe "BYRON_CLI_WALLETS" $ do
                     , "--wallet-style", style
                     ]
             --create
-            (c, out, err) <- createWalletViaCLI @_ @(ResourceT IO) ctx
+            (c, out, err) <- createWalletViaCLI @_ @IO ctx
                         args (unwords $ T.unpack <$> mnemonic)
                         "\n" "secure-passphrase"
             T.unpack err `shouldContain` cmdOk

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Port.hs
@@ -41,6 +41,7 @@ import Test.Integration.Framework.DSL
     , listWalletsViaCLI
     , postTransactionViaCLI
     , proc'
+    , runResourceT
     , updateWalletNameViaCLI
     )
 import UnliftIO.Process
@@ -64,7 +65,7 @@ spec = describe "COMMON_CLI_PORTS" $ do
         -- hence asserting only for exit code
         c `shouldBe` ExitFailure 1
 
-    it "PORT_01 - Can't reach server with wrong port (wallet create)" $ \ctx -> do
+    it "PORT_01 - Can't reach server with wrong port (wallet create)" $ \ctx -> runResourceT $ do
         let ctx' = overPort @"wallet" (+1) ctx
         let name = "Wallet created via CLI"
         Stdout mnemonics <- generateMnemonicsViaCLI ["--size", "15"]

--- a/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/CLI/Shelley/Wallets.hs
@@ -37,7 +37,7 @@ import Cardano.Wallet.Primitive.Types
 import Control.Monad
     ( forM_ )
 import Control.Monad.IO.Class
-    ( MonadIO, liftIO )
+    ( MonadIO )
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO (..) )
 import Control.Monad.Trans.Resource
@@ -195,7 +195,7 @@ spec = describe "SHELLEY_CLI_WALLETS" $ do
 
         -- create a wallet
         Stdout m <- generateMnemonicsViaCLI []
-        (c1, o1, e1) <- liftIO $ createWalletViaCLI ctx ["n"] m "\n" "secure-passphrase"
+        (c1, o1, e1) <- createWalletViaCLI ctx ["n"] m "\n" "secure-passphrase"
         c1 `shouldBe` ExitSuccess
         T.unpack e1 `shouldContain` cmdOk
         wDest <- expectValidJSON (Proxy @ApiWallet) o1


### PR DESCRIPTION

- [x] Make `createWalletViaCLI` run in `ResourceT` for automatic cleanup

### Comments

There has been strange CI failures where the wallet seems overloaded
(balance is 0, and wallet is unsynced even after 90s). They seem CLI
specific.

There may be several reasons for the CLI specific failures. But one is:
It seems createWalletViaCLI does not automatically clean up wallets
using ResourceT. In the CLI.Shelley.Wallets module there are 15 calls to
createWalletViaCLI, but only 5 corresponding deleteWalletViaCLI ones.

The wallet server does not perform well with many wallets. So leaking
wallets might contribute to slowness and failures.

We should simply make createWalletViaCLI use ResourceT.

Running
```
NO_POOLS=1 NO_CLEANUP=1 stack test cardano-wallet:integration --ta '-j 8 --match "CLI"'
ls $CLUSTER_DIR/wallets/*.sqlite | wc -l
```
I get 22 remaining files with the fix, compared to 49 without it.

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1090

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
