### PR TITLE
Add stake key deposit parameters to runWalletCoinSelection

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -209,6 +209,7 @@ library
       Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction
       Cardano.Wallet.Unsafe
+      Cardano.Wallet.Util
       Cardano.Wallet.Version
       Cardano.Wallet.Version.TH
       Control.Concurrent.Concierge

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -282,7 +282,6 @@ import Cardano.Wallet.Primitive.Types
     , NetworkParameters (..)
     , PoolId (..)
     , PoolMetadataGCStatus (..)
-    , ShowFmt (..)
     , SlotInEpoch (..)
     , SlotLength (..)
     , SlotNo (..)
@@ -316,6 +315,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( BoundType, HistogramBar (..), UTxOStatistics (..) )
 import Cardano.Wallet.TokenMetadata
     ( TokenMetadataError (..) )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
 import Codec.Binary.Bech32
     ( dataPartFromBytes, dataPartToBytes )
 import Codec.Binary.Bech32.TH

--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -159,6 +159,8 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( AssetId (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.Monad
     ( forM, forM_, unless, void, when, (<=<) )
 import Control.Monad.Extra
@@ -2522,7 +2524,7 @@ instance
                 (Seq.internalPool st, Seq.externalPool st)
         let (Seq.ParentContextUtxo accXPubInternal) = Seq.context intPool
         let (Seq.ParentContextUtxo accXPubExternal) = Seq.context extPool
-        let (accountXPub, _) = W.invariant
+        let (accountXPub, _) = invariant
                 "Internal & External pool use different account public keys!"
                 ( accXPubExternal, accXPubInternal )
                 (uncurry (==))

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Byron.hs
@@ -75,11 +75,13 @@ import Cardano.Wallet.Primitive.AddressDerivation
     , hex
     )
 import Cardano.Wallet.Primitive.Types
-    ( invariant, testnetMagic )
+    ( testnetMagic )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.DeepSeq
     ( NFData )
 import Crypto.Hash

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Icarus.hs
@@ -71,11 +71,13 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     ( SeqState, coinTypeAda, purposeBIP44 )
 import Cardano.Wallet.Primitive.Types
-    ( invariant, testnetMagic )
+    ( testnetMagic )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.Arrow
     ( first, left )
 import Control.DeepSeq

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/SharedKey.hs
@@ -38,10 +38,10 @@ import Cardano.Address.Style.Shelley
     ( Credential (..), delegationAddress, paymentAddress )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationType (..), Index (..), NetworkDiscriminant (..) )
-import Cardano.Wallet.Primitive.Types
-    ( invariant )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.DeepSeq
     ( NFData (..) )
 import Data.Maybe

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDerivation/Shelley.hs
@@ -88,12 +88,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , purposeCIP1852
     , rewardAccountKey
     )
-import Cardano.Wallet.Primitive.Types
-    ( invariant )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Hash
     ( Hash (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/AddressDiscovery/Sequential.hs
@@ -112,12 +112,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     , coinTypeAda
     )
-import Cardano.Wallet.Primitive.Types
-    ( invariant )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
+import Cardano.Wallet.Util
+    ( invariant )
 import Codec.Binary.Encoding
     ( AbstractEncoding (..), encode )
 import Control.Applicative

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -132,7 +132,6 @@ module Cardano.Wallet.Primitive.Types
     -- * Polymorphic
     , Signature (..)
     , ShowFmt (..)
-    , invariant
 
     -- * Settings
     , Settings(..)
@@ -164,6 +163,8 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount (..) )
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..), TxSize (..) )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.Arrow
     ( left, right )
 import Control.DeepSeq
@@ -1382,28 +1383,6 @@ instance NFData a => NFData (ShowFmt a)
 
 instance Buildable a => Show (ShowFmt a) where
     show (ShowFmt a) = fmt (build a)
