### PR TITLE
Add collateral constraints and parameters to coin selection API 

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1459,6 +1459,7 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 case view #txDelegationAction txCtx of
                     Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
+            , utxoAvailableForCollateral = UTxOIndex.toUTxO utxoAvailable
             , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
             }
     case mSel of

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -296,6 +296,7 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
 import Cardano.Wallet.Primitive.CoinSelection
     ( ErrPrepareOutputs (..)
     , Selection
+    , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionError (..)
     , SelectionOf (..)
@@ -1463,6 +1464,10 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 case view #txDelegationAction txCtx of
                     Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
+              -- TODO: [ADP-957]
+              -- Until support for collateral is fully integrated, specify
+              -- that collateral is not required:
+            , collateralRequirement = SelectionCollateralNotRequired
             , utxoAvailableForCollateral = UTxOIndex.toUTxO utxoAvailable
             , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
             }

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1459,7 +1459,7 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 case view #txDelegationAction txCtx of
                     Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
-            , utxoAvailable = UTxOSelection.fromIndex utxoAvailable
+            , utxoAvailableForInputs = UTxOSelection.fromIndex utxoAvailable
             }
     case mSel of
         Left e -> liftIO $

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -308,6 +308,8 @@ import Cardano.Wallet.Primitive.CoinSelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( UnableToConstructChangeError (..), emptySkeleton )
+import Cardano.Wallet.Primitive.Collateral
+    ( asCollateral )
 import Cardano.Wallet.Primitive.Migration
     ( MigrationPlan (..) )
 import Cardano.Wallet.Primitive.Model
@@ -1443,6 +1445,8 @@ selectAssets ctx (utxoAvailable, cp, pending) txCtx outputs transform = do
                 view #stakeKeyDeposit pp
             , maximumCollateralInputCount =
                 view #maximumCollateralInputCount pp
+            , utxoSuitableForCollateral =
+                asCollateral . snd
             }
         SelectionParams
             { -- Until we properly support minting and burning, set to empty:

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -68,6 +68,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxOut
     , txOutMaxTokenQuantity
     )
+import Cardano.Wallet.Primitive.Types.UTxO
+    ( UTxO )
 import Cardano.Wallet.Primitive.Types.UTxOSelection
     ( UTxOSelection )
 import Control.Monad.Random.Class
@@ -267,6 +269,13 @@ data SelectionParams = SelectionParams
     , certificateDepositsReturned
         :: !Natural
         -- ^ Number of deposits from stake key de-registrations.
+    , utxoAvailableForCollateral
+        :: !UTxO
+        -- ^ Specifies a set of UTxOs that are available for selection as
+        -- collateral inputs.
+        --
+        -- This set is allowed to intersect with 'utxoAvailableForInputs',
+        -- since the ledger does not require that these sets are disjoint.
     , utxoAvailableForInputs
         :: !UTxOSelection
         -- ^ Specifies a set of UTxOs that are available for selection as

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -163,7 +163,7 @@ toBalanceConstraintsParams (constraints, params) =
         , outputsToCover =
             view #outputsToCover params
         , utxoAvailable =
-            view #utxoAvailable params
+            view #utxoAvailableForInputs params
         }
 
 -- | Makes a selection from an ordinary selection and a collateral selection.
@@ -267,7 +267,7 @@ data SelectionParams = SelectionParams
     , certificateDepositsReturned
         :: !Natural
         -- ^ Number of deposits from stake key de-registrations.
-    , utxoAvailable
+    , utxoAvailableForInputs
         :: !UTxOSelection
         -- ^ Specifies a set of UTxOs that are available for selection as
         -- ordinary inputs and optionally, a subset that has already been

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -119,9 +119,6 @@ performSelection constraints params = do
     -- https://input-output.atlassian.net/browse/ADP-1037
     -- Adjust coin selection and fee estimation to handle collateral inputs
     --
-    -- https://input-output.atlassian.net/browse/ADP-1070
-    -- Adjust coin selection and fee estimation to handle pre-existing inputs
-    --
     preparedOutputs <- withExceptT SelectionOutputsError $ except
         $ prepareOutputs constraints (view #outputsToCover params)
     withExceptT SelectionBalanceError

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -245,6 +245,11 @@ data SelectionConstraints = SelectionConstraints
         :: Word16
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
         -- that can be selected as collateral.
+    , utxoSuitableForCollateral
+        :: (TxIn, TxOut) -> Maybe Coin
+        -- ^ Indicates whether an individual UTxO entry is suitable for use as
+        -- a collateral input. This function should return a 'Coin' value if
+        -- (and only if) the given UTxO is suitable for use as collateral.
     }
     deriving Generic
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -24,6 +24,7 @@
 --
 module Cardano.Wallet.Primitive.CoinSelection
     ( performSelection
+    , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionParams (..)
     , SelectionError (..)
@@ -274,6 +275,9 @@ data SelectionParams = SelectionParams
     , certificateDepositsReturned
         :: !Natural
         -- ^ Number of deposits from stake key de-registrations.
+    , collateralRequirement
+        :: !SelectionCollateralRequirement
+        -- ^ Specifies the collateral requirement for this selection.
     , utxoAvailableForCollateral
         :: !UTxO
         -- ^ Specifies a set of UTxOs that are available for selection as
@@ -290,6 +294,15 @@ data SelectionParams = SelectionParams
         -- Further entries from this set will be selected to cover any deficit.
     }
     deriving (Eq, Generic, Show)
+
+-- | Indicates the collateral requirement for a selection.
+--
+data SelectionCollateralRequirement
+    = SelectionCollateralRequired
+    -- ^ Indicates that collateral is required.
+    | SelectionCollateralNotRequired
+    -- ^ Indicates that collateral is not required.
+    deriving (Eq, Show)
 
 -- | Indicates that an error occurred while performing a coin selection.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -721,11 +721,6 @@ type PerformSelection m outputs =
 -- selection criteria, this function guarantees to return a 'SelectionResult'
 -- for which 'selectionHasValidSurplus' returns 'True'.
 --
--- This function also guarantees that:
---
---    inputsSelected ∪ utxoRemaining == utxoAvailable
---    inputsSelected ∩ utxoRemaining == ∅
---
 performSelection
     :: forall m. (HasCallStack, MonadRandom m)
     => PerformSelection m [TxOut]


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR makes the following additions and modifications to the internal coin selection API:

```patch
 SelectionConstraints 
     { ...
+    , utxoSuitableForCollateral
+        :: (TxIn, TxOut) -> Maybe Coin
     }
```

```patch
 SelectionParams
     { ...
+    , collateralRequirement
+        :: SelectionCollateralRequirement
+    , utxoAvailableForCollateral
+        :: UTxO
-    , utxoAvailable
+    , utxoAvailableForInputs
+        :: UTxOSelection
     }
     
+data SelectionCollateralRequirement
+    = SelectionCollateralRequired
+    | SelectionCollateralNotRequired
```

It also slightly revises the types within `CoinSelection.Collateral` to match those of the other coin selection modules. We now have:

```hs
CoinSelection           .Selection{Constraints,Params,Error}
CoinSelection.Balance   .Selection{Constraints,Params,Error}
CoinSelection.Collateral.Selection{Constraints,Params,Error}
```

In each case:
- `SelectionConstraints` are common to all selections in the current era, and depend upon the protocol parameters.
- `SelectionParams` are specific to a particular selection, and do not depend upon the protocol parameters.