### PR TITLE
Don't require all minted assets to be spent or burned

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -357,7 +357,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionResult (..)
     , UnableToConstructChangeError (..)
     , balanceMissing
-    , missingOutputAssets
     , selectionDelta
     )
 import Cardano.Wallet.Primitive.Delegation.UTxO
@@ -3797,13 +3796,6 @@ instance IsServerError ErrSelectAssets where
                         , "specify an ada value for an output. Otherwise, you "
                         , "must specify enough ada. Here are the problematic "
                         , "outputs:\n" <> pretty (indentF 2 $ blockListF xs)
-                        ]
-                Balance.OutputsInsufficient e ->
-                    apiError err403 TokensMintedButNotSpentOrBurned $ mconcat
-                        [ "I can't process this transaction because some "
-                        , "minted values were not spent or burned. These "
-                        , "are the values that should be spent or burned: "
-                        , pretty . Flat $ missingOutputAssets e
                         ]
                 Balance.UnableToConstructChange e ->
                     apiError err403 CannotCoverFee $ T.unwords

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -38,7 +38,6 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionResult (..)
     , SelectionError (..)
     , BalanceInsufficientError (..)
-    , OutputsInsufficientError (..)
     , SelectionInsufficientError (..)
     , InsufficientMinCoinValueError (..)
     , UnableToConstructChangeError (..)
@@ -115,7 +114,6 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , distance
     , mapMaybe
     , balanceMissing
-    , missingOutputAssets
     ) where
 
 import Prelude
@@ -507,55 +505,10 @@ data SelectionError
         SelectionInsufficientError
     | InsufficientMinCoinValues
         (NonEmpty InsufficientMinCoinValueError)
-    | OutputsInsufficient
-        OutputsInsufficientError
     | UnableToConstructChange
         UnableToConstructChangeError
     | EmptyUTxO
     deriving (Generic, Eq, Show)
-
--- | Indicates that a portion of the minted assets were not spent or burned.
---
--- This situation occurs if the following inequality does not hold:
---
--- >>> assetsToMint `leq` (assetsToBurn <> requestedOutputAssets)
---
--- The existence of this error reflects a deliberate design choice: all minted
--- assets must either be explicitly spent or explicitly burned by the caller.
--- In future, we could revise this design to allow excess minted assets (those
--- that are neither spent nor burned) to be returned to the wallet as change.
---
-data OutputsInsufficientError = OutputsInsufficientError
-    { assetsToMint
-        :: !TokenMap
-      -- ^ The assets to mint
-    , assetsToBurn
-        :: !TokenMap
-      -- ^ The assets to burn
-    , requestedOutputAssets
-        :: !TokenMap
-      -- ^ The complete set of assets found within the user-specified outputs
-    } deriving (Generic, Eq, Show)
-
--- | Computes the portion of minted assets that are not spent or burned.
---
-missingOutputAssets :: OutputsInsufficientError -> TokenMap
-missingOutputAssets e =
-    -- We use 'difference' which will show us the quantities in 'assetsToMint'
-    -- that are not in 'assetsToBurn <> requestedOutputAssets'.
-    --
-    -- Any asset quantity present in 'assetsToBurn <> requestedOutputAssets'
-    -- but not present in 'assetsToMint' will simply be zeroed out, which is
-    -- the behaviour we want for this error report.
-    --
-    assetsToMint `TokenMap.difference`
-        (assetsToBurn `TokenMap.add` requestedOutputAssets)
-  where
-    OutputsInsufficientError
-        { assetsToMint
-        , assetsToBurn
-        , requestedOutputAssets
-        } = e
 
 -- | Indicates that the balance of selected UTxO entries was insufficient to
 --   cover the balance required.
@@ -684,11 +637,6 @@ performSelection
         -- ^ The selection goal to satisfy.
     -> m (Either SelectionError (SelectionResult TokenBundle))
 performSelection minCoinFor costFor bundleSizeAssessor criteria