-
--- | Checks whether or not an invariant holds, by applying the given predicate
---   to the given value.
---
--- If the invariant does not hold (indicated by the predicate function
--- returning 'False'), throws an error with the specified message.
---
--- >>> invariant "not empty" [1,2,3] (not . null)
--- [1, 2, 3]
---
--- >>> invariant "not empty" [] (not . null)
--- *** Exception: not empty
-invariant
-    :: String
-        -- ^ The message
-    -> a
-        -- ^ The value to test
-    -> (a -> Bool)
-        -- ^ The predicate
-    -> a
-invariant msg a predicate =
-    if predicate a then a else error msg
 
 {-------------------------------------------------------------------------------
                                Metadata services

--- a/lib/core/src/Cardano/Wallet/Primitive/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types.hs
@@ -131,7 +131,6 @@ module Cardano.Wallet.Primitive.Types
 
     -- * Polymorphic
     , Signature (..)
-    , ShowFmt (..)
 
     -- * Settings
     , Settings(..)
@@ -164,7 +163,7 @@ import Cardano.Wallet.Primitive.Types.RewardAccount
 import Cardano.Wallet.Primitive.Types.Tx
     ( Tx (..), TxSize (..) )
 import Cardano.Wallet.Util
-    ( invariant )
+    ( ShowFmt (..), invariant )
 import Control.Arrow
     ( left, right )
 import Control.DeepSeq
@@ -1373,16 +1372,6 @@ getPoolRetirementCertificate = \case
 newtype Signature (what :: Type) = Signature { getSignature :: ByteString }
     deriving stock (Show, Eq, Generic)
     deriving newtype (ByteArrayAccess)
-
--- | A polymorphic wrapper type with a custom show instance to display data
--- through 'Buildable' instances.
-newtype ShowFmt a = ShowFmt { unShowFmt :: a }
-    deriving (Generic, Eq, Ord)
-
-instance NFData a => NFData (ShowFmt a)
-
-instance Buildable a => Show (ShowFmt a) where
-    show (ShowFmt a) = fmt (build a)
 
 {-------------------------------------------------------------------------------
                                Metadata services

--- a/lib/core/src/Cardano/Wallet/Util.hs
+++ b/lib/core/src/Cardano/Wallet/Util.hs
@@ -1,0 +1,86 @@
+-- |
+-- Copyright: © 2020-2021 IOHK
+-- License: Apache-2.0
+--
+-- General utility functions.
+--
+module Cardano.Wallet.Util
+    ( -- * Partial functions for "impossible" situations
+      HasCallStack
+    , internalError
+    , tina
+    , invariant
+
+    -- ** Handling errors for "impossible" situations.
+    , isInternalError
+    , tryInternalError
+    ) where
+
+import Prelude
+
+import Control.Exception
+    ( ErrorCall, displayException )
+import Control.Monad.IO.Unlift
+    ( MonadUnliftIO )
+import Data.Foldable
+    ( asum )
+import Data.List
+    ( isPrefixOf )
+import Data.Maybe
+    ( fromMaybe )
+import Fmt
+    ( Buildable (..), Builder, fmt, (+|) )
+import GHC.Generics
+    ( Generic )
+import GHC.Stack
+    ( HasCallStack )
+import UnliftIO.Exception
+    ( evaluate, tryJust )
+
+-- | Calls the 'error' function, which will usually crash the program.
+internalError :: HasCallStack => Builder -> a
+internalError msg = error $ fmt $ "INTERNAL ERROR: "+|msg
+
+isInternalErrorMsg :: String -> Bool
+isInternalErrorMsg msg = "INTERNAL ERROR" `isPrefixOf` msg
+
+-- | Take the first 'Just' from a list of 'Maybe', or die trying.
+-- There is no alternative.
+tina :: HasCallStack => Builder -> [Maybe a] -> a
+tina msg = fromMaybe (internalError msg) . asum
+
+-- | Checks whether or not an invariant holds, by applying the given predicate
+--   to the given value.
+--
+-- If the invariant does not hold (indicated by the predicate function
+-- returning 'False'), throws an error with the specified message.
+--
+-- >>> invariant "not empty" [1,2,3] (not . null)
+-- [1, 2, 3]
+--
+-- >>> invariant "not empty" [] (not . null)
+-- *** Exception: not empty
+invariant
+    :: HasCallStack
+    => String
+        -- ^ The message
+    -> a
+        -- ^ The value to test
+    -> (a -> Bool)
+        -- ^ The predicate
+    -> a
+invariant msg a predicate = if predicate a then a else error msg
+
+-- | Tests whether an 'Exception' was caused by 'internalError'.
+isInternalError :: ErrorCall -> Maybe String
+isInternalError (displayException -> msg)
+    | isInternalErrorMsg msg = Just msg
+    | otherwise = Nothing
+
+-- | Evaluates a pure expression to WHNF and handles any occurrence of
+-- 'internalError'.
+--
+-- This is intended for use in testing. Don't use this in application code --
+-- that's what normal IO exceptions are for.
+tryInternalError :: MonadUnliftIO m => a -> m (Either String a)
+tryInternalError = tryJust isInternalError . evaluate

--- a/lib/core/src/Cardano/Wallet/Util.hs
+++ b/lib/core/src/Cardano/Wallet/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 -- |
 -- Copyright: © 2020-2021 IOHK
 -- License: Apache-2.0
@@ -14,10 +16,15 @@ module Cardano.Wallet.Util
     -- ** Handling errors for "impossible" situations.
     , isInternalError
     , tryInternalError
+
+    -- * String formatting
+    , ShowFmt (..)
     ) where
 
 import Prelude
 
+import Control.DeepSeq
+    ( NFData (..) )
 import Control.Exception
     ( ErrorCall, displayException )
 import Control.Monad.IO.Unlift
@@ -84,3 +91,17 @@ isInternalError (displayException -> msg)
 -- that's what normal IO exceptions are for.
 tryInternalError :: MonadUnliftIO m => a -> m (Either String a)
 tryInternalError = tryJust isInternalError . evaluate
+
+{-------------------------------------------------------------------------------
+                               Formatting helpers
+-------------------------------------------------------------------------------}
+
+-- | A polymorphic wrapper type with a custom show instance to display data
+-- through 'Buildable' instances.
+newtype ShowFmt a = ShowFmt { unShowFmt :: a }
+    deriving (Generic, Eq, Ord)
+
+instance NFData a => NFData (ShowFmt a)
+
+instance Buildable a => Show (ShowFmt a) where
+    show (ShowFmt a) = fmt (build a)

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -92,7 +92,6 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , ProtocolParameters (..)
     , Range (..)
-    , ShowFmt (..)
     , SlotInEpoch (..)
     , SlotNo (..)
     , SortOrder (..)
@@ -136,6 +135,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic, unsafeMkPercentage )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
 import Control.Arrow
     ( second )
 import Control.DeepSeq

