### PR TITLE
Support coin selection with no outputs.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1421,7 +1421,7 @@ selectAssetsNoOutputs ctx wid wal tx transform = do
     deposit <- calcMinimumDeposit @_ @s @k ctx wid
     let dummyAddress = Address ""
     let dummyOutput  = TxOut dummyAddress (TokenBundle.fromCoin deposit)
-    let outs = dummyOutput :| []
+    let outs = [dummyOutput]
     selectAssets @ctx @s @k ctx wal tx outs $ \s sel -> transform s $ sel
         { outputsCovered = mempty
         , changeGenerated =
@@ -1515,7 +1515,7 @@ selectAssets
     => ctx
     -> (UTxOIndex, Wallet s, Set Tx)
     -> TransactionCtx
-    -> NonEmpty TxOut
+    -> [TxOut]
     -> (s -> SelectionResult TokenBundle -> result)
     -> ExceptT ErrSelectAssets IO result
 selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
@@ -2822,7 +2822,7 @@ data WalletFollowLog
 
 -- | Log messages from API server actions running in a wallet worker context.
 data WalletLog
-    = MsgSelectionStart UTxOIndex (NonEmpty TxOut)
+    = MsgSelectionStart UTxOIndex [TxOut]
     | MsgSelectionError SelectionError
     | MsgSelectionReportSummarized SelectionReportSummarized
     | MsgSelectionReportDetailed SelectionReportDetailed
@@ -2868,7 +2868,7 @@ instance ToText WalletLog where
         MsgSelectionStart utxo recipients ->
             "Starting coin selection " <>
             "|utxo| = "+|UTxOIndex.size utxo|+" " <>
-            "#recipients = "+|NE.length recipients|+""
+            "#recipients = "+|length recipients|+""
         MsgSelectionError e ->
             "Failed to select assets:\n"+|| e ||+""
         MsgSelectionReportSummarized s ->

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -304,7 +304,8 @@ import Cardano.Wallet.Primitive.CoinSelection
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionReportDetailed
     , SelectionReportSummarized
-    , SelectionResult (..)
+    , SelectionResult
+    , SelectionResultOf (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , makeSelectionReportDetailed

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -360,7 +360,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , SelectionError (..)
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult (..)
+    ( SelectionResultOf (..)
     , UnableToConstructChangeError (..)
     , balanceMissing
     , selectionDelta

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -61,8 +61,6 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
 import Data.Maybe
     ( fromMaybe )
 import Data.Word
@@ -76,7 +74,6 @@ import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
-import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
 
 -- | Performs a coin selection.
@@ -102,7 +99,7 @@ performSelection selectionConstraints selectionParams =
     -- https://input-output.atlassian.net/browse/ADP-1070
     -- Adjust coin selection and fee estimation to handle pre-existing inputs
     --
-    case prepareOutputs selectionConstraints (NE.toList outputsToCover) of
+    case prepareOutputs selectionConstraints outputsToCover of
         Left e ->
             pure $ Left $ SelectionOutputsError e
         Right preparedOutputsToCover ->
@@ -183,7 +180,7 @@ data SelectionParams = SelectionParams
         :: !TokenMap
         -- ^ Specifies a set of assets to mint.
     , outputsToCover
-        :: !(NonEmpty TxOut)
+        :: ![TxOut]
         -- ^ Specifies a set of outputs that must be paid for.
     , rewardWithdrawal
         :: !(Maybe Coin)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -76,6 +76,7 @@ import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as Set
 
 -- | Performs a coin selection.
@@ -120,7 +121,7 @@ performSelection selectionConstraints selectionParams =
                       -- TODO: Use this for stake key deposits and anything else
                       -- that consumes ada:
                     , extraCoinSink = Coin 0
-                    , outputsToCover = preparedOutputsToCover
+                    , outputsToCover = NE.toList preparedOutputsToCover
                     , utxoAvailable
                     }
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -102,7 +102,7 @@ performSelection selectionConstraints selectionParams =
     -- https://input-output.atlassian.net/browse/ADP-1070
     -- Adjust coin selection and fee estimation to handle pre-existing inputs
     --
-    case prepareOutputs selectionConstraints outputsToCover of
+    case prepareOutputs selectionConstraints (NE.toList outputsToCover) of
         Left e ->
             pure $ Left $ SelectionOutputsError e
         Right preparedOutputsToCover ->
@@ -121,7 +121,7 @@ performSelection selectionConstraints selectionParams =
                       -- TODO: Use this for stake key deposits and anything else
                       -- that consumes ada:
                     , extraCoinSink = Coin 0
-                    , outputsToCover = NE.toList preparedOutputsToCover
+                    , outputsToCover = preparedOutputsToCover
                     , utxoAvailable
                     }
   where
@@ -207,8 +207,8 @@ data SelectionError
 --
 prepareOutputs
     :: SelectionConstraints
-    -> NonEmpty TxOut
-    -> Either ErrPrepareOutputs (NonEmpty TxOut)
+    -> [TxOut]
+    -> Either ErrPrepareOutputs [TxOut]
 prepareOutputs constraints outputsUnprepared
     | (address, assetCount) : _ <- excessivelyLargeBundles =
         Left $

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -32,7 +32,8 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , prepareOutputsWith
     , emptySkeleton
     , SelectionConstraints (..)
-    , SelectionParams (..)
+    , SelectionParams
+    , SelectionParamsOf (..)
     , SelectionLimit
     , SelectionLimitOf (..)
     , SelectionSkeleton (..)
@@ -218,11 +219,13 @@ data SelectionConstraints = SelectionConstraints
     }
     deriving Generic
 
