### PR TITLE
Allow coin selection with pre-selected inputs

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -161,7 +161,6 @@ import Test.Integration.Framework.TestData
     , errMsg403MinUTxOValue
     , errMsg403NotAShelleyWallet
     , errMsg403NotEnoughMoney
-    , errMsg403TxTooBig
     , errMsg403WithdrawalNotWorth
     , errMsg403WrongPass
     , errMsg404CannotFindTx
@@ -1112,7 +1111,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status403 r
-        expectErrorMessage errMsg403TxTooBig r
+        expectErrorMessage errMsg403EmptyUTxO r
 
     it "TRANSMETA_ESTIMATE_01 - fee estimation includes metadata" $ \ctx -> runResourceT $ do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
@@ -1175,7 +1174,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         verify r
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403TxTooBig
+            , expectErrorMessage errMsg403EmptyUTxO
             ]
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -520,6 +520,7 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.ByteArray as BA
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -1458,7 +1459,7 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 case view #txDelegationAction txCtx of
                     Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
-            , utxoAvailable
+            , utxoAvailable = UTxOSelection.fromIndex utxoAvailable
             }
     case mSel of
         Left e -> liftIO $

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3808,7 +3808,7 @@ instance IsServerError ErrSelectAssets where
                         , "enough funds available in the wallet. I am "
                         , "missing: ", pretty . Flat $ balanceMissing e
                         ]
-                Balance.SelectionInsufficient e ->
+                Balance.SelectionLimitReached e ->
                     apiError err403 TransactionIsTooBig $ mconcat
                         [ "I am not able to finalize the transaction "
                         , "because I need to select additional inputs and "

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -68,8 +68,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxOut
     , txOutMaxTokenQuantity
     )
-import Cardano.Wallet.Primitive.Types.UTxOIndex
-    ( UTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOSelection
+    ( UTxOSelection )
 import Control.Monad.Random.Class
     ( MonadRandom )
 import Control.Monad.Trans.Except
@@ -271,10 +271,12 @@ data SelectionParams = SelectionParams
         :: !Natural
         -- ^ Number of deposits from stake key de-registrations.
     , utxoAvailable
-        :: !UTxOIndex
-        -- ^ Specifies the set of all available UTxO entries. The algorithm
-        -- will choose entries from this set when selecting ordinary inputs
-        -- and collateral inputs.
+        :: !UTxOSelection
+        -- ^ Specifies a set of UTxOs that are available for selection as
+        -- ordinary inputs and optionally, a subset that has already been
+        -- selected.
+        --
+        -- Further entries from this set will be selected to cover any deficit.
     }
     deriving (Eq, Generic, Show)
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -828,8 +828,6 @@ performSelectionNonEmpty constraints params
             , minimumBalance = utxoBalanceRequired
             }
         case maybeSelection of
-            Nothing | selectionLimit <= MaximumInputLimit 0 ->
-                selectionLimitReachedError []
             Nothing ->
                 pure $ Left EmptyUTxO
             Just selection | selectionLimitExceeded selection selectionLimit ->

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -35,8 +35,6 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionConstraints (..)
     , SelectionParams
     , SelectionParamsOf (..)
-    , SelectionLimit
-    , SelectionLimitOf (..)
     , SelectionSkeleton (..)
     , SelectionResult
     , SelectionResultOf (..)
@@ -45,6 +43,11 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionInsufficientError (..)
     , InsufficientMinCoinValueError (..)
     , UnableToConstructChangeError (..)
+
+    -- * Selection limits
+    , SelectionLimit
+    , SelectionLimitOf (..)
+    , selectionLimitExceeded
 
     -- * Querying selections
     , SelectionDelta (..)
@@ -433,6 +436,13 @@ instance Ord a => Ord (SelectionLimitOf a) where
         (MaximumInputLimit _, NoLimit            ) -> LT
         (NoLimit            , MaximumInputLimit _) -> GT
         (MaximumInputLimit x, MaximumInputLimit y) -> compare x y
+
+-- | Indicates whether or not the given selection limit has been exceeded.
+--
+selectionLimitExceeded :: IsUTxOSelection s => s -> SelectionLimit -> Bool
+selectionLimitExceeded s = \case
+    NoLimit -> False
+    MaximumInputLimit n -> UTxOSelection.selectedSize s > n
 
 type SelectionResult = SelectionResultOf [TxOut]
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -835,6 +835,9 @@ performSelectionNonEmpty constraints params
                 selectionInsufficientError []
             Nothing ->
                 pure $ Left EmptyUTxO
+            Just selection | selectionLimitExceeded selection selectionLimit ->
+                selectionInsufficientError $ F.toList $
+                    UTxOSelection.selectedList selection
             Just selection -> do
                 let utxoSelected = UTxOSelection.selectedIndex selection
                 let utxoBalanceSelected = UTxOIndex.balance utxoSelected

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -10,6 +10,7 @@ module Cardano.Wallet.Primitive.Types.Tx.Gen
     , genTxHash
     , genTxIndex
     , genTxIn
+    , genTxInFunction
     , genTxInLargeRange
     , genTxOut
     , genTxScriptValidity