--- a/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Properties.hs
@@ -51,7 +51,6 @@ import Cardano.Wallet.Primitive.Types
     ( BlockHeader (..)
     , GenesisParameters
     , ProtocolParameters
-    , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
     , SortOrder (..)
@@ -72,6 +71,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     )
 import Cardano.Wallet.Unsafe
     ( unsafeRunExceptT )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
 import Control.Monad
     ( forM, forM_, void )
 import Control.Monad.IO.Class

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/AddressDiscovery/SequentialSpec.hs
@@ -75,12 +75,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , purposeCIP1852
     , role
     )
-import Cardano.Wallet.Primitive.Types
-    ( ShowFmt (..) )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..), AddressState (..) )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
 import Control.Arrow
     ( first )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , fullBalance
     )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..) )
+    ( Coin (..), addCoin, scaleCoin )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, shrinkCoin )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -126,10 +126,15 @@ balanceSufficient SelectionParams{..} =
     balanceRequired =
         F.foldMap (view #tokens) outputsToCover
             <> TB.fromTokenMap assetsToBurn
+            <> TB.fromCoin (deposit certificateDepositsTaken)
     balanceAvailable =
         fullBalance utxoAvailable (Just extraCoinSource)
             <> TB.fromTokenMap assetsToMint
-    extraCoinSource = rewardWithdrawals
+    extraCoinSource = deposit certificateDepositsReturned
+        `addCoin` rewardWithdrawals
+
+deposit :: Integral n => n -> Coin
+deposit n = scaleCoin n (depositAmount testSelectionConstraints)
 
 testSelectionConstraints :: SelectionConstraints
 testSelectionConstraints = SelectionConstraints

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -49,7 +49,6 @@ import Cardano.Wallet.Primitive.Types
     ( Block (..)
     , BlockHeader (..)
     , EpochLength (..)
-    , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
     )
@@ -87,7 +86,7 @@ import Cardano.Wallet.Primitive.Types.UTxO
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
 import Cardano.Wallet.Util
-    ( invariant )
+    ( ShowFmt (..), invariant )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -52,7 +52,6 @@ import Cardano.Wallet.Primitive.Types
     , ShowFmt (..)
     , SlotId (..)
     , SlotNo (..)
-    , invariant
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -87,6 +86,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     ( Dom (..), UTxO (..), balance, excluding, filterByAddress, restrictedTo )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
     ( genUTxO, shrinkUTxO )
+import Cardano.Wallet.Util
+    ( invariant )
 import Control.DeepSeq
     ( NFData (..) )
 import Control.Monad

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -1,3 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
 module Cardano.Wallet.Primitive.Types.CoinSpec
     ( spec
     ) where
@@ -5,51 +12,68 @@ module Cardano.Wallet.Primitive.Types.CoinSpec
 import Prelude
 
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin (..), isValidCoin )
+    ( Coin (..), isValidCoin, scaleCoin, sumCoins )
 import Cardano.Wallet.Primitive.Types.Coin.Gen
     ( genCoin, genCoinPositive, shrinkCoin, shrinkCoinPositive )
