### PR TITLE
Adjust chain-following code to account for collateral inputs

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -62,6 +62,7 @@ library
     , fmt
     , foldl
     , generic-lens
+    , generic-arbitrary
     , hashable
     , http-api-data
     , http-client

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2892,7 +2892,7 @@ data MkApiTransactionParams = MkApiTransactionParams
     , txMeta :: W.TxMeta
     , txMetadata :: Maybe W.TxMetadata
     , txTime :: UTCTime
-    , txIsValidScript :: Maybe Bool
+    , txIsValidScript :: W.ScriptValidation
     }
     deriving (Eq, Generic, Show)
 
@@ -2942,7 +2942,7 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
         , mint = mempty  -- TODO: ADP-xxx
         , status = ApiT (tx ^. (#txMeta . #status))
         , metadata = ApiTxMetadata $ ApiT <$> (tx ^. #txMetadata)
-        , isValidScript = tx ^. #txIsValidScript
+        , isValidScript = ApiT $ tx ^. #txIsValidScript
         }
 
     depositIfAny :: Natural

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1883,6 +1883,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
             , txMeta
             , txMetadata = tx ^. #metadata
             , txTime
+            , txIsValidScript = (tx ^. #isValidScript)
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -1950,6 +1951,7 @@ mkApiTransactionFromInfo ti info = do
             , txMeta = info ^. #txInfoMeta
             , txMetadata = info ^. #txInfoMetadata
             , txTime = info ^. #txInfoTime
+            , txIsValidScript = info ^. #txInfoIsValidScript
             }
     return $ case info ^. (#txInfoMeta . #status) of
         Pending  -> apiTx
@@ -2145,6 +2147,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
             , txMeta
             , txMetadata = Nothing
             , txTime
+            , txIsValidScript = tx ^. #isValidScript
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -2235,6 +2238,7 @@ quitStakePool ctx (ApiT wid) body = do
             , txMeta
             , txMetadata = Nothing
             , txTime
+            , txIsValidScript = tx ^. #isValidScript
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -2489,6 +2493,7 @@ migrateWallet ctx withdrawalType (ApiT wid) postData = do
                     , txMeta
                     , txMetadata = Nothing
                     , txTime
+                    , txIsValidScript = tx ^. #isValidScript
                     }
   where
     addresses = getApiT . fst <$> view #addresses postData
@@ -2887,6 +2892,7 @@ data MkApiTransactionParams = MkApiTransactionParams
     , txMeta :: W.TxMeta
     , txMetadata :: Maybe W.TxMetadata
     , txTime :: UTCTime
+    , txIsValidScript :: Maybe Bool
     }
     deriving (Eq, Generic, Show)
 
@@ -2936,6 +2942,7 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
         , mint = mempty  -- TODO: ADP-xxx
         , status = ApiT (tx ^. (#txMeta . #status))
         , metadata = ApiTxMetadata $ ApiT <$> (tx ^. #txMetadata)
+        , isValidScript = tx ^. #txIsValidScript
         }
 
     depositIfAny :: Natural

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2892,7 +2892,7 @@ data MkApiTransactionParams = MkApiTransactionParams
     , txMeta :: W.TxMeta
     , txMetadata :: Maybe W.TxMetadata
     , txTime :: UTCTime
-    , txIsValidScript :: W.ScriptValidation
+    , txIsValidScript :: W.TxScriptValidity
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -1883,7 +1883,7 @@ postTransactionOld ctx genChange (ApiT wid) body = do
             , txMeta
             , txMetadata = tx ^. #metadata
             , txTime
-            , txIsValidScript = (tx ^. #isValidScript)
+            , txScriptValidity = tx ^. #scriptValidity
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -1951,7 +1951,7 @@ mkApiTransactionFromInfo ti info = do
             , txMeta = info ^. #txInfoMeta
             , txMetadata = info ^. #txInfoMetadata
             , txTime = info ^. #txInfoTime
-            , txIsValidScript = info ^. #txInfoIsValidScript
+            , txScriptValidity = info ^. #txInfoScriptValidity
             }
     return $ case info ^. (#txInfoMeta . #status) of
         Pending  -> apiTx
@@ -2147,7 +2147,7 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
             , txMeta
             , txMetadata = Nothing
             , txTime
-            , txIsValidScript = tx ^. #isValidScript
+            , txScriptValidity = tx ^. #scriptValidity
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -2238,7 +2238,7 @@ quitStakePool ctx (ApiT wid) body = do
             , txMeta
             , txMetadata = Nothing
             , txTime
-            , txIsValidScript = tx ^. #isValidScript
+            , txScriptValidity = tx ^. #scriptValidity
             }
   where
     ti :: TimeInterpreter (ExceptT PastHorizonException IO)
@@ -2493,7 +2493,7 @@ migrateWallet ctx withdrawalType (ApiT wid) postData = do
                     , txMeta
                     , txMetadata = Nothing
                     , txTime
-                    , txIsValidScript = tx ^. #isValidScript
+                    , txScriptValidity = tx ^. #scriptValidity
                     }
   where
     addresses = getApiT . fst <$> view #addresses postData
@@ -2892,7 +2892,7 @@ data MkApiTransactionParams = MkApiTransactionParams
     , txMeta :: W.TxMeta
     , txMetadata :: Maybe W.TxMetadata
     , txTime :: UTCTime
-    , txIsValidScript :: W.TxScriptValidity
+    , txScriptValidity :: W.TxScriptValidity
     }
     deriving (Eq, Generic, Show)
 
@@ -2942,7 +2942,7 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
         , mint = mempty  -- TODO: ADP-xxx
         , status = ApiT (tx ^. (#txMeta . #status))
         , metadata = ApiTxMetadata $ ApiT <$> (tx ^. #txMetadata)
-        , isValidScript = ApiT $ tx ^. #txIsValidScript
+        , scriptValidity = ApiT $ tx ^. #txScriptValidity
         }
 
     depositIfAny :: Natural

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2892,7 +2892,7 @@ data MkApiTransactionParams = MkApiTransactionParams
     , txMeta :: W.TxMeta
     , txMetadata :: Maybe W.TxMetadata
     , txTime :: UTCTime
-    , txScriptValidity :: W.TxScriptValidity
+    , txScriptValidity :: Maybe W.TxScriptValidity
     }
     deriving (Eq, Generic, Show)
 
@@ -2942,7 +2942,7 @@ mkApiTransaction timeInterpreter setTimeReference tx = do
         , mint = mempty  -- TODO: ADP-xxx
         , status = ApiT (tx ^. (#txMeta . #status))
         , metadata = ApiTxMetadata $ ApiT <$> (tx ^. #txMetadata)
-        , scriptValidity = ApiT $ tx ^. #txScriptValidity
+        , scriptValidity = ApiT <$> tx ^. #txScriptValidity
         }
 
     depositIfAny :: Natural

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1094,7 +1094,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , mint :: !(ApiT W.TokenMap)
     , status :: !(ApiT TxStatus)
     , metadata :: !ApiTxMetadata
-    , scriptValidity :: !(ApiT TxScriptValidity)
+    , scriptValidity :: !(Maybe (ApiT TxScriptValidity))
     } deriving (Eq, Generic, Show, Typeable)
       deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -3641,9 +3641,9 @@ instance ToJSON (ApiT (Script KeyHash)) where
     toJSON = toJSON . getApiT
 
 instance FromJSON (ApiT TxScriptValidity) where
-    parseJSON = fmap ApiT . genericParseJSON (Aeson.defaultOptions
-        { constructorTagModifier = camelTo2 '_' . drop 8 })
+    parseJSON = fmap ApiT . genericParseJSON Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 }
 
 instance ToJSON (ApiT TxScriptValidity) where
-    toJSON = genericToJSON (Aeson.defaultOptions
-        { constructorTagModifier = camelTo2 '_' . drop 8 }) . getApiT
+    toJSON = genericToJSON Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 } . getApiT

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -346,7 +346,6 @@ import Data.Aeson.Types
     , rejectUnknownFields
     , sumEncoding
     , tagSingleConstructors
-    , typeMismatch
     , withObject
     , withText
     , (.!=)
@@ -3642,14 +3641,9 @@ instance ToJSON (ApiT (Script KeyHash)) where
     toJSON = toJSON . getApiT
 
 instance FromJSON (ApiT TxScriptValidity) where
-    parseJSON (Aeson.Null) = pure $ ApiT TxScriptsUnsupported
-    parseJSON (Aeson.Bool True) = pure $ ApiT TxScriptValid
-    parseJSON (Aeson.Bool False) = pure $ ApiT TxScriptInvalid
-    parseJSON invalid =
-        prependFailure "parsing TxScriptValidity failed, "
-            (typeMismatch "Maybe Bool" invalid)
+    parseJSON = fmap ApiT . genericParseJSON (Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 })
 
 instance ToJSON (ApiT TxScriptValidity) where
-    toJSON (ApiT TxScriptsUnsupported) = Aeson.Null
-    toJSON (ApiT TxScriptValid) = Aeson.Bool True
-    toJSON (ApiT TxScriptInvalid) = Aeson.Bool False
+    toJSON = genericToJSON (Aeson.defaultOptions
+        { constructorTagModifier = camelTo2 '_' . drop 8 }) . getApiT

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1095,7 +1095,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , mint :: !(ApiT W.TokenMap)
     , status :: !(ApiT TxStatus)
     , metadata :: !ApiTxMetadata
-    , isValidScript :: !(ApiT TxScriptValidity)
+    , scriptValidity :: !(ApiT TxScriptValidity)
     } deriving (Eq, Generic, Show, Typeable)
       deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1093,6 +1093,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , mint :: !(ApiT W.TokenMap)
     , status :: !(ApiT TxStatus)
     , metadata :: !ApiTxMetadata
+    , isValidScript :: !(Maybe Bool)
     } deriving (Eq, Generic, Show, Typeable)
       deriving anyclass NFData
 

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -304,6 +304,7 @@ import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , SerialisedTx (..)
     , TxConstraints (..)
     , TxIn (..)
@@ -1093,7 +1094,7 @@ data ApiTransaction (n :: NetworkDiscriminant) = ApiTransaction
     , mint :: !(ApiT W.TokenMap)
     , status :: !(ApiT TxStatus)
     , metadata :: !ApiTxMetadata
-    , isValidScript :: !(Maybe Bool)
+    , isValidScript :: !(ApiT ScriptValidation)
     } deriving (Eq, Generic, Show, Typeable)
       deriving anyclass NFData
 
@@ -3638,3 +3639,14 @@ instance FromJSON (ApiT (Script KeyHash)) where
     parseJSON = fmap ApiT . parseJSON
 instance ToJSON (ApiT (Script KeyHash)) where
     toJSON = toJSON . getApiT
