### PR TITLE
Add collateral to coin selection: preparation work

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -70,6 +70,7 @@ library
     , http-client-tls
     , http-media
     , http-types
+    , int-cast
     , io-classes
     , iohk-monitoring
     , lattices

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -463,6 +463,8 @@ import Data.Generics.Labels
     ()
 import Data.Generics.Product.Typed
     ( HasType, typed )
+import Data.IntCast
+    ( intCast )
 import Data.Kind
     ( Type )
 import Data.List
@@ -488,7 +490,7 @@ import Data.Type.Equality
 import Data.Void
     ( Void )
 import Data.Word
-    ( Word64 )
+    ( Word16, Word64 )
 import Fmt
     ( Buildable
     , blockListF
@@ -1461,7 +1463,7 @@ selectAssets ctx params transform = do
             , depositAmount =
                 view #stakeKeyDeposit pp
             , maximumCollateralInputCount =
-                view #maximumCollateralInputCount pp
+                intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , utxoSuitableForCollateral =
                 asCollateral . snd
             }

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -85,8 +85,6 @@ import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Semigroup
     ( mtimesDefault )
-import Data.Word
-    ( Word16 )
 import Fmt
     ( Buildable (..), genericF )
 import GHC.Generics
@@ -243,7 +241,7 @@ data SelectionConstraints = SelectionConstraints
         -- ^ Amount that should be taken from/returned back to the wallet for
         -- each stake key registration/de-registration in the transaction.
     , maximumCollateralInputCount
-        :: Word16
+        :: Int
         -- ^ Specifies an inclusive upper bound on the number of unique inputs
         -- that can be selected as collateral.
     , utxoSuitableForCollateral

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -159,6 +159,8 @@ import Data.Generics.Internal.VL.Lens
     ( over, view )
 import Data.Generics.Labels
     ()
+import Data.IntCast
+    ( intCast )
 import Data.List.NonEmpty
     ( NonEmpty (..) )
 import Data.Map.Strict
@@ -1128,7 +1130,7 @@ coinSelectionLens
 coinSelectionLens limit minimumCoinQuantity = SelectionLens
     { currentQuantity = selectedCoinQuantity
     , updatedQuantity = selectedCoinQuantity
-    , minimumQuantity = fromIntegral $ unCoin minimumCoinQuantity
+    , minimumQuantity = intCast $ unCoin minimumCoinQuantity
     , selectQuantity  = selectCoinQuantity limit
     }
 
@@ -2112,7 +2114,7 @@ selectedAssetQuantity asset
 
 selectedCoinQuantity :: IsUTxOSelection s => s -> Natural
 selectedCoinQuantity
-    = fromIntegral
+    = intCast
     . unCoin
     . TokenBundle.getCoin
     . UTxOSelection.selectedBalance

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -27,6 +28,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Collateral
     , SelectionResult (..)
     , SelectionError (..)
     , SearchSpaceLimit (..)
+    , searchSpaceLimitDefault
 
     -- * Internal API
 
@@ -134,6 +136,15 @@ data SearchSpaceLimit
     -- ^ Specifies that there is no search space limit. This should only be
     -- used for testing purposes.
     deriving (Eq, Show)
+
+-- | The default search space limit.
+--
+-- This constant is used by the test suite, so we can be reasonably confident
+-- that performing selections with this limit will not use inordinate amounts
+-- of time and space.
+--
+searchSpaceLimitDefault :: SearchSpaceLimit
+searchSpaceLimitDefault = SearchSpaceLimit 1_000_000
 
 -- | Represents a successful selection of collateral.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
@@ -65,6 +65,8 @@ import Cardano.Wallet.Primitive.Types.Tx
     ( TxIn )
 import Data.Function
     ( (&) )
+import Data.IntCast
+    ( intCast, intCastMaybe )
 import Data.List.NonEmpty
     ( NonEmpty )
 import Data.Map.Strict
@@ -417,12 +419,12 @@ numberOfSubsequencesOfSize n k
     | k == 0 || k ==  n      = Just 1
     | k == 1 || k == (n - 1) = Just n
     | resultOutOfBounds      = Nothing
-    | otherwise              = Just (fromIntegral resultExact)
+    | otherwise              = intCastMaybe resultExact
   where
     resultExact :: Integer
     resultExact = MathExact.choose
-        (fromIntegral @Int @Integer n)
-        (fromIntegral @Int @Integer k)
+        (intCast @Int @Integer n)
+        (intCast @Int @Integer k)
 
     resultFast :: Integer
     resultFast = floor (MathFast.choose n k)
@@ -430,9 +432,9 @@ numberOfSubsequencesOfSize n k
     resultOutOfBounds :: Bool
     resultOutOfBounds = False
         || resultFast  < 0
