### PR TITLE
Suggestions for PR 2848

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -403,6 +403,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.TokenMapSpec.TypeErrorSpec
       Cardano.Wallet.Primitive.Types.TokenPolicySpec
       Cardano.Wallet.Primitive.Types.TokenQuantitySpec
+      Cardano.Wallet.Primitive.Types.UTxOSpec
       Cardano.Wallet.Primitive.Types.UTxOIndexSpec
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -396,6 +396,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Slotting.Legacy
       Cardano.Wallet.Primitive.SlottingSpec
       Cardano.Wallet.Primitive.SyncProgressSpec
+      Cardano.Wallet.Primitive.Types.AddressSpec
       Cardano.Wallet.Primitive.Types.CoinSpec
       Cardano.Wallet.Primitive.Types.HashSpec
       Cardano.Wallet.Primitive.Types.TokenBundleSpec

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -1,6 +1,12 @@
 module Cardano.Wallet.Primitive.Types.Address.Gen
-    ( genAddress
+    (
+      -- * Generators and shrinkers
+      genAddress
     , shrinkAddress
+
+      -- * Indicator functions on addresses
+    , addressParity
+    , Parity (..)
     )
     where
 
@@ -11,6 +17,8 @@ import Cardano.Wallet.Primitive.Types.Address
 import Test.QuickCheck
     ( Gen, elements, sized )
 
+import qualified Data.Bits as Bits
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 
 --------------------------------------------------------------------------------
@@ -29,6 +37,47 @@ shrinkAddress a
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]
+
+--------------------------------------------------------------------------------
+-- Indicator functions on addresses
+--------------------------------------------------------------------------------
+
+-- | Computes the parity of an address.
+--
+-- Parity is defined in the following way:
+--
+--    - even-parity address:
+--      an address with a pop count (Hamming weight) that is even.
+--
+--    - odd-parity address:
+--      an address with a pop count (Hamming weight) that is odd.
+--
+-- Examples of even-parity and odd-parity addresses:
+--
+--    - 0b00000000 : even (Hamming weight = 0)
+--    - 0b00000001 : odd  (Hamming weight = 1)
+--    - 0b00000010 : odd  (Hamming weight = 1)
+--    - 0b00000011 : even (Hamming weight = 2)
+--    - 0b00000100 : odd  (Hamming weight = 1)
+--    - ...
+--    - 0b11111110 : odd  (Hamming weight = 7)
+--    - 0b11111111 : even (Hamming weight = 8)
+--
+addressParity :: Address -> Parity
+addressParity = parity . addressPopCount
+  where
+    addressPopCount :: Address -> Int
+    addressPopCount = BS.foldl' (\acc -> (acc +) . Bits.popCount) 0 . unAddress
+
+    parity :: Integral a => a -> Parity
+    parity a
+        | even a    = Even
+        | otherwise = Odd
+
+-- | Represents the parity of a value (whether the value is even or odd).
+--
+data Parity = Even | Odd
+    deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
 -- Internal utilities

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -144,8 +144,10 @@ null (UTxO u) = Map.null u
 size :: UTxO -> Int
 size (UTxO u) = Map.size u
 
--- | Limit a UTxO set to just the UTxOs that are ours, according to some
--- given function.
+-- | Filters a 'UTxO' set with an indicator function on 'Address' values.
+--
+-- Returns the subset of UTxO entries that have addresses for which the given
+-- indicator function returns 'True'.
 --
 -- filterByAddressM (const $ pure True) u = u
 -- filterByAddressM (const $ pure False) u = mempty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -199,10 +199,10 @@ spec = do
             it "has expected entries" (property prop_applyTxToUTxO_entries)
 
         describe "filterByAddress" $ do
