### PR TITLE
Suggestions for PR 2856

### DIFF
--- a/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Wallet/DB/Sqlite.hs
@@ -1819,7 +1819,8 @@ mkTxHistory
         , [TxWithdrawal]
         )
 mkTxHistory wid txs = flatTxHistory
-    [ ( mkTxMetaEntity wid txid (W.fee tx) (W.metadata tx) derived (W.scriptValidity tx)
+    [ ( mkTxMetaEntity
+          wid txid (W.fee tx) (W.metadata tx) derived (W.scriptValidity tx)
       , mkTxInputsOutputs (txid, tx)
       , mkTxWithdrawals (txid, tx)
       )

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -377,11 +377,11 @@ applyTxToUTxO tx !u = spendTx tx u <> utxoFromTx tx
 spendTx :: Tx -> UTxO -> UTxO
 spendTx tx !u =
     u `excluding` Set.fromList inputsToExclude
-    where
-        inputsToExclude =
-            if failedScriptValidation (tx ^. #scriptValidity)
-            then collateralInputs tx
-            else inputs tx
+  where
+    inputsToExclude =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then collateralInputs tx
+        else inputs tx
 
 -- | Construct a UTxO corresponding to a given transaction. It is important for
 -- the transaction outputs to be ordered correctly, since they become available
@@ -569,10 +569,10 @@ changeUTxO
 changeUTxO pending = evalState $
     mconcat
     <$> mapM (filterByAddressM isOurAddress . mkUTxOFromTx) (Set.toList pending)
-    where
-        -- Generate a UTxO from an transaction, assuming that it passes phase-2
-        -- script validation. Crucially, utxoFromTx will exclude failed
-        -- transactions, hence we define our own function.
-        mkUTxOFromTx :: Tx -> UTxO
-        mkUTxOFromTx Tx {txId, outputs} =
-            UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs
+  where
+    -- Generate a UTxO from an transaction, assuming that it passes phase-2
+    -- script validation. Crucially, utxoFromTx will exclude failed
+    -- transactions, hence we define our own function.
+    mkUTxOFromTx :: Tx -> UTxO
+    mkUTxOFromTx Tx {txId, outputs} =
+        UTxO $ Map.fromList $ zip (TxIn txId <$> [0..]) outputs

--- a/lib/core/src/Cardano/Wallet/Primitive/Model.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Model.hs
@@ -379,7 +379,7 @@ spendTx tx !u =
     u `excluding` Set.fromList inputsToExclude
   where
     inputsToExclude =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then collateralInputs tx
         else inputs tx
 
@@ -390,8 +390,8 @@ spendTx tx !u =
 -- balance (utxoFromTx tx) = foldMap tokens (outputs tx)
 -- utxoFromTx tx `excluding` Set.fromList (inputs tx) = utxoFrom tx
 utxoFromTx :: Tx -> UTxO
-utxoFromTx tx@Tx {scriptValidity} =
-    if failedScriptValidation scriptValidity
+utxoFromTx tx =
+    if failedScriptValidation tx
     then mempty
     else utxoFromUnvalidatedTx tx
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -497,12 +498,13 @@ data TxScriptValidity
 
 instance NFData TxScriptValidity
 
--- | Returns True when the script has failed validation.
-failedScriptValidation :: Maybe TxScriptValidity -> Bool
-failedScriptValidation (Just TxScriptInvalid) = True
-failedScriptValidation (Just TxScriptValid) = False
--- Script validation always passes in eras that don't support scripts
-failedScriptValidation Nothing = False
+-- | Returns 'True' if and only if a transaction has failed script validation.
+failedScriptValidation :: Tx -> Bool
+failedScriptValidation Tx {scriptValidity} = case scriptValidity of
+    Just TxScriptInvalid -> True
+    Just TxScriptValid -> False
+    -- Script validation always passes in eras that don't support scripts
+    Nothing -> False
 
 -- | Reconstruct a transaction info from a transaction.
 fromTransactionInfo :: TransactionInfo -> Tx

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -524,11 +524,12 @@ fileModeSpec =  do
             testOpeningCleaning f (`readCheckpoint'` testWid) (Just testCp) Nothing
 
         describe "Golden rollback scenarios" $ do
-            let dummyHash x = Hash $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
-            let dummyAddr x = Address $ x <> BS.pack (replicate (32 - (BS.length x)) 0)
+            let dummyHash x = Hash $
+                    x <> BS.pack (replicate (32 - (BS.length x)) 0)
+            let dummyAddr x = Address $
+                    x <> BS.pack (replicate (32 - (BS.length x)) 0)
 
-            let
-                mockApply DBLayer{..} h mockTxs = do
+            let mockApply DBLayer{..} h mockTxs = do
                     Just cpA <- atomically $ readCheckpoint testWid
                     let slotA = view #slotNo $ currentTip cpA
                     let Quantity bhA = view #blockHeight $ currentTip cpA
@@ -551,10 +552,9 @@ fileModeSpec =  do
                         unsafeRunExceptT $ putTxHistory testWid txs
                         unsafeRunExceptT $ prune testWid (Quantity 2160)
 
-
-            it "Should remove collateral inputs from the UTxO set if validation \
-               \fails" $ \f ->
-                withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
+            it "Should remove collateral inputs from the UTxO set if \
+                \validation fails" $
+                \f -> withShelleyFileDBLayer f $ \db@DBLayer{..} -> do
 
                     let ourAddrs =
                             map (\(a,s,_) -> (a,s)) $
@@ -594,11 +594,15 @@ fileModeSpec =  do
                         [ Tx
                             { txId = dummyHash "tx2a"
                             , fee = Nothing
-                            , resolvedInputs = [(TxIn (dummyHash "tx1") 0, Coin 4)]
-                            , resolvedCollateral = [(TxIn (dummyHash "tx1") 1, Coin 8)]
+                            , resolvedInputs =
+                                [(TxIn (dummyHash "tx1") 0, Coin 4)]
+                            , resolvedCollateral =
+                                [(TxIn (dummyHash "tx1") 1, Coin 8)]
                             , outputs =
-                                [ TxOut (dummyAddr "faucetAddr2") (coinToBundle 2)
-                                , TxOut (fst $ ourAddrs !! 1) (coinToBundle 2)
+                                [ TxOut
+                                    (dummyAddr "faucetAddr2") (coinToBundle 2)
+                                , TxOut
+                                    (fst $ ourAddrs !! 1) (coinToBundle 2)
                                 ]
                             , withdrawals = mempty
                             , metadata = Nothing

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -1594,6 +1594,12 @@ prop_applyTxToUTxO_balance tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (applyTxToUTxO tx u) === expectedBalance
   where
     expectedBalance =
@@ -1613,6 +1619,12 @@ prop_applyTxToUTxO_entries tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     applyTxToUTxO tx u === expectedResult
   where
     expectedResult =
@@ -1630,6 +1642,12 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
     cover 10
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
     ===
     expectedResult
@@ -1646,6 +1664,13 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
 
 prop_utxoFromTx_is_unspent :: Tx -> Property
 prop_utxoFromTx_is_unspent tx =
+    checkCoverage $
+    cover 10
+        (utxoFromTx tx /= mempty)
+        "utxoFromTx tx /= mempty" $
+    cover 10
+        (Set.fromList (inputs tx) /= mempty)
+        "Set.fromList (inputs tx) /= mempty" $
     utxoFromTx tx `excluding` Set.fromList (inputs tx)
     === utxoFromTx tx
 
@@ -1673,6 +1698,16 @@ unit_applyTxToUTxO_loses_collateral tx txin txout coin =
 
 prop_utxoFromTx_balance :: Tx -> Property
 prop_utxoFromTx_balance tx =
+    checkCoverage $
+    cover 10
+        (outputs tx /= mempty)
+        "outputs tx /= mempty" $
+    cover 10
+        (failedScriptValidation (tx ^. #scriptValidity))
+        "failedScriptValidation (tx ^. #scriptValidity)" $
+    cover 10
+        (not $ failedScriptValidation (tx ^. #scriptValidity))
+        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
     balance (utxoFromTx tx) === foldMap f (outputs tx)
   where
     f output =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -100,7 +100,7 @@ import Data.Function
 import Data.Functor
     ( ($>) )
 import Data.Generics.Internal.VL.Lens
-    ( over, view, (^.) )
+    ( over, view )
 import Data.Generics.Labels
     ()
 import Data.List
@@ -1595,15 +1595,15 @@ prop_applyTxToUTxO_balance tx u =
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     balance (applyTxToUTxO tx u) === expectedBalance
   where
     expectedBalance =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then
             balance (u `excluding` Set.fromList (collateralInputs tx))
         else
@@ -1620,15 +1620,15 @@ prop_applyTxToUTxO_entries tx u =
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     applyTxToUTxO tx u === expectedResult
   where
     expectedResult =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then u `excluding` Set.fromList (collateralInputs tx)
         else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
 
@@ -1643,17 +1643,17 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
     ===
     expectedResult
   where
     expectedResult =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then mempty
         else foldMap m (outputs tx)
       where
@@ -1703,15 +1703,15 @@ prop_utxoFromTx_balance tx =
         (outputs tx /= mempty)
         "outputs tx /= mempty" $
     cover 10
-        (failedScriptValidation (tx ^. #scriptValidity))
-        "failedScriptValidation (tx ^. #scriptValidity)" $
+        (failedScriptValidation tx)
+        "failedScriptValidation tx)" $
     cover 10
-        (not $ failedScriptValidation (tx ^. #scriptValidity))
-        "not $ failedScriptValidation (tx ^. #scriptValidity)" $
+        (not $ failedScriptValidation tx)
+        "not $ failedScriptValidation tx)" $
     balance (utxoFromTx tx) === foldMap f (outputs tx)
   where
     f output =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then mempty
         else tokens output
 
@@ -1752,7 +1752,7 @@ prop_spendTx_balance tx u =
     rhs = TokenBundle.unsafeSubtract (balance u) toSubtract
       where
         toSubtract =
-            if failedScriptValidation (tx ^. #scriptValidity)
+            if failedScriptValidation tx
             then balance
                 (u `UTxO.restrictedBy` Set.fromList (collateralInputs tx))
             else balance
@@ -1767,7 +1767,7 @@ prop_spendTx tx u =
     spendTx tx u === u `excluding` toExclude
   where
     toExclude =
-        if failedScriptValidation (tx ^. #scriptValidity)
+        if failedScriptValidation tx
         then Set.fromList (collateralInputs tx)
         else Set.fromList (inputs tx)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -204,8 +204,10 @@ spec = do
                 (property prop_applyTxToUTxO_balance)
             it "has expected entries"
                 (property prop_applyTxToUTxO_entries)
-            it "consumes inputs" unit_applyTxToUTxO_spends_input
-            it "loses collateral" unit_applyTxToUTxO_loses_collateral
+            it "consumes inputs"
+                unit_applyTxToUTxO_spends_input
+            it "loses collateral"
+                unit_applyTxToUTxO_loses_collateral
             it "applyTxToUTxO then filterByAddress"
                 (property prop_filterByAddress_balance_applyTxToUTxO)
             it "spendTx/applyTxToUTxO/utxoFromTx"
@@ -1580,15 +1582,15 @@ prop_applyTxToUTxO_balance tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
-    balance (applyTxToUTxO tx u)
-    ===
-    (if failedScriptValidation (tx ^. #scriptValidity)
-     then
-         balance (u `excluding` Set.fromList (collateralInputs tx))
-     else
-         balance (u `excluding` Set.fromList (inputs tx))
-             `TokenBundle.add` balance (utxoFromTx tx)
-    )
+    balance (applyTxToUTxO tx u) === expectedBalance
+  where
+    expectedBalance =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then
+            balance (u `excluding` Set.fromList (collateralInputs tx))
+        else
+            balance (u `excluding` Set.fromList (inputs tx))
+                `TokenBundle.add` balance (utxoFromTx tx)
 
 prop_applyTxToUTxO_entries :: Tx -> UTxO -> Property
 prop_applyTxToUTxO_entries tx u =
@@ -1599,12 +1601,12 @@ prop_applyTxToUTxO_entries tx u =
     cover 10
         (applyTxToUTxO tx u /= u)
         "applyTxToUTxO tx u /= u" $
-    applyTxToUTxO tx u
-    ===
-    (if failedScriptValidation (tx ^. #scriptValidity)
-     then u `excluding` Set.fromList (collateralInputs tx)
-     else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
-    )
+    applyTxToUTxO tx u === expectedResult
+  where
+    expectedResult =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then u `excluding` Set.fromList (collateralInputs tx)
+        else u `excluding` Set.fromList (inputs tx) <> utxoFromTx tx
 
 prop_filterByAddress_balance_applyTxToUTxO
     :: (Address -> Bool) -> Tx -> Property
@@ -1617,12 +1619,18 @@ prop_filterByAddress_balance_applyTxToUTxO f tx =
         (filterByAddress f (applyTxToUTxO tx mempty) /= mempty)
         "filterByAddress f (applyTxToUTxO tx mempty) /= mempty" $
     balance (filterByAddress f (applyTxToUTxO tx mempty))
-    === if failedScriptValidation (tx ^. #scriptValidity)
+    ===
+    expectedResult
+  where
+    expectedResult =
+        if failedScriptValidation (tx ^. #scriptValidity)
         then mempty
-        else foldMap (\o -> if f (address o)
-                            then tokens o
-                            else mempty
-                     ) (outputs tx)
+        else foldMap m (outputs tx)
+      where
+        m output =
+            if f (address output)
+            then tokens output
+            else mempty
 
 prop_utxoFromTx_is_unspent :: Tx -> Property
 prop_utxoFromTx_is_unspent tx =
@@ -1635,13 +1643,14 @@ unit_applyTxToUTxO_spends_input =
     forAllShrink genTxIn shrinkTxIn $ \txin ->
     forAllShrink genTxOut shrinkTxOut $ \txout ->
     forAllShrink genCoin shrinkCoin $ \coin ->
-      let
-          tx' = tx { resolvedInputs = [(txin, coin)]
-                   , scriptValidity = Nothing
-                   }
-      in
-          applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
-          === utxoFromTx tx' `excluding` Set.singleton txin
+    let
+        tx' = tx
+            { resolvedInputs = [(txin, coin)]
+            , scriptValidity = Nothing
+            }
+    in
+        applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
+        === utxoFromTx tx' `excluding` Set.singleton txin
 
 unit_applyTxToUTxO_loses_collateral :: Property
 unit_applyTxToUTxO_loses_collateral =
@@ -1649,21 +1658,23 @@ unit_applyTxToUTxO_loses_collateral =
     forAllShrink genTxIn shrinkTxIn $ \txin ->
     forAllShrink genTxOut shrinkTxOut $ \txout ->
     forAllShrink genCoin shrinkCoin $ \coin ->
-      let
-          tx' = tx { resolvedCollateral = [(txin, coin)]
-                   , scriptValidity = Just TxScriptInvalid
-                   }
-      in
-          applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
-          === mempty
+    let
+        tx' = tx
+            { resolvedCollateral = [(txin, coin)]
+            , scriptValidity = Just TxScriptInvalid
+            }
+    in
+        applyTxToUTxO tx' (UTxO $ Map.fromList [(txin, txout)])
+        === mempty
 
 prop_utxoFromTx_balance :: Tx -> Property
 prop_utxoFromTx_balance tx =
-    balance (utxoFromTx tx)
-    === foldMap (\o -> if failedScriptValidation (tx ^. #scriptValidity)
-                       then mempty
-                       else tokens o
-                ) (outputs tx)
+    balance (utxoFromTx tx) === foldMap f (outputs tx)
+  where
+    f output =
+        if failedScriptValidation (tx ^. #scriptValidity)
+        then mempty
+        else tokens output
 
 -- spendTx tx u `isSubsetOf` u
 prop_spendTx_isSubset :: Tx -> UTxO -> Property
@@ -1699,14 +1710,14 @@ prop_spendTx_balance tx u =
     lhs === rhs
   where
     lhs = balance (spendTx tx u)
-    rhs = TokenBundle.unsafeSubtract
-        (balance u)
-        ( if failedScriptValidation (tx ^. #scriptValidity)
-          then balance (u `UTxO.restrictedBy`
-                         Set.fromList (collateralInputs tx))
-          else balance (u `UTxO.restrictedBy`
-                         Set.fromList (inputs tx))
-        )
+    rhs = TokenBundle.unsafeSubtract (balance u) toSubtract
+      where
+        toSubtract =
+            if failedScriptValidation (tx ^. #scriptValidity)
+            then balance
+                (u `UTxO.restrictedBy` Set.fromList (collateralInputs tx))
+            else balance
+                (u `UTxO.restrictedBy` Set.fromList (inputs tx))
 
 prop_spendTx :: Tx -> UTxO -> Property
 prop_spendTx tx u =
@@ -1714,11 +1725,12 @@ prop_spendTx tx u =
     cover 10
         (spendTx tx u /= mempty)
         "spendTx tx u /= mempty" $
-    spendTx tx u === u `excluding` (
+    spendTx tx u === u `excluding` toExclude
+  where
+    toExclude =
         if failedScriptValidation (tx ^. #scriptValidity)
         then Set.fromList (collateralInputs tx)
         else Set.fromList (inputs tx)
-    )
 
 prop_spendTx_utxoFromTx :: Tx -> UTxO -> Property
 prop_spendTx_utxoFromTx tx u =
@@ -1731,7 +1743,6 @@ prop_applyTxToUTxO_spendTx_utxoFromTx tx u =
         (spendTx tx u /= mempty && utxoFromTx tx /= mempty)
         "spendTx tx u /= mempty && utxoFromTx tx /= mempty" $
     applyTxToUTxO tx u === spendTx tx u <> utxoFromTx tx
-
 
 prop_spendTx_filterByAddress :: (Address -> Bool) -> Tx -> UTxO -> Property
 prop_spendTx_filterByAddress f tx u =

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -114,7 +114,7 @@ genSized2 genA genB = (,)
 genSized2With :: (a -> b -> c) -> Gen a -> Gen b -> Gen c
 genSized2With f genA genB = uncurry f <$> genSized2 genA genB
 
--- | Similar to 'liftShrink2', but applicable to 6-tuples.
+-- | Similar to 'liftShrink2', but applicable to 7-tuples.
 --
 liftShrink7
     :: (a1 -> [a1])


### PR DESCRIPTION
## Issue Number

ADP-1036

## Summary

This PR makes a number of fixes and suggested changes to PR #2856:

It:
- adds coverage checks to newly-introduced properties.
- adds coverage checks to modified properties.
- uses `Arbitrary` instances to remove some boilerplate from property tests.
- extracts out function `utxoFromUnvalidatedTx` from `utxoFromTx`.
  (this allows us to remove some code duplication)
- makes `failedScriptValidation` take a `Tx` argument.
  (this is always called in a context where the `Tx` value is available)
- fixes a few typos and formatting errors.