### PR TITLE
Adjust top-level coin selection module.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1533,6 +1533,8 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 calcMinimumCost tl pp txCtx
             , computeSelectionLimit =
                 view #computeSelectionLimit tl pp txCtx
+            , depositAmount =
+                view #stakeKeyDeposit pp
             , maximumCollateralInputCount =
                 view #maximumCollateralInputCount pp
             }

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1543,8 +1543,8 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
               assetsToBurn = TokenMap.empty
             , assetsToMint = TokenMap.empty
             , outputsToCover = outputs
-            , rewardWithdrawal = Just
-                $ addCoin (withdrawalToCoin $ view #txWithdrawal txCtx)
+            , rewardWithdrawal =
+                addCoin (withdrawalToCoin $ view #txWithdrawal txCtx)
                 $ case view #txDelegationAction txCtx of
                     Just Quit -> stakeKeyDeposit pp
                     _ -> Coin 0

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1522,7 +1522,7 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
     guardPendingWithdrawal
     pp <- liftIO $ currentProtocolParameters nl
     liftIO $ traceWith tr $ MsgSelectionStart utxoAvailable outputs
-    mSel <- performSelection
+    mSel <- runExceptT $ performSelection
         SelectionConstraints
             { assessTokenBundleSize =
                 tokenBundleSizeAssessor tl $

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -90,7 +90,7 @@ performSelection
     => SelectionConstraints
     -> SelectionParams
     -> m (Either SelectionError (SelectionResult TokenBundle))
-performSelection selectionConstraints selectionParams =
+performSelection constraints params =
     -- TODO:
     --
     -- https://input-output.atlassian.net/browse/ADP-1037
@@ -99,7 +99,7 @@ performSelection selectionConstraints selectionParams =
     -- https://input-output.atlassian.net/browse/ADP-1070
     -- Adjust coin selection and fee estimation to handle pre-existing inputs
     --
-    case prepareOutputs selectionConstraints outputsToCover of
+    case prepareOutputs constraints outputsToCover of
         Left e ->
             pure $ Left $ SelectionOutputsError e
         Right preparedOutputsToCover ->
@@ -127,14 +127,14 @@ performSelection selectionConstraints selectionParams =
         , computeMinimumAdaQuantity
         , computeMinimumCost
         , computeSelectionLimit
-        } = selectionConstraints
+        } = constraints
     SelectionParams
         { assetsToBurn
         , assetsToMint
         , outputsToCover
         , rewardWithdrawal
         , utxoAvailable
-        } = selectionParams
+        } = params
 
 -- | Specifies all constraints required for coin selection.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -61,8 +61,6 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Data.Generics.Labels
     ()
-import Data.Maybe
-    ( fromMaybe )
 import Data.Word
     ( Word16 )
 import GHC.Generics
@@ -130,7 +128,7 @@ toBalanceConstraintsParams (constraints, params) =
         , assetsToMint =
             view #assetsToMint params
         , extraCoinSource =
-            fromMaybe (Coin 0) (view #rewardWithdrawal params)
+            view #rewardWithdrawal params
         , extraCoinSink =
           -- TODO: Use this for stake key deposits and anything else that
           -- consumes ada:
@@ -193,7 +191,7 @@ data SelectionParams = SelectionParams
         :: ![TxOut]
         -- ^ Specifies a set of outputs that must be paid for.
     , rewardWithdrawal
-        :: !(Maybe Coin)
+        :: !Coin
         -- ^ Specifies the value of a withdrawal from a reward account.
     , utxoAvailable
         :: !UTxOIndex

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -169,6 +169,10 @@ data SelectionConstraints = SelectionConstraints
         :: [TxOut] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
+    , depositAmount
+        :: Coin
+        -- ^ Amount that should be taken from/returned back to the wallet for
+        -- each stake key registration/de-registration in the transaction.
     , maximumCollateralInputCount
         :: Word16
         -- ^ Specifies an inclusive upper bound on the number of unique inputs


### PR DESCRIPTION
## Issue Number

ADP-1136

## Summary

This PR makes some small adjustments to the top-level `CoinSelection` module in preparation for future PRs, including https://github.com/input-output-hk/cardano-wallet/pull/2917.

Changes:
- [x] Uses `ExceptT` in `CoinSelection.performSelection`.
- [x] Extracts out pure function `toBalanceConstraintsParams`.
- [x] Adjusts the type of `rewardWithdrawal` to `Coin` (rather than `Maybe Coin`).
- [x] Adds `depositAmount` field to `SelectionConstraints`.