-            it "if all utxos belong to us, the result utxo should not change"
-                (property prop_filterByAddress_allOurs)
-            it "if no utxos belong to us, the result utxo should be nothing"
-                (property prop_filterByAddress_noneOurs)
+            it "matching everything gives us everything"
+                (property prop_filterByAddress_matchAll)
+            it "matching nothing gives us nothing"
+                (property prop_filterByAddress_matchNone)
             it "if there are no utxos, the result utxo should be empty"
                 (property prop_filterByAddress_empty)
             it "applyTxToUTxO then filterByAddress"
@@ -1442,7 +1442,7 @@ prop_applyTxToUTxO_balance =
               balance (utxoFromTx tx)
           `TokenBundle.difference`
               balance (u `UTxO.restrictedBy` Set.fromList (inputs tx))
- 
+
 prop_applyTxToUTxO_entries :: Property
 prop_applyTxToUTxO_entries =
     forAllShrink genTx shrinkTx $ \tx ->
@@ -1453,14 +1453,14 @@ prop_applyTxToUTxO_entries =
               unUTxO (utxoFromTx tx)
           `Map.difference`
               unUTxO (u `UTxO.restrictedBy` Set.fromList (inputs tx))
-    
-prop_filterByAddress_allOurs :: Property
-prop_filterByAddress_allOurs =
+
+prop_filterByAddress_matchAll :: Property
+prop_filterByAddress_matchAll =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const True) u === u
 
-prop_filterByAddress_noneOurs :: Property
-prop_filterByAddress_noneOurs =
+prop_filterByAddress_matchNone :: Property
+prop_filterByAddress_matchNone =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const False) u === mempty
 
@@ -1472,7 +1472,7 @@ prop_filterByAddress_empty b =
         filterByAddress f mempty === mempty
 
 prop_filterByAddress_balance_applyTxToUTxO :: Bool -> Property
