### PR TITLE
Fix `TxMetaText` generators.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Gen.hs
@@ -228,29 +228,20 @@ shrinkByteString bs
 genTxMetaText :: Gen Text
 genTxMetaText =
     (T.pack . take 32 . getPrintableString <$> arbitrary)
-    `suchThat` guardTxMetaText
+    `suchThat` guardTxMetaTextLength
 
 shrinkTxMetaText :: Text -> [Text]
 shrinkTxMetaText t
     | n <= 1    = []
-    | otherwise = filter guardTxMetaTextPrefix
-        [ T.take (n `div` 2) t, T.drop (n `div` 2) t ]
+    | otherwise = [T.take (n `div` 2) t, T.drop (n `div` 2) t]
   where
     n = T.length t
-
-guardTxMetaText :: Text -> Bool
-guardTxMetaText t = (&&)
-    (guardTxMetaTextLength t)
-    (guardTxMetaTextPrefix t)
 
 guardTxMetaTextLength :: Text -> Bool
 guardTxMetaTextLength =
     -- The UT8-encoded length of a metadata text value must not be greater
     -- than 64 bytes:
     (<= 64) . BS.length . T.encodeUtf8
-
-guardTxMetaTextPrefix :: Text -> Bool
-guardTxMetaTextPrefix t = not ("0x" `T.isPrefixOf` t)
 
 -- | Generates a 'TxMetadata' with arbitrary levels of nesting.
 genNestedTxMetadata :: Gen TxMetadata

--- a/lib/core/src/Cardano/Wallet/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Gen.hs
@@ -18,9 +18,9 @@ module Cardano.Wallet.Gen
     , shrinkActiveSlotCoefficient
     , genSlotNo
     , shrinkSlotNo
-    , genTxMetadata
+    , genNestedTxMetadata
+    , genSimpleTxMetadata
     , shrinkTxMetadata
-    , genSmallTxMetadata
     , genScript
     , genScriptCosigners
     , genScriptTemplate
@@ -252,8 +252,9 @@ guardTxMetaTextLength =
 guardTxMetaTextPrefix :: Text -> Bool
 guardTxMetaTextPrefix t = not ("0x" `T.isPrefixOf` t)
 
-genTxMetadata :: Gen TxMetadata
-genTxMetadata = do
+-- | Generates a 'TxMetadata' with arbitrary levels of nesting.
+genNestedTxMetadata :: Gen TxMetadata
+genNestedTxMetadata = do
     let (maxBreadth, maxDepth) = (3, 3)
     d <- scale (`mod` maxBreadth) $ listOf1 (sizedMetadataValue maxDepth)
     i <- vectorOf @Word (length d) arbitrary
@@ -262,9 +263,9 @@ genTxMetadata = do
         Left e -> error $ show e <> ": " <> show (Aeson.encode json)
         Right metadata -> pure metadata
 
--- | Generates a 'TxMetadata' containing only simple values.
-genSmallTxMetadata :: Gen TxMetadata
-genSmallTxMetadata = TxMetadata <$>
+-- | Generates a 'TxMetadata' containing only simple values, without nesting.
+genSimpleTxMetadata :: Gen TxMetadata
+genSimpleTxMetadata = TxMetadata <$>
     (Map.singleton <$> arbitrary <*> genSimpleTxMetadataValue)
 
 genSimpleTxMetadataValue :: Gen TxMetadataValue

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -22,7 +22,7 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
 import Prelude
 
 import Cardano.Wallet.Gen
-    ( genTxMetadata, shrinkTxMetadata )
+    ( genNestedTxMetadata, shrinkTxMetadata )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress, shrinkAddress )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -103,7 +103,7 @@ genTxWithoutId = TxWithoutId
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
     <*> listOf1 genTxOut
-    <*> liftArbitrary genTxMetadata
+    <*> liftArbitrary genNestedTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
 
 shrinkTxWithoutId :: TxWithoutId -> [TxWithoutId]

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -182,12 +182,12 @@ import Cardano.Wallet.Api.Types
 import Cardano.Wallet.Gen
     ( genMnemonic
     , genNatural
+    , genNestedTxMetadata
     , genPercentage
     , genScript
     , genScriptCosigners
     , genScriptTemplate
     , genScriptTemplateEntry
-    , genTxMetadata
     , shrinkPercentage
     , shrinkTxMetadata
     )
@@ -2146,7 +2146,7 @@ instance Arbitrary SerialisedTxParts where
         ]
 
 instance Arbitrary TxMetadata where
-    arbitrary = genTxMetadata
+    arbitrary = genNestedTxMetadata
     shrink = shrinkTxMetadata
 
 instance Arbitrary ApiTxMetadata where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -42,7 +42,7 @@ import Cardano.Wallet.DB.Model
 import Cardano.Wallet.DummyTarget.Primitive.Types as DummyTarget
     ( block0, mkTx )
 import Cardano.Wallet.Gen
-    ( genMnemonic, genSmallTxMetadata, shrinkSlotNo, shrinkTxMetadata )
+    ( genMnemonic, genSimpleTxMetadata, shrinkSlotNo, shrinkTxMetadata )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..)
     , DerivationType (..)
@@ -414,7 +414,7 @@ instance Arbitrary TxStatus where
     arbitrary = elements [Pending, InLedger]
 
 instance Arbitrary TxMetadata where
