### PR TITLE
Expose collateral selection errors in the API

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1454,14 +1454,14 @@ selectAssets ctx params transform = do
             { assessTokenBundleSize =
                 tokenBundleSizeAssessor tl $
                     pp ^. (#txParameters . #getTokenBundleMaxSize)
+            , certificateDepositAmount =
+                view #stakeKeyDeposit pp
             , computeMinimumAdaQuantity =
                 view #txOutputMinimumAdaQuantity $ constraints tl pp
             , computeMinimumCost =
                 calcMinimumCost tl pp $ params ^. #txContext
             , computeSelectionLimit =
                 view #computeSelectionLimit tl pp $ params ^. #txContext
-            , depositAmount =
-                view #stakeKeyDeposit pp
             , maximumCollateralInputCount =
                 intCast @Word16 @Int $ view #maximumCollateralInputCount pp
             , minimumCollateralPercentage =

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -309,7 +309,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , performSelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( UnableToConstructChangeError (..), emptySkeleton )
+    ( emptySkeleton )
 import Cardano.Wallet.Primitive.Collateral
     ( asCollateral )
 import Cardano.Wallet.Primitive.Migration
@@ -2173,7 +2173,7 @@ estimateFee
         e@(ErrSelectAssetsSelectionError se) -> case se of
             SelectionBalanceError (Balance.UnableToConstructChange ce) ->
                 case ce of
-                    UnableToConstructChangeError {requiredCost} ->
+                    Balance.UnableToConstructChangeError {requiredCost} ->
                         pure requiredCost
             _ ->
                 throwE  e

--- a/lib/core/src/Cardano/Wallet/Api/Types.hs
+++ b/lib/core/src/Cardano/Wallet/Api/Types.hs
@@ -1515,6 +1515,7 @@ data ApiErrorCode
     | MalformedTxPayload
     | KeyNotFoundForAddress
     | NotEnoughMoney
+    | InsufficientCollateral
     | TransactionIsTooBig
     | InputsDepleted
     | CannotCoverFee

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -156,11 +156,11 @@ toBalanceConstraintsParams (constraints, params) =
             view #rewardWithdrawal params <>
             mtimesDefault
                 (view #certificateDepositsReturned params)
-                (view #depositAmount constraints)
+                (view #certificateDepositAmount constraints)
         , extraCoinSink =
             mtimesDefault
                 (view #certificateDepositsTaken params)
-                (view #depositAmount constraints)
+                (view #certificateDepositAmount constraints)
         , outputsToCover =
             view #outputsToCover params
         , utxoAvailable =
@@ -226,6 +226,10 @@ data SelectionConstraints = SelectionConstraints
         -- what can be included in a transaction output. See documentation for
         -- the 'TokenBundleSizeAssessor' type to learn about the expected
         -- properties of this field.
+    , certificateDepositAmount
+        :: Coin
+        -- ^ Amount that should be taken from/returned back to the wallet for
+        -- each stake key registration/de-registration in the transaction.
     , computeMinimumAdaQuantity
         :: TokenMap -> Coin
         -- ^ Computes the minimum ada quantity required for a given output.
@@ -236,10 +240,6 @@ data SelectionConstraints = SelectionConstraints
         :: [TxOut] -> SelectionLimit
         -- ^ Computes an upper bound for the number of ordinary inputs to
         -- select, given a current set of outputs.
-    , depositAmount
-        :: Coin
-        -- ^ Amount that should be taken from/returned back to the wallet for
-        -- each stake key registration/de-registration in the transaction.
     , maximumCollateralInputCount
         :: Int
         -- ^ Specifies an inclusive upper bound on the number of unique inputs

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -95,6 +95,7 @@ import Numeric.Natural
     ( Natural )
 
 import qualified Cardano.Wallet.Primitive.CoinSelection.Balance as Balance
+import qualified Cardano.Wallet.Primitive.CoinSelection.Collateral as Collateral
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Data.Foldable as F
@@ -309,8 +310,12 @@ data SelectionCollateralRequirement
 -- | Indicates that an error occurred while performing a coin selection.
 --
 data SelectionError
-    = SelectionBalanceError Balance.SelectionError
-    | SelectionOutputsError ErrPrepareOutputs
+    = SelectionBalanceError
+        Balance.SelectionError
+    | SelectionCollateralError
+        Collateral.SelectionError
+    | SelectionOutputsError
+        ErrPrepareOutputs
     deriving (Eq, Show)
 
 -- | Represents a balanced selection.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/CollateralSpec.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE NumericUnderscores #-}
@@ -242,7 +243,7 @@ prop_performSelection_onFailure constraints params err =
     counterexample ("Error: " <> show (Pretty err)) $
     conjoin
         [ F.fold (largestCombinationAvailable err)
-            < minimumSelectionAmount params
+            < view #minimumSelectionAmount params
         , F.length (largestCombinationAvailable err)
             <= maximumSelectionSize constraints
         , largestCombinationAvailable err
@@ -259,9 +260,9 @@ prop_performSelection_onSuccess constraints params result =
     counterexample ("Result: " <> show (Pretty result)) $
     conjoin
         [ F.fold (coinsAvailable params)
-            >= minimumSelectionAmount params
+            >= view #minimumSelectionAmount params
         , F.fold (coinsSelected result)
-            >= minimumSelectionAmount params
+            >= view #minimumSelectionAmount params
         , F.length (coinsSelected result)
             <= maximumSelectionSize constraints
         , coinsSelected result
@@ -665,8 +666,12 @@ unitTests_selectCollateralLargest_insufficient = unitTests
                 , minimumSelectionAmount = Coin minimumSelectionAmount
                 }
             )
-        , result = Left $
-            SelectionError $ Coin <$> largestCombinationAvailable
+        , result = Left SelectionError
+            { largestCombinationAvailable =
+                Coin <$> largestCombinationAvailable
+            , minimumSelectionAmount =
+                Coin minimumSelectionAmount
+            }
         }
     tests =
         [ ( 225, [F ▶ 32, G ▶ 64, H ▶ 128])

--- a/specifications/api/swagger.yaml
+++ b/specifications/api/swagger.yaml
@@ -3649,6 +3649,20 @@ x-errNotEnoughMoney: &errNotEnoughMoney
       type: string
       enum: ['not_enough_money']
 
+x-errInsufficientCollateral: &errInsufficientCollateral
+  <<: *responsesErr
+  title: insufficient_collateral
+  properties:
+    message:
+      type: string
+      description: |
+        May occur when the total balance of pure ada UTxOs in the wallet is
+        insufficient to cover the minimum collateral amount required for a
+        transaction requiring collateral.
+    code:
+      type: string
+      enum: ['insufficient_collateral']
+
 x-errTransactionIsTooBig: &errTransactionIsTooBig
   <<: *responsesErr
   title: transaction_is_too_big
@@ -4514,6 +4528,7 @@ x-responsesSelectCoins: &responsesSelectCoins
             - <<: *errAlreadyWithdrawing
             - <<: *errUtxoTooSmall
             - <<: *errNotEnoughMoney
+            - <<: *errInsufficientCollateral
             - <<: *errCannotCoverFee
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
@@ -4600,6 +4615,7 @@ x-responsesPostTransaction: &responsesPostTransaction
             - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
+            - <<: *errInsufficientCollateral
             - <<: *errTransactionIsTooBig
             - <<: *errNoRootKey
             - <<: *errWrongEncryptionPassphrase
@@ -4631,6 +4647,7 @@ x-responsesConstructTransaction: &responsesConstructTransaction
             - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
+            - <<: *errInsufficientCollateral
             - <<: *errTransactionIsTooBig
   <<: *responsesErr404WalletNotFound
   <<: *responsesErr406
@@ -4710,6 +4727,7 @@ x-responsesPostTransactionFee: &responsesPostTransactionFee
             - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
+            - <<: *errInsufficientCollateral
             - <<: *errInputsDepleted
             - <<: *errInvalidCoinSelection
             - <<: *errOutputTokenQuantityExceedsLimit
@@ -5002,6 +5020,7 @@ x-responsesBalanceTransaction: &responsesBalanceTransaction
             - <<: *errUtxoTooSmall
             - <<: *errCannotCoverFee
             - <<: *errNotEnoughMoney
+            - <<: *errInsufficientCollateral
             - <<: *errTransactionIsTooBig
             - <<: *errTransactionAlreadyBalanced
   <<: *responsesErr404WalletNotFound


### PR DESCRIPTION
## Issue Number 

ADP-1039

## Summary

This PR exposes collateral selection errors in the API, and adds descriptions of these errors to the API specification.

It also makes a couple of small tweaks to the internal coin selection API, to make the naming more consistent.

## Not included in this PR

API integration tests that verify collateral selection errors.

We can't write these yet, as the collateral selection algorithm is not fully integrated into coin selection. (Though it soon will be, as part of ADP-1037.)