### PR TITLE
remove unused node-config volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     volumes:
       - node-${NETWORK}-db:/data
       - node-ipc:/ipc
-      - node-config:/nix/store
     restart: on-failure
     logging:
       driver: "json-file"


### PR DESCRIPTION
<!--
Detail in a few bullet points the work accomplished in this PR.

Before you submit, don't forget to:

* Make sure the GitHub PR fields are correct:
   ✓ Set a good Title for your PR.
   ✓ Assign yourself to the PR.
   ✓ Assign one or more reviewer(s).
   ✓ Link to a Jira issue, and/or other GitHub issues or PRs.
   ✓ In the PR description delete any empty sections
     and all text commented in <!--, so that this text does not appear
     in merge commit messages.

* Don't waste reviewers' time:
   ✓ If it's a draft, select the Create Draft PR option.
   ✓ Self-review your changes to make sure nothing unexpected slipped through.

* Try to make your intent clear:
   ✓ Write a good Description that explains what this PR is meant to do.
   ✓ Jira will detect and link to this PR once created, but you can also
     link this PR in the description of the corresponding Jira ticket.
   ✓ Highlight what Testing you have done.
   ✓ Acknowledge any changes required to the Documentation.
-->


- [ ] remove unused node-config volume

### Comments
There was unused node-config volume on the node docker, leftover from https://github.com/input-output-hk/cardano-wallet/pull/2830, which seems to cause problems on starting docker-compose with newer version of the node (1.29.0 -> 1.30.1) on top of older db.

### Issue Number

ADP-1165
