### PR TITLE
tests: Add --env NAME=VALUE option to hspec runners

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,6 @@ env:
   CACHE_DIR: "/cache/cardano-wallet"
   LC_ALL: "en_US.UTF-8"
   TESTS_LOGDIR: "/tmp/wallet-integration-logs"
-  TESTS_RETRY_FAILED: "yes"
 
 steps:
   - label: 'Prevent merging to wrong branch'

--- a/lib/core/test/unit/Main.hs
+++ b/lib/core/test/unit/Main.hs
@@ -4,16 +4,10 @@ import Prelude
 
 import Cardano.Startup
     ( withUtf8Encoding )
-import Test.Hspec.Core.Runner
-    ( defaultConfig, hspecWith )
 import Test.Hspec.Extra
-    ( configWithExecutionTimes )
-import Test.Utils.Startup
-    ( withLineBuffering )
+    ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = withLineBuffering
-    $ withUtf8Encoding
-    $ hspecWith (configWithExecutionTimes defaultConfig) Spec.spec
+main = withUtf8Encoding $ hspecMain Spec.spec

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -211,6 +211,7 @@ test-suite unit
     , cardano-ledger-core
     , cardano-wallet
     , cardano-wallet-core
+    , cardano-wallet-launcher
     , cardano-wallet-test-utils
     , containers
     , contra-tracer

--- a/lib/shelley/test/integration/Main.hs
+++ b/lib/shelley/test/integration/Main.hs
@@ -116,12 +116,10 @@ import System.Environment
     ( setEnv )
 import System.FilePath
     ( (</>) )
-import Test.Hspec.Core.Runner
-    ( defaultConfig, hspecWith )
 import Test.Hspec.Core.Spec
     ( Spec, SpecWith, describe, parallel, sequential )
 import Test.Hspec.Extra
