### PR TITLE
Strengthen tests for `applyTx` and `filterByAddress`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Address/Gen.hs
@@ -3,6 +3,7 @@ module Cardano.Wallet.Primitive.Types.Address.Gen
       -- * Generators and shrinkers
       genAddress
     , shrinkAddress
+    , coarbitraryAddress
 
       -- * Indicator functions on addresses
     , addressParity
@@ -15,7 +16,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Test.QuickCheck
-    ( Gen, elements, sized )
+    ( Gen, coarbitrary, elements, sized )
 
 import qualified Data.Bits as Bits
 import qualified Data.ByteString as BS
@@ -34,6 +35,9 @@ shrinkAddress a
     | otherwise = [simplest]
   where
     simplest = head addresses
+
+coarbitraryAddress :: Address -> Gen a -> Gen a
+coarbitraryAddress = coarbitrary . BS.unpack . unAddress
 
 addresses :: [Address]
 addresses = mkAddress <$> ['0' ..]

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -59,6 +59,7 @@ import Test.QuickCheck
     , liftArbitrary2
     , liftShrink
     , liftShrink2
+    , listOf
     , listOf1
     , shrinkList
     , shrinkMapBy
@@ -102,7 +103,7 @@ genTxWithoutId = TxWithoutId
     <$> liftArbitrary genCoinPositive
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
     <*> listOf1 (liftArbitrary2 genTxIn genCoinPositive)
-    <*> listOf1 genTxOut
+    <*> listOf genTxOut
     <*> liftArbitrary genTxMetadata
     <*> genMapWith genRewardAccount genCoinPositive
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1490,8 +1490,8 @@ prop_spendTx_balance_inequality :: Tx -> UTxO -> Property
 prop_spendTx_balance_inequality tx u =
     checkCoverage $
     cover 10
-        (lhs /= mempty && lhs `leq` rhs)
-        "lhs /= mempty && lhs `leq` rhs" $
+        (lhs /= mempty && lhs `leq` rhs && lhs /= rhs)
+        "lhs /= mempty && lhs `leq` rhs && lhs /= rhs" $
     isJust (rhs `TokenBundle.subtract` lhs)
         & counterexample ("balance (spendTx tx u) = " <> show lhs)
         & counterexample ("balance u = " <> show rhs)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1400,16 +1400,22 @@ blockchain =
 prop_tx_utxo_coverage :: Tx -> UTxO -> Property
 prop_tx_utxo_coverage tx u =
     checkCoverage $
-    cover 5 (UTxO.null u) "UTxO empty" $
-    cover 30 (not $ UTxO.null u) "UTxO not empty" $
+    cover 2 (UTxO.null u)
+        "UTxO empty" $
+    cover 30 (not $ UTxO.null u)
+        "UTxO not empty" $
     cover 30 (not $ Set.disjoint (dom u) (Set.fromList $ inputs tx))
         "UTxO and Tx not disjoint" $
     cover 10 (Set.disjoint (dom u) (Set.fromList $ inputs tx))
         "UTxO and Tx disjoint" $
-    cover 10 (length (inputs tx) > 3) "Number of tx inputs > 3" $
-    cover 10 (length (inputs tx) < 3) "Number of tx inputs < 3" $
-    cover 10 (length (outputs tx) > 3) "Number of tx outputs > 3" $
-    cover 10 (length (outputs tx) < 3) "Number of tx outputs < 3" $
+    cover 4 (length (inputs tx) > 3)
+        "Number of tx inputs > 3" $
+    cover 4 (length (inputs tx) < 3)
+        "Number of tx inputs < 3" $
+    cover 4 (length (outputs tx) > 3)
+        "Number of tx outputs > 3" $
+    cover 4 (length (outputs tx) < 3)
+        "Number of tx outputs < 3" $
     property True
 
 prop_applyTxToUTxO_balance :: Tx -> UTxO -> Property

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -56,10 +56,16 @@ spec =
 
 prop_filterByAddress_matchAll :: UTxO -> Property
 prop_filterByAddress_matchAll u =
+    checkCoverage $
+    cover 2 (u == mempty) "empty" $
+    cover 8 (u /= mempty) "non-empty" $
     filterByAddress (const True) u === u
 
 prop_filterByAddress_matchNone :: UTxO -> Property
 prop_filterByAddress_matchNone u =
+    checkCoverage $
+    cover 2 (u == mempty) "empty" $
+    cover 8 (u /= mempty) "non-empty" $
     filterByAddress (const False) u === mempty
 
 prop_filterByAddress_matchSome :: UTxO -> Property
@@ -91,11 +97,23 @@ prop_filterByAddress_empty f =
 
 prop_filterByAddress_filterByAddressM :: UTxO -> (Address -> Bool) -> Property
 prop_filterByAddress_filterByAddressM u f =
+    checkCoverage $
+    cover 10 isNonEmptyProperSubset "is non-empty proper subset" $
     filterByAddress f u === runIdentity (filterByAddressM (pure . f) u)
+  where
+    isNonEmptyProperSubset = (&&)
+        (filterByAddress f u /= mempty)
+        (dom (filterByAddress f u) `Set.isProperSubsetOf` dom u)
 
 prop_filterByAddress_isSubset :: UTxO -> (Address -> Bool) -> Property
 prop_filterByAddress_isSubset u f =
+    checkCoverage $
+    cover 10 isNonEmptyProperSubset "is non-empty proper subset" $
     property $ filterByAddress f u `isSubsetOf` u
+  where
+    isNonEmptyProperSubset = (&&)
+        (filterByAddress f u /= mempty)
+        (dom (filterByAddress f u) `Set.isProperSubsetOf` dom u)
 
 instance CoArbitrary Address where
     coarbitrary = coarbitraryAddress


### PR DESCRIPTION
### Comments

This PR strengthens test coverage for PR 2848.

### Issue Number

#2848 

## Changes

- [x] Introduces `CoArbitrary` instance for `Address`, which enables us to generate arbitrary functions of type `Address -> Bool`.
- [x] Use arbitrary `Address -> Bool` functions to strengthen property tests that formerly relied on constant functions.
- [x] Adds relevant coverage checks to individual properties.