### PR TITLE
Add `collateral` field to result of `CoinSelection.performSelection`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -298,17 +298,17 @@ import Cardano.Wallet.Primitive.CoinSelection
     , SelectionConstraints (..)
     , SelectionError (..)
     , SelectionParams (..)
+    , SelectionReportDetailed
+    , SelectionReportSummarized
+    , makeSelectionReportDetailed
+    , makeSelectionReportSummarized
     , performSelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionReportDetailed
-    , SelectionReportSummarized
-    , SelectionResult
+    ( SelectionResult
     , SelectionResultOf (..)
     , UnableToConstructChangeError (..)
     , emptySkeleton
-    , makeSelectionReportDetailed
-    , makeSelectionReportSummarized
     )
 import Cardano.Wallet.Primitive.Migration
     ( MigrationPlan (..) )

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -130,7 +130,7 @@ module Cardano.Wallet
     -- ** Migration
     , createMigrationPlan
     , migrationPlanToSelectionWithdrawals
-    , SelectionResultWithoutChange
+    , SelectionWithoutChange
     , ErrCreateMigrationPlan (..)
 
     -- ** Delegation
@@ -295,8 +295,10 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     )
 import Cardano.Wallet.Primitive.CoinSelection
     ( ErrPrepareOutputs (..)
+    , Selection
     , SelectionConstraints (..)
     , SelectionError (..)
+    , SelectionOf (..)
     , SelectionParams (..)
     , SelectionReportDetailed
     , SelectionReportSummarized
@@ -305,11 +307,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , performSelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResult
-    , SelectionResultOf (..)
-    , UnableToConstructChangeError (..)
-    , emptySkeleton
-    )
+    ( UnableToConstructChangeError (..), emptySkeleton )
 import Cardano.Wallet.Primitive.Migration
     ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
@@ -1261,14 +1259,14 @@ normalizeDelegationAddress s addr = do
 assignChangeAddresses
     :: forall s. GenChange s
     => ArgGenChange s
-    -> SelectionResult TokenBundle
+    -> Selection
     -> s
-    -> (SelectionResult TxOut, s)
+    -> (SelectionOf TxOut, s)
 assignChangeAddresses argGenChange sel = runState $ do
-    changeOuts <- forM (changeGenerated sel) $ \bundle -> do
+    changeOuts <- forM (view #change sel) $ \bundle -> do
         addr <- state (genChange argGenChange)
         pure $ TxOut addr bundle
-    pure $ sel { changeGenerated = changeOuts }
+    pure $ sel { change = changeOuts }
 
 assignChangeAddressesAndUpdateDb
     :: forall ctx s k.
@@ -1278,8 +1276,8 @@ assignChangeAddressesAndUpdateDb
     => ctx
     -> WalletId
     -> ArgGenChange s
-    -> SelectionResult TokenBundle
-    -> ExceptT ErrSignPayment IO (SelectionResult TxOut)
+    -> Selection
+    -> ExceptT ErrSignPayment IO (SelectionOf TxOut)
 assignChangeAddressesAndUpdateDb ctx wid generateChange selection =
     db & \DBLayer{..} -> mapExceptT atomically $ do
         cp <- withExceptT ErrSignPaymentNoSuchWallet $
@@ -1300,8 +1298,8 @@ assignChangeAddressesWithoutDbUpdate
     => ctx
     -> WalletId
     -> ArgGenChange s
-    -> SelectionResult TokenBundle
-    -> ExceptT ErrConstructTx IO (SelectionResult TxOut)
+    -> Selection
+    -> ExceptT ErrConstructTx IO (SelectionOf TxOut)
 assignChangeAddressesWithoutDbUpdate ctx wid generateChange selection =
     db & \DBLayer{..} -> mapExceptT atomically $ do
         cp <- withExceptT ErrConstructTxNoSuchWallet $
@@ -1321,28 +1319,23 @@ selectionToUnsignedTx
         , withdrawal ~ (RewardAccount, Coin, NonEmpty DerivationIndex)
         )
     => Withdrawal
-    -> SelectionResult TxOut
+    -> SelectionOf TxOut
     -> s
     -> (UnsignedTx input output change withdrawal)
 selectionToUnsignedTx wdrl sel s =
     UnsignedTx
         { unsignedInputs =
-            fullyQualifiedInputs $ inputsSelected sel
+            fullyQualifiedInputs $ view #inputs sel
         , unsignedOutputs =
-            outputsCovered sel
+            view #outputs sel
         , unsignedChange =
-            fullyQualifiedChange $ changeGenerated sel
+            fullyQualifiedChange $ view #change sel
         , unsignedCollateral =
-            fullyQualifiedInputs collateral
+            fullyQualifiedInputs $ view #collateral sel
         , unsignedWithdrawals =
             fullyQualifiedWithdrawal wdrl
         }
   where
