### PR TITLE
Split runWalletCoinSelection wrapper into a separate function

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/DSL.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/DSL.hs
@@ -1439,7 +1439,7 @@ fixtureMultiAssetRandomWallet ctx = do
 
     -- send assets to Byron wallet
     rtx <- request @(ApiTransaction n) ctx
-        (Link.createTransaction @'Shelley wMA) Default payload
+        (Link.createTransactionOld @'Shelley wMA) Default payload
     expectResponseCode HTTP.status202 rtx
 
     eventually "Byron wallet has assets" $ do
@@ -1480,7 +1480,7 @@ fixtureMultiAssetIcarusWallet ctx = do
 
     -- send assets to Icarus wallet
     rtx <- request @(ApiTransaction n) ctx
-        (Link.createTransaction @'Shelley wMA) Default payload
+        (Link.createTransactionOld @'Shelley wMA) Default payload
     expectResponseCode HTTP.status202 rtx
 
     eventually "Icarus wallet has assets" $ do
@@ -1905,7 +1905,7 @@ fixtureWalletWith ctx coins0 = do
                 "passphrase": #{fixturePassphrase}
             }|]
         request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley src) Default payload
+            (Link.createTransactionOld @'Shelley src) Default payload
             >>= expectResponseCode HTTP.status202
         eventually "balance available = balance total" $ do
             rb <- request @ApiWallet ctx
@@ -1970,7 +1970,7 @@ moveByronCoins ctx src (dest, addrs) coins = do
             "passphrase": #{fixturePassphrase}
         }|]
     request @(ApiTransaction n) ctx
-        (Link.createTransaction @'Byron src) Default payload
+        (Link.createTransactionOld @'Byron src) Default payload
         >>= expectResponseCode HTTP.status202
     eventually "balance available = balance total" $ do
         rb <- request @ApiByronWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/HWWallets.hs
@@ -142,7 +142,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                 "passphrase": "cardano-wallet"
             }|]
         rTrans <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Byron wSrc) Default payload
+            (Link.createTransactionOld @'Byron wSrc) Default payload
         expectResponseCode HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do
@@ -197,7 +197,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                     "passphrase": "cardano-wallet"
                 }|]
             rTrans <- request @(ApiTransaction n) ctx
-                (Link.createTransaction @'Byron wSrc) Default payload
+                (Link.createTransactionOld @'Byron wSrc) Default payload
             expectResponseCode HTTP.status403 rTrans
             expectErrorMessage (errMsg403NoRootKey $ wSrc ^. walletId) rTrans
 
@@ -254,7 +254,7 @@ spec = describe "BYRON_HW_WALLETS" $ do
                 }|]
 
             rFee <- request @ApiFee ctx