+
+instance FromJSON (ApiT ScriptValidation) where
+    parseJSON (Aeson.Null) = pure $ ApiT ScriptsNotSupported
+    parseJSON (Aeson.Bool True) = pure $ ApiT ScriptValidationPassed
+    parseJSON (Aeson.Bool False) = pure $ ApiT ScriptValidationFailed
+    parseJSON _ = pure $ ApiT ScriptValidationFailed
+
+instance ToJSON (ApiT ScriptValidation) where
+    toJSON (ApiT ScriptsNotSupported) = Aeson.Null
+    toJSON (ApiT ScriptValidationPassed) = Aeson.Bool True
+    toJSON (ApiT ScriptValidationFailed) = Aeson.Bool False

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -485,6 +485,8 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
             slotStartTime' (meta ^. #slotNo)
         , txInfoMetadata =
             (tx ^. #metadata)
+        , txInfoIsValidScript =
+            (tx ^. #isValidScript)
         }
       where
         txH  = getQuantity

--- a/lib/core/src/Cardano/Wallet/DB/Model.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Model.hs
@@ -485,8 +485,8 @@ mReadTxHistory ti wid minWithdrawal order range mstatus db@(Database wallets txs
             slotStartTime' (meta ^. #slotNo)
         , txInfoMetadata =
             (tx ^. #metadata)
-        , txInfoIsValidScript =
-            (tx ^. #isValidScript)
+        , txInfoScriptValidity =
+            (tx ^. #scriptValidity)
         }
       where
         txH  = getQuantity

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1935,11 +1935,9 @@ mkTxMetaEntity wid txid mfee meta derived scriptValidity = TxMeta
     , txMetaFee = fromIntegral . W.unCoin <$> mfee
     , txMetaSlotExpires = derived ^. #expiry
     , txMetadata = meta
-    , txMetaScriptValidity =
-            case scriptValidity of
-                Nothing -> Nothing
-                (Just W.TxScriptValid) -> Just True
-                (Just W.TxScriptInvalid) -> Just False
+    , txMetaScriptValidity = scriptValidity <&> \case
+          W.TxScriptValid -> True
+          W.TxScriptInvalid -> False
     }
 
 -- note: TxIn records must already be sorted by order
@@ -1990,11 +1988,9 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
                 Quantity $ fromIntegral $ if tipH > txH then tipH - txH else 0
             , W.txInfoTime =
                 t
-            , W.txInfoScriptValidity =
-                case isValid of
-                    Nothing -> Nothing
-                    Just False -> Just W.TxScriptInvalid
-                    Just True -> Just W.TxScriptValid
+            , W.txInfoScriptValidity = isValid <&> \case
+                  False -> W.TxScriptInvalid
+                  True -> W.TxScriptValid
             }
       where
         txH  = getQuantity (derived ^. #blockHeight)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1922,7 +1922,7 @@ mkTxMetaEntity
     -> Maybe W.Coin
     -> Maybe W.TxMetadata
     -> W.TxMeta
-    -> W.ScriptValidation
+    -> W.TxScriptValidity
     -> TxMeta
 mkTxMetaEntity wid txid mfee meta derived isValidScript = TxMeta
     { txMetaTxId = TxId txid
@@ -1937,9 +1937,9 @@ mkTxMetaEntity wid txid mfee meta derived isValidScript = TxMeta
     , txMetadata = meta
     , txMetaIsValid =
             case isValidScript of
-                W.ScriptsNotSupported    -> Nothing
-                W.ScriptValidationPassed -> Just True
-                W.ScriptValidationFailed -> Just False
+                W.TxScriptsUnsupported -> Nothing
+                W.TxScriptValid -> Just True
+                W.TxScriptInvalid -> Just False
     }
 
 -- note: TxIn records must already be sorted by order
@@ -1987,9 +1987,9 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
                 t
             , W.txInfoIsValidScript =
                     case isValid of
-                        Nothing -> W.ScriptsNotSupported
-                        Just False -> W.ScriptValidationFailed
-                        Just True -> W.ScriptValidationPassed
+                        Nothing -> W.TxScriptsUnsupported
+                        Just False -> W.TxScriptInvalid
+                        Just True -> W.TxScriptValid
             }
       where
         txH  = getQuantity (derived ^. #blockHeight)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1991,10 +1991,10 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
             , W.txInfoTime =
                 t
             , W.txInfoScriptValidity =
-                    case isValid of
-                        Nothing -> Nothing
-                        Just False -> Just W.TxScriptInvalid
-                        Just True -> Just W.TxScriptValid
+                case isValid of
+                    Nothing -> Nothing
+                    Just False -> Just W.TxScriptInvalid
+                    Just True -> Just W.TxScriptValid
             }
       where
         txH  = getQuantity (derived ^. #blockHeight)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1819,7 +1819,8 @@ mkTxHistory
         , [TxWithdrawal]
         )
 mkTxHistory wid txs = flatTxHistory
-    [ ( mkTxMetaEntity wid txid (W.fee tx) (W.metadata tx) derived (W.scriptValidity tx)
+    [ ( mkTxMetaEntity
+          wid txid (W.fee tx) (W.metadata tx) derived (W.scriptValidity tx)
       , mkTxInputsOutputs (txid, tx)
       , mkTxWithdrawals (txid, tx)
       )

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1957,11 +1957,11 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
   where
     startTime' = interpretQuery ti . slotToUTCTime
     mkItem m = mkTxWith
-               (txMetaTxId m)
-               (txMetaFee m)
-               (txMetadata m)
-               (mkTxDerived m)
-               (txMetaScriptValidity m)
+        (txMetaTxId m)
+        (txMetaFee m)
+        (txMetadata m)
+        (mkTxDerived m)
+        (txMetaScriptValidity m)
     mkTxWith txid mfee meta derived isValid = do
         t <- startTime' (derived ^. #slotNo)
         return $ W.TransactionInfo

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1922,7 +1922,7 @@ mkTxMetaEntity
     -> Maybe W.Coin
     -> Maybe W.TxMetadata
     -> W.TxMeta
-    -> W.TxScriptValidity
+    -> Maybe W.TxScriptValidity
     -> TxMeta
 mkTxMetaEntity wid txid mfee meta derived scriptValidity = TxMeta
     { txMetaTxId = TxId txid
@@ -1937,9 +1937,9 @@ mkTxMetaEntity wid txid mfee meta derived scriptValidity = TxMeta
     , txMetadata = meta
     , txMetaScriptValidity =
             case scriptValidity of
-                W.TxScriptUnsupported -> Nothing
-                W.TxScriptValid -> Just True
-                W.TxScriptInvalid -> Just False
+                Nothing -> Nothing
+                (Just W.TxScriptValid) -> Just True
+                (Just W.TxScriptInvalid) -> Just False
     }
 
 -- note: TxIn records must already be sorted by order
@@ -1992,9 +1992,9 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
                 t
             , W.txInfoScriptValidity =
                     case isValid of
-                        Nothing -> W.TxScriptUnsupported
-                        Just False -> W.TxScriptInvalid
-                        Just True -> W.TxScriptValid
+                        Nothing -> Nothing
+                        Just False -> Just W.TxScriptInvalid
+                        Just True -> Just W.TxScriptValid
             }
       where
         txH  = getQuantity (derived ^. #blockHeight)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1937,7 +1937,7 @@ mkTxMetaEntity wid txid mfee meta derived scriptValidity = TxMeta
     , txMetadata = meta
     , txMetaScriptValidity =
             case scriptValidity of
-                W.TxScriptsUnsupported -> Nothing
+                W.TxScriptUnsupported -> Nothing
                 W.TxScriptValid -> Just True
                 W.TxScriptInvalid -> Just False
     }
@@ -1992,7 +1992,7 @@ txHistoryFromEntity ti tip metas ins cins outs ws =
                 t
             , W.txInfoScriptValidity =
                     case isValid of
-                        Nothing -> W.TxScriptsUnsupported
+                        Nothing -> W.TxScriptUnsupported
                         Just False -> W.TxScriptInvalid
                         Just True -> W.TxScriptValid
             }

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -111,6 +111,7 @@ TxMeta
     txMetadata              W.TxMetadata Maybe  sql=data
     txMetaSlotExpires       SlotNo Maybe        sql=slot_expires
     txMetaFee               Word64 Maybe        sql=fee
+    txMetaIsValid           Bool Maybe          sql=is_valid
 
     Primary txMetaTxId txMetaWalletId
     Foreign Wallet OnDeleteCascade fk_wallet_tx_meta txMetaWalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/TH.hs
@@ -111,7 +111,7 @@ TxMeta
     txMetadata              W.TxMetadata Maybe  sql=data
     txMetaSlotExpires       SlotNo Maybe        sql=slot_expires
     txMetaFee               Word64 Maybe        sql=fee
-    txMetaIsValid           Bool Maybe          sql=is_valid
+    txMetaScriptValidity    Bool Maybe          sql=script_validity
 
     Primary txMetaTxId txMetaWalletId
     Foreign Wallet OnDeleteCascade fk_wallet_tx_meta txMetaWalletId

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -807,18 +807,19 @@ instance PersistFieldSql DerivationPrefix where
 -- ScriptValidation
 
 instance PersistField TxScriptValidity where
-    toPersistValue TxScriptValid = PersistBool True
-    toPersistValue TxScriptInvalid = PersistBool False
+    toPersistValue = \case
+        TxScriptValid -> PersistBool True
+        TxScriptInvalid -> PersistBool False
 
-    fromPersistValue (PersistBool True) = Right TxScriptValid
-    fromPersistValue (PersistBool False) = Right TxScriptInvalid
-    fromPersistValue x =
-        Left $ T.concat [
-          "Failed to parse Haskell type `ScriptValidation`;"
-          , " expected null or boolean"
-          , " from database, but received: "
-          , T.pack (show x)
-          ]
+    fromPersistValue = \case
+        PersistBool True -> Right TxScriptValid
+        PersistBool False -> Right TxScriptInvalid
+        x -> Left $ T.unwords
+            [ "Failed to parse Haskell type `ScriptValidation`;"
+            , "expected null or boolean"
+            , "from database, but received:"
+            , T.pack (show x)
+            ]
 
 instance PersistFieldSql TxScriptValidity where
     sqlType _ = sqlType (Proxy @(Maybe Bool))

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -811,11 +811,9 @@ instance PersistFieldSql DerivationPrefix where
 -- ScriptValidation
 
 instance PersistField TxScriptValidity where
-    toPersistValue TxScriptUnsupported = PersistNull
     toPersistValue TxScriptValid = PersistBool True
     toPersistValue TxScriptInvalid = PersistBool False
 
-    fromPersistValue PersistNull = Right TxScriptUnsupported
     fromPersistValue (PersistBool True) = Right TxScriptValid
     fromPersistValue (PersistBool False) = Right TxScriptInvalid
     fromPersistValue x =

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -815,7 +815,7 @@ instance PersistField TxScriptValidity where
         PersistBool True -> Right TxScriptValid
         PersistBool False -> Right TxScriptInvalid
         x -> Left $ T.unwords
-            [ "Failed to parse Haskell type `ScriptValidation`;"
+            [ "Failed to parse Haskell type `TxScriptValidity`;"
             , "expected null or boolean"
             , "from database, but received:"
             , T.pack (show x)

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -72,9 +72,9 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , SealedTx (..)
     , TxMetadata
+    , TxScriptValidity (..)
     , TxStatus (..)
     )
 import Control.Arrow
@@ -810,14 +810,14 @@ instance PersistFieldSql DerivationPrefix where
 ----------------------------------------------------------------------------
 -- ScriptValidation
 
-instance PersistField ScriptValidation where
-    toPersistValue ScriptsNotSupported = PersistNull
-    toPersistValue ScriptValidationPassed = PersistBool True
-    toPersistValue ScriptValidationFailed = PersistBool False
+instance PersistField TxScriptValidity where
+    toPersistValue TxScriptsUnsupported = PersistNull
+    toPersistValue TxScriptValid = PersistBool True
+    toPersistValue TxScriptInvalid = PersistBool False
 
-    fromPersistValue PersistNull = Right ScriptsNotSupported
-    fromPersistValue (PersistBool True) = Right ScriptValidationPassed
-    fromPersistValue (PersistBool False) = Right ScriptValidationFailed
+    fromPersistValue PersistNull = Right TxScriptsUnsupported
+    fromPersistValue (PersistBool True) = Right TxScriptValid
+    fromPersistValue (PersistBool False) = Right TxScriptInvalid
     fromPersistValue x =
         Left $ T.concat [
           "Failed to parse Haskell type `ScriptValidation`;"
@@ -826,7 +826,7 @@ instance PersistField ScriptValidation where
           , T.pack (show x)
           ]
 
-instance PersistFieldSql ScriptValidation where
+instance PersistFieldSql TxScriptValidity where
     -- sqlType _ = sqlType (Proxy @ScriptValidation)
     sqlType _ = SqlBool
 

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -117,11 +117,7 @@ import Data.Word
 import Data.Word.Odd
     ( Word31 )
 import Database.Persist.Sqlite
-    ( PersistField (..)
-    , PersistFieldSql (..)
-    , PersistValue (..)
-    , SqlType (SqlBool)
-    )
+    ( PersistField (..), PersistFieldSql (..), PersistValue (..) )
 import Database.Persist.TH
     ( MkPersistSettings (..), sqlSettings )
 import GHC.Generics
@@ -825,8 +821,7 @@ instance PersistField TxScriptValidity where
           ]
 
 instance PersistFieldSql TxScriptValidity where
-    -- sqlType _ = sqlType (Proxy @ScriptValidation)
-    sqlType _ = SqlBool
+    sqlType _ = sqlType (Proxy @(Maybe Bool))
 
 ----------------------------------------------------------------------------
 -- Other

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite/Types.hs
@@ -811,11 +811,11 @@ instance PersistFieldSql DerivationPrefix where
 -- ScriptValidation
 
 instance PersistField TxScriptValidity where
-    toPersistValue TxScriptsUnsupported = PersistNull
+    toPersistValue TxScriptUnsupported = PersistNull
     toPersistValue TxScriptValid = PersistBool True
     toPersistValue TxScriptInvalid = PersistBool False
 
-    fromPersistValue PersistNull = Right TxScriptsUnsupported
+    fromPersistValue PersistNull = Right TxScriptUnsupported
     fromPersistValue (PersistBool True) = Right TxScriptValid
     fromPersistValue (PersistBool False) = Right TxScriptInvalid
     fromPersistValue x =

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -377,11 +377,11 @@ applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
 spendTx tx !u =
     u `excluding` Set.fromList inputsToExclude
-    where
-        inputsToExclude =
-            if failedScriptValidation (tx ^. #scriptValidity)
-            then collateralInputs tx
-            else inputs tx
+  where
+    inputsToExclude =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then collateralInputs tx
+        else inputs tx
 
 -- | Construct a UTxO corresponding to a given transaction. It is important for
 -- the transaction outputs to be ordered correctly, since they become available
@@ -569,10 +569,10 @@ changeUTxO
 changeUTxO pending = evalState $
     mconcat
     <$> mapM (filterByAddressM isOurAddress . mkUTxOFromTx) (Set.toList pending)
-    where
-        -- Generate a UTxO from an transaction, assuming that it passes phase-2
-        -- script validation. Crucially, utxoFromTx will exclude failed
-        -- transactions, hence we define our own function.
-        mkUTxOFromTx :: Tx -> UTxO
-        mkUTxOFromTx Tx {txId, outputs} =
-            UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
+  where
+    -- Generate a UTxO from an transaction, assuming that it passes phase-2
+    -- script validation. Crucially, utxoFromTx will exclude failed
+    -- transactions, hence we define our own function.
+    mkUTxOFromTx :: Tx -> UTxO
+    mkUTxOFromTx Tx {txId, outputs} =
+        UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -78,6 +78,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxIn (..)
     , TxMeta (..)
     , TxStatus (..)
+    , collateralInputs
+    , failedScriptValidation
     , inputs
     , txOutCoin
     )
@@ -373,7 +375,12 @@ applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 -- spendTx tx (filterByAddress f u) = filterByAddress f (spendTx tx u)
 -- spendTx tx (u <> utxoFromTx tx) = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
-spendTx tx !u = u `excluding` Set.fromList (inputs tx)
+spendTx tx !u =
+    u `excluding` (
+        if failedScriptValidation (tx ^. #isValidScript)
+        then Set.fromList (collateralInputs tx)
+        else Set.fromList (inputs tx)
+    )
 
 -- | Construct a UTxO corresponding to a given transaction. It is important for
 -- the transaction outputs to be ordered correctly, since they become available
@@ -382,8 +389,10 @@ spendTx tx !u = u `excluding` Set.fromList (inputs tx)
 -- balance (utxoFromTx tx) = foldMap tokens (outputs tx)
 -- utxoFromTx tx `excluding` Set.fromList (inputs tx) = utxoFrom tx
 utxoFromTx :: Tx -> UTxO
-utxoFromTx Tx {txId, outputs} =
-    UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
+utxoFromTx Tx {txId, outputs, isValidScript} =
+    if failedScriptValidation isValidScript
+    then mempty
+    else UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
 
 isOurAddress
     :: forall s m
@@ -558,4 +567,11 @@ changeUTxO
     -> UTxO
 changeUTxO pending = evalState $
     mconcat
-    <$> mapM (filterByAddressM isOurAddress . utxoFromTx) (Set.toList pending)
+    <$> mapM (filterByAddressM isOurs' . mkUTxOFromTx) (Set.toList pending)
+    where
+        -- Generate a UTxO from an transaction, assuming that it passes phase-2
+        -- script validation. Crucially, utxoFromTx will exclude failed
+        -- transactions, hence we define our own function.
+        mkUTxOFromTx :: Tx -> UTxO
+        mkUTxOFromTx Tx {txId, outputs} =
+            UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -567,7 +567,7 @@ changeUTxO
     -> UTxO
 changeUTxO pending = evalState $
     mconcat
-    <$> mapM (filterByAddressM isOurs' . mkUTxOFromTx) (Set.toList pending)
+    <$> mapM (filterByAddressM isOurAddress . mkUTxOFromTx) (Set.toList pending)
     where
         -- Generate a UTxO from an transaction, assuming that it passes phase-2
         -- script validation. Crucially, utxoFromTx will exclude failed

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -376,11 +376,12 @@ applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 -- spendTx tx (u <> utxoFromTx tx) = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
 spendTx tx !u =
-    u `excluding` (
-        if failedScriptValidation (tx ^. #scriptValidity)
-        then Set.fromList (collateralInputs tx)
-        else Set.fromList (inputs tx)
-    )
+    u `excluding` Set.fromList inputsToExclude
+    where
+        inputsToExclude =
+            if failedScriptValidation (tx ^. #scriptValidity)
+            then collateralInputs tx
+            else inputs tx
 
 -- | Construct a UTxO corresponding to a given transaction. It is important for
 -- the transaction outputs to be ordered correctly, since they become available

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -526,7 +526,9 @@ prefilterBlock b u0 = runState $ do
 
         return $ if hasKnownOutput && not hasKnownInput then
             let dir = Incoming in
-            ( (tx { fee = actualFee dir }, mkTxMeta (TB.getCoin received) dir) : txs
+            ( ( tx { fee = actualFee dir }
+              , mkTxMeta (TB.getCoin received) dir
+              ) : txs
             , ourNextUTxO
             )
         else if hasKnownInput || hasKnownWithdrawal then

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -379,7 +379,7 @@ spendTx tx !u =
     u `excluding` Set.fromList inputsToExclude
   where
     inputsToExclude =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then collateralInputs tx
         else inputs tx
 
@@ -390,8 +390,8 @@ spendTx tx !u =
 -- balance (utxoFromTx tx) = foldMap tokens (outputs tx)
 -- utxoFromTx tx `excluding` Set.fromList (inputs tx) = utxoFrom tx
 utxoFromTx :: Tx -> UTxO
-utxoFromTx tx@Tx {scriptValidity} =
-    if failedScriptValidation scriptValidity
+utxoFromTx tx =
+    if failedScriptValidation tx
     then mempty
     else utxoFromUnvalidatedTx tx
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -377,7 +377,7 @@ applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
 spendTx tx !u =
     u `excluding` (
-        if failedScriptValidation (tx ^. #isValidScript)
+        if failedScriptValidation (tx ^. #scriptValidity)
         then Set.fromList (collateralInputs tx)
         else Set.fromList (inputs tx)
     )
@@ -389,8 +389,8 @@ spendTx tx !u =
 -- balance (utxoFromTx tx) = foldMap tokens (outputs tx)
 -- utxoFromTx tx `excluding` Set.fromList (inputs tx) = utxoFrom tx
 utxoFromTx :: Tx -> UTxO
-utxoFromTx Tx {txId, outputs, isValidScript} =
-    if failedScriptValidation isValidScript
+utxoFromTx Tx {txId, outputs, scriptValidity} =
+    if failedScriptValidation scriptValidity
     then mempty
     else UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -497,12 +498,13 @@ data TxScriptValidity
 
 instance NFData TxScriptValidity
 
--- | Returns True when the script has failed validation.
-failedScriptValidation :: Maybe TxScriptValidity -> Bool
-failedScriptValidation (Just TxScriptInvalid) = True
-failedScriptValidation (Just TxScriptValid) = False
--- Script validation always passes in eras that don't support scripts
-failedScriptValidation Nothing = False
+-- | Returns 'True' if and only if a transaction has failed script validation.
+failedScriptValidation :: Tx -> Bool
+failedScriptValidation Tx {scriptValidity} = case scriptValidity of
+    Just TxScriptInvalid -> True
+    Just TxScriptValid -> False
+    -- Script validation always passes in eras that don't support scripts
+    Nothing -> False
 
 -- | Reconstruct a transaction info from a transaction.
 fromTransactionInfo :: TransactionInfo -> Tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -227,7 +227,7 @@ instance Buildable Tx where
         ]
 
 instance Buildable TxScriptValidity where
-    build TxScriptsUnsupported = "<scripts not supported>"
+    build TxScriptUnsupported = "<scripts not supported>"
     build TxScriptValid = "true"
     build TxScriptInvalid = "false"
 
@@ -490,7 +490,7 @@ instance NFData TransactionInfo
 -- | Indicates whether the script associated with a transaction has passed or
 -- failed validation. Pre-Alonzo era, scripts were not supported.
 data TxScriptValidity
-    = TxScriptsUnsupported
+    = TxScriptUnsupported
     -- ^ Indicates that scripts were not supported in the era in which this
     -- transaction was created.
     | TxScriptValid
@@ -506,7 +506,7 @@ failedScriptValidation :: TxScriptValidity -> Bool
 failedScriptValidation TxScriptInvalid = True
 failedScriptValidation TxScriptValid = False
 -- Script validation always passes in eras that don't support scripts
-failedScriptValidation TxScriptsUnsupported = False
+failedScriptValidation TxScriptUnsupported = False
 
 -- | Reconstruct a transaction info from a transaction.
 fromTransactionInfo :: TransactionInfo -> Tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -38,11 +38,13 @@ module Cardano.Wallet.Primitive.Types.Tx
     -- * Functions
     , fromTransactionInfo
     , inputs
+    , collateralInputs
     , isPending
     , toTxHistory
     , txIns
     , txMetadataIsNull
     , txOutCoin
+    , failedScriptValidation
 
     -- * Constants
     , txOutMinTokenQuantity
@@ -228,6 +230,9 @@ txIns = foldMap (Set.fromList . inputs)
 
 inputs :: Tx -> [TxIn]
 inputs = map fst . resolvedInputs
+
+collateralInputs :: Tx -> [TxIn]
+collateralInputs = map fst . resolvedCollateral
 
 data TxIn = TxIn
     { inputId
@@ -474,6 +479,13 @@ data TransactionInfo = TransactionInfo
     } deriving (Generic, Show, Eq)
 
 instance NFData TransactionInfo
+
+-- | Returns True when the script has failed validation.
+failedScriptValidation :: Maybe Bool -> Bool
+failedScriptValidation (Just False) = True
+failedScriptValidation (Just True)  = False
+-- Script validation always passes in eras that don't support scripts
+failedScriptValidation Nothing      = False
 
 -- | Reconstruct a transaction info from a transaction.
 fromTransactionInfo :: TransactionInfo -> Tx

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -199,7 +199,7 @@ data Tx = Tx
         -- See Appendix E of
         -- <https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec Shelley Ledger: Delegation/Incentives Design Spec>.
 
-    , isValidScript
+    , scriptValidity
         :: !TxScriptValidity
         -- ^ Tag indicating whether non-native scripts in this transaction are
         -- expected to validate. This is added by the block creator when
@@ -223,7 +223,7 @@ instance Buildable Tx where
             tupleF (Map.toList $ view #withdrawals t)
         , nameF "metadata"
             (maybe "" build $ view #metadata t)
-        , nameF "isValidScript" (build $ view #isValidScript t)
+        , nameF "scriptValidity" (build $ view #scriptValidity t)
         ]
 
 instance Buildable TxScriptValidity where
@@ -478,7 +478,7 @@ data TransactionInfo = TransactionInfo
     -- ^ Creation time of the block including this transaction.
     , txInfoMetadata :: !(Maybe TxMetadata)
     -- ^ Application-specific extension data.
-    , txInfoIsValidScript :: !TxScriptValidity
+    , txInfoScriptValidity :: !TxScriptValidity
     -- ^ Tag indicating whether non-native scripts in this transaction are
     -- expected to validate. This is added by the block creator when
     -- constructing the block. For pre-Alonzo era transactions, scripts are not
@@ -518,7 +518,7 @@ fromTransactionInfo info = Tx
     , outputs = txInfoOutputs info
     , withdrawals = txInfoWithdrawals info
     , metadata = txInfoMetadata info
-    , isValidScript = txInfoIsValidScript info
+    , scriptValidity = txInfoScriptValidity info
     }
   where
     drop3rd :: (a, b, c) -> (a, b)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -202,10 +202,10 @@ data Tx = Tx
 
     , scriptValidity
         :: !(Maybe TxScriptValidity)
-        -- ^ Tag indicating whether non-native scripts in this transaction are
-        -- expected to validate. This is added by the block creator when
-        -- constructing the block. For pre-Alonzo era transactions, scripts are
-        -- not supported, and so script validation always passes.
+        -- ^ Tag indicating whether non-native scripts in this transaction
+        -- passed validation. This is added by the block creator when
+        -- constructing the block. May be 'Nothing' for pre-Alonzo and pending
+        -- transactions.
     } deriving (Show, Generic, Ord, Eq)
 
 instance NFData Tx
@@ -479,10 +479,9 @@ data TransactionInfo = TransactionInfo
     , txInfoMetadata :: !(Maybe TxMetadata)
     -- ^ Application-specific extension data.
     , txInfoScriptValidity :: !(Maybe TxScriptValidity)
-    -- ^ Tag indicating whether non-native scripts in this transaction are
-    -- expected to validate. This is added by the block creator when
-    -- constructing the block. May be Nothing for pre-Alonzo and pending
-    -- transactions.
+    -- ^ Tag indicating whether non-native scripts in this transaction passed
+    -- validation. This is added by the block creator when constructing the
+    -- block. May be 'Nothing' for pre-Alonzo and pending transactions.
     } deriving (Generic, Show, Eq)
 
 instance NFData TransactionInfo

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -195,6 +195,13 @@ data Tx = Tx
         --
         -- See Appendix E of
         -- <https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec Shelley Ledger: Delegation/Incentives Design Spec>.
+
+    , isValidScript
+        :: !(Maybe Bool)
+        -- ^ Tag indicating whether non-native scripts in this transaction are
+        -- expected to validate. This is added by the block creator when
+        -- constructing the block. For pre-Alonzo era transactions, scripts are
+        -- not supported, and so script validation always passes.
     } deriving (Show, Generic, Ord, Eq)
 
 instance NFData Tx
@@ -213,6 +220,7 @@ instance Buildable Tx where
             tupleF (Map.toList $ view #withdrawals t)
         , nameF "metadata"
             (maybe "" build $ view #metadata t)
+        , nameF "isValidScript" (build $ view #isValidScript t)
         ]
 
 txIns :: Set Tx -> Set TxIn
@@ -459,6 +467,10 @@ data TransactionInfo = TransactionInfo
     -- ^ Creation time of the block including this transaction.
     , txInfoMetadata :: !(Maybe TxMetadata)
     -- ^ Application-specific extension data.
+    , txInfoIsValidScript :: !(Maybe Bool)
+    -- ^ Tag indicating whether non-native scripts in this transaction are
+    -- expected to validate. This is added by the block creator when
+    -- constructing the block. Nothing for pre-Alonzo era transactions.
     } deriving (Generic, Show, Eq)
 
 instance NFData TransactionInfo
@@ -473,6 +485,7 @@ fromTransactionInfo info = Tx
     , outputs = txInfoOutputs info
     , withdrawals = txInfoWithdrawals info
     , metadata = txInfoMetadata info
+    , isValidScript = txInfoIsValidScript info
     }
   where
     drop3rd :: (a, b, c) -> (a, b)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -61,6 +61,7 @@ import Test.QuickCheck
     , liftShrink2
     , listOf
     , listOf1
+    , shrink
     , shrinkList
     , shrinkMapBy
     , sized
@@ -69,7 +70,7 @@ import Test.QuickCheck
 import Test.QuickCheck.Extra
     ( genMapWith
     , genSized2With
-    , liftShrink6
+    , liftShrink7
     , shrinkInterleaved
     , shrinkMapWith
     )
@@ -95,6 +96,7 @@ data TxWithoutId = TxWithoutId
     , outputs :: ![TxOut]
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
+    , isValidScript :: !(Maybe Bool)
     }
     deriving (Eq, Ord, Show)
 
@@ -106,16 +108,18 @@ genTxWithoutId = TxWithoutId
     <*> listOf genTxOut
     <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
+    <*> arbitrary
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
 shrinkTxWithoutId =
-    shrinkMapBy tupleToTxWithoutId txWithoutIdToTuple $ liftShrink6
+    shrinkMapBy tupleToTxWithoutId txWithoutIdToTuple $ liftShrink7
         (liftShrink shrinkCoinPositive)
         (shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive))
         (shrinkList (liftShrink2 shrinkTxIn shrinkCoinPositive))
         (shrinkList shrinkTxOut)
         (liftShrink shrinkTxMetadata)
         (shrinkMapWith shrinkRewardAccount shrinkCoinPositive)
+        shrink
 
 txWithoutIdToTx :: TxWithoutId -> Tx
 txWithoutIdToTx tx@TxWithoutId {..} = Tx {txId = mockHash tx, ..}
@@ -124,12 +128,12 @@ txToTxWithoutId :: Tx -> TxWithoutId
 txToTxWithoutId Tx {..} = TxWithoutId {..}
 
 txWithoutIdToTuple :: TxWithoutId -> _
-txWithoutIdToTuple (TxWithoutId a1 a2 a3 a4 a5 a6) =
-    (a1, a2, a3, a4, a5, a6)
+txWithoutIdToTuple (TxWithoutId a1 a2 a3 a4 a5 a6 a7) =
+    (a1, a2, a3, a4, a5, a6, a7)
 
 tupleToTxWithoutId :: _ -> TxWithoutId
-tupleToTxWithoutId (a1, a2, a3, a4, a5, a6) =
-    (TxWithoutId a1 a2 a3 a4 a5 a6)
+tupleToTxWithoutId (a1, a2, a3, a4, a5, a6, a7) =
+    (TxWithoutId a1 a2 a3 a4 a5 a6 a7)
 
 --------------------------------------------------------------------------------
 -- Transaction hashes generated according to the size parameter

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -11,11 +11,13 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , genTxIn
     , genTxInLargeRange
     , genTxOut
+    , genScriptValidation
     , shrinkTx
     , shrinkTxHash
     , shrinkTxIndex
     , shrinkTxIn
     , shrinkTxOut
+    , shrinkScriptValidation
     )
     where
 
@@ -40,7 +42,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..) )
+    ( ScriptValidation (..), Tx (..), TxIn (..), TxMetadata (..), TxOut (..) )
 import Control.Monad
     ( replicateM )
 import Data.Either
@@ -61,12 +63,13 @@ import Test.QuickCheck
     , liftShrink2
     , listOf
     , listOf1
-    , shrink
     , shrinkList
     , shrinkMapBy
     , sized
     , suchThat
     )
+import Test.QuickCheck.Arbitrary.Generic
+    ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Extra
     ( genMapWith
     , genSized2With
@@ -96,7 +99,7 @@ data TxWithoutId = TxWithoutId
     , outputs :: ![TxOut]
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
-    , isValidScript :: !(Maybe Bool)
+    , isValidScript :: !ScriptValidation
     }
     deriving (Eq, Ord, Show)
 
@@ -108,7 +111,7 @@ genTxWithoutId = TxWithoutId
     <*> listOf genTxOut
     <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
-    <*> arbitrary
+    <*> genScriptValidation
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
 shrinkTxWithoutId =
@@ -119,7 +122,7 @@ shrinkTxWithoutId =
         (shrinkList shrinkTxOut)
         (liftShrink shrinkTxMetadata)
         (shrinkMapWith shrinkRewardAccount shrinkCoinPositive)
-        shrink
+        shrinkScriptValidation
 
 txWithoutIdToTx :: TxWithoutId -> Tx
 txWithoutIdToTx tx@TxWithoutId {..} = Tx {txId = mockHash tx, ..}
@@ -134,6 +137,12 @@ txWithoutIdToTuple (TxWithoutId a1 a2 a3 a4 a5 a6 a7) =
 tupleToTxWithoutId :: _ -> TxWithoutId
 tupleToTxWithoutId (a1, a2, a3, a4, a5, a6, a7) =
     (TxWithoutId a1 a2 a3 a4 a5 a6 a7)
+
+genScriptValidation :: Gen ScriptValidation
+genScriptValidation = genericArbitrary
+
+shrinkScriptValidation :: ScriptValidation -> [ScriptValidation]
+shrinkScriptValidation = genericShrink
 
 --------------------------------------------------------------------------------
 -- Transaction hashes generated according to the size parameter

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -99,7 +99,7 @@ data TxWithoutId = TxWithoutId
     , outputs :: ![TxOut]
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
-    , isValidScript :: !TxScriptValidity
+    , scriptValidity :: !TxScriptValidity
     }
     deriving (Eq, Ord, Show)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -11,13 +11,13 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , genTxIn
     , genTxInLargeRange
     , genTxOut
-    , genScriptValidation
+    , genTxScriptValidity
     , shrinkTx
     , shrinkTxHash
     , shrinkTxIndex
     , shrinkTxIn
     , shrinkTxOut
-    , shrinkScriptValidation
+    , shrinkTxScriptValidity
     )
     where
 
@@ -42,7 +42,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange, shrinkTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( ScriptValidation (..), Tx (..), TxIn (..), TxMetadata (..), TxOut (..) )
+    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxScriptValidity (..) )
 import Control.Monad
     ( replicateM )
 import Data.Either
