### PR TITLE
Fix description of `--ttl` option

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -1458,7 +1458,7 @@ timeToLiveOption = optional $ fmap Quantity $ optionT $ mempty
     <> metavar "DURATION"
     <> help ("Time-to-live value. "
              <> "Expressed in seconds with a trailing 's'. "
-             <> "Default is 3600s (2 hours).")
+             <> "Default is 7200s (2 hours).")
 
 -- | <address=ADDRESS>
 addressIdArgument :: Parser Text

--- a/lib/cli/test/data/Cardano/CLISpec/transaction create --help
+++ b/lib/cli/test/data/Cardano/CLISpec/transaction create --help
@@ -16,4 +16,4 @@ Available options:
                            cardano-wallet OpenAPI specification.
   --ttl DURATION           Time-to-live value. Expressed in
                            seconds with a trailing 's'. Default
-                           is 3600s (2 hours).
+                           is 7200s (2 hours).

--- a/lib/cli/test/data/Cardano/CLISpec/transaction fees --help
+++ b/lib/cli/test/data/Cardano/CLISpec/transaction fees --help
@@ -16,4 +16,4 @@ Available options:
                            cardano-wallet OpenAPI specification.
   --ttl DURATION           Time-to-live value. Expressed in
                            seconds with a trailing 's'. Default
-                           is 3600s (2 hours).
+                           is 7200s (2 hours).


### PR DESCRIPTION
This pull request fixes a small issue with the documentation of the `--ttl` option.

The default transaction TTL is 2 hours, but this is equal to 7200 seconds,

https://github.com/input-output-hk/cardano-wallet/blob/aea6d3bb180b105ef9d5053409ccb113405b8d98/lib/core/src/Cardano/Wallet.hs#L1598-L1599

but not equal to 3600 seconds as the command line option `--help` originally stated.