+type SelectionParams = SelectionParamsOf (NonEmpty TxOut)
+
 -- | Specifies all parameters that are specific to a given selection.
 --
-data SelectionParams = SelectionParams
+data SelectionParamsOf outputs = SelectionParams
     { outputsToCover
-        :: !(NonEmpty TxOut)
+        :: !outputs
         -- ^ The complete set of outputs to be covered.
     , utxoAvailable
         :: !UTxOIndex

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -28,7 +28,9 @@
 module Cardano.Wallet.Primitive.CoinSelection.Balance
     (
     -- * Performing a selection
-      performSelection
+      PerformSelection
+    , performSelection
+    , performSelectionEmpty
     , prepareOutputsWith
     , emptySkeleton
     , SelectionConstraints (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -224,7 +224,7 @@ data SelectionConstraints = SelectionConstraints
     }
     deriving Generic
 
-type SelectionParams = SelectionParamsOf (NonEmpty TxOut)
+type SelectionParams = SelectionParamsOf [TxOut]
 
 -- | Specifies all parameters that are specific to a given selection.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -29,7 +29,6 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     (
     -- * Performing a selection
       performSelection
-    , performSelectionNonEmpty
     , prepareOutputsWith
     , emptySkeleton
     , SelectionConstraints (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -37,7 +37,8 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionLimit
     , SelectionLimitOf (..)
     , SelectionSkeleton (..)
-    , SelectionResult (..)
+    , SelectionResult
+    , SelectionResultOf (..)
     , SelectionError (..)
     , BalanceInsufficientError (..)
     , SelectionInsufficientError (..)
@@ -394,9 +395,11 @@ instance Ord a => Ord (SelectionLimitOf a) where
         (NoLimit            , MaximumInputLimit _) -> GT
         (MaximumInputLimit x, MaximumInputLimit y) -> compare x y
 
+type SelectionResult change = SelectionResultOf [TxOut] change
+
 -- | The result of performing a successful selection.
 --
-data SelectionResult change = SelectionResult
+data SelectionResultOf outputs change = SelectionResult
     { inputsSelected
         :: !(NonEmpty (TxIn, TxOut))
         -- ^ A (non-empty) list of inputs selected from 'utxoAvailable'.
@@ -407,16 +410,8 @@ data SelectionResult change = SelectionResult
         :: !Coin
         -- ^ An extra sink for ada.
     , outputsCovered
-        :: ![TxOut]
+        :: !outputs
         -- ^ A list of outputs covered.
-        -- FIXME: Left as a list to allow to work-around the limitation of
-        -- 'performSelection' which cannot run for no output targets (e.g. in
-        -- the context of a delegation transaction). This allows callers to
-        -- specify a dummy 'TxOut' as argument, and remove it later in the
-        -- result; Ideally, we want to handle this in a better way by allowing
-        -- 'performSelection' to work with empty output targets. At the moment
-        -- of writing these lines, I've already been yak-shaving for a while and
-        -- this is the last remaining obstacle, not worth the effort _yet_.
     , changeGenerated
         :: ![change]
         -- ^ A list of generated change outputs.

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -283,12 +283,17 @@ data UTxOBalanceSufficiencyInfo = UTxOBalanceSufficiencyInfo
 
 -- | Computes the balance of UTxO entries available for selection.
 --
-computeUTxOBalanceAvailable :: SelectionParams -> TokenBundle
+computeUTxOBalanceAvailable
+    :: SelectionParamsOf (f TxOut)
+    -> TokenBundle
 computeUTxOBalanceAvailable = UTxOIndex.balance . view #utxoAvailable
 
 -- | Computes the balance of UTxO entries required to be selected.
 --
-computeUTxOBalanceRequired :: SelectionParams -> TokenBundle
+computeUTxOBalanceRequired
+    :: Foldable f
+    => SelectionParamsOf (f TxOut)
+    -> TokenBundle
 computeUTxOBalanceRequired params =
     balanceOut `TokenBundle.difference` balanceIn
   where
@@ -307,7 +312,10 @@ computeUTxOBalanceRequired params =
 --
 -- See 'UTxOBalanceSufficiency'.
 --
-computeUTxOBalanceSufficiency :: SelectionParams -> UTxOBalanceSufficiency
+computeUTxOBalanceSufficiency
+    :: Foldable f
+    => SelectionParamsOf (f TxOut)
+    -> UTxOBalanceSufficiency
 computeUTxOBalanceSufficiency = sufficiency . computeUTxOBalanceSufficiencyInfo
 
 -- | Computes information about the UTxO balance sufficiency.
@@ -315,7 +323,8 @@ computeUTxOBalanceSufficiency = sufficiency . computeUTxOBalanceSufficiencyInfo
 -- See 'UTxOBalanceSufficiencyInfo'.
 --
 computeUTxOBalanceSufficiencyInfo
-    :: SelectionParams
+    :: Foldable f
+    => SelectionParamsOf (f TxOut)
     -> UTxOBalanceSufficiencyInfo
 computeUTxOBalanceSufficiencyInfo params =
     UTxOBalanceSufficiencyInfo {available, required, difference, sufficiency}
@@ -336,7 +345,10 @@ computeUTxOBalanceSufficiencyInfo params =
 -- The balance of available UTxO entries is sufficient if (and only if) it
 -- is greater than or equal to the required balance.
 --
-isUTxOBalanceSufficient :: SelectionParams -> Bool
+isUTxOBalanceSufficient
+    :: Foldable f
+    => SelectionParamsOf (f TxOut)
+    -> Bool
 isUTxOBalanceSufficient params =
     case computeUTxOBalanceSufficiency params of
         UTxOBalanceSufficient   -> True

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -691,8 +691,8 @@ data UnableToConstructChangeError = UnableToConstructChangeError
 --
 prepareOutputsWith
     :: (TokenMap -> Coin)
-    -> NonEmpty TxOut
-    -> NonEmpty TxOut
+    -> [TxOut]
+    -> [TxOut]
 prepareOutputsWith minCoinValueFor = fmap $ \out ->
     out { Tx.tokens = augmentBundle (Tx.tokens out) }
   where

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -469,7 +469,8 @@ instance Buildable a => Buildable (SelectionDelta a) where
 -- See 'SelectionDelta'.
 --
 selectionDeltaAllAssets
-    :: SelectionResult TokenBundle
+    :: Foldable f
+    => SelectionResultOf (f TxOut) TokenBundle
     -> SelectionDelta TokenBundle
 selectionDeltaAllAssets result
     | balanceOut `leq` balanceIn =
@@ -506,13 +507,17 @@ selectionDeltaAllAssets result
 -- See 'SelectionDelta'.
 --
 selectionDeltaCoin
-    :: SelectionResult TokenBundle
+    :: Foldable f
+    => SelectionResultOf (f TxOut) TokenBundle
     -> SelectionDelta Coin
 selectionDeltaCoin = fmap TokenBundle.getCoin . selectionDeltaAllAssets
 
 -- | Indicates whether or not a selection result has a valid surplus.
 --
-selectionHasValidSurplus :: SelectionResult TokenBundle -> Bool
+selectionHasValidSurplus
+    :: Foldable f
+    => SelectionResultOf (f TxOut) TokenBundle
+    -> Bool
 selectionHasValidSurplus result =
     case selectionDeltaAllAssets result of
         SelectionSurplus surplus ->
@@ -530,7 +535,8 @@ selectionHasValidSurplus result =
 -- a deficit.
 --
 selectionSurplusCoin
-    :: SelectionResult TokenBundle
+    :: Foldable f
+    => SelectionResultOf (f TxOut) TokenBundle
     -> Coin
 selectionSurplusCoin result =
     case selectionDeltaCoin result of

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -71,6 +71,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , runSelectionStep
     , selectionDeltaAllAssets
     , selectionHasValidSurplus
+    , selectionMinimumCost
     , splitBundleIfAssetCountExcessive
     , splitBundlesWithExcessiveAssetCounts
     , splitBundlesWithExcessiveTokenQuantities
@@ -955,7 +956,7 @@ prop_performSelection mockConstraints (Blind params) coverage =
             SelectionDeficit d -> error $ unwords
                 ["Unexpected deficit:", show d]
         minExpectedCoinSurplus :: Coin
-        minExpectedCoinSurplus = view #computeMinimumCost constraints skeleton
+        minExpectedCoinSurplus = selectionMinimumCost constraints result
         maxExpectedCoinSurplus :: Coin
         maxExpectedCoinSurplus = minExpectedCoinSurplus `addCoin` toAdd
           where
@@ -968,18 +969,6 @@ prop_performSelection mockConstraints (Blind params) coverage =
             , changeGenerated
             , outputsCovered
             } = result
-        skeleton = SelectionSkeleton
-            { skeletonInputCount =
-                length inputsSelected
-            , skeletonOutputs =
-                NE.toList outputsToCover
-            , skeletonChange =
-                fmap (TokenMap.getAssets . view #tokens) changeGenerated
-            , skeletonAssetsToMint =
-                assetsToMint
-            , skeletonAssetsToBurn =
-                assetsToBurn
-            }
         utxoSelected :: UTxO
         utxoSelected = UTxO $ Map.fromList $ F.toList inputsSelected
         balanceChange =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -1162,14 +1163,7 @@ data TransformationReport paramsTransformed result resultTransformed =
         , resultTransformed :: resultTransformed
             -- ^ The transformed result.
         }
-    deriving Generic
-
--- | A functor instance on 'TransformationReport' that allows the final result
---   value to be transformed by a function transformer.
---
-instance Functor (TransformationReport paramsTransformed result) where
-    fmap f (TransformationReport paramsTransformed result resultUntransformed)
-        = TransformationReport paramsTransformed result (f resultUntransformed)
+    deriving (Functor, Generic)
 
 -- | Constructs a function transformation report.
 --

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -37,7 +37,8 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionLimitOf (..)
     , SelectionParams
     , SelectionParamsOf (..)
-    , SelectionResult (..)
+    , SelectionResult
+    , SelectionResultOf (..)
     , SelectionSkeleton (..)
     , SelectionState (..)
     , UnableToConstructChangeError (..)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -549,7 +549,7 @@ prop_AssetCount_TokenMap_placesEmptyMapsFirst maps =
 
 prop_prepareOutputsWith_twice
     :: MockComputeMinimumAdaQuantity
-    -> NonEmpty TxOut
+    -> [TxOut]
     -> Property
 prop_prepareOutputsWith_twice minCoinValueDef outs =
     once === twice
@@ -559,7 +559,7 @@ prop_prepareOutputsWith_twice minCoinValueDef outs =
 
 prop_prepareOutputsWith_length
     :: MockComputeMinimumAdaQuantity
-    -> NonEmpty TxOut
+    -> [TxOut]
     -> Property
 prop_prepareOutputsWith_length minCoinValueDef outs =
     F.length (prepareOutputsWith minCoinValueFor outs) === F.length outs
@@ -568,7 +568,7 @@ prop_prepareOutputsWith_length minCoinValueDef outs =
 
 prop_prepareOutputsWith_assetsUnchanged
     :: MockComputeMinimumAdaQuantity
-    -> NonEmpty TxOut
+    -> [TxOut]
     -> Property
 prop_prepareOutputsWith_assetsUnchanged minCoinValueDef outs =
     (txOutAssets <$> (prepareOutputsWith minCoinValueFor outs))
@@ -580,10 +580,10 @@ prop_prepareOutputsWith_assetsUnchanged minCoinValueDef outs =
 
 prop_prepareOutputsWith_preparedOrExistedBefore
     :: MockComputeMinimumAdaQuantity
-    -> NonEmpty TxOut
+    -> [TxOut]
     -> Property
 prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
-    property $ F.all isPreparedOrExistedBefore (NE.zip outs outs')
+    property $ F.all isPreparedOrExistedBefore (zip outs outs')
   where
     minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
     outs' = prepareOutputsWith minCoinValueFor outs

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -35,7 +35,8 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionLens (..)
     , SelectionLimit
     , SelectionLimitOf (..)
-    , SelectionParams (..)
+    , SelectionParams
+    , SelectionParamsOf (..)
     , SelectionResult (..)
     , SelectionSkeleton (..)
     , SelectionState (..)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -2073,20 +2073,16 @@ data MockAssessTokenBundleSize
     = MockAssessTokenBundleSizeUnlimited
       -- ^ Indicates that there is no limit on a token bundle's size.
     | MockAssessTokenBundleSizeUpperLimit Int
-      -- ^ Indicates an inclusive upper bound on the number of assets in a
-      -- token bundle.
+      -- ^ Indicates an inclusive positive upper bound on the number of assets
+      -- in a token bundle.
     deriving (Eq, Show)
 
 genMockAssessTokenBundleSize :: Gen MockAssessTokenBundleSize
-genMockAssessTokenBundleSize =
-    -- TODO:
-    --
-    -- We currently only test with constraints where the token bundle size is
-    -- unlimited.
-    --
-    -- We should add coverage of the case where token bundle sizes are limited.
-    --
-    pure MockAssessTokenBundleSizeUnlimited
+genMockAssessTokenBundleSize = oneof
+    [ pure MockAssessTokenBundleSizeUnlimited
+    , MockAssessTokenBundleSizeUpperLimit . getPositive
+        <$> arbitrary @(Positive Int)
+    ]
 
 shrinkMockAssessTokenBundleSize
     :: MockAssessTokenBundleSize -> [MockAssessTokenBundleSize]
@@ -2094,7 +2090,8 @@ shrinkMockAssessTokenBundleSize = \case
     MockAssessTokenBundleSizeUnlimited ->
         []
     MockAssessTokenBundleSizeUpperLimit n ->
-        MockAssessTokenBundleSizeUpperLimit <$> filter (> 0) (shrink n)
+        MockAssessTokenBundleSizeUpperLimit . getPositive
+            <$> shrink (Positive n)
 
 unMockAssessTokenBundleSize
     :: MockAssessTokenBundleSize -> (TokenBundle -> TokenBundleSizeAssessment)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -908,8 +908,8 @@ prop_performSelection mockConstraints (Blind params) coverage =
             "isUTxOBalanceSufficient params"
             (isUTxOBalanceSufficient params)
         assertOnSuccess
-            "selectionHasValidSurplus result"
-            (selectionHasValidSurplus result)
+            "selectionHasValidSurplus constraints result"
+            (selectionHasValidSurplus constraints result)
         assertOnSuccess
             "view #tokens surplus == TokenMap.empty"
             (view #tokens surplus == TokenMap.empty)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -2029,8 +2029,10 @@ computeMinimumCostLinear s
     = Coin
     $ fromIntegral
     $ skeletonInputCount s
-    + F.length (skeletonOutputs s)
-    + F.length (skeletonChange s)
+    + F.length (TokenMap.size . view (#tokens . #tokens) <$> skeletonOutputs s)
+    + F.sum (Set.size <$> skeletonChange s)
+    + TokenMap.size (skeletonAssetsToMint s)
+    + TokenMap.size (skeletonAssetsToBurn s)
 
 --------------------------------------------------------------------------------
 -- Computing selection limits

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -34,7 +34,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionLens (..)
     , SelectionLimit
     , SelectionLimitOf (..)
-    , SelectionParams
     , SelectionParamsOf (..)
     , SelectionResultOf (..)
     , SelectionSkeleton (..)
@@ -59,7 +58,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , makeChangeForUserSpecifiedAsset
     , mapMaybe
     , performSelection
-    , performSelectionNonEmpty
     , prepareOutputsWith
     , reduceTokenQuantities
     , removeBurnValueFromChangeMaps
@@ -1524,7 +1522,7 @@ type BoundaryTestEntry = (Coin, [(AssetId, TokenQuantity)])
 
 mkBoundaryTestExpectation :: BoundaryTestData -> Expectation
 mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
-    actualResult <- performSelectionNonEmpty constraints
+    actualResult <- performSelection constraints
         (encodeBoundaryTestCriteria params)
     fmap decodeBoundaryTestResult actualResult `shouldBe` Right expectedResult
   where
@@ -1536,9 +1534,9 @@ mkBoundaryTestExpectation (BoundaryTestData params expectedResult) = do
         , computeSelectionLimit = const NoLimit
         }
 
-encodeBoundaryTestCriteria :: BoundaryTestCriteria -> SelectionParams
+encodeBoundaryTestCriteria :: BoundaryTestCriteria -> SelectionParamsOf [TxOut]
 encodeBoundaryTestCriteria c = SelectionParams
-    { outputsToCover = NE.fromList $
+    { outputsToCover =
         zipWith TxOut
             (dummyAddresses)
             (uncurry TokenBundle.fromFlatList <$> boundaryTestOutputs c)
@@ -1563,7 +1561,7 @@ encodeBoundaryTestCriteria c = SelectionParams
     dummyTxIns = [TxIn (Hash "") x | x <- [0 ..]]
 
 decodeBoundaryTestResult
-    :: SelectionResultOf (NonEmpty TxOut) TokenBundle -> BoundaryTestResult
+    :: SelectionResultOf [TxOut] TokenBundle -> BoundaryTestResult
 decodeBoundaryTestResult r = BoundaryTestResult
     { boundaryTestInputs = L.sort $ NE.toList $
         TokenBundle.toFlatList . view #tokens . snd <$> view #inputsSelected r

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -2830,28 +2830,28 @@ unit_assignCoinsToChangeMaps =
         [ ( Coin 1
           , computeMinimumAdaQuantityLinear
           , m 42 [] :| []
-          , Just [b 1 []]
+          , Right [b 1 []]
           )
 
         -- Simple case, with a single MA output
         , ( Coin 2
           , computeMinimumAdaQuantityLinear
           , m 42 [(assetA, 1337)] :| []
-          , Just [b 2 [(assetA, 1337)]]
+          , Right [b 2 [(assetA, 1337)]]
           )
 
         -- Single Ada-only output, but not enough left to create a change
         , ( Coin 1
           , (`addCoin` Coin 1) . computeMinimumAdaQuantityLinear
           , m 42 [] :| []
-          , Just []
+          , Right []
           )
 
         -- Single MA output, but not enough left to create a change
         , ( Coin 1
           , computeMinimumAdaQuantityLinear
           , m 42 [(assetA, 1337)] :| []
-          , Nothing
+          , Left (Coin 1)
           )
 
         -- Multiple Ada-only change, not enough Ada left to create them all
@@ -2862,7 +2862,7 @@ unit_assignCoinsToChangeMaps =
             , m   14 []
             , m   42 []
             ]
-          , Just [b 1 [], b 1 []]
+          , Right [b 1 [], b 1 []]
           )
 
         -- Hybrid Ada & MA, not enough to cover both => Ada change is dropped
@@ -2873,7 +2873,7 @@ unit_assignCoinsToChangeMaps =
             , m 14 []
             , m  2 [(assetA, 1337)]
             ]
-          , Just [b 2 [(assetA, 1337)]]
+          , Right [b 2 [(assetA, 1337)]]
           )
         ]
 

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -79,7 +79,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery
 import Cardano.Wallet.Primitive.CoinSelection
     ( SelectionError (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult (..) )
+    ( SelectionResultOf (..) )
 import Cardano.Wallet.Primitive.Migration.SelectionSpec
     ( MockTxConstraints (..), genTokenBundleMixed, unMockTxConstraints )
 import Cardano.Wallet.Primitive.SyncProgress

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -166,8 +166,6 @@ import Data.Aeson
     ( ToJSON (..), genericToJSON, (.=) )
 import Data.List
     ( foldl' )
-import Data.List.NonEmpty
-    ( NonEmpty (..) )
 import Data.Proxy
     ( Proxy (..) )
 import Data.Quantity
@@ -459,7 +457,7 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         let txCtx = defaultTransactionCtx
         let getFee = const (selectionDelta TokenBundle.getCoin)
         wal <- unsafeRunExceptT $ W.readWalletUTxOIndex @_ @s @k w wid
-        let runSelection = W.selectAssets @_ @s @k w wal txCtx (out :| []) getFee
+        let runSelection = W.selectAssets @_ @s @k w wal txCtx [out] getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     oneAddress <- genAddresses 1 cp
@@ -550,7 +548,7 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
         let txCtx = defaultTransactionCtx
         let getFee = const (selectionDelta TokenBundle.getCoin)
         wal <- unsafeRunExceptT $ W.readWalletUTxOIndex w wid
-        let runSelection = W.selectAssets @_ @s @k w wal txCtx (out :| []) getFee
+        let runSelection = W.selectAssets @_ @s @k w wal txCtx [out] getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -82,7 +82,8 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey, toRewardAccountRaw )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionLimitOf (..)
-    , SelectionResult (changeGenerated, inputsSelected, outputsCovered)
+    , SelectionResult
+    , SelectionResultOf (..)
     , SelectionSkeleton (..)
     , selectionDelta
     )

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -67,7 +67,7 @@ import Cardano.Wallet.Primitive.AddressDerivation.Shelley
 import Cardano.Wallet.Primitive.CoinSelection
     ( SelectionError (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult (..)
+    ( SelectionResultOf (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
     , selectionDelta


### PR DESCRIPTION
### Issue Number

ADP-1136

### Summary

This PR makes it possible to perform coin selection when there are no user-specified outputs.