@@ -99,7 +99,7 @@ data TxWithoutId = TxWithoutId
     , outputs :: ![TxOut]
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
-    , isValidScript :: !ScriptValidation
+    , isValidScript :: !TxScriptValidity
     }
     deriving (Eq, Ord, Show)
 
@@ -111,7 +111,7 @@ genTxWithoutId = TxWithoutId
     <*> listOf genTxOut
     <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
-    <*> genScriptValidation
+    <*> genTxScriptValidity
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
 shrinkTxWithoutId =
@@ -122,7 +122,7 @@ shrinkTxWithoutId =
         (shrinkList shrinkTxOut)
         (liftShrink shrinkTxMetadata)
         (shrinkMapWith shrinkRewardAccount shrinkCoinPositive)
-        shrinkScriptValidation
+        shrinkTxScriptValidity
 
 txWithoutIdToTx :: TxWithoutId -> Tx
 txWithoutIdToTx tx@TxWithoutId {..} = Tx {txId = mockHash tx, ..}
@@ -138,11 +138,11 @@ tupleToTxWithoutId :: _ -> TxWithoutId
 tupleToTxWithoutId (a1, a2, a3, a4, a5, a6, a7) =
     (TxWithoutId a1 a2 a3 a4 a5 a6 a7)
 
-genScriptValidation :: Gen ScriptValidation
-genScriptValidation = genericArbitrary
+genTxScriptValidity :: Gen TxScriptValidity
+genTxScriptValidity = genericArbitrary
 
-shrinkScriptValidation :: ScriptValidation -> [ScriptValidation]
-shrinkScriptValidation = genericShrink
+shrinkTxScriptValidity :: TxScriptValidity -> [TxScriptValidity]
+shrinkTxScriptValidity = genericShrink
 
 --------------------------------------------------------------------------------
 -- Transaction hashes generated according to the size parameter

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -99,7 +99,7 @@ data TxWithoutId = TxWithoutId
     , outputs :: ![TxOut]
     , metadata :: !(Maybe TxMetadata)
     , withdrawals :: !(Map RewardAccount Coin)
-    , scriptValidity :: !TxScriptValidity
+    , scriptValidity :: !(Maybe TxScriptValidity)
     }
     deriving (Eq, Ord, Show)
 
@@ -111,7 +111,7 @@ genTxWithoutId = TxWithoutId
     <*> listOf genTxOut
     <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
-    <*> genTxScriptValidity
+    <*> liftArbitrary genTxScriptValidity
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]
 shrinkTxWithoutId =
@@ -122,7 +122,7 @@ shrinkTxWithoutId =
         (shrinkList shrinkTxOut)
         (liftShrink shrinkTxMetadata)
         (shrinkMapWith shrinkRewardAccount shrinkCoinPositive)
-        shrinkTxScriptValidity
+        (liftShrink shrinkTxScriptValidity)
 
 txWithoutIdToTx :: TxWithoutId -> Tx
 txWithoutIdToTx tx@TxWithoutId {..} = Tx {txId = mockHash tx, ..}

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -135,12 +135,12 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , TransactionInfo
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxStatus (..)
     )
 import Cardano.Wallet.Primitive.Types.UTxO
@@ -580,7 +580,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = ScriptsNotSupported
+            , isValidScript = TxScriptsUnsupported
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -580,7 +580,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
-            , scriptValidity = TxScriptsUnsupported
+            , scriptValidity = TxScriptUnsupported
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -135,6 +135,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , TransactionInfo
     , Tx (..)
     , TxIn (..)
@@ -579,7 +580,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = Nothing
+            , isValidScript = ScriptsNotSupported
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -580,7 +580,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = TxScriptsUnsupported
+            , scriptValidity = TxScriptsUnsupported
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -140,7 +140,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
-    , TxScriptValidity (..)
     , TxStatus (..)
     )
 import Cardano.Wallet.Primitive.Types.UTxO
@@ -580,7 +579,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
-            , scriptValidity = TxScriptUnsupported
+            , scriptValidity = Nothing
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/bench/db/Main.hs
+++ b/lib/core/test/bench/db/Main.hs
@@ -579,6 +579,7 @@ mkTxHistory numTx numInputs numOutputs numAssets range =
             , outputs
             , withdrawals = mempty
             , metadata = Nothing
+            , isValidScript = Nothing
             }
         , TxMeta
             { status = [InLedger, Pending] !! (i `mod` 2)

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTTxScriptValidity.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTTxScriptValidity.json
@@ -1,0 +1,15 @@
+{
+    "seed": -6515206906517192264,
+    "samples": [
+        "invalid",
+        "invalid",
+        "invalid",
+        "valid",
+        "invalid",
+        "invalid",
+        "valid",
+        "invalid",
+        "valid",
+        "invalid"
+    ]
+}

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
@@ -1,235 +1,144 @@
 {
-    "seed": -9079353597400186282,
+    "seed": 272315937488619540,
     "samples": [
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 215,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 155,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1874-03-05T22:00:00Z",
-                "epoch_number": 25032,
-                "absolute_slot_number": 3965817,
-                "slot_number": 26067
-            },
-            "metadata": {
-                "11": {
-                    "bytes": "087c6c0bfc2b373f60270d0d5db36747ef0b574b505ae2b2673d"
-                }
-            },
-            "depth": {
-                "quantity": 29393,
-                "unit": "block"
-            },
-            "id": "7f46db7b003946066b69074ac7564309376d07467e2b7c3a701bb451250d1b7b",
-            "deposit": {
-                "quantity": 38,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 9,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                }
-            ]
-        },
         {
             "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 123,
+                "quantity": 201,
                 "unit": "lovelace"
             },
             "inputs": [],
-            "direction": "outgoing",
+            "direction": "incoming",
             "fee": {
-                "quantity": 93,
+                "quantity": 84,
                 "unit": "lovelace"
             },
             "outputs": [],
             "expires_at": {
-                "time": "1860-04-08T21:41:33Z",
-                "epoch_number": 17205,
-                "absolute_slot_number": 595268,
-                "slot_number": 18861
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 28335,
-                    "unit": "block"
-                },
-                "time": "1905-06-11T01:52:29.013343212987Z",
-                "epoch_number": 5965,
-                "absolute_slot_number": 13784568,
-                "slot_number": 69
+                "time": "1868-11-22T10:00:00Z",
+                "epoch_number": 17148,
+                "absolute_slot_number": 799355,
+                "slot_number": 32144
             },
             "metadata": {
-                "5": {
+                "12": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 14602,
+                "unit": "block"
+            },
+            "id": "2901737c27ff46576160b35d0c101b675d60595211633920056b4b5d17bc2248",
+            "deposit": {
+                "quantity": 135,
+                "unit": "lovelace"
+            },
+            "is_valid_script": true,
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 19,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 8,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 12,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 31,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 11,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 28,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 9,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 8,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 14,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 25,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 4,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "inserted_at": {
+                "height": {
+                    "quantity": 5523,
+                    "unit": "block"
+                },
+                "time": "1874-02-16T10:29:06.479812124804Z",
+                "epoch_number": 26668,
+                "absolute_slot_number": 1372852,
+                "slot_number": 3220
+            },
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 164,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 133,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "metadata": {
+                "21": {
                     "map": []
                 }
             },
             "depth": {
-                "quantity": 19870,
+                "quantity": 1412,
                 "unit": "block"
             },
-            "id": "5474065f7f7bf07f29635853355a08685c7949711c4602b61ed06c60391d92bf",
+            "id": "0bfa3e0641570251e41c02215657083c58086852d1297840ff427c634a464554",
             "deposit": {
-                "quantity": 67,
+                "quantity": 70,
                 "unit": "lovelace"
             },
+            "is_valid_script": null,
             "collateral": [],
             "mint": [
                 {
-                    "asset_name": "546f6b656e44",
+                    "asset_name": "546f6b656e45",
                     "quantity": 5,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 29,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 19,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 13,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                }
-            ]
-        },
-        {
-            "status": "pending",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 27,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 63,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1902-06-14T05:00:00Z",
-                "epoch_number": 20965,
-                "absolute_slot_number": 11986603,
-                "slot_number": 4876
-            },
-            "metadata": {
-                "4": {
-                    "map": [
-                        {
-                            "k": {
-                                "string": ",T𢞆"
-                            },
-                            "v": {
-                                "int": 0
-                            }
-                        }
-                    ]
-                }
-            },
-            "depth": {
-                "quantity": 16144,
-                "unit": "block"
-            },
-            "id": "6d0fb6387fbcb2614950761063203b55751123fc3ef2ab45397e55d96d7f735d",
-            "deposit": {
-                "quantity": 146,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 1,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                }
-            ]
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 30699,
-                    "unit": "block"
-                },
-                "time": "1888-02-11T05:42:43Z",
-                "epoch_number": 6906,
-                "absolute_slot_number": 7517799,
-                "slot_number": 29836
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 54,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 189,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": null,
-            "depth": {
-                "quantity": 21581,
-                "unit": "block"
-            },
-            "id": "7405661656ef8d61f06e943530ea1210692adac01e3175342b06072505b4147d",
-            "deposit": {
-                "quantity": 18,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": []
-        },
-        {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 97,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 231,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "14": {
-                    "int": 0
-                }
-            },
-            "id": "17202c1074180d7220793d536527cdc4acca2e5c146b6e566227312246431564",
-            "deposit": {
-                "quantity": 37,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e46",
-                    "quantity": 22,
                     "policy_id": "11111111111111111111111111111111111111111111111111111111"
                 }
             ]