-    arbitrary = genSmallTxMetadata
+    arbitrary = genSimpleTxMetadata
     shrink = shrinkTxMetadata
 
 instance Arbitrary Coin where

--- a/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Sqlite/TypesSpec.hs
@@ -14,9 +14,9 @@ import Prelude
 import Cardano.Wallet.DB.Sqlite.Types
     ( stdGenFromString )
 import Cardano.Wallet.Gen
-    ( genSlotNo
-    , genSmallTxMetadata
-    , genTxMetadata
+    ( genNestedTxMetadata
+    , genSimpleTxMetadata
+    , genSlotNo
     , shrinkSlotNo
     , shrinkTxMetadata
     )
@@ -70,8 +70,8 @@ spec = do
         persistRoundtrip $ Proxy @POSIXTime
         persistRoundtrip $ Proxy @TokenQuantity
         persistRoundtrip $ Proxy @StdGen
-        persistRoundtrip $ Proxy @(Small TxMetadata)
-        persistRoundtrip $ Proxy @(Large TxMetadata)
+        persistRoundtrip $ Proxy @(Nested TxMetadata)
+        persistRoundtrip $ Proxy @(Simple TxMetadata)
 
     describe "Backwards compatible instance PersistField StdGen" $ do
         it "rnd_state empty" $
@@ -146,24 +146,24 @@ instance Arbitrary TokenQuantity where
     arbitrary = genTokenQuantityFullRange
     shrink = shrinkTokenQuantityFullRange
 
-newtype Small a = Small { unSmall :: a } deriving (Eq, Show)
-newtype Large a = Large { unLarge :: a } deriving (Eq, Show)
+newtype Nested a = Nested { unNested :: a } deriving (Eq, Show)
+newtype Simple a = Simple { unSimple :: a } deriving (Eq, Show)
 
-instance Arbitrary (Small TxMetadata) where
-    arbitrary = Small <$> genSmallTxMetadata
-    shrink = shrinkMapBy Small unSmall shrinkTxMetadata
+instance Arbitrary (Nested TxMetadata) where
+    arbitrary = Nested <$> genNestedTxMetadata
+    shrink = shrinkMapBy Nested unNested shrinkTxMetadata
 
-instance Arbitrary (Large TxMetadata) where
-    arbitrary = Large <$> genTxMetadata
-    shrink = shrinkMapBy Large unLarge shrinkTxMetadata
+instance Arbitrary (Simple TxMetadata) where
+    arbitrary = Simple <$> genSimpleTxMetadata
+    shrink = shrinkMapBy Simple unSimple shrinkTxMetadata
 
-instance PersistField a => PersistField (Small a) where
-    toPersistValue = toPersistValue . unSmall
-    fromPersistValue = fmap Small . fromPersistValue
+instance PersistField a => PersistField (Nested a) where
+    toPersistValue = toPersistValue . unNested
+    fromPersistValue = fmap Nested . fromPersistValue
 
-instance PersistField a => PersistField (Large a) where
-    toPersistValue = toPersistValue . unLarge
-    fromPersistValue = fmap Large . fromPersistValue
+instance PersistField a => PersistField (Simple a) where
+    toPersistValue = toPersistValue . unSimple
+    fromPersistValue = fmap Simple . fromPersistValue
 
 instance Arbitrary StdGen where
     arbitrary = mkStdGen <$> arbitrary

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -20,8 +20,8 @@ import Cardano.Address.Derivation
 import Cardano.Wallet.Gen
     ( genActiveSlotCoefficient
     , genBlockHeader
+    , genNestedTxMetadata
     , genSlotNo
-    , genTxMetadata
     , shrinkActiveSlotCoefficient
     , shrinkSlotNo
     , shrinkTxMetadata
@@ -1181,7 +1181,7 @@ instance Arbitrary Tx where
 
 instance Arbitrary TxMetadata where
     shrink = shrinkTxMetadata
-    arbitrary = genTxMetadata
+    arbitrary = genNestedTxMetadata
 
 instance Arbitrary RewardAccount where
     arbitrary = RewardAccount . BS.pack <$> vector 28

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -48,7 +48,12 @@ import Cardano.Wallet.DummyTarget.Primitive.Types
     , mkTxId
     )
 import Cardano.Wallet.Gen
-    ( genMnemonic, genSlotNo, genTxMetadata, shrinkSlotNo, shrinkTxMetadata )
+    ( genMnemonic
+    , genNestedTxMetadata
+    , genSlotNo
+    , shrinkSlotNo
+    , shrinkTxMetadata
+    )
 import Cardano.Wallet.Network
     ( NetworkLayer (..) )
 import Cardano.Wallet.Primitive.AddressDerivation
@@ -1450,4 +1455,4 @@ instance Arbitrary TxMeta where
 
 instance Arbitrary TxMetadata where
     shrink = shrinkTxMetadata
-    arbitrary = genTxMetadata
+    arbitrary = genNestedTxMetadata


### PR DESCRIPTION
### Issue Number

#2861

### Comments

This PR:

- [x] fixes generators for `TxMetadata` so that they only produce `TxMetaText` values where the UTF-8-serialized length does not exceed 64 bytes.
- [x] renames generators to `genSimpleTxMetadata` and `genNestedTxMetadata` to emphasise the difference in generated values (simple vs nested).
- [x] uses `UnicodeString` to generate `TxMetaText` content.
- [x] adds round-trip persistence tests for `genSimpleTxMetadata` and `genNestedTxMetadata`.