-    collateral :: [(TxIn, TxOut)]
-    collateral =
-        -- TODO: (ADP-957)
-        []
-
     qualifyAddresses
         :: forall a t. (Traversable t)
         => (a -> Address)
@@ -1428,7 +1421,7 @@ selectAssets
     -> (UTxOIndex, Wallet s, Set Tx)
     -> TransactionCtx
     -> [TxOut]
-    -> (s -> SelectionResult TokenBundle -> result)
+    -> (s -> Selection -> result)
     -> ExceptT ErrSelectAssets IO result
 selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
     guardPendingWithdrawal
@@ -1532,7 +1525,7 @@ buildAndSignTransaction
        -- ^ Reward account derived from the root key (or somewhere else).
     -> Passphrase "raw"
     -> TransactionCtx
-    -> SelectionResult TxOut
+    -> SelectionOf TxOut
     -> ExceptT ErrSignPayment IO (Tx, TxMeta, UTCTime, SealedTx)
 buildAndSignTransaction ctx wid mkRwdAcct pwd txCtx sel = db & \DBLayer{..} -> do
     era <- liftIO $ currentNodeEra nl
@@ -1569,7 +1562,7 @@ constructTransaction
     => ctx
     -> WalletId
     -> TransactionCtx
-    -> SelectionResult TxOut
+    -> SelectionOf TxOut
     -> ExceptT ErrConstructTx IO SealedTx
 constructTransaction ctx wid txCtx sel = db & \DBLayer{..} -> do
     era <- liftIO $ currentNodeEra nl
@@ -1615,17 +1608,17 @@ mkTxMeta
     -> BlockHeader
     -> s
     -> TransactionCtx
-    -> SelectionResult TxOut
+    -> SelectionOf TxOut
     -> IO (UTCTime, TxMeta)
 mkTxMeta ti' blockHeader wState txCtx sel =
     let
         amtOuts = sumCoins $