-    -- Is the minted value all spent or burnt?
-    | not (assetsToMint `leq` (assetsToBurn <> requestedOutputAssets)) =
-        pure $ Left $ OutputsInsufficient $ OutputsInsufficientError
-            {assetsToMint, assetsToBurn, requestedOutputAssets}
-
     -- Is the total available UTXO balance sufficient?
     | not utxoBalanceSufficient =
         pure $ Left $ BalanceInsufficient $ BalanceInsufficientError
@@ -732,12 +680,6 @@ performSelection minCoinFor costFor bundleSizeAssessor criteria
             { inputsSelected
             , utxoBalanceRequired
             }
-
-    requestedOutputBalance :: TokenBundle
-    requestedOutputBalance = F.foldMap (view #tokens) outputsToCover
-
-    requestedOutputAssets :: TokenMap
-    requestedOutputAssets = view #tokens requestedOutputBalance
 
     mkInputsSelected :: UTxOIndex -> NonEmpty (TxIn, TxOut)
     mkInputsSelected =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1153,7 +1153,7 @@ prop_runSelection_UTxO_notEnough (Small index) = monadicIO $ do
         (balanceLeftover == TokenBundle.empty)
   where
     balanceAvailable = view #balance index
-    balanceRequested = adjustAllQuantities (* 2) balanceAvailable
+    balanceRequested = adjustAllTokenBundleQuantities (* 2) balanceAvailable
 
 prop_runSelection_UTxO_exactlyEnough
     :: Small UTxOIndex
@@ -1218,7 +1218,7 @@ prop_runSelection_UTxO_moreThanEnough (Small index) = monadicIO $ do
     assetsAvailable = TokenBundle.getAssets balanceAvailable
     assetsRequested = TokenBundle.getAssets balanceRequested
     balanceAvailable = view #balance index
-    balanceRequested = adjustAllQuantities (`div` 8) $
+    balanceRequested = adjustAllTokenBundleQuantities (`div` 8) $
         cutAssetSetSizeInHalf balanceAvailable
 
 prop_runSelection_UTxO_muchMoreThanEnough
@@ -1262,7 +1262,7 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
     assetsAvailable = TokenBundle.getAssets balanceAvailable
     assetsRequested = TokenBundle.getAssets balanceRequested
     balanceAvailable = view #balance index
-    balanceRequested = adjustAllQuantities (`div` 256) $
+    balanceRequested = adjustAllTokenBundleQuantities (`div` 256) $
         cutAssetSetSizeInHalf balanceAvailable
 
 --------------------------------------------------------------------------------
@@ -3575,8 +3575,9 @@ assertWith description condition = do
     monitor $ counterexample ("Assertion failed: " <> description)
     assert condition
 
-adjustAllQuantities :: (Natural -> Natural) -> TokenBundle -> TokenBundle
-adjustAllQuantities f b = uncurry TokenBundle.fromFlatList $ bimap
+adjustAllTokenBundleQuantities
+    :: (Natural -> Natural) -> TokenBundle -> TokenBundle
+adjustAllTokenBundleQuantities f b = uncurry TokenBundle.fromFlatList $ bimap
     (adjustCoin)
     (fmap (fmap adjustTokenQuantity))
     (TokenBundle.toFlatList b)
@@ -3586,6 +3587,12 @@ adjustAllQuantities f b = uncurry TokenBundle.fromFlatList $ bimap
 
     adjustTokenQuantity :: TokenQuantity -> TokenQuantity
     adjustTokenQuantity = TokenQuantity . f . unTokenQuantity
+
+adjustAllTokenMapQuantities
+    :: (Natural -> Natural) -> TokenMap -> TokenMap
+adjustAllTokenMapQuantities f m = view #tokens
+    $ adjustAllTokenBundleQuantities f
+    $ TokenBundle.fromTokenMap m
 
 cutAssetSetSizeInHalf :: TokenBundle -> TokenBundle
 cutAssetSetSizeInHalf = uncurry TokenBundle.fromFlatList

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -27,7 +27,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , BalanceInsufficientError (..)
     , InsufficientMinCoinValueError (..)
     , MakeChangeCriteria (..)
-    , OutputsInsufficientError (..)
     , RunSelectionParams (..)
     , SelectionCriteria (..)
     , SelectionDelta (..)
@@ -58,7 +57,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , makeChangeForNonUserSpecifiedAssets
     , makeChangeForUserSpecifiedAsset
     , mapMaybe
-    , missingOutputAssets
     , performSelection
     , prepareOutputsWith
     , reduceTokenQuantities
@@ -748,6 +746,12 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
     cover 2 (noAssetsAreBothSpentAndBurned)
         "No assets are both spent and burned" $
 
+    -- Inspect the relationship between minted, burned, and spent assets:
+    cover 2 (allMintedAssetsEitherBurnedOrSpent)
+        "All minted assets were either spent or burned" $
+    cover 2 (not allMintedAssetsEitherBurnedOrSpent)
+        "Some minted assets were neither spent nor burned" $
+
     prop_performSelection minCoinValueFor costFor (Blind criteria) $ \result ->
         cover 10 (selectionUnlimited && selectionSufficient result)
             "selection unlimited and sufficient"
@@ -755,8 +759,6 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
             "selection limited but sufficient"
         . cover 10 (selectionLimited && selectionInsufficient result)
             "selection limited and insufficient"
-        . cover 2 (outputsInsufficient result)
-            "A portion of the minted assets were not spent or burned"
   where
     utxoHasAtLeastOneAsset = not
         . Set.null
@@ -770,11 +772,6 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
             . F.toList
             . fmap (view #tokens)
             $ outputsToCover criteria
-
-    outputsInsufficient :: PerformSelectionResult -> Bool
-    outputsInsufficient = \case
-        Left (OutputsInsufficient _) -> True
-        _ -> False
 
     selectionLimited :: Bool
     selectionLimited = case view #selectionLimit criteria of
@@ -797,6 +794,12 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
     assetsSpentByUserSpecifiedOutputs :: TokenMap
     assetsSpentByUserSpecifiedOutputs =
         F.foldMap (view (#tokens . #tokens)) (outputsToCover criteria)
+
+    allMintedAssetsEitherBurnedOrSpent :: Bool
+    allMintedAssetsEitherBurnedOrSpent =
+        view #assetsToMint criteria `leq` TokenMap.add
+            (view #assetsToBurn criteria)
+            (assetsSpentByUserSpecifiedOutputs)
 
     someAssetsAreBothMintedAndBurned :: Bool
     someAssetsAreBothMintedAndBurned
@@ -969,8 +972,6 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
     onFailure = \case
         BalanceInsufficient e ->
             onBalanceInsufficient e
-        OutputsInsufficient e ->
-            onOutputsInsufficient e
         SelectionInsufficient e ->
             onSelectionInsufficient e
         InsufficientMinCoinValues es ->
@@ -1026,27 +1027,6 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             errorBalanceRequired errorInputsSelected = e
         errorBalanceSelected =
             F.foldMap (view #tokens . snd) errorInputsSelected
-
-    onOutputsInsufficient e = do
-        monitor $ counterexample $ unlines
-            [ "assets to mint:"
-            , pretty (Flat errorAssetsToMint)
-            , "assets to burn:"
-            , pretty (Flat errorAssetsToBurn)
-            , "requested output assets:"
-            , pretty (Flat errorRequestedOutputAssets)
-            , "assets minted but not spent or burned:"
-            , pretty (Flat $ missingOutputAssets e)
-            ]
-        assert $ errorAssetsToMint == assetsToMint
-        assert $ errorAssetsToBurn == assetsToBurn
-        assert
-            $ not
-            $ errorAssetsToMint
-                `leq` (errorRequestedOutputAssets <> errorAssetsToBurn)
-      where
-        OutputsInsufficientError
-            errorAssetsToMint errorAssetsToBurn errorRequestedOutputAssets = e
 
     onInsufficientMinCoinValues es = do
         monitor $ counterexample $ unlines


### PR DESCRIPTION
### Issue Number

ADP-1113

### Summary

This PR removes the restriction that all minted assets must be spent or burned.

Minted assets that are not spent or burned are now returned in the change outputs.