### PR TITLE
Simplify type of `CoinSelection.Balance.performSelection`

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -34,11 +34,7 @@ module Cardano.Wallet.Primitive.CoinSelection
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionCriteria (..)
-    , SelectionLimit
-    , SelectionResult
-    , SelectionSkeleton
-    )
+    ( SelectionLimit, SelectionResult, SelectionSkeleton )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address )
 import Cardano.Wallet.Primitive.Types.Coin
@@ -108,10 +104,12 @@ performSelection selectionConstraints selectionParams =
             pure $ Left $ SelectionOutputsError e
         Right preparedOutputsToCover ->
             first SelectionBalanceError <$> Balance.performSelection
-                computeMinimumAdaQuantity
-                computeMinimumCost
-                assessTokenBundleSize
-                SelectionCriteria
+                Balance.SelectionConstraints
+                    { computeMinimumAdaQuantity
+                    , computeMinimumCost
+                    , assessTokenBundleSize
+                    }
+                Balance.SelectionCriteria
                     { assetsToBurn
                     , assetsToMint
                     , extraCoinSource = rewardWithdrawal

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -109,7 +109,7 @@ performSelection selectionConstraints selectionParams =
                     , computeMinimumCost
                     , assessTokenBundleSize
                     }
-                Balance.SelectionCriteria
+                Balance.SelectionParams
                     { assetsToBurn
                     , assetsToMint
                     , extraCoinSource = rewardWithdrawal


### PR DESCRIPTION
## Issue Number

ADP-1070

## Summary

This PR uses records to simplify the type of `Balance.performSelection` to:
```hs
performSelection
    :: forall m. (HasCallStack, MonadRandom m)
    => SelectionConstraints
    -> SelectionParams
    -> m (Either SelectionError (SelectionResult TokenBundle))
```

We now have consistency between `CoinSelection` and `CoinSelection.Balance`:
```hs
CoinSelection.SelectionConstraints
CoinSelection.SelectionParams

CoinSelection.Balance.SelectionConstraints
CoinSelection.Balance.SelectionParams
```

In both cases:

- `SelectionConstraints` are constraints that are **common to all selections**.
- `SelectionParams` are parameters that are  **specific to a particular selection**.
