### PR TITLE
Move counterexample combinators to `Test.QuickCheck.Extra`

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/PlanningSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/PlanningSpec.hs
@@ -27,7 +27,6 @@ import Cardano.Wallet.Primitive.Migration.SelectionSpec
     , genMockInput
     , genRewardWithdrawal
     , genTokenBundleMixed
-    , report
     , shrinkMockInput
     , testAll
     , unMockTxConstraints
@@ -72,6 +71,8 @@ import Test.QuickCheck
     , withMaxSuccess
     , (===)
     )
+import Test.QuickCheck.Extra
+    ( report )
 import Test.Utils.Pretty
     ( Pretty (..) )
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/PlanningSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/PlanningSpec.hs
@@ -30,7 +30,6 @@ import Cardano.Wallet.Primitive.Migration.SelectionSpec
     , shrinkMockInput
     , testAll
     , unMockTxConstraints
-    , verify
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -72,7 +71,7 @@ import Test.QuickCheck
     , (===)
     )
 import Test.QuickCheck.Extra
-    ( report )
+    ( report, verify )
 import Test.Utils.Pretty
     ( Pretty (..) )
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -73,7 +73,7 @@ import Data.Semigroup
 import Data.Word
     ( Word8 )
 import Fmt
-    ( indentF, pretty, (+|), (|+) )
+    ( pretty )
 import Numeric.Natural
     ( Natural )
 import Test.Hspec
@@ -87,7 +87,6 @@ import Test.QuickCheck
     , Blind (..)
     , Gen
     , Property
-    , Testable
     , checkCoverage
     , choose
     , counterexample
@@ -104,8 +103,8 @@ import Test.QuickCheck
     , withMaxSuccess
     , (.&&.)
     )
-import Test.Utils.Pretty
-    ( pShowBuilder )
+import Test.QuickCheck.Extra
+    ( report )
 
 import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1045,13 +1044,6 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
 --------------------------------------------------------------------------------
 -- Internal types and functions
 --------------------------------------------------------------------------------
-
--- | Adds a named variable to the counterexample output of a property.
---
--- On failure, uses pretty-printing to show the contents of the variable.
---
-report :: (Show a, Testable prop) => a -> String -> prop -> Property
-report a name = counterexample (""+|name|+":\n"+|indentF 4 (pShowBuilder a)|+"")
 
 -- | Adds a named condition to a property.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -89,7 +89,6 @@ import Test.QuickCheck
     , Property
     , checkCoverage
     , choose
-    , counterexample
     , cover
     , elements
     , forAllBlind
@@ -101,10 +100,9 @@ import Test.QuickCheck
     , suchThatMap
     , vectorOf
     , withMaxSuccess
-    , (.&&.)
     )
 import Test.QuickCheck.Extra
-    ( report )
+    ( report, verify )
 
 import qualified Cardano.Wallet.Primitive.Migration.Selection as Selection
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
@@ -1044,16 +1042,6 @@ instance Arbitrary a => Arbitrary (NonEmpty a) where
 --------------------------------------------------------------------------------
 -- Internal types and functions
 --------------------------------------------------------------------------------
-
--- | Adds a named condition to a property.
---
--- On failure, reports the name of the condition that failed.
---
-verify :: Bool -> String -> Property -> Property
-verify condition conditionTitle =
-    (.&&.) (counterexample counterexampleText $ property condition)
-  where
-    counterexampleText = "Condition violated: " <> conditionTitle
 
 -- | Tests a collection of properties defined with 'verify'.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/MigrationSpec.hs
@@ -16,7 +16,6 @@ import Cardano.Wallet.Primitive.Migration.SelectionSpec
     , genTokenBundleMixed
     , testAll
     , unMockTxConstraints
-    , verify
     )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( genAddress )
@@ -40,6 +39,8 @@ import Test.Hspec.Extra
     ( parallel )
 import Test.QuickCheck
     ( Blind (..), Gen, Property, choose, forAllBlind, property )
+import Test.QuickCheck.Extra
+    ( verify )
 
 import qualified Cardano.Wallet.Primitive.Migration.Planning as Planning
 import qualified Data.List.NonEmpty as NE

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -83,11 +83,7 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionResult (..) )
 import Cardano.Wallet.Primitive.Migration.SelectionSpec