@@ -73,7 +74,8 @@ import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
     ( genericArbitrary, genericShrink )
 import Test.QuickCheck.Extra
-    ( genMapWith
+    ( genFunction
+    , genMapWith
     , genSized2With
     , liftShrink7
     , shrinkInterleaved
@@ -174,9 +176,6 @@ genTxHashLargeRange = Hash . B8.pack <$> replicateM 32 arbitrary
 -- Transaction indices generated according to the size parameter
 --------------------------------------------------------------------------------
 
-coarbitraryTxIn :: TxIn -> Gen a -> Gen a
-coarbitraryTxIn = coarbitrary . show
-
 genTxIndex :: Gen Word32
 genTxIndex = sized $ \size -> elements $ take (max 1 size) txIndices
 
@@ -198,6 +197,16 @@ shrinkTxIn :: TxIn -> [TxIn]
 shrinkTxIn (TxIn h i) = uncurry TxIn <$> shrinkInterleaved
     (h, shrinkTxHash)
     (i, shrinkTxIndex)
+
+--------------------------------------------------------------------------------
+-- Transaction input functions
+--------------------------------------------------------------------------------
+
+coarbitraryTxIn :: TxIn -> Gen a -> Gen a
+coarbitraryTxIn = coarbitrary . show
+
+genTxInFunction :: Gen a -> Gen (TxIn -> a)
+genTxInFunction = genFunction coarbitraryTxIn
 
 --------------------------------------------------------------------------------
 -- Transaction inputs chosen from a large range (to minimize collisions)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -61,6 +61,8 @@ module Cardano.Wallet.Primitive.Types.UTxOSelection
     , isProperSubSelectionOf
 
       -- * Accessor functions
+    , availableBalance
+    , availableUTxO
     , leftoverBalance
     , leftoverSize
     , leftoverIndex
@@ -297,6 +299,35 @@ isProperSubSelectionOf u1 u2 = state u1 /= state u2 && u1 `isSubSelectionOf` u2
 --------------------------------------------------------------------------------
 -- Accessor functions
 --------------------------------------------------------------------------------
+
+-- | Computes the available balance.
+--
+-- The available balance is the sum of the selected and the leftover balances.
+--
+-- It predicts what 'selectedBalance' would be if every single UTxO were
+-- selected.
+--
+-- This result of this function remains constant over applications of 'select'
+-- and 'selectMany':
+--
+-- >>> availableBalance u == availableBalance (selectMany is u)
+--
+availableBalance :: IsUTxOSelection u => u -> TokenBundle
+availableBalance u = leftoverBalance u <> selectedBalance u
+
+-- | Computes the available UTxO set.
+--
+-- The available UTxO set is the union of the selected and leftover UTxO sets.
+--
+-- It predicts what 'selectedUTxO' would be if every single UTxO were selected.
+--
+-- This result of this function remains constant over applications of 'select'
+-- and 'selectMany':
+--
+-- >>> availableUTxO u == availableUTxO (selectMany is u)
+--
+availableUTxO :: IsUTxOSelection u => u -> UTxO
+availableUTxO u = leftoverUTxO u <> selectedUTxO u
 
 -- | Retrieves the balance of leftover UTxOs.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
@@ -13,7 +13,7 @@ import Prelude
 import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn )
 import Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( coarbitraryTxIn )
+    ( genTxInFunction )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, shrinkUTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
@@ -22,8 +22,6 @@ import Data.Maybe
     ( mapMaybe )
 import Test.QuickCheck
     ( Gen, arbitrary, liftShrink2, shrinkMapBy, suchThatMap )
-import Test.QuickCheck.Extra
-    ( genFunction )
 
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 
@@ -37,7 +35,7 @@ genUTxOSelection = UTxOSelection.fromIndexFiltered
     <*> genUTxOIndex
   where
     genFilter :: Gen (TxIn -> Bool)
-    genFilter = genFunction coarbitraryTxIn (arbitrary @Bool)
+    genFilter = genTxInFunction (arbitrary @Bool)
 
 shrinkUTxOSelection :: UTxOSelection -> [UTxOSelection]
 shrinkUTxOSelection =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1229,17 +1229,22 @@ prop_runSelection_UTxO_empty balanceRequested = monadicIO $ do
     result <- run $ runSelection
         RunSelectionParams
             { selectionLimit = NoLimit
-            , utxoAvailable = UTxOSelection.fromIndex UTxOIndex.empty
+            , utxoAvailable
             , minimumBalance = balanceRequested
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
+    assertWith
+        "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
+        (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
     assertWith
         "balanceSelected == TokenBundle.empty"
         (balanceSelected == TokenBundle.empty)
     assertWith
         "balanceLeftover == TokenBundle.empty"
         (balanceLeftover == TokenBundle.empty)
+  where
+    utxoAvailable = UTxOSelection.fromIndex UTxOIndex.empty
 
 prop_runSelection_UTxO_notEnough :: UTxOSelection -> Property
 prop_runSelection_UTxO_notEnough utxoAvailable = monadicIO $ do
@@ -1251,6 +1256,9 @@ prop_runSelection_UTxO_notEnough utxoAvailable = monadicIO $ do
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
+    assertWith
+        "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
+        (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
     assertWith
         "balanceSelected == balanceAvailable"
         (balanceSelected == balanceAvailable)
@@ -1271,6 +1279,9 @@ prop_runSelection_UTxO_exactlyEnough utxoAvailable = monadicIO $ do
             }
     let balanceSelected = UTxOSelection.selectedBalance result
     let balanceLeftover = UTxOSelection.leftoverBalance result
+    assertWith
+        "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
+        (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
     assertWith
         "balanceLeftover == TokenBundle.empty"
         (balanceLeftover == TokenBundle.empty)
@@ -1311,6 +1322,9 @@ prop_runSelection_UTxO_moreThanEnough utxoAvailable = monadicIO $ do
         , pretty (Flat balanceLeftover)
         ]
     assertWith
+        "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
+        (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
+    assertWith
         "balanceRequested `leq` balanceSelected"
         (balanceRequested `leq` balanceSelected)
     assertWith
@@ -1334,7 +1348,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
         result <- run $ runSelection
             RunSelectionParams
                 { selectionLimit = NoLimit
-                , utxoAvailable = UTxOSelection.fromIndex index
+                , utxoAvailable
                 , minimumBalance = balanceRequested
                 }
         let balanceSelected = UTxOSelection.selectedBalance result
@@ -1355,6 +1369,9 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
             , pretty (Flat balanceLeftover)
             ]
         assertWith
+            "utxoAvailable `UTxOSelection.isSubSelectionOf` result"
+            (utxoAvailable `UTxOSelection.isSubSelectionOf` result)
+        assertWith
             "balanceRequested `leq` balanceSelected"
             (balanceRequested `leq` balanceSelected)
         assertWith
@@ -1366,6 +1383,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
     balanceAvailable = view #balance index
     balanceRequested = adjustAllTokenBundleQuantities (`div` 256) $
         cutAssetSetSizeInHalf balanceAvailable
+    utxoAvailable = UTxOSelection.fromIndex index
 
 --------------------------------------------------------------------------------
 -- Running a selection (non-empty)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -43,6 +43,7 @@ import Test.QuickCheck
     )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 
@@ -85,6 +86,8 @@ spec =
 
     parallel $ describe "Indicator and accessor functions" $ do
 
+        it "prop_availableBalance_availableUTxO" $
+            property prop_availableBalance_availableUTxO
         it "prop_isNonEmpty_selectedSize" $
             property prop_isNonEmpty_selectedSize
         it "prop_isNonEmpty_selectedIndex" $
@@ -108,6 +111,10 @@ spec =
             property prop_select_isSelected
         it "prop_select_isProperSubSelectionOf" $
             property prop_select_isProperSubSelectionOf
+        it "prop_select_availableBalance" $
+            property prop_select_availableBalance
+        it "prop_select_availableUTxO" $
+            property prop_select_availableUTxO
         it "prop_select_leftoverSize" $
             property prop_select_leftoverSize
         it "prop_select_selectedSize" $
@@ -223,6 +230,12 @@ prop_toNonEmpty_fromNonEmpty s =
 -- Indicator and accessor functions
 --------------------------------------------------------------------------------
 
+prop_availableBalance_availableUTxO :: UTxOSelection -> Property
+prop_availableBalance_availableUTxO s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.availableBalance s
+    === UTxO.balance (UTxOSelection.availableUTxO s)
+
 prop_isNonEmpty_selectedSize :: UTxOSelection -> Property
 prop_isNonEmpty_selectedSize s =
     checkCoverage_UTxOSelection s $
@@ -292,6 +305,24 @@ prop_select_isProperSubSelectionOf i s =
     (UTxOSelection.isProperSubSelectionOf s <$> UTxOSelection.select i s)
     ===
     if UTxOSelection.isLeftover i s then Just True else Nothing
+
+prop_select_availableBalance :: TxIn -> UTxOSelection -> Property
+prop_select_availableBalance i s =
+    checkCoverage_select i s $
+    (UTxOSelection.availableBalance <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s
+    then Just (UTxOSelection.availableBalance s)
+    else Nothing
+
+prop_select_availableUTxO :: TxIn -> UTxOSelection -> Property
+prop_select_availableUTxO i s =
+    checkCoverage_select i s $
+    (UTxOSelection.availableUTxO <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s
+    then Just (UTxOSelection.availableUTxO s)
+    else Nothing
 
 prop_select_leftoverSize :: TxIn -> UTxOSelection -> Property
 prop_select_leftoverSize i s =


### PR DESCRIPTION
## Issue Number

ADP-1118

## Summary and Scope

This PR makes it possible to call `CoinSelection.performSelection` with an available UTXO set that has some entries pre-selected. The pre-selected entries will be included in the result.

In addition, this PR:
- renames `SelectionInsufficientError` to `SelectionLimitReachedError` to clarify that this error condition relates to the selection limit.

## Limitations

This PR only adjusts the API provided by `CoinSelection` (and `CoinSelection.Balance`). It does not adjust `Wallet.selectAssets` to accept a `UTxOSelection`. This is left to future PRs.