-        || resultFast  > fromIntegral @Int @Integer (maxBound @Int)
+        || resultFast  > intCast @Int @Integer (maxBound @Int)
         || resultExact < 0
-        || resultExact > fromIntegral @Int @Integer (maxBound @Int)
+        || resultExact > intCast @Int @Integer (maxBound @Int)
 
 -- | Generates all subsequences of size 'k' from a particular sequence.
 --

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Collateral.hs
@@ -23,10 +23,14 @@ module Cardano.Wallet.Primitive.CoinSelection.Collateral
 
       performSelection
     , PerformSelection
+    , PerformSelectionOf
     , SelectionConstraints (..)
-    , SelectionParams (..)
-    , SelectionResult (..)
-    , SelectionError (..)
+    , SelectionParams
+    , SelectionParamsOf (..)
+    , SelectionResult
+    , SelectionResultOf (..)
+    , SelectionError
+    , SelectionErrorOf (..)
     , SearchSpaceLimit (..)
     , searchSpaceLimitDefault
 
@@ -57,6 +61,8 @@ module Cardano.Wallet.Primitive.CoinSelection.Collateral
 
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxIn )
 import Data.Function
     ( (&) )
 import Data.List.NonEmpty
@@ -87,10 +93,16 @@ import qualified Numeric.SpecFunctions as MathFast
 -- Public API
 --------------------------------------------------------------------------------
 
-type PerformSelection inputId =
+-- | The type of all functions that perform selections.
+--
+type PerformSelectionOf inputId =
     SelectionConstraints ->
-    SelectionParams inputId ->
-    Either (SelectionError inputId) (SelectionResult inputId)
+    SelectionParamsOf inputId ->
+    Either (SelectionErrorOf inputId) (SelectionResultOf inputId)
+
+-- | The default type for 'PerformSelectionOf'.
+--
+type PerformSelection = PerformSelectionOf TxIn
 
 -- | Specifies all constraints required for collateral selection.
 --
@@ -116,7 +128,7 @@ data SelectionConstraints = SelectionConstraints
 
 -- | Specifies all parameters that are specific to a given selection.
 --
-data SelectionParams inputId = SelectionParams
+data SelectionParamsOf inputId = SelectionParams
     { coinsAvailable
         :: Map inputId Coin
         -- ^ The set of all coins available for selection as collateral.
@@ -125,6 +137,10 @@ data SelectionParams inputId = SelectionParams
         -- ^ A lower bound on the sum of coins to be selected as collateral.
     }
     deriving (Eq, Generic, Show)
+
+-- | The default type for 'SelectionParamsOf'.
+--
+type SelectionParams = SelectionParamsOf TxIn
 
 -- | Specifies an upper bound on the search space size.
 --
@@ -148,19 +164,27 @@ searchSpaceLimitDefault = SearchSpaceLimit 1_000_000
 
 -- | Represents a successful selection of collateral.
 --
-newtype SelectionResult inputId = SelectionResult
+newtype SelectionResultOf inputId = SelectionResult
     { coinsSelected :: Map inputId Coin
         -- ^ The coins that were selected for collateral.
     }
     deriving (Eq, Generic, Show)
 
+-- | The default type for 'SelectionResultOf'.
+--
+type SelectionResult = SelectionResultOf TxIn
+
 -- | Represents an unsuccessful attempt to select collateral.
 --
-newtype SelectionError inputId = SelectionError
+newtype SelectionErrorOf inputId = SelectionError
     { largestCombinationAvailable :: Map inputId Coin
         -- ^ The largest combination of coins available.
     }
     deriving (Eq, Generic, Show)
+
+-- | The default type for `SelectionErrorOf`.
+--
+type SelectionError = SelectionErrorOf TxIn
 
 -- | Selects coins for collateral.
 --
@@ -195,7 +219,7 @@ newtype SelectionError inputId = SelectionError
 --    >>> size largestCombinationAvailable ≤ maximumSelectionSize
 --    >>>      largestCombinationAvailable ⊆ coinsAvailable
 --