-    ( MockTxConstraints (..)
-    , genTokenBundleMixed
-    , report
-    , unMockTxConstraints
-    )
+    ( MockTxConstraints (..), genTokenBundleMixed, unMockTxConstraints )
 import Cardano.Wallet.Primitive.SyncProgress
     ( SyncTolerance (..) )
 import Cardano.Wallet.Primitive.Types
@@ -250,6 +246,8 @@ import Test.QuickCheck
     )
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
+import Test.QuickCheck.Extra
+    ( report )
 import Test.QuickCheck.Monadic
     ( assert, monadicIO, monitor, run )
 import Test.Utils.Time

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -22,6 +22,7 @@ module Test.QuickCheck.Extra
 
       -- * Counterexamples
     , report
+    , verify
 
       -- * Utilities
     , interleaveRoundRobin
@@ -42,9 +43,11 @@ import Test.QuickCheck
     , liftArbitrary2
     , liftShrink2
     , listOf
+    , property
     , scale
     , shrinkList
     , shrinkMapBy
+    , (.&&.)
     )
 import Test.Utils.Pretty
     ( pShowBuilder )
@@ -193,3 +196,13 @@ shrinkMapWith shrinkKey shrinkValue
 report :: (Show a, Testable prop) => a -> String -> prop -> Property
 report a name = counterexample $
     "" +|name|+ ":\n" +|indentF 4 (pShowBuilder a) |+ ""
+
+-- | Adds a named condition to a property.
+--
+-- On failure, reports the name of the condition that failed.
+--
+verify :: Bool -> String -> Property -> Property
+verify condition conditionTitle =
+    (.&&.) (counterexample counterexampleText $ property condition)
+  where
+    counterexampleText = "Condition violated: " <> conditionTitle

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -20,6 +20,9 @@ module Test.QuickCheck.Extra
     , shrinkInterleaved
     , shrinkMapWith
 
+      -- * Counterexamples
+    , report
+
       -- * Utilities
     , interleaveRoundRobin
 
@@ -29,8 +32,13 @@ import Prelude
 
 import Data.Map.Strict
     ( Map )
+import Fmt
+    ( indentF, (+|), (|+) )
 import Test.QuickCheck
     ( Gen
+    , Property
+    , Testable
+    , counterexample
     , liftArbitrary2
     , liftShrink2
     , listOf
@@ -38,6 +46,8 @@ import Test.QuickCheck
     , shrinkList
     , shrinkMapBy
     )
+import Test.Utils.Pretty
+    ( pShowBuilder )
 
 import qualified Data.List as L
 import qualified Data.Map.Strict as Map
@@ -171,3 +181,15 @@ shrinkMapWith shrinkKey shrinkValue
     = shrinkMapBy Map.fromList Map.toList
     $ shrinkList
     $ liftShrink2 shrinkKey shrinkValue
+
+--------------------------------------------------------------------------------
+-- Counterexamples
+--------------------------------------------------------------------------------
+
+-- | Adds a named variable to the counterexample output of a property.
+--
+-- On failure, uses pretty-printing to show the contents of the variable.
+--
+report :: (Show a, Testable prop) => a -> String -> prop -> Property
+report a name = counterexample $
+    "" +|name|+ ":\n" +|indentF 4 (pShowBuilder a) |+ ""

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -8,14 +8,21 @@
 --
 
 module Test.QuickCheck.Extra
-    ( genMapWith
+    (
+      -- * Generation
+      genMapWith
     , genSized2
     , genSized2With
-    , interleaveRoundRobin
-    , liftShrink6
     , reasonablySized
+
+      -- * Shrinking
+    , liftShrink6
     , shrinkInterleaved
     , shrinkMapWith
+
+      -- * Utilities
+    , interleaveRoundRobin
+
     ) where
 
 import Prelude


### PR DESCRIPTION
### Issue Number

ADP-1070

### Comments

This PR moves the following combinators to `Test.QuickCheck.Extra`:
- `report`
- `verify`

These are generally useful and used by a variety of test modules, so it makes sense to locate them in a shared module, rather than importing them from `SelectionSpec`.