### PR TITLE
Simplify handling of `extraCoinSource` within `Balance` module.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Framework/TestData.hs
+++ b/lib/core-integration/src/Test/Integration/Framework/TestData.hs
@@ -45,6 +45,7 @@ module Test.Integration.Framework.TestData
     , errMsg403NotAByronWallet
     , errMsg403NotAnIcarusWallet
     , errMsg403NotEnoughMoney
+    , errMsg403EmptyUTxO
     , errMsg403WrongPass
     , errMsg403AlreadyInLedger
     , errMsg404NoSuchPool
@@ -321,6 +322,12 @@ errMsg403NotEnoughMoney :: String
 errMsg403NotEnoughMoney =
     "I can't process this payment as there are not enough funds available in \
     \the wallet."
+
+errMsg403EmptyUTxO :: String
+errMsg403EmptyUTxO =
+    "Cannot create a transaction because the wallet \
+    \has no UTxO entries. At least one UTxO entry is \
+    \required in order to create a transaction."
 
 errMsg403TxTooBig :: String
 errMsg403TxTooBig =

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -137,7 +137,8 @@ import Test.Integration.Framework.DSL
     , (.>=)
     )
 import Test.Integration.Framework.TestData
-    ( errMsg403Fee
+    ( errMsg403EmptyUTxO
+    , errMsg403Fee
     , errMsg403NonNullReward
     , errMsg403NotDelegating
     , errMsg403NotEnoughMoney
@@ -948,7 +949,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
 
             quitStakePool @n ctx (w, fixturePassphrase) >>= flip verify
                 [ expectResponseCode HTTP.status403
-                , expectErrorMessage errMsg403NotEnoughMoney
+                , expectErrorMessage errMsg403EmptyUTxO
                 ]
 
     it "STAKE_POOLS_ESTIMATE_FEE_01 - can estimate fees" $ \ctx -> runResourceT $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -156,6 +156,7 @@ import Test.Integration.Framework.TestData
     , errMsg400StartTimeLaterThanEndTime
     , errMsg400TxMetadataStringTooLong
     , errMsg403AlreadyInLedger
+    , errMsg403EmptyUTxO
     , errMsg403Fee
     , errMsg403MinUTxOValue
     , errMsg403NotAShelleyWallet
@@ -2155,7 +2156,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransaction @'Shelley wSelf) Default payload
         verify rTx
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403NotEnoughMoney
+            , expectErrorMessage errMsg403EmptyUTxO
             ]
 
     it "SHELLEY_TX_REDEEM_06b - Can't redeem rewards if utxo = 0 from self" $ \ctx -> runResourceT $ do

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -3838,6 +3838,12 @@ instance IsServerError ErrSelectAssets where
                         , "ada to proceed. Try increasing your wallet balance"
                         , "or sending a smaller amount."
                         ]
+                Balance.EmptyUTxO ->
+                    apiError err403 NotEnoughMoney $ T.unwords
+                        [ "Cannot create a transaction because the wallet"
+                        , "has no UTxO entries. At least one UTxO entry is"
+                        , "required in order to create a transaction."
+                        ]
         ErrSelectAssetsSelectionError (SelectionOutputsError selectionError) ->
             toServerError selectionError
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -316,6 +316,7 @@ data SelectionError
         OutputsInsufficientError
     | UnableToConstructChange
         UnableToConstructChangeError
+    | EmptyUTxO
     deriving (Generic, Eq, Show)
 
 -- | Indicates that a portion of the minted assets were not spent or burned.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -865,7 +865,7 @@ data SelectionState = SelectionState
     , leftover
         :: !UTxOIndex
     }
-    deriving (Eq, Show)
+    deriving (Eq, Generic, Show)
 
 runSelection
     :: forall m. MonadRandom m

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -953,8 +953,8 @@ selectAssetQuantity
     -> SelectionLimit
     -> SelectionState
     -> m (Maybe SelectionState)
-selectAssetQuantity asset limit =
-    selectMatchingQuantity limit (WithAssetOnly asset :| [WithAsset asset])
+selectAssetQuantity asset =
+    selectMatchingQuantity (WithAssetOnly asset :| [WithAsset asset])
 
 -- | Specializes 'selectMatchingQuantity' to ada.
 --
@@ -963,8 +963,8 @@ selectCoinQuantity
     => SelectionLimit
     -> SelectionState
     -> m (Maybe SelectionState)
-selectCoinQuantity limit =
-    selectMatchingQuantity limit (WithAdaOnly :| [Any])
+selectCoinQuantity =
+    selectMatchingQuantity (WithAdaOnly :| [Any])
 
 -- | Selects a UTxO entry that matches one of the specified filters.
 --
@@ -984,17 +984,17 @@ selectCoinQuantity limit =
 --
 selectMatchingQuantity
     :: MonadRandom m
