### PR TITLE
Provide `MockSelectionConstraints` type and generator.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -115,7 +115,6 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
 import qualified Network.HTTP.Types.Status as HTTP
 import qualified Test.Hspec as Hspec
 
@@ -243,7 +242,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 [ expectField (#balance . #available . #getQuantity)
                     (.> 0)
                 , expectField (#assets . #available . #getApiT)
-                    ((.> 0) . Set.size . TokenMap.getAssets)
+                    ((.> 0) . TokenMap.size)
                 ]
 
             targetWallet <- emptyWallet ctx
@@ -404,9 +403,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField (#balance . #total . #getQuantity)
                     (`shouldBe` expectedBalanceAda)
                 , expectField (#assets . #available . #getApiT)
-                    ((`shouldBe` expectedAssetCount)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((`shouldBe` expectedAssetCount) . TokenMap.size)
                 ]
             let expectedSourceDistributionAfterMinting =
                     [ ( 10_000_000, 120)
@@ -443,15 +440,11 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField (#balanceSelected . #ada . #getQuantity)
                     (`shouldBe` expectedBalanceAda)
                 , expectField (#balanceSelected . #assets . #getApiT)
-                    ((`shouldBe` expectedAssetCount)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((`shouldBe` expectedAssetCount) . TokenMap.size)
                 , expectField (#balanceLeftover . #ada . #getQuantity)
                     (`shouldBe` 0)
                 , expectField (#balanceLeftover . #assets . #getApiT)
-                    ((`shouldBe` 0)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((`shouldBe` 0) . TokenMap.size)
                 ]
 
     Hspec.it "SHELLEY_CREATE_MIGRATION_PLAN_08 - \
@@ -530,9 +523,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField (#balance . #total . #getQuantity)
                     (`shouldBe` expectedBalanceAda)
                 , expectField (#assets . #available . #getApiT)
-                    ((`shouldBe` expectedAssetCount)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((`shouldBe` expectedAssetCount) . TokenMap.size)
                 ]
             let expectedSourceDistributionAfterMinting =
                     [ ( 10_000_000, 120)
@@ -572,13 +563,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 , expectField (#balanceLeftover . #ada . #getQuantity)
                     (`shouldBe`  29_687_500)
                 , expectField (#balanceSelected . #assets . #getApiT)
-                    ((.> 0)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((.> 0) . TokenMap.size)
                 , expectField (#balanceLeftover . #assets . #getApiT)
-                    ((.> 0)
-                        . Set.size
-                        . TokenMap.getAssets)
+                    ((.> 0) . TokenMap.size)
                 ]
 
     describe "SHELLEY_MIGRATE_01 - \
@@ -1027,9 +1014,9 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     , expectField (#balance . #total . #getQuantity)
                         (`shouldBe` expectedAdaBalance)
                     , expectField (#assets . #available . #getApiT)
-                        ((`shouldBe` 8) . Set.size . TokenMap.getAssets)
+                        ((`shouldBe` 8) . TokenMap.size)
                     , expectField (#assets . #total . #getApiT)
-                        ((`shouldBe` 8) . Set.size . TokenMap.getAssets)
+                        ((`shouldBe` 8) . TokenMap.size)
                     ]
                 let balanceAda = response
                         & getFromResponse (#balance . #available . #getQuantity)

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -2023,7 +2023,6 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
         selection = SelectionResult
             { inputsSelected = view #inputIds migrationSelection
             , outputsCovered
-            , utxoRemaining = UTxOIndex.empty
             , extraCoinSource
             , extraCoinSink = Coin 0
             , changeGenerated = []

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -109,7 +109,8 @@ performSelection selectionConstraints selectionParams =
                 Balance.SelectionConstraints
                     { computeMinimumAdaQuantity
                     , computeMinimumCost
-                    , assessTokenBundleSize
+                    , assessTokenBundleSize =
+                        view #assessTokenBundleSize assessTokenBundleSize
                     }
                 Balance.SelectionParams
                     { assetsToBurn

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -109,6 +109,7 @@ performSelection selectionConstraints selectionParams =
                 Balance.SelectionConstraints
                     { computeMinimumAdaQuantity
                     , computeMinimumCost
+                    , computeSelectionLimit
                     , assessTokenBundleSize =
                         view #assessTokenBundleSize assessTokenBundleSize
                     }
@@ -120,8 +121,6 @@ performSelection selectionConstraints selectionParams =
                       -- that consumes ada:
                     , extraCoinSink = Coin 0
                     , outputsToCover = preparedOutputsToCover
-                    , selectionLimit =
-                        computeSelectionLimit $ F.toList preparedOutputsToCover
                     , utxoAvailable
                     }
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -411,10 +411,6 @@ data SelectionResult change = SelectionResult
     , changeGenerated
         :: ![change]
         -- ^ A list of generated change outputs.
-    , utxoRemaining
-        :: !UTxOIndex
-        -- ^ The subset of 'utxoAvailable' that remains after performing
-        -- the selection.
     , assetsToMint
         :: !TokenMap
         -- ^ The assets to mint.
@@ -874,14 +870,13 @@ performSelection constraints params
             , extraCoinSink
             , changeGenerated = changeGenerated
             , outputsCovered = NE.toList outputsToCover
-            , utxoRemaining = leftover
             , assetsToMint
             , assetsToBurn
             }
 
         selectOneEntry = selectCoinQuantity selectionLimit
 
-        SelectionState {selected, leftover} = s
+        SelectionState {selected} = s
 
         requiredCost = computeMinimumCost SelectionSkeleton
             { skeletonInputCount = UTxOIndex.size selected
@@ -947,7 +942,6 @@ data SelectionReportSummarized = SelectionReportSummarized
     , numberOfUniqueNonAdaAssetsInSelectedInputs :: Int
     , numberOfUniqueNonAdaAssetsInRequestedOutputs :: Int
     , numberOfUniqueNonAdaAssetsInGeneratedChangeOutputs :: Int
-    , sizeOfRemainingUtxoSet :: Int
     }
     deriving (Eq, Generic, Show)
 
@@ -1012,8 +1006,6 @@ makeSelectionReportSummarized s = SelectionReportSummarized {..}
         = Set.size
         $ F.foldMap TokenBundle.getAssets
         $ view #changeGenerated s
-    sizeOfRemainingUtxoSet
-        = UTxOIndex.size $ utxoRemaining s
 
 makeSelectionReportDetailed
     :: SelectionResult TokenBundle -> SelectionReportDetailed

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -644,13 +644,6 @@ prepareOutputsWith minCoinValueFor = fmap $ \out ->
 
 -- | Performs a coin selection and generates change bundles in one step.
 --
--- Returns 'BalanceInsufficient' if the total balance of 'utxoAvailable' is not
--- strictly greater than or equal to the total balance of 'outputsToCover'.
---
--- Returns 'OutputsInsufficientError' if the 'minted' values are not a subset
--- of the 'outputsToCover' plus the 'burned' values. That is, the minted values
--- are not spent or burned.
---
 -- Provided that 'isUTxOBalanceSufficient' returns 'True' for the given
 -- selection criteria, this function guarantees to return a 'SelectionResult'
 -- for which 'selectionHasValidSurplus' returns 'True'.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -2120,7 +2120,7 @@ instance Ord (AssetCount TokenMap) where
             GT -> GT
             EQ -> comparing TokenMap.toNestedList m1 m2
       where
-        assetCount = Set.size . TokenMap.getAssets
+        assetCount = TokenMap.size
 
 newtype AssetCount a = AssetCount
     { unAssetCount :: a }

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -200,7 +200,7 @@ import qualified Data.Set as Set
 --
 data SelectionConstraints = SelectionConstraints
     { assessTokenBundleSize
-        :: TokenBundleSizeAssessor
+        :: TokenBundle -> TokenBundleSizeAssessment
         -- ^ Assesses the size of a token bundle relative to the upper limit of
         -- what can be included in a transaction output. See documentation for
         -- the 'TokenBundleSizeAssessor' type to learn about the expected
@@ -781,7 +781,7 @@ performSelection constraints params
         (fmap (TokenMap.getAssets . view #tokens))
         (makeChange MakeChangeCriteria
             { minCoinFor = noMinimumCoin
-            , bundleSizeAssessor = assessTokenBundleSize
+            , bundleSizeAssessor = TokenBundleSizeAssessor assessTokenBundleSize
             , requiredCost = noCost
             , extraCoinSource
             , extraCoinSink
@@ -860,7 +860,7 @@ performSelection constraints params
         mChangeGenerated :: Either UnableToConstructChangeError [TokenBundle]
         mChangeGenerated = makeChange MakeChangeCriteria
             { minCoinFor = computeMinimumAdaQuantity
-            , bundleSizeAssessor = assessTokenBundleSize
+            , bundleSizeAssessor = TokenBundleSizeAssessor assessTokenBundleSize
             , requiredCost
             , extraCoinSource
             , extraCoinSink

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Coin.hs
@@ -25,6 +25,7 @@ module Cardano.Wallet.Primitive.Types.Coin
     , addCoin
     , subtractCoin
     , sumCoins
+    , difference
     , distance
 
       -- * Partitioning
@@ -165,6 +166,13 @@ addCoin (Coin a) (Coin b) = Coin (a + b)
 -- | Add a list of coins together.
 sumCoins :: Foldable t => t Coin -> Coin
 sumCoins = foldl' addCoin (Coin 0)
+
+-- | Subtracts the second coin from the first.
+--
+-- Returns 'Coin 0' if the second coin is strictly greater than the first.
+--
+difference :: Coin -> Coin -> Coin
+difference a b = fromMaybe (Coin 0) (subtractCoin a b)
 
 -- | Absolute difference between two coin amounts. The result is never negative.
 distance :: Coin -> Coin -> Coin

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenBundle.hs
@@ -92,8 +92,6 @@ import Data.Map.Strict
     ( Map )
 import Data.Map.Strict.NonEmptyMap
     ( NonEmptyMap )
-import Data.Maybe
-    ( fromMaybe )
 import Data.Set
     ( Set )
 import Fmt
@@ -293,11 +291,13 @@ subtract a b = guard (b `leq` a) $> unsafeSubtract a b
 -- >>> let oneToken = fromFlatList coin [(aid, TokenQuantity 1)]
 -- >>> (mempty `difference` oneToken) `add` oneToken
 -- oneToken
+--
 difference :: TokenBundle -> TokenBundle -> TokenBundle
 difference (TokenBundle c1 m1) (TokenBundle c2 m2) =
     TokenBundle
-        (fromMaybe (Coin 0) $ Coin.subtractCoin c1 c2)
+        (Coin.difference c1 c2)
         (TokenMap.difference m1 m2)
+
 --------------------------------------------------------------------------------
 -- Quantities
 --------------------------------------------------------------------------------

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/TokenMap.hs
@@ -60,6 +60,9 @@ module Cardano.Wallet.Primitive.Types.TokenMap
     , difference
     , intersection
 
+    -- * Queries
+    , size
+
     -- * Tests
     , isEmpty
     , isNotEmpty
@@ -567,6 +570,15 @@ intersection m1 m2 =
 
     sharedAssets :: Set AssetId
     sharedAssets = Set.intersection (getAssets m1) (getAssets m2)
+
+--------------------------------------------------------------------------------
+-- Queries
+--------------------------------------------------------------------------------
+
+-- | Returns the number of unique assets in a token map.
+--
+size :: TokenMap -> Int
+size = Set.size . getAssets
 
 --------------------------------------------------------------------------------
 -- Tests

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -843,7 +843,9 @@ prop_performSelection minCoinValueFor costFor (Blind params) coverage =
         either onFailure onSuccess result
   where
     constraints = SelectionConstraints
-        { assessTokenBundleSize = mkBundleSizeAssessor NoBundleSizeLimit
+        { assessTokenBundleSize
+            = view #assessTokenBundleSize
+            $ mkBundleSizeAssessor NoBundleSizeLimit
         , computeMinimumAdaQuantity = mkMinCoinValueFor minCoinValueFor
         , computeMinimumCost = mkCostFor costFor
         }
@@ -1036,10 +1038,10 @@ prop_performSelection minCoinValueFor costFor (Blind params) coverage =
             "shortfall e > Coin 0"
             (shortfall e > Coin 0)
         let params' = set #selectionLimit NoLimit params
-        let assessBundleSize =
-                mkBundleSizeAssessor NoBundleSizeLimit
         let constraints' = SelectionConstraints
-                { assessTokenBundleSize = assessBundleSize
+                { assessTokenBundleSize
+                    = view #assessTokenBundleSize
+                    $ mkBundleSizeAssessor NoBundleSizeLimit
                 , computeMinimumAdaQuantity = noMinCoin
                 , computeMinimumCost = const noCost
                 }
@@ -1541,8 +1543,9 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
     constraints = SelectionConstraints
         { computeMinimumAdaQuantity = noMinCoin
         , computeMinimumCost = mkCostFor NoCost
-        , assessTokenBundleSize = mkBundleSizeAssessor $
-            boundaryTestBundleSizeAssessor params
+        , assessTokenBundleSize = view #assessTokenBundleSize
+            $ mkBundleSizeAssessor
+            $ boundaryTestBundleSizeAssessor params
         }
 
 encodeBoundaryTestCriteria :: BoundaryTestCriteria -> SelectionParams

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -621,14 +621,8 @@ genSelectionParams genUTxOIndex' = do
         choose (1, UTxOIndex.size utxoAvailable `div` 8)
     outputsToCover <- NE.fromList <$>
         replicateM outputCount genTxOut
-    selectionLimit <- frequency
-        [ (5, pure NoLimit)
-        , (1, pure $ MaximumInputLimit 0)
-        , (1, pure $ MaximumInputLimit (UTxOIndex.size utxoAvailable))
-        , (4, MaximumInputLimit <$> choose
-            (1, UTxOIndex.size utxoAvailable `div` 8)
-          )
-        ]
+    selectionLimit <- ($ []) . unMockComputeSelectionLimit <$>
+        genMockComputeSelectionLimit
     extraCoinSource <-
         oneof [pure $ Coin 0, genCoinPositive]
     extraCoinSink <-

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -843,9 +843,8 @@ prop_performSelection minCoinValueFor costFor (Blind params) coverage =
         either onFailure onSuccess result
   where
     constraints = SelectionConstraints
-        { assessTokenBundleSize
-            = view #assessTokenBundleSize
-            $ mkBundleSizeAssessor NoBundleSizeLimit
+        { assessTokenBundleSize =
+            unMockAssessTokenBundleSize MockAssessTokenBundleSizeUnlimited
         , computeMinimumAdaQuantity = mkMinCoinValueFor minCoinValueFor
         , computeMinimumCost = mkCostFor costFor
         }
@@ -1039,9 +1038,8 @@ prop_performSelection minCoinValueFor costFor (Blind params) coverage =
             (shortfall e > Coin 0)
         let params' = set #selectionLimit NoLimit params
         let constraints' = SelectionConstraints
-                { assessTokenBundleSize
-                    = view #assessTokenBundleSize
-                    $ mkBundleSizeAssessor NoBundleSizeLimit
+                { assessTokenBundleSize = unMockAssessTokenBundleSize
+                    MockAssessTokenBundleSizeUnlimited
                 , computeMinimumAdaQuantity = noMinCoin
                 , computeMinimumCost = const noCost
                 }
@@ -1516,7 +1514,7 @@ data BoundaryTestData = BoundaryTestData
 
 data BoundaryTestCriteria = BoundaryTestCriteria
     { boundaryTestBundleSizeAssessor
-        :: MockTokenBundleSizeAssessor
+        :: MockAssessTokenBundleSize
     , boundaryTestOutputs
         :: [BoundaryTestEntry]
     , boundaryTestUTxO
@@ -1543,9 +1541,8 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
     constraints = SelectionConstraints
         { computeMinimumAdaQuantity = noMinCoin
         , computeMinimumCost = mkCostFor NoCost
-        , assessTokenBundleSize = view #assessTokenBundleSize
-            $ mkBundleSizeAssessor
-            $ boundaryTestBundleSizeAssessor params
+        , assessTokenBundleSize = unMockAssessTokenBundleSize $
+            boundaryTestBundleSizeAssessor params
         }
 
 encodeBoundaryTestCriteria :: BoundaryTestCriteria -> SelectionParams
@@ -1613,7 +1610,7 @@ boundaryTest_largeTokenQuantities_1 = BoundaryTestData
     }
   where
     (q1, q2) = (TokenQuantity 1, TokenQuantity.pred txOutMaxTokenQuantity)
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1642,7 +1639,7 @@ boundaryTest_largeTokenQuantities_2 = BoundaryTestData
     }
   where
     q1 :| [q2] = TokenQuantity.equipartition txOutMaxTokenQuantity (() :| [()])
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1672,7 +1669,7 @@ boundaryTest_largeTokenQuantities_3 = BoundaryTestData
   where
     q1 :| [q2] = TokenQuantity.equipartition
         (TokenQuantity.succ txOutMaxTokenQuantity) (() :| [()])
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1702,7 +1699,7 @@ boundaryTest_largeTokenQuantities_4 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_500_000, []) ]
     boundaryTestUTxO =
@@ -1730,7 +1727,7 @@ boundaryTest_largeTokenQuantities_5 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 2_000_000, []) ]
     boundaryTestUTxO =
@@ -1768,7 +1765,7 @@ boundaryTest_largeTokenQuantities_6 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = NoBundleSizeLimit
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUnlimited
     boundaryTestOutputs =
       [ (Coin 1_000_000, [])
       , (Coin 1_000_000, [])
@@ -1818,7 +1815,7 @@ boundaryTest_largeAssetCounts_1 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 4
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 4
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -1849,7 +1846,7 @@ boundaryTest_largeAssetCounts_2 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 3
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 3
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -1875,7 +1872,7 @@ boundaryTest_largeAssetCounts_3 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 2
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 2
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -1901,7 +1898,7 @@ boundaryTest_largeAssetCounts_4 = BoundaryTestData
     , boundaryTestExpectedResult = BoundaryTestResult {..}
     }
   where
-    boundaryTestBundleSizeAssessor = BundleAssetCountUpperLimit 1
+    boundaryTestBundleSizeAssessor = MockAssessTokenBundleSizeUpperLimit 1
     boundaryTestOutputs =
       [ (Coin 1_000_000, []) ]
     boundaryTestUTxO =
@@ -1980,20 +1977,20 @@ linearCost s
 -- Assessing token bundle sizes
 --------------------------------------------------------------------------------
 
-data MockTokenBundleSizeAssessor
-    = NoBundleSizeLimit
+data MockAssessTokenBundleSize
+    = MockAssessTokenBundleSizeUnlimited
       -- ^ Indicates that there is no limit on a token bundle's size.
-    | BundleAssetCountUpperLimit Int
+    | MockAssessTokenBundleSizeUpperLimit Int
       -- ^ Indicates an inclusive upper bound on the number of assets in a
       -- token bundle.
     deriving (Eq, Show)
 
-mkBundleSizeAssessor
-    :: MockTokenBundleSizeAssessor -> TokenBundleSizeAssessor
-mkBundleSizeAssessor m = TokenBundleSizeAssessor $ case m of
-    NoBundleSizeLimit ->
+unMockAssessTokenBundleSize
+    :: MockAssessTokenBundleSize -> (TokenBundle -> TokenBundleSizeAssessment)
+unMockAssessTokenBundleSize = \case
+    MockAssessTokenBundleSizeUnlimited ->
         const TokenBundleSizeWithinLimit
-    BundleAssetCountUpperLimit upperLimit ->
+    MockAssessTokenBundleSizeUpperLimit upperLimit ->
         \bundle ->
             let assetCount = Set.size $ TokenBundle.getAssets bundle in
             case assetCount `compare` upperLimit of
@@ -2001,12 +1998,17 @@ mkBundleSizeAssessor m = TokenBundleSizeAssessor $ case m of
                 EQ -> TokenBundleSizeWithinLimit
                 GT -> OutputTokenBundleSizeExceedsLimit
 
+mkTokenBundleSizeAssessor
+    :: MockAssessTokenBundleSize -> TokenBundleSizeAssessor
+mkTokenBundleSizeAssessor =
+    TokenBundleSizeAssessor . unMockAssessTokenBundleSize
+
 --------------------------------------------------------------------------------
 -- Making change
 --------------------------------------------------------------------------------
 
 type MakeChangeData =
-    MakeChangeCriteria MinCoinValueFor MockTokenBundleSizeAssessor
+    MakeChangeCriteria MinCoinValueFor MockAssessTokenBundleSize
 
 isValidMakeChangeData :: MakeChangeData -> Bool
 isValidMakeChangeData p = (&&)
@@ -2029,7 +2031,7 @@ genMakeChangeData = flip suchThat isValidMakeChangeData $ do
     let inputBundleCount = outputBundleCount * 4
     MakeChangeCriteria
         <$> arbitrary
-        <*> pure NoBundleSizeLimit
+        <*> pure MockAssessTokenBundleSizeUnlimited
         <*> genRequiredCost
         <*> genExtraCoinSource
         <*> genExtraCoinSink
@@ -2063,7 +2065,7 @@ makeChangeWith
     -> Either UnableToConstructChangeError [TokenBundle]
 makeChangeWith p = makeChange p
     { minCoinFor = mkMinCoinValueFor $ minCoinFor p
-    , bundleSizeAssessor = mkBundleSizeAssessor $ bundleSizeAssessor p
+    , bundleSizeAssessor = mkTokenBundleSizeAssessor $ bundleSizeAssessor p
     }
 
 prop_makeChange_identity
@@ -2077,7 +2079,8 @@ prop_makeChange_identity bundles = (===)
         , requiredCost = Coin 0
         , extraCoinSource = Coin 0
         , extraCoinSink = Coin 0
-        , bundleSizeAssessor = mkBundleSizeAssessor NoBundleSizeLimit
+        , bundleSizeAssessor =
+            mkTokenBundleSizeAssessor MockAssessTokenBundleSizeUnlimited
         , inputBundles = bundles
         , outputBundles = bundles
         , assetsToMint = TokenMap.empty
@@ -2135,11 +2138,13 @@ prop_makeChange_length p =
 
     mChangeUnsplit =
         makeChange zeroCostMakeChangeScenario
-            { bundleSizeAssessor = mkBundleSizeAssessor NoBundleSizeLimit }
+            { bundleSizeAssessor =
+                mkTokenBundleSizeAssessor MockAssessTokenBundleSizeUnlimited
+            }
     mChangeSplit = mChangeUnsplit >>= \changeUnsplit ->
         makeChange zeroCostMakeChangeScenario
-            { bundleSizeAssessor = mkBundleSizeAssessor
-                $ BundleAssetCountUpperLimit
+            { bundleSizeAssessor = mkTokenBundleSizeAssessor
+                $ MockAssessTokenBundleSizeUpperLimit
                 $ max 1
                 $ (`div` 2)
                 $ getLargestAssetSetSize changeUnsplit
@@ -2434,7 +2439,8 @@ unit_makeChange =
               }
     ]
   where
-    bundleSizeAssessor = mkBundleSizeAssessor NoBundleSizeLimit
+    bundleSizeAssessor =
+        mkTokenBundleSizeAssessor MockAssessTokenBundleSizeUnlimited
     matrix =
         -- Simple, only ada, should construct a single change output with 1 ada.
         [ ( noMinCoin, noCost

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -189,6 +189,7 @@ import Test.QuickCheck
     , oneof
     , property
     , shrinkList
+    , sized
     , suchThat
     , tabulate
     , withMaxSuccess
@@ -1984,6 +1985,20 @@ data MockAssessTokenBundleSize
       -- ^ Indicates an inclusive upper bound on the number of assets in a
       -- token bundle.
     deriving (Eq, Show)
+
+genMockAssessTokenBundleSize :: Gen MockAssessTokenBundleSize
+genMockAssessTokenBundleSize = oneof
+    [ pure MockAssessTokenBundleSizeUnlimited
+    , MockAssessTokenBundleSizeUpperLimit <$> sized (\n -> choose (1, max 1 n))
+    ]
+
+shrinkMockAssessTokenBundleSize
+    :: MockAssessTokenBundleSize -> [MockAssessTokenBundleSize]
+shrinkMockAssessTokenBundleSize = \case
+    MockAssessTokenBundleSizeUnlimited ->
+        []
+    MockAssessTokenBundleSizeUpperLimit n ->
+        MockAssessTokenBundleSizeUpperLimit <$> filter (> 0) (shrink n)
 
 unMockAssessTokenBundleSize
     :: MockAssessTokenBundleSize -> (TokenBundle -> TokenBundleSizeAssessment)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -907,6 +907,12 @@ prop_performSelection mockConstraints (Blind params) coverage =
             "outputsCovered == NE.toList outputsToCover"
             (outputsCovered == NE.toList outputsToCover)
         assertOnSuccess
+            "view #assetsToMint result == view #assetsToMint params"
+            (view #assetsToMint result == view #assetsToMint params)
+        assertOnSuccess
+            "view #assetsToBurn result == view #assetsToBurn params"
+            (view #assetsToBurn result == view #assetsToBurn params)
+        assertOnSuccess
             "view #extraCoinSource result == view #extraCoinSource params"
             (view #extraCoinSource result == view #extraCoinSource params)
         assertOnSuccess

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -190,6 +190,7 @@ import Test.QuickCheck
     , property
     , shrinkList
     , shrinkMapBy
+    , sized
     , suchThat
     , tabulate
     , withMaxSuccess
@@ -2035,6 +2036,37 @@ computeMinimumCostLinear s
     $ skeletonInputCount s
     + F.length (skeletonOutputs s)
     + F.length (skeletonChange s)
+
+--------------------------------------------------------------------------------
+-- Computing selection limits
+--------------------------------------------------------------------------------
+
+data MockComputeSelectionLimit
+    = MockComputeSelectionLimitNone
+    | MockComputeSelectionLimit Int
+    deriving (Eq, Show)
+
+genMockComputeSelectionLimit :: Gen MockComputeSelectionLimit
+genMockComputeSelectionLimit = oneof
+    [ pure MockComputeSelectionLimitNone
+    , MockComputeSelectionLimit <$> sized (\n -> choose (1, max 1 n))
+    ]
+
+shrinkMockComputeSelectionLimit
+    :: MockComputeSelectionLimit -> [MockComputeSelectionLimit]
+shrinkMockComputeSelectionLimit = \case
+    MockComputeSelectionLimitNone ->
+        []
+    MockComputeSelectionLimit n ->
+        MockComputeSelectionLimit <$> filter (> 0) (shrink n)
+
+unMockComputeSelectionLimit
+    :: MockComputeSelectionLimit -> ([TxOut] -> SelectionLimit)
+unMockComputeSelectionLimit = \case
+    MockComputeSelectionLimitNone ->
+        const NoLimit
+    MockComputeSelectionLimit n ->
+        const $ MaximumInputLimit n
 
 --------------------------------------------------------------------------------
 -- Assessing token bundle sizes

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1920,7 +1920,7 @@ boundaryTest_largeAssetCounts_4 = BoundaryTestData
       ]
 
 --------------------------------------------------------------------------------
--- Making change
+-- Computing minimum ada quantities
 --------------------------------------------------------------------------------
 
 data MinCoinValueFor
@@ -1949,6 +1949,10 @@ linearMinCoin m =
 noMinCoin :: TokenMap -> Coin
 noMinCoin = const (Coin 0)
 
+--------------------------------------------------------------------------------
+-- Computing minimum costs
+--------------------------------------------------------------------------------
+
 data CostFor
     = NoCost
     | LinearCost
@@ -1972,8 +1976,9 @@ linearCost s
     + F.length (skeletonOutputs s)
     + F.length (skeletonChange s)
 
-type MakeChangeData =
-    MakeChangeCriteria MinCoinValueFor MockTokenBundleSizeAssessor
+--------------------------------------------------------------------------------
+-- Assessing token bundle sizes
+--------------------------------------------------------------------------------
 
 data MockTokenBundleSizeAssessor
     = NoBundleSizeLimit
@@ -1995,6 +2000,13 @@ mkBundleSizeAssessor m = TokenBundleSizeAssessor $ case m of
                 LT -> TokenBundleSizeWithinLimit
                 EQ -> TokenBundleSizeWithinLimit
                 GT -> OutputTokenBundleSizeExceedsLimit
+
+--------------------------------------------------------------------------------
+-- Making change
+--------------------------------------------------------------------------------
+
+type MakeChangeData =
+    MakeChangeCriteria MinCoinValueFor MockTokenBundleSizeAssessor
 
 isValidMakeChangeData :: MakeChangeData -> Bool
 isValidMakeChangeData p = (&&)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -2013,7 +2013,7 @@ computeMinimumAdaQuantityZero = const (Coin 0)
 --
 computeMinimumAdaQuantityLinear :: TokenMap -> Coin
 computeMinimumAdaQuantityLinear m =
-    Coin (1 + fromIntegral (Set.size (TokenMap.getAssets m)))
+    Coin (1 + fromIntegral (TokenMap.size m))
 
 --------------------------------------------------------------------------------
 -- Computing minimum costs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -110,7 +110,6 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Set as Set
 import qualified Data.Text.Encoding as T
 
 spec :: Spec
@@ -855,7 +854,7 @@ unMockTxOutputMinimumAdaQuantity
     :: MockTxOutputMinimumAdaQuantity
     -> (TokenMap -> Coin)
 unMockTxOutputMinimumAdaQuantity mock m =
-    let assetCount = Set.size $ TokenMap.getAssets m in
+    let assetCount = TokenMap.size m in
     perOutput mock
         <> mtimesDefault assetCount (perOutputAsset mock)
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Migration/SelectionSpec.hs
@@ -66,8 +66,6 @@ import Data.Generics.Labels
     ()
 import Data.List.NonEmpty
     ( NonEmpty (..) )
-import Data.Maybe
-    ( fromMaybe )
 import Data.Semigroup
     ( mtimesDefault, stimes )
 import Data.Word
@@ -558,7 +556,7 @@ prop_minimizeFeeStep_inner mockConstraints feeExcessBefore outputBefore =
     costOfEliminatingFeeExcess = Coin.distance
         (txOutputCoinCost constraints outputCoinAfter)
         (txOutputCoinCost constraints (outputCoinAfter <> feeExcessAfter))
-    gainOfEliminatingFeeExcess = fromMaybe (Coin 0) $ Coin.subtractCoin
+    gainOfEliminatingFeeExcess = Coin.difference
         feeExcessAfter
         costOfEliminatingFeeExcess
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/CoinSpec.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
 module Cardano.Wallet.Primitive.Types.CoinSpec
     ( spec
     ) where
@@ -13,16 +15,44 @@ import Test.Hspec
 import Test.Hspec.Extra
     ( parallel )
 import Test.QuickCheck
-    ( Property, conjoin, forAll, property )
+    ( Arbitrary (..)
+    , Property
+    , Testable
+    , checkCoverage
+    , conjoin
+    , cover
+    , forAll
+    , property
+    , (===)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 
 spec :: Spec
-spec = do
+spec = describe "Cardano.Wallet.Primitive.Types.CoinSpec" $ do
+
+    parallel $ describe "Arithmetic operations" $ do
+
+        it "prop_add_toNatural" $ do
+            property prop_add_toNatural
+        it "prop_add_subtract" $ do
+            property prop_add_subtract
+        it "prop_difference_distance" $ do
+            property prop_difference_distance
+        it "prop_difference_subtract" $ do
+            property prop_difference_subtract
+        it "prop_distance_commutative" $ do
+            property prop_distance_commutative
+        it "prop_subtract_toNatural" $ do
+            property prop_subtract_toNatural
 
     parallel $ describe "Generators and shrinkers" $ do
 
         describe "Coins that can be zero" $ do
             it "genCoin" $
                 property prop_genCoin
+            it "genCoin_coverage" $
+                property prop_genCoin_coverage
             it "shrinkCoin" $
                 property prop_shrinkCoin
 
@@ -33,11 +63,77 @@ spec = do
                 property prop_shrinkCoinPositive
 
 --------------------------------------------------------------------------------
+-- Arithmetic operations
+--------------------------------------------------------------------------------
+
+prop_add_subtract :: Coin -> Coin -> Property
+prop_add_subtract a b =
+    checkCoverageCoin a b $
+    conjoin
+    [ (a `Coin.addCoin` b) `Coin.subtractCoin` b === Just a
+    , (b `Coin.addCoin` a) `Coin.subtractCoin` a === Just b
+    ]
+
+prop_add_toNatural :: Coin -> Coin -> Property
+prop_add_toNatural a b =
+    checkCoverageCoin a b $
+    (===)
+        (Coin.coinToNatural (a `Coin.addCoin` b))
+        (Coin.coinToNatural a + Coin.coinToNatural b)
+
+prop_difference_distance :: Coin -> Coin -> Property
+prop_difference_distance a b =
+    checkCoverageCoin a b $
+    if (a >= b)
+    then a `Coin.distance` b == a `Coin.difference` b
+    else a `Coin.distance` b == b `Coin.difference` a
+
+prop_difference_subtract :: Coin -> Coin -> Property
+prop_difference_subtract a b =
+    checkCoverageCoin a b $
+    if (a >= b)
+    then a `Coin.subtractCoin` b === Just (a `Coin.difference` b)
+    else a `Coin.subtractCoin` b === Nothing
+
+prop_distance_commutative :: Coin -> Coin -> Property
+prop_distance_commutative a b =
+    checkCoverageCoin a b $
+    a `Coin.distance` b === b `Coin.distance` a
+
+prop_subtract_toNatural :: Coin -> Coin -> Property
+prop_subtract_toNatural a b =
+    checkCoverageCoin a b $
+    if (a >= b)
+    then
+        (Coin.coinToNatural <$> (a `Coin.subtractCoin` b))
+        ===
+        (Just (Coin.coinToNatural a - Coin.coinToNatural b))
+    else
+        (Coin.coinToNatural <$> (b `Coin.subtractCoin` a))
+        ===
+        (Just (Coin.coinToNatural b - Coin.coinToNatural a))
+
+--------------------------------------------------------------------------------
 -- Coins that can be zero
 --------------------------------------------------------------------------------
 
 prop_genCoin :: Property
 prop_genCoin = forAll genCoin isValidCoin
+
+prop_genCoin_coverage :: Coin -> Coin -> Property
+prop_genCoin_coverage a b =
+    checkCoverageCoin a b True
+
+checkCoverageCoin :: Testable prop => Coin -> Coin -> (prop -> Property)
+checkCoverageCoin a b
+    = checkCoverage
+    . cover  1 (a == Coin 0 && b == Coin 0) "a == 0 && b == 0"
+    . cover  2 (a == Coin 0 && b /= Coin 0) "a == 0 && b /= 0"
+    . cover  2 (a /= Coin 0 && b == Coin 0) "a /= 0 && b == 0"
+    . cover 10 (a /= Coin 0 && b /= Coin 0) "a /= 0 && b /= 0"
+    . cover 10 (a <  b) "a < b"
+    . cover  2 (a == b) "a = b"
+    . cover 10 (a >  b) "a > b"
 
 prop_shrinkCoin :: Property
 prop_shrinkCoin = forAll genCoin $ \c ->
@@ -64,3 +160,11 @@ prop_shrinkCoinPositive = forAll genCoinPositive $ \c ->
 
 isValidCoinPositive :: Coin -> Bool
 isValidCoinPositive c = c > Coin 0 && c <= maxBound
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary Coin where
+    arbitrary = genCoin
+    shrink = shrinkCoin

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -681,7 +681,7 @@ prop_equipartitionAssets_coverage m = checkCoverage $
         "32 <= asset count <= 63"
     True
   where
-    assetCount = Set.size $ TokenMap.getAssets $ getLarge $ getBlind m
+    assetCount = TokenMap.size $ getLarge $ getBlind m
 
 prop_equipartitionAssets_length
     :: Blind (Large TokenMap) -> NonEmpty () -> Property
@@ -694,7 +694,7 @@ prop_equipartitionAssets_sizes (Blind (Large m)) count = (.||.)
     (assetCountDifference == 0)
     (assetCountDifference == 1)
   where
-    assetCounts = Set.size . TokenMap.getAssets <$> results
+    assetCounts = TokenMap.size <$> results
     assetCountMin = F.minimum assetCounts
     assetCountMax = F.maximum assetCounts
     assetCountDifference = assetCountMax - assetCountMin

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/TokenMapSpec.hs
@@ -87,6 +87,7 @@ import Test.QuickCheck
     , Blind (..)
     , Fun
     , Property
+    , Testable
     , applyFun
     , checkCoverage
     , choose
@@ -238,6 +239,13 @@ spec =
             property prop_adjustQuantity_hasQuantity
         it "prop_maximumQuantity_all" $
             property prop_maximumQuantity_all
+
+    parallel $ describe "Queries" $ do
+
+        it "prop_size_isEmpty" $ do
+            property prop_size_isEmpty
+        it "prop_size_toFlatList" $ do
+            property prop_size_toFlatList
 
     parallel $ describe "Partitioning assets" $ do
 
@@ -663,6 +671,30 @@ prop_maximumQuantity_all b =
     property $ all (<= maxQ) (snd <$> TokenMap.toFlatList b)
   where
     maxQ = TokenMap.maximumQuantity b
+
+--------------------------------------------------------------------------------
+-- Queries
+--------------------------------------------------------------------------------
+
+prop_size_isEmpty :: TokenMap -> Property
+prop_size_isEmpty m =
+    checkCoverage_size m $
+    if TokenMap.isEmpty m
+    then TokenMap.size m == 0
+    else TokenMap.size m > 0
+
+prop_size_toFlatList :: TokenMap -> Property
+prop_size_toFlatList m =
+    checkCoverage_size m $
+    TokenMap.size m === length (TokenMap.toFlatList m)
+
+checkCoverage_size :: Testable prop => TokenMap -> (prop -> Property)
+checkCoverage_size m
+    = checkCoverage
+    . cover 2 (TokenMap.size m == 0) "size == 0"
+    . cover 2 (TokenMap.size m == 1) "size == 1"
+    . cover 2 (TokenMap.size m == 2) "size == 2"
+    . cover 2 (TokenMap.size m >= 3) "size >= 3"
 
 --------------------------------------------------------------------------------
 -- Partitioning assets

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -224,7 +224,6 @@ import qualified Cardano.Api as Cardano
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
-import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -839,7 +838,6 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
             , extraCoinSink = Coin 0
             , outputsCovered = outs
             , changeGenerated = chgs
-            , utxoRemaining = UTxOIndex.empty
             , assetsToMint = mempty
             , assetsToBurn = mempty
             }
@@ -921,7 +919,6 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
         , extraCoinSink = Coin 0
         , outputsCovered = []
         , changeGenerated = outs
-        , utxoRemaining = UTxOIndex.empty
         -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
@@ -958,7 +955,6 @@ makeByronTx era testCase = Cardano.makeSignedTransaction byronWits unsigned
         , extraCoinSink = Coin 0
         , outputsCovered = []
         , changeGenerated = outs
-        , utxoRemaining = UTxOIndex.empty
         -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -17,6 +17,7 @@ module Test.QuickCheck.Extra
 
       -- * Shrinking
     , liftShrink3
+    , liftShrink4
     , liftShrink7
     , shrinkInterleaved
     , shrinkMapWith
@@ -133,6 +134,23 @@ liftShrink3 s1 s2 s3 (a1, a2, a3) =
     [ [ (a1', a2 , a3 ) | a1' <- s1 a1 ]
     , [ (a1 , a2', a3 ) | a2' <- s2 a2 ]
     , [ (a1 , a2 , a3') | a3' <- s3 a3 ]
+    ]
+
+-- | Similar to 'liftShrink2', but applicable to 4-tuples.
+--
+liftShrink4
+    :: (a1 -> [a1])
+    -> (a2 -> [a2])
+    -> (a3 -> [a3])
+    -> (a4 -> [a4])
+    -> (a1, a2, a3, a4)
+    -> [(a1, a2, a3, a4)]
+liftShrink4 s1 s2 s3 s4 (a1, a2, a3, a4) =
+    interleaveRoundRobin
+    [ [ (a1', a2 , a3 , a4 ) | a1' <- s1 a1 ]
+    , [ (a1 , a2', a3 , a4 ) | a2' <- s2 a2 ]
+    , [ (a1 , a2 , a3', a4 ) | a3' <- s3 a3 ]
+    , [ (a1 , a2 , a3 , a4') | a4' <- s4 a4 ]
     ]
 
 -- | Similar to 'liftShrink2', but applicable to 7-tuples.


### PR DESCRIPTION
## Issue Number

ADP-1118
ADP-1136

## Summary

This PR:
- [x] Introduces the `MockSelectionConstraints` type with an associated generator and shrinker.
    The goal of this type is to:
    - generate arbitrary selection constraints to test `performSelection`;
    - provide good shrinking of these constraints.
- [x] Uses the `MockSelectionConstraints` type to simplify the `prop_performSelection` family of properties.
- [x] Moves `computeSelectionLimit` out of the `SelectionParams` record and into the `SelectionConstraints` record.
    This location is more appropriate, since:
    - `SelectionConstraints` is designed to collect constraints that are _common to all selections in the current era_, whereas `SelectionParams` is designed to collect parameters _specific to a given selection_.
    - `SelectionConstraints` is now a subset of `SelectionConstraints` in the parent module.

Additional work (to be used by a future PR):
- [x] Adds the `Coin.difference` function with property tests.
- [x] Adds the `TokenMap.size` function with property tests.
