### PR TITLE
Add docker-compose smoke test into GH actions for Linux and MacOS

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -1,0 +1,30 @@
+name: Docker-compose Linux
+on:
+  schedule:
+  - cron:  "0 23 * * *"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'NETWORK'
+        required: true
+        default: 'testnet'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+      - name: Install cardano_wallet gem
+        run: gem install cardano_wallet
+      - name: Check docker-compose
+        run: |
+          docker-compose up -d
+          ./scripts/connect_wallet.rb
+        env:
+          NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/.github/workflows/docker_macos.yml
+++ b/.github/workflows/docker_macos.yml
@@ -1,0 +1,31 @@
+name: Docker-compose MacOS
+on:
+  schedule:
+  - cron:  "0 23 * * *"
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'NETWORK'
+        required: true
+        default: 'testnet'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, macos-11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker-practice/actions-setup-docker@1.0.8
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.1
+      - name: Install cardano_wallet gem
+        run: gem install cardano_wallet
+      - name: Check docker-compose
+        run: |
+          docker-compose up -d
+          ./scripts/connect_wallet.rb
+        env:
+          NETWORK: ${{ github.event.inputs.network || 'testnet' }}

--- a/scripts/connect_wallet.rb
+++ b/scripts/connect_wallet.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'cardano_wallet'
+
+timeout = 100
+treshold = Time.now + timeout
+
+def is_connected?
+  begin
+    CardanoWallet.new.misc.network.information
+    true
+  rescue
+    false
+  end
+end
+
+while (is_connected? == false && (Time.now <= treshold))
+  puts "Wallet is not up yet... will check again in 5 seconds"
+  sleep 5
+end
+
+if is_connected?
+  puts "Wallet is up and running!!!"
+  exit 0
+else
+  puts "Didn't manage to connect to wallet within #{timeout}s!!!"
+  exit 1
+end

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -6,6 +6,8 @@
 # E2E testing
 [![E2E Docker](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-docker.yml) [![E2E Linux](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-linux.yml) [![E2E MacOS](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-macos.yml) [![E2E Windows](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/e2e-windows.yml)
 
+[![Docker-compose Linux](https://github.com/input-output-hk/cardano-wallet/actions/workflows/docker_linux.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/docker_linux.yml) [![Docker-compose MacOS](https://github.com/input-output-hk/cardano-wallet/actions/workflows/docker_macos.yml/badge.svg)](https://github.com/input-output-hk/cardano-wallet/actions/workflows/docker_macos.yml)
+
 E2E functional tests of cardano-wallet are running nightly on [cardano testnet](https://testnets.cardano.org/en/cardano/overview/). Running tests against public testnet allows to excercise cardano-wallet on environment close to production (mainnet) utilizing and integrating maximally all components of the Cardano ecosystem like Stake pools, SMASH, metadata token server etc.
 
 


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [ ] Trying to reproduce the issue and as a result adding GH actions workflows for testing docker-compose.yml on Linux and MacOS

### Comments

Cannot add workflow for Windows as Linux based containers are not supported on Windows VMs in GH actions (https://github.com/actions/virtual-environments/issues/252)

### Issue Number

ADP-1115
