### PR TITLE
Remove `selectAssetsNoOutputs` workaround

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/StakePools.hs
@@ -141,7 +141,6 @@ import Test.Integration.Framework.TestData
     , errMsg403Fee
     , errMsg403NonNullReward
     , errMsg403NotDelegating
-    , errMsg403NotEnoughMoney
     , errMsg403PoolAlreadyJoined
     , errMsg403WrongPass
     , errMsg404NoSuchPool
@@ -967,7 +966,7 @@ spec = describe "SHELLEY_STAKE_POOLS" $ do
         w <- emptyWallet ctx
         delegationFee ctx w >>= flip verify
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403NotEnoughMoney
+            , expectErrorMessage errMsg403EmptyUTxO
             ]
 
     describe "STAKE_POOLS_LIST_01 - List stake pools" $ do

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -151,7 +151,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
     it "TRANS_NEW_CREATE_02 - Only metadata" $ \ctx -> runResourceT $ do
         wa <- fixtureWallet ctx
         let metadata = Json [json|{ "metadata": { "1": { "string": "hello" } } }|]
-        let expectedFee = 1129500
+        let expectedFee = 129500
 
         rTx <- request @(ApiConstructTransaction n) ctx
             (Link.createUnsignedTransaction @'Shelley wa) Default metadata

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/TransactionsNew.hs
@@ -186,7 +186,7 @@ spec = describe "NEW_SHELLEY_TRANSACTIONS" $ do
         (_, mw) <- rewardWallet ctx
         wa <- fixtureWallet ctx
         let withdrawal = Json [json|{ "withdrawal": #{mnemonicToText mw} }|]
-        let expectedFee = 1139500
+        let expectedFee = 139500
         -- let withdrawalAmt = 1000000000000
 
         rTx <- request @(ApiConstructTransaction n) ctx

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1548,6 +1548,10 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 $ case view #txDelegationAction txCtx of
                     Just Quit -> stakeKeyDeposit pp
                     _ -> Coin 0
+            -- TODO: [ADP-919]
+            , certificateDepositsReturned = 0
+            -- TODO: [ADP-919]
+            , certificateDepositsTaken = 0
             , utxoAvailable
             }
     case mSel of

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -109,7 +109,6 @@ module Cardano.Wallet
     , getTxExpiry
     , selectAssets
     , readWalletUTxOIndex
-    , selectAssetsNoOutputs
     , assignChangeAddresses
     , assignChangeAddressesAndUpdateDb
     , assignChangeAddressesWithoutDbUpdate
@@ -1394,93 +1393,6 @@ readWalletUTxOIndex ctx wid = do
     (cp, _, pending) <- readWallet @ctx @s @k ctx wid
     let utxo = UTxOIndex.fromUTxO $ availableUTxO @s pending cp
     return (utxo, cp, pending)
-
-selectAssetsNoOutputs
-    :: forall ctx s k result.
-        ( HasTransactionLayer k ctx
-        , HasLogger WalletWorkerLog ctx
-        , HasDBLayer IO s k ctx
-        , HasNetworkLayer IO ctx
-        )
-    => ctx
-    -> WalletId
-    -> (UTxOIndex, Wallet s, Set Tx)
-    -> TransactionCtx
-    -> (s -> SelectionResult TokenBundle -> result)
-    -> ExceptT ErrSelectAssets IO result
-selectAssetsNoOutputs ctx wid wal tx transform = do
-    -- NOTE:
-    -- Could be made nicer by allowing 'performSelection' to run with no target
-    -- outputs, but to satisfy a minimum Ada target.
-    --
-    -- To work-around this immediately, I am simply creating a dummy output of
-    -- exactly the required deposit amount, only to discard it on the final
-    -- result. The resulting selection will therefore have a delta that is at
-    -- least the size of the deposit (in practice, slightly bigger because this
-    -- extra outputs also increases the apparent minimum fee).
-    deposit <- calcMinimumDeposit @_ @s @k ctx wid
-    let dummyAddress = Address ""
-    let dummyOutput  = TxOut dummyAddress (TokenBundle.fromCoin deposit)
-    let outs = [dummyOutput]
-    selectAssets @ctx @s @k ctx wal tx outs $ \s sel -> transform s $ sel
-        { outputsCovered = mempty
-        , changeGenerated =
-            let
-                -- NOTE 1: There are in principle 6 cases we may ran into, which
-                -- can be grouped in 3 groups of 2 cases:
-                --
-                -- (1) When registering a key and delegating
-                -- (2) When delegating
-                -- (3) When de-registering a key
-                --
-                -- For each case, there may be one or zero change output. For
-                -- all 3 cases, we'll treat the case where there's no change
-                -- output as an edge-case and also leave no change. This may be
-                -- in practice more costly than necessary because, by removing
-                -- the fake output, we'd in practice have some more Ada
-                -- available to create a change (and a less expensive
-                -- transaction). Yet, this would require quite some extra logic
-                -- here in addition to all the existing logic inside the
-                -- CoinSelection/Balance module already. If we were not
-                -- able to add a change output already, let's not try to do it
-                -- here. Worse that can be list is:
-                --
-                --     max (minUTxOValue, keyDepositValue)
-                --
-                -- which we'll deem acceptable under the circumstances (that can
-                -- only really happen if one is trying to delegate with already
-                -- a very small Ada balance, so that it's left with no Ada after
-                -- having paid for the delegation certificate. Why would one be
-                -- delegating almost nothing certainly is an edge-case not worth
-                -- considering for too long).
-                --
-                -- However, if a change output has been create, then we want to
-                -- transfer the surplus of value from the change output to that
-                -- change output (which is already safe). That surplus is
-                -- non-null if the `minUTxOValue` protocol parameter is
-                -- non-null, and comes from the fact that the selection
-                -- algorithm automatically assigns this value when presented
-                -- with a null output. In the case of (1), the output's value is
-                -- equal to the stake key deposit value, which may be in
-                -- practice greater than the `minUTxOValue`. In the case of (2)
-                -- and (3), the deposit is null. So it suffices to subtract
-                -- `deposit` to the value of the covered output to get the
-                -- surplus.
-                --
-                -- NOTE 2: This subtraction and head are safe because of the
-                -- invariants enforced by the asset selection algorithm. The
-                -- output list has the exact same length as the input list, and
-                -- outputs are at least as large as the specified outputs.
-                surplus = TokenBundle.unsafeSubtract
-                    (view #tokens (head $ outputsCovered sel))
-                    (TokenBundle.fromCoin deposit)
-            in
-                surplus `addToHead` changeGenerated sel
-        }
-  where
-    addToHead :: TokenBundle -> [TokenBundle] -> [TokenBundle]
-    addToHead _    [] = []
-    addToHead x (h:q) = TokenBundle.add x h : q
 
 -- | Calculate the minimum coin values required for a bunch of specified
 -- outputs.

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1544,14 +1544,15 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
             , assetsToMint = TokenMap.empty
             , outputsToCover = outputs
             , rewardWithdrawal =
-                addCoin (withdrawalToCoin $ view #txWithdrawal txCtx)
-                $ case view #txDelegationAction txCtx of
-                    Just Quit -> stakeKeyDeposit pp
-                    _ -> Coin 0
-            -- TODO: [ADP-919]
-            , certificateDepositsReturned = 0
-            -- TODO: [ADP-919]
-            , certificateDepositsTaken = 0
+                withdrawalToCoin $ view #txWithdrawal txCtx
+            , certificateDepositsReturned =
+                case view #txDelegationAction txCtx of
+                    Just Quit -> 1
+                    _ -> 0
+            , certificateDepositsTaken =
+                case view #txDelegationAction txCtx of
+                    Just (RegisterKeyAndJoin _) -> 1
+                    _ -> 0
             , utxoAvailable
             }
     case mSel of

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -579,7 +579,6 @@ import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Icarus as Icarus
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
 import qualified Cardano.Wallet.Primitive.Types as W
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
@@ -2185,10 +2184,10 @@ delegationFee ctx (ApiT wid) = do
     txCtx :: TransactionCtx
     txCtx = defaultTransactionCtx
 
-    runSelection wrk deposit wal =
+    runSelection wrk _deposit wal =
         W.selectAssets @_ @s @k wrk wal txCtx [] calcFee
       where
-        calcFee _ = Coin.distance deposit . selectionDelta TokenBundle.getCoin
+        calcFee _ = selectionDelta TokenBundle.getCoin
 
 quitStakePool
     :: forall ctx s n k.

--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -2062,7 +2062,8 @@ constructTransaction ctx genChange (ApiT wid) body = do
                 sel <- liftHandler $
                     W.assignChangeAddressesWithoutDbUpdate wrk wid genChange utx
                 sel' <- liftHandler
-                    $ W.selectAssets @_ @s @k wrk w txCtx [] transform
+                    $ W.selectAssets @_ @s @k wrk w txCtx (F.toList outs)
+                        transform
                 pure (sel, sel', estMin)
             Just (ApiPaymentAll _) -> do
                 liftHandler $ throwE $ ErrConstructTxNotImplemented "ADP-909"


### PR DESCRIPTION
## Issue Number

ADP-1136 (and others)

## Summary

This PR removes the `selectAssetsNoOutputs` workaround.