-prop_filterByAddress_balance_applyTxToUTxO b = 
+prop_filterByAddress_balance_applyTxToUTxO b =
     let
         f = const b
     in

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/AddressSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/AddressSpec.hs
@@ -1,0 +1,33 @@
+module Cardano.Wallet.Primitive.Types.AddressSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( Parity (..), addressParity, genAddress )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Property, checkCoverage, cover, forAll, property )
+
+spec :: Spec
+spec =
+    describe "Cardano.Wallet.Primitive.Types.AddressSpec" $ do
+
+    describe "addressParity" $ do
+
+        it "prop_addressParity_coverage" $
+            property prop_addressParity_coverage
+
+-- | Verifies that addresses are generated with both even and odd parity.
+--
+prop_addressParity_coverage :: Property
+prop_addressParity_coverage =
+    forAll genAddress $ \addr ->
+    checkCoverage $
+    cover 40 (addressParity addr == Even)
+        "address parity is even" $
+    cover 40 (addressParity addr == Odd)
+        "address parity is odd" $
+    property True

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -1,0 +1,55 @@
+module Cardano.Wallet.Primitive.Types.UTxOSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( filterByAddress, filterByAddressM )
+import Cardano.Wallet.Primitive.Types.UTxO.Gen
+    ( genUTxO, shrinkUTxO )
+import Data.Functor.Identity
+    ( runIdentity )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.QuickCheck
+    ( Property, forAllShrink, property, (===) )
+
+spec :: Spec
+spec =
+    describe "Cardano.Wallet.Primitive.Types.UTxOSpec" $ do
+
+    describe "filterByAddress" $ do
+        it "matching everything gives us everything" $
+            property prop_filterByAddress_matchAll
+        it "matching nothing gives us nothing" $
+            property prop_filterByAddress_matchNone
+        it "if there are no utxos, the result utxo should be empty" $
+            property prop_filterByAddress_empty
+        it "filterByAddress/filterByAddressM" $
+            property prop_filterByAddress_filterByAddressM
+
+prop_filterByAddress_matchAll :: Property
+prop_filterByAddress_matchAll =
+    forAllShrink genUTxO shrinkUTxO $ \u ->
+        filterByAddress (const True) u === u
+
+prop_filterByAddress_matchNone :: Property
+prop_filterByAddress_matchNone =
+    forAllShrink genUTxO shrinkUTxO $ \u ->
+        filterByAddress (const False) u === mempty
+
+prop_filterByAddress_empty :: Bool -> Property
+prop_filterByAddress_empty b =
+    let
+        f = const b
+    in
+        filterByAddress f mempty === mempty
+
+prop_filterByAddress_filterByAddressM :: Bool -> Property
+prop_filterByAddress_filterByAddressM b =
+    let
+        f = const b
+    in
+        forAllShrink genUTxO shrinkUTxO $ \u ->
+            filterByAddress f u === runIdentity (filterByAddressM (pure . f) u)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -1,19 +1,28 @@
+{-# LANGUAGE OverloadedLabels #-}
+
 module Cardano.Wallet.Primitive.Types.UTxOSpec
     ( spec
     ) where
 
 import Prelude
 
+import Cardano.Wallet.Primitive.Types.Address.Gen
+    ( Parity (..), addressParity )
 import Cardano.Wallet.Primitive.Types.UTxO
-    ( filterByAddress, filterByAddressM )
+    ( UTxO (..), dom, filterByAddress, filterByAddressM )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
 import Data.Functor.Identity
     ( runIdentity )
+import Data.Generics.Internal.VL.Lens
+    ( view )
 import Test.Hspec
     ( Spec, describe, it )
 import Test.QuickCheck
-    ( Property, forAllShrink, property, (===) )
+    ( Property, checkCoverage, conjoin, cover, forAllShrink, property, (===) )
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 spec :: Spec
 spec =
@@ -24,6 +33,8 @@ spec =
             property prop_filterByAddress_matchAll
         it "matching nothing gives us nothing" $
             property prop_filterByAddress_matchNone
+        it "matching some addresses gives us the appropriate subset" $
+            property prop_filterByAddress_matchSome
         it "if there are no utxos, the result utxo should be empty" $
             property prop_filterByAddress_empty
         it "filterByAddress/filterByAddressM" $
@@ -38,6 +49,32 @@ prop_filterByAddress_matchNone :: Property
 prop_filterByAddress_matchNone =
     forAllShrink genUTxO shrinkUTxO $ \u ->
         filterByAddress (const False) u === mempty
+
+prop_filterByAddress_matchSome :: Property
+prop_filterByAddress_matchSome =
+    forAllShrink genUTxO shrinkUTxO prop_inner
+  where
+    prop_inner utxo =
+        checkCoverage $
+        cover 10
+            (domEven /= mempty && domEven `Set.isProperSubsetOf` dom utxo)
+            "domEven /= mempty && domEven `Set.isProperSubsetOf` dom utxo" $
+        cover 10
+            (domOdd /= mempty && domOdd `Set.isProperSubsetOf` dom utxo)
+            "domOdd /= mempty && domOdd `Set.isProperSubsetOf` dom utxo" $
+        conjoin
+            [ utxoEven <> utxoOdd == utxo
+            , unUTxO utxoEven `Map.isSubmapOf` unUTxO utxo
+            , unUTxO utxoOdd  `Map.isSubmapOf` unUTxO utxo
+            , all ((== Even) . addressParity . view #address) (unUTxO utxoEven)
+            , all ((==  Odd) . addressParity . view #address) (unUTxO utxoOdd)
+            ]
+      where
+        domEven = dom utxoEven
+        domOdd  = dom utxoOdd
+
+        utxoEven = filterByAddress ((== Even) . addressParity) utxo
+        utxoOdd  = filterByAddress ((==  Odd) . addressParity) utxo
 
 prop_filterByAddress_empty :: Bool -> Property
 prop_filterByAddress_empty b =


### PR DESCRIPTION
### Issue Number

#2848

### Comments

This PR:

- [x] Moves UTxO-specific property tests to `UTxOSpec` module.
- [x] Generalizes comments and test names for `filterByAddress`
- [x] Adds property test `prop_filterByAddress_matchSome`, which reuses the `addressParity` function.