-            (txOutCoin <$> changeGenerated sel)
+            (txOutCoin <$> view #change sel)
             ++
-            mapMaybe ourCoin (outputsCovered sel)
+            mapMaybe ourCoin (view #outputs sel)
 
         amtInps
-            = sumCoins (txOutCoin . snd <$> inputsSelected sel)
+            = sumCoins (txOutCoin . snd <$> view #inputs sel)
             -- NOTE: In case where rewards were pulled from an external
             -- source, they aren't added to the calculation because the
             -- money is considered to come from outside of the wallet; which
@@ -1915,13 +1908,13 @@ createMigrationPlan ctx wid rewardWithdrawal = do
     nl = ctx ^. networkLayer
     tl = ctx ^. transactionLayer @k
 
-type SelectionResultWithoutChange = SelectionResult Void
+type SelectionWithoutChange = SelectionOf Void
 
 migrationPlanToSelectionWithdrawals
     :: MigrationPlan
     -> Withdrawal
     -> NonEmpty Address
-    -> Maybe (NonEmpty (SelectionResultWithoutChange, Withdrawal))
+    -> Maybe (NonEmpty (SelectionWithoutChange, Withdrawal))
 migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
     = NE.nonEmpty
     $ L.reverse
@@ -1933,19 +1926,20 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
   where
     accumulate
         :: Migration.Selection (TxIn, TxOut)
-        -> ([(SelectionResultWithoutChange, Withdrawal)], [Address])
-        -> ([(SelectionResultWithoutChange, Withdrawal)], [Address])
+        -> ([(SelectionWithoutChange, Withdrawal)], [Address])
+        -> ([(SelectionWithoutChange, Withdrawal)], [Address])
     accumulate migrationSelection (selectionWithdrawals, outputAddresses) =
         ( (selection, withdrawal) : selectionWithdrawals
         , outputAddressesRemaining
         )
       where
-        selection = SelectionResult
-            { inputsSelected = view #inputIds migrationSelection
-            , outputsCovered
+        selection = Selection
+            { inputs = view #inputIds migrationSelection
+            , collateral = []
+            , outputs
             , extraCoinSource
             , extraCoinSink = Coin 0
-            , changeGenerated = []
+            , change = []
             , assetsToMint = TokenMap.empty
             , assetsToBurn = TokenMap.empty
             }
@@ -1972,14 +1966,14 @@ migrationPlanToSelectionWithdrawals plan rewardWithdrawal outputAddressesToCycle
             then rewardWithdrawal
             else NoWithdrawal
 
-        outputsCovered :: [TxOut]
-        outputsCovered = zipWith TxOut
+        outputs :: [TxOut]
+        outputs = zipWith TxOut
             (outputAddresses)
             (NE.toList $ view #outputs migrationSelection)
 
         outputAddressesRemaining :: [Address]
         outputAddressesRemaining =
-            drop (length outputsCovered) outputAddresses
+            drop (length outputs) outputAddresses
 
 {-------------------------------------------------------------------------------
                                   Delegation

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -94,7 +94,6 @@ import Numeric.Natural
     ( Natural )
 
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
-import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
@@ -438,8 +437,6 @@ data SelectionReport = SelectionReport
 --
 data SelectionReportSummarized = SelectionReportSummarized
     { computedFee :: Coin
-    , totalAdaBalanceIn :: Coin
-    , totalAdaBalanceOut :: Coin
     , adaBalanceOfSelectedInputs :: Coin
     , adaBalanceOfExtraCoinSource :: Coin
     , adaBalanceOfExtraCoinSink :: Coin
@@ -482,11 +479,7 @@ makeSelectionReportSummarized :: Selection -> SelectionReportSummarized
 makeSelectionReportSummarized s = SelectionReportSummarized {..}
   where
     computedFee
-        = Coin.distance totalAdaBalanceIn totalAdaBalanceOut
-    totalAdaBalanceIn
-        = adaBalanceOfSelectedInputs <> adaBalanceOfExtraCoinSource
-    totalAdaBalanceOut
-        = adaBalanceOfGeneratedChangeOutputs <> adaBalanceOfRequestedOutputs
+        = selectionDelta TokenBundle.getCoin s
     adaBalanceOfSelectedInputs
         = F.foldMap (view (#tokens . #coin) . snd) $ view #inputs s
     adaBalanceOfExtraCoinSource

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -446,6 +446,7 @@ data SelectionReportSummarized = SelectionReportSummarized
     , adaBalanceOfRequestedOutputs :: Coin
     , adaBalanceOfGeneratedChangeOutputs :: Coin
     , numberOfSelectedInputs :: Int
+    , numberOfSelectedCollateralInputs :: Int
     , numberOfRequestedOutputs :: Int
     , numberOfGeneratedChangeOutputs :: Int
     , numberOfUniqueNonAdaAssetsInSelectedInputs :: Int
@@ -458,6 +459,7 @@ data SelectionReportSummarized = SelectionReportSummarized
 --
 data SelectionReportDetailed = SelectionReportDetailed
     { selectedInputs :: [(TxIn, TxOut)]
+    , selectedCollateral :: [(TxIn, TxOut)]
     , requestedOutputs :: [TxOut]
     , generatedChangeOutputs :: [TokenBundle.Flat TokenBundle]
     }
@@ -497,6 +499,8 @@ makeSelectionReportSummarized s = SelectionReportSummarized {..}
         = F.foldMap (view (#tokens . #coin)) $ view #outputs s
     numberOfSelectedInputs
         = length $ view #inputs s
+    numberOfSelectedCollateralInputs
+        = length $ view #collateral s
     numberOfRequestedOutputs
         = length $ view #outputs s
     numberOfGeneratedChangeOutputs
@@ -518,6 +522,8 @@ makeSelectionReportDetailed :: Selection -> SelectionReportDetailed
 makeSelectionReportDetailed s = SelectionReportDetailed
     { selectedInputs
         = F.toList $ view #inputs s
+    , selectedCollateral
+        = F.toList $ view #collateral s
     , requestedOutputs
         = view #outputs s
     , generatedChangeOutputs

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -176,7 +176,7 @@ toBalanceConstraintsParams (constraints, params) =
 -- Adjust this function to accept the result of a collateral selection as a
 -- parameter.
 --
-mkSelection :: Balance.SelectionResult TokenBundle -> Selection
+mkSelection :: Balance.SelectionResult -> Selection
 mkSelection balanceResult = Selection
     { inputs = view #inputsSelected balanceResult
     , collateral = [] --TODO: [ADP-1037]
@@ -188,7 +188,7 @@ mkSelection balanceResult = Selection
     , extraCoinSink = view #extraCoinSink balanceResult
     }
 
-toBalanceSelection :: Selection -> Balance.SelectionResult TokenBundle
+toBalanceSelection :: Selection -> Balance.SelectionResult
 toBalanceSelection selection = Balance.SelectionResult
     { inputsSelected = view #inputs selection
     , outputsCovered = view #outputs selection

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -48,10 +48,10 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
 
     -- * Querying selections
     , SelectionDelta (..)
-    , selectionDelta
     , selectionDeltaAllAssets
     , selectionDeltaCoin
     , selectionHasValidSurplus
+    , selectionSurplusCoin
     , selectionMinimumCost
     , selectionSkeleton
 
@@ -571,24 +571,11 @@ selectionHasValidSurplus constraints selection =
 -- a deficit.
 --
 selectionSurplusCoin
-    :: Foldable f
-    => SelectionResultOf (f TxOut) TokenBundle
-    -> Coin
+    :: Foldable f => SelectionResultOf (f TxOut) -> Coin
 selectionSurplusCoin result =
     case selectionDeltaCoin result of
         SelectionSurplus surplus -> surplus
         SelectionDeficit _       -> Coin 0
-
--- | TODO: Deprecated. See 'selectionSurplusCoin'.
---
-selectionDelta
-    :: (change -> Coin)
-    -- ^ A function to extract the coin value from a change output.
-    -> SelectionResult change
-    -> Coin
-selectionDelta getChangeCoin
-    = selectionSurplusCoin
-    . over #changeGenerated (fmap (TokenBundle.fromCoin . getChangeCoin))
 
 -- | Converts a selection into a skeleton.
 --

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -42,8 +42,10 @@ import Cardano.Api
     ( AnyCardanoEra )
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationIndex, Passphrase )
+import Cardano.Wallet.Primitive.CoinSelection
+    ( SelectionOf (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionLimit, SelectionResult, SelectionSkeleton )
+    ( SelectionLimit, SelectionSkeleton )
 import Cardano.Wallet.Primitive.Slotting
     ( PastHorizonException )
 import Cardano.Wallet.Primitive.Types
@@ -90,7 +92,7 @@ data TransactionLayer k tx = TransactionLayer
             -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
-        -> SelectionResult TxOut
+        -> SelectionOf TxOut
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction (Tx, tx)
@@ -111,7 +113,7 @@ data TransactionLayer k tx = TransactionLayer
             -- Current protocol parameters
         -> TransactionCtx
             -- An additional context about the transaction
-        -> SelectionResult TxOut
+        -> SelectionOf TxOut
             -- A balanced coin selection where all change addresses have been
             -- assigned.
         -> Either ErrMkTransaction tx

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -604,8 +604,7 @@ prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
 --
 -- We define this type alias to shorten type signatures.
 --
-type PerformSelectionResult =
-    Either SelectionError (SelectionResult TokenBundle)
+type PerformSelectionResult = Either SelectionError SelectionResult
 
 genSelectionParams :: Gen UTxOIndex -> Gen SelectionParams
 genSelectionParams genUTxOIndex' = do
@@ -1126,10 +1125,10 @@ prop_performSelectionEmpty mockConstraints (Small params) =
     paramsTransformed :: SelectionParamsOf (NonEmpty TxOut)
     paramsTransformed = view #paramsTransformed report
 
-    result :: SelectionResultOf (NonEmpty TxOut) TokenBundle
+    result :: SelectionResultOf (NonEmpty TxOut)
     result = expectRight $ view #result report
 
-    resultTransformed :: SelectionResultOf [TxOut] TokenBundle
+    resultTransformed :: SelectionResultOf [TxOut]
     resultTransformed = expectRight $ view #resultTransformed report
 
     -- Provides a report of how 'performSelectionEmpty' has transformed
@@ -1172,18 +1171,17 @@ withTransformationReport p r = TransformationReport p r r
 --    - a single input to cover the cost and input deficit.
 --    - a single change output to cover the output deficit.
 --
-mockPerformSelectionNonEmpty
-    :: PerformSelection Identity (NonEmpty TxOut) TokenBundle
+mockPerformSelectionNonEmpty :: PerformSelection Identity (NonEmpty TxOut)
 mockPerformSelectionNonEmpty constraints params = Identity $ Right result
   where
-    result :: SelectionResultOf (NonEmpty TxOut) TokenBundle
+    result :: SelectionResultOf (NonEmpty TxOut)
     result = resultWithoutDelta & set #inputsSelected
         (makeInputsOfValue $ deficitIn <> TokenBundle.fromCoin minimumCost)
       where
         minimumCost :: Coin
         minimumCost = selectionMinimumCost constraints resultWithoutDelta
 
-    resultWithoutDelta :: SelectionResultOf (NonEmpty TxOut) TokenBundle
+    resultWithoutDelta :: SelectionResultOf (NonEmpty TxOut)
     resultWithoutDelta = SelectionResult
         { inputsSelected = makeInputsOfValue deficitIn
         , changeGenerated = makeChangeOfValue deficitOut
@@ -1668,7 +1666,7 @@ encodeBoundaryTestCriteria c = SelectionParams
     dummyTxIns :: [TxIn]
     dummyTxIns = [TxIn (Hash "") x | x <- [0 ..]]
 
-decodeBoundaryTestResult :: SelectionResult TokenBundle -> BoundaryTestResult
+decodeBoundaryTestResult :: SelectionResult -> BoundaryTestResult
 decodeBoundaryTestResult r = BoundaryTestResult
     { boundaryTestInputs = L.sort $ NE.toList $
         TokenBundle.toFlatList . view #tokens . snd <$> view #inputsSelected r

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -102,7 +102,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Sequential
     , mkSeqAnyState
     , purposeCIP1852
     )
-import Cardano.Wallet.Primitive.CoinSelection.Balance
+import Cardano.Wallet.Primitive.CoinSelection
     ( selectionDelta )
 import Cardano.Wallet.Primitive.Model
     ( Wallet, currentTip, getState, totalUTxO )

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -65,13 +65,9 @@ import Cardano.Wallet.Primitive.AddressDerivation.Icarus
 import Cardano.Wallet.Primitive.AddressDerivation.Shelley
     ( ShelleyKey )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( SelectionError (..) )
+    ( SelectionError (..), SelectionOf (..), selectionDelta )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionResultOf (..)
-    , UnableToConstructChangeError (..)
-    , emptySkeleton
-    , selectionDelta
-    )
+    ( UnableToConstructChangeError (..), emptySkeleton )
 import Cardano.Wallet.Primitive.Types
     ( ExecutionUnitPrices (..)
     , ExecutionUnits (..)
@@ -832,12 +828,13 @@ binaryCalculationsSpec' era = describe ("calculateBinary - "+||era||+"") $ do
           addrWits = zipWith (mkByronWitness' unsigned) inps pairs
           fee = toCardanoLovelace $ selectionDelta txOutCoin cs
           Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee
-          cs = SelectionResult
-            { inputsSelected = NE.fromList inps
+          cs = Selection
+            { inputs = NE.fromList inps
+            , collateral = []
             , extraCoinSource = Coin 0
             , extraCoinSink = Coin 0
-            , outputsCovered = outs
-            , changeGenerated = chgs
+            , outputs = outs
+            , change = chgs
             , assetsToMint = mempty
             , assetsToBurn = mempty
             }
@@ -913,12 +910,13 @@ makeShelleyTx era testCase = Cardano.makeSignedTransaction addrWits unsigned
     fee = toCardanoLovelace $ selectionDelta txOutCoin cs
     Right unsigned = mkUnsignedTx era slotNo cs md mempty [] fee
     addrWits = map (mkShelleyWitness unsigned) pairs
-    cs = SelectionResult
-        { inputsSelected = NE.fromList inps
+    cs = Selection
+        { inputs = NE.fromList inps
+        , collateral = []
         , extraCoinSource = Coin 0
         , extraCoinSink = Coin 0
-        , outputsCovered = []
-        , changeGenerated = outs
+        , outputs = []
+        , change = outs
         -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty
@@ -949,12 +947,13 @@ makeByronTx era testCase = Cardano.makeSignedTransaction byronWits unsigned
     Right unsigned = mkUnsignedTx era slotNo cs Nothing mempty [] fee
     -- byronWits = map (mkByronWitness unsigned ntwrk Nothing) pairs
     byronWits = map (error "makeByronTx: broken") pairs  -- TODO: [ADP-919]
-    cs = SelectionResult
-        { inputsSelected = NE.fromList inps
+    cs = Selection
+        { inputs = NE.fromList inps
+        , collateral = []
         , extraCoinSource = Coin 0
         , extraCoinSink = Coin 0
-        , outputsCovered = []
-        , changeGenerated = outs
+        , outputs = []
+        , change = outs
         -- TODO: [ADP-346]
         , assetsToMint = TokenMap.empty
         , assetsToBurn = TokenMap.empty


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR:
- Adds a `collateral` field to the record returned by `CoinSelection.performSelection`.
- Adjusts `SelectionReport{Detailed,Summarized}` to include a report of collateral inputs.
- Removes a now-redundant type parameter from the `CoinSelection.Balance.SelectionResult` type.
- Fixes a small bug with the `computedFee` field of `SelectionReportSummarized`.