-performSelection :: forall inputId. Ord inputId => PerformSelection inputId
+performSelection :: forall inputId. Ord inputId => PerformSelectionOf inputId
 performSelection constraints =
     firstRight $ fmap ($ constraints)
         [ selectCollateralSmallest
@@ -219,7 +243,7 @@ performSelection constraints =
 -- function will return without computing a result.
 --
 selectCollateralSmallest
-    :: forall inputId. Ord inputId => PerformSelection inputId
+    :: forall inputId. Ord inputId => PerformSelectionOf inputId
 selectCollateralSmallest constraints params =
     case smallestValidCombination of
         Just coinsSelected ->
@@ -285,7 +309,7 @@ selectCollateralSmallest constraints params =
 -- This result can be computed very quickly, without using much search space.
 --
 selectCollateralLargest
-    :: forall inputId. Ord inputId => PerformSelection inputId
+    :: forall inputId. Ord inputId => PerformSelectionOf inputId
 selectCollateralLargest constraints params =
     case smallestValidSubmapOfLargestCombinationAvailable of
         Just coinsSelected ->

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
@@ -24,13 +24,13 @@ import Prelude hiding
     ( sequence )
 
 import Cardano.Wallet.Primitive.CoinSelection.Collateral
-    ( PerformSelection
+    ( PerformSelectionOf
     , SearchSpaceLimit (..)
     , SearchSpaceRequirement (..)
     , SelectionConstraints (..)
-    , SelectionError (..)
-    , SelectionParams (..)
-    , SelectionResult (..)
+    , SelectionErrorOf (..)
+    , SelectionParamsOf (..)
+    , SelectionResultOf (..)
     , firstRight
     , guardSearchSpaceSize
     , numberOfSubsequencesOfSize
@@ -197,7 +197,7 @@ spec = do
 --  - maximum selection sizes
 --
 prop_performSelection_general_withFunction
-    :: PerformSelection LongInputId -> Property
+    :: PerformSelectionOf LongInputId -> Property
 prop_performSelection_general_withFunction performSelectionFn =
     checkCoverage $
     forAll (arbitrary @(Map LongInputId Coin))
@@ -220,8 +220,8 @@ prop_performSelection_general_withFunction performSelectionFn =
 prop_performSelection_general_withResult
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParams inputId
-    -> Either (SelectionError inputId) (SelectionResult inputId)
+    -> SelectionParamsOf inputId
+    -> Either (SelectionErrorOf inputId) (SelectionResultOf inputId)
     -> Property
 prop_performSelection_general_withResult constraints params eitherErrorResult =
     cover 20.0 (isLeft  eitherErrorResult) "Failure" $
@@ -235,8 +235,8 @@ prop_performSelection_general_withResult constraints params eitherErrorResult =
 prop_performSelection_onFailure
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParams inputId
-    -> SelectionError inputId
+    -> SelectionParamsOf inputId
+    -> SelectionErrorOf inputId
     -> Property
 prop_performSelection_onFailure constraints params err =
     counterexample ("Error: " <> show (Pretty err)) $
@@ -252,8 +252,8 @@ prop_performSelection_onFailure constraints params err =
 prop_performSelection_onSuccess
     :: (Ord inputId, Show inputId)
     => SelectionConstraints
-    -> SelectionParams inputId
-    -> SelectionResult inputId
+    -> SelectionParamsOf inputId
+    -> SelectionResultOf inputId
     -> Property
 prop_performSelection_onSuccess constraints params result =
     counterexample ("Result: " <> show (Pretty result)) $

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
@@ -35,6 +35,7 @@ import Cardano.Wallet.Primitive.CoinSelection.Collateral
     , guardSearchSpaceSize
     , numberOfSubsequencesOfSize
     , performSelection
+    , searchSpaceLimitDefault
     , selectCollateralLargest
     , selectCollateralSmallest
     , submaps
@@ -207,7 +208,7 @@ prop_performSelection_general_withFunction performSelectionFn =
         $ \maximumSelectionSize ->
     let constraints = SelectionConstraints
             { maximumSelectionSize
-            , searchSpaceLimit = SearchSpaceLimit 1_000_000
+            , searchSpaceLimit = searchSpaceLimitDefault
             } in
     let params = SelectionParams
             { coinsAvailable

--- a/nix/.stack.nix/cardano-wallet-core.nix
+++ b/nix/.stack.nix/cardano-wallet-core.nix
@@ -66,6 +66,7 @@
           (hsPkgs."http-client-tls" or (errorHandler.buildDepError "http-client-tls"))
           (hsPkgs."http-media" or (errorHandler.buildDepError "http-media"))
           (hsPkgs."http-types" or (errorHandler.buildDepError "http-types"))
+          (hsPkgs."int-cast" or (errorHandler.buildDepError "int-cast"))
           (hsPkgs."io-classes" or (errorHandler.buildDepError "io-classes"))
           (hsPkgs."iohk-monitoring" or (errorHandler.buildDepError "iohk-monitoring"))
           (hsPkgs."lattices" or (errorHandler.buildDepError "lattices"))


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR makes the following changes in preparation for adding collateral to coin selection:
- Extracts out a `searchSpaceLimitDefault` constant, and uses this constant in the test suite.
- Adds type synonyms to `CoinSelection.Collateral` to simplify type signatures in `CoinSelection`.
- Uses the `intCast` function to replace `fromInteger`, allowing the compiler to check that integer conversions are safe.
- Changes the type of `maximumCollateralInputCount` to `Int`.