### PR TITLE
Unify `selectionDelta` calculations.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2052,6 +2052,8 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
             , utxoRemaining = UTxOIndex.empty
             , extraCoinSource
             , changeGenerated = []
+            , assetsToMint = TokenMap.empty
+            , assetsToBurn = TokenMap.empty
             }
 
         -- NOTE:

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -373,6 +373,12 @@ data SelectionResult change = SelectionResult
         :: !UTxOIndex
         -- ^ The subset of 'utxoAvailable' that remains after performing
         -- the selection.
+    , assetsToMint
+        :: !TokenMap
+        -- ^ The assets to mint.
+    , assetsToBurn
+        :: !TokenMap
+        -- ^ The assets to burn.
     }
     deriving (Generic, Eq, Show)
 
@@ -809,6 +815,8 @@ performSelection minCoinFor costFor bundleSizeAssessor criteria
             , changeGenerated = changeGenerated
             , outputsCovered = NE.toList outputsToCover
             , utxoRemaining = leftover
+            , assetsToMint
+            , assetsToBurn
             }
 
         selectOneEntry = selectCoinQuantity selectionLimit

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -142,6 +142,8 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex (..) )
 import Control.Monad.Random.Class
     ( MonadRandom (..) )
+import Data.Bifunctor
+    ( first )
 import Data.Function
     ( (&) )
 import Data.Functor.Identity
@@ -161,7 +163,7 @@ import Data.Ord
 import Data.Set
     ( Set )
 import Fmt
-    ( Buildable (..), genericF, nameF, unlinesF )
+    ( Buildable (..), Builder, blockMapF, genericF, nameF, unlinesF )
 import GHC.Generics
     ( Generic )
 import GHC.Stack
@@ -405,6 +407,14 @@ data SelectionDelta a
     = SelectionSurplus a
     | SelectionDeficit a
     deriving (Eq, Functor, Show)
+
+instance Buildable a => Buildable (SelectionDelta a) where
+    build d = case d of
+        SelectionSurplus surplus -> buildMap [("surplus", build surplus)]
+        SelectionDeficit deficit -> buildMap [("deficit", build deficit)]
+      where
+        buildMap :: [(String, Builder)] -> Builder
+        buildMap = blockMapF . fmap (first $ id @String)
 
 -- | Calculates the selection delta for all assets.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -69,6 +69,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , runSelectionNonEmptyWith
     , runSelectionStep
     , selectionDeltaAllAssets
+    , selectionHasValidSurplus
     , splitBundleIfAssetCountExcessive
     , splitBundlesWithExcessiveAssetCounts
     , splitBundlesWithExcessiveTokenQuantities
@@ -899,6 +900,9 @@ prop_performSelection minCoinValueFor costFor (Blind criteria) coverage =
         assertOnSuccess
             "isUTxOBalanceSufficient criteria"
             (isUTxOBalanceSufficient criteria)
+        assertOnSuccess
+            "selectionHasValidSurplus result"
+            (selectionHasValidSurplus result)
         assertOnSuccess
             "view #tokens surplus == TokenMap.empty"
             (view #tokens surplus == TokenMap.empty)

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -273,6 +273,7 @@ import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Migration as Migration
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -644,6 +645,10 @@ walletKeyIsReencrypted (wid, wname) (xprv, pwd) newPwd =
             [ (TokenBundle.fromCoin $ Coin 1) ]
         , utxoRemaining =
             UTxOIndex.empty
+        , assetsToBurn =
+            TokenMap.empty
+        , assetsToMint =
+            TokenMap.empty
         }
 
     ctx = defaultTransactionCtx

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -451,6 +451,7 @@ spec = do
                       , outputsCovered = outs
                       , changeGenerated = chgs
                       , utxoRemaining = UTxOIndex.empty
+                      -- TODO: [ADP-346]
                       , assetsToMint = TokenMap.empty
                       , assetsToBurn = TokenMap.empty
                       }
@@ -547,6 +548,7 @@ spec = do
                     , outputsCovered = outs
                     , changeGenerated = chgs
                     , utxoRemaining = UTxOIndex.empty
+                    -- TODO: [ADP-346]
                     , assetsToMint = TokenMap.empty
                     , assetsToBurn = TokenMap.empty
                     }
@@ -695,6 +697,7 @@ prop_decodeSignedShelleyTxRoundtrip shelleyEra (DecodeShelleySetup utxo outs md 
         , outputsCovered = []
         , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
+        -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
         }
@@ -723,6 +726,7 @@ prop_decodeSignedByronTxRoundtrip (DecodeByronSetup utxo outs slotNo ntwrk pairs
         , outputsCovered = []
         , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
+        -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
         }

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -192,6 +192,7 @@ import Test.QuickCheck.Random
 import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
@@ -450,6 +451,8 @@ spec = do
                       , outputsCovered = outs
                       , changeGenerated = chgs
                       , utxoRemaining = UTxOIndex.empty
+                      , assetsToMint = TokenMap.empty
+                      , assetsToBurn = TokenMap.empty
                       }
                   inps = Map.toList $ unUTxO utxo
         it "1 input, 2 outputs" $ do
@@ -544,6 +547,8 @@ spec = do
                     , outputsCovered = outs
                     , changeGenerated = chgs
                     , utxoRemaining = UTxOIndex.empty
+                    , assetsToMint = TokenMap.empty
+                    , assetsToBurn = TokenMap.empty
                     }
                   inps = Map.toList $ unUTxO utxo
         it "1 input, 2 outputs" $ do
@@ -690,6 +695,8 @@ prop_decodeSignedShelleyTxRoundtrip shelleyEra (DecodeShelleySetup utxo outs md 
         , outputsCovered = []
         , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
+        , assetsToMint = TokenMap.empty
+        , assetsToBurn = TokenMap.empty
         }
 
 prop_decodeSignedByronTxRoundtrip
@@ -716,6 +723,8 @@ prop_decodeSignedByronTxRoundtrip (DecodeByronSetup utxo outs slotNo ntwrk pairs
         , outputsCovered = []
         , changeGenerated = outs
         , utxoRemaining = UTxOIndex.empty
+        , assetsToMint = TokenMap.empty
+        , assetsToBurn = TokenMap.empty
         }
 
 -- | Increasing the number of outputs reduces the number of inputs.


### PR DESCRIPTION
## Issue Number

ADP-1070

## Summary

This PR:
- introduces the `SelectionDelta` type, which encodes the possibility of:
  - a `SelectionSurplus`
    (where all output assets are paid for by the inputs)
  - a `SelectionDeficit`
    (where some output assets are not paid for by the inputs)
- introduces the `selectionDelta{AllAssets,Coin}` functions, which compute the selection delta for all assets, or just the ada asset, respectively.
- uses the `selectionDelta{AllAssets,Coin}` functions to unify several repeated calculations relating to deltas, including within the test suite.