@@ -238,292 +147,108 @@
             "status": "expired",
             "withdrawals": [],
             "amount": {
-                "quantity": 194,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 5,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1870-11-26T05:55:42Z",
-                "epoch_number": 578,
-                "absolute_slot_number": 3422204,
-                "slot_number": 15506
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 24390,
-                    "unit": "block"
-                },
-                "time": "1903-10-11T07:00:00Z",
-                "epoch_number": 344,
-                "absolute_slot_number": 15732320,
-                "slot_number": 32326
-            },
-            "metadata": null,
-            "id": "165e4f0d048ed4640c5df4a985a459c80072298c31206d4055609968092a91eb",
-            "deposit": {
-                "quantity": 80,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": []
-        },
-        {
-            "status": "pending",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 128,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 89,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1908-05-08T06:07:21Z",
-                "epoch_number": 25547,
-                "absolute_slot_number": 1131598,
-                "slot_number": 21155
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 5620,
-                    "unit": "block"
-                },
-                "time": "1896-02-07T04:54:21Z",
-                "epoch_number": 17394,
-                "absolute_slot_number": 14654795,
-                "slot_number": 21393
-            },
-            "metadata": {
-                "7": {
-                    "map": [
-                        {
-                            "k": {
-                                "string": ""
-                            },
-                            "v": {
-                                "list": [
-                                    {
-                                        "map": [
-                                            {
-                                                "k": {
-                                                    "string": ""
-                                                },
-                                                "v": {
-                                                    "bytes": "173bba16234f2d03630a5148633f520e"
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "list": []
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "k": {
-                                "string": "bG"
-                            },
-                            "v": {
-                                "int": 3
-                            }
-                        },
-                        {
-                            "k": {
-                                "string": "~K"
-                            },
-                            "v": {
-                                "list": []
-                            }
-                        }
-                    ]
-                }
-            },
-            "id": "734d45721e8522d827772e666a4f203a076d2a4a6fef7afb315971010b3ca25e",
-            "deposit": {
-                "quantity": 231,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 7,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e46",
-                    "quantity": 22,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 14,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 27,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e46",
-                    "quantity": 30,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 24,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 52,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 7,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 11,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 41,
-                    "policy_id": "55555555555555555555555555555555555555555555555555555555"
-                }
-            ]
-        },
-        {
-            "status": "pending",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 127,
+                "quantity": 94,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "outgoing",
             "fee": {
-                "quantity": 44,
+                "quantity": 20,
                 "unit": "lovelace"
             },
             "outputs": [],
             "expires_at": {
-                "time": "1867-04-12T05:00:00Z",
-                "epoch_number": 19981,
-                "absolute_slot_number": 16432527,
-                "slot_number": 30327
+                "time": "1863-08-11T00:10:54Z",
+                "epoch_number": 13025,
+                "absolute_slot_number": 15971135,
+                "slot_number": 21967
             },
             "metadata": {
-                "4": {
-                    "map": [
+                "6": {
+                    "list": [
                         {
-                            "k": {
-                                "string": ""
-                            },
-                            "v": {
-                                "bytes": "2d11753d4a587b46580675386141246671012089"
-                            }
+                            "int": 3
                         },
                         {
-                            "k": {
-                                "string": "="
-                            },
-                            "v": {
-                                "map": []
-                            }
-                        },
-                        {
-                            "k": {
-                                "string": "BC"
-                            },
-                            "v": {
-                                "int": -3
-                            }
+                            "list": [
+                                {
+                                    "int": 0
+                                }
+                            ]
                         }
                     ]
                 }
             },
             "depth": {
-                "quantity": 18502,
+                "quantity": 12219,
                 "unit": "block"
             },
-            "id": "77046e3c4d27277473232f623938073d0d6bf7024e4877318c042344bc634175",
+            "id": "059d2f78fde773120c170d2f5511eb0d335ad84101552919010b386c6a73c5d8",
             "deposit": {
-                "quantity": 255,
+                "quantity": 93,
                 "unit": "lovelace"
             },
+            "is_valid_script": true,
             "collateral": [],
-            "mint": []
+            "mint": [
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 28,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 14,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 16,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 24,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
         },
         {
             "inserted_at": {
                 "height": {
-                    "quantity": 26685,
+                    "quantity": 27796,
                     "unit": "block"
                 },
-                "time": "1883-03-10T05:00:00Z",
-                "epoch_number": 4937,
-                "absolute_slot_number": 3653874,
-                "slot_number": 3826
+                "time": "1884-08-05T16:00:00Z",
+                "epoch_number": 25715,
+                "absolute_slot_number": 6214281,
+                "slot_number": 11435
             },
             "status": "in_ledger",
             "withdrawals": [],
             "amount": {
-                "quantity": 204,
+                "quantity": 26,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 136,
+                "quantity": 106,
                 "unit": "lovelace"
             },
             "outputs": [],
             "metadata": null,
-            "depth": {
-                "quantity": 15248,
-                "unit": "block"
-            },
-            "id": "524216f7564c77ab5474141b4d4f5ee81f7a1e67d7664262740a7e230f8545f9",
+            "id": "7f9cb80b5c060e11477f1c990c445f1ddd01742f73da76c346010c2772415b30",
             "deposit": {
-                "quantity": 230,
+                "quantity": 236,
                 "unit": "lovelace"
             },
+            "is_valid_script": false,
             "collateral": [],
             "mint": [
                 {
-                    "asset_name": "546f6b656e46",
-                    "quantity": 29,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 17,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 15,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 13,
+                    "asset_name": "546f6b656e42",
+                    "quantity": 6,
                     "policy_id": "44444444444444444444444444444444444444444444444444444444"
                 }
             ]
@@ -532,38 +257,324 @@
             "status": "in_ledger",
             "withdrawals": [],
             "amount": {
-                "quantity": 215,
+                "quantity": 223,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 64,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "metadata": {
+                "21": {
+                    "list": [
+                        {
+                            "map": [
+                                {
+                                    "k": {
+                                        "string": "l!"
+                                    },
+                                    "v": {
+                                        "string": "@"
+                                    }
+                                },
+                                {
+                                    "k": {
+                                        "string": "r"
+                                    },
+                                    "v": {
+                                        "int": 0
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "id": "3918406a71117509676c681a014cbbb92703564609015f44c903107652b15e21",
+            "deposit": {
+                "quantity": 154,
+                "unit": "lovelace"
+            },
+            "is_valid_script": null,
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 25,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                }
+            ]
+        },
+        {
+            "inserted_at": {
+                "height": {
+                    "quantity": 21469,
+                    "unit": "block"
+                },
+                "time": "1895-02-26T01:00:00Z",
+                "epoch_number": 329,
+                "absolute_slot_number": 11342127,
+                "slot_number": 29219
+            },
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 221,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 171,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "metadata": {
+                "4": {
+                    "list": [
+                        {
+                            "string": "!y-"
+                        },
+                        {
+                            "list": [
+                                {
+                                    "string": ".𡛇"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "depth": {
+                "quantity": 10258,
+                "unit": "block"
+            },
+            "id": "503d261c2ac53a2b087ba516270e7949921127619e2a492a45db522a514d2f00",
+            "deposit": {
+                "quantity": 101,
+                "unit": "lovelace"
+            },
+            "is_valid_script": false,
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 30,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 19,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 1,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 23,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 16,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 43,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 30,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 17,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 1,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 166,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 191,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "metadata": {
+                "7": {
+                    "string": ""
+                }
+            },
+            "depth": {
+                "quantity": 21260,
+                "unit": "block"
+            },
+            "id": "692ef54f08267a6b6278d4180a215dac1c39ab0d2555fc1a072bdd764210ad22",
+            "deposit": {
+                "quantity": 153,
+                "unit": "lovelace"
+            },
+            "is_valid_script": null,
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 227,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 40,
+                "quantity": 192,
                 "unit": "lovelace"
             },
             "outputs": [],
             "metadata": {
-                "0": {
-                    "bytes": "25f82e3e22d851546c1a5d1c7c343a41dc7ff9f62a07ec084869101258105f04144f0084106a6f251840336d410d6c79177b0e3c6f54a47820432b5d4f11"
+                "22": {
+                    "map": []
                 }
             },
             "depth": {
-                "quantity": 15998,
+                "quantity": 18429,
                 "unit": "block"
             },
-            "id": "ec6130776213c64e7a0a533211762551155612765d05272714300147373a2531",
+            "id": "771664396a145a76608d763a5d2536d5a51f445c5367482e2c46750848a5cc4b",
             "deposit": {
-                "quantity": 117,
+                "quantity": 205,
                 "unit": "lovelace"
             },
+            "is_valid_script": false,
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e45",
-                    "quantity": 27,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                    "quantity": 12,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
                 }
             ]
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 205,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 115,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1900-12-05T08:06:34.56474251296Z",
+                "epoch_number": 9919,
+                "absolute_slot_number": 15804468,
+                "slot_number": 20347
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 16276,
+                    "unit": "block"
+                },
+                "time": "1903-01-31T00:00:00Z",
+                "epoch_number": 25641,
+                "absolute_slot_number": 16670178,
+                "slot_number": 22729
+            },
+            "metadata": null,
+            "depth": {
+                "quantity": 7077,
+                "unit": "block"
+            },
+            "id": "4744153cca880d3b57627173635964270338412e2ad65c6060344d5309e60604",
+            "deposit": {
+                "quantity": 61,
+                "unit": "lovelace"
+            },
+            "is_valid_script": true,
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 7,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 28,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 188,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 21,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1906-04-09T21:00:00Z",
+                "epoch_number": 4167,
+                "absolute_slot_number": 14198707,
+                "slot_number": 27063
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 23346,
+                    "unit": "block"
+                },
+                "time": "1899-05-04T13:19:30.25623172511Z",
+                "epoch_number": 28224,
+                "absolute_slot_number": 3927793,
+                "slot_number": 32478
+            },
+            "metadata": null,
+            "depth": {
+                "quantity": 31290,
+                "unit": "block"
+            },
+            "id": "330122712731461a1324bd422e1a6f51700e0e701b79695d625eba632301614a",
+            "deposit": {
+                "quantity": 203,
+                "unit": "lovelace"
+            },
+            "is_valid_script": null,
+            "collateral": [],
+            "mint": []
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
@@ -1,146 +1,393 @@
 {
-    "seed": 1103795655592747646,
+    "seed": -757484659495994533,
     "samples": [
         {
-            "status": "expired",
+            "inserted_at": {
+                "height": {
+                    "quantity": 31554,
+                    "unit": "block"
+                },
+                "time": "1880-01-13T02:00:00Z",
+                "epoch_number": 18372,
+                "absolute_slot_number": 1908564,
+                "slot_number": 29875
+            },
+            "status": "in_ledger",
             "withdrawals": [],
             "amount": {
-                "quantity": 9,
+                "quantity": 30,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 127,
+                "quantity": 113,
                 "unit": "lovelace"
             },
             "outputs": [],
-            "script_validity": null,
-            "expires_at": {
-                "time": "1878-08-29T13:34:24.552524729184Z",
-                "epoch_number": 19957,
-                "absolute_slot_number": 15584168,
-                "slot_number": 13563
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 8070,
-                    "unit": "block"
-                },
-                "time": "1880-03-07T14:23:00Z",
-                "epoch_number": 1526,
-                "absolute_slot_number": 6243176,
-                "slot_number": 13122
-            },
+            "script_validity": "valid",
             "metadata": {
-                "1": {
-                    "int": 0
+                "8": {
+                    "string": "緰"
                 }
             },
             "depth": {
-                "quantity": 10430,
+                "quantity": 30459,
                 "unit": "block"
             },
-            "id": "4efb126d5a2126d1192e1aad2829132c7d44342c313ec73479ae06766918382c",
+            "id": "ff6d6f2c68c3f20c5d69065b425b1849495048677ae2175f3f0d303ef061843c",
             "deposit": {
-                "quantity": 214,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 23,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                }
-            ]
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 207,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 224,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "script_validity": true,
-            "expires_at": {
-                "time": "1863-10-03T02:55:49.132547904722Z",
-                "epoch_number": 23076,
-                "absolute_slot_number": 250329,
-                "slot_number": 5086
-            },
-            "metadata": null,
-            "id": "41782ed0475c40521223455b17de316b612b2b6b23074417e4515b4051321d76",
-            "deposit": {
-                "quantity": 153,
+                "quantity": 250,
                 "unit": "lovelace"
             },
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e41",
-                    "quantity": 14,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                    "quantity": 28,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 22,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 24,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 19,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 3,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 29,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
                 }
             ]
         },
         {
             "inserted_at": {
                 "height": {
-                    "quantity": 3956,
+                    "quantity": 16532,
                     "unit": "block"
                 },
-                "time": "1890-09-02T11:00:27Z",
-                "epoch_number": 596,
-                "absolute_slot_number": 8374223,
-                "slot_number": 10389
+                "time": "1864-10-01T19:20:19Z",
+                "epoch_number": 6894,
+                "absolute_slot_number": 11041441,
+                "slot_number": 641
             },
             "status": "in_ledger",
             "withdrawals": [],
             "amount": {
-                "quantity": 188,
+                "quantity": 60,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 162,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": "invalid",
+            "metadata": {
+                "25": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 4802,
+                "unit": "block"
+            },
+            "id": "496413320678654a4530794868dc14fe2c06a7014ff01f06658d525a5f4a5847",
+            "deposit": {
+                "quantity": 158,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 197,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 70,
+                "quantity": 133,
                 "unit": "lovelace"
             },
             "outputs": [],
-            "script_validity": false,
+            "script_validity": "invalid",
+            "pending_since": {
+                "height": {
+                    "quantity": 2188,
+                    "unit": "block"
+                },
+                "time": "1885-05-15T16:22:01Z",
+                "epoch_number": 24237,
+                "absolute_slot_number": 3784659,
+                "slot_number": 19841
+            },
+            "metadata": {
+                "17": {
+                    "bytes": "e362ddcf035a6208552e7062303d473707040d065f0b7a7c5eb843712c2e077955482f2a42204d20801e1e26200b384669"
+                }
+            },
+            "id": "d5b52c3cce37234c5b404419431299787c5819677364173f503c6e454538785b",
+            "deposit": {
+                "quantity": 167,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 50,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 172,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "expires_at": {
+                "time": "1862-06-27T23:03:53.182020854875Z",
+                "epoch_number": 15884,
+                "absolute_slot_number": 11516056,
+                "slot_number": 9341
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 11980,
+                    "unit": "block"
+                },
+                "time": "1874-10-12T18:00:00Z",
+                "epoch_number": 3829,
+                "absolute_slot_number": 6211276,
+                "slot_number": 28311
+            },
             "metadata": {
                 "5": {
-                    "bytes": "0b58d740792abb5e9c7c065407af1b265406ac6b5256051a35246e6d552c001545530733"
+                    "int": 0
                 }
             },
             "depth": {
-                "quantity": 23576,
+                "quantity": 18707,
                 "unit": "block"
             },
-            "id": "5307d66a387168485d442a6e2a33df332b0f295c66650d5333a31bd1276a625f",
+            "id": "368f977b0b86541f5d316d0a2d453d245827510b3b0ff37465706a4f7a68461b",
             "deposit": {
-                "quantity": 247,
+                "quantity": 156,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 13,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                }
+            ]
+        },
+        {
+            "inserted_at": {
+                "height": {
+                    "quantity": 9744,
+                    "unit": "block"
+                },
+                "time": "1875-07-02T20:19:30Z",
+                "epoch_number": 20558,
+                "absolute_slot_number": 16761225,
+                "slot_number": 21420
+            },
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 223,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 137,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "metadata": {
+                "20": {
+                    "int": 0
+                }
+            },
+            "id": "4b2c2852097c57077f6410a704184912744539ec48352f714e45595928264559",
+            "deposit": {
+                "quantity": 32,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 175,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 0,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": "invalid",
+            "metadata": {
+                "21": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 29512,
+                "unit": "block"
+            },
+            "id": "5664377b724f6a271901631f3b621e00ce45381c20a74d67194ac04f44063492",
+            "deposit": {
+                "quantity": 56,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 24,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 24,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 21,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 1,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 25,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 41,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 28,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 21,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 17,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 51,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 164,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": "valid",
+            "expires_at": {
+                "time": "1896-05-16T07:00:00Z",
+                "epoch_number": 14456,
+                "absolute_slot_number": 4827140,
+                "slot_number": 20371
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 26225,
+                    "unit": "block"
+                },
+                "time": "1886-11-02T07:18:58Z",
+                "epoch_number": 4687,
+                "absolute_slot_number": 13855376,
+                "slot_number": 21005
+            },
+            "metadata": {
+                "29": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 7211,
+                "unit": "block"
+            },
+            "id": "662dfa1b46703e704614255c3d476c74356b170428315b8620b7b5781a4a4e37",
+            "deposit": {
+                "quantity": 254,
                 "unit": "lovelace"
             },
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e41",
-                    "quantity": 12,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                    "quantity": 21,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
                 }
             ]
         },
         {
-            "status": "pending",
+            "inserted_at": {
+                "height": {
+                    "quantity": 20358,
+                    "unit": "block"
+                },
+                "time": "1888-09-08T21:00:00Z",
+                "epoch_number": 8914,
+                "absolute_slot_number": 14100133,
+                "slot_number": 4287
+            },
+            "status": "in_ledger",
             "withdrawals": [],
             "amount": {
                 "quantity": 130,
@@ -149,288 +396,85 @@
             "inputs": [],
             "direction": "outgoing",
             "fee": {
-                "quantity": 243,
+                "quantity": 18,
                 "unit": "lovelace"
             },
             "outputs": [],
-            "script_validity": null,
-            "expires_at": {
-                "time": "1899-01-26T06:00:00Z",
-                "epoch_number": 6280,
-                "absolute_slot_number": 15152845,
-                "slot_number": 29341
+            "metadata": null,
+            "depth": {
+                "quantity": 25288,
+                "unit": "block"
             },
-            "pending_since": {
-                "height": {
-                    "quantity": 6493,
-                    "unit": "block"
-                },
-                "time": "1903-12-20T14:00:00Z",
-                "epoch_number": 14911,
-                "absolute_slot_number": 6627462,
-                "slot_number": 27390
-            },
-            "metadata": {
-                "27": {
-                    "map": []
-                }
-            },
-            "id": "00334c6d494a6b69012c52106e5f666f6b7e1d712171cc097240af543273635b",
+            "id": "30383c3736469b74052f3964583f7e10510e07447e2b264960423c15799e5f6e",
             "deposit": {
-                "quantity": 140,
+                "quantity": 123,
                 "unit": "lovelace"
             },
             "collateral": [],
             "mint": [
                 {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 26,
+                    "asset_name": "546f6b656e43",
+                    "quantity": 20,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 27,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 7,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 5,
                     "policy_id": "44444444444444444444444444444444444444444444444444444444"
                 }
             ]
         },
         {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 45,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 30,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "script_validity": true,
-            "metadata": {
-                "8": {
-                    "list": [
-                        {
-                            "map": [
-                                {
-                                    "k": {
-                                        "string": ""
-                                    },
-                                    "v": {
-                                        "map": []
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "map": [
-                                {
-                                    "k": {
-                                        "string": ""
-                                    },
-                                    "v": {
-                                        "list": []
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "map": [
-                                {
-                                    "k": {
-                                        "string": "Z0"
-                                    },
-                                    "v": {
-                                        "list": [
-                                            {
-                                                "int": 0
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
-                                    "k": {
-                                        "string": "Z펯"
-                                    },
-                                    "v": {
-                                        "list": []
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "5a732f63263a5c1c6f7f8095ab1891034417795a1902740c6726709c033c7158",
-            "deposit": {
-                "quantity": 140,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 10,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                }
-            ]
-        },
-        {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 29,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 193,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "script_validity": false,
-            "metadata": null,
-            "depth": {
-                "quantity": 1006,
-                "unit": "block"
-            },
-            "id": "53a6607478011a774bca54ac3a52610d542b3b5057497e483b341a6518101939",
-            "deposit": {
-                "quantity": 102,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": []
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 11486,
-                    "unit": "block"
-                },
-                "time": "1864-09-07T06:32:33Z",
-                "epoch_number": 26557,
-                "absolute_slot_number": 14800228,
-                "slot_number": 9072
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 32,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 78,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "script_validity": null,
-            "metadata": {
-                "16": {
-                    "list": []
-                }
-            },
-            "depth": {
-                "quantity": 3658,
-                "unit": "block"
-            },
-            "id": "8345960a6f4d990c663a744c54167c942613745d0ad5c6cd647d6130684e9853",
-            "deposit": {
-                "quantity": 13,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 12,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                }
-            ]
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 27069,
-                    "unit": "block"
-                },
-                "time": "1906-11-06T02:00:00Z",
-                "epoch_number": 22399,
-                "absolute_slot_number": 6905615,
-                "slot_number": 21657
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 69,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 233,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "script_validity": false,
-            "metadata": {
-                "3": {
-                    "string": ""
-                }
-            },
-            "id": "425b123b0a55005502702a59744509f7465906497d6042176d663c3bb5202208",
-            "deposit": {
-                "quantity": 200,
-                "unit": "lovelace"
-            },
-            "collateral": [],
-            "mint": []
-        },
-        {
             "status": "pending",
             "withdrawals": [],
             "amount": {
-                "quantity": 244,
+                "quantity": 171,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "outgoing",
             "fee": {
-                "quantity": 118,
+                "quantity": 97,
                 "unit": "lovelace"
             },
             "outputs": [],
-            "script_validity": false,
+            "script_validity": "invalid",
             "pending_since": {
                 "height": {
-                    "quantity": 28533,
+                    "quantity": 295,
                     "unit": "block"
                 },
-                "time": "1874-10-12T16:41:06Z",
-                "epoch_number": 15637,
-                "absolute_slot_number": 6233727,
-                "slot_number": 23644
+                "time": "1898-09-21T07:30:21Z",
+                "epoch_number": 4486,
+                "absolute_slot_number": 2479998,
+                "slot_number": 5782
             },
             "metadata": {
-                "7": {
-                    "int": 0
+                "28": {
+                    "string": "󿯪"
                 }
             },
-            "depth": {
-                "quantity": 30168,
-                "unit": "block"
-            },
-            "id": "2d42305f6a4c0a2ae3ce5dce7a2f6823b71a48330f5165182a3927fa1b076256",
+            "id": "60e02e3b8048a879e73ba9a2710d5a6e3dc279404c000a487f715afa63357567",
             "deposit": {
-                "quantity": 97,
+                "quantity": 183,
                 "unit": "lovelace"
             },
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e44",
-                    "quantity": 7,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                    "quantity": 24,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
                 }
             ]
         },
@@ -438,43 +482,86 @@
             "status": "expired",
             "withdrawals": [],
             "amount": {
-                "quantity": 132,
+                "quantity": 218,
                 "unit": "lovelace"
             },
             "inputs": [],
-            "direction": "incoming",
+            "direction": "outgoing",
             "fee": {
-                "quantity": 38,
+                "quantity": 113,
                 "unit": "lovelace"
             },
             "outputs": [],
-            "script_validity": true,
+            "script_validity": "valid",
             "expires_at": {
-                "time": "1885-10-03T08:06:18Z",
-                "epoch_number": 1934,
-                "absolute_slot_number": 12094157,
-                "slot_number": 17272
+                "time": "1908-01-17T04:49:48Z",
+                "epoch_number": 588,
+                "absolute_slot_number": 15792036,
+                "slot_number": 5434
             },
-            "metadata": {
-                "12": {
-                    "list": [
-                        {
-                            "bytes": "1120b2620a2f77534d7e493c5b105040976b737b4e"
-                        }
-                    ]
-                }
-            },
+            "metadata": null,
             "depth": {
-                "quantity": 19940,
+                "quantity": 17728,
                 "unit": "block"
             },
-            "id": "1a442b7f7a9519222953f3283f1e3b664848238a0ed3923b12591c134c5f3a59",
+            "id": "05251a335b350825bf1d4f2a380d5a4b0f5b200e66526e582842f23f103c1d3f",
             "deposit": {
-                "quantity": 193,
+                "quantity": 148,
                 "unit": "lovelace"
             },
             "collateral": [],
-            "mint": []
+            "mint": [
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 3,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 32,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e43",
+                    "quantity": 12,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 13,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 26,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 3,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                },
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 3,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 24,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 7,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                },
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 12,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
         }
     ]
 }

--- a/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
+++ b/lib/core/test/data/Cardano/Wallet/Api/ApiTransactionTestnet0.json
@@ -1,145 +1,57 @@
 {
-    "seed": 272315937488619540,
+    "seed": 1103795655592747646,
     "samples": [
         {
-            "status": "pending",
+            "status": "expired",
             "withdrawals": [],
             "amount": {
-                "quantity": 201,
+                "quantity": 9,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "incoming",
             "fee": {
-                "quantity": 84,
+                "quantity": 127,
                 "unit": "lovelace"
             },
             "outputs": [],
+            "script_validity": null,
             "expires_at": {
-                "time": "1868-11-22T10:00:00Z",
-                "epoch_number": 17148,
-                "absolute_slot_number": 799355,
-                "slot_number": 32144
+                "time": "1878-08-29T13:34:24.552524729184Z",
+                "epoch_number": 19957,
+                "absolute_slot_number": 15584168,
+                "slot_number": 13563
+            },
+            "pending_since": {
+                "height": {
+                    "quantity": 8070,
+                    "unit": "block"
+                },
+                "time": "1880-03-07T14:23:00Z",
+                "epoch_number": 1526,
+                "absolute_slot_number": 6243176,
+                "slot_number": 13122
             },
             "metadata": {
-                "12": {
+                "1": {
                     "int": 0
                 }
             },
             "depth": {
-                "quantity": 14602,
+                "quantity": 10430,
                 "unit": "block"
             },
-            "id": "2901737c27ff46576160b35d0c101b675d60595211633920056b4b5d17bc2248",
+            "id": "4efb126d5a2126d1192e1aad2829132c7d44342c313ec73479ae06766918382c",
             "deposit": {
-                "quantity": 135,
+                "quantity": 214,
                 "unit": "lovelace"
             },
-            "is_valid_script": true,
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e43",
-                    "quantity": 19,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 8,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 12,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 31,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 11,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 28,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 9,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 8,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 14,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 25,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 4,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 5523,
-                    "unit": "block"
-                },
-                "time": "1874-02-16T10:29:06.479812124804Z",
-                "epoch_number": 26668,
-                "absolute_slot_number": 1372852,
-                "slot_number": 3220
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 164,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 133,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "21": {
-                    "map": []
-                }
-            },
-            "depth": {
-                "quantity": 1412,
-                "unit": "block"
-            },
-            "id": "0bfa3e0641570251e41c02215657083c58086852d1297840ff427c634a464554",
-            "deposit": {
-                "quantity": 70,
-                "unit": "lovelace"
-            },
-            "is_valid_script": null,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 5,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
+                    "quantity": 23,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
                 }
             ]
         },
@@ -147,432 +59,420 @@
             "status": "expired",
             "withdrawals": [],
             "amount": {
-                "quantity": 94,
+                "quantity": 207,
                 "unit": "lovelace"
             },
             "inputs": [],
             "direction": "outgoing",
             "fee": {
-                "quantity": 20,
+                "quantity": 224,
                 "unit": "lovelace"
             },
             "outputs": [],
+            "script_validity": true,
             "expires_at": {
-                "time": "1863-08-11T00:10:54Z",
-                "epoch_number": 13025,
-                "absolute_slot_number": 15971135,
-                "slot_number": 21967
+                "time": "1863-10-03T02:55:49.132547904722Z",
+                "epoch_number": 23076,
+                "absolute_slot_number": 250329,
+                "slot_number": 5086
             },
-            "metadata": {
-                "6": {
-                    "list": [
-                        {
-                            "int": 3
-                        },
-                        {
-                            "list": [
-                                {
-                                    "int": 0
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "depth": {
-                "quantity": 12219,
-                "unit": "block"
-            },
-            "id": "059d2f78fde773120c170d2f5511eb0d335ad84101552919010b386c6a73c5d8",
-            "deposit": {
-                "quantity": 93,
-                "unit": "lovelace"
-            },
-            "is_valid_script": true,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 28,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 14,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 16,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 24,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 27796,
-                    "unit": "block"
-                },
-                "time": "1884-08-05T16:00:00Z",
-                "epoch_number": 25715,
-                "absolute_slot_number": 6214281,
-                "slot_number": 11435
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 26,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 106,
-                "unit": "lovelace"
-            },
-            "outputs": [],
             "metadata": null,
-            "id": "7f9cb80b5c060e11477f1c990c445f1ddd01742f73da76c346010c2772415b30",
-            "deposit": {
-                "quantity": 236,
-                "unit": "lovelace"
-            },
-            "is_valid_script": false,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 6,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 223,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 64,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "21": {
-                    "list": [
-                        {
-                            "map": [
-                                {
-                                    "k": {
-                                        "string": "l!"
-                                    },
-                                    "v": {
-                                        "string": "@"
-                                    }
-                                },
-                                {
-                                    "k": {
-                                        "string": "r"
-                                    },
-                                    "v": {
-                                        "int": 0
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "id": "3918406a71117509676c681a014cbbb92703564609015f44c903107652b15e21",
-            "deposit": {
-                "quantity": 154,
-                "unit": "lovelace"
-            },
-            "is_valid_script": null,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 25,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                }
-            ]
-        },
-        {
-            "inserted_at": {
-                "height": {
-                    "quantity": 21469,
-                    "unit": "block"
-                },
-                "time": "1895-02-26T01:00:00Z",
-                "epoch_number": 329,
-                "absolute_slot_number": 11342127,
-                "slot_number": 29219
-            },
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 221,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 171,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "4": {
-                    "list": [
-                        {
-                            "string": "!y-"
-                        },
-                        {
-                            "list": [
-                                {
-                                    "string": ".𡛇"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            },
-            "depth": {
-                "quantity": 10258,
-                "unit": "block"
-            },
-            "id": "503d261c2ac53a2b087ba516270e7949921127619e2a492a45db522a514d2f00",
-            "deposit": {
-                "quantity": 101,
-                "unit": "lovelace"
-            },
-            "is_valid_script": false,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 30,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 19,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 1,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 23,
-                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
-                },
-                {
-                    "asset_name": "546f6b656e44",
-                    "quantity": 16,
-                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 43,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e43",
-                    "quantity": 30,
-                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
-                },
-                {
-                    "asset_name": "546f6b656e41",
-                    "quantity": 17,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 1,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 166,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "outgoing",
-            "fee": {
-                "quantity": 191,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "7": {
-                    "string": ""
-                }
-            },
-            "depth": {
-                "quantity": 21260,
-                "unit": "block"
-            },
-            "id": "692ef54f08267a6b6278d4180a215dac1c39ab0d2555fc1a072bdd764210ad22",
+            "id": "41782ed0475c40521223455b17de316b612b2b6b23074417e4515b4051321d76",
             "deposit": {
                 "quantity": 153,
                 "unit": "lovelace"
             },
-            "is_valid_script": null,
-            "collateral": [],
-            "mint": []
-        },
-        {
-            "status": "in_ledger",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 227,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 192,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "metadata": {
-                "22": {
-                    "map": []
-                }
-            },
-            "depth": {
-                "quantity": 18429,
-                "unit": "block"
-            },
-            "id": "771664396a145a76608d763a5d2536d5a51f445c5367482e2c46750848a5cc4b",
-            "deposit": {
-                "quantity": 205,
-                "unit": "lovelace"
-            },
-            "is_valid_script": false,
-            "collateral": [],
-            "mint": [
-                {
-                    "asset_name": "546f6b656e45",
-                    "quantity": 12,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
-                }
-            ]
-        },
-        {
-            "status": "expired",
-            "withdrawals": [],
-            "amount": {
-                "quantity": 205,
-                "unit": "lovelace"
-            },
-            "inputs": [],
-            "direction": "incoming",
-            "fee": {
-                "quantity": 115,
-                "unit": "lovelace"
-            },
-            "outputs": [],
-            "expires_at": {
-                "time": "1900-12-05T08:06:34.56474251296Z",
-                "epoch_number": 9919,
-                "absolute_slot_number": 15804468,
-                "slot_number": 20347
-            },
-            "pending_since": {
-                "height": {
-                    "quantity": 16276,
-                    "unit": "block"
-                },
-                "time": "1903-01-31T00:00:00Z",
-                "epoch_number": 25641,
-                "absolute_slot_number": 16670178,
-                "slot_number": 22729
-            },
-            "metadata": null,
-            "depth": {
-                "quantity": 7077,
-                "unit": "block"
-            },
-            "id": "4744153cca880d3b57627173635964270338412e2ad65c6060344d5309e60604",
-            "deposit": {
-                "quantity": 61,
-                "unit": "lovelace"
-            },
-            "is_valid_script": true,
             "collateral": [],
             "mint": [
                 {
                     "asset_name": "546f6b656e41",
-                    "quantity": 7,
-                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
-                },
-                {
-                    "asset_name": "546f6b656e42",
-                    "quantity": 28,
-                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                    "quantity": 14,
+                    "policy_id": "11111111111111111111111111111111111111111111111111111111"
                 }
             ]
         },
         {
-            "status": "expired",
+            "inserted_at": {
+                "height": {
+                    "quantity": 3956,
+                    "unit": "block"
+                },
+                "time": "1890-09-02T11:00:27Z",
+                "epoch_number": 596,
+                "absolute_slot_number": 8374223,
+                "slot_number": 10389
+            },
+            "status": "in_ledger",
             "withdrawals": [],
             "amount": {
                 "quantity": 188,
                 "unit": "lovelace"
             },
             "inputs": [],
-            "direction": "outgoing",
+            "direction": "incoming",
             "fee": {
-                "quantity": 21,
+                "quantity": 70,
                 "unit": "lovelace"
             },
             "outputs": [],
+            "script_validity": false,
+            "metadata": {
+                "5": {
+                    "bytes": "0b58d740792abb5e9c7c065407af1b265406ac6b5256051a35246e6d552c001545530733"
+                }
+            },
+            "depth": {
+                "quantity": 23576,
+                "unit": "block"
+            },
+            "id": "5307d66a387168485d442a6e2a33df332b0f295c66650d5333a31bd1276a625f",
+            "deposit": {
+                "quantity": 247,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e41",
+                    "quantity": 12,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 130,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 243,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": null,
             "expires_at": {
-                "time": "1906-04-09T21:00:00Z",
-                "epoch_number": 4167,
-                "absolute_slot_number": 14198707,
-                "slot_number": 27063
+                "time": "1899-01-26T06:00:00Z",
+                "epoch_number": 6280,
+                "absolute_slot_number": 15152845,
+                "slot_number": 29341
             },
             "pending_since": {
                 "height": {
-                    "quantity": 23346,
+                    "quantity": 6493,
                     "unit": "block"
                 },
-                "time": "1899-05-04T13:19:30.25623172511Z",
-                "epoch_number": 28224,
-                "absolute_slot_number": 3927793,
-                "slot_number": 32478
+                "time": "1903-12-20T14:00:00Z",
+                "epoch_number": 14911,
+                "absolute_slot_number": 6627462,
+                "slot_number": 27390
             },
-            "metadata": null,
-            "depth": {
-                "quantity": 31290,
-                "unit": "block"
+            "metadata": {
+                "27": {
+                    "map": []
+                }
             },
-            "id": "330122712731461a1324bd422e1a6f51700e0e701b79695d625eba632301614a",
+            "id": "00334c6d494a6b69012c52106e5f666f6b7e1d712171cc097240af543273635b",
             "deposit": {
-                "quantity": 203,
+                "quantity": 140,
                 "unit": "lovelace"
             },
-            "is_valid_script": null,
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e45",
+                    "quantity": 26,
+                    "policy_id": "44444444444444444444444444444444444444444444444444444444"
+                }
+            ]
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 45,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 30,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": true,
+            "metadata": {
+                "8": {
+                    "list": [
+                        {
+                            "map": [
+                                {
+                                    "k": {
+                                        "string": ""
+                                    },
+                                    "v": {
+                                        "map": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "map": [
+                                {
+                                    "k": {
+                                        "string": ""
+                                    },
+                                    "v": {
+                                        "list": []
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "map": [
+                                {
+                                    "k": {
+                                        "string": "Z0"
+                                    },
+                                    "v": {
+                                        "list": [
+                                            {
+                                                "int": 0
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "k": {
+                                        "string": "Z펯"
+                                    },
+                                    "v": {
+                                        "list": []
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "id": "5a732f63263a5c1c6f7f8095ab1891034417795a1902740c6726709c033c7158",
+            "deposit": {
+                "quantity": 140,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 10,
+                    "policy_id": "00000000000000000000000000000000000000000000000000000000"
+                }
+            ]
+        },
+        {
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 29,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 193,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": false,
+            "metadata": null,
+            "depth": {
+                "quantity": 1006,
+                "unit": "block"
+            },
+            "id": "53a6607478011a774bca54ac3a52610d542b3b5057497e483b341a6518101939",
+            "deposit": {
+                "quantity": 102,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "inserted_at": {
+                "height": {
+                    "quantity": 11486,
+                    "unit": "block"
+                },
+                "time": "1864-09-07T06:32:33Z",
+                "epoch_number": 26557,
+                "absolute_slot_number": 14800228,
+                "slot_number": 9072
+            },
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 32,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 78,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": null,
+            "metadata": {
+                "16": {
+                    "list": []
+                }
+            },
+            "depth": {
+                "quantity": 3658,
+                "unit": "block"
+            },
+            "id": "8345960a6f4d990c663a744c54167c942613745d0ad5c6cd647d6130684e9853",
+            "deposit": {
+                "quantity": 13,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e42",
+                    "quantity": 12,
+                    "policy_id": "22222222222222222222222222222222222222222222222222222222"
+                }
+            ]
+        },
+        {
+            "inserted_at": {
+                "height": {
+                    "quantity": 27069,
+                    "unit": "block"
+                },
+                "time": "1906-11-06T02:00:00Z",
+                "epoch_number": 22399,
+                "absolute_slot_number": 6905615,
+                "slot_number": 21657
+            },
+            "status": "in_ledger",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 69,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 233,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": false,
+            "metadata": {
+                "3": {
+                    "string": ""
+                }
+            },
+            "id": "425b123b0a55005502702a59744509f7465906497d6042176d663c3bb5202208",
+            "deposit": {
+                "quantity": 200,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": []
+        },
+        {
+            "status": "pending",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 244,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "outgoing",
+            "fee": {
+                "quantity": 118,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": false,
+            "pending_since": {
+                "height": {
+                    "quantity": 28533,
+                    "unit": "block"
+                },
+                "time": "1874-10-12T16:41:06Z",
+                "epoch_number": 15637,
+                "absolute_slot_number": 6233727,
+                "slot_number": 23644
+            },
+            "metadata": {
+                "7": {
+                    "int": 0
+                }
+            },
+            "depth": {
+                "quantity": 30168,
+                "unit": "block"
+            },
+            "id": "2d42305f6a4c0a2ae3ce5dce7a2f6823b71a48330f5165182a3927fa1b076256",
+            "deposit": {
+                "quantity": 97,
+                "unit": "lovelace"
+            },
+            "collateral": [],
+            "mint": [
+                {
+                    "asset_name": "546f6b656e44",
+                    "quantity": 7,
+                    "policy_id": "33333333333333333333333333333333333333333333333333333333"
+                }
+            ]
+        },
+        {
+            "status": "expired",
+            "withdrawals": [],
+            "amount": {
+                "quantity": 132,
+                "unit": "lovelace"
+            },
+            "inputs": [],
+            "direction": "incoming",
+            "fee": {
+                "quantity": 38,
+                "unit": "lovelace"
+            },
+            "outputs": [],
+            "script_validity": true,
+            "expires_at": {
+                "time": "1885-10-03T08:06:18Z",
+                "epoch_number": 1934,
+                "absolute_slot_number": 12094157,
+                "slot_number": 17272
+            },
+            "metadata": {
+                "12": {
+                    "list": [
+                        {
+                            "bytes": "1120b2620a2f77534d7e493c5b105040976b737b4e"
+                        }
+                    ]
+                }
+            },
+            "depth": {
+                "quantity": 19940,
+                "unit": "block"
+            },
+            "id": "1a442b7f7a9519222953f3283f1e3b664848238a0ed3923b12591c134c5f3a59",
+            "deposit": {
+                "quantity": 193,
+                "unit": "lovelace"
+            },
             "collateral": [],
             "mint": []
         }

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -48,7 +48,13 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( Tx (..), TxIn (..), TxMetadata (..), TxOut (..), TxSize (..) )
+    ( ScriptValidation (..)
+    , Tx (..)
+    , TxIn (..)
+    , TxMetadata (..)
+    , TxOut (..)
+    , TxSize (..)
+    )
 import Data.Coerce
     ( coerce )
 import Data.Functor.Identity
@@ -130,7 +136,7 @@ mkTx
     -> [TxOut]
     -> Map RewardAccount Coin
     -> Maybe TxMetadata
-    -> Maybe Bool
+    -> ScriptValidation
     -> Tx
 mkTx fees ins cins outs wdrls md isValid =
     Tx

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -48,11 +48,11 @@ import Cardano.Wallet.Primitive.Types.Hash
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( ScriptValidation (..)
-    , Tx (..)
+    ( Tx (..)
     , TxIn (..)
     , TxMetadata (..)
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxSize (..)
     )
 import Data.Coerce
@@ -136,7 +136,7 @@ mkTx
     -> [TxOut]
     -> Map RewardAccount Coin
     -> Maybe TxMetadata
-    -> ScriptValidation
+    -> TxScriptValidity
     -> Tx
 mkTx fees ins cins outs wdrls md isValid =
     Tx

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -138,7 +138,7 @@ mkTx
     -> Maybe TxMetadata
     -> Maybe TxScriptValidity
     -> Tx
-mkTx fees ins cins outs wdrls md isValid =
+mkTx fees ins cins outs wdrls md validity =
     Tx
       { txId = (mkTxId ins outs wdrls md)
       , fee = fees
@@ -147,7 +147,7 @@ mkTx fees ins cins outs wdrls md isValid =
       , outputs = outs
       , withdrawals = wdrls
       , metadata = md
-      , scriptValidity = isValid
+      , scriptValidity = validity
       }
 
 -- | txId calculation for testing purposes.

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -136,7 +136,7 @@ mkTx
     -> [TxOut]
     -> Map RewardAccount Coin
     -> Maybe TxMetadata
-    -> TxScriptValidity
+    -> Maybe TxScriptValidity
     -> Tx
 mkTx fees ins cins outs wdrls md isValid =
     Tx

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -130,8 +130,9 @@ mkTx
     -> [TxOut]
     -> Map RewardAccount Coin
     -> Maybe TxMetadata
+    -> Maybe Bool
     -> Tx
-mkTx fees ins cins outs wdrls md =
+mkTx fees ins cins outs wdrls md isValid =
     Tx
       { txId = (mkTxId ins outs wdrls md)
       , fee = fees
@@ -140,6 +141,7 @@ mkTx fees ins cins outs wdrls md =
       , outputs = outs
       , withdrawals = wdrls
       , metadata = md
+      , isValidScript = isValid
       }
 
 -- | txId calculation for testing purposes.

--- a/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test/shared/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -147,7 +147,7 @@ mkTx fees ins cins outs wdrls md isValid =
       , outputs = outs
       , withdrawals = wdrls
       , metadata = md
-      , isValidScript = isValid
+      , scriptValidity = isValid
       }
 
 -- | txId calculation for testing purposes.

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -387,6 +387,7 @@ import Test.QuickCheck
     , counterexample
     , elements
     , frequency
+    , liftArbitrary
     , liftShrink
     , liftShrink2
     , listOf
@@ -2194,7 +2195,7 @@ instance Arbitrary (ApiTransaction n) where
             <*> arbitrary
             <*> pure txStatus
             <*> arbitrary
-            <*> arbitrary
+            <*> (liftArbitrary $ ApiT <$> genTxScriptValidity)
       where
         genInputs =
             Test.QuickCheck.scale (`mod` 3) arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -2195,7 +2195,7 @@ instance Arbitrary (ApiTransaction n) where
             <*> arbitrary
             <*> pure txStatus
             <*> arbitrary
-            <*> (liftArbitrary $ ApiT <$> genTxScriptValidity)
+            <*> liftArbitrary (ApiT <$> genTxScriptValidity)
       where
         genInputs =
             Test.QuickCheck.scale (`mod` 3) arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -526,6 +526,7 @@ spec = parallel $ do
             jsonRoundtripAndGolden $ Proxy @(ApiT Direction)
             jsonRoundtripAndGolden $ Proxy @(ApiT TxMetadata)
             jsonRoundtripAndGolden $ Proxy @(ApiT TxStatus)
+            jsonRoundtripAndGolden $ Proxy @(ApiT TxScriptValidity)
             jsonRoundtripAndGolden $ Proxy @(ApiWalletBalance)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletId)
             jsonRoundtripAndGolden $ Proxy @(ApiT WalletName)

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -268,16 +268,16 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenName )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , SerialisedTx (..)
     , SerialisedTxParts (..)
     , TxIn (..)
     , TxMetadata (..)
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxStatus (..)
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genScriptValidation, shrinkScriptValidation )
+    ( genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( HistogramBar (..)
     , UTxO (..)
@@ -2205,9 +2205,9 @@ instance Arbitrary (ApiTransaction n) where
         genCollateral =
             Test.QuickCheck.scale (`mod` 3) arbitrary
 
-instance Arbitrary ScriptValidation where
-    arbitrary = genScriptValidation
-    shrink = shrinkScriptValidation
+instance Arbitrary TxScriptValidity where
+    arbitrary = genTxScriptValidity
+    shrink = shrinkTxScriptValidity
 
 instance Arbitrary (ApiWithdrawal (t :: NetworkDiscriminant)) where
     arbitrary = ApiWithdrawal

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -268,6 +268,7 @@ import Cardano.Wallet.Primitive.Types.TokenPolicy.Gen
     ( genTokenName )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , SerialisedTx (..)
     , SerialisedTxParts (..)
     , TxIn (..)
@@ -275,6 +276,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxOut (..)
     , TxStatus (..)
     )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genScriptValidation, shrinkScriptValidation )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( HistogramBar (..)
     , UTxO (..)
@@ -2201,6 +2204,10 @@ instance Arbitrary (ApiTransaction n) where
             Test.QuickCheck.scale (`mod` 3) arbitrary
         genCollateral =
             Test.QuickCheck.scale (`mod` 3) arbitrary
+
+instance Arbitrary ScriptValidation where
+    arbitrary = genScriptValidation
+    shrink = shrinkScriptValidation
 
 instance Arbitrary (ApiWithdrawal (t :: NetworkDiscriminant)) where
     arbitrary = ApiWithdrawal

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1109,6 +1109,8 @@ spec = parallel $ do
                         (x :: ApiTransaction ('Testnet 0))
                     , metadata = metadata
                         (x :: ApiTransaction ('Testnet 0))
+                    , isValidScript = isValidScript
+                        (x :: ApiTransaction ('Testnet 0))
                     }
             in
                 x' === x .&&. show x' === show x
@@ -2188,6 +2190,7 @@ instance Arbitrary (ApiTransaction n) where
             <*> genWithdrawals
             <*> arbitrary
             <*> pure txStatus
+            <*> arbitrary
             <*> arbitrary
       where
         genInputs =

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -1112,7 +1112,7 @@ spec = parallel $ do
                         (x :: ApiTransaction ('Testnet 0))
                     , metadata = metadata
                         (x :: ApiTransaction ('Testnet 0))
-                    , isValidScript = isValidScript
+                    , scriptValidity = scriptValidity
                         (x :: ApiTransaction ('Testnet 0))
                     }
             in

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -380,10 +380,10 @@ arbitraryChainLength = 10
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Tx where
-    shrink (Tx _tid fees ins cins outs wdrls md isValid) =
-        [ mkTx fees ins' cins' outs' wdrls' md' isValid'
-        | (ins', cins', outs', wdrls', md', isValid') <-
-            shrink (ins, cins, outs, wdrls, md, isValid)
+    shrink (Tx _tid fees ins cins outs wdrls md validity) =
+        [ mkTx fees ins' cins' outs' wdrls' md' validity'
+        | (ins', cins', outs', wdrls', md', validity') <-
+            shrink (ins, cins, outs, wdrls, md, validity)
         ]
 
     arbitrary = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -186,6 +186,7 @@ import Test.QuickCheck
     , frequency
     , generate
     , genericShrink
+    , liftArbitrary
     , oneof
     , scale
     , shrinkIntegral
@@ -391,7 +392,8 @@ instance Arbitrary Tx where
         outs <- fmap (L.take 5 . getNonEmpty) arbitrary
         wdrls <- fmap (Map.fromList . L.take 5) arbitrary
         fees <- arbitrary
-        mkTx fees ins cins outs wdrls <$> arbitrary <*> arbitrary
+        mkTx fees ins cins outs wdrls
+            <$> arbitrary <*> liftArbitrary genTxScriptValidity
 
 instance Arbitrary TxIn where
     arbitrary = TxIn

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -376,10 +376,10 @@ arbitraryChainLength = 10
 -------------------------------------------------------------------------------}
 
 instance Arbitrary Tx where
-    shrink (Tx _tid fees ins cins outs wdrls md) =
-        [ mkTx fees ins' cins' outs' wdrls' md'
-        | (ins', cins', outs', wdrls', md') <-
-            shrink (ins, cins, outs, wdrls, md)
+    shrink (Tx _tid fees ins cins outs wdrls md isValid) =
+        [ mkTx fees ins' cins' outs' wdrls' md' isValid'
+        | (ins', cins', outs', wdrls', md', isValid') <-
+            shrink (ins, cins, outs, wdrls, md, isValid)
         ]
 
     arbitrary = do
@@ -388,7 +388,7 @@ instance Arbitrary Tx where
         outs <- fmap (L.take 5 . getNonEmpty) arbitrary
         wdrls <- fmap (Map.fromList . L.take 5) arbitrary
         fees <- arbitrary
-        mkTx fees ins cins outs wdrls <$> arbitrary
+        mkTx fees ins cins outs wdrls <$> arbitrary <*> arbitrary
 
 instance Arbitrary TxIn where
     arbitrary = TxIn

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -121,17 +121,17 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
     , TxMetadata
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxStatus (..)
     , isPending
     )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genScriptValidation, shrinkScriptValidation )
+    ( genTxScriptValidity, shrinkTxScriptValidity )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe
@@ -720,9 +720,9 @@ instance Arbitrary AddressState where
 instance Arbitrary SomeMnemonic where
     arbitrary = SomeMnemonic <$> genMnemonic @12
 
-instance Arbitrary ScriptValidation where
-    arbitrary = genScriptValidation
-    shrink = shrinkScriptValidation
+instance Arbitrary TxScriptValidity where
+    arbitrary = genTxScriptValidity
+    shrink = shrinkTxScriptValidity
 
 {-------------------------------------------------------------------------------
                                    Buildable

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -121,6 +121,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genTokenBundleSmallRange )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
@@ -129,6 +130,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxStatus (..)
     , isPending
     )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genScriptValidation, shrinkScriptValidation )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe
@@ -716,6 +719,10 @@ instance Arbitrary AddressState where
 
 instance Arbitrary SomeMnemonic where
     arbitrary = SomeMnemonic <$> genMnemonic @12
+
+instance Arbitrary ScriptValidation where
+    arbitrary = genScriptValidation
+    shrink = shrinkScriptValidation
 
 {-------------------------------------------------------------------------------
                                    Buildable

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
@@ -27,9 +27,9 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( ScriptValidation, TxMetadata )
+    ( TxMetadata, TxScriptValidity )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genScriptValidation, shrinkScriptValidation )
+    ( genTxScriptValidity, shrinkTxScriptValidity )
 import Data.Either
     ( isLeft )
 import Data.Proxy
@@ -74,7 +74,7 @@ spec = do
         persistRoundtrip $ Proxy @StdGen
         persistRoundtrip $ Proxy @(Nested TxMetadata)
         persistRoundtrip $ Proxy @(Simple TxMetadata)
-        persistRoundtrip $ Proxy @ScriptValidation
+        persistRoundtrip $ Proxy @TxScriptValidity
 
     describe "Backwards compatible instance PersistField StdGen" $ do
         it "rnd_state empty" $
@@ -171,6 +171,6 @@ instance PersistField a => PersistField (Simple a) where
 instance Arbitrary StdGen where
     arbitrary = mkStdGen <$> arbitrary
 
-instance Arbitrary ScriptValidation where
-    arbitrary = genScriptValidation
-    shrink = shrinkScriptValidation
+instance Arbitrary TxScriptValidity where
+    arbitrary = genTxScriptValidity
+    shrink = shrinkTxScriptValidity

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
@@ -27,7 +27,9 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.TokenQuantity.Gen
     ( genTokenQuantityFullRange, shrinkTokenQuantityFullRange )
 import Cardano.Wallet.Primitive.Types.Tx
-    ( TxMetadata )
+    ( ScriptValidation, TxMetadata )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genScriptValidation, shrinkScriptValidation )
 import Data.Either
     ( isLeft )
 import Data.Proxy
@@ -72,6 +74,7 @@ spec = do
         persistRoundtrip $ Proxy @StdGen
         persistRoundtrip $ Proxy @(Nested TxMetadata)
         persistRoundtrip $ Proxy @(Simple TxMetadata)
+        persistRoundtrip $ Proxy @ScriptValidation
 
     describe "Backwards compatible instance PersistField StdGen" $ do
         it "rnd_state empty" $
@@ -167,3 +170,7 @@ instance PersistField a => PersistField (Simple a) where
 
 instance Arbitrary StdGen where
     arbitrary = mkStdGen <$> arbitrary
+
+instance Arbitrary ScriptValidation where
+    arbitrary = genScriptValidation
+    shrink = shrinkScriptValidation

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -148,6 +148,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , TransactionInfo (..)
     , Tx (..)
     , TxIn (..)
@@ -580,7 +581,7 @@ fileModeSpec =  do
                                     ]
                                 , withdrawals = mempty
                                 , metadata = Nothing
-                                , isValidScript = Just True
+                                , isValidScript = ScriptValidationPassed
                                 }
                             ]
 
@@ -601,7 +602,7 @@ fileModeSpec =  do
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = Just False
+                            , isValidScript = ScriptValidationFailed
                             }
                         ]
 
@@ -638,7 +639,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = Nothing
+                            , isValidScript = ScriptsNotSupported
                             }
                         ]
 
@@ -660,7 +661,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = Nothing
+                        , isValidScript = ScriptsNotSupported
                         }
                     ]
 
@@ -1272,7 +1273,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = Nothing
+        , isValidScript = ScriptsNotSupported
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -581,7 +581,7 @@ fileModeSpec =  do
                                     ]
                                 , withdrawals = mempty
                                 , metadata = Nothing
-                                , scriptValidity = TxScriptValid
+                                , scriptValidity = Just TxScriptValid
                                 }
                             ]
 
@@ -602,7 +602,7 @@ fileModeSpec =  do
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , scriptValidity = TxScriptInvalid
+                            , scriptValidity = Just TxScriptInvalid
                             }
                         ]
 
@@ -639,7 +639,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , scriptValidity = TxScriptUnsupported
+                            , scriptValidity = Nothing
                             }
                         ]
 
@@ -661,7 +661,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , scriptValidity = TxScriptUnsupported
+                        , scriptValidity = Nothing
                         }
                     ]
 
@@ -1273,7 +1273,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
-        , scriptValidity = TxScriptUnsupported
+        , scriptValidity = Nothing
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -581,7 +581,7 @@ fileModeSpec =  do
                                     ]
                                 , withdrawals = mempty
                                 , metadata = Nothing
-                                , isValidScript = TxScriptValid
+                                , scriptValidity = TxScriptValid
                                 }
                             ]
 
@@ -602,7 +602,7 @@ fileModeSpec =  do
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = TxScriptInvalid
+                            , scriptValidity = TxScriptInvalid
                             }
                         ]
 
@@ -639,7 +639,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = TxScriptsUnsupported
+                            , scriptValidity = TxScriptsUnsupported
                             }
                         ]
 
@@ -661,7 +661,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = TxScriptsUnsupported
+                        , scriptValidity = TxScriptsUnsupported
                         }
                     ]
 
@@ -1273,7 +1273,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = TxScriptsUnsupported
+        , scriptValidity = TxScriptsUnsupported
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -524,11 +524,12 @@ fileModeSpec =  do
             testOpeningCleaning f (`readCheckpoint'` testWid) (Just testCp) Nothing
 
         describe "Golden rollback scenarios" $ do
-            let dummyHash x = Hash $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
-            let dummyAddr x = Address $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
+            let dummyHash x = Hash $
+                    x <> BS.pack (replicate (32 - (BS.length x)) 0)
+            let dummyAddr x = Address $
+                    x <> BS.pack (replicate (32 - (BS.length x)) 0)
 
-            let
-                mockApply DBLayer{..} h mockTxs = do
+            let mockApply DBLayer{..} h mockTxs = do
                     Just cpA <- atomically $ readCheckpoint testWid
                     let slotA = view #slotNo $ currentTip cpA
                     let Quantity bhA = view #blockHeight $ currentTip cpA
@@ -551,10 +552,9 @@ fileModeSpec =  do
                         unsafeRunExceptT $ putTxHistory testWid txs
                         unsafeRunExceptT $ prune testWid (Quantity 2160)
 
-
-            it "Should remove collateral inputs from the UTxO set if validation \
-               \fails" $ \f ->
-                withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
+            it "Should remove collateral inputs from the UTxO set if \
+                \validation fails" $
+                \f -> withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
 
                     let ourAddrs =
                             map (\(a,s,_) -> (a,s)) $
@@ -594,11 +594,15 @@ fileModeSpec =  do
                         [ Tx
                             { txId = dummyHash "tx2a"
                             , fee = Nothing
-                            , resolvedInputs = [(TxIn (dummyHash "tx1") 0, Coin 4)]
-                            , resolvedCollateral = [(TxIn (dummyHash "tx1") 1, Coin 8)]
+                            , resolvedInputs =
+                                [(TxIn (dummyHash "tx1") 0, Coin 4)]
+                            , resolvedCollateral =
+                                [(TxIn (dummyHash "tx1") 1, Coin 8)]
                             , outputs =
-                                [ TxOut (dummyAddr "faucetAddr2") (coinToBundle 2)
-                                , TxOut (fst $ ourAddrs !! 1) (coinToBundle 2)
+                                [ TxOut
+                                    (dummyAddr "faucetAddr2") (coinToBundle 2)
+                                , TxOut
+                                    (fst $ ourAddrs !! 1) (coinToBundle 2)
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -639,7 +639,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , scriptValidity = TxScriptsUnsupported
+                            , scriptValidity = TxScriptUnsupported
                             }
                         ]
 
@@ -661,7 +661,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , scriptValidity = TxScriptsUnsupported
+                        , scriptValidity = TxScriptUnsupported
                         }
                     ]
 
@@ -1273,7 +1273,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
-        , scriptValidity = TxScriptsUnsupported
+        , scriptValidity = TxScriptUnsupported
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -118,6 +118,7 @@ import Cardano.Wallet.Primitive.Model
     , currentTip
     , getState
     , initWallet
+    , utxo
     )
 import Cardano.Wallet.Primitive.Types
     ( ActiveSlotCoefficient (..)
@@ -525,6 +526,95 @@ fileModeSpec =  do
             let dummyHash x = Hash $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
             let dummyAddr x = Address $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
 
+            let
+                mockApply DBLayer{..} h mockTxs = do
+                    Just cpA <- atomically $ readCheckpoint testWid
+                    let slotA = view #slotNo $ currentTip cpA
+                    let Quantity bhA = view #blockHeight $ currentTip cpA
+                    let hashA = headerHash $ currentTip cpA
+                    let fakeBlock = Block
+                            (BlockHeader
+                            { slotNo = slotA + 100
+                            -- Increment blockHeight by steps greater than k
+                            -- Such that old checkpoints are always pruned.
+                            , blockHeight = Quantity $ bhA + 5000
+                            , headerHash = h
+                            , parentHeaderHash = hashA
+                            })
+                            mockTxs
+                            mempty
+                    let (FilteredBlock _ txs, cpB) = applyBlock fakeBlock cpA
+                    print $ utxo cpB
+                    atomically $ do
+                        unsafeRunExceptT $ putCheckpoint testWid cpB
+                        unsafeRunExceptT $ putTxHistory testWid txs
+                        unsafeRunExceptT $ prune testWid (Quantity 2160)
+
+
+            it "Should remove collateral inputs from the UTxO set if validation \
+               \fails" $ \f ->
+                withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
+
+                    let ourAddrs =
+                            map (\(a,s,_) -> (a,s)) $
+                            knownAddresses (getState testCp)
+
+                    atomically $ unsafeRunExceptT $ initializeWallet
+                        testWid testCp testMetadata mempty gp
+
+                    -- Provide funds for us to transfer AND use as collateral
+                    let mockApplyBlock1 = mockApply db (dummyHash "block1")
+                            [ Tx
+                                { txId = dummyHash "tx1"
+                                , fee = Nothing
+                                , resolvedInputs =
+                                    [ (TxIn (dummyHash "faucet") 0, Coin 4)
+                                    , (TxIn (dummyHash "faucet") 1, Coin 8)
+                                    ]
+                                , resolvedCollateral = []
+                                , outputs =
+                                    [ TxOut (fst $ head ourAddrs)
+                                            (coinToBundle 4)
+                                    , TxOut (fst $ head $ tail ourAddrs)
+                                            (coinToBundle 8)
+                                    ]
+                                , withdrawals = mempty
+                                , metadata = Nothing
+                                , isValidScript = Just True
+                                }
+                            ]
+
+                    -- Slot 1 0
+                    mockApplyBlock1
+                    getAvailableBalance db `shouldReturn` 12
+
+                    -- Slot 200
+                    mockApply db (dummyHash "block2a")
+                        [ Tx
+                            { txId = dummyHash "tx2a"
+                            , fee = Nothing
+                            , resolvedInputs = [(TxIn (dummyHash "tx1") 0, Coin 4)]
+                            , resolvedCollateral = [(TxIn (dummyHash "tx1") 1, Coin 8)]
+                            , outputs =
+                                [ TxOut (dummyAddr "faucetAddr2") (coinToBundle 2)
+                                , TxOut (fst $ ourAddrs !! 1) (coinToBundle 2)
+                                ]
+                            , withdrawals = mempty
+                            , metadata = Nothing
+                            , isValidScript = Just False
+                            }
+                        ]
+
+                    -- Slot 300
+                    mockApply db (dummyHash "block3a") []
+                    getTxsInLedger db `shouldReturn`
+                        -- We lost 8 to collateral
+                        [ (Outgoing, 8)
+                        -- We got 12 from the faucet
+                        , (Incoming, 12)
+                        ]
+                    getAvailableBalance db `shouldReturn` 4
+
             it "(Regression test #1575) - TxMetas and checkpoints should \
                \rollback to the same place" $ \f -> do
               withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
@@ -536,29 +626,7 @@ fileModeSpec =  do
                 atomically $ unsafeRunExceptT $ initializeWallet
                     testWid testCp testMetadata mempty gp
 
-                let mockApply h mockTxs = do
-                        Just cpA <- atomically $ readCheckpoint testWid
-                        let slotA = view #slotNo $ currentTip cpA
-                        let Quantity bhA = view #blockHeight $ currentTip cpA
-                        let hashA = headerHash $ currentTip cpA
-                        let fakeBlock = Block
-                                (BlockHeader
-                                { slotNo = slotA + 100
-                                -- Increment blockHeight by steps greater than k
-                                -- Such that old checkpoints are always pruned.
-                                , blockHeight = Quantity $ bhA + 5000
-                                , headerHash = h
-                                , parentHeaderHash = hashA
-                                })
-                                mockTxs
-                                mempty
-                        let (FilteredBlock _ txs, cpB) = applyBlock fakeBlock cpA
-                        atomically $ do
-                            unsafeRunExceptT $ putCheckpoint testWid cpB
-                            unsafeRunExceptT $ putTxHistory testWid txs
-                            unsafeRunExceptT $ prune testWid (Quantity 2160)
-
-                let mockApplyBlock1 = mockApply (dummyHash "block1")
+                let mockApplyBlock1 = mockApply db (dummyHash "block1")
                         [ Tx
                             { txId = dummyHash "tx1"
                             , fee = Nothing
@@ -579,7 +647,7 @@ fileModeSpec =  do
                 getAvailableBalance db `shouldReturn` 4
 
                 -- Slot 200
-                mockApply (dummyHash "block2a")
+                mockApply db (dummyHash "block2a")
                     [ Tx
                         { txId = dummyHash "tx2a"
                         , fee = Nothing
@@ -597,7 +665,7 @@ fileModeSpec =  do
                     ]
 
                 -- Slot 300
-                mockApply (dummyHash "block3a") []
+                mockApply db (dummyHash "block3a") []
                 getAvailableBalance db `shouldReturn` 2
                 getTxsInLedger db `shouldReturn` [(Outgoing, 2), (Incoming, 4)]
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -570,6 +570,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
+                            , isValidScript = Nothing
                             }
                         ]
 
@@ -591,6 +592,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
+                        , isValidScript = Nothing
                         }
                     ]
 
@@ -1202,6 +1204,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
+        , isValidScript = Nothing
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -148,12 +148,12 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , TransactionInfo (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (..)
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxStatus (..)
     , toTxHistory
     )
@@ -581,7 +581,7 @@ fileModeSpec =  do
                                     ]
                                 , withdrawals = mempty
                                 , metadata = Nothing
-                                , isValidScript = ScriptValidationPassed
+                                , isValidScript = TxScriptValid
                                 }
                             ]
 
@@ -602,7 +602,7 @@ fileModeSpec =  do
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = ScriptValidationFailed
+                            , isValidScript = TxScriptInvalid
                             }
                         ]
 
@@ -639,7 +639,7 @@ fileModeSpec =  do
                                 [TxOut (fst $ head ourAddrs) (coinToBundle 4)]
                             , withdrawals = mempty
                             , metadata = Nothing
-                            , isValidScript = ScriptsNotSupported
+                            , isValidScript = TxScriptsUnsupported
                             }
                         ]
 
@@ -661,7 +661,7 @@ fileModeSpec =  do
                             ]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = ScriptsNotSupported
+                        , isValidScript = TxScriptsUnsupported
                         }
                     ]
 
@@ -1273,7 +1273,7 @@ testTxs = [(tx, txMeta)]
         , outputs = [TxOut (Address "addr") (coinToBundle 1)]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = ScriptsNotSupported
+        , isValidScript = TxScriptsUnsupported
         }
     txMeta = TxMeta
         { status = InLedger

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -963,9 +963,8 @@ instance ToExpr WalletMetadata where
 instance ToExpr Tx where
     toExpr = genericToExpr
 
-    -- toExpr = genericToExpr
-    toExpr = error "toExpr"
 instance ToExpr TxScriptValidity where
+    toExpr = genericToExpr
 
 instance ToExpr TxIn where
     toExpr = genericToExpr

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -153,7 +153,6 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , LocalTxSubmissionStatus (..)
-    , ScriptValidation
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -161,6 +160,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxMetadata
     , TxOut (..)
+    , TxScriptValidity
     , TxSize (..)
     , TxStatus
     , inputs
@@ -963,9 +963,9 @@ instance ToExpr WalletMetadata where
 instance ToExpr Tx where
     toExpr = genericToExpr
 
-instance ToExpr ScriptValidation where
     -- toExpr = genericToExpr
     toExpr = error "toExpr"
+instance ToExpr TxScriptValidity where
 
 instance ToExpr TxIn where
     toExpr = genericToExpr

--- a/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/StateMachine.hs
@@ -153,6 +153,7 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , LocalTxSubmissionStatus (..)
+    , ScriptValidation
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -961,6 +962,10 @@ instance ToExpr WalletMetadata where
 
 instance ToExpr Tx where
     toExpr = genericToExpr
+
+instance ToExpr ScriptValidation where
+    -- toExpr = genericToExpr
+    toExpr = error "toExpr"
 
 instance ToExpr TxIn where
     toExpr = genericToExpr

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -70,11 +70,11 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
-    , ScriptValidation (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (direction)
     , TxOut (..)
+    , TxScriptValidity (..)
     , collateralInputs
     , failedScriptValidation
     , inputs
@@ -831,7 +831,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = ScriptsNotSupported
+                        , isValidScript = TxScriptsUnsupported
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -907,7 +907,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -942,7 +942,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -966,7 +966,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1001,7 +1001,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1025,7 +1025,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1060,7 +1060,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1105,7 +1105,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1139,7 +1139,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1174,7 +1174,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1223,7 +1223,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1298,7 +1298,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1322,7 +1322,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1357,7 +1357,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1381,7 +1381,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1476,7 +1476,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1500,7 +1500,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1535,7 +1535,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = ScriptsNotSupported
+                , isValidScript = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1633,7 +1633,7 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedInputs = [(txin, coin)]
-                   , isValidScript = ScriptsNotSupported
+                   , isValidScript = TxScriptsUnsupported
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
@@ -1647,7 +1647,7 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , isValidScript = ScriptValidationFailed
+                   , isValidScript = TxScriptInvalid
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -152,7 +152,8 @@ import Test.QuickCheck
     , (.&&.)
     , (===)
     )
-import Test.QuickCheck.Extra (report)
+import Test.QuickCheck.Extra
+    ( report )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1594,6 +1594,12 @@ prop_applyTxToUTxO_balance tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (applyTxToUTxO tx u) === expectedBalance
   where
     expectedBalance =
@@ -1613,6 +1619,12 @@ prop_applyTxToUTxO_entries tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     applyTxToUTxO tx u === expectedResult
   where
     expectedResult =
@@ -1630,6 +1642,12 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
     cover 10
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
     ===
     expectedResult
@@ -1646,6 +1664,13 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
 
 prop_utxoFromTx_is_unspent :: Tx -> Property
 prop_utxoFromTx_is_unspent tx =
+    checkCoverage $
+    cover 10
+        (utxoFromTx tx /= mempty)
+        "utxoFromTx tx /= mempty" $
+    cover 10
+        (Set.fromList (inputs tx) /= mempty)
+        "Set.fromList (inputs tx) /= mempty" $
     utxoFromTx tx `excluding` Set.fromList (inputs tx)
     === utxoFromTx tx
 
@@ -1673,6 +1698,16 @@ unit_applyTxToUTxO_loses_collateral tx txin txout coin =
 
 prop_utxoFromTx_balance :: Tx -> Property
 prop_utxoFromTx_balance tx =
+    checkCoverage $
+    cover 10
+        (outputs tx /= mempty)
+        "outputs tx /= mempty" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (utxoFromTx tx) === foldMap f (outputs tx)
   where
     f output =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -831,7 +831,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = TxScriptsUnsupported
+                        , scriptValidity = TxScriptsUnsupported
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -907,7 +907,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -942,7 +942,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -966,7 +966,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1001,7 +1001,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1025,7 +1025,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1060,7 +1060,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1105,7 +1105,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1139,7 +1139,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1174,7 +1174,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1223,7 +1223,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1298,7 +1298,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1322,7 +1322,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1357,7 +1357,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1381,7 +1381,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1476,7 +1476,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1500,7 +1500,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1535,7 +1535,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = TxScriptsUnsupported
+                , scriptValidity = TxScriptsUnsupported
                 }
             ]
         , delegations = []
@@ -1584,11 +1584,6 @@ prop_applyTxToUTxO_balance tx u =
              `TokenBundle.add` balance (utxoFromTx tx)
     )
 
-prop_applyTxToUTxO_entries :: Property
-prop_applyTxToUTxO_entries =
-    forAllShrink genTx shrinkTx $ \tx ->
-    forAllShrink genUTxO shrinkUTxO $ \u ->
-
 prop_applyTxToUTxO_entries :: Tx -> UTxO -> Property
 prop_applyTxToUTxO_entries tx u =
     checkCoverage $
@@ -1633,7 +1628,7 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedInputs = [(txin, coin)]
-                   , isValidScript = TxScriptsUnsupported
+                   , scriptValidity = TxScriptsUnsupported
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
@@ -1647,7 +1642,7 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , isValidScript = TxScriptInvalid
+                   , scriptValidity = TxScriptInvalid
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
@@ -1660,7 +1655,7 @@ prop_filterByAddress_balance_applyTxToUTxO b =
     in
         forAllShrink genTx shrinkTx $ \tx ->
             balance (filterByAddress f (applyTxToUTxO tx mempty))
-            === if failedScriptValidation (tx ^. #isValidScript)
+            === if failedScriptValidation (tx ^. #scriptValidity)
                 then mempty
                 else foldMap (\o -> if f (address o)
                                     then tokens o

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -152,6 +152,7 @@ import Test.QuickCheck
     , (.&&.)
     , (===)
     )
+import Test.QuickCheck.Extra (report)
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
@@ -503,8 +504,12 @@ prop_changeUTxO_inner pendingTxs =
           -- No outputs are omitted when we select everything:
         , UTxO.size utxoAll == F.sum (F.length . view #outputs <$> pendingTxs)
         ]
-    & counterexample ("size utxoAll = " <> show (UTxO.size utxoAll))
-    & counterexample ("sum outputs = " <> show (F.sum (F.length . view #outputs <$> pendingTxs)))
+    & report
+        (UTxO.size utxoAll)
+        "UTxO.size utxoAll"
+    & report
+        (F.sum (F.length . view #outputs <$> pendingTxs))
+        "F.sum (F.length . view #outputs <$> pendingTxs)"
   where
     -- Computes the parity of an output based on its address parity.
     txOutParity :: TxOut -> Parity

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -70,6 +70,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
+    , ScriptValidation (..)
     , Tx (..)
     , TxIn (..)
     , TxMeta (direction)
@@ -830,7 +831,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , isValidScript = Nothing
+                        , isValidScript = ScriptsNotSupported
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -906,7 +907,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -941,7 +942,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -965,7 +966,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1000,7 +1001,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1024,7 +1025,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1059,7 +1060,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1104,7 +1105,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1138,7 +1139,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1173,7 +1174,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1222,7 +1223,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1297,7 +1298,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1321,7 +1322,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1356,7 +1357,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1380,7 +1381,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1475,7 +1476,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1499,7 +1500,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1534,7 +1535,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , isValidScript = Nothing
+                , isValidScript = ScriptsNotSupported
                 }
             ]
         , delegations = []
@@ -1632,7 +1633,7 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedInputs = [(txin, coin)]
-                   , isValidScript = Nothing
+                   , isValidScript = ScriptsNotSupported
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
@@ -1646,7 +1647,7 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , isValidScript = Just False
+                   , isValidScript = ScriptValidationFailed
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -822,6 +822,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
+                        , isValidScript = Nothing
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -897,6 +898,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -931,6 +933,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -954,6 +957,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -988,6 +992,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1011,6 +1016,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1045,6 +1051,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1089,6 +1096,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1122,6 +1130,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1156,6 +1165,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1204,6 +1214,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1278,6 +1289,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1301,6 +1313,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1335,6 +1348,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1358,6 +1372,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1452,6 +1467,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1475,6 +1491,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []
@@ -1509,6 +1526,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
+                , isValidScript = Nothing
                 }
             ]
         , delegations = []

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -831,7 +831,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , scriptValidity = TxScriptsUnsupported
+                        , scriptValidity = TxScriptUnsupported
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -907,7 +907,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -942,7 +942,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -966,7 +966,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1001,7 +1001,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1025,7 +1025,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1060,7 +1060,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1105,7 +1105,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1139,7 +1139,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1174,7 +1174,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1223,7 +1223,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1298,7 +1298,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1322,7 +1322,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1357,7 +1357,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1381,7 +1381,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1476,7 +1476,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1500,7 +1500,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1535,7 +1535,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptsUnsupported
+                , scriptValidity = TxScriptUnsupported
                 }
             ]
         , delegations = []
@@ -1631,7 +1631,7 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedInputs = [(txin, coin)]
-                   , scriptValidity = TxScriptsUnsupported
+                   , scriptValidity = TxScriptUnsupported
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -831,7 +831,7 @@ instance Arbitrary (WithPending WalletState) where
                         , outputs = [out {tokens}]
                         , withdrawals = mempty
                         , metadata = Nothing
-                        , scriptValidity = TxScriptUnsupported
+                        , scriptValidity = Nothing
                         }
 
                 elements [Set.singleton pending, Set.empty]
@@ -907,7 +907,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -942,7 +942,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             , Tx
                 { txId = Hash "b17ca3d2b8a991ea4680d1ebd9940a03449b1b6261fbe625d5cae6599726ea41"
@@ -966,7 +966,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1001,7 +1001,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             , Tx
                 { txId = Hash "6ed51b05821f0dc130a9411f0d63a241a624fbc8a9c8a2a13da8194ce3c463f4"
@@ -1025,7 +1025,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1060,7 +1060,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1105,7 +1105,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1139,7 +1139,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1174,7 +1174,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1223,7 +1223,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1298,7 +1298,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             , Tx
                 { txId = Hash "611ce641f0f9282a35b1678fcd996016833c0de9e83a04bfa1178c8f045196ea"
@@ -1322,7 +1322,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1357,7 +1357,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             , Tx
                 { txId = Hash "b8e9699ffff40c993d6778f586110b78cd30826feaa5314adf3a2e9894b9313a"
@@ -1381,7 +1381,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1476,7 +1476,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
               , Tx
                   { txId = Hash "7726526b5cc003f71d9629c611397285004b5438eac9a118c2b20e2810e0783e"
@@ -1500,7 +1500,7 @@ blockchain =
                       ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1535,7 +1535,7 @@ blockchain =
                     ]
                 , withdrawals = mempty
                 , metadata = Nothing
-                , scriptValidity = TxScriptUnsupported
+                , scriptValidity = Nothing
                 }
             ]
         , delegations = []
@@ -1631,7 +1631,7 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedInputs = [(txin, coin)]
-                   , scriptValidity = TxScriptUnsupported
+                   , scriptValidity = Nothing
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
@@ -1645,7 +1645,7 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genCoin shrinkCoin $ \coin ->
       let
           tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , scriptValidity = TxScriptInvalid
+                   , scriptValidity = Just TxScriptInvalid
                    }
       in
           applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -100,7 +100,7 @@ import Data.Function
 import Data.Functor
     ( ($>) )
 import Data.Generics.Internal.VL.Lens
-    ( over, view, (^.) )
+    ( over, view )
 import Data.Generics.Labels
     ()
 import Data.List
@@ -1595,15 +1595,15 @@ prop_applyTxToUTxO_balance tx u =
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     balance (applyTxToUTxO tx u) === expectedBalance
   where
     expectedBalance =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then
             balance (u `excluding` Set.fromList (collateralInputs tx))
         else
@@ -1620,15 +1620,15 @@ prop_applyTxToUTxO_entries tx u =
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     applyTxToUTxO tx u === expectedResult
   where
     expectedResult =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then u `excluding` Set.fromList (collateralInputs tx)
         else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
 
@@ -1643,17 +1643,17 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
     ===
     expectedResult
   where
     expectedResult =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then mempty
         else foldMap m (outputs tx)
       where
@@ -1703,15 +1703,15 @@ prop_utxoFromTx_balance tx =
         (outputs tx /= mempty)
         "outputs tx /= mempty" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx)" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx)" $
     balance (utxoFromTx tx) === foldMap f (outputs tx)
   where
     f output =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then mempty
         else tokens output
 
@@ -1752,7 +1752,7 @@ prop_spendTx_balance tx u =
     rhs = TokenBundle.unsafeSubtract (balance u) toSubtract
       where
         toSubtract =
-            if failedScriptValidation (tx ^. #scriptValidity)
+            if failedScriptValidation tx
             then balance
                 (u `UTxO.restrictedBy` Set.fromList (collateralInputs tx))
             else balance
@@ -1767,7 +1767,7 @@ prop_spendTx tx u =
     spendTx tx u === u `excluding` toExclude
   where
     toExclude =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then Set.fromList (collateralInputs tx)
         else Set.fromList (inputs tx)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -204,8 +204,10 @@ spec = do
                 (property prop_applyTxToUTxO_balance)
             it "has expected entries"
                 (property prop_applyTxToUTxO_entries)
-            it "consumes inputs" unit_applyTxToUTxO_spends_input
-            it "loses collateral" unit_applyTxToUTxO_loses_collateral
+            it "consumes inputs"
+                unit_applyTxToUTxO_spends_input
+            it "loses collateral"
+                unit_applyTxToUTxO_loses_collateral
             it "applyTxToUTxO then filterByAddress"
                 (property prop_filterByAddress_balance_applyTxToUTxO)
             it "spendTx/applyTxToUTxO/utxoFromTx"
@@ -1580,15 +1582,15 @@ prop_applyTxToUTxO_balance tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
-    balance (applyTxToUTxO tx u)
-    ===
-    (if failedScriptValidation (tx ^. #scriptValidity)
-     then
-         balance (u `excluding` Set.fromList (collateralInputs tx))
-     else
-         balance (u `excluding` Set.fromList (inputs tx))
-             `TokenBundle.add` balance (utxoFromTx tx)
-    )
+    balance (applyTxToUTxO tx u) === expectedBalance
+  where
+    expectedBalance =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then
+            balance (u `excluding` Set.fromList (collateralInputs tx))
+        else
+            balance (u `excluding` Set.fromList (inputs tx))
+                `TokenBundle.add` balance (utxoFromTx tx)
 
 prop_applyTxToUTxO_entries :: Tx -> UTxO -> Property
 prop_applyTxToUTxO_entries tx u =
@@ -1599,12 +1601,12 @@ prop_applyTxToUTxO_entries tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
-    applyTxToUTxO tx u
-    ===
-    (if failedScriptValidation (tx ^. #scriptValidity)
-     then u `excluding` Set.fromList (collateralInputs tx)
-     else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
-    )
+    applyTxToUTxO tx u === expectedResult
+  where
+    expectedResult =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then u `excluding` Set.fromList (collateralInputs tx)
+        else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
 
 prop_filterByAddress_balance_applyTxToUTxO
     :: (Address -> Bool) -> Tx -> Property
@@ -1617,12 +1619,18 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
-    === if failedScriptValidation (tx ^. #scriptValidity)
+    ===
+    expectedResult
+  where
+    expectedResult =
+        if failedScriptValidation (tx ^. #scriptValidity)
         then mempty
-        else foldMap (\o -> if f (address o)
-                            then tokens o
-                            else mempty
-                     ) (outputs tx)
+        else foldMap m (outputs tx)
+      where
+        m output =
+            if f (address output)
+            then tokens output
+            else mempty
 
 prop_utxoFromTx_is_unspent :: Tx -> Property
 prop_utxoFromTx_is_unspent tx =
@@ -1635,13 +1643,14 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genTxIn shrinkTxIn $ \txin ->
     forAllShrink genTxOut shrinkTxOut $ \txout ->
     forAllShrink genCoin shrinkCoin $ \coin ->
-      let
-          tx' = tx { resolvedInputs = [(txin, coin)]
-                   , scriptValidity = Nothing
-                   }
-      in
-          applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
-          === utxoFromTx tx' `excluding` Set.singleton txin
+    let
+        tx' = tx
+            { resolvedInputs = [(txin, coin)]
+            , scriptValidity = Nothing
+            }
+    in
+        applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
+        === utxoFromTx tx' `excluding` Set.singleton txin
 
 unit_applyTxToUTxO_loses_collateral :: Property
 unit_applyTxToUTxO_loses_collateral =
@@ -1649,21 +1658,23 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genTxIn shrinkTxIn $ \txin ->
     forAllShrink genTxOut shrinkTxOut $ \txout ->
     forAllShrink genCoin shrinkCoin $ \coin ->
-      let
-          tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , scriptValidity = Just TxScriptInvalid
-                   }
-      in
-          applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
-          === mempty
+    let
+        tx' = tx
+            { resolvedCollateral = [(txin, coin)]
+            , scriptValidity = Just TxScriptInvalid
+            }
+    in
+        applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
+        === mempty
 
 prop_utxoFromTx_balance :: Tx -> Property
 prop_utxoFromTx_balance tx =
-    balance (utxoFromTx tx)
-    === foldMap (\o -> if failedScriptValidation (tx ^. #scriptValidity)
-                       then mempty
-                       else tokens o
-                ) (outputs tx)
+    balance (utxoFromTx tx) === foldMap f (outputs tx)
+  where
+    f output =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then mempty
+        else tokens output
 
 -- spendTx tx u `isSubsetOf` u
 prop_spendTx_isSubset :: Tx -> UTxO -> Property
@@ -1699,14 +1710,14 @@ prop_spendTx_balance tx u =
     lhs === rhs
   where
     lhs = balance (spendTx tx u)
-    rhs = TokenBundle.unsafeSubtract
-        (balance u)
-        ( if failedScriptValidation (tx ^. #scriptValidity)
-          then balance (u `UTxO.restrictedBy`
-                         Set.fromList (collateralInputs tx))
-          else balance (u `UTxO.restrictedBy`
-                         Set.fromList (inputs tx))
-        )
+    rhs = TokenBundle.unsafeSubtract (balance u) toSubtract
+      where
+        toSubtract =
+            if failedScriptValidation (tx ^. #scriptValidity)
+            then balance
+                (u `UTxO.restrictedBy` Set.fromList (collateralInputs tx))
+            else balance
+                (u `UTxO.restrictedBy` Set.fromList (inputs tx))
 
 prop_spendTx :: Tx -> UTxO -> Property
 prop_spendTx tx u =
@@ -1714,11 +1725,12 @@ prop_spendTx tx u =
     cover 10
         (spendTx tx u /= mempty)
         "spendTx tx u /= mempty" $
-    spendTx tx u === u `excluding` (
+    spendTx tx u === u `excluding` toExclude
+  where
+    toExclude =
         if failedScriptValidation (tx ^. #scriptValidity)
         then Set.fromList (collateralInputs tx)
         else Set.fromList (inputs tx)
-    )
 
 prop_spendTx_utxoFromTx :: Tx -> UTxO -> Property
 prop_spendTx_utxoFromTx tx u =
@@ -1731,7 +1743,6 @@ prop_applyTxToUTxO_spendTx_utxoFromTx tx u =
         (spendTx tx u /= mempty && utxoFromTx tx /= mempty)
         "spendTx tx u /= mempty && utxoFromTx tx /= mempty" $
     applyTxToUTxO tx u === spendTx tx u <> utxoFromTx tx
-
 
 prop_spendTx_filterByAddress :: (Address -> Bool) -> Tx -> UTxO -> Property
 prop_spendTx_filterByAddress f tx u =

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -752,7 +752,7 @@ instance Arbitrary GenTxHistory where
         genTx' = mkTx <$> genTid
         hasPending = any ((== Pending) . view #status . snd)
         genTid = Hash . B8.pack <$> listOf1 (elements ['A'..'Z'])
-        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing
+        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing Nothing
         genTxMeta = do
             sl <- genSmallSlot
             let bh = Quantity $ fromIntegral $ unSlotNo sl
@@ -1288,7 +1288,7 @@ dummyTransactionLayer = TransactionLayer
         -- TODO: (ADP-957)
         let cinps' = []
         let tid = mkTxId inps' (outputsCovered cs) mempty Nothing
-        let tx = Tx tid Nothing inps' cinps' (outputsCovered cs) mempty Nothing
+        let tx = Tx tid Nothing inps' cinps' (outputsCovered cs) mempty Nothing Nothing
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither
                 (ErrKeyNotFoundForAddress addr) $ keystore addr

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -120,7 +120,6 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , LocalTxSubmissionStatus (..)
-    , ScriptValidation (..)
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -128,6 +127,7 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxMetadata
     , TxOut (..)
+    , TxScriptValidity (..)
     , TxStatus (..)
     , isPending
     , txOutCoin
@@ -753,7 +753,7 @@ instance Arbitrary GenTxHistory where
         genTx' = mkTx <$> genTid
         hasPending = any ((== Pending) . view #status . snd)
         genTid = Hash . B8.pack <$> listOf1 (elements ['A'..'Z'])
-        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing ScriptsNotSupported
+        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing TxScriptsUnsupported
         genTxMeta = do
             sl <- genSmallSlot
             let bh = Quantity $ fromIntegral $ unSlotNo sl
@@ -1296,7 +1296,7 @@ dummyTransactionLayer = TransactionLayer
                     (outputsCovered cs)
                     mempty
                     Nothing
-                    ScriptsNotSupported
+                    TxScriptsUnsupported
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither
                 (ErrKeyNotFoundForAddress addr) $ keystore addr

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1289,14 +1289,16 @@ dummyTransactionLayer = TransactionLayer
         -- TODO: (ADP-957)
         let cinps' = []
         let tid = mkTxId inps' (outputsCovered cs) mempty Nothing
-        let tx = Tx tid
-                    Nothing
-                    inps'
-                    cinps'
-                    (outputsCovered cs)
-                    mempty
-                    Nothing
-                    TxScriptsUnsupported
+        let tx = Tx
+                 { txId = tid
+                 , fee = Nothing
+                 , resolvedInputs = inps'
+                 , resolvedCollateral = cinps'
+                 , outputs = outputsCovered cs
+                 , withdrawals = mempty
+                 , metadata = Nothing
+                 , isValidScript = TxScriptsUnsupported
+                 }
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither
                 (ErrKeyNotFoundForAddress addr) $ keystore addr

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -1297,7 +1297,7 @@ dummyTransactionLayer = TransactionLayer
                  , outputs = outputsCovered cs
                  , withdrawals = mempty
                  , metadata = Nothing
-                 , isValidScript = TxScriptsUnsupported
+                 , scriptValidity = TxScriptsUnsupported
                  }
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -127,7 +127,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxMeta (..)
     , TxMetadata
     , TxOut (..)
-    , TxScriptValidity (..)
     , TxStatus (..)
     , isPending
     , txOutCoin
@@ -753,7 +752,7 @@ instance Arbitrary GenTxHistory where
         genTx' = mkTx <$> genTid
         hasPending = any ((== Pending) . view #status . snd)
         genTid = Hash . B8.pack <$> listOf1 (elements ['A'..'Z'])
-        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing TxScriptUnsupported
+        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing Nothing
         genTxMeta = do
             sl <- genSmallSlot
             let bh = Quantity $ fromIntegral $ unSlotNo sl
@@ -1297,7 +1296,7 @@ dummyTransactionLayer = TransactionLayer
                  , outputs = outputsCovered cs
                  , withdrawals = mempty
                  , metadata = Nothing
-                 , scriptValidity = TxScriptUnsupported
+                 , scriptValidity = Nothing
                  }
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -753,7 +753,7 @@ instance Arbitrary GenTxHistory where
         genTx' = mkTx <$> genTid
         hasPending = any ((== Pending) . view #status . snd)
         genTid = Hash . B8.pack <$> listOf1 (elements ['A'..'Z'])
-        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing TxScriptsUnsupported
+        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing TxScriptUnsupported
         genTxMeta = do
             sl <- genSmallSlot
             let bh = Quantity $ fromIntegral $ unSlotNo sl
@@ -1297,7 +1297,7 @@ dummyTransactionLayer = TransactionLayer
                  , outputs = outputsCovered cs
                  , withdrawals = mempty
                  , metadata = Nothing
-                 , scriptValidity = TxScriptsUnsupported
+                 , scriptValidity = TxScriptUnsupported
                  }
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -120,6 +120,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
 import Cardano.Wallet.Primitive.Types.Tx
     ( Direction (..)
     , LocalTxSubmissionStatus (..)
+    , ScriptValidation (..)
     , SealedTx (..)
     , TransactionInfo (..)
     , Tx (..)
@@ -752,7 +753,7 @@ instance Arbitrary GenTxHistory where
         genTx' = mkTx <$> genTid
         hasPending = any ((== Pending) . view #status . snd)
         genTid = Hash . B8.pack <$> listOf1 (elements ['A'..'Z'])
-        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing Nothing
+        mkTx tid = Tx tid Nothing [] [] [] mempty Nothing ScriptsNotSupported
         genTxMeta = do
             sl <- genSmallSlot
             let bh = Quantity $ fromIntegral $ unSlotNo sl
@@ -1288,7 +1289,14 @@ dummyTransactionLayer = TransactionLayer
         -- TODO: (ADP-957)
         let cinps' = []
         let tid = mkTxId inps' (outputsCovered cs) mempty Nothing
-        let tx = Tx tid Nothing inps' cinps' (outputsCovered cs) mempty Nothing Nothing
+        let tx = Tx tid
+                    Nothing
+                    inps'
+                    cinps'
+                    (outputsCovered cs)
+                    mempty
+                    Nothing
+                    ScriptsNotSupported
         wit <- forM (inputsSelected cs) $ \(_, TxOut addr _) -> do
             (xprv, Passphrase pwd) <- withEither
                 (ErrKeyNotFoundForAddress addr) $ keystore addr

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,7 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = W.ScriptsNotSupported
+        , isValidScript = W.TxScriptsUnsupported
         }
 
 --------------------------------------------------------------------------------
@@ -280,7 +280,7 @@ fromTxAux txAux = case taTx txAux of
             Nothing
 
         , isValidScript =
-            W.ScriptsNotSupported
+            W.TxScriptsUnsupported
         }
 
 fromTxIn :: TxIn -> W.TxIn

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,7 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = Nothing
+        , isValidScript = W.ScriptsNotSupported
         }
 
 --------------------------------------------------------------------------------
@@ -280,7 +280,7 @@ fromTxAux txAux = case taTx txAux of
             Nothing
 
         , isValidScript =
-            Nothing
+            W.ScriptsNotSupported
         }
 
 fromTxIn :: TxIn -> W.TxIn

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,7 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
-        , scriptValidity = W.TxScriptUnsupported
+        , scriptValidity = Nothing
         }
 
 --------------------------------------------------------------------------------
@@ -280,7 +280,7 @@ fromTxAux txAux = case taTx txAux of
             Nothing
 
         , scriptValidity =
-            W.TxScriptUnsupported
+            Nothing
         }
 
 fromTxIn :: TxIn -> W.TxIn

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,7 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
-        , scriptValidity = W.TxScriptsUnsupported
+        , scriptValidity = W.TxScriptUnsupported
         }
 
 --------------------------------------------------------------------------------
@@ -280,7 +280,7 @@ fromTxAux txAux = case taTx txAux of
             Nothing
 
         , scriptValidity =
-            W.TxScriptsUnsupported
+            W.TxScriptUnsupported
         }
 
 fromTxIn :: TxIn -> W.TxIn

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,7 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
-        , isValidScript = W.TxScriptsUnsupported
+        , scriptValidity = W.TxScriptsUnsupported
         }
 
 --------------------------------------------------------------------------------
@@ -279,7 +279,7 @@ fromTxAux txAux = case taTx txAux of
         , metadata =
             Nothing
 
-        , isValidScript =
+        , scriptValidity =
             W.TxScriptsUnsupported
         }
 

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -212,6 +212,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , outputs = [out]
         , withdrawals = mempty
         , metadata = Nothing
+        , isValidScript = Nothing
         }
 
 --------------------------------------------------------------------------------
@@ -276,6 +277,9 @@ fromTxAux txAux = case taTx txAux of
             mempty
 
         , metadata =
+            Nothing
+
+        , isValidScript =
             Nothing
         }
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,7 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
-            , scriptValidity = W.TxScriptsUnsupported
+            , scriptValidity = W.TxScriptUnsupported
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -872,7 +872,7 @@ fromShelleyTx tx =
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
-            W.TxScriptsUnsupported
+            W.TxScriptUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -904,7 +904,7 @@ fromAllegraTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
-            W.TxScriptsUnsupported
+            W.TxScriptUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -940,7 +940,7 @@ fromMaryTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , scriptValidity =
-            W.TxScriptsUnsupported
+            W.TxScriptUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -986,7 +986,7 @@ fromAlonzoTxBodyAndAux bod mad =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , scriptValidity =
-            W.TxScriptsUnsupported
+            W.TxScriptUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,6 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
+            , isValidScript = Nothing
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -870,6 +871,8 @@ fromShelleyTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
+        , isValidScript =
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -900,6 +903,8 @@ fromAllegraTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
+        , isValidScript =
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -934,6 +939,8 @@ fromMaryTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
+        , isValidScript =
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -978,6 +985,8 @@ fromAlonzoTxBodyAndAux bod mad =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
+        , isValidScript =
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -1023,8 +1032,9 @@ fromAlonzoTx
        , [W.DelegationCertificate]
        , [W.PoolCertificate]
        )
-fromAlonzoTx (Alonzo.ValidatedTx bod _wits _isValidating aux) =
-    fromAlonzoTxBodyAndAux bod aux
+fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
+    (\(tx, d, p) -> (tx { W.isValidScript = Just isValid }, d, p))
+    $ fromAlonzoTxBodyAndAux bod aux
 
 fromCardanoValue :: HasCallStack => Cardano.Value -> TokenBundle.TokenBundle
 fromCardanoValue = uncurry TokenBundle.fromFlatList . extract

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,7 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = Nothing
+            , isValidScript = W.ScriptsNotSupported
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -872,7 +872,7 @@ fromShelleyTx tx =
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
         , isValidScript =
-            Nothing
+            W.ScriptsNotSupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -904,7 +904,7 @@ fromAllegraTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
         , isValidScript =
-            Nothing
+            W.ScriptsNotSupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -940,7 +940,7 @@ fromMaryTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , isValidScript =
-            Nothing
+            W.ScriptsNotSupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -986,7 +986,7 @@ fromAlonzoTxBodyAndAux bod mad =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , isValidScript =
-            Nothing
+            W.ScriptsNotSupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -1033,7 +1033,10 @@ fromAlonzoTx
        , [W.PoolCertificate]
        )
 fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
-    (\(tx, d, p) -> (tx { W.isValidScript = Just isValid }, d, p))
+    (\(tx, d, p) -> (tx { W.isValidScript = if isValid
+                                            then W.ScriptValidationPassed
+                                            else W.ScriptValidationFailed
+                        }, d, p))
     $ fromAlonzoTxBodyAndAux bod aux
 
 fromCardanoValue :: HasCallStack => Cardano.Value -> TokenBundle.TokenBundle

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,7 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = W.ScriptsNotSupported
+            , isValidScript = W.TxScriptsUnsupported
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -872,7 +872,7 @@ fromShelleyTx tx =
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
         , isValidScript =
-            W.ScriptsNotSupported
+            W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -904,7 +904,7 @@ fromAllegraTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
         , isValidScript =
-            W.ScriptsNotSupported
+            W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -940,7 +940,7 @@ fromMaryTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , isValidScript =
-            W.ScriptsNotSupported
+            W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -986,7 +986,7 @@ fromAlonzoTxBodyAndAux bod mad =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , isValidScript =
-            W.ScriptsNotSupported
+            W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -1034,8 +1034,8 @@ fromAlonzoTx
        )
 fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
     (\(tx, d, p) -> (tx { W.isValidScript = if isValid
-                                            then W.ScriptValidationPassed
-                                            else W.ScriptValidationFailed
+                                            then W.TxScriptValid
+                                            else W.TxScriptInvalid
                         }, d, p))
     $ fromAlonzoTxBodyAndAux bod aux
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -1033,11 +1033,13 @@ fromAlonzoTx
        , [W.PoolCertificate]
        )
 fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
-    (\(tx, d, p) -> (tx { W.scriptValidity = if isValid
-                                            then Just W.TxScriptValid
-                                            else Just W.TxScriptInvalid
-                        }, d, p))
+    (\(tx, d, p) -> (tx { W.scriptValidity = validity }, d, p))
     $ fromAlonzoTxBodyAndAux bod aux
+    where
+        validity =
+            if isValid
+            then Just W.TxScriptValid
+            else Just W.TxScriptInvalid
 
 fromCardanoValue :: HasCallStack => Cardano.Value -> TokenBundle.TokenBundle
 fromCardanoValue = uncurry TokenBundle.fromFlatList . extract

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,7 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
-            , scriptValidity = W.TxScriptUnsupported
+            , scriptValidity = Nothing
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -872,7 +872,7 @@ fromShelleyTx tx =
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
-            W.TxScriptUnsupported
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -904,7 +904,7 @@ fromAllegraTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
         , scriptValidity =
-            W.TxScriptUnsupported
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -940,7 +940,7 @@ fromMaryTx tx =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , scriptValidity =
-            W.TxScriptUnsupported
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -986,7 +986,7 @@ fromAlonzoTxBodyAndAux bod mad =
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
         , scriptValidity =
-            W.TxScriptUnsupported
+            Nothing
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
     , mapMaybe fromShelleyRegistrationCert (toList certs)
@@ -1034,8 +1034,8 @@ fromAlonzoTx
        )
 fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
     (\(tx, d, p) -> (tx { W.scriptValidity = if isValid
-                                            then W.TxScriptValid
-                                            else W.TxScriptInvalid
+                                            then Just W.TxScriptValid
+                                            else Just W.TxScriptInvalid
                         }, d, p))
     $ fromAlonzoTxBodyAndAux bod aux
 

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -761,7 +761,7 @@ fromGenesisData g initialFunds =
                 ]
             , withdrawals = mempty
             , metadata = Nothing
-            , isValidScript = W.TxScriptsUnsupported
+            , scriptValidity = W.TxScriptsUnsupported
             }
           where
             W.TxIn pseudoHash _ = fromShelleyTxIn $
@@ -871,7 +871,7 @@ fromShelleyTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD <$> SL.strictMaybeToMaybe mmd
-        , isValidScript =
+        , scriptValidity =
             W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
@@ -903,7 +903,7 @@ fromAllegraTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mmd
-        , isValidScript =
+        , scriptValidity =
             W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
@@ -939,7 +939,7 @@ fromMaryTx tx =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
-        , isValidScript =
+        , scriptValidity =
             W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
@@ -985,7 +985,7 @@ fromAlonzoTxBodyAndAux bod mad =
             fromShelleyWdrl wdrls
         , metadata =
             fromShelleyMD . toSLMetadata <$> SL.strictMaybeToMaybe mad
-        , isValidScript =
+        , scriptValidity =
             W.TxScriptsUnsupported
         }
     , mapMaybe fromShelleyDelegationCert (toList certs)
@@ -1033,7 +1033,7 @@ fromAlonzoTx
        , [W.PoolCertificate]
        )
 fromAlonzoTx (Alonzo.ValidatedTx bod _wits (Alonzo.IsValid isValid) aux) =
-    (\(tx, d, p) -> (tx { W.isValidScript = if isValid
+    (\(tx, d, p) -> (tx { W.scriptValidity = if isValid
                                             then W.TxScriptValid
                                             else W.TxScriptInvalid
                         }, d, p))

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -13,6 +13,8 @@ module Test.QuickCheck.Extra
       genMapWith
     , genSized2
     , genSized2With
+    , interleaveRoundRobin
+    , liftShrink7
     , reasonablySized
 
       -- * Shrinking
@@ -116,23 +118,25 @@ genSized2With f genA genB = uncurry f <$> genSized2 genA genB
 
 -- | Similar to 'liftShrink2', but applicable to 6-tuples.
 --
-liftShrink6
+liftShrink7
     :: (a1 -> [a1])
     -> (a2 -> [a2])
     -> (a3 -> [a3])
     -> (a4 -> [a4])
     -> (a5 -> [a5])
     -> (a6 -> [a6])
-    -> (a1, a2, a3, a4, a5, a6)
-    -> [(a1, a2, a3, a4, a5, a6)]
-liftShrink6 s1 s2 s3 s4 s5 s6 (a1, a2, a3, a4, a5, a6) =
+    -> (a7 -> [a7])
+    -> (a1, a2, a3, a4, a5, a6, a7)
+    -> [(a1, a2, a3, a4, a5, a6, a7)]
+liftShrink7 s1 s2 s3 s4 s5 s6 s7 (a1, a2, a3, a4, a5, a6, a7) =
     interleaveRoundRobin
-    [ [ (a1', a2 , a3 , a4 , a5 , a6 ) | a1' <- s1 a1 ]
-    , [ (a1 , a2', a3 , a4 , a5 , a6 ) | a2' <- s2 a2 ]
-    , [ (a1 , a2 , a3', a4 , a5 , a6 ) | a3' <- s3 a3 ]
-    , [ (a1 , a2 , a3 , a4', a5 , a6 ) | a4' <- s4 a4 ]
-    , [ (a1 , a2 , a3 , a4 , a5', a6 ) | a5' <- s5 a5 ]
-    , [ (a1 , a2 , a3 , a4 , a5 , a6') | a6' <- s6 a6 ]
+    [ [ (a1', a2 , a3 , a4 , a5 , a6 , a7 ) | a1' <- s1 a1 ]
+    , [ (a1 , a2', a3 , a4 , a5 , a6 , a7 ) | a2' <- s2 a2 ]
+    , [ (a1 , a2 , a3', a4 , a5 , a6 , a7 ) | a3' <- s3 a3 ]
+    , [ (a1 , a2 , a3 , a4', a5 , a6 , a7 ) | a4' <- s4 a4 ]
+    , [ (a1 , a2 , a3 , a4 , a5', a6 , a7 ) | a5' <- s5 a5 ]
+    , [ (a1 , a2 , a3 , a4 , a5 , a6', a7 ) | a6' <- s6 a6 ]
+    , [ (a1 , a2 , a3 , a4 , a5 , a6 , a7') | a7' <- s7 a7 ]
     ]
 
 -- Interleaves the given lists together in round-robin order.

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -114,7 +114,7 @@ genSized2 genA genB = (,)
 genSized2With :: (a -> b -> c) -> Gen a -> Gen b -> Gen c
 genSized2With f genA genB = uncurry f <$> genSized2 genA genB
 
--- | Similar to 'liftShrink2', but applicable to 6-tuples.
+-- | Similar to 'liftShrink2', but applicable to 7-tuples.
 --
 liftShrink7
     :: (a1 -> [a1])

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -13,12 +13,10 @@ module Test.QuickCheck.Extra
       genMapWith
     , genSized2
     , genSized2With
-    , interleaveRoundRobin
-    , liftShrink7
     , reasonablySized
 
       -- * Shrinking
-    , liftShrink6
+    , liftShrink7
     , shrinkInterleaved
     , shrinkMapWith
 

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -58,6 +58,7 @@
           (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
           (hsPkgs."foldl" or (errorHandler.buildDepError "foldl"))
           (hsPkgs."generic-lens" or (errorHandler.buildDepError "generic-lens"))
+          (hsPkgs."generic-arbitrary" or (errorHandler.buildDepError "generic-arbitrary"))
           (hsPkgs."hashable" or (errorHandler.buildDepError "hashable"))
           (hsPkgs."http-api-data" or (errorHandler.buildDepError "http-api-data"))
           (hsPkgs."http-client" or (errorHandler.buildDepError "http-client"))

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1674,14 +1674,17 @@ x-maximumTokenBundleSize: &maximumTokenBundleSize
       enum:
         - byte
 
-x-transactionScriptValidity: &transactionScriptValidity
+x-txScriptValidity: &txScriptValidity
   description: |
     For Alonzo-era and later transactions, indicates whether the phase-2
     monetary policy script (e.g. Plutus script) used in the transaction
-    validated or not. Previous to Alonzo-era, this is null.
-  nullable: true
-  type: boolean
-  default: null
+    validated or not. Previous to Alonzo-era, this is unsupported.
+  type: string
+  enum:
+    - unsupported
+    - valid
+    - invalid
+  default: unsupported
 
 #############################################################################
 #                                                                           #
@@ -2105,7 +2108,7 @@ components:
         mint: *transactionMint
         status: *transactionStatus
         metadata: *transactionMetadata
-        script_validity: *transactionScriptValidity
+        script_validity: *txScriptValidity
 
     x-txBody: &txBody
       oneOf:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1676,15 +1676,16 @@ x-maximumTokenBundleSize: &maximumTokenBundleSize
 
 x-txScriptValidity: &txScriptValidity
   description: |
-    For Alonzo-era and later transactions, indicates whether the phase-2
-    monetary policy script (e.g. Plutus script) used in the transaction
-    validated or not. Previous to Alonzo-era, this is unsupported.
+    Indicates whether the phase-2 monetary policy script (e.g. Plutus script)
+    used in the transaction validated or not. Validity may be null if this
+    transaction was from an era that doesn't support phase-2 monetary policy
+    scripts, or is a pending transaction (we don't know if validation passed or
+    failed until the transaction hits the ledger).
+  nullable: true
   type: string
   enum:
-    - unsupported
     - valid
     - invalid
-  default: unsupported
 
 #############################################################################
 #                                                                           #

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1674,6 +1674,14 @@ x-maximumTokenBundleSize: &maximumTokenBundleSize
       enum:
         - byte
 
+x-transactionScriptValidity: &transactionScriptValidity
+  description: |
+    For Alonzo-era and later transactions, indicates whether the phase-2
+    monetary policy script (e.g. Plutus script) used in the transaction
+    validated or not. Previous to Alonzo-era, this is null.
+  nullable: true
+  type: boolean
+  default: null
 
 #############################################################################
 #                                                                           #
@@ -2097,6 +2105,7 @@ components:
         mint: *transactionMint
         status: *transactionStatus
         metadata: *transactionMetadata
+        is_valid_script: *transactionScriptValidity
 
     x-txBody: &txBody
       oneOf:

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -2105,7 +2105,7 @@ components:
         mint: *transactionMint
         status: *transactionStatus
         metadata: *transactionMetadata
-        is_valid_script: *transactionScriptValidity
+        script_validity: *transactionScriptValidity
 
     x-txBody: &txBody
       oneOf:


### PR DESCRIPTION
The purpose of this PR is to modify the the code that follows the blockchain to adjust the Wallet's UTxO when collateral inputs are lost due to a transaction that fails phase-2 script validation (Plutus scripts).

I have:
- Add valid script field to `MkApiTransactionParams`, `ApiTransaction`, `TxMeta`, `Tx`, and `TransactionInfo`.
- Modify state transition logic (when a Tx is applied to a UTxO) to account for collateral inputs.
- Add integration test for collateral inputs.
- Add property tests for state transition logic.
- Add is_valid_script field to API specification.

### Issue Number

ADP-1036
