### PR TITLE
Bump version from 2021.9.9 to 2021.9.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ See **Installation Instructions** for each available [release](https://github.co
 > | cardano-wallet | cardano-node (compatible versions) | SMASH (compatible versions)
 > | --- | --- | ---
 > | `master` branch | [1.30.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.30.0) | [1.6.0](https://github.com/input-output-hk/smash/releases/tag/1.6.0)
+> | [v2021-09-22](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-09-22) | [1.30.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.30.0) | [1.6.0](https://github.com/input-output-hk/smash/releases/tag/1.6.0)
 > | [v2021-09-09](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-09-09) | [1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) | [1.6.0](https://github.com/input-output-hk/smash/releases/tag/1.6.0)
 > | [v2021-08-27](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-27) | [1.29.0](https://github.com/input-output-hk/cardano-node/releases/tag/1.29.0) | [1.6.0](https://github.com/input-output-hk/smash/releases/tag/1.6.0)
-> | [v2021-08-11](https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-08-11) | [alonzo-purple-1.0.1](https://github.com/input-output-hk/cardano-node/releases/tag/alonzo-purple-1.0.1) | [1.4.0](https://github.com/input-output-hk/smash/releases/tag/1.4.0)
 
 ## How to build from sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cardano-node:
-    image: inputoutput/cardano-node:1.29.0
+    image: inputoutput/cardano-node:1.30.0
     environment:
       NETWORK:
     volumes:
@@ -18,7 +18,7 @@ services:
         max-size: "50m"
 
   cardano-wallet:
-    image: inputoutput/cardano-wallet:2021.9.9
+    image: inputoutput/cardano-wallet:2021.9.22
     volumes:
       - wallet-${NETWORK}-db:/wallet-db
       - node-ipc:/ipc

--- a/lib/cli/cardano-wallet-cli.cabal
+++ b/lib/cli/cardano-wallet-cli.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-cli
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Utilities for a building Command-Line Interfaces
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/core-integration/cardano-wallet-core-integration.cabal
+++ b/lib/core-integration/cardano-wallet-core-integration.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core-integration
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Core integration test library.
 description:         Shared core functionality for our integration test suites.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-core
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            The Wallet Backend for a Cardano node.
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/launcher/cardano-wallet-launcher.cabal
+++ b/lib/launcher/cardano-wallet-launcher.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-launcher
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Utilities for a building commands launcher
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Wallet backend protocol-specific bits implemented using Shelley nodes
 description:         Please see README.md
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/test-utils/cardano-wallet-test-utils.cabal
+++ b/lib/test-utils/cardano-wallet-test-utils.cabal
@@ -1,5 +1,5 @@
 name:                cardano-wallet-test-utils
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Shared utilities for writing unit and property tests.
 description:         Shared utilities for writing unit and property tests.
 homepage:            https://github.com/input-output-hk/cardano-wallet

--- a/lib/text-class/text-class.cabal
+++ b/lib/text-class/text-class.cabal
@@ -1,5 +1,5 @@
 name:                text-class
-version:             2021.9.9
+version:             2021.9.22
 synopsis:            Extra helpers to convert data-types to and from Text
 homepage:            https://github.com/input-output-hk/cardano-wallet
 author:              IOHK Engineering Team

--- a/nix/.stack.nix/cardano-wallet-cli.nix
+++ b/nix/.stack.nix/cardano-wallet-cli.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-cli"; version = "2021.9.9"; };
+      identifier = { name = "cardano-wallet-cli"; version = "2021.9.22"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-core-integration.nix
+++ b/nix/.stack.nix/cardano-wallet-core-integration.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-core-integration";
-        version = "2021.9.9";
+        version = "2021.9.22";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-core"; version = "2021.9.9"; };
+      identifier = { name = "cardano-wallet-core"; version = "2021.9.22"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-launcher.nix
+++ b/nix/.stack.nix/cardano-wallet-launcher.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet-launcher"; version = "2021.9.9"; };
+      identifier = { name = "cardano-wallet-launcher"; version = "2021.9.22"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/cardano-wallet-test-utils.nix
+++ b/nix/.stack.nix/cardano-wallet-test-utils.nix
@@ -13,7 +13,7 @@
       specVersion = "1.10";
       identifier = {
         name = "cardano-wallet-test-utils";
-        version = "2021.9.9";
+        version = "2021.9.22";
         };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";

--- a/nix/.stack.nix/cardano-wallet.nix
+++ b/nix/.stack.nix/cardano-wallet.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "cardano-wallet"; version = "2021.9.9"; };
+      identifier = { name = "cardano-wallet"; version = "2021.9.22"; };
       license = "Apache-2.0";
       copyright = "2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/nix/.stack.nix/text-class.nix
+++ b/nix/.stack.nix/text-class.nix
@@ -11,7 +11,7 @@
     flags = { release = false; };
     package = {
       specVersion = "1.10";
-      identifier = { name = "text-class"; version = "2021.9.9"; };
+      identifier = { name = "text-class"; version = "2021.9.22"; };
       license = "Apache-2.0";
       copyright = "2018-2020 IOHK";
       maintainer = "operations@iohk.io";

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 ################################################################################
 # Release-specific parameters. Can be changed interactively by running the script.
 # Release tags must follow format vYYYY-MM-DD.
-GIT_TAG="v2021-09-09"
-OLD_GIT_TAG="v2021-08-27"
-CARDANO_NODE_TAG="1.29.0"
+GIT_TAG="v2021-09-22"
+OLD_GIT_TAG="v2021-09-09"
+CARDANO_NODE_TAG="1.30.0"
 
 ################################################################################
 # Tag munging functions

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Cardano Wallet Backend API
-  version: v2021-09-09
+  version: v2021-09-22
   license:
     name: Apache-2.0
     url: https://raw.githubusercontent.com/input-output-hk/cardano-wallet/master/LICENSE


### PR DESCRIPTION
- [x] Bump wallet version to 2021.9.22 

### Comments

### Issue Number

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
