### PR TITLE
Extract out type `UTxOSelection`

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -417,6 +417,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.UTxOIndexSpec
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
       Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
+      Cardano.Wallet.Primitive.Types.UTxOSelectionSpec.TypeErrorSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TokenMetadataSpec
       Cardano.Wallet.RegistrySpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -416,6 +416,7 @@ test-suite unit
       Cardano.Wallet.Primitive.Types.UTxOSpec
       Cardano.Wallet.Primitive.Types.UTxOIndexSpec
       Cardano.Wallet.Primitive.Types.UTxOIndex.TypeErrorSpec
+      Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
       Cardano.Wallet.Primitive.TypesSpec
       Cardano.Wallet.TokenMetadataSpec
       Cardano.Wallet.RegistrySpec

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -206,6 +206,7 @@ library
       Cardano.Wallet.Primitive.Types.UTxO
       Cardano.Wallet.Primitive.Types.UTxOIndex
       Cardano.Wallet.Primitive.Types.UTxOIndex.Internal
+      Cardano.Wallet.Primitive.Types.UTxOSelection
       Cardano.Wallet.Registry
       Cardano.Wallet.TokenMetadata.MockServer
       Cardano.Wallet.Transaction

--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -245,6 +245,7 @@ library
       Cardano.Wallet.Primitive.Types.Tx.Gen
       Cardano.Wallet.Primitive.Types.UTxO.Gen
       Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+      Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
       Cardano.Wallet.Gen
   other-modules:
       Paths_cardano_wallet_core

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Gen.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.Wallet.Primitive.CoinSelection.Gen
@@ -13,10 +12,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Gen
 import Prelude
 
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionLimit
-    , SelectionLimitOf (..)
-    , SelectionSkeleton (..)
-    )
+    ( SelectionLimit, SelectionLimitOf (..), SelectionSkeleton (..) )
 import Cardano.Wallet.Primitive.Types.TokenMap.Gen
     ( genAssetId, genTokenMap, shrinkAssetId, shrinkTokenMap )
 import Cardano.Wallet.Primitive.Types.Tx.Gen

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/Tx/Gen.hs
@@ -5,7 +5,8 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Cardano.Wallet.Primitive.Types.Tx.Gen
-    ( genTx
+    ( coarbitraryTxIn
+    , genTx
     , genTxHash
     , genTxIndex
     , genTxIn
@@ -56,6 +57,7 @@ import Data.Word
 import Test.QuickCheck
     ( Gen
     , arbitrary
+    , coarbitrary
     , elements
     , liftArbitrary
     , liftArbitrary2
@@ -171,6 +173,9 @@ genTxHashLargeRange = Hash . B8.pack <$> replicateM 32 arbitrary
 --------------------------------------------------------------------------------
 -- Transaction indices generated according to the size parameter
 --------------------------------------------------------------------------------
+
+coarbitraryTxIn :: TxIn -> Gen a -> Gen a
+coarbitraryTxIn = coarbitrary . show
 
 genTxIndex :: Gen Word32
 genTxIndex = sized $ \size -> elements $ take (max 1 size) txIndices

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOIndex.hs
@@ -38,6 +38,10 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
     , delete
     , deleteMany
 
+    -- * Filtering and partitioning
+    , filter
+    , partition
+
     -- * Queries
     , assets
     , balance
@@ -48,6 +52,7 @@ module Cardano.Wallet.Primitive.Types.UTxOIndex
 
     -- * Set operations
     , difference
+    , disjoint
 
     -- * Selection
     , SelectionFilter (..)

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+-- Copyright: © 2018-2021 IOHK
+-- License: Apache-2.0
+--
+-- Provides the 'UTxOSelection' type, which represents a selection of UTxO
+-- entries from a UTxO set.
+--
+-- It consists of a pair of UTxO sets:
+--
+--    - the selected set: UTxOs that have already been selected;
+--    - the leftover set: UTxOs that have not yet been selected.
+--
+-- To construct a 'UTxOSelection' where none of the UTxOs are selected, use
+-- the 'fromIndex' function.
+--
+-- To construct a 'UTxOSelection' where some of the UTxOs are selected, use
+-- either the 'fromIndexFiltered' or the 'fromIndexPair' functions.
+--
+-- To select an element (and move it from the leftover set to the selected
+-- set), use the 'select' function.
+--
+-- A 'UTxOSelection' can be promoted to a 'UTxOSelectionNonEmpty', indicating
+-- that the selected set contains at least one UTxO. To promote a selection,
+-- either use the 'toNonEmpty' function to assert that it is non-empty, or use
+-- the 'select' function to select a single entry.
+--
+module Cardano.Wallet.Primitive.Types.UTxOSelection
+    (
+      -- * Classes
+      IsUTxOSelection
+
+      -- * Types
+    , UTxOSelection
+    , UTxOSelectionNonEmpty
+
+      -- * Construction and deconstruction
+    , empty
+    , fromIndex
+    , fromIndexFiltered
+    , fromIndexPair
+    , toIndexPair
+
+      -- * Promotion and demotion
+    , fromNonEmpty
+    , toNonEmpty
+
+      -- * Indicator functions
+    , isEmpty
+    , isNonEmpty
+    , isMember
+    , isLeftover
+    , isSelected
+    , isSubSelectionOf
+    , isProperSubSelectionOf
+
+      -- * Accessor functions
+    , leftoverBalance
+    , leftoverSize
+    , leftoverIndex
+    , leftoverList
+    , leftoverUTxO
+    , selectedBalance
+    , selectedSize
+    , selectedIndex
+    , selectedList
+    , selectedUTxO
+
+      -- * Modification
+    , select
+    , selectMany
+
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.TokenBundle
+    ( TokenBundle )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn, TxOut )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO )
+import Cardano.Wallet.Primitive.Types.UTxOIndex
+    ( UTxOIndex )
+import Control.Monad
+    ( ap, (<=<) )
+import Data.Bool
+    ( bool )
+import Data.Function
+    ( (&) )
+import Data.Generics.Internal.VL.Lens
+    ( over )
+import Data.Generics.Labels
+    ()
+import Data.List.NonEmpty
+    ( NonEmpty )
+import Data.Maybe
+    ( fromMaybe )
+import Data.Tuple
+    ( swap )
+import GHC.Generics
+    ( Generic )
+
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Data.Foldable as F
+import qualified Data.List.NonEmpty as NonEmpty
+
+--------------------------------------------------------------------------------
+-- Classes
+--------------------------------------------------------------------------------
+
+class HasUTxOSelectionState u where
+
+    -- | Retrieves the internal state from a selection.
+    state :: u -> State
+
+    -- | Reconstructs a selection from an internal state.
+    fromState :: State -> u
+
+class HasUTxOSelectionState u => IsUTxOSelection u where
+
+    -- | The type of the list of selected UTxOs.
+    type SelectedList u
+
+    -- | Retrieves a list of the selected UTxOs.
+    selectedList :: u -> SelectedList u
+
+--------------------------------------------------------------------------------
+-- Types
+--------------------------------------------------------------------------------
+
+-- | The internal state of a selection.
+--
+data State = State
+    { leftover :: !UTxOIndex
+      -- ^ UTxOs that have not yet been selected.
+    , selected :: !UTxOIndex
+      -- ^ UTxOs that have already been selected.
+    }
+    deriving (Eq, Generic, Show)
+
+-- | A selection for which 'isNonEmpty' may be 'False'.
+--
+newtype UTxOSelection = UTxOSelection State
+    deriving (Eq, Generic, Show)
+
+-- | A selection for which 'isNonEmpty' must be 'True'.
+--
+newtype UTxOSelectionNonEmpty = UTxOSelectionNonEmpty State
+    deriving (Eq, Generic, Show)
+
+instance HasUTxOSelectionState UTxOSelection where
+    state (UTxOSelection s) = s
+    fromState s = UTxOSelection s
+
+instance HasUTxOSelectionState UTxOSelectionNonEmpty where
+    state (UTxOSelectionNonEmpty s) = s
+    fromState s = UTxOSelectionNonEmpty s
+
+instance IsUTxOSelection UTxOSelection where
+    type SelectedList UTxOSelection = [(TxIn, TxOut)]
+    selectedList = UTxOIndex.toList . selectedIndex
+
+instance IsUTxOSelection UTxOSelectionNonEmpty where
+    type SelectedList UTxOSelectionNonEmpty = NonEmpty (TxIn, TxOut)
+    selectedList = NonEmpty.fromList . UTxOIndex.toList . selectedIndex
+
+--------------------------------------------------------------------------------
+-- Construction and deconstruction
+--------------------------------------------------------------------------------
+
+-- | A completely empty selection with no selected or leftover UTxOs.
+--
+empty :: UTxOSelection
+empty = fromIndex UTxOIndex.empty
+
+-- | Creates a selection where none of the UTxOs are selected.
+--
+-- All UTxOs in the index will be added to the leftover set.
+--
+fromIndex :: UTxOIndex -> UTxOSelection
+fromIndex i = UTxOSelection State
+    { leftover = i
+    , selected = UTxOIndex.empty
+    }
+
+-- | Creates a selection from an index and a filter.
+--
+-- All UTxOs that match the given filter will be added to the selected set,
+-- whereas all UTxOs that do not match will be added to the leftover set.
+--
+fromIndexFiltered :: (TxIn -> Bool) -> UTxOIndex -> UTxOSelection
+fromIndexFiltered f =
+    UTxOSelection . uncurry State . swap . UTxOIndex.partition f
+
+-- | Creates a selection from a pair of indices.
+--
+-- The 1st index in the pair represents the leftover set.
+-- The 2nd index in the pair represents the selected set.
+--
+-- Any items that are in both sets are removed from the leftover set.
+--
+fromIndexPair :: (UTxOIndex, UTxOIndex) -> UTxOSelection
+fromIndexPair (leftover, selected) =
+    UTxOSelection State
+        { leftover = leftover `UTxOIndex.difference` selected
+        , selected
+        }
+
+-- | Converts a selection to a pair of indices.
+--
+-- The 1st index in the pair represents the leftover set.
+-- The 2nd index in the pair represents the selected set.
+--
+toIndexPair :: IsUTxOSelection u => u -> (UTxOIndex, UTxOIndex)
+toIndexPair s = (leftoverIndex s, selectedIndex s)
+
+--------------------------------------------------------------------------------
+-- Promotion and demotion
+--------------------------------------------------------------------------------
+
+-- | Demotes a non-empty selection to an ordinary selection.
+--
+fromNonEmpty :: UTxOSelectionNonEmpty -> UTxOSelection
+fromNonEmpty = UTxOSelection . state
+
+-- | Promotes an ordinary selection to a non-empty selection.
+--
+-- Returns 'Nothing' if the the selected set is empty.
+--
+toNonEmpty :: IsUTxOSelection u => u -> Maybe UTxOSelectionNonEmpty
+toNonEmpty s = bool Nothing (Just $ fromState $ state s) (isNonEmpty s)
+
+--------------------------------------------------------------------------------
+-- Indicator functions
+--------------------------------------------------------------------------------
+
+-- | Returns 'True' if and only if the selected set is empty.
+--
+isEmpty :: IsUTxOSelection u => u -> Bool
+isEmpty = (== 0) . selectedSize
+
+-- | Returns 'True' if and only if the selected set is non-empty.
+--
+isNonEmpty :: IsUTxOSelection u => u -> Bool
+isNonEmpty = not . isEmpty
+
+-- | Returns 'True' if the given 'TxIn' is a member of either set.
+--
+-- Otherwise, returns 'False'.
+--
+isMember :: IsUTxOSelection s => TxIn -> s -> Bool
+isMember i s = isLeftover i s || isSelected i s
+
+-- | Returns 'True' iff. the given 'TxIn' is a member of the leftover set.
+--
+isLeftover :: IsUTxOSelection s => TxIn -> s -> Bool
+isLeftover i = UTxOIndex.member i . leftoverIndex
+
+-- | Returns 'True' iff. the given 'TxIn' is a member of the selected set.
+--
+isSelected :: IsUTxOSelection s => TxIn -> s -> Bool
+isSelected i = UTxOIndex.member i . selectedIndex
+
+-- | Returns 'True' iff. the first selection is a sub-selection of the second.
+--
+-- A selection 's1' is a sub-selection of selection 's2' if (and only if) it
+-- is possible to transform 's1' into 's2' through zero or more applications
+-- of the 'select' function.
+--
+isSubSelectionOf
+    :: IsUTxOSelection u1 => IsUTxOSelection u2 => u1 -> u2 -> Bool
+isSubSelectionOf u1 u2 = state (selectMany toSelect u1) == state u2
+  where
+    toSelect :: [TxIn]
+    toSelect = fst <$> UTxO.toList
+        (selectedUTxO u2 `UTxO.difference` selectedUTxO u1)
+
+-- | Returns 'True' iff. the first selection is a proper sub-selection of the
+--   second.
+--
+-- A selection 's1' is a proper sub-selection of selection 's2' if (and only
+-- if) it is possible to transform 's1' into 's2' through one or more
+-- applications of the 'select' function.
+--
+isProperSubSelectionOf
+    :: IsUTxOSelection u1 => IsUTxOSelection u2 => u1 -> u2 -> Bool
+isProperSubSelectionOf u1 u2 = state u1 /= state u2 && u1 `isSubSelectionOf` u2
+
+--------------------------------------------------------------------------------
+-- Accessor functions
+--------------------------------------------------------------------------------
+
+-- | Retrieves the balance of leftover UTxOs.
+--
+leftoverBalance :: IsUTxOSelection u => u -> TokenBundle
+leftoverBalance = UTxOIndex.balance . leftoverIndex
+
+-- | Retrieves the size of the leftover UTxO set.
+--
+leftoverSize :: IsUTxOSelection u => u -> Int
+leftoverSize = UTxOIndex.size . leftoverIndex
+
+-- | Retrieves an index of the leftover UTxOs.
+--
+leftoverIndex :: IsUTxOSelection u => u -> UTxOIndex
+leftoverIndex = leftover . state
+
+-- | Retrieves the leftover UTxO set.
+--
+leftoverUTxO :: IsUTxOSelection u => u -> UTxO
+leftoverUTxO = UTxOIndex.toUTxO . leftoverIndex
+
+-- | Retrieves a list of the leftover UTxOs.
+--
+leftoverList :: IsUTxOSelection u => u -> [(TxIn, TxOut)]
+leftoverList = UTxOIndex.toList . leftoverIndex
+
+-- | Retrieves the balance of selected UTxOs.
+--
+selectedBalance :: IsUTxOSelection u => u -> TokenBundle
+selectedBalance = UTxOIndex.balance . selectedIndex
+
+-- | Retrieves the size of the selected UTxO set.
+--
+selectedSize :: IsUTxOSelection u => u -> Int
+selectedSize = UTxOIndex.size . selectedIndex
+
+-- | Retrieves an index of the selected UTxOs.
+--
+selectedIndex :: IsUTxOSelection u => u -> UTxOIndex
+selectedIndex = selected . state
+
+-- | Retrieves the selected UTxO set.
+--
+selectedUTxO :: IsUTxOSelection u => u -> UTxO
+selectedUTxO = UTxOIndex.toUTxO . selectedIndex
+
+--------------------------------------------------------------------------------
+-- Modification
+--------------------------------------------------------------------------------
+
+-- | Moves a single entry from the leftover set to the selected set.
+--
+-- Returns 'Nothing' if the given entry is not a member of the leftover set.
+--
+select :: IsUTxOSelection u => TxIn -> u -> Maybe UTxOSelectionNonEmpty
+select = (toNonEmpty <=<) . withState . selectState
+
+-- | Moves multiple entries from the leftover set to the selected set.
+--
+selectMany :: IsUTxOSelection u => Foldable f => f TxIn -> u -> u
+selectMany = ap fromMaybe . withState . flip (F.foldrM selectState)
+
+--------------------------------------------------------------------------------
+-- Modification (Internal)
+--------------------------------------------------------------------------------
+
+-- | Moves a single entry from the leftover set to the selected set.
+--
+selectState :: TxIn -> State -> Maybe State
+selectState i s =
+    updateFields <$> UTxOIndex.lookup i (leftover s)
+  where
+    updateFields o = s
+        & over #leftover (UTxOIndex.delete i)
+        & over #selected (UTxOIndex.insert i o)
+
+-- | Applies the given function to the internal state.
+--
+withState :: Functor f => IsUTxOSelection u => (State -> f State) -> u -> f u
+withState f = fmap fromState . f . state

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -109,7 +110,7 @@ import GHC.Generics
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Data.Foldable as F
-import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.List.NonEmpty as NE
 
 --------------------------------------------------------------------------------
 -- Classes
@@ -169,7 +170,7 @@ instance IsUTxOSelection UTxOSelection where
 
 instance IsUTxOSelection UTxOSelectionNonEmpty where
     type SelectedList UTxOSelectionNonEmpty = NonEmpty (TxIn, TxOut)
-    selectedList = NonEmpty.fromList . UTxOIndex.toList . selectedIndex
+    selectedList = NE.fromList . UTxOIndex.toList . selectedIndex
 
 --------------------------------------------------------------------------------
 -- Construction and deconstruction

--- a/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection/Gen.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+    ( genUTxOSelection
+    , genUTxOSelectionNonEmpty
+    , shrinkUTxOSelection
+    , shrinkUTxOSelectionNonEmpty
+    )
+    where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( coarbitraryTxIn )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOSelection
+    ( UTxOSelection, UTxOSelectionNonEmpty )
+import Data.Maybe
+    ( mapMaybe )
+import Test.QuickCheck
+    ( Gen, arbitrary, liftShrink2, shrinkMapBy, suchThatMap )
+import Test.QuickCheck.Extra
+    ( genFunction )
+
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+
+--------------------------------------------------------------------------------
+-- Selections that may be empty
+--------------------------------------------------------------------------------
+
+genUTxOSelection :: Gen UTxOSelection
+genUTxOSelection = UTxOSelection.fromIndexFiltered
+    <$> genFilter
+    <*> genUTxOIndex
+  where
+    genFilter :: Gen (TxIn -> Bool)
+    genFilter = genFunction coarbitraryTxIn (arbitrary @Bool)
+
+shrinkUTxOSelection :: UTxOSelection -> [UTxOSelection]
+shrinkUTxOSelection =
+    shrinkMapBy UTxOSelection.fromIndexPair UTxOSelection.toIndexPair $
+        liftShrink2
+            shrinkUTxOIndex
+            shrinkUTxOIndex
+
+--------------------------------------------------------------------------------
+-- Selections that are non-empty
+--------------------------------------------------------------------------------
+
+genUTxOSelectionNonEmpty :: Gen UTxOSelectionNonEmpty
+genUTxOSelectionNonEmpty =
+    genUTxOSelection `suchThatMap` UTxOSelection.toNonEmpty
+
+shrinkUTxOSelectionNonEmpty :: UTxOSelectionNonEmpty -> [UTxOSelectionNonEmpty]
+shrinkUTxOSelectionNonEmpty
+    = mapMaybe UTxOSelection.toNonEmpty
+    . shrinkUTxOSelection
+    . UTxOSelection.fromNonEmpty
+

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -3660,7 +3660,7 @@ runMockRoundRobin
     :: forall k n. (Ord k, Integral n)
     => MockRoundRobinState k n
     -> MockRoundRobinState k n
-runMockRoundRobin initialState = runRoundRobin initialState processors
+runMockRoundRobin initialState = runRoundRobin initialState id processors
   where
     processors :: [MockRoundRobinState k n -> Maybe (MockRoundRobinState k n)]
     processors = mkProcessor <$> Map.toList (processorLifetimes initialState)
@@ -3684,7 +3684,7 @@ runMockRoundRobin initialState = runRoundRobin initialState processors
 prop_runRoundRobin_identity
     :: forall state. (Eq state, Show state) => state -> [()] -> Property
 prop_runRoundRobin_identity state processors =
-    runRoundRobin state (const Nothing <$ processors) === state
+    runRoundRobin state id (const Nothing <$ processors) === state
 
 prop_runRoundRobin_iterationCount
     :: forall k n. (Ord k, Integral n)

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -80,9 +80,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , ungroupByKey
     )
 import Cardano.Wallet.Primitive.CoinSelection.Gen
-    ( genSelectionLimit
-    , shrinkSelectionLimit
-    )
+    ( genSelectionLimit, shrinkSelectionLimit )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Coin

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -41,7 +41,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionResult
     , SelectionResultOf (..)
     , SelectionSkeleton (..)
-    , SelectionState (..)
     , UnableToConstructChangeError (..)
     , addMintValueToChangeMaps
     , addMintValuesToChangeMaps
@@ -82,9 +81,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     )
 import Cardano.Wallet.Primitive.CoinSelection.Gen
     ( genSelectionLimit
-    , genSelectionState
     , shrinkSelectionLimit
-    , shrinkSelectionState
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -131,6 +128,10 @@ import Cardano.Wallet.Primitive.Types.UTxOIndex
     ( SelectionFilter (..), UTxOIndex )
 import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
     ( genUTxOIndex, genUTxOIndexLarge, genUTxOIndexLargeN, shrinkUTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOSelection
+    ( UTxOSelection, UTxOSelectionNonEmpty )
+import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+    ( genUTxOSelection, shrinkUTxOSelection )
 import Control.Monad
     ( forM_, replicateM )
 import Data.Bifunctor
@@ -187,7 +188,6 @@ import Test.QuickCheck
     , cover
     , disjoin
     , elements
-    , forAll
     , frequency
     , generate
     , genericShrink
@@ -219,6 +219,7 @@ import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Foldable as F
 import qualified Data.List as L
@@ -279,15 +280,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.BalanceSpec" $
 
         it "prop_performSelectionEmpty" $
             property prop_performSelectionEmpty
-
-    parallel $ describe "Selection states" $ do
-
-        it "prop_genSelectionState_coverage" $
-            property prop_genSelectionState_coverage
-        it "prop_genSelectionState_valid" $
-            property prop_genSelectionState_valid
-        it "prop_shrinkSelectionState_valid" $
-            property prop_shrinkSelectionState_valid
 
     parallel $ describe "Running a selection (without making change)" $ do
 
@@ -1214,55 +1206,19 @@ mockPerformSelectionNonEmpty constraints params = Identity $ Right result
     (deficitIn, deficitOut) = computeDeficitInOut params
 
 --------------------------------------------------------------------------------
--- Selection states
---------------------------------------------------------------------------------
-
-prop_genSelectionState_coverage :: Property
-prop_genSelectionState_coverage =
-    forAll genSelectionState prop_genSelectionState_coverage_inner
-
-prop_genSelectionState_coverage_inner :: SelectionState -> Property
-prop_genSelectionState_coverage_inner state =
-    checkCoverage $
-    cover 0.1 (noneLeftover && noneSelected) "noneLeftover && noneSelected" $
-    cover 1.0 (haveLeftover && noneSelected) "haveLeftover && noneSelected" $
-    cover 1.0 (noneLeftover && haveSelected) "noneLeftover && haveSelected" $
-    cover 8.0 (haveLeftover && haveSelected) "haveLeftover && haveSelected" $
-    property True
-  where
-    haveLeftover = view #leftover state /= UTxOIndex.empty
-    noneLeftover = view #leftover state == UTxOIndex.empty
-    haveSelected = view #selected state /= UTxOIndex.empty
-    noneSelected = view #selected state == UTxOIndex.empty
-
-prop_genSelectionState_valid :: Property
-prop_genSelectionState_valid =
-    forAll genSelectionState isSelectionStateValid
-
-prop_shrinkSelectionState_valid :: Property
-prop_shrinkSelectionState_valid =
-    forAll genSelectionState $ \state ->
-        all isSelectionStateValid (shrinkSelectionState state)
-
-isSelectionStateValid :: SelectionState -> Bool
-isSelectionStateValid state = Set.disjoint
-    (Map.keysSet $ unUTxO $ UTxOIndex.toUTxO $ view #selected state)
-    (Map.keysSet $ unUTxO $ UTxOIndex.toUTxO $ view #leftover state)
-
---------------------------------------------------------------------------------
 -- Running a selection (without making change)
 --------------------------------------------------------------------------------
 
 prop_runSelection_UTxO_empty :: TokenBundle -> Property
 prop_runSelection_UTxO_empty balanceRequested = monadicIO $ do
-    SelectionState {selected, leftover} <-
-        run $ runSelection RunSelectionParams
+    result <- run $ runSelection
+        RunSelectionParams
             { selectionLimit = NoLimit
             , utxoAvailable = UTxOIndex.empty
             , minimumBalance = balanceRequested
             }
-    let balanceSelected = view #balance selected
-    let balanceLeftover = view #balance leftover
+    let balanceSelected = UTxOSelection.selectedBalance result
+    let balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "balanceSelected == TokenBundle.empty"
         (balanceSelected == TokenBundle.empty)
@@ -1274,14 +1230,14 @@ prop_runSelection_UTxO_notEnough
     :: Small UTxOIndex
     -> Property
 prop_runSelection_UTxO_notEnough (Small index) = monadicIO $ do
-    SelectionState {selected, leftover} <-
-        run $ runSelection RunSelectionParams
+    result <- run $ runSelection
+        RunSelectionParams
             { selectionLimit = NoLimit
             , utxoAvailable = index
             , minimumBalance = balanceRequested
             }
-    let balanceSelected = view #balance selected
-    let balanceLeftover = view #balance leftover
+    let balanceSelected = UTxOSelection.selectedBalance result
+    let balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "balanceSelected == balanceAvailable"
         (balanceSelected == balanceAvailable)
@@ -1296,14 +1252,14 @@ prop_runSelection_UTxO_exactlyEnough
     :: Small UTxOIndex
     -> Property
 prop_runSelection_UTxO_exactlyEnough (Small index) = monadicIO $ do
-    SelectionState {selected, leftover} <-
-        run $ runSelection RunSelectionParams
+    result <- run $ runSelection
+        RunSelectionParams
             { selectionLimit = NoLimit
             , utxoAvailable = index
             , minimumBalance = balanceRequested
             }
-    let balanceSelected = view #balance selected
-    let balanceLeftover = view #balance leftover
+    let balanceSelected = UTxOSelection.selectedBalance result
+    let balanceLeftover = UTxOSelection.leftoverBalance result
     assertWith
         "balanceLeftover == TokenBundle.empty"
         (balanceLeftover == TokenBundle.empty)
@@ -1322,14 +1278,14 @@ prop_runSelection_UTxO_moreThanEnough
     :: Small UTxOIndex
     -> Property
 prop_runSelection_UTxO_moreThanEnough (Small index) = monadicIO $ do
-    SelectionState {selected, leftover} <-
-        run $ runSelection RunSelectionParams
+    result <- run $ runSelection
+        RunSelectionParams
             { selectionLimit = NoLimit
             , utxoAvailable = index
             , minimumBalance = balanceRequested
             }
-    let balanceSelected = view #balance selected
-    let balanceLeftover = view #balance leftover
+    let balanceSelected = UTxOSelection.selectedBalance result
+    let balanceLeftover = UTxOSelection.leftoverBalance result
     monitor $ cover 80
         (assetsRequested `Set.isProperSubsetOf` assetsAvailable)
         "assetsRequested ⊂ assetsAvailable"
@@ -1366,14 +1322,14 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
     withMaxSuccess 100 $
     checkCoverage $
     monadicIO $ do
-        SelectionState {selected, leftover} <-
-            run $ runSelection RunSelectionParams
+        result <- run $ runSelection
+            RunSelectionParams
                 { selectionLimit = NoLimit
                 , utxoAvailable = index
                 , minimumBalance = balanceRequested
                 }
-        let balanceSelected = view #balance selected
-        let balanceLeftover = view #balance leftover
+        let balanceSelected = UTxOSelection.selectedBalance result
+        let balanceLeftover = UTxOSelection.leftoverBalance result
         monitor $ cover 80
             (assetsRequested `Set.isProperSubsetOf` assetsAvailable)
             "assetsRequested ⊂ assetsAvailable"
@@ -1406,14 +1362,8 @@ prop_runSelection_UTxO_muchMoreThanEnough (Blind (Large index)) =
 -- Running a selection (non-empty)
 --------------------------------------------------------------------------------
 
-prop_runSelectionNonEmpty :: SelectionState -> Property
-prop_runSelectionNonEmpty result = conjoin
-    [ prop_genSelectionState_coverage_inner result
-    , prop_runSelectionNonEmpty_inner result
-    ]
-
-prop_runSelectionNonEmpty_inner :: SelectionState -> Property
-prop_runSelectionNonEmpty_inner result =
+prop_runSelectionNonEmpty :: UTxOSelection -> Property
+prop_runSelectionNonEmpty result =
     case (haveLeftover, haveSelected) of
         (False, False) ->
             -- In this case, the available UTxO set was completely empty.
@@ -1423,12 +1373,12 @@ prop_runSelectionNonEmpty_inner result =
             -- In this case, we've already selected all entries from the
             -- available UTxO, so there's no more work to do. We need to check
             -- that 'runSelectionNonEmpty' does not expand the selection:
-            maybeResultNonEmpty === Just result
+            maybeResultNonEmpty === UTxOSelection.toNonEmpty result
         (True, True) ->
             -- In this case, we've already selected some entries from the
             -- available UTxO, so there's no more work to do. We need to check
             -- that 'runSelectionNonEmpty' does not expand the selection:
-            maybeResultNonEmpty === Just result
+            maybeResultNonEmpty === UTxOSelection.toNonEmpty result
         (True, False) ->
             -- This represents the case where 'runSelection' does not select
             -- anything at all, even though we do have at least one UTxO entry
@@ -1437,8 +1387,8 @@ prop_runSelectionNonEmpty_inner result =
             -- entry, and no more:
             checkResultNonEmpty
   where
-    haveLeftover = view #leftover result /= UTxOIndex.empty
-    haveSelected = view #selected result /= UTxOIndex.empty
+    haveLeftover = UTxOSelection.leftoverSize result > 0
+    haveSelected = UTxOSelection.selectedSize result > 0
 
     checkResultNonEmpty :: Property
     checkResultNonEmpty = checkSelectedElement &
@@ -1448,27 +1398,26 @@ prop_runSelectionNonEmpty_inner result =
         checkSelectedElement = do
             resultNonEmpty <- maybeResultNonEmpty
             (i, o) <- matchSingletonList $
-                UTxOIndex.toList $ view #selected resultNonEmpty
+                UTxOSelection.selectedList resultNonEmpty
             pure $
-                UTxOIndex.insert i o (view #leftover resultNonEmpty)
-                === view #leftover result
+                UTxOIndex.insert i o
+                    (UTxOSelection.leftoverIndex resultNonEmpty)
+                === UTxOSelection.leftoverIndex result
 
-    maybeResultNonEmpty :: Maybe SelectionState
+    maybeResultNonEmpty :: Maybe UTxOSelectionNonEmpty
     maybeResultNonEmpty = runIdentity $ runSelectionNonEmptyWith
         (Identity <$> mockSelectSingleEntry)
         (result)
 
-mockSelectSingleEntry :: SelectionState -> Maybe SelectionState
+mockSelectSingleEntry :: UTxOSelection -> Maybe UTxOSelectionNonEmpty
 mockSelectSingleEntry state =
-    selectEntry <$> firstLeftoverEntry state
+    selectEntry =<< firstLeftoverEntry state
   where
-    firstLeftoverEntry :: SelectionState -> Maybe (TxIn, TxOut)
-    firstLeftoverEntry = Map.lookupMin . unUTxO . UTxOIndex.toUTxO . leftover
+    firstLeftoverEntry :: UTxOSelection -> Maybe (TxIn, TxOut)
+    firstLeftoverEntry = Map.lookupMin . unUTxO . UTxOSelection.leftoverUTxO
 
-    selectEntry :: (TxIn, TxOut) -> SelectionState
-    selectEntry (i, o) = state
-        & over #selected (UTxOIndex.insert i o)
-        & over #leftover (UTxOIndex.delete i)
+    selectEntry :: (TxIn, TxOut) -> Maybe UTxOSelectionNonEmpty
+    selectEntry (i, _o) = UTxOSelection.select i state
 
 --------------------------------------------------------------------------------
 -- Running a selection step
@@ -1488,9 +1437,10 @@ runMockSelectionStep :: MockSelectionStepData -> Maybe Natural
 runMockSelectionStep d =
     runIdentity $ runSelectionStep lens $ mockSelected d
   where
-    lens :: SelectionLens Identity Natural
+    lens :: SelectionLens Identity Natural Natural
     lens = SelectionLens
         { currentQuantity = id
+        , updatedQuantity = id
         , minimumQuantity = mockMinimum d
         , selectQuantity = \s -> pure $ (+ s) <$> mockNext d
         }
@@ -1597,8 +1547,8 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
                 -- _something_ that matches.
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
-            Just SelectionState {selected} -> do
-                let output = head $ snd <$> UTxOIndex.toList selected
+            Just result -> do
+                let output = NE.head $ snd <$> UTxOSelection.selectedList result
                 let bundle = view #tokens output
                 case F.toList $ TokenBundle.getAssets bundle of
                     [a] -> assertWith
@@ -1610,7 +1560,7 @@ prop_assetSelectionLens_givesPriorityToSingletonAssets (Blind (Small u)) =
   where
     asset = Set.findMin $ UTxOIndex.assets u
     assetCount = Set.size $ UTxOIndex.assets u
-    initialState = SelectionState UTxOIndex.empty u
+    initialState = UTxOSelection.fromIndex u
     lens = assetSelectionLens NoLimit (asset, minimumAssetQuantity)
     minimumAssetQuantity = TokenQuantity 1
 
@@ -1633,15 +1583,15 @@ prop_coinSelectionLens_givesPriorityToCoins (Blind (Small u)) =
                 -- _something_ that matches.
                 monitor $ counterexample "Error: unable to select any entry"
                 assert False
-            Just SelectionState {selected} -> do
-                let output = head $ snd <$> UTxOIndex.toList selected
+            Just result -> do
+                let output = NE.head $ snd <$> UTxOSelection.selectedList result
                 let bundle = view #tokens output
                 case F.toList $ TokenBundle.getAssets bundle of
                     [] -> assertWith     "hasCoin" (    hasCoin)
                     _  -> assertWith "not hasCoin" (not hasCoin)
   where
     entryCount = UTxOIndex.size u
-    initialState = SelectionState UTxOIndex.empty u
+    initialState = UTxOSelection.fromIndex u
     lens = coinSelectionLens NoLimit minimumCoinQuantity
     minimumCoinQuantity = Coin 1
 
@@ -3929,9 +3879,9 @@ expectRight = \case
     Left _a -> error "Expected right"
     Right b -> b
 
-matchSingletonList :: [a] -> Maybe a
+matchSingletonList :: NonEmpty a -> Maybe a
 matchSingletonList = \case
-    [a] -> Just a
+    a :| [] -> Just a
     _   -> Nothing
 
 mockAsset :: ByteString -> AssetId
@@ -3946,7 +3896,7 @@ unitTests lbl cases =
         it (lbl <> " example #" <> show @Int i) test
 
 --------------------------------------------------------------------------------
--- Arbitraries
+-- Arbitrary instances
 --------------------------------------------------------------------------------
 
 instance Arbitrary a => Arbitrary (NonEmpty a) where
@@ -3995,10 +3945,6 @@ instance Arbitrary SelectionLimit where
     arbitrary = genSelectionLimit
     shrink = shrinkSelectionLimit
 
-instance Arbitrary SelectionState where
-    arbitrary = genSelectionState
-    shrink = shrinkSelectionState
-
 instance Arbitrary TokenMap where
     arbitrary = genTokenMapSmallRange
     shrink = shrinkTokenMap
@@ -4010,6 +3956,10 @@ instance Arbitrary TokenQuantity where
 instance Arbitrary TxOut where
     arbitrary = genTxOut
     shrink = shrinkTxOut
+
+instance Arbitrary UTxOSelection where
+    arbitrary = genUTxOSelection
+    shrink = shrinkUTxOSelection
 
 newtype Large a = Large
     { getLarge :: a }

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -370,11 +370,10 @@ checkCoverage_filter_partition f u
         (filterSize f u < filterSize (not . f) u)
         "filterSize f u < filterSize (not . f) u"
   where
-    u1 `isNonEmptyProperSubsetOf` u2 = and
-        [ not (UTxOIndex.null u1)
-        , UTxOIndex.toUTxO u1 `UTxO.isSubsetOf` UTxOIndex.toUTxO u2
-        , u1 /= u2
-        ]
+    u1 `isNonEmptyProperSubsetOf` u2 =
+        not (UTxOIndex.null u1)
+        && UTxOIndex.toUTxO u1 `UTxO.isSubsetOf` UTxOIndex.toUTxO u2
+        && u1 /= u2
 
     filterSize g = UTxOIndex.size . UTxOIndex.filter g
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOIndexSpec.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Primitive.Types.UTxOIndexSpec
     ( spec

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -1,0 +1,395 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( coarbitraryTxIn, genTxIn, shrinkTxIn )
+import Cardano.Wallet.Primitive.Types.UTxOIndex
+    ( UTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOIndex.Gen
+    ( genUTxOIndex, shrinkUTxOIndex )
+import Cardano.Wallet.Primitive.Types.UTxOSelection
+    ( IsUTxOSelection, UTxOSelection, UTxOSelectionNonEmpty )
+import Cardano.Wallet.Primitive.Types.UTxOSelection.Gen
+    ( genUTxOSelection
+    , genUTxOSelectionNonEmpty
+    , shrinkUTxOSelection
+    , shrinkUTxOSelectionNonEmpty
+    )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Arbitrary (..)
+    , CoArbitrary (..)
+    , Property
+    , Testable
+    , checkCoverage
+    , conjoin
+    , cover
+    , forAll
+    , property
+    , (===)
+    )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
+
+spec :: Spec
+spec =
+    describe "Cardano.Wallet.Primitive.Types.UTxOSelectionSpec" $ do
+
+    parallel $ describe "Generators and shrinkers" $ do
+
+        it "prop_genUTxOSelection" $
+            property prop_genUTxOSelection
+        it "prop_genUTxOSelectionNonEmpty" $
+            property prop_genUTxOSelectionNonEmpty
+        it "prop_shrinkUTxOSelection" $
+            property prop_shrinkUTxOSelection
+        it "prop_shrinkUTxOSelectionNonEmpty" $
+            property prop_shrinkUTxOSelectionNonEmpty
+
+    parallel $ describe "Construction and deconstruction" $ do
+
+        it "prop_fromIndex_isValid" $
+            property prop_fromIndex_isValid
+        it "prop_fromIndexFiltered_isValid" $
+            property prop_fromIndexFiltered_isValid
+        it "prop_fromIndexPair_isValid" $
+            property prop_fromIndexPair_isValid
+        it "prop_fromIndex_toIndexPair" $
+            property prop_fromIndex_toIndexPair
+        it "prop_fromIndexFiltered_toIndexPair" $
+            property prop_fromIndexFiltered_toIndexPair
+        it "prop_fromIndexPair_toIndexPair" $
+            property prop_fromIndexPair_toIndexPair
+
+    parallel $ describe "Promotion and demotion" $ do
+
+        it "prop_fromNonEmpty_toNonEmpty" $
+            property prop_fromNonEmpty_toNonEmpty
+        it "prop_toNonEmpty_fromNonEmpty" $
+            property prop_toNonEmpty_fromNonEmpty
+
+    parallel $ describe "Indicator and accessor functions" $ do
+
+        it "prop_isNonEmpty_selectedSize" $
+            property prop_isNonEmpty_selectedSize
+        it "prop_isNonEmpty_selectedIndex" $
+            property prop_isNonEmpty_selectedIndex
+        it "prop_isNonEmpty_selectedList" $
+            property prop_isNonEmpty_selectedList
+        it "prop_leftoverBalance_selectedBalance" $
+            property prop_leftoverBalance_selectedBalance
+        it "prop_leftoverSize_selectedSize" $
+            property prop_leftoverSize_selectedSize
+
+    parallel $ describe "Modification" $ do
+
+        it "prop_select_empty" $
+            property prop_select_empty
+        it "prop_select_isValid" $
+            property prop_select_isValid
+        it "prop_select_isLeftover" $
+            property prop_select_isLeftover
+        it "prop_select_isSelected" $
+            property prop_select_isSelected
+        it "prop_select_isProperSubSelectionOf" $
+            property prop_select_isProperSubSelectionOf
+        it "prop_select_leftoverSize" $
+            property prop_select_leftoverSize
+        it "prop_select_selectedSize" $
+            property prop_select_selectedSize
+        it "prop_selectMany_isSubSelectionOf" $
+            property prop_selectMany_isSubSelectionOf
+        it "prop_selectMany_leftoverSize_all" $
+            property prop_selectMany_leftoverSize_all
+        it "prop_selectMany_selectedSize_all" $
+            property prop_selectMany_selectedSize_all
+
+--------------------------------------------------------------------------------
+-- Generators and shrinkers
+--------------------------------------------------------------------------------
+
+prop_genUTxOSelection :: Property
+prop_genUTxOSelection =
+    forAll genUTxOSelection $ \s ->
+    checkCoverage_UTxOSelection s $
+    isValidSelection s === True
+
+prop_genUTxOSelectionNonEmpty :: Property
+prop_genUTxOSelectionNonEmpty =
+    forAll genUTxOSelectionNonEmpty $ \s ->
+    checkCoverage_UTxOSelectionNonEmpty s $
+    isValidSelectionNonEmpty s === True
+
+prop_shrinkUTxOSelection :: Property
+prop_shrinkUTxOSelection =
+    forAll genUTxOSelection $ \s ->
+    conjoin (isValidSelection <$> shrinkUTxOSelection s)
+
+prop_shrinkUTxOSelectionNonEmpty :: Property
+prop_shrinkUTxOSelectionNonEmpty =
+    forAll genUTxOSelectionNonEmpty $ \s ->
+    conjoin (isValidSelectionNonEmpty <$> shrinkUTxOSelectionNonEmpty s)
+
+checkCoverage_UTxOSelection
+    :: Testable p => IsUTxOSelection s => s -> (p -> Property)
+checkCoverage_UTxOSelection s
+    = checkCoverage_UTxOSelectionNonEmpty s
+    . cover 2 (0 == ssize && ssize == lsize) "0 == lsize && lsize == ssize"
+    . cover 2 (0 == ssize && ssize <  lsize) "0 == ssize && ssize <  lsize"
+  where
+    lsize = UTxOSelection.leftoverSize s
+    ssize = UTxOSelection.selectedSize s
+
+checkCoverage_UTxOSelectionNonEmpty
+    :: Testable p => IsUTxOSelection s => s -> (p -> Property)
+checkCoverage_UTxOSelectionNonEmpty s
+    = checkCoverage
+    . cover 2 (0 == lsize && lsize <  ssize) "0 == lsize && lsize <  ssize"
+    . cover 2 (0 <  lsize && lsize == ssize) "0 <  lsize && lsize == ssize"
+    . cover 2 (0 <  lsize && lsize <  ssize) "0 <  lsize && lsize <  ssize"
+    . cover 2 (0 <  ssize && ssize == lsize) "0 <  ssize && ssize == lsize"
+    . cover 2 (0 <  ssize && ssize <  lsize) "0 <  ssize && ssize <  lsize"
+  where
+    lsize = UTxOSelection.leftoverSize s
+    ssize = UTxOSelection.selectedSize s
+
+--------------------------------------------------------------------------------
+-- Construction and deconstruction
+--------------------------------------------------------------------------------
+
+prop_fromIndex_isValid :: UTxOIndex -> Property
+prop_fromIndex_isValid u =
+    isValidSelection (UTxOSelection.fromIndex u)
+    === True
+
+prop_fromIndexFiltered_isValid :: (TxIn -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_isValid f u =
+    isValidSelection (UTxOSelection.fromIndexFiltered f u)
+    === True
+
+prop_fromIndexPair_isValid :: (UTxOIndex, UTxOIndex) -> Property
+prop_fromIndexPair_isValid (u1, u2) =
+    isValidSelection (UTxOSelection.fromIndexPair (u1, u2))
+    === True
+
+prop_fromIndex_toIndexPair :: UTxOIndex -> Property
+prop_fromIndex_toIndexPair u =
+    UTxOSelection.toIndexPair (UTxOSelection.fromIndex u)
+    === (u, UTxOIndex.empty)
+
+prop_fromIndexFiltered_toIndexPair :: (TxIn -> Bool) -> UTxOIndex -> Property
+prop_fromIndexFiltered_toIndexPair f u =
+    UTxOSelection.toIndexPair (UTxOSelection.fromIndexFiltered f u)
+    === (UTxOIndex.filter (not . f) u, UTxOIndex.filter f u)
+
+prop_fromIndexPair_toIndexPair :: UTxOSelection -> Property
+prop_fromIndexPair_toIndexPair s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.fromIndexPair (UTxOSelection.toIndexPair s)
+    === s
+
+--------------------------------------------------------------------------------
+-- Promotion and demotion
+--------------------------------------------------------------------------------
+
+prop_fromNonEmpty_toNonEmpty :: UTxOSelectionNonEmpty -> Property
+prop_fromNonEmpty_toNonEmpty s =
+    checkCoverage_UTxOSelectionNonEmpty s $
+    UTxOSelection.toNonEmpty (UTxOSelection.fromNonEmpty s)
+    === Just s
+
+prop_toNonEmpty_fromNonEmpty :: UTxOSelection -> Property
+prop_toNonEmpty_fromNonEmpty s =
+    checkCoverage_UTxOSelection s $
+    (UTxOSelection.fromNonEmpty <$> UTxOSelection.toNonEmpty s)
+    === (if UTxOSelection.isNonEmpty s then Just s else Nothing)
+
+--------------------------------------------------------------------------------
+-- Indicator and accessor functions
+--------------------------------------------------------------------------------
+
+prop_isNonEmpty_selectedSize :: UTxOSelection -> Property
+prop_isNonEmpty_selectedSize s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.isNonEmpty s
+    === (UTxOSelection.selectedSize s > 0)
+
+prop_isNonEmpty_selectedIndex :: UTxOSelection -> Property
+prop_isNonEmpty_selectedIndex s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.isNonEmpty s
+    === not (UTxOIndex.null (UTxOSelection.selectedIndex s))
+
+prop_isNonEmpty_selectedList :: UTxOSelection -> Property
+prop_isNonEmpty_selectedList s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.isNonEmpty s
+    === not (null (UTxOSelection.selectedList s))
+
+prop_leftoverBalance_selectedBalance :: UTxOSelection -> Property
+prop_leftoverBalance_selectedBalance s =
+    checkCoverage_UTxOSelection s $
+    (UTxOSelection.leftoverBalance s <> UTxOSelection.selectedBalance s)
+    ===
+    TokenBundle.add
+        (UTxOIndex.balance (UTxOSelection.leftoverIndex s))
+        (UTxOIndex.balance (UTxOSelection.selectedIndex s))
+
+prop_leftoverSize_selectedSize :: UTxOSelection -> Property
+prop_leftoverSize_selectedSize s =
+    checkCoverage_UTxOSelection s $
+    (UTxOSelection.leftoverSize s + UTxOSelection.selectedSize s)
+    ===
+    (+)
+        (UTxOIndex.size (UTxOSelection.leftoverIndex s))
+        (UTxOIndex.size (UTxOSelection.selectedIndex s))
+
+--------------------------------------------------------------------------------
+-- Modification
+--------------------------------------------------------------------------------
+
+prop_select_empty :: TxIn -> Property
+prop_select_empty i =
+    UTxOSelection.select i UTxOSelection.empty === Nothing
+
+prop_select_isValid :: TxIn -> UTxOSelection -> Property
+prop_select_isValid i s = property $
+    checkCoverage_select i s $
+    maybe True isValidSelectionNonEmpty (UTxOSelection.select i s)
+
+prop_select_isLeftover :: TxIn -> UTxOSelection -> Property
+prop_select_isLeftover i s =
+    checkCoverage_select i s $
+    (UTxOSelection.isLeftover i <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s then Just False else Nothing
+
+prop_select_isSelected :: TxIn -> UTxOSelection -> Property
+prop_select_isSelected i s =
+    checkCoverage_select i s $
+    (UTxOSelection.isSelected i <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s then Just True else Nothing
+
+prop_select_isProperSubSelectionOf :: TxIn -> UTxOSelection -> Property
+prop_select_isProperSubSelectionOf i s =
+    checkCoverage_select i s $
+    (UTxOSelection.isProperSubSelectionOf s <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s then Just True else Nothing
+
+prop_select_leftoverSize :: TxIn -> UTxOSelection -> Property
+prop_select_leftoverSize i s =
+    checkCoverage_select i s $
+    (UTxOSelection.leftoverSize <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s
+    then Just (UTxOSelection.leftoverSize s - 1)
+    else Nothing
+
+prop_select_selectedSize :: TxIn -> UTxOSelection -> Property
+prop_select_selectedSize i s =
+    checkCoverage_select i s $
+    (UTxOSelection.selectedSize <$> UTxOSelection.select i s)
+    ===
+    if UTxOSelection.isLeftover i s
+    then Just (UTxOSelection.selectedSize s + 1)
+    else Nothing
+
+prop_selectMany_isSubSelectionOf :: (TxIn -> Bool) -> UTxOSelection -> Property
+prop_selectMany_isSubSelectionOf f s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.isSubSelectionOf s (UTxOSelection.selectMany toSelect s)
+    === True
+  where
+    toSelect = filter f $ fst <$> UTxOSelection.leftoverList s
+
+prop_selectMany_leftoverSize_all :: UTxOSelection -> Property
+prop_selectMany_leftoverSize_all s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.leftoverSize
+        (UTxOSelection.selectMany (fst <$> UTxOSelection.leftoverList s) s)
+    === 0
+
+prop_selectMany_selectedSize_all :: UTxOSelection -> Property
+prop_selectMany_selectedSize_all s =
+    checkCoverage_UTxOSelection s $
+    UTxOSelection.selectedSize
+        (UTxOSelection.selectMany (fst <$> UTxOSelection.leftoverList s) s)
+    === (UTxOSelection.leftoverSize s + UTxOSelection.selectedSize s)
+
+checkCoverage_select
+    :: Testable prop => TxIn -> UTxOSelection -> (prop -> Property)
+checkCoverage_select i s
+    = checkCoverage
+    . cover 10 (UTxOSelection.isLeftover i s)
+        "in leftover set"
+    . cover 10 (UTxOSelection.isSelected i s)
+        "in selected set"
+    . cover 10 (not (UTxOSelection.isMember i s))
+        "in neither set"
+
+--------------------------------------------------------------------------------
+-- Validity
+--------------------------------------------------------------------------------
+
+isValidSelection :: IsUTxOSelection s => s -> Bool
+isValidSelection s = UTxOIndex.disjoint
+    (UTxOSelection.selectedIndex s)
+    (UTxOSelection.leftoverIndex s)
+
+isValidSelectionNonEmpty :: UTxOSelectionNonEmpty -> Bool
+isValidSelectionNonEmpty s = True
+    && (isValidSelection s)
+    && (UTxOSelection.isNonEmpty s)
+    && (UTxOSelection.selectedSize s > 0)
+    && (UTxOSelection.selectedIndex s /= UTxOIndex.empty)
+    && (not (null (UTxOSelection.selectedList s)))
+
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
+instance Arbitrary TxIn where
+    arbitrary = genTxIn
+    shrink = shrinkTxIn
+
+instance Arbitrary UTxOIndex where
+    arbitrary = genUTxOIndex
+    shrink = shrinkUTxOIndex
+
+instance Arbitrary UTxOSelection where
+    arbitrary = genUTxOSelection
+    shrink = shrinkUTxOSelection
+
+instance Arbitrary UTxOSelectionNonEmpty where
+    arbitrary = genUTxOSelectionNonEmpty
+    shrink = shrinkUTxOSelectionNonEmpty
+
+--------------------------------------------------------------------------------
+-- CoArbitrary instances
+--------------------------------------------------------------------------------
+
+instance CoArbitrary TxIn where
+    coarbitrary = coarbitraryTxIn
+
+--------------------------------------------------------------------------------
+-- Show instances
+--------------------------------------------------------------------------------
+
+instance Show (TxIn -> Bool) where
+    show = const "(TxIn -> Bool)"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -1,6 +1,7 @@
+{-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Primitive.Types.UTxOSelectionSpec
     ( spec

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec.hs
@@ -353,12 +353,12 @@ isValidSelection s = UTxOIndex.disjoint
     (UTxOSelection.leftoverIndex s)
 
 isValidSelectionNonEmpty :: UTxOSelectionNonEmpty -> Bool
-isValidSelectionNonEmpty s = True
-    && (isValidSelection s)
-    && (UTxOSelection.isNonEmpty s)
-    && (UTxOSelection.selectedSize s > 0)
-    && (UTxOSelection.selectedIndex s /= UTxOIndex.empty)
-    && (not (null (UTxOSelection.selectedList s)))
+isValidSelectionNonEmpty s =
+    isValidSelection s
+    && UTxOSelection.isNonEmpty s
+    && UTxOSelection.selectedSize s > 0
+    && UTxOSelection.selectedIndex s /= UTxOIndex.empty
+    && not (null (UTxOSelection.selectedList s))
 
 --------------------------------------------------------------------------------
 -- Arbitrary instances

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec/TypeErrorSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSelectionSpec/TypeErrorSpec.hs
@@ -1,0 +1,43 @@
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+{-# OPTIONS_GHC -fno-warn-deferred-out-of-scope-variables #-}
+{-# OPTIONS_GHC -fno-warn-deferred-type-errors #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-imports #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+
+module Cardano.Wallet.Primitive.Types.UTxOSelectionSpec.TypeErrorSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.Types.UTxOSelection
+    ( UTxOSelection (..), UTxOSelectionNonEmpty (..) )
+import Test.Hspec
+    ( Expectation, Spec, describe, it )
+import Test.ShouldNotTypecheck
+    ( shouldNotTypecheck )
+
+-- The data constructors for 'UTxOSelection' and 'UTxOSelectionNonEmpty' are
+-- not exported, by design, as their internal data structures have invariants
+-- that must be preserved across all operations.
+--
+-- Exporting these constructors would make it possible for functions outside
+-- the 'UTxOSelection' module to break these invariants.
+--
+-- Therefore, we test here that they are not exported.
+--
+spec :: Spec
+spec = describe "UTxOSelection type error tests" $ do
+
+    it "Data constructor is not exported for UTxOSelection"
+        testDataConstructorNotExportedForUTxOSelection
+    it "Data constructor is not exported for UTxOSelectionNonEmpty"
+        testDataConstructorNotExportedForUTxOSelectionNonEmpty
+
+testDataConstructorNotExportedForUTxOSelection :: Expectation
+testDataConstructorNotExportedForUTxOSelection =
+    shouldNotTypecheck UTxOSelection
+
+testDataConstructorNotExportedForUTxOSelectionNonEmpty :: Expectation
+testDataConstructorNotExportedForUTxOSelectionNonEmpty =
+    shouldNotTypecheck UTxOSelectionNonEmpty

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -12,6 +12,10 @@ import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
 import Cardano.Wallet.Primitive.Types.Address.Gen
     ( Parity (..), addressParity, coarbitraryAddress )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn )
+import Cardano.Wallet.Primitive.Types.Tx.Gen
+    ( coarbitraryTxIn )
 import Cardano.Wallet.Primitive.Types.UTxO
     ( UTxO (..), dom, filterByAddress, filterByAddressM, isSubsetOf )
 import Cardano.Wallet.Primitive.Types.UTxO.Gen
@@ -22,10 +26,13 @@ import Data.Generics.Internal.VL.Lens
     ( view )
 import Test.Hspec
     ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
 import Test.QuickCheck
     ( Arbitrary (..)
     , CoArbitrary (..)
     , Property
+    , Testable
     , checkCoverage
     , conjoin
     , cover
@@ -33,6 +40,8 @@ import Test.QuickCheck
     , (===)
     )
 
+import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
+import qualified Data.List as L
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -40,7 +49,21 @@ spec :: Spec
 spec =
     describe "Cardano.Wallet.Primitive.Types.UTxOSpec" $ do
 
-    describe "filterByAddress" $ do
+    parallel $ describe "filtering and partitioning" $ do
+
+        it "prop_filter_disjoint" $
+            property prop_filter_disjoint
+        it "prop_filter_partition" $
+            property prop_filter_partition
+        it "prop_filter_toList" $
+            property prop_filter_toList
+        it "prop_partition_disjoint" $
+            property prop_partition_disjoint
+        it "prop_partition_mappend" $
+            property prop_partition_mappend
+
+    parallel $ describe "filtering by address" $ do
+
         it "matching everything gives us everything" $
             property prop_filterByAddress_matchAll
         it "matching nothing gives us nothing" $
@@ -53,6 +76,61 @@ spec =
             property prop_filterByAddress_filterByAddressM
         it "filterByAddress is always subset" $
             property prop_filterByAddress_isSubset
+
+--------------------------------------------------------------------------------
+-- Filtering and partitioning
+--------------------------------------------------------------------------------
+
+prop_filter_disjoint :: (TxIn -> Bool) -> UTxO -> Property
+prop_filter_disjoint f u =
+    checkCoverage_filter_partition f u $
+    UTxO.filter f u `UTxO.disjoint` UTxO.filter (not . f) u === True
+
+prop_filter_partition :: (TxIn -> Bool) -> UTxO -> Property
+prop_filter_partition f u =
+    checkCoverage_filter_partition f u $
+    (UTxO.filter f u, UTxO.filter (not . f) u) === UTxO.partition f u
+
+prop_filter_toList :: (TxIn -> Bool) -> UTxO -> Property
+prop_filter_toList f u =
+    checkCoverage_filter_partition f u $
+    UTxO.toList (UTxO.filter f u) === L.filter (f . fst) (UTxO.toList u)
+
+prop_partition_disjoint :: (TxIn -> Bool) -> UTxO -> Property
+prop_partition_disjoint f u =
+    checkCoverage_filter_partition f u $
+    uncurry UTxO.disjoint (UTxO.partition f u) === True
+
+prop_partition_mappend :: (TxIn -> Bool) -> UTxO -> Property
+prop_partition_mappend f u =
+    checkCoverage_filter_partition f u $
+    uncurry (<>) (UTxO.partition f u) === u
+
+checkCoverage_filter_partition
+    :: Testable prop => (TxIn -> Bool) -> UTxO -> (prop -> Property)
+checkCoverage_filter_partition f u
+    = checkCoverage
+    . cover 10
+        (UTxO.filter f u `isNonEmptyProperSubsetOf` u)
+        "UTxO.filter f u `isNonEmptyProperSubsetOf` u"
+    . cover 10
+        (UTxO.filter (not . f) u `isNonEmptyProperSubsetOf` u)
+        "UTxO.filter (not . f) u `isNonEmptyProperSubsetOf` u"
+    . cover 10
+        (UTxO.size (UTxO.filter f u) > UTxO.size (UTxO.filter (not . f) u))
+        "UTxO.size (UTxO.filter f u) > UTxO.size (UTxO.filter (not . f) u)"
+    . cover 10
+        (UTxO.size (UTxO.filter f u) < UTxO.size (UTxO.filter (not . f) u))
+        "UTxO.size (UTxO.filter f u) < UTxO.size (UTxO.filter (not . f) u)"
+  where
+    u1 `isNonEmptyProperSubsetOf` u2 = True
+        && (not (UTxO.null u1))
+        && (u1 `UTxO.isSubsetOf` u2)
+        && (u1 /= u2)
+
+--------------------------------------------------------------------------------
+-- Filtering by address
+--------------------------------------------------------------------------------
 
 prop_filterByAddress_matchAll :: UTxO -> Property
 prop_filterByAddress_matchAll u =
@@ -115,12 +193,26 @@ prop_filterByAddress_isSubset u f =
         (filterByAddress f u /= mempty)
         (dom (filterByAddress f u) `Set.isProperSubsetOf` dom u)
 
+--------------------------------------------------------------------------------
+-- Arbitrary instances
+--------------------------------------------------------------------------------
+
 instance CoArbitrary Address where
     coarbitrary = coarbitraryAddress
 
-instance Show (Address -> Bool) where
-    show = const "(Address -> Bool)"
+instance CoArbitrary TxIn where
+    coarbitrary = coarbitraryTxIn
 
 instance Arbitrary UTxO where
     arbitrary = genUTxO
     shrink = shrinkUTxO
+
+--------------------------------------------------------------------------------
+-- Show instances
+--------------------------------------------------------------------------------
+
+instance Show (Address -> Bool) where
+    show = const "(Address -> Bool)"
+
+instance Show (TxIn -> Bool) where
+    show = const "(TxIn -> Bool)"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -123,10 +123,10 @@ checkCoverage_filter_partition f u
         (UTxO.size (UTxO.filter f u) < UTxO.size (UTxO.filter (not . f) u))
         "UTxO.size (UTxO.filter f u) < UTxO.size (UTxO.filter (not . f) u)"
   where
-    u1 `isNonEmptyProperSubsetOf` u2 = True
-        && (not (UTxO.null u1))
-        && (u1 `UTxO.isSubsetOf` u2)
-        && (u1 /= u2)
+    u1 `isNonEmptyProperSubsetOf` u2 =
+        not (UTxO.null u1)
+        && u1 `UTxO.isSubsetOf` u2
+        && u1 /= u2
 
 --------------------------------------------------------------------------------
 -- Filtering by address

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/Types/UTxOSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{- HLINT ignore "Use camelCase" -}
 
 module Cardano.Wallet.Primitive.Types.UTxOSpec
     ( spec

--- a/lib/test-utils/src/Test/QuickCheck/Extra.hs
+++ b/lib/test-utils/src/Test/QuickCheck/Extra.hs
@@ -10,7 +10,8 @@
 module Test.QuickCheck.Extra
     (
       -- * Generation
-      genMapWith
+      genFunction
+    , genMapWith
     , genSized2
     , genSized2With
     , reasonablySized
@@ -58,6 +59,8 @@ import Test.QuickCheck
     , suchThat
     , (.&&.)
     )
+import Test.QuickCheck.Gen.Unsafe
+    ( promote )
 import Test.Utils.Pretty
     ( pShowBuilder )
 
@@ -244,6 +247,17 @@ shrinkInterleaved (a, shrinkA) (b, shrinkB) = interleave
     interleave (x : xs) (y : ys) = x : y : interleave xs ys
     interleave xs [] = xs
     interleave [] ys = ys
+
+--------------------------------------------------------------------------------
+-- Generating functions
+--------------------------------------------------------------------------------
+
+-- | Generates a function.
+--
+-- This is based on the implementation of 'Arbitrary' for 'a -> b'.
+--
+genFunction :: (a -> Gen b -> Gen b) -> Gen b -> Gen (a -> b)
+genFunction coarbitraryFn gen = promote (`coarbitraryFn` gen)
 
 --------------------------------------------------------------------------------
 -- Generating and shrinking key-value maps


### PR DESCRIPTION
## Issue Number

ADP-1118

## Summary

This PR introduces the `UTxOSelection` and `UTxOSelectionNonEmpty` types, which represent in-progress selections of entries from a UTxO set.

These types have the following characteristics:
- `UTxOSelection`
  a selection where the selected set may be empty
- `UTxOSelectionNonEmpty`
  a selection where the selected set cannot be empty

Both types share the same internal state:

```hs
data State = State
    { leftover :: !UTxOIndex
      -- ^ UTxOs that have not yet been selected.
    , selected :: !UTxOIndex
      -- ^ UTxOs that have already been selected.
    }
```

The non-emptiness of a UTxO selection is an important post-condition of `Balance.runSelection`, so this PR uses this type to remove some run-time assertions from the `Balance` module. (These assertions are moved to the `UTxOSelection` module, where they are tested with property tests.)

Additionally, this PR:
- uses the `UTxOSelection` and `UTxOSelectionNonEmpty` types to replace the use of `SelectionState` within `CoinSelection.Balance`.
- removes the now-redundant run-time assertions for a non-empty selection from `Balance`, as the `UTxOSelectionNonEmpty` type handles this internally.

## Follow-on work

Adjust `Balance.performSelection` to accept a `UTxOSelection` as part of the `SelectionParams` instead of the existing `utxoAvailable :: UTxOIndex` field. With a few adjustments, this will allow `performSelection` to be called with existing inputs.