### PR TITLE
Fix `decodeUnsignedTx` to correctly try previous eras

### DIFF
--- a/lib/core/src/Cardano/Wallet/Unsafe.hs
+++ b/lib/core/src/Cardano/Wallet/Unsafe.hs
@@ -26,6 +26,8 @@ module Cardano.Wallet.Unsafe
     , unsafeMkMnemonic
     , unsafeMkEntropy
     , unsafeMkSomeMnemonicFromEntropy
+
+    , safeDeserialiseCbor
     ) where
 
 import Prelude
@@ -64,6 +66,8 @@ import Data.Char
     ( isHexDigit )
 import Data.Either
     ( fromRight )
+import Data.Either.Combinators
+    ( mapRight )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -163,6 +167,13 @@ unsafeDeserialiseCbor decoder bytes = either
     (\e -> error $ "unsafeSerializeCbor: " <> show e)
     snd
     (CBOR.deserialiseFromBytes decoder bytes)
+
+safeDeserialiseCbor
+    :: (forall s. CBOR.Decoder s a)
+    -> BL.ByteString
+    -> Either CBOR.DeserialiseFailure a
+safeDeserialiseCbor decoder bytes =
+    mapRight snd (CBOR.deserialiseFromBytes decoder bytes)
 
 unsafeMkEntropy
     :: forall ent csz.

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -71,6 +71,7 @@ import Cardano.Wallet.Primitive.SyncProgress
     ( SyncProgress (..), SyncTolerance )
 import Cardano.Wallet.Shelley.Compatibility
     ( StandardCrypto
+    , ToCardanoGenTx (..)
     , fromAlonzoPParams
     , fromCardanoHash
     , fromChainHash
@@ -88,7 +89,6 @@ import Cardano.Wallet.Shelley.Compatibility
     , toPoint
     , toShelleyCoin
     , toStakeCredential
-    , unsealShelleyTx
     )
 import Control.Applicative
     ( liftA3 )
@@ -260,6 +260,7 @@ import UnliftIO.Concurrent
 import UnliftIO.Exception
     ( Handler (..), IOException )
 
+import qualified Cardano.Api as Cardano
 import qualified Cardano.Ledger.Alonzo.PParams as Alonzo
 import qualified Cardano.Wallet.Primitive.SyncProgress as SyncProgress
 import qualified Cardano.Wallet.Primitive.Types as W
@@ -473,27 +474,27 @@ withNetworkLayerBase tr np conn versionData tol action = do
                 throwE $ ErrPostTxProtocolFailure "Invalid era: Byron"
 
             AnyCardanoEra ShelleyEra -> do
-                let cmd = CmdSubmitTx $ unsealShelleyTx GenTxShelley tx
+                let cmd = CmdSubmitTx $ toCardanoGenTx @Cardano.ShelleyEra tx
                 result <- liftIO $ localTxSubmissionQ `send` cmd
                 case result of
                     SubmitSuccess -> pure ()
                     SubmitFail err -> throwE $ ErrPostTxBadRequest $ T.pack (show err)
 
             AnyCardanoEra AllegraEra -> do
-                let cmd = CmdSubmitTx $ unsealShelleyTx GenTxAllegra tx
+                let cmd = CmdSubmitTx $ toCardanoGenTx @Cardano.AllegraEra tx
                 result <- liftIO $ localTxSubmissionQ `send` cmd
                 case result of
                     SubmitSuccess -> pure ()
                     SubmitFail err -> throwE $ ErrPostTxBadRequest $ T.pack (show err)
 
             AnyCardanoEra MaryEra -> do
-                let cmd = CmdSubmitTx $ unsealShelleyTx GenTxMary tx
+                let cmd = CmdSubmitTx $ toCardanoGenTx @Cardano.MaryEra tx
                 result <- liftIO $ localTxSubmissionQ `send` cmd
                 case result of
                     SubmitSuccess -> pure ()
                     SubmitFail err -> throwE $ ErrPostTxBadRequest $ T.pack (show err)
             AnyCardanoEra AlonzoEra -> do
-                let cmd = CmdSubmitTx $ unsealShelleyTx GenTxAlonzo tx
+                let cmd = CmdSubmitTx $ toCardanoGenTx @Cardano.AlonzoEra tx
                 result <- liftIO $ localTxSubmissionQ `send` cmd
                 case result of
                     SubmitSuccess -> pure ()

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -492,28 +492,28 @@ _decodeSignedTx era bytes = do
                 Just tx -> pure tx
                 Nothing ->
                     Left $ ErrDecodeSignedTxWrongPayload
-                        "wrong shelley tx format"
+                        "expected shelley tx format"
 
         AnyCardanoEra AllegraEra ->
             case tryAllegraTx <|> tryShelleyTx of
                 Just tx -> pure tx
                 Nothing ->
                     Left $ ErrDecodeSignedTxWrongPayload
-                        "wrong shelley and allegra tx format"
+                        "expected shelley or allegra tx format"
 
         AnyCardanoEra MaryEra ->
             case tryMaryTx <|> tryAllegraTx <|> tryShelleyTx of
                 Just tx -> pure tx
                 Nothing ->
                     Left $ ErrDecodeSignedTxWrongPayload
-                        "wrong shelley, allegra and mary tx format"
+                        "expected shelley, allegra or mary tx format"
 
         AnyCardanoEra AlonzoEra ->
             case tryAlonzoTx <|> tryMaryTx <|> tryAllegraTx <|> tryShelleyTx of
                 Just tx -> pure tx
                 Nothing ->
                     Left $ ErrDecodeSignedTxWrongPayload
-                        "wrong shelley, allegra, mary and alonzo tx format"
+                        "expected shelley, allegra, mary or alonzo tx format"
 
         AnyCardanoEra ByronEra ->
             Left ErrDecodeSignedTxNotSupported


### PR DESCRIPTION
### Issue Number

ADP-1110

### Comments

This PR adjusts `decodeSignedTx` so that when decoding in a given era, it also correctly tries all previous eras.