+import Cardano.Wallet.Util
+    ( tryInternalError )
+import Data.List
+    ( isInfixOf )
+import GHC.Generics
+    ( Generic )
 import Test.Hspec
-    ( Spec, describe, it )
+    ( Spec, describe )
 import Test.Hspec.Extra
     ( parallel )
+import Test.Hspec.QuickCheck
+    ( prop )
 import Test.QuickCheck
-    ( Property, conjoin, forAll, property )
+    ( Arbitrary (..)
+    , Property
+    , conjoin
+    , counterexample
+    , forAll
+    , frequency
+    , genericShrink
+    , getNonNegative
+    , label
+    , property
+    , (===)
+    )
+import Test.QuickCheck.Monadic
+    ( assert, monadicIO, monitor, run )
 
 spec :: Spec
-spec = do
-
-    parallel $ describe "Generators and shrinkers" $ do
-
+spec = parallel $ do
+    describe "Generators and shrinkers" $ do
         describe "Coins that can be zero" $ do
-            it "genCoin" $
-                property prop_genCoin
-            it "shrinkCoin" $
-                property prop_shrinkCoin
+            prop "genCoin" prop_genCoin
+            prop "shrinkCoin" prop_shrinkCoin
 
         describe "Coins that are strictly positive" $ do
-            it "genCoinPositive" $
-                property prop_genCoinPositive
-            it "shrinkCoinPositive" $
-                property prop_shrinkCoinPositive
+            prop "genCoinPositive" prop_genCoinPositive
+            prop "shrinkCoinPositive" prop_shrinkCoinPositive
 
---------------------------------------------------------------------------------
--- Coins that can be zero
---------------------------------------------------------------------------------
+    describe "Operations" $ do
+        prop "scaleCoin" prop_scaleCoin
 
-prop_genCoin :: Property
-prop_genCoin = forAll genCoin isValidCoin
+{-------------------------------------------------------------------------------
+                             Coins that can be zero
+-------------------------------------------------------------------------------}
 
-prop_shrinkCoin :: Property
-prop_shrinkCoin = forAll genCoin $ \c ->
-    let shrunken = shrinkCoin c in
-    conjoin $ ($ shrunken) <$>
+prop_genCoin :: Coin -> Property
+prop_genCoin = property . isValidCoin
+
+prop_shrinkCoin :: Coin -> Property
+prop_shrinkCoin c = conjoin $
+    ($ shrinkCoin c) <$>
         [ all (< c)
         , all isValidCoin
         ]
 