-    => SelectionLimit
-        -- ^ A limit to adhere to when selecting entries.
-    -> NonEmpty SelectionFilter
+    => NonEmpty SelectionFilter
         -- ^ A list of selection filters to be traversed from left-to-right,
         -- in descending order of priority.
+    -> SelectionLimit
+        -- ^ A limit to adhere to when selecting entries.
     -> SelectionState
         -- ^ The current selection state.
     -> m (Maybe SelectionState)
         -- ^ An updated selection state that includes a matching UTxO entry,
         -- or 'Nothing' if no such entry could be found.
-selectMatchingQuantity limit filters s
+selectMatchingQuantity filters limit s
     | limitReached =
         pure Nothing
     | otherwise =

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxO.hs
@@ -29,6 +29,7 @@ module Cardano.Wallet.Primitive.Types.UTxO
     , balance
     , computeStatistics
     , computeUtxoStatistics
+    , difference
     , excluding
     , isSubsetOf
     , empty
@@ -118,6 +119,9 @@ balance =
   where
     fn :: TokenBundle -> TxOut -> TokenBundle
     fn tot out = tot `TB.add` view #tokens out
+
+difference :: UTxO -> UTxO -> UTxO
+difference a b = a `excluding` Map.keysSet (unUTxO b)
 
 -- | ins⋪ u
 excluding :: UTxO -> Set TxIn ->  UTxO

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -46,6 +46,9 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     , null
     , size
 
+    -- * Set operations
+    , difference
+
     -- * Selection
     , SelectionFilter (..)
     , selectRandom

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex/Internal.hs
@@ -60,6 +60,9 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
     , null
     , size
 
+    -- * Set operations
+    , difference
+
     -- * Selection
     , SelectionFilter (..)
     , selectRandom
@@ -115,6 +118,7 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
@@ -321,6 +325,13 @@ null = (== 0) . size
 --
 size :: UTxOIndex -> Int
 size = Map.size . utxo
+
+--------------------------------------------------------------------------------
+-- Set operations
+--------------------------------------------------------------------------------
+
+difference :: UTxOIndex -> UTxOIndex -> UTxOIndex
+difference a b = fromUTxO $ UTxO.difference (toUTxO a) (toUTxO b)
 
 --------------------------------------------------------------------------------
 -- Selection

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -48,9 +48,9 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , collateNonUserSpecifiedAssetQuantities
     , computeUTxOBalanceAvailable
     , computeUTxOBalanceRequired
-     ,computeUTxOBalanceSufficiencyInfo
-    , isUTxOBalanceSufficient
+    , computeUTxOBalanceSufficiencyInfo
     , groupByKey
+    , isUTxOBalanceSufficient
     , makeChange
     , makeChangeForCoin
     , makeChangeForNonUserSpecifiedAsset

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -992,6 +992,8 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
             onInsufficientMinCoinValues es
         UnableToConstructChange e ->
             onUnableToConstructChange e
+        EmptyUTxO ->
+            onEmptyUTxO
 
     onBalanceInsufficient e = do
         let balanceAvailable' =
@@ -1107,6 +1109,10 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
       where
         assertOnUnableToConstructChange =
             assertWith . (<>) "onUnableToConstructChange: "
+
+    onEmptyUTxO = assertWith
+        "utxoAvailable == UTxOIndex.empty"
+        (utxoAvailable == UTxOIndex.empty)
 
     balanceRequired  =
       F.foldMap (view #tokens) outputsToCover

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -702,7 +702,7 @@ prop_performSelection_small minCoinValueFor costFor (Blind (Small criteria)) =
 
     -- Inspect the UTxO and user-specified outputs:
     cover 5 (utxoHasAtLeastOneAsset)
-        "UTxO has at least one assest" $
+        "UTxO has at least one asset" $
     cover 5 (not outputsHaveAtLeastOneAsset)
         "No assets to cover" $
     cover 2 (outputsHaveAtLeastOneAsset && not utxoHasAtLeastOneAsset)


### PR DESCRIPTION
## Issue Number

ADP-1113

## Overview

This PR:
- simplifies the handling of `extraCoinSource` within the `Balance` module.
- clarifies the handling of the case where we produce an empty selection (one where we have selected no inputs).
- provides a set of functions to calculate UTXO balance sufficiency, and uses them to reduce code duplication in `Balance` and `BalanceSpec`.

## Details

Many parts of the `Balance` module give special consideration to the "extra coin source", by performing various calculations to add and subtract it from the balance. It's considered in all of the following places:

- `performSelection`
- `runSelection`
- `makeChange`

There's quite a bit of code duplication. This makes introducing further changes riskier than necessary.

In reality, a finished selection must **_always_** include at least one input. So it's safe to assume that the extra coin source can always be completely spent.

Therefore, it's unnecessary to even consider the extra coin source when selecting UTxO entries within `runSelection`, provided that `runSelection` is called with the correct balance to cover, and provided we ensure that `runSelection` always produces at least one input.