### PR TITLE
Make dummyAddress 57 bytes instead of 65

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Byron/Migrations.hs
@@ -134,7 +134,7 @@ spec = describe "BYRON_MIGRATIONS" $ do
             verify response
                 [ expectResponseCode HTTP.status202
                 , expectField (#totalFee . #getQuantity)
-                    (`shouldBe` 334_700)
+                    (`shouldBe` 333_900)
                 , expectField (#selections)
                     ((`shouldBe` 1) . length)
                 , expectField (#balanceSelected . #ada . #getQuantity)
@@ -305,7 +305,7 @@ spec = describe "BYRON_MIGRATIONS" $ do
             [ expectResponseCode HTTP.status202
             , expectField
                 (#totalFee . #getQuantity)
-                (`shouldBe` 2_461_400)
+                (`shouldBe` 2_459_800)
             , expectField
                 (#selections)
                 ((`shouldBe` 2) . length)
@@ -396,7 +396,7 @@ spec = describe "BYRON_MIGRATIONS" $ do
         $ \ctx -> forM_ [fixtureRandomWallet, fixtureIcarusWallet]
         $ \fixtureByronWallet -> runResourceT @IO $ do
 
-            let feeExpected = 334_700
+            let feeExpected = 333_900
 
             -- Restore a source wallet with funds.
             sourceWallet <- fixtureByronWallet ctx

--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Migrations.hs
@@ -142,7 +142,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             verify response
                 [ expectResponseCode HTTP.status202
                 , expectField (#totalFee . #getQuantity)
-                    (`shouldBe` 255_700)
+                    (`shouldBe` 254_900)
                 , expectField (#selections)
                     ((`shouldBe` 1) . length)
                 , expectField (#balanceSelected . #ada . #getQuantity)
@@ -306,7 +306,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             verify response
                 [ expectResponseCode HTTP.status202
                 , expectField (#totalFee . #getQuantity)
-                    (`shouldBe` 139_800)
+                    (`shouldBe` 139_000)
                 , expectField (#selections)
                     ((`shouldBe` 1) . length)
                 , expectField (#selections)
@@ -614,7 +614,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
             [ expectResponseCode HTTP.status202
             , expectField
                 (#totalFee . #getQuantity)
-                (`shouldBe` 3_121_400)
+                (`shouldBe` 3_119_800)
             , expectField
                 (#selections)
                 ((`shouldBe` 2) . length)
@@ -703,7 +703,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
         \Actual fee for migration is identical to predicted fee."
         $ \ctx -> runResourceT @IO $ do
 
-            let feeExpected = 255_700
+            let feeExpected = 254_900
 
             -- Restore a source wallet with funds:
             sourceWallet <- fixtureWallet ctx
@@ -864,7 +864,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     (\(ApiTypes.ApiAddress addrId _ _) -> addrId)
 
             -- Compute the expected migration plan:
-            let feeExpected = 255_300
+            let feeExpected = 254_500
             responsePlan <- request @(ApiWalletMigrationPlan n) ctx
                 (Link.createMigrationPlan @'Shelley sourceWallet) Default
                 (Json [json|{addresses: #{targetAddressIds}}|])
@@ -958,7 +958,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                     }|]
 
             -- Verify the fee is as expected:
-            let expectedFee = 139_800
+            let expectedFee = 139_000
             verify responseMigrate
                 [ expectResponseCode HTTP.status202
                 , expectField id ((`shouldBe` 1) . length)
@@ -1039,7 +1039,7 @@ spec = describe "SHELLEY_MIGRATIONS" $ do
                 Json [json|{addresses: #{targetAddressIds}}|]
 
             -- Verify the plan is as expected:
-            let expectedFee = 191_600
+            let expectedFee = 190_800
             verify responsePlan
                 [ expectResponseCode HTTP.status202
                 , expectField (#totalFee . #getQuantity)

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Transaction.hs
@@ -731,11 +731,10 @@ txConstraints protocolParams witnessTag = TxConstraints
         dummyAddress = Address $ BS.replicate dummyAddressLength nullByte
 
         dummyAddressLength :: Int
-        dummyAddressLength = 65
-        -- Note: This is almost certainly too high. However, we are at liberty
-        -- to overestimate the length of an address (which is safe). Therefore,
-        -- we can choose a length that we know is greater than or equal to all
-        -- address lengths.
+        dummyAddressLength = 57
+        -- Note: We are at liberty to overestimate the length of an address
+        -- (which is safe). Therefore, we can choose a length that we know is
+        -- greater than or equal to all address lengths.
 
         nullByte :: Word8
         nullByte = 0

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -196,7 +196,6 @@ import Test.Hspec
     , pendingWith
     , shouldBe
     , xdescribe
-    , xit
     )
 import Test.Hspec.QuickCheck
     ( prop )
@@ -322,11 +321,11 @@ decodeSealedTxSpec = describe "SealedTx serialisation/deserialisation" $ do
 estimateMaxInputsSpec :: Spec
 estimateMaxInputsSpec = do
     estimateMaxInputsTests @ShelleyKey
-        [(1,114),(5,109),(10,103),(20,91),(50,51)]
+        [(1,115),(5,109),(10,104),(20,93),(50,54)]
     estimateMaxInputsTests @ByronKey
-        [(1,73),(5,69),(10,65),(20,56),(50,27)]
+        [(1,73),(5,69),(10,65),(20,57),(50,29)]
     estimateMaxInputsTests @IcarusKey
-        [(1,73),(5,69),(10,65),(20,56),(50,27)]
+        [(1,73),(5,69),(10,65),(20,57),(50,29)]
 
 feeCalculationSpec :: Spec
 feeCalculationSpec = describe "fee calculations" $ do
@@ -1084,7 +1083,7 @@ instance Arbitrary Coin where
 instance Arbitrary TxOut where
     arbitrary = TxOut addr <$> scale (`mod` 4) genTokenBundleSmallRange
       where
-        addr = Address $ BS.pack (1:replicate 64 0)
+        addr = Address $ BS.pack (1:replicate 56 0)
 
 instance Arbitrary TokenBundle where
     arbitrary = genTokenBundleSmallRange
@@ -1103,7 +1102,7 @@ instance Arbitrary UTxO where
     arbitrary = do
         n <- choose (1,10)
         inps <- vectorOf n arbitrary
-        let addr = Address $ BS.pack (1:replicate 64 0)
+        let addr = Address $ BS.pack (1:replicate 56 0)
         coins <- vectorOf n arbitrary
         let outs = map (TxOut addr) coins
         pure $ UTxO $ Map.fromList $ zip inps outs
@@ -1148,7 +1147,7 @@ instance Arbitrary (Quantity "byte" Word16) where
 
 dummyAddress :: Word8 -> Address
 dummyAddress b =
-    Address $ BS.pack $ 1 : replicate 64 b
+    Address $ BS.pack $ 1 : replicate 56 b
 
 coinToBundle :: Word64 -> TokenBundle
 coinToBundle = TokenBundle.fromCoin . Coin
@@ -1628,8 +1627,7 @@ updateSealedTxSpec :: Spec
 updateSealedTxSpec = do
     describe "updateSealedTx" $ do
         describe "no existing key witnesses" $ do
-            -- TODO: [ADP-1140] dummyAddress has wrong length and gets cut off.
-            xit "combines ins, outs and sets new fee"
+            it "combines ins, outs and sets new fee"
                 $ property prop_updateSealedTx
 
             -- TODO [ADP-1140]: These should be mergable with the property


### PR DESCRIPTION
- [x] Decrease length of dummyAddress from 65 bytes to 57 bytes (from 32 byte hashes to 28 byte hashes), used by `txConstraints` / migration coin selection, and `TransactionSpec` tests.
- [x] Update various golden tests 
- [x] Enable the updateSealedTx property 

### Motivation

`prop_updateSealedTx` was failing because addresses were not roundtripping between wallet and cardano-api types. I presume this was because our dummy addresses were of length 65 bytes (1+32+32) whereas shelley key hashes ended up having length 28, i.e. 57 bytes (1+28+28) for a normal base address.

### Comments

Follow-up to #2914 

<!-- Additional comments, links, or screenshots to attach, if any. -->

### Issue Number

ADP-1140

<!-- Reference the Jira/GitHub issue that this PR relates to, and which requirements it tackles.
  Note: Jira issues of the form ADP- will be auto-linked. -->
