### PR TITLE
Fix leaks of ≈21 more wallets in integration tests

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -83,6 +83,7 @@ import Test.Integration.Framework.DSL
     , icarusAddresses
     , json
     , minUTxOValue
+    , postByronWallet
     , request
     , restoreWalletFromPubKey
     , selectCoins
@@ -117,7 +118,8 @@ spec = describe "BYRON_HW_WALLETS" $ do
             "passphrase": #{fixturePassphrase},
             "style": "icarus"
             }|]
-        rInit <- request @ApiByronWallet ctx (Link.postWallet @'Byron) Default payldCrt
+
+        rInit <- postByronWallet ctx payldCrt
         verify rInit
             [ expectResponseCode HTTP.status201
             , expectField (#balance . #available) (`shouldBe` Quantity 0)
@@ -294,8 +296,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                     "account_public_key": #{pubKey},
                     "address_pool_gap": #{addrPoolGap}
                 }|]
-            rRestore <- request @ApiByronWallet ctx (Link.postWallet @'Byron)
-                    Default payloadRestore
+            rRestore <- postByronWallet ctx payloadRestore
             expectResponseCode HTTP.status201 rRestore
 
             let wPub = getFromResponse id rRestore
@@ -385,7 +386,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                 "passphrase": #{fixturePassphrase},
                 "style": "icarus"
                 }|]
-            r <- request @ApiByronWallet ctx (Link.postWallet @'Byron) Default payldCrt
+            r <- postByronWallet ctx payldCrt
             expectResponseCode HTTP.status201 r
 
             -- create from account public key


### PR DESCRIPTION
- [x] Replace 3 manual calls to `Link.postWallets` with the `ResourceT` `postByronWallet`
- [x] Also make `createWalletFromPublicKeyViaCLI` run in `ResourceT`

### Comments

- 21 wallets is a pretty significant number, so will be good to fix. Although the leaks were at the end of the tests, which lessens the impact.
- There seem to be _some_ concurrency related leaks.

#### Before second fix

- --match "WALLET" -j 1 ->18 leaks, all at the end

#### After fixes

- --match "WALLET" -j 1, no leaks
- --match "WALLET" -j 8, 10 leaks (3 BUSY, 6 others)

```
SQLITE_BUSY in logs:
ica.14828b804a1ebe804caddd1abb5d314d2be0a62a.sqlite
ica.25341683360a040721f587d069b95762b302f608.sqlite
rnd.5fc0960622bc4d3a5d366a0920dfd9b5ef578ced.sqlite

rnd.81273c47add77e98b3993e01cab8b2a836cd48b7.sqlite
she.95cff5e68f07b759c72d4da4f1aa96e0b101bba2.sqlite
she.a99218ce4bbc77f05617d642c0595246621b67b6.sqlite

Remaining DBs:
ica.14828b804a1ebe804caddd1abb5d314d2be0a62a.sqlite
ica.25341683360a040721f587d069b95762b302f608.sqlite
rnd.5fc0960622bc4d3a5d366a0920dfd9b5ef578ced.sqlite

ica.ed49f6e7723fa2c15575c147566981beab6aba3e.sqlite
rnd.693940686b48985ab6ec8035a56575e0473e96de.sqlite
rnd.81273c47add77e98b3993e01cab8b2a836cd48b7.sqlite
sha.9316fc445533f9e58becf0d367d3a9404585ea86.sqlite
she.3464b427c15341dab8aaf6d89c8f79e5f24f9eae.sqlite
she.a0bd7c6accac92d54fb667bf32bcba4db4cd552f.sqlite
stake-pools.sqlite
```


<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1090