---------------------------------------------------------------------------------
--- Coins that are strictly positive
---------------------------------------------------------------------------------
+{-------------------------------------------------------------------------------
+                        Coins that are strictly positive
+-------------------------------------------------------------------------------}
 
 prop_genCoinPositive :: Property
 prop_genCoinPositive = forAll genCoinPositive isValidCoinPositive
@@ -64,3 +88,52 @@ prop_shrinkCoinPositive = forAll genCoinPositive $ \c ->
 
 isValidCoinPositive :: Coin -> Bool
 isValidCoinPositive c = c > Coin 0 && c <= maxBound
+
+{-------------------------------------------------------------------------------
+                                   Operations
+-------------------------------------------------------------------------------}
+
+data ScaleCoin = ScaleCoin
+    { scale :: Integer
+    , coin :: Coin
+    } deriving (Generic, Show, Eq)
+
+prop_scaleCoin :: ScaleCoin -> Property
+prop_scaleCoin (ScaleCoin s c)
+    | overflow  = label "overflow error" $ catchError "overflow"
+    | underflow = label "underflow error" $ catchError "underflow"
+    | otherwise = result === expected
+  where
+    result = scaleCoin s c
+    expected = sumCoins (replicate (fromIntegral s) c)
+
+    overflow = fromIntegral (unCoin c) * s > fromIntegral (unCoin maxBound)
+    underflow = s < 0
+
+    catchError e = monadicIO $ do
+        res <- run $ tryInternalError result
+        monitor (counterexample ("res = " ++ show res))
+        case res of
+            Right (Coin 0) -> pure ()
+            Right _ -> fail "expected scaleCoin to crash but it didn't"
+            Left msg -> assert $ e `isInfixOf` msg
+
+{-------------------------------------------------------------------------------
+                              Arbitrary Instances
+-------------------------------------------------------------------------------}
+
+instance Arbitrary Coin where
+    arbitrary = genCoin
+    shrink = shrinkCoin
+
+instance Arbitrary ScaleCoin where
+    arbitrary = ScaleCoin
+        <$> frequency
+            [ (75, getNonNegative <$> arbitrary)
+            , (20, arbitrary)
+            , (5, (* 1000000) <$> arbitrary) ]
+        <*> frequency
+            [ (60, arbitrary)
+            , (40, Coin . (* 45000000) <$> arbitrary) ]
+
+    shrink = genericShrink

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/TypesSpec.hs
@@ -58,7 +58,6 @@ import Cardano.Wallet.Primitive.Types
     , PoolOwner (..)
     , Range (..)
     , RangeBound (..)
-    , ShowFmt (..)
     , SlotId (..)
     , SlotInEpoch (..)
     , SlotLength (..)
@@ -126,6 +125,8 @@ import Cardano.Wallet.Primitive.Types.UTxO
     )
 import Cardano.Wallet.Unsafe
     ( someDummyMnemonic )
+import Cardano.Wallet.Util
+    ( ShowFmt (..) )
 import Control.Monad
     ( forM_, replicateM )
 import Crypto.Hash

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -71,9 +71,6 @@ module Cardano.Wallet.Shelley.Compatibility
     , rewardAccountFromAddress
     , fromShelleyPParams
     , fromAlonzoPParams
-    , unsafeIntToWord
-    , internalError
-    , isInternalError
     , ToCardanoGenTx (..)
 
       -- ** Assessing sizes of token bundles
@@ -170,15 +167,15 @@ import Cardano.Wallet.Primitive.Types
     , TxParameters (getTokenBundleMaxSize)
     )
 import Cardano.Wallet.Unsafe
-    ( safeDeserialiseCbor, unsafeMkPercentage )
+    ( safeDeserialiseCbor, unsafeIntToWord, unsafeMkPercentage )
+import Cardano.Wallet.Util
+    ( internalError, tina )
 import Codec.Binary.Bech32
     ( dataPartFromBytes, dataPartToBytes )
 import Control.Applicative
     ( (<|>) )
 import Control.Arrow
     ( left )
