### PR TITLE
Add shrinker for `SelectionParams` type.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -355,16 +355,22 @@ data SelectionSkeleton = SelectionSkeleton
         :: ![TxOut]
     , skeletonChange
         :: ![Set AssetId]
+    , skeletonAssetsToMint
+        :: !TokenMap
+    , skeletonAssetsToBurn
+        :: !TokenMap
     }
     deriving (Eq, Generic, Show)
 
--- | Creates an empty 'SelectionSkeleton' with no inputs, no outputs and no
--- change.
+-- | Creates an empty 'SelectionSkeleton'.
+--
 emptySkeleton :: SelectionSkeleton
 emptySkeleton = SelectionSkeleton
     { skeletonInputCount = 0
     , skeletonOutputs = mempty
     , skeletonChange = mempty
+    , skeletonAssetsToMint = TokenMap.empty
+    , skeletonAssetsToBurn = TokenMap.empty
     }
 
 -- | Specifies a limit to adhere to when performing a selection.
@@ -882,6 +888,8 @@ performSelection constraints params
             { skeletonInputCount = UTxOIndex.size selected
             , skeletonOutputs = NE.toList outputsToCover
             , skeletonChange
+            , skeletonAssetsToMint = assetsToMint
+            , skeletonAssetsToBurn = assetsToBurn
             }
 
         skeletonChange = predictChange selected

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -957,6 +957,10 @@ prop_performSelection mockConstraints (Blind params) coverage =
                 NE.toList outputsToCover
             , skeletonChange =
                 fmap (TokenMap.getAssets . view #tokens) changeGenerated
+            , skeletonAssetsToMint =
+                assetsToMint
+            , skeletonAssetsToBurn =
+                assetsToBurn
             }
         utxoSelected :: UTxO
         utxoSelected = UTxO $ Map.fromList $ F.toList inputsSelected

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -3907,11 +3907,11 @@ instance Arbitrary (Small SelectionParams) where
 
 instance Arbitrary (Large UTxOIndex) where
     arbitrary = Large <$> genUTxOIndexLarge
-    -- No shrinking
+    shrink = shrinkMapBy Large getLarge shrinkUTxOIndex
 
 instance Arbitrary (Small UTxOIndex) where
     arbitrary = Small <$> genUTxOIndex
-    shrink = fmap Small . shrinkUTxOIndex . getSmall
+    shrink = shrinkMapBy Small getSmall shrinkUTxOIndex
 
 instance Arbitrary Coin where
     arbitrary = genCoinPositive

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -184,6 +184,7 @@ import qualified Cardano.Ledger.Core as SL
 import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Shelley.Compatibility as Compatibility
 import qualified Codec.CBOR.Encoding as CBOR
 import qualified Codec.CBOR.Write as CBOR
@@ -492,6 +493,10 @@ dummySkeleton inputCount outputs = SelectionSkeleton
         outputs
     , skeletonChange =
         TokenBundle.getAssets . view #tokens <$> outputs
+    , skeletonAssetsToMint =
+        TokenMap.empty
+    , skeletonAssetsToBurn =
+        TokenMap.empty
     }
 
 _calcScriptExecutionCost

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -18,6 +18,8 @@ module Test.QuickCheck.Extra
       -- * Shrinking
     , liftShrink3
     , liftShrink4
+    , liftShrink5
+    , liftShrink6
     , liftShrink7
     , shrinkInterleaved
     , shrinkMapWith
@@ -151,6 +153,46 @@ liftShrink4 s1 s2 s3 s4 (a1, a2, a3, a4) =
     , [ (a1 , a2', a3 , a4 ) | a2' <- s2 a2 ]
     , [ (a1 , a2 , a3', a4 ) | a3' <- s3 a3 ]
     , [ (a1 , a2 , a3 , a4') | a4' <- s4 a4 ]
+    ]
+
+-- | Similar to 'liftShrink2', but applicable to 5-tuples.
+--
+liftShrink5
+    :: (a1 -> [a1])
+    -> (a2 -> [a2])
+    -> (a3 -> [a3])
+    -> (a4 -> [a4])
+    -> (a5 -> [a5])
+    -> (a1, a2, a3, a4, a5)
+    -> [(a1, a2, a3, a4, a5)]
+liftShrink5 s1 s2 s3 s4 s5 (a1, a2, a3, a4, a5) =
+    interleaveRoundRobin
+    [ [ (a1', a2 , a3 , a4 , a5 ) | a1' <- s1 a1 ]
+    , [ (a1 , a2', a3 , a4 , a5 ) | a2' <- s2 a2 ]
+    , [ (a1 , a2 , a3', a4 , a5 ) | a3' <- s3 a3 ]
+    , [ (a1 , a2 , a3 , a4', a5 ) | a4' <- s4 a4 ]
+    , [ (a1 , a2 , a3 , a4 , a5') | a5' <- s5 a5 ]
+    ]
+
+-- | Similar to 'liftShrink2', but applicable to 6-tuples.
+--
+liftShrink6
+    :: (a1 -> [a1])
+    -> (a2 -> [a2])
+    -> (a3 -> [a3])
+    -> (a4 -> [a4])
+    -> (a5 -> [a5])
+    -> (a6 -> [a6])
+    -> (a1, a2, a3, a4, a5, a6)
+    -> [(a1, a2, a3, a4, a5, a6)]
+liftShrink6 s1 s2 s3 s4 s5 s6 (a1, a2, a3, a4, a5, a6) =
+    interleaveRoundRobin
+    [ [ (a1', a2 , a3 , a4 , a5 , a6 ) | a1' <- s1 a1 ]
+    , [ (a1 , a2', a3 , a4 , a5 , a6 ) | a2' <- s2 a2 ]
+    , [ (a1 , a2 , a3', a4 , a5 , a6 ) | a3' <- s3 a3 ]
+    , [ (a1 , a2 , a3 , a4', a5 , a6 ) | a4' <- s4 a4 ]
+    , [ (a1 , a2 , a3 , a4 , a5', a6 ) | a5' <- s5 a5 ]
+    , [ (a1 , a2 , a3 , a4 , a5 , a6') | a6' <- s6 a6 ]
     ]
 
 -- | Similar to 'liftShrink2', but applicable to 7-tuples.

--- a/weeder.dhall
+++ b/weeder.dhall
@@ -19,7 +19,7 @@
   , "^UnliftIO\\.Compat\\.mkRetryHandler\$"
   , "^Spec\\.main\$"
   , "^Test\\..*\\.spec\$"
-  , "^Test\\.QuickCheck\\.Extra\\.liftShrink3\$"
+  , "^Test\\.QuickCheck\\.Extra\\.liftShrink\$"
   , "^Test\\.Utils\\.Paths\\.getTestData"
   , "^Cardano\\.Wallet\\.Api\\.Malformed\\."
   , "^Cardano\\.Wallet\\.DB\\.StateMachine\\.showLabelledExamples\$"


### PR DESCRIPTION
## Issue Number

ADP-1136

## Summary

This PR:
- [x] adds a shrinker for the `SelectionParams` type.
- [x] adds minted and burned assets to the `SelectionSkeleton` type.
- [x] improves shrinking of `UTxOIndex` values.