-                (Link.getTransactionFee @'Byron wSrc) Default payload
+                (Link.getTransactionFeeOld @'Byron wSrc) Default payload
             expectResponseCode HTTP.status202 rFee
 
         it "Can delete" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Transactions.hs
@@ -152,7 +152,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination (minUTxOValue' * 2) [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Byron wSrc) Default payload
+            (Link.createTransactionOld @'Byron wSrc) Default payload
         expectResponseCode HTTP.status202 rtx
 
         eventually "Payee wallet balance is as expected" $ do
@@ -184,7 +184,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination minUTxOValue' [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Byron wSrc) Default payload
+            (Link.createTransactionOld @'Byron wSrc) Default payload
         expectResponseCode HTTP.status403 rtx
         expectErrorMessage "Some outputs have ada values that are too small." rtx
 
@@ -206,7 +206,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Byron wSrc) Default payload
+            (Link.createTransactionOld @'Byron wSrc) Default payload
         expectResponseCode HTTP.status202 rtx
 
         eventually "Payee wallet balance is as expected" $ do
@@ -324,7 +324,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
             }|]
 
         rFeeEst <- request @ApiFee ctx
-            (Link.getTransactionFee @'Byron wByron) Default payload
+            (Link.getTransactionFeeOld @'Byron wByron) Default payload
         verify rFeeEst
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -333,7 +333,7 @@ spec = describe "BYRON_TRANSACTIONS" $ do
         let (Quantity feeEstMax) = getFromResponse #estimatedMax rFeeEst
 
         r <- postTx @n ctx
-            (wByron, Link.createTransaction @'Byron, fixturePassphrase)
+            (wByron, Link.createTransactionOld @'Byron, fixturePassphrase)
             wShelley
             amt
         verify r

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shared/Wallets.hs
@@ -1082,8 +1082,8 @@ spec = describe "SHARED_WALLETS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         (_, ApiFee (Quantity _) (Quantity feeMax) _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wShelley) payloadTx
-        let ep = Link.createTransaction @'Shelley
+            (Link.getTransactionFeeOld @'Shelley wShelley) payloadTx
+        let ep = Link.createTransactionOld @'Shelley
         rTx <- request @(ApiTransaction n) ctx (ep wShelley) Default payloadTx
         expectResponseCode HTTP.status202 rTx
         eventually "wShelley balance is decreased" $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Addresses.hs
@@ -228,7 +228,7 @@ spec = describe "SHELLEY_ADDRESSES" $ do
                 }|]
 
             rTrans <- request @(ApiTransaction n) ctx
-                (Link.createTransaction @'Shelley wSrc) Default payload
+                (Link.createTransactionOld @'Shelley wSrc) Default payload
             expectResponseCode HTTP.status202 rTrans
 
         -- make sure all transactions are in ledger
@@ -309,7 +309,7 @@ spec = describe "SHELLEY_ADDRESSES" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         (_, rtx) <- unsafeRequest @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wA) payload
+            (Link.createTransactionOld @'Shelley wA) payload
 
         -- 3. Check that there's one more used addresses on A.
         --

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/HWWallets.hs
@@ -119,7 +119,7 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 "passphrase": "cardano-wallet"
             }|]
         rTrans <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do
@@ -174,7 +174,7 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                     "passphrase": "cardano-wallet"
                 }|]
             rTrans <- request @(ApiTransaction n) ctx
-                (Link.createTransaction @'Shelley wSrc) Default payload
+                (Link.createTransactionOld @'Shelley wSrc) Default payload
             expectResponseCode HTTP.status403 rTrans
             expectErrorMessage (errMsg403NoRootKey $ wSrc ^. walletId) rTrans
 
@@ -231,7 +231,7 @@ spec = describe "SHELLEY_HW_WALLETS" $ do
                 }|]
 
             rFee <- request @ApiFee ctx
-                (Link.getTransactionFee @'Shelley wSrc) Default payload
+                (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
             expectResponseCode HTTP.status202 rFee
 
         it "Can delete" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -291,7 +291,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         -- cannot use rewards by default
         r1 <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley src)
+            (Link.createTransactionOld @'Shelley src)
             Default (Json payload)
         expectResponseCode HTTP.status202 r1
         eventually "Wallet has not consumed rewards" $ do
@@ -348,7 +348,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
         waitForNextEpoch ctx
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley src)
+            (Link.createTransactionOld @'Shelley src)
             Default (Json payloadWithdrawal)
         verify rTx
             [ expectField #amount (.> (Quantity coin))
@@ -1293,7 +1293,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 }|]
 
         request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley w)
+            (Link.createTransactionOld @'Shelley w)
             Default (Json payload)
             >>= flip verify
                 [ expectResponseCode HTTP.status202 ]
@@ -1334,7 +1334,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
                 , "passphrase": #{fixturePassphrase}
                 }|]
         request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley w)
+            (Link.createTransactionOld @'Shelley w)
             Default (Json payload)
             >>= flip verify
                 [ expectResponseCode HTTP.status202 ]

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -214,7 +214,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
               "passphrase": #{fixturePassphrase}
           }|]
 
-      let ep = Link.createTransaction @'Shelley
+      let ep = Link.createTransactionOld @'Shelley
       r <- request @(ApiTransaction n) ctx (ep wSrc) Default payload
       expectResponseCode HTTP.status403 r
       expectErrorMessage errMsg403MinUTxOValue r
@@ -243,10 +243,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             mkTxPayload ctx wSrc (minUTxOValue (_mainEra ctx)) fixturePassphrase
 
         (_, ApiFee (Quantity feeMin) (Quantity feeMax) _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wSrc) payload
+            (Link.getTransactionFeeOld @'Shelley wSrc) payload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
 
         verify r
             [ expectSuccess
@@ -280,7 +280,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             -- Post Tx
             let amt = (minUTxOValue (_mainEra ctx) :: Natural)
             r <- postTx @n ctx
-                (wSrc, Link.createTransaction @'Shelley,fixturePassphrase)
+                (wSrc, Link.createTransactionOld @'Shelley,fixturePassphrase)
                 wDest
                 amt
             let tx = getFromResponse Prelude.id r
@@ -313,9 +313,9 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- liftIO $ mkTxPayload ctx wb amt fixturePassphrase
 
         (_, ApiFee (Quantity feeMin) (Quantity feeMax) minCoins _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wa) payload
+            (Link.getTransactionFeeOld @'Shelley wa) payload
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
         ra <- request @ApiWallet ctx
             (Link.getWallet @'Shelley wa) Default Empty
 
@@ -412,10 +412,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             }|]
 
         (_, ApiFee (Quantity feeMin) (Quantity feeMax) _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wSrc) payload
+            (Link.getTransactionFeeOld @'Shelley wSrc) payload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
 
         ra <- request @ApiWallet ctx (Link.getWallet @'Shelley wSrc) Default Empty
 
@@ -463,7 +463,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- liftIO $ mkTxPayload ctx wDest amt fixturePassphrase
 
         (_, ApiFee (Quantity feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wDest) payload
+            (Link.getTransactionFeeOld @'Shelley wDest) payload
 
         -- NOTE It's a little tricky to estimate the fee needed for a
         -- transaction with no change output, because in order to know the right
@@ -478,7 +478,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         wSrc <- fixtureWalletWith @n ctx [feeMin+amt+margin]
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#direction . #getApiT) (`shouldBe` Outgoing)
@@ -516,12 +516,12 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         payload <- liftIO $ mkTxPayload ctx wDest minUTxOValue' fixturePassphrase
         (_, ApiFee (Quantity feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wDest) payload
+            (Link.getTransactionFeeOld @'Shelley wDest) payload
 
         wSrc <- fixtureWalletWith @n ctx [minUTxOValue' + (feeMin `div` 2)]
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Fee
@@ -534,7 +534,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotEnoughMoney
@@ -557,7 +557,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": "This password is wrong"
             }|]
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403WrongPass
@@ -580,7 +580,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": "cardano-wallet"
             }|]
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley w) Default payload
+            (Link.createTransactionOld @'Shelley w) Default payload
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
@@ -603,7 +603,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             w <- emptyWallet ctx
             let payload = nonJson
             r <- request @(ApiTransaction n) ctx
-                (Link.createTransaction @'Shelley w) Default payload
+                (Link.createTransactionOld @'Shelley w) Default payload
             expectResponseCode HTTP.status400 r
 
     it "TRANS_ASSETS_CREATE_01 - Multi-asset balance" $ \ctx -> runResourceT $ do
@@ -638,12 +638,12 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- use minimum coin value provided by the server
         payloadFee <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
         rFee <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wSrc) Default payloadFee
+            (Link.getTransactionFeeOld @'Shelley wSrc) Default payloadFee
         let [Quantity minCoin] = getFromResponse #minimumCoins rFee
 
         payload <- mkTxPayloadMA @n destination minCoin [val] fixturePassphrase
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 rtx
 
         eventually "Payee wallet balance is as expected" $ do
@@ -680,7 +680,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination coin [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         -- It should fail with InsufficientMinCoinValueError
         expectResponseCode HTTP.status403 rtx
         expectErrorMessage "Some outputs have ada values that are too small." rtx
@@ -701,7 +701,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 rtx
 
         eventually "Payee wallet balance is as expected" $ do
@@ -760,7 +760,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                         (_, Left e) -> Left $ show e
 
                 (nPerAddr,) . verifyRes <$> request @(ApiTransaction n) ctx
-                    (Link.createTransaction @'Shelley wSrc) Default payload
+                    (Link.createTransactionOld @'Shelley wSrc) Default payload
 
             -- 3. They should all succeed
             responses `shouldBe` (map (, Right ()) assetsPerAddrScenarios)
@@ -783,7 +783,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- mkTxPayloadMA @n destination 0 [val] fixturePassphrase
 
         rtx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
 
         verify rtx
             [ expectSuccess
@@ -909,7 +909,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         payload <- mkTxPayload ctx wb amt fixturePassphrase
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         verify r
             [ expectSuccess
@@ -945,7 +945,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxTTL (realToFrac testTTL) basePayload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         verify r
             [ expectSuccess
@@ -990,7 +990,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxTTL 0.1 basePayload
 
         ra <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         verify ra
             [ expectSuccess
@@ -1023,7 +1023,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxTTL (realToFrac hugeTTL) basePayload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         -- If another HFC Era is added, then this payment request will fail
         -- because the expiry would be past the slotting horizon.
@@ -1088,7 +1088,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxMetadata txMeta basePayload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status400 r
         expectErrorMessage errMsg400TxMetadataStringTooLong r
@@ -1108,7 +1108,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxMetadata txMeta basePayload
 
         r <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status403 r
         expectErrorMessage errMsg403TxTooBig r
@@ -1123,7 +1123,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payloadWithMetadata = addTxMetadata txMeta payload
 
         ra <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wa) Default payloadWithMetadata
+            (Link.getTransactionFeeOld @'Shelley wa) Default payloadWithMetadata
         verify ra
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -1134,7 +1134,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- check that it's estimated to have less fees for transactions without
         -- metadata.
         rb <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wa) Default payload
+            (Link.getTransactionFeeOld @'Shelley wa) Default payload
         verify rb
             [ expectResponseCode HTTP.status202
             , expectField (#estimatedMin . #getQuantity) (.< feeEstMin)
@@ -1151,7 +1151,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxMetadata txMeta basePayload
 
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wa) Default payload
+            (Link.getTransactionFeeOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status400 r
         expectErrorMessage errMsg400TxMetadataStringTooLong r
@@ -1170,7 +1170,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             bytes = [json|{ "bytes": #{T.replicate 64 "a"} }|]
         let payload = addTxMetadata txMeta basePayload
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wa) Default payload
+            (Link.getTransactionFeeOld @'Shelley wa) Default payload
 
         verify r
             [ expectResponseCode HTTP.status403
@@ -1196,14 +1196,14 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             w <- emptyWallet ctx
             let payload = nonJson
             r <- request @ApiFee ctx
-                (Link.getTransactionFee @'Shelley w) Default payload
+                (Link.getTransactionFeeOld @'Shelley w) Default payload
             expectResponseCode HTTP.status400 r
 
     it "TRANS_ESTIMATE_03a - we see result when we can't cover fee" $ \ctx -> runResourceT $ do
         wSrc <- fixtureWallet ctx
         payload <- mkTxPayload ctx wSrc faucetAmt fixturePassphrase
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wSrc) Default payload
+            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#estimatedMin . #getQuantity) (.>= 0)
@@ -1231,7 +1231,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wSrc) Default payload
+            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status202
             , expectField (#estimatedMin . #getQuantity) (.>= 0)
@@ -1245,7 +1245,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         wDest <- emptyWallet ctx
         payload <- mkTxPayload ctx wDest reqAmt fixturePassphrase
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wSrc) Default payload
+            (Link.getTransactionFeeOld @'Shelley wSrc) Default payload
         verify r
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotEnoughMoney
@@ -1258,7 +1258,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let minUTxOValue' = minUTxOValue (_mainEra ctx)
         payload <- mkTxPayload ctx wDest minUTxOValue' fixturePassphrase
         r <- request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley w) Default payload
+            (Link.getTransactionFeeOld @'Shelley w) Default payload
         expectResponseCode HTTP.status404 r
         expectErrorMessage (errMsg404NoWallet $ w ^. walletId) r
 
@@ -1281,7 +1281,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             }|]
 
         tx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 tx
         eventually "Wallet balance is as expected" $ do
             rGet <- request @ApiWallet ctx
@@ -1334,7 +1334,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let a2 = Quantity (2 * minUTxOValue')
         (wSrc, w) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
         -- post txs
-        let linkTx = (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+        let linkTx = (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
         _ <- postTx @n ctx linkTx w minUTxOValue'
         verifyWalletBalance ctx w (Quantity minUTxOValue')
 
@@ -1705,7 +1705,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- post tx
         let amt = minUTxOValue (_mainEra ctx) :: Natural
         rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
             wDest
             amt
         let txid = getFromResponse #id rMkTx
@@ -1759,7 +1759,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- post tx
         let amt = minUTxOValue (_mainEra ctx) :: Natural
         rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
             wDest
             amt
         verify rMkTx
@@ -1782,7 +1782,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- post tx
         let amt = minUTxOValue (_mainEra ctx) :: Natural
         rMkTx <- postTx @n ctx
-            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
             wDest
             amt
         let txid = getFromResponse #id rMkTx
@@ -1846,7 +1846,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         -- post transaction
         rTx <-
             postTx @n ctx
-            (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+            (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
             wDest
             (minUTxOValue (_mainEra ctx) :: Natural)
         let txid = getFromResponse #id rTx
@@ -1886,7 +1886,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
         let payload = addTxTTL 0.1 basePayload
 
         ra <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectSuccess ra
 
@@ -1932,7 +1932,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         verify rTx
             [ expectResponseCode HTTP.status202
             , expectField #withdrawals
@@ -1966,10 +1966,10 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         (_, ApiFee (Quantity _) (Quantity fee) _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wSelf) payload
+            (Link.getTransactionFeeOld @'Shelley wSelf) payload
 
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status202
             , expectField #withdrawals
@@ -2046,7 +2046,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         -- Withdraw rewards from the other wallet.
         _ <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         eventually "rewards disappear from other" $ do
             rWOther <- request @ApiWallet ctx
                 (Link.getWallet @'Shelley wOther) Default payload
@@ -2057,7 +2057,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         -- Try withdrawing AGAIN, rewards that aren't there anymore.
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403WithdrawalNotWorth
@@ -2080,7 +2080,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             }|]
 
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status202
             , expectField #withdrawals (`shouldSatisfy` null)
@@ -2104,7 +2104,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             }|]
 
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403WithdrawalNotWorth
@@ -2127,7 +2127,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             }|]
 
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Byron wSelf) Default payload
+            (Link.createTransactionOld @'Byron wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotAShelleyWallet
@@ -2152,7 +2152,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         -- Try withdrawing when no UTxO on a wallet
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotEnoughMoney
@@ -2192,7 +2192,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 "passphrase": #{fixturePassphrase}
             }|]
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wRewards) Default payload
+            (Link.createTransactionOld @'Shelley wRewards) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotEnoughMoney
@@ -2215,7 +2215,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         -- Try withdrawing when cannot cover fee
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403Fee
@@ -2238,7 +2238,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         -- Try withdrawing when no not enough money
         rTx <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSelf) Default payload
+            (Link.createTransactionOld @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
             , expectErrorMessage errMsg403NotEnoughMoney
@@ -2307,7 +2307,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
                 , "metadata": #{ApiT <$> txMetadata}
                 }|]
         ra <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wa) Default payload
+            (Link.createTransactionOld @'Shelley wa) Default payload
         verify ra
             [ expectSuccess
             , expectResponseCode HTTP.status202
@@ -2396,7 +2396,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             -- post tx
             (wSrc, wDest) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
             rMkTx <- postTx @n ctx
-                (wSrc, Link.createTransaction @'Shelley, "cardano-wallet")
+                (wSrc, Link.createTransactionOld @'Shelley, "cardano-wallet")
                 wDest
                 (minUTxOValue (_mainEra ctx) :: Natural)
 

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -213,7 +213,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         payload <- liftIO $ mkTxPayload ctx wb amt
 
         (_, ApiFee (Quantity feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wa) payload
+            (Link.getTransactionFeeOld @'Shelley wa) payload
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx
@@ -319,7 +319,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
             }|]
 
         (_, ApiFee (Quantity feeMin) _ _ _) <- unsafeRequest ctx
-            (Link.getTransactionFee @'Shelley wa) payload
+            (Link.getTransactionFeeOld @'Shelley wa) payload
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default payload
         verify rTx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Wallets.hs
@@ -259,7 +259,7 @@ spec = describe "SHELLEY_WALLETS" $ do
                 "passphrase": "cardano-wallet"
             }|]
         rTrans <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default payload
+            (Link.createTransactionOld @'Shelley wSrc) Default payload
         expectResponseCode HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do
@@ -883,7 +883,7 @@ spec = describe "SHELLEY_WALLETS" $ do
                     "passphrase": #{pass}
                     }|]
             r <- request @(ApiTransaction n) ctx
-                (Link.createTransaction @'Shelley wSrc) Default payloadTrans
+                (Link.createTransactionOld @'Shelley wSrc) Default payloadTrans
             verify r expectations
 
     describe "WALLETS_UPDATE_PASS_07 - HTTP headers" $ do
@@ -977,7 +977,7 @@ spec = describe "SHELLEY_WALLETS" $ do
                 }|]
 
         rTrans <- request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wSrc) Default (Json payload)
+            (Link.createTransactionOld @'Shelley wSrc) Default (Json payload)
         expectResponseCode HTTP.status202 rTrans
 
         eventually "Wallet balance is as expected" $ do

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -389,6 +389,7 @@ test-suite unit
       Cardano.Wallet.Primitive.AddressDiscovery.SharedSpec
       Cardano.Wallet.Primitive.Delegation.StateSpec
       Cardano.Wallet.Primitive.AddressDiscoverySpec
+      Cardano.Wallet.Primitive.CoinSelectionSpec
       Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
       Cardano.Wallet.Primitive.CoinSelection.CollateralSpec
       Cardano.Wallet.Primitive.CollateralSpec

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -220,7 +220,13 @@ import Cardano.Wallet.DB
     , sparseCheckpoints
     )
 import Cardano.Wallet.Logging
-    ( BracketLog, bracketTracer, traceWithExceptT, unliftIOTracer )
+    ( BracketLog
+    , BracketLog' (..)
+    , bracketTracer
+    , resultTracer
+    , traceWithExceptT
+    , unliftIOTracer
+    )
 import Cardano.Wallet.Network
     ( ErrPostTx (..)
     , FollowAction (..)

--- a/lib/core/src/Cardano/Wallet/Api/Link.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Link.hs
@@ -74,10 +74,10 @@ module Cardano.Wallet.Api.Link
     , mintBurnAssets
 
       -- * Transactions
-    , createTransaction
+    , createTransactionOld
     , listTransactions
     , listTransactions'
-    , getTransactionFee
+    , getTransactionFeeOld
     , deleteTransaction
     , getTransaction
     , createUnsignedTransaction
@@ -535,7 +535,7 @@ getByronAsset w pid n
 -- Transactions
 --
 
-createTransaction
+createTransactionOld
     :: forall style w.
         ( HasCallStack
         , HasType (ApiT WalletId) w
@@ -543,7 +543,7 @@ createTransaction
         )
     => w
     -> (Method, Text)
-createTransaction w = discriminate @style
+createTransactionOld w = discriminate @style
     (endpoint @(Api.CreateTransactionOld Net) (wid &))
     (endpoint @(Api.CreateByronTransactionOld Net) (wid &))
     (notSupported "Shared")
@@ -581,7 +581,7 @@ listTransactions' w minWithdrawal inf sup order = discriminate @style
   where
     wid = w ^. typed @(ApiT WalletId)
 
-getTransactionFee
+getTransactionFeeOld
     :: forall style w.
         ( HasCallStack
         , HasType (ApiT WalletId) w
@@ -589,7 +589,7 @@ getTransactionFee
         )
     => w
     -> (Method, Text)
-getTransactionFee w = discriminate @style
+getTransactionFeeOld w = discriminate @style
     (endpoint @(Api.PostTransactionFeeOld Net) (wid &))
     (endpoint @(Api.PostByronTransactionFeeOld Net) (wid &))
     (notSupported "Shared")

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -3,12 +3,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 -- |
 -- Copyright: © 2021 IOHK
 -- License: Apache-2.0
 --
--- This module provides a high-level interface for coin selection.
+-- This module provides a high-level interface for coin selection in a Cardano
+-- wallet.
 --
 -- It handles the following responsibilities:
 --
@@ -20,29 +23,36 @@
 -- Use the 'performSelection' function to perform a coin selection.
 --
 module Cardano.Wallet.Primitive.CoinSelection
-    ( performSelection
+    ( runWalletCoinSelection
     , SelectionConstraints (..)
     , SelectionParams (..)
-    , SelectionError (..)
 
-    , prepareOutputs
+    , validateTxOutsForSelection
+    , ErrWalletSelection (..)
     , ErrPrepareOutputs (..)
     , ErrOutputTokenBundleSizeExceedsLimit (..)
     , ErrOutputTokenQuantityExceedsLimit (..)
+
+    -- * Internals
+    , makeWrapper
     ) where
 
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionCriteria (..)
+    ( PerformSelection (..)
+    , SelectionCriteria (..)
+    , SelectionError
     , SelectionLimit
     , SelectionResult
     , SelectionSkeleton
+    , performSelection
+    , prepareOutputsWith
     )
 import Cardano.Wallet.Primitive.Types.Address
-    ( Address )
+    ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin
-    ( Coin )
+    ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenMap
@@ -52,15 +62,17 @@ import Cardano.Wallet.Primitive.Types.TokenQuantity
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessment (..)
     , TokenBundleSizeAssessor (..)
-    , TxOut
+    , TxOut (..)
     , txOutMaxTokenQuantity
     )
 import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( UTxOIndex )
+import Control.Monad
+    ( (<=<) )
 import Control.Monad.Random.Class
     ( MonadRandom )
-import Data.Bifunctor
-    ( first )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), withExceptT )
 import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
@@ -73,14 +85,16 @@ import GHC.Generics
     ( Generic )
 import GHC.Stack
     ( HasCallStack )
+import Numeric.Natural
+    ( Natural )
 
-import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
 
--- | Performs a coin selection.
+-- | Performs coin selection for a Cardano transaction.
 --
 -- This function has the following responsibilities:
 --
@@ -89,51 +103,52 @@ import qualified Data.Set as Set
 --  - producing change outputs to return excess value to the wallet;
 --  - balancing a selection to pay for the transaction fee.
 --
-performSelection
+runWalletCoinSelection
     :: (HasCallStack, MonadRandom m)
     => SelectionConstraints
     -> SelectionParams
-    -> m (Either SelectionError (SelectionResult TokenBundle))
-performSelection selectionConstraints selectionParams =
-    -- TODO:
-    --
-    -- https://input-output.atlassian.net/browse/ADP-1037
-    -- Adjust coin selection and fee estimation to handle collateral inputs
-    --
-    -- https://input-output.atlassian.net/browse/ADP-1070
-    -- Adjust coin selection and fee estimation to handle pre-existing inputs
-    --
-    case prepareOutputs selectionConstraints outputsToCover of
-        Left e ->
-            pure $ Left $ SelectionOutputsError e
-        Right preparedOutputsToCover ->
-            first SelectionBalanceError <$> Balance.performSelection
-                computeMinimumAdaQuantity
-                computeMinimumCost
-                assessTokenBundleSize
-                SelectionCriteria
-                    { assetsToBurn
-                    , assetsToMint
-                    , extraCoinSource = rewardWithdrawal
-                    , outputsToCover = preparedOutputsToCover
-                    , selectionLimit =
-                        computeSelectionLimit $ F.toList preparedOutputsToCover
-                    , utxoAvailable
-                    }
+    -> ExceptT ErrWalletSelection m (SelectionResult TokenBundle)
+runWalletCoinSelection sc sp = do
+    (postProcess, params) <- withExceptT ErrWalletSelectionOutputs $ ExceptT $
+        pure $ makeWrapper sc sp
+    withExceptT ErrWalletSelectionBalance $ ExceptT $
+        postProcess <$> performSelection params
+
+type SelectionReturn = Either SelectionError (SelectionResult TokenBundle)
+
+makeWrapper
+    :: SelectionConstraints
+    -> SelectionParams
+    -> Either ErrPrepareOutputs (SelectionReturn -> SelectionReturn, PerformSelection)
+makeWrapper sc@SelectionConstraints{..} SelectionParams{..} =
+    (id,) . getArgs <$> prepareOutputs outputsToCover
   where
-    SelectionConstraints
-        { assessTokenBundleSize
-        , computeMinimumAdaQuantity
+    -- TODO: [ADP-1037] Adjust coin selection and fee estimation to handle
+    -- collateral inputs.
+    --
+    -- TODO: [ADP-1070] Adjust coin selection and fee estimation to handle
+    -- pre-existing inputs.
+    getArgs outputsToCover' = PerformSelection
+        { computeMinimumAdaQuantity
         , computeMinimumCost
-        , computeSelectionLimit
-        } = selectionConstraints
-    SelectionParams
-        { assetsToBurn
-        , assetsToMint
-        , outputsToCover
-        , rewardWithdrawal
-        , utxoAvailable
-        } = selectionParams
+        , bundleSizeAssessor
+        , selectionCriteria = SelectionCriteria
+            { outputsToCover = outputsToCover'
+            , utxoAvailable
+            , selectionLimit = computeSelectionLimit $ F.toList outputsToCover'
+            , extraCoinSource = Just rewardWithdrawals
+            , assetsToMint
+            , assetsToBurn
+            }
+        }
+
+    prepareOutputs :: [TxOut] -> Either ErrPrepareOutputs (NonEmpty TxOut)
+    prepareOutputs = (validateTxOutsForSelection sc <=< ensureNonEmptyOutputs)
+
+    -- At present, the coin selection algorithm does not permit an empty output
+    -- list, so validate for this precondition.
+    ensureNonEmptyOutputs =
+        maybe (Left ErrPrepareOutputsTxOutMissing) Right . NE.nonEmpty
 
 -- | Specifies all constraints required for coin selection.
 --
@@ -147,7 +162,7 @@ performSelection selectionConstraints selectionParams =
 --    - are not specific to a given selection.
 --
 data SelectionConstraints = SelectionConstraints
-    { assessTokenBundleSize
+    { bundleSizeAssessor
         :: TokenBundleSizeAssessor
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output. See documentation for
@@ -167,6 +182,10 @@ data SelectionConstraints = SelectionConstraints
         :: Word16
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
         -- that can be selected as collateral.
+    , depositAmount
+        :: Coin
+        -- ^ Amount that should be taken from/returned back to the wallet for
+        -- each stake key registration/de-registration in the transaction.
     }
 
 -- | Specifies all parameters that are specific to a given selection.
@@ -178,12 +197,18 @@ data SelectionParams = SelectionParams
     , assetsToMint
         :: !TokenMap
         -- ^ Specifies a set of assets to mint.
-    , outputsToCover
-        :: !(NonEmpty TxOut)
-        -- ^ Specifies a set of outputs that must be paid for.
-    , rewardWithdrawal
-        :: !(Maybe Coin)
+    , rewardWithdrawals
+        :: !Coin
         -- ^ Specifies the value of a withdrawal from a reward account.
+    , certificateDepositsTaken
+        :: !Natural
+        -- ^ Number of deposits for stake key registrations.
+    , certificateDepositsReturned
+        :: !Natural
+        -- ^ Number of deposits from stake key de-registrations.
+    , outputsToCover
+        :: ![TxOut]
+        -- ^ Specifies a set of outputs that must be paid for.
     , utxoAvailable
         :: !UTxOIndex
         -- ^ Specifies the set of all available UTxO entries. The algorithm
@@ -192,20 +217,19 @@ data SelectionParams = SelectionParams
     }
     deriving (Eq, Generic, Show)
 
--- | Indicates that an error occurred while performing a coin selection.
---
-data SelectionError
-    = SelectionBalanceError Balance.SelectionError
-    | SelectionOutputsError ErrPrepareOutputs
+-- | Indicates that coin selection failed, or a precondition to coin selection
+-- failed.
+data ErrWalletSelection
+    = ErrWalletSelectionOutputs ErrPrepareOutputs
+    | ErrWalletSelectionBalance SelectionError
     deriving (Eq, Show)
 
 -- | Prepares the given user-specified outputs, ensuring that they are valid.
---
-prepareOutputs
+validateTxOutsForSelection
     :: SelectionConstraints
     -> NonEmpty TxOut
     -> Either ErrPrepareOutputs (NonEmpty TxOut)
-prepareOutputs constraints outputsUnprepared
+validateTxOutsForSelection constraints outputsUnprepared
     | (address, assetCount) : _ <- excessivelyLargeBundles =
         Left $
             -- We encountered one or more excessively large token bundles.
@@ -223,11 +247,10 @@ prepareOutputs constraints outputsUnprepared
                 , quantity
                 , quantityMaxBound = txOutMaxTokenQuantity
                 }
-    | otherwise =
-        pure outputsToCover
+    | otherwise = pure outputsToCover
   where
     SelectionConstraints
-        { assessTokenBundleSize
+        { bundleSizeAssessor
         , computeMinimumAdaQuantity
         } = constraints
 
@@ -248,7 +271,7 @@ prepareOutputs constraints outputsUnprepared
             TokenBundleSizeWithinLimit -> False
             OutputTokenBundleSizeExceedsLimit -> True
           where
-            assessSize = view #assessTokenBundleSize assessTokenBundleSize
+            assessSize = view #assessTokenBundleSize bundleSizeAssessor
 
     -- The complete list of token quantities that exceed the maximum quantity
     -- allowed in a transaction output:
@@ -262,8 +285,8 @@ prepareOutputs constraints outputsUnprepared
         , quantity > txOutMaxTokenQuantity
         ]
 
-    outputsToCover =
-        Balance.prepareOutputsWith computeMinimumAdaQuantity outputsUnprepared
+    outputsToCover = prepareOutputsWith computeMinimumAdaQuantity
+        outputsUnprepared
 
 -- | Indicates a problem when preparing outputs for a coin selection.
 --
@@ -272,6 +295,7 @@ data ErrPrepareOutputs
         ErrOutputTokenBundleSizeExceedsLimit
     | ErrPrepareOutputsTokenQuantityExceedsLimit
         ErrOutputTokenQuantityExceedsLimit
+    | ErrPrepareOutputsTxOutMissing
     deriving (Eq, Generic, Show)
 
 data ErrOutputTokenBundleSizeExceedsLimit = ErrOutputTokenBundleSizeExceedsLimit

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Gen.hs
@@ -6,8 +6,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Gen
     , genSelectionSkeleton
     , shrinkSelectionLimit
     , shrinkSelectionSkeleton
-    )
-    where
+    ) where
 
 import Prelude
 

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -19,7 +19,7 @@ import Cardano.Wallet.Primitive.Types.Coin.Gen
 import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetIdLargeRange, genTokenMapSmallRange, shrinkTokenMapSmallRange )
+    ( genAssetIdLargeRange, genTokenMapSmallRange, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.TokenQuantity
     ( TokenQuantity (..) )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -86,7 +86,7 @@ shrinkTokenBundleSmallRange :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRange (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
         (c, shrinkCoin)
-        (m, shrinkTokenMapSmallRange)
+        (m, shrinkTokenMap)
 
 genTokenBundleSmallRangePositive :: Gen TokenBundle
 genTokenBundleSmallRangePositive = TokenBundle
@@ -97,4 +97,4 @@ shrinkTokenBundleSmallRangePositive :: TokenBundle -> [TokenBundle]
 shrinkTokenBundleSmallRangePositive (TokenBundle c m) =
     uncurry TokenBundle <$> shrinkInterleaved
         (c, shrinkCoinPositive)
-        (m, shrinkTokenMapSmallRange)
+        (m, shrinkTokenMap)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle/Gen.hs
@@ -2,7 +2,7 @@ module Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genFixedSizeTokenBundle
     , genTokenBundleSmallRange
     , genTokenBundleSmallRangePositive
-    , genVariableSizedTokenBundle
+    , genTokenBundle
     , shrinkTokenBundleSmallRange
     , shrinkTokenBundleSmallRangePositive
     ) where
@@ -27,7 +27,7 @@ import Cardano.Wallet.Primitive.Types.Tx
 import Control.Monad
     ( replicateM )
 import Test.QuickCheck
-    ( Gen, choose, oneof )
+    ( Gen, choose, oneof, sized )
 import Test.QuickCheck.Extra
     ( shrinkInterleaved )
 
@@ -64,14 +64,15 @@ genFixedSizeTokenBundle fixedAssetCount
         integerToTokenQuantity = TokenQuantity . fromIntegral
 
 --------------------------------------------------------------------------------
--- Token bundles with variable numbers of assets, with an upper bound.
+-- Token bundles with variable numbers of assets, the upper bound being
+-- QuickCheck's size parameter.
 --
 -- Policy identifiers, asset names, token quantities are all allowed to vary.
 --------------------------------------------------------------------------------
 
-genVariableSizedTokenBundle :: Int -> Gen TokenBundle
-genVariableSizedTokenBundle maxAssetCount =
-    genFixedSizeTokenBundle =<< choose (0, maxAssetCount)
+genTokenBundle :: Gen TokenBundle
+genTokenBundle = sized $ \maxAssetCount ->
+    choose (0, maxAssetCount) >>= genFixedSizeTokenBundle
 
 --------------------------------------------------------------------------------
 -- Token bundles with coins, assets, and quantities chosen from small ranges

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap/Gen.hs
@@ -4,10 +4,10 @@
 module Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId
     , genAssetIdLargeRange
-    , genTokenMapSized
+    , genTokenMap
     , genTokenMapSmallRange
     , shrinkAssetId
-    , shrinkTokenMapSmallRange
+    , shrinkTokenMap
     , AssetIdF (..)
     ) where
 
@@ -77,8 +77,8 @@ genAssetIdLargeRange = AssetId
 -- size parameter
 --------------------------------------------------------------------------------
 
-genTokenMapSized :: Gen TokenMap
-genTokenMapSized = sized $ \size -> do
+genTokenMap :: Gen TokenMap
+genTokenMap = sized $ \size -> do
     assetCount <- choose (0, size)
     TokenMap.fromFlatList <$> replicateM assetCount genAssetQuantity
   where
@@ -103,8 +103,8 @@ genTokenMapSmallRange = do
         <$> genAssetId
         <*> genTokenQuantity
 
-shrinkTokenMapSmallRange :: TokenMap -> [TokenMap]
-shrinkTokenMapSmallRange
+shrinkTokenMap :: TokenMap -> [TokenMap]
+shrinkTokenMap
     = fmap TokenMap.fromFlatList
     . shrinkList shrinkAssetQuantity
     . TokenMap.toFlatList

--- a/lib/core/src/Cardano/Wallet/TokenMetadata.hs
+++ b/lib/core/src/Cardano/Wallet/TokenMetadata.hs
@@ -78,7 +78,12 @@ import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
     ( HasPrivacyAnnotation, HasSeverityAnnotation (..) )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), LoggedException (..), bracketTracer, produceTimings )
+    ( BracketLog
+    , BracketLog' (..)
+    , LoggedException (..)
+    , bracketTracer
+    , produceTimings
+    )
 import Cardano.Wallet.Primitive.Types
     ( TokenMetadataServer (..) )
 import Cardano.Wallet.Primitive.Types.Hash

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -438,9 +438,7 @@ spec = parallel $ do
     let jsonRoundtripAndGolden = Utils.jsonRoundtripAndGolden
             ($(getTestData) </> "Cardano" </> "Wallet" </> "Api")
 
-    parallel $ describe
-        "can perform roundtrip JSON serialization & deserialization, \
-        \and match existing golden files" $ do
+    describe "JSON golden roundtrip" $ do
             jsonRoundtripAndGolden $ Proxy @AnyAddress
             jsonRoundtripAndGolden $ Proxy @ApiCredential
             jsonRoundtripAndGolden $ Proxy @ApiAddressData
@@ -544,8 +542,7 @@ spec = parallel $ do
             jsonRoundtripAndGolden $ Proxy @ApiNullStakeKey
             jsonRoundtripAndGolden $ Proxy @(PostMintBurnAssetData ('Testnet 0))
 
-    describe "Textual encoding" $ do
-        describe "Can perform roundtrip textual encoding & decoding" $ do
+    describe "ToText-FromText Roundtrip" $ do
             textRoundtrip $ Proxy @Iso8601Time
             textRoundtrip $ Proxy @SortOrder
             textRoundtrip $ Proxy @Coin
@@ -560,8 +557,7 @@ spec = parallel $ do
                 fromText @(AddressAmount Text) "22323"
                     === Left (TextDecodingError err)
 
-    describe
-        "can perform roundtrip HttpApiData serialization & deserialization" $ do
+    describe "HttpApiData roundtrip" $ do
             httpApiDataRoundtrip $ Proxy @(ApiT WalletId)
             httpApiDataRoundtrip $ Proxy @(ApiT AddressState)
             httpApiDataRoundtrip $ Proxy @Iso8601Time
@@ -589,7 +585,7 @@ spec = parallel $ do
         \existing path in the specification" $
         validateEveryPath (Proxy :: Proxy (Api ('Testnet 0) ApiStakePool))
 
-    parallel $ describe "verify JSON parsing failures too" $ do
+    describe "verify JSON parsing failures too" $ do
         it "ApiT (Passphrase \"raw\") (too short)" $ do
             let minLength = passphraseMinLength (Proxy :: Proxy "raw")
             let msg = "Error in $: passphrase is too short: \

--- a/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/TypesSpec.hs
@@ -253,7 +253,7 @@ import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
 import Cardano.Wallet.Primitive.Types.TokenMap
     ( TokenMap )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
-    ( genAssetId, genTokenMapSmallRange, shrinkTokenMapSmallRange )
+    ( genAssetId, genTokenMapSmallRange, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( AssetDecimals (..)
     , AssetLogo (..)
@@ -2233,7 +2233,7 @@ instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange
 
 instance Arbitrary TokenMap where
-    shrink = shrinkTokenMapSmallRange
+    shrink = shrinkTokenMap
     arbitrary = genTokenMapSmallRange
 
 instance Arbitrary TxOut where

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -28,6 +28,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , InsufficientMinCoinValueError (..)
     , MakeChangeCriteria (..)
     , OutputsInsufficientError (..)
+    , PerformSelection (..)
     , SelectionCriteria (..)
     , SelectionError (..)
     , SelectionInsufficientError (..)
@@ -88,7 +89,7 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     , genAssetIdLargeRange
     , genTokenMapSmallRange
     , shrinkAssetId
-    , shrinkTokenMapSmallRange
+    , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName (..), TokenPolicyId (..) )
@@ -847,7 +848,7 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             , "assetsToBurn:"
             , pretty (Flat assetsToBurn)
             ]
-        result <- run $ performSelection
+        result <- run $ performSelection $ PerformSelection
             (mkMinCoinValueFor minCoinValueFor)
             (mkCostFor costFor)
             (mkBundleSizeAssessor NoBundleSizeLimit)
@@ -1069,7 +1070,7 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
         let criteria' = criteria { selectionLimit = NoLimit }
         let assessBundleSize =
                 mkBundleSizeAssessor NoBundleSizeLimit
-        let performSelection' = performSelection
+        let performSelection' = performSelection $ PerformSelection
                 noMinCoin (const noCost) assessBundleSize criteria'
         run performSelection' >>= \case
             Left e' -> do
@@ -1445,7 +1446,7 @@ type BoundaryTestEntry = (Coin, [(AssetId, TokenQuantity)])
 
 mkBoundaryTestExpectation :: BoundaryTestData -> Expectation
 mkBoundaryTestExpectation (BoundaryTestData criteria expectedResult) = do
-    actualResult <- performSelection
+    actualResult <- performSelection $ PerformSelection
         (noMinCoin)
         (mkCostFor NoCost)
         (mkBundleSizeAssessor $ boundaryTestBundleSizeAssessor criteria)
@@ -1972,7 +1973,7 @@ makeChangeWith
     -> Either UnableToConstructChangeError [TokenBundle]
 makeChangeWith p = makeChange p
     { minCoinFor = mkMinCoinValueFor $ minCoinFor p
-    , bundleSizeAssessor = mkBundleSizeAssessor $ bundleSizeAssessor p
+    , bundleSizeAssessor = mkBundleSizeAssessor $ view #bundleSizeAssessor p
     }
 
 prop_makeChange_identity
@@ -3587,7 +3588,7 @@ instance Arbitrary SelectionLimit where
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange
-    shrink = shrinkTokenMapSmallRange
+    shrink = shrinkTokenMap
 
 instance Arbitrary TokenQuantity where
     arbitrary = genTokenQuantityPositive

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -1,0 +1,190 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
+module Cardano.Wallet.Primitive.CoinSelectionSpec (spec) where
+
+import Prelude
+
+import Algebra.PartialOrd
+    ( PartialOrd (..) )
+import Cardano.Wallet.Primitive.CoinSelection
+    ( ErrPrepareOutputs (..)
+    , ErrWalletSelection (..)
+    , SelectionConstraints (..)
+    , SelectionParams (..)
+    , makeWrapper
+    , runWalletCoinSelection
+    )
+import Cardano.Wallet.Primitive.CoinSelection.Balance
+    ( PerformSelection (..)
+    , SelectionError (..)
+    , SelectionLimitOf (..)
+    , SelectionResult (..)
+    , fullBalance
+    )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Coin.Gen
+    ( genCoin, shrinkCoin )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap )
+import Cardano.Wallet.Primitive.Types.TokenMap.Gen
+    ( genTokenMap, shrinkTokenMap )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TokenBundleSizeAssessment (..)
+    , TokenBundleSizeAssessor (..)
+    , TxOut (..)
+    )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( genTxOut, shrinkTxOut )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+    ( UTxOIndex )
+import Control.Monad.Random.Lazy
+    ( Rand, StdGen, evalRand, mkStdGen )
+import Control.Monad.Trans.Except
+    ( ExceptT (..), runExceptT )
+import Data.Generics.Internal.VL
+    ( view )
+import Fmt
+    ( (+||), (||+) )
+import Numeric.Natural
+    ( Natural )
+import Test.Hspec
+    ( Spec )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Property
+    , Testable
+    , conjoin
+    , counterexample
+    , elements
+    , frequency
+    , label
+    , property
+    , suchThat
+    , (===)
+    )
+import Test.Utils.Pretty
+    ( Pretty (..) )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TB
+import qualified Data.Foldable as F
+
+spec :: Spec
+spec = do
+    prop "makeWrapper" prop_makeWrapper
+    prop "runWalletCoinSelection" prop_runWalletCoinSelection
+
+prop_makeWrapper :: Pretty SelectionParams -> Property
+prop_makeWrapper (Pretty sp) = case makeWrapper testSelectionConstraints sp of
+    Right (_transform, PerformSelection{..}) -> property True
+    Left e -> constructorLabel e $ case e of
+        ErrPrepareOutputsTokenBundleSizeExceedsLimit _ -> property False
+        ErrPrepareOutputsTokenQuantityExceedsLimit _ -> property False
+        ErrPrepareOutputsTxOutMissing -> view #outputsToCover sp === mempty
+
+prop_runWalletCoinSelection :: StdGen -> Pretty SelectionParams -> Property
+prop_runWalletCoinSelection g (Pretty sp) = counterexample ce $ case res of
+    Right sel -> label "success" $ conjoin
+        [ property (balanceSufficient sp)
+        , outputsCovered sel === outputsToCover sp
+        ]
+    Left (ErrWalletSelectionBalance e) -> constructorLabel e $ case e of
+        BalanceInsufficient _ -> balanceSufficient sp === False
+        OutputsInsufficient _ -> todo
+        SelectionInsufficient _ -> todo
+        InsufficientMinCoinValues _ -> property True
+        UnableToConstructChange _ -> todo
+    Left (ErrWalletSelectionOutputs e) -> constructorLabel e todo
+  where
+    res = eval g $ runWalletCoinSelection testSelectionConstraints sp
+    ce = "res = "+||Pretty res||+""
+    todo = label "incomplete" True
+
+constructorLabel :: (Show a, Testable prop) => a -> prop -> Property
+constructorLabel = label . head . words . show
+
+eval :: StdGen -> ExceptT e (Rand StdGen) a -> Either e a
+eval s a = evalRand (runExceptT a) s
+
+balanceSufficient :: SelectionParams -> Bool
+balanceSufficient SelectionParams{..} =
+    balanceRequired `leq` balanceAvailable
+  where
+    balanceRequired =
+        F.foldMap (view #tokens) outputsToCover
+            <> TB.fromTokenMap assetsToBurn
+    balanceAvailable =
+        fullBalance utxoAvailable (Just extraCoinSource)
+            <> TB.fromTokenMap assetsToMint
+    extraCoinSource = rewardWithdrawals
+
+testSelectionConstraints :: SelectionConstraints
+testSelectionConstraints = SelectionConstraints
+    { bundleSizeAssessor = TokenBundleSizeAssessor $ const TokenBundleSizeWithinLimit
+    , computeMinimumAdaQuantity = const (Coin 1_000_000)
+    , computeMinimumCost = const (Coin 500_000)
+    , computeSelectionLimit = const NoLimit
+    , maximumCollateralInputCount = 5
+    , depositAmount = Coin 10_000_000
+    }
+
+{-------------------------------------------------------------------------------
+                              Arbitrary test data
+-------------------------------------------------------------------------------}
+
+instance Arbitrary StdGen where
+    arbitrary = mkStdGen <$> arbitrary
+
+instance Arbitrary UTxOIndex where
+    arbitrary = genUTxOIndex
+    shrink = shrinkUTxOIndex
+
+instance Arbitrary TxOut where
+    arbitrary = genTxOut
+    shrink = shrinkTxOut
+
+instance Arbitrary TokenMap where
+    arbitrary = genTokenMap
+    shrink = shrinkTokenMap
+
+instance Arbitrary Coin where
+    arbitrary = genCoin
+    shrink = shrinkCoin
+
+instance Arbitrary SelectionParams where
+    arbitrary = (arbitrary >>= genFromUTxO) `suchThat` hasOutput
+      where
+        genFromUTxO utxo = SelectionParams mempty mempty
+            <$> frequency [(7, pure (Coin 0)), (3, arbitrary)]
+            <*> elements [0, 0, 0, 1, 2]
+            <*> elements [0, 0, 0, 1, 2]
+            <*> arbitrary
+            <*> pure utxo
+    shrink (SelectionParams b m w dt dr o u) =
+        [ sp'
+        | (b', m', w', dt', dr', o', u') <- shrink (b, m, w, i dt, i dr, o, u)
+        , let sp' = SelectionParams b' m' w' (nat dt') (nat dr') o' u'
+        , hasOutput sp'
+        ]
+      where
+        i = fromIntegral :: Natural -> Int
+        nat = fromIntegral :: Int -> Natural
+
+hasOutput :: SelectionParams -> Bool
+hasOutput SelectionParams{..} =
+    not (null outputsToCover) ||
+    certificateDepositsTaken > 0 ||
+    certificateDepositsReturned > 0

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -23,10 +23,10 @@ import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( AssetIdF (..)
     , genAssetId
     , genAssetIdLargeRange
-    , genTokenMapSized
+    , genTokenMap
     , genTokenMapSmallRange
     , shrinkAssetId
-    , shrinkTokenMapSmallRange
+    , shrinkTokenMap
     )
 import Cardano.Wallet.Primitive.Types.TokenPolicy
     ( TokenName, TokenPolicyId, mkTokenName )
@@ -520,12 +520,12 @@ prop_difference_equality x y = checkCoverage $
 
 prop_intersection_associativity :: Property
 prop_intersection_associativity =
-    forAllBlind genTokenMap $ \x ->
-    forAllBlind genTokenMap $ \y ->
-    forAllBlind genTokenMap $ \z ->
+    forAllBlind gen $ \x ->
+    forAllBlind gen $ \y ->
+    forAllBlind gen $ \z ->
     prop_inner x y z
   where
-    genTokenMap = scale (* 4) genTokenMapSized
+    gen = scale (* 4) genTokenMap
     prop_inner x y z =
         checkCoverage $
         cover 50 (x /= y && y /= z)
@@ -540,11 +540,11 @@ prop_intersection_associativity =
 
 prop_intersection_commutativity :: Property
 prop_intersection_commutativity =
-    forAllBlind genTokenMap $ \x ->
-    forAllBlind genTokenMap $ \y ->
+    forAllBlind gen $ \x ->
+    forAllBlind gen $ \y ->
     prop_inner x y
   where
-    genTokenMap = scale (* 2) genTokenMapSized
+    gen = scale (* 2) genTokenMap
     prop_inner x y =
         checkCoverage $
         cover 50 (x /= y)
@@ -566,11 +566,11 @@ prop_intersection_empty x =
 
 prop_intersection_equality :: Property
 prop_intersection_equality =
-    forAllBlind genTokenMap $ \x ->
-    forAllBlind genTokenMap $ \y ->
+    forAllBlind gen $ \x ->
+    forAllBlind gen $ \y ->
     prop_inner x y
   where
-    genTokenMap = scale (* 2) genTokenMapSized
+    gen = scale (* 2) genTokenMap
     prop_inner x y =
         checkCoverage $
         cover 50 (x /= y)
@@ -594,11 +594,11 @@ prop_intersection_identity x =
 
 prop_intersection_subset :: Property
 prop_intersection_subset =
-    forAllBlind genTokenMap $ \x ->
-    forAllBlind genTokenMap $ \y ->
+    forAllBlind gen $ \x ->
+    forAllBlind gen $ \y ->
     prop_inner x y
   where
-    genTokenMap = scale (* 2) genTokenMapSized
+    gen = scale (* 2) genTokenMap
     prop_inner x y =
         checkCoverage $
         cover 50 (x /= y)
@@ -1013,7 +1013,7 @@ instance Arbitrary AssetId where
 
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange
-    shrink = shrinkTokenMapSmallRange
+    shrink = shrinkTokenMap
 
 instance Arbitrary (Large TokenMap) where
     arbitrary = Large <$> do

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -26,7 +26,8 @@ import Cardano.Api
 import Cardano.Mnemonic
     ( SomeMnemonic (..) )
 import Cardano.Wallet
-    ( ErrSignPayment (..)
+    ( ErrSelectAssets (..)
+    , ErrSignPayment (..)
     , ErrSubmitTx (..)
     , ErrUpdatePassphrase (..)
     , ErrWithRootKey (..)
@@ -79,9 +80,12 @@ import Cardano.Wallet.Primitive.AddressDiscovery
     , KnownAddresses (..)
     )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( SelectionError (..) )
+    ( ErrWalletSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult (..) )
+    ( BalanceInsufficientError (..)
+    , SelectionError (..)
+    , SelectionResult (..)
+    )
 import Cardano.Wallet.Primitive.Migration.SelectionSpec
     ( MockTxConstraints (..), genTokenBundleMixed, unMockTxConstraints )
 import Cardano.Wallet.Primitive.SyncProgress
@@ -270,7 +274,6 @@ import qualified Cardano.Crypto.Wallet as CC
 import qualified Cardano.Wallet as W
 import qualified Cardano.Wallet.DB.MVar as MVar
 import qualified Cardano.Wallet.DB.Sqlite as Sqlite
-import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
@@ -695,12 +698,11 @@ prop_estimateFee (NonEmpty coins) =
                     `closeTo` (1/10 :: Double)
                 ]
   where
-    genericError :: W.ErrSelectAssets
-    genericError
-        = W.ErrSelectAssetsSelectionError
-        $ SelectionBalanceError
-        $ Balance.BalanceInsufficient
-        $ Balance.BalanceInsufficientError TokenBundle.empty TokenBundle.empty
+    genericError :: ErrSelectAssets
+    genericError = ErrSelectAssets
+        $ ErrWalletSelectionBalance
+        $ BalanceInsufficient
+        $ BalanceInsufficientError TokenBundle.empty TokenBundle.empty
 
     runSelection
         :: ExceptT W.ErrSelectAssets (State Int) Coin

--- a/lib/shelley/bench/Latency.hs
+++ b/lib/shelley/bench/Latency.hs
@@ -255,7 +255,7 @@ walletApiBench capture ctx = do
     repeatPostTx wDest amtToSend batchSize amtExp = do
         wSrc <- fixtureWallet ctx
         replicateM_ batchSize
-            (postTx (wSrc, Link.createTransaction @'Shelley, fixturePassphrase) wDest amtToSend)
+            (postTx (wSrc, Link.createTransactionOld @'Shelley, fixturePassphrase) wDest amtToSend)
         eventually "repeatPostTx: wallet balance is as expected" $ do
             rWal1 <- request @ApiWallet  ctx (Link.getWallet @'Shelley wDest) Default Empty
             verify rWal1
@@ -326,7 +326,7 @@ walletApiBench capture ctx = do
                 }]
             }|]
         t6 <- measureApiLogs capture $ request @ApiFee ctx
-            (Link.getTransactionFee @'Shelley wal1) Default payload
+            (Link.getTransactionFeeOld @'Shelley wal1) Default payload
         fmtResult "postTransactionFee " t6
 
         let payloadTx = Json [json|{
@@ -340,7 +340,7 @@ walletApiBench capture ctx = do
                 "passphrase": #{fixturePassphrase}
             }|]
         t7 <- measureApiLogs capture $ request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wal1) Default payloadTx
+            (Link.createTransactionOld @'Shelley wal1) Default payloadTx
         fmtResult "postTransaction    " t7
 
         let addresses = replicate 5 destination
@@ -358,14 +358,14 @@ walletApiBench capture ctx = do
             }|]
 
         t7a <- measureApiLogs capture $ request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley wal2) Default payloadTxTo5Addr
+            (Link.createTransactionOld @'Shelley wal2) Default payloadTxTo5Addr
         fmtResult "postTransTo5Addrs  " t7a
 
         let assetsToSend = walMA ^. #assets . #total . #getApiT
         let val = minUTxOValue era <$ pickAnAsset assetsToSend
         payloadMA <- mkTxPayloadMA @n destination (2 * minUTxOValue era) [val] fixturePassphrase
         t7b <- measureApiLogs capture $ request @(ApiTransaction n) ctx
-            (Link.createTransaction @'Shelley walMA) Default payloadMA
+            (Link.createTransactionOld @'Shelley walMA) Default payloadMA
         fmtResult "postTransactionMA  " t7b
 
         t8 <- measureApiLogs capture $ request @[ApiStakePool] ctx

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch.hs
@@ -48,7 +48,7 @@ import Cardano.Launcher
 import Cardano.Launcher.Node
     ( CardanoNodeConn, cardanoNodeConn, isWindows )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), bracketTracer )
+    ( BracketLog, BracketLog' (..), bracketTracer )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( NetworkDiscriminant (..) )
 import Cardano.Wallet.Primitive.Types

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Launch/Cluster.hs
@@ -107,7 +107,7 @@ import Cardano.Wallet.Api.Server
 import Cardano.Wallet.Api.Types
     ( ApiEra (..), HealthStatusSMASH (..) )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), bracketTracer )
+    ( BracketLog, bracketTracer )
 import Cardano.Wallet.Network.Ports
     ( randomUnusedTCPPorts )
 import Cardano.Wallet.Primitive.AddressDerivation

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Network.hs
@@ -58,7 +58,7 @@ import Cardano.Launcher.Node
 import Cardano.Wallet.Byron.Compatibility
     ( byronCodecConfig, protocolParametersFromUpdateState )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), bracketTracer, produceTimings )
+    ( BracketLog, bracketTracer, produceTimings )
 import Cardano.Wallet.Network
     ( Cursor, ErrPostTx (..), NetworkLayer (..), mapCursor )
 import Cardano.Wallet.Primitive.Slotting

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -42,7 +42,7 @@ import Cardano.Startup
 import Cardano.Wallet.Api.Types
     ( EncodeAddress (..) )
 import Cardano.Wallet.Logging
-    ( BracketLog (..), bracketTracer, stdoutTextTracer, trMessageText )
+    ( BracketLog, bracketTracer, stdoutTextTracer, trMessageText )
 import Cardano.Wallet.Network.Ports
     ( portFromURL )
 import Cardano.Wallet.Primitive.AddressDerivation

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/CompatibilitySpec.hs
@@ -66,8 +66,8 @@ import Cardano.Wallet.Primitive.Types.TokenBundle
     ( TokenBundle )
 import Cardano.Wallet.Primitive.Types.TokenBundle.Gen
     ( genFixedSizeTokenBundle
+    , genTokenBundle
     , genTokenBundleSmallRange
-    , genVariableSizedTokenBundle
     , shrinkTokenBundleSmallRange
     )
 import Cardano.Wallet.Primitive.Types.Tx
@@ -148,6 +148,7 @@ import Test.QuickCheck
     , frequency
     , oneof
     , property
+    , resize
     , vector
     , withMaxSuccess
     , (===)
@@ -818,11 +819,11 @@ instance Arbitrary (FixedSize128 TokenBundle) where
     -- No shrinking
 
 instance Arbitrary (VariableSize16 TokenBundle) where
-    arbitrary = VariableSize16 <$> genVariableSizedTokenBundle 16
+    arbitrary = VariableSize16 <$> resize 16 genTokenBundle
     -- No shrinking
 
 instance Arbitrary (VariableSize128 TokenBundle) where
-    arbitrary = VariableSize128 <$> genVariableSizedTokenBundle 128
+    arbitrary = VariableSize128 <$> resize 128 genTokenBundle
     -- No shrinking
 
 --

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -50,9 +50,10 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( SelectionError (..) )
+    ( ErrWalletSelection (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult (..)
+    ( SelectionError (..)
+    , SelectionResult (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , selectionDelta
@@ -183,7 +184,6 @@ import Test.QuickCheck.Random
     ( mkQCGen )
 
 import qualified Cardano.Api as Cardano
-import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.ByteArray as BA
@@ -385,10 +385,10 @@ spec = do
     it "regression #1740 - fee estimation at the boundaries" $ do
         let requiredCost = Coin 166029
         let runSelection = except $ Left
-                $ ErrSelectAssetsSelectionError
-                $ SelectionBalanceError
-                $ Balance.UnableToConstructChange
-                $ Balance.UnableToConstructChangeError
+                $ ErrSelectAssets
+                $ ErrWalletSelectionBalance
+                $ UnableToConstructChange
+                $ UnableToConstructChangeError
                     { requiredCost
                     , shortfall = Coin 100000
                     }

--- a/lib/text-class/src/Test/Text/Roundtrip.hs
+++ b/lib/text-class/src/Test/Text/Roundtrip.hs
@@ -24,9 +24,5 @@ textRoundtrip
     :: forall a. (Arbitrary a, Eq a, Show a, ToText a, FromText a, Typeable a)
     => Proxy a
     -> Spec
-textRoundtrip proxy = it
-    ("can perform roundtrip textual encoding and decoding for values of type '"
-        <> show (typeRep proxy)
-        <> "'")
-    (property $ \a ->
-        fromText (toText @a a) === Right a)
+textRoundtrip proxy = it (show (typeRep proxy)) $
+    property $ \a -> fromText (toText @a a) === Right a


### PR DESCRIPTION
The `runWalletCoinSelection` function calls the generic `performSelection` function.

This PR splits the preparation of `performSelection` parameters into a new wrapper function.

### Issue Number

ADP-919