-import Control.Exception
-    ( ErrorCall, displayException )
 import Control.Monad
     ( when, (>=>) )
 import Crypto.Hash.Utils
@@ -204,11 +201,9 @@ import Data.Coerce
 import Data.Either.Extra
     ( eitherToMaybe )
 import Data.Foldable
-    ( asum, toList )
+    ( toList )
 import Data.Function
     ( (&) )
-import Data.List
-    ( isPrefixOf )
 import Data.Map.Strict
     ( Map )
 import Data.Maybe
@@ -221,12 +216,10 @@ import Data.Text
     ( Text )
 import Data.Text.Class
     ( TextDecodingError (..) )
-import Data.Typeable
-    ( Typeable, typeRep )
 import Data.Word
     ( Word16, Word32, Word64, Word8 )
 import Fmt
-    ( Buildable (..), Builder, fmt, (+|), (+||), (|+), (||+) )
+    ( Buildable (..), Builder, (+|), (+||), (||+) )
 import GHC.Records
     ( HasField (..) )
 import GHC.Stack
@@ -1133,52 +1126,11 @@ toWalletCoin = W.Coin . unsafeCoinToWord64
 unsafeCoinToWord64 :: HasCallStack => SL.Coin -> Word64
 unsafeCoinToWord64 (SL.Coin c) = unsafeIntToWord c
 
--- | Convert an integer type of any range to a machine word.
---
--- Only use it for values which have come from the ledger, and should fit in the
--- given type, according to the spec.
---
--- If this conversion would under/overflow, there is not much we can do except
--- to hastily exit.
-unsafeIntToWord
-    :: forall from to
-     . ( HasCallStack
-       , Integral from
-       , Bounded to
-       , Integral to
-       , Typeable from
-       , Typeable to
-       , Show from)
-    => from -> to
-unsafeIntToWord n
-    | n < fromIntegral (minBound :: to) = crash "underflow"
-    | n > fromIntegral (maxBound :: to) = crash "overflow"
-    | otherwise = fromIntegral n
-  where
-    crash :: Builder -> to
-    crash err = internalError $ err |+" converting value "+|| n ||+
-        " from " +|| typeRep (Proxy @from) ||+
-        " to "+|| typeRep (Proxy @to) ||+"!"
-
--- | Calls the 'error' function, which will usually crash the program.
-internalError :: HasCallStack => Builder -> a
-internalError msg = error $ fmt $ "INTERNAL ERROR: "+|msg
-
--- | Tests whether an 'Exception' was caused by 'internalError'.
-isInternalError :: ErrorCall -> Bool
-isInternalError e = "INTERNAL ERROR" `isPrefixOf` displayException e
-
--- | Take the first 'Just' from a list of 'Maybe', or die trying.
--- There is no alternative.
-tina :: HasCallStack => Builder -> [Maybe a] -> a
-tina msg = fromMaybe (internalError msg) . asum
-
 fromPoolMetadata :: SL.PoolMetadata -> (W.StakePoolMetadataUrl, W.StakePoolMetadataHash)
 fromPoolMetadata meta =
     ( W.StakePoolMetadataUrl (urlToText (SL._poolMDUrl meta))
     , W.StakePoolMetadataHash (SL._poolMDHash meta)
     )
-
 
 -- | Convert a stake credentials to a 'RewardAccount' type.
 --


### PR DESCRIPTION
This is the coin selection part extracted from PR #2754.

The goal is to remove certificate deposit / withdrawal hacks from `Cardano.Wallet.selectAssets` and move the logic towards the coin selection module.

There are some Cardano.Wallet.Util and logging improvements also brought across, which are used by `selectAssets` and `runWalletCoinSelection`.

### Comments

There is a new `CoinSelectionSpec` module with a property for `runWalletCoinSelection`, but it's not able to handle all cases yet.

Based on the PR #2887 branch - merge that first.

### Issue Number

ADP-919