### PR TITLE
Give callers of `selectAssets` more control over UTxO selection

### DIFF
--- a/lib/core/src/Cardano/Wallet/Api/Server.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Server.hs
@@ -580,6 +580,8 @@ import qualified Cardano.Wallet.Primitive.Types as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
 import qualified Cardano.Wallet.Primitive.Types.UTxO as UTxO
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Cardano.Wallet.Registry as Registry
 import qualified Control.Concurrent.Concierge as Concierge
 import qualified Data.Aeson as Aeson
@@ -1555,7 +1557,10 @@ selectCoins ctx genChange (ApiT wid) body = do
                 { outputs = F.toList outs
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 transform
@@ -1603,7 +1608,10 @@ selectCoinsForJoin ctx knownPools getPoolStatus pid wid = do
                 { outputs = []
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 transform
@@ -1645,7 +1653,10 @@ selectCoinsForQuit ctx (ApiT wid) = do
                 { outputs = []
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 transform
@@ -1884,7 +1895,10 @@ postTransactionOld ctx genChange (ApiT wid) body = do
                 { outputs = F.toList outs
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2019,7 +2033,10 @@ postTransactionFeeOld ctx (ApiT wid) body = do
                 { outputs = F.toList outs
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 } getFee
               where getFee = const (selectionDelta TokenBundle.getCoin)
@@ -2081,7 +2098,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                         { outputs = []
                         , pendingTxs
                         , txContext = txCtx
-                        , utxoAvailable
+                        , utxoAvailableForInputs =
+                            UTxOSelection.fromIndex utxoAvailable
+                        , utxoAvailableForCollateral =
+                            UTxOIndex.toUTxO utxoAvailable
                         , wallet
                         }
                         (const Prelude.id)
@@ -2091,7 +2111,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                             { outputs = []
                             , pendingTxs
                             , txContext = txCtx
-                            , utxoAvailable
+                            , utxoAvailableForInputs =
+                                UTxOSelection.fromIndex utxoAvailable
+                            , utxoAvailableForCollateral =
+                                UTxOIndex.toUTxO utxoAvailable
                             , wallet
                             }
                             getFee
@@ -2102,7 +2125,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                         { outputs = []
                         , pendingTxs
                         , txContext = txCtx
-                        , utxoAvailable
+                        , utxoAvailableForInputs =
+                            UTxOSelection.fromIndex utxoAvailable
+                        , utxoAvailableForCollateral =
+                            UTxOIndex.toUTxO utxoAvailable
                         , wallet
                         }
                         transform
@@ -2115,7 +2141,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                         { outputs = F.toList outs
                         , pendingTxs
                         , txContext = txCtx
-                        , utxoAvailable
+                        , utxoAvailableForInputs =
+                            UTxOSelection.fromIndex utxoAvailable
+                        , utxoAvailableForCollateral =
+                            UTxOIndex.toUTxO utxoAvailable
                         , wallet
                         }
                         (const Prelude.id)
@@ -2125,7 +2154,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                         { outputs = F.toList outs
                         , pendingTxs
                         , txContext = txCtx
-                        , utxoAvailable
+                        , utxoAvailableForInputs =
+                            UTxOSelection.fromIndex utxoAvailable
+                        , utxoAvailableForCollateral =
+                            UTxOIndex.toUTxO utxoAvailable
                         , wallet
                         }
                         getFee
@@ -2136,7 +2168,10 @@ constructTransaction ctx genChange (ApiT wid) body = do
                         { outputs = F.toList outs
                         , pendingTxs
                         , txContext = txCtx
-                        , utxoAvailable
+                        , utxoAvailableForInputs =
+                            UTxOSelection.fromIndex utxoAvailable
+                        , utxoAvailableForCollateral =
+                            UTxOIndex.toUTxO utxoAvailable
                         , wallet
                         }
                         transform
@@ -2215,7 +2250,10 @@ joinStakePool ctx knownPools getPoolStatus apiPoolId (ApiT wid) body = do
                 { outputs = []
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)
@@ -2273,7 +2311,10 @@ delegationFee ctx (ApiT wid) = do
             { outputs = []
             , pendingTxs
             , txContext = txCtx
-            , utxoAvailable
+            , utxoAvailableForInputs =
+                UTxOSelection.fromIndex utxoAvailable
+            , utxoAvailableForCollateral =
+                UTxOIndex.toUTxO utxoAvailable
             , wallet
             } calcFee
       where
@@ -2319,7 +2360,10 @@ quitStakePool ctx (ApiT wid) body = do
                 { outputs = []
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 }
                 (const Prelude.id)

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -216,6 +216,8 @@ import qualified Cardano.Wallet.DB.Sqlite as Sqlite
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Byron as Byron
 import qualified Cardano.Wallet.Primitive.AddressDerivation.Shelley as Shelley
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
+import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B8
@@ -462,7 +464,10 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
                 { outputs = [out]
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
@@ -560,7 +565,10 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
                 { outputs = [out]
                 , pendingTxs
                 , txContext = txCtx
-                , utxoAvailable
+                , utxoAvailableForInputs =
+                    UTxOSelection.fromIndex utxoAvailable
+                , utxoAvailableForCollateral =
+                    UTxOIndex.toUTxO utxoAvailable
                 , wallet
                 } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection

--- a/lib/shelley/bench/Restore.hs
+++ b/lib/shelley/bench/Restore.hs
@@ -456,8 +456,15 @@ benchmarksRnd _ w wid wname benchname restoreTime = do
         let out = TxOut (dummyAddress @n) (TokenBundle.fromCoin $ Coin 1)
         let txCtx = defaultTransactionCtx
         let getFee = const (selectionDelta TokenBundle.getCoin)
-        wal <- unsafeRunExceptT $ W.readWalletUTxOIndex @_ @s @k w wid
-        let runSelection = W.selectAssets @_ @s @k w wal txCtx [out] getFee
+        (utxoAvailable, wallet, pendingTxs) <-
+            unsafeRunExceptT $ W.readWalletUTxOIndex @_ @s @k w wid
+        let runSelection = W.selectAssets @_ @s @k w W.SelectAssetsParams
+                { outputs = [out]
+                , pendingTxs
+                , txContext = txCtx
+                , utxoAvailable
+                , wallet
+                } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     oneAddress <- genAddresses 1 cp
@@ -547,8 +554,15 @@ benchmarksSeq _ w wid _wname benchname restoreTime = do
         let out = TxOut (dummyAddress @n) (TokenBundle.fromCoin $ Coin 1)
         let txCtx = defaultTransactionCtx
         let getFee = const (selectionDelta TokenBundle.getCoin)
-        wal <- unsafeRunExceptT $ W.readWalletUTxOIndex w wid
-        let runSelection = W.selectAssets @_ @s @k w wal txCtx [out] getFee
+        (utxoAvailable, wallet, pendingTxs) <-
+            unsafeRunExceptT $ W.readWalletUTxOIndex w wid
+        let runSelection = W.selectAssets @_ @s @k w W.SelectAssetsParams
+                { outputs = [out]
+                , pendingTxs
+                , txContext = txCtx
+                , utxoAvailable
+                , wallet
+                } getFee
         runExceptT $ withExceptT show $ W.estimateFee runSelection
 
     let walletOverview = WalletOverview{utxo,addresses,transactions}


### PR DESCRIPTION
## Issue Numbers

ADP-1037
ADP-1118

## Summary

This PR splits the `utxoAvailable` parameter of `selectAssets` into two:
- `utxoAvailableForInputs`.
- `utxoAvailableForCollateral`.

Note that these two UTxO sets **_are_** allowed to intersect: the ledger does **_not_** require that they are disjoint. So it's perfectly acceptable to supply the same set in both cases.

However, some callers of `selectAssets` may prefer to **pre-select** a subset of inputs within `utxoAvailableForInputs`. This is possible with the following constructors for `UTxOSelection`:

- [`fromIndexFiltered`](https://github.com/input-output-hk/cardano-wallet/blob/6626489542ce442a8451fb46fb5339346e62b4ee/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs#L196)
- [`fromIndexPair`](https://github.com/input-output-hk/cardano-wallet/blob/6626489542ce442a8451fb46fb5339346e62b4ee/lib/core/src/Cardano/Wallet/Primitive/Types/UTxOSelection.hs#L205)