-    ( aroundAll, configWithExecutionTimes )
+    ( aroundAll, hspecMain )
 import Test.Integration.Faucet
     ( genRewardAccounts
     , maryIntegrationTestAssets
@@ -133,8 +131,6 @@ import Test.Integration.Framework.Context
     ( Context (..), PoolGarbageCollectionEvent (..) )
 import Test.Utils.Paths
     ( getTestData, inNixBuild )
-import Test.Utils.Startup
-    ( withLineBuffering )
 import UnliftIO.Async
     ( race )
 import UnliftIO.Exception
@@ -177,7 +173,7 @@ import qualified Test.Integration.Scenario.CLI.Shelley.Wallets as WalletsCLI
 main :: forall n. (n ~ 'Mainnet) => IO ()
 main = withTestsSetup $ \testDir tracers -> do
     nix <- inNixBuild
-    hspecWith (configWithExecutionTimes defaultConfig) $ do
+    hspecMain $ do
         describe "No backend required" $
             parallelIf (not nix) $ describe "Miscellaneous CLI tests"
                 MiscellaneousCLI.spec
@@ -235,7 +231,7 @@ withTestsSetup action = do
     setEnv "CARDANO_WALLET_TEST_INTEGRATION" "1"
     -- Flush test output as soon as a line is printed.
     -- Set UTF-8, regardless of user locale.
-    withLineBuffering $ withUtf8Encoding $
+    withUtf8Encoding $
         -- This temporary directory will contain logs, and all other data
         -- produced by the integration tests.
         withSystemTempDir stdoutTextTracer "test" $ \testDir ->

--- a/lib/shelley/test/unit/Main.hs
+++ b/lib/shelley/test/unit/Main.hs
@@ -2,12 +2,12 @@ module Main where
 
 import Prelude
 
-import Test.Hspec.Core.Runner
-    ( defaultConfig, hspecWith )
+import Cardano.Startup
+    ( withUtf8Encoding )
 import Test.Hspec.Extra
-    ( configWithExecutionTimes )
+    ( hspecMain )
 
 import qualified Spec
 
 main :: IO ()
-main = hspecWith (configWithExecutionTimes defaultConfig) Spec.spec
+main = withUtf8Encoding $ hspecMain Spec.spec

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -65,6 +65,7 @@ library
       Test.Hspec.Extra
       Test.Hspec.Goldens
       Test.QuickCheck.Extra
+      Test.Utils.Env
       Test.Utils.FilePath
       Test.Utils.Laws
       Test.Utils.Laws.PartialOrd

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -47,6 +47,7 @@ library
     , HUnit
     , iohk-monitoring
     , lattices
+    , optparse-applicative
     , pretty-simple
     , QuickCheck
     , quickcheck-classes
@@ -93,10 +94,12 @@ test-suite unit
   build-depends:
       base
     , cardano-wallet-test-utils
+    , fmt
     , hspec
     , hspec-core
     , hspec-expectations-lifted
     , silently
+    , QuickCheck
     , unliftio
     , unliftio-core
   build-tools:

--- a/lib/test-utils/src/Test/Utils/Env.hs
+++ b/lib/test-utils/src/Test/Utils/Env.hs
@@ -1,0 +1,58 @@
+-- |
+-- Copyright: © 2021 IOHK
+-- License: Apache-2.0
+--
+module Test.Utils.Env
+  ( withEnv
+  , withAddedEnv
+  , clearEnv
+  ) where
+
+import Prelude
+
+import Control.Monad.IO.Unlift
+    ( MonadIO, MonadUnliftIO (..) )
+import UnliftIO.Environment
+    ( getEnvironment, setEnv, unsetEnv )
+import UnliftIO.Exception
+    ( bracket )
+
+-- | Runs an IO action with exactly the given environment variables.
+-- After the action finishes, the original environment variables are restored.
+--
+-- NOTE: The process environment is a global variable -- this function is not
+-- threadsafe.
+withEnv :: MonadUnliftIO m => [(String, String)] -> m a -> m a
+withEnv = withEnv' clearEnvs
+
+-- | Runs an IO action with the given environment variables set, in addition to
+-- the current environment variables. After the action finishes, the
+-- environment variables are restored back to the original state.
+--
+-- NOTE: The process environment is a global variable -- this function is not
+-- threadsafe.
+withAddedEnv :: MonadUnliftIO m => [(String, String)] -> m a -> m a
+withAddedEnv = withEnv' (const $ pure ())
+
+-- | Runs an action with the given environment variables set.
+withEnv'
+    :: MonadUnliftIO m
+    => ([(String, String)] -> m ())
+    -- ^ Prepare environment function - given the current environment.
+    -> [(String, String)]
+    -- ^ Environment variables to set.
+    -> m a
+    -- ^ Action to run with environment variables set.
+    -> m a
+withEnv' prepare env = bracket getEnvironment resetEnvironment . run
+  where
+    resetEnvironment pre = clearEnv >> setEnvs pre
+    setEnvs = mapM_ (uncurry setEnv)
+    run action = \pre -> prepare pre >> setEnvs env >> action
+
+-- | Unsets all environment variables for this process.
+clearEnv :: MonadIO m => m ()
+clearEnv = getEnvironment >>= clearEnvs
+
+clearEnvs :: MonadIO m => [(String, a)] -> m ()
+clearEnvs = mapM_ (unsetEnv . fst)

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -5,18 +5,28 @@ module Test.Hspec.ExtraSpec (spec) where
 
 import Prelude
 
+import Control.Monad
+    ( forM_, unless )
 import Control.Monad.IO.Unlift
     ( MonadUnliftIO (..) )
 import Data.Bifunctor
     ( first )
+import Data.Function
+    ( on )
 import Data.IORef
     ( IORef, newIORef, readIORef, writeIORef )
 import Data.List
-    ( isPrefixOf )
-import System.Environment
-    ( setEnv )
+    ( isPrefixOf, nubBy )
+import Data.Maybe
+    ( fromMaybe )
+import Fmt
+    ( (+|), (+||), (|+), (||+) )
+import System.Exit
+    ( ExitCode (..) )
+import System.IO
+    ( stderr, stdout )
 import System.IO.Silently
-    ( capture_, silence )
+    ( capture_, hCapture, silence )
 import Test.Hspec
     ( ActionWith
     , Expectation
@@ -37,20 +47,41 @@ import Test.Hspec.Core.Spec
 import Test.Hspec.Expectations.Lifted
     ( shouldReturn )
 import Test.Hspec.Extra
-    ( aroundAll )
+    ( aroundAll, hspecMain )
+import Test.Hspec.QuickCheck
+    ( prop )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , Gen
+    , Positive (..)
+    , PrintableString (..)
+    , Property
+    , counterexample
+    , elements
+    , listOf
+    , oneof
+    )
+import Test.QuickCheck.Monadic
+    ( assert, monadicIO, monitor, run )
+import Test.Utils.Env
+    ( withEnv )
 import UnliftIO.Concurrent
     ( threadDelay )
+import UnliftIO.Environment
+    ( lookupEnv, setEnv, withArgs )
 import UnliftIO.Exception
-    ( bracket, throwString, tryAny )
+    ( bracket, throwString, tryAny, tryDeep )
 import UnliftIO.MVar
     ( MVar, newEmptyMVar, newMVar, putMVar, tryReadMVar, tryTakeMVar )
 
 import qualified Test.Hspec.Extra as Extra
 
+
 spec :: Spec
 spec = do
     itSpec
     aroundAllSpec
+    mainSpec
 
 itSpec :: Spec
 itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
@@ -84,7 +115,7 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
         let timeout = do
                 threadDelay (micro 10)
                 expectationFailure "should have timed out"
-        res <- run (Extra.itWithCustomTimeout 2) timeout
+        res <- runIt (Extra.itWithCustomTimeout 2) timeout
         res `shouldContain` "timed out in 2 seconds"
 
   where
@@ -93,19 +124,19 @@ itSpec = describe "Extra.it" $ before_ (setEnv "TESTS_RETRY_FAILED" "y") $ do
     -- and execution time-information.
     shouldMatchHSpecIt :: IO () -> IO () -> Expectation
     shouldMatchHSpecIt extraTest hspecTest = do
-        extraRes <- run Extra.it extraTest
-        hspecRes <- run it hspecTest
+        extraRes <- runIt Extra.it extraTest
+        hspecRes <- runIt it hspecTest
         extraRes `shouldBe` hspecRes
 
-    run
+    runIt
         :: (String -> ActionWith () -> SpecWith ()) -- ^ it version
         -> IO () -- ^ test body
         -> IO String -- ^ hspec output
-    run anyIt prop = fmap stripTime
+    runIt anyIt body = fmap stripTime
         $ capture_
         $ flip runSpec defaultConfig
         $ beforeAll (return ())
-        $ anyIt "<test spec>" (const prop)
+        $ anyIt "<test spec>" (const body)
       where
         -- | Remove time and seed such that we can compare the captured stdout
         -- of two different hspec runs.
@@ -183,3 +214,101 @@ aroundAllSpec = sequential $ do
                         it "spec" $ const $
                             pure @IO ()
                 b `shouldBe` Right (Summary 1 0)
+
+mainSpec :: Spec
+mainSpec = sequential $ describe "hspecMain" $ do
+  prop "correctly sets environment variables" prop_hspecMain
+
+prop_hspecMain
+  :: [((NiceString, PrintableString), ArgStyle)]
+  -> NiceString
+  -> HspecArgs
+  -> HspecArgs
+  -> Bool
+  -> Property
+prop_hspecMain vars (NiceString other) (HspecArgs argsBefore) (HspecArgs argsAfter) pass = monadicIO $ do
+    monitor $ counterexample ("args = "+|args|+"")
+    ((err, out), res) <- run $ captureBoth $ tryDeep doTest
+    monitor $ counterexample $ unlines
+        [ "res = "+||res||+""
+        , "error output:", err
+        , "other output:", out
+        , "success = "+||success||+""
+        ]
+    assert $ case res of
+        Right () -> success
+        Left exitCode -> case exitCode of
+            ExitSuccess -> success
+            ExitFailure 89 -> argsError
+            ExitFailure _ -> failure
+  where
+    doTest = withEnv [] $ withArgs args $ hspecMain exampleSpec
+    success = pass || null env
+    failure = not pass
+    argsError = any (\((n,_), _) -> null n || elem '=' n) env
+
+    vars' = nubBy ((==) `on` (fst . fst)) vars
+    env = [ ((n, v), s)
+          | ((NiceString n, PrintableString v), s) <- vars'
+          , n /= other ]
+
+    mainArgs = mconcat
+        [fmtArg "-e" "--env" (n <> "=" <> v) s | ((n, v), s) <- env]
+    args = argsBefore ++ mainArgs ++ argsAfter
+
+    exampleSpec :: Spec
+    exampleSpec = describe "example spec" $ do
+            forM_ env $ \((n, v), _) -> it ("env "+|n|+" set") $
+                lookupEnv @IO n `shouldReturn`
+                    if null v then Nothing else Just v
+            unless (null other) $ it "env not set" $
+                lookupEnv @IO other `shouldReturn` Nothing
+            it "should we pass?" $
+                True `shouldBe` pass
+
+newtype NiceString = NiceString String deriving (Show, Eq)
+
+instance Arbitrary NiceString where
+    arbitrary = fmap NiceString $ listOf $ elements $ mconcat
+        [ ['0'..'9'], ['a'..'z'], ['A'..'Z'], "_." ]
+    shrink (NiceString s) = NiceString <$> shrink s
+
+data ArgStyle = Short | LongSpace | LongEqual deriving (Show, Eq, Ord)
+
+fmtArg :: String -> String -> String -> ArgStyle -> [String]
+fmtArg s _ v Short     = [s, v]
+fmtArg _ l v LongSpace = [l, v]
+fmtArg _ l v LongEqual = [l ++ "=" ++ v]
+
+instance Arbitrary ArgStyle where
+  arbitrary = elements [Short, LongSpace, LongEqual]
+
+newtype HspecArgs = HspecArgs { getHspecArgs :: [String] }
+    deriving (Show, Eq)
+
+instance Arbitrary HspecArgs where
+    arbitrary = HspecArgs . mconcat . nubArgs <$> listOf (oneof args)
+      where
+        args = [ genArg (Just "-j") "--jobs" =<< num
+               , pure <$> genOpt "fail-fast"
+               , pure <$> genOpt "randomize"
+               , genArg Nothing "--seed" =<< num
+               ]
+        num = show @Int . getPositive <$> arbitrary
+
+        nubArgs = nubBy ((==) `on` head)
+
+        genOpt :: String -> Gen String
+        genOpt name = elements $ map ("--" ++) [name, "no-" ++ name]
+
+        genArg :: Maybe String -> String -> String -> Gen [String]
+        genArg short long val = fmtArg short' long val <$> elements styles
+          where
+            short' = fromMaybe "" short
+            styles = maybe id (const (Short:)) short [LongSpace, LongEqual]
+
+-- | Capture both @(stderr, stdout)@ from an IO action.
+captureBoth :: IO a -> IO ((String, String), a)
+captureBoth = fmap reorder . hCapture [stderr] . hCapture [stdout]
+  where
+    reorder (e, (s, a)) = ((e, s), a)

--- a/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
+++ b/lib/test-utils/test/Test/Hspec/ExtraSpec.hs
@@ -54,7 +54,6 @@ import Test.QuickCheck
     ( Arbitrary (..)
     , Gen
     , Positive (..)
-    , PrintableString (..)
     , Property
     , counterexample
     , elements
@@ -220,7 +219,7 @@ mainSpec = sequential $ describe "hspecMain" $ do
   prop "correctly sets environment variables" prop_hspecMain
 
 prop_hspecMain
-  :: [((NiceString, PrintableString), ArgStyle)]
+  :: [((NiceString, NiceString), ArgStyle)]
   -> NiceString
   -> HspecArgs
   -> HspecArgs
@@ -249,7 +248,7 @@ prop_hspecMain vars (NiceString other) (HspecArgs argsBefore) (HspecArgs argsAft
 
     vars' = nubBy ((==) `on` (fst . fst)) vars
     env = [ ((n, v), s)
-          | ((NiceString n, PrintableString v), s) <- vars'
+          | ((NiceString n, NiceString v), s) <- vars'
           , n /= other ]
 
     mainArgs = mconcat

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -47,6 +47,7 @@
           (hsPkgs."HUnit" or (errorHandler.buildDepError "HUnit"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))
+          (hsPkgs."optparse-applicative" or (errorHandler.buildDepError "optparse-applicative"))
           (hsPkgs."pretty-simple" or (errorHandler.buildDepError "pretty-simple"))
           (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
           (hsPkgs."quickcheck-classes" or (errorHandler.buildDepError "quickcheck-classes"))
@@ -67,10 +68,12 @@
           depends = [
             (hsPkgs."base" or (errorHandler.buildDepError "base"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
+            (hsPkgs."fmt" or (errorHandler.buildDepError "fmt"))
             (hsPkgs."hspec" or (errorHandler.buildDepError "hspec"))
             (hsPkgs."hspec-core" or (errorHandler.buildDepError "hspec-core"))
             (hsPkgs."hspec-expectations-lifted" or (errorHandler.buildDepError "hspec-expectations-lifted"))
             (hsPkgs."silently" or (errorHandler.buildDepError "silently"))
+            (hsPkgs."QuickCheck" or (errorHandler.buildDepError "QuickCheck"))
             (hsPkgs."unliftio" or (errorHandler.buildDepError "unliftio"))
             (hsPkgs."unliftio-core" or (errorHandler.buildDepError "unliftio-core"))
             ];

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -154,6 +154,7 @@
             (hsPkgs."cardano-ledger-core" or (errorHandler.buildDepError "cardano-ledger-core"))
             (hsPkgs."cardano-wallet" or (errorHandler.buildDepError "cardano-wallet"))
             (hsPkgs."cardano-wallet-core" or (errorHandler.buildDepError "cardano-wallet-core"))
+            (hsPkgs."cardano-wallet-launcher" or (errorHandler.buildDepError "cardano-wallet-launcher"))
             (hsPkgs."cardano-wallet-test-utils" or (errorHandler.buildDepError "cardano-wallet-test-utils"))
             (hsPkgs."containers" or (errorHandler.buildDepError "containers"))
             (hsPkgs."contra-tracer" or (errorHandler.buildDepError "contra-tracer"))

--- a/stack.yaml
+++ b/stack.yaml
@@ -48,9 +48,11 @@ ghc-options:
 
 nix:
   shell-file: nix/stack-shell.nix
-  # Disabling the pure nix-shell allows environment variables to be
-  # passed down to tests. We need this for integration tests.
-  pure: false
+  # NOTE: Using a pure nix-shell (the default setting in Stack)
+  # prevents environment variables from being passed down to tests.
+  # If an environment variable needs to be set, add --env VAR=VAL
+  # options on the test suite command line.
+  pure: true
 
 # This completely disables checking of Cabal file version bounds, and
 # is necessary for Stack to successfully construct its build plan.


### PR DESCRIPTION
Adds extra option handling to the integration test suite.
Environment variables can be set from the command line, which can be helpful.
