### PR TITLE
Refactor DBLayer to use in-memory Checkpoints

### DIFF
--- a/lib/core/bench/db-bench.hs
+++ b/lib/core/bench/db-bench.hs
@@ -304,7 +304,7 @@ mkCheckpoints numCheckpoints utxoSize numAssets =
             (SlotNo $ fromIntegral i)
             (Quantity $ fromIntegral i)
             (Hash $ label "parentHeaderHash" i)
-            (Hash $ label "headerHash" i)
+            (Just $ Hash $ label "headerHash" i)
         )
         initDummySeqState
 

--- a/lib/core/src/Cardano/Pool/DB/Sqlite.hs
+++ b/lib/core/src/Cardano/Pool/DB/Sqlite.hs
@@ -55,7 +55,7 @@ import Cardano.Pool.DB.Log
 import Cardano.Pool.DB.Sqlite.TH hiding
     ( BlockHeader, blockHeight )
 import Cardano.Wallet.DB.Sqlite.Types
-    ( BlockId (..) )
+    ( BlockId (..), fromMaybeHash, toMaybeHash )
 import Cardano.Wallet.Logging
     ( bracketTracer )
 import Cardano.Wallet.Primitive.Slotting
@@ -912,7 +912,7 @@ mkPoolProduction pool block = PoolProduction
     { poolProductionPoolId = pool
     , poolProductionSlot = view #slotNo block
     , poolProductionHeaderHash = BlockId (headerHash block)
-    , poolProductionParentHash = BlockId (parentHeaderHash block)
+    , poolProductionParentHash = fromMaybeHash (parentHeaderHash block)
     , poolProductionBlockHeight = getQuantity (blockHeight block)
     }
 
@@ -925,7 +925,7 @@ fromPoolProduction (PoolProduction pool slot headerH parentH height) =
         { slotNo = slot
         , blockHeight = Quantity height
         , headerHash = getBlockId headerH
-        , parentHeaderHash = getBlockId parentH
+        , parentHeaderHash = toMaybeHash parentH
         }
     )
 
@@ -935,7 +935,7 @@ mkBlockHeader
 mkBlockHeader block = TH.BlockHeader
     { blockSlot = view #slotNo block
     , blockHeaderHash = BlockId (headerHash block)
-    , blockParentHash = BlockId (parentHeaderHash block)
+    , blockParentHash = fromMaybeHash (parentHeaderHash block)
     , TH.blockHeight = getQuantity (blockHeight block)
     }
 
@@ -944,7 +944,7 @@ fromBlockHeaders h =
     BlockHeader blockSlot
         (Quantity blockHeight)
         (getBlockId blockHeaderHash)
-        (getBlockId blockParentHash)
+        (toMaybeHash blockParentHash)
   where
     TH.BlockHeader
         { blockSlot

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1062,7 +1062,7 @@ restoreBlocks ctx tr wid blocks nodeTip = db & \DBLayer{..} -> mapExceptT atomic
     logDelegation = traceWith tr . uncurry MsgDiscoveredDelegationCert
 
     isParentOf :: Wallet s -> Block -> Bool
-    isParentOf cp = (== parent) . parentHeaderHash . header
+    isParentOf cp = (== Just parent) . parentHeaderHash . header
       where parent = headerHash $ currentTip cp
 
 -- | Remove an existing wallet. Note that there's no particular work to

--- a/lib/core/src/Cardano/Wallet/DB.hs
+++ b/lib/core/src/Cardano/Wallet/DB.hs
@@ -42,10 +42,11 @@ import Cardano.Wallet.Primitive.AddressDerivation
 import Cardano.Wallet.Primitive.Model
     ( Wallet )
 import Cardano.Wallet.Primitive.Types
-    ( BlockHeader
+    ( ChainPoint
     , DelegationCertificate
     , GenesisParameters
     , Range (..)
+    , Slot
     , SlotNo (..)
     , SortOrder (..)
     , WalletId
@@ -161,7 +162,7 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , listCheckpoints
         :: WalletId
-        -> stm [BlockHeader]
+        -> stm [ChainPoint]
         -- ^ List all known checkpoint tips, ordered by slot ids from the oldest
         -- to the newest.
 
@@ -301,12 +302,13 @@ data DBLayer m s k = forall stm. (MonadIO stm, MonadFail stm) => DBLayer
 
     , rollbackTo
         :: WalletId
-        -> SlotNo
-        -> ExceptT ErrNoSuchWallet stm BlockHeader
-        -- ^ Drops all checkpoints and transaction data after the given slot.
+        -> Slot
+        -> ExceptT ErrNoSuchWallet stm ChainPoint
+        -- ^ Drops all checkpoints and transaction data which
+        -- have appeared after the given 'ChainPoint'.
         --
-        -- Returns the actual slot to which the database has rolled back. This
-        -- slot is guaranteed to be earlier than (or identical to) the given
+        -- Returns the actual 'ChainPoint' to which the database has rolled back.
+        -- Its slot is guaranteed to be earlier than (or identical to) the given
         -- point of rollback but can't be guaranteed to be exactly the same
         -- because the database may only keep sparse checkpoints.
 

--- a/lib/core/src/Cardano/Wallet/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Gen.hs
@@ -189,7 +189,7 @@ genSlot = frequency
 
 genBlockHeader :: SlotNo -> Gen BlockHeader
 genBlockHeader sl = do
-        BlockHeader sl (mockBlockHeight sl) <$> genHash <*> genHash
+        BlockHeader sl (mockBlockHeight sl) <$> genHash <*> (Just <$> genHash)
       where
         mockBlockHeight :: SlotNo -> Quantity "block" Word32
         mockBlockHeight = Quantity . fromIntegral . unSlotNo

--- a/lib/core/src/Cardano/Wallet/Gen.hs
+++ b/lib/core/src/Cardano/Wallet/Gen.hs
@@ -15,6 +15,7 @@ module Cardano.Wallet.Gen
     , genLegacyAddress
     , genBlockHeader
     , genChainPoint
+    , genSlot
     , genActiveSlotCoefficient
     , shrinkActiveSlotCoefficient
     , genSlotNo
@@ -53,7 +54,9 @@ import Cardano.Wallet.Primitive.Types
     , BlockHeader (..)
     , ChainPoint (..)
     , ProtocolMagic (..)
+    , Slot
     , SlotNo (..)
+    , WithOrigin (..)
     )
 import Cardano.Wallet.Primitive.Types.Address
     ( Address (..) )
@@ -177,6 +180,12 @@ genChainPoint = frequency
     ]
   where
     toChainPoint (BlockHeader slot _ h _) = ChainPoint slot h
+
+genSlot :: Gen Slot
+genSlot = frequency
+    [ ( 1, pure Origin)
+    , (40, At <$> genSlotNo)
+    ]
 
 genBlockHeader :: SlotNo -> Gen BlockHeader
 genBlockHeader sl = do

--- a/lib/core/src/Cardano/Wallet/Network.hs
+++ b/lib/core/src/Cardano/Wallet/Network.hs
@@ -491,7 +491,7 @@ flushStats
     -> IO (FollowStats Rearview)
 flushStats t calcSyncProgress var = do
     s <- atomically $ takeTMVar var
-    p <- calcSyncProgress $ pseudoPointSlot $ current $ localTip s
+    p <- calcSyncProgress $ pseudoSlotNo $ current $ localTip s
     let s' = s { time = overCurrent (const t) (time s) }
                { prog = overCurrent (const p) (prog s) }
     atomically $ putTMVar var $ hoistStats forgetPast s'
@@ -500,9 +500,9 @@ flushStats t calcSyncProgress var = do
     forgetPast (Rearview _past curr) = initRearview curr
 
 -- See NOTE [PointSlotNo]
-pseudoPointSlot :: ChainPoint -> SlotNo
-pseudoPointSlot ChainPointAtGenesis = SlotNo 0
-pseudoPointSlot (ChainPoint slot _) = slot
+pseudoSlotNo :: ChainPoint -> SlotNo
+pseudoSlotNo ChainPointAtGenesis = SlotNo 0
+pseudoSlotNo (ChainPoint slot _) = slot
 
 -- | Monitors health and statistics by inspecting the messages
 -- submitted to a 'ChainSyncLog' tracer.

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -9,7 +9,7 @@ module Cardano.Wallet.DummyTarget.Primitive.Types
     , dummyGenesisParameters
     , dummySlottingParameters
     , dummyTimeInterpreter
-    , genesisHash
+    , dummyGenesisHash
     , mkTxId
     , mkTx
 
@@ -41,6 +41,7 @@ import Cardano.Wallet.Primitive.Types
     , TokenBundleMaxSize (..)
     , TxParameters (..)
     , emptyEraInfo
+    , hashOfNoParent
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -56,8 +57,6 @@ import Cardano.Wallet.Primitive.Types.Tx
     , TxScriptValidity (..)
     , TxSize (..)
     )
-import Data.Coerce
-    ( coerce )
 import Data.Functor.Identity
     ( Identity (..) )
 import Data.Map.Strict
@@ -69,8 +68,8 @@ import Data.Time.Clock.POSIX
 
 import qualified Data.ByteString.Char8 as B8
 
-genesisHash :: Hash "Genesis"
-genesisHash = Hash (B8.replicate 32 '0')
+dummyGenesisHash :: Hash "Genesis"
+dummyGenesisHash = Hash (B8.replicate 32 '0')
 
 block0 :: Block
 block0 = Block
@@ -78,7 +77,7 @@ block0 = Block
         { slotNo = SlotNo 0
         , blockHeight = Quantity 0
         , headerHash = mockHash $ SlotNo 0
-        , parentHeaderHash = coerce genesisHash
+        , parentHeaderHash = hashOfNoParent
         }
     , transactions = []
     , delegations = []
@@ -86,7 +85,7 @@ block0 = Block
 
 dummyGenesisParameters :: GenesisParameters
 dummyGenesisParameters = GenesisParameters
-    { getGenesisBlockHash = genesisHash
+    { getGenesisBlockHash = dummyGenesisHash
     , getGenesisBlockDate = StartTime $ posixSecondsToUTCTime 0
     }
 

--- a/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
+++ b/lib/core/test-common/Cardano/Wallet/DummyTarget/Primitive/Types.hs
@@ -41,7 +41,6 @@ import Cardano.Wallet.Primitive.Types
     , TokenBundleMaxSize (..)
     , TxParameters (..)
     , emptyEraInfo
-    , hashOfNoParent
     )
 import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
@@ -69,15 +68,15 @@ import Data.Time.Clock.POSIX
 import qualified Data.ByteString.Char8 as B8
 
 dummyGenesisHash :: Hash "Genesis"
-dummyGenesisHash = Hash (B8.replicate 32 '0')
+dummyGenesisHash = Hash (B8.replicate 32 '1')
 
 block0 :: Block
 block0 = Block
     { header = BlockHeader
         { slotNo = SlotNo 0
         , blockHeight = Quantity 0
-        , headerHash = mockHash $ SlotNo 0
-        , parentHeaderHash = hashOfNoParent
+        , headerHash = Hash $ getHash dummyGenesisHash
+        , parentHeaderHash = Nothing
         }
     , transactions = []
     , delegations = []

--- a/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Pool/DB/Arbitrary.hs
@@ -385,7 +385,7 @@ instance Arbitrary StakePoolsFixture where
             { slotNo = s
             , blockHeight = Quantity 0
             , headerHash = Hash "00000000000000000000000000000001"
-            , parentHeaderHash = Hash "00000000000000000000000000000000"
+            , parentHeaderHash = Just $ Hash "00000000000000000000000000000000"
             }
 
         generateNextSlots :: [SlotNo] -> Int -> [SlotNo]

--- a/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Api/ServerSpec.hs
@@ -208,7 +208,7 @@ networkInfoSpec = describe "getNetworkInformation" $ do
                     sl
                     (Quantity $ fromIntegral $ unSlotNo sl)
                     (Hash "header hash")
-                    (Hash "prevHeaderHash")
+                    (Just $ Hash "prevHeaderHash")
         , timeInterpreter = ti
         }
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -94,6 +94,7 @@ import Cardano.Wallet.Primitive.Types
     , PoolId (..)
     , ProtocolParameters (..)
     , Range (..)
+    , Slot
     , SlotInEpoch (..)
     , SlotNo (..)
     , SortOrder (..)
@@ -104,6 +105,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
+    , WithOrigin (..)
     , rangeIsValid
     , unsafeEpochNo
     , wholeRange
@@ -364,6 +366,14 @@ instance Arbitrary SlotNo where
         EpochNo ep <- arbitrary
         pure $ SlotNo $ fromIntegral $ fromIntegral ep * arbitraryChainLength + sl
     shrink = shrinkSlotNo
+
+instance Arbitrary Slot where
+    arbitrary = frequency
+        [ ( 1, pure Origin)
+        , (40, At <$> arbitrary)
+        ]
+    shrink Origin = [Origin]
+    shrink (At slot) = At <$> shrinkSlotNo slot
 
 instance Arbitrary SlotInEpoch where
     shrink (SlotInEpoch x) = SlotInEpoch <$> shrink x

--- a/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/Arbitrary.hs
@@ -302,7 +302,7 @@ instance Arbitrary MockChain where
                     slot
                     (Quantity height)
                     (mockHash slot)
-                    (mockHash slot)
+                    (Just $ mockHash slot)
             Block h
                 <$> (choose (1, 10) >>= vector)
                 <*> pure []
@@ -358,7 +358,7 @@ instance Arbitrary BlockHeader where
         let h = fromIntegral sl + fromIntegral ep * arbitraryEpochLength
         blockH <- arbitrary
         let slot = SlotNo $ fromIntegral h
-        pure $ BlockHeader slot (Quantity h) blockH (coerce blockH)
+        pure $ BlockHeader slot (Quantity h) blockH (Just blockH)
 
 instance Arbitrary SlotNo where
     arbitrary = do

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -136,6 +136,7 @@ import Cardano.Wallet.Primitive.Types
     , WalletMetadata (..)
     , WalletName (..)
     , WalletPassphraseInfo (..)
+    , WithOrigin (At)
     , wholeRange
     )
 import Cardano.Wallet.Primitive.Types.Address
@@ -676,7 +677,7 @@ fileModeSpec =  do
                 getTxsInLedger db `shouldReturn` [(Outgoing, 2), (Incoming, 4)]
 
                 atomically . void . unsafeRunExceptT $
-                    rollbackTo testWid (SlotNo 200)
+                    rollbackTo testWid (At $ SlotNo 200)
                 Just cp <- atomically $ readCheckpoint testWid
                 view #slotNo (currentTip cp) `shouldBe` (SlotNo 0)
 

--- a/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/DB/SqliteSpec.hs
@@ -543,7 +543,7 @@ fileModeSpec =  do
                             -- Such that old checkpoints are always pruned.
                             , blockHeight = Quantity $ bhA + 5000
                             , headerHash = h
-                            , parentHeaderHash = hashA
+                            , parentHeaderHash = Just hashA
                             })
                             mockTxs
                             mempty
@@ -913,7 +913,7 @@ manualMigrationsSpec = describe "Manual migrations" $ do
                 , blockHeight = Quantity 1124949
                 , headerHash = Hash $ unsafeFromHex
                     "3b309f1ca388459f0ce2c4ccca20ea646b75e6fc1447be032a41d43f209ecb50"
-                , parentHeaderHash = Hash $ unsafeFromHex
+                , parentHeaderHash = Just $ Hash $ unsafeFromHex
                     "e9414e08d8c5ca177dd0cb6a9e4bf868e1ea03389c31f5f7a6b099a3bcdfdedf"
                 }
             )

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/ModelSpec.hs
@@ -983,7 +983,7 @@ blockchain =
             { slotNo = slot 2 19218
             , blockHeight = Quantity 62392
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
+            , parentHeaderHash = Just $ Hash "y\130\145\211\146\234S\221\150\GS?\212>\167B\134C\r\160J\230\173\SOHn\188\245\141\151u\DC4\236\154"
             }
         , transactions =
             [ Tx
@@ -1022,7 +1022,7 @@ blockchain =
             { slotNo = slot 13 20991
             , blockHeight = Quantity 301749
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
+            , parentHeaderHash = Just $ Hash "m\FS\235\ETB6\151'\250M\SUB\133\235%\172\196B_\176n\164k\215\236\246\152\214cc\214\&9\207\142"
             }
         , transactions =
             [ Tx
@@ -1081,7 +1081,7 @@ blockchain =
             { slotNo = slot 13 21458
             , blockHeight = Quantity 302216
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
+            , parentHeaderHash = Just $ Hash "hA\130\182\129\161\&7u8\CANx\218@S{\131w\166\192Bo\131) 2\190\217\134\&7\223\&2>"
             }
         , transactions =
             [ Tx
@@ -1140,7 +1140,7 @@ blockchain =
             { slotNo = slot 13 21586
             , blockHeight = Quantity 1321586
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
+            , parentHeaderHash = Just $ Hash "D\152\178<\174\160\225\230w\158\194-$\221\212:z\DC1\255\239\220\148Q!\220h+\134\220\195e5"
             }
         , transactions =
             [ Tx
@@ -1175,7 +1175,7 @@ blockchain =
             { slotNo = slot 14 0
             , blockHeight = Quantity 302358
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
+            , parentHeaderHash = Just $ Hash "39d89a1e837e968ba35370be47cdfcbfd193cd992fdeed557b77c49b77ee59cf"
             }
         , transactions = []
         , delegations = []
@@ -1185,7 +1185,7 @@ blockchain =
             { slotNo = slot 14 1
             , blockHeight = Quantity 302359
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
+            , parentHeaderHash = Just $ Hash "2d04732b41d07e45a2b87c05888f956805f94b108f59e1ff3177860a17c292db"
             }
         , transactions =
             [ Tx
@@ -1220,7 +1220,7 @@ blockchain =
             { slotNo = slot 14 2
             , blockHeight = Quantity 302360
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
+            , parentHeaderHash = Just $ Hash "e95a6e7da3cd61e923e30b1998b135d40958419e4157a9f05d2f0f194e4d7bba"
             }
         , transactions =
             [ Tx
@@ -1254,7 +1254,7 @@ blockchain =
             { slotNo = slot 14 3
             , blockHeight = Quantity 302361
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
+            , parentHeaderHash = Just $ Hash "b5d970285a2f8534e94119cd631888c20b3a4ec0707a821f6df5c96650fe01dd"
             }
         , transactions =
             [ Tx
@@ -1289,7 +1289,7 @@ blockchain =
               { slotNo = slot 14 4
               , blockHeight = Quantity 302362
               , headerHash = Hash "unused"
-              , parentHeaderHash = Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
+              , parentHeaderHash = Just $ Hash "cb96ff923728a67e52dfad54df01fc5a20c7aaf386226a0564a1185af9798cb1"
               }
         , transactions = []
         , delegations = []
@@ -1299,7 +1299,7 @@ blockchain =
               { slotNo = slot 14 5
               , blockHeight = Quantity 302363
               , headerHash = Hash "unused"
-              , parentHeaderHash = Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
+              , parentHeaderHash = Just $ Hash "63040af5ed7eb2948e2c09a43f946c91d5dd2efaa168bbc5c4f3e989cfc337e6"
               }
         , transactions =
             [ Tx
@@ -1338,7 +1338,7 @@ blockchain =
             { slotNo = slot 14 6
             , blockHeight = Quantity 302364
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
+            , parentHeaderHash = Just $ Hash "1a32e01995225c7cd514e0fe5087f19a6fd597a6071ad4ad1fbf5b20de39670b"
             }
         , transactions = []
         , delegations = []
@@ -1348,7 +1348,7 @@ blockchain =
             { slotNo = slot 14 7
             , blockHeight = Quantity 302365
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
+            , parentHeaderHash = Just $ Hash "7855c0f101b6761b234058e7e9fd19fbed9fee90a202cca899da1f6cbf29518d"
             }
         , transactions = []
         , delegations = []
@@ -1358,7 +1358,7 @@ blockchain =
             { slotNo = slot 14 8
             , blockHeight = Quantity 302366
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
+            , parentHeaderHash = Just $ Hash "9007e0513b9fea848034a7203b380cdbbba685073bcfb7d8bb795130d92e7be8"
             }
         , transactions = []
         , delegations = []
@@ -1368,7 +1368,7 @@ blockchain =
             { slotNo = slot 14 9
             , blockHeight = Quantity 302367
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
+            , parentHeaderHash = Just $ Hash "0af8082504f59eb1b7114981b7dee9009064638420382211118730b45ad385ae"
             }
         , transactions = []
         , delegations = []
@@ -1378,7 +1378,7 @@ blockchain =
             { slotNo = slot 14 10
             , blockHeight = Quantity 302368
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
+            , parentHeaderHash = Just $ Hash "adc8c71d2c85cee39fbb34cdec6deca2a4d8ce6493d6d28f542d891d5504fc38"
             }
         , transactions =
             [ Tx
@@ -1437,7 +1437,7 @@ blockchain =
             { slotNo = slot 14 11
             , blockHeight = Quantity 302369
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
+            , parentHeaderHash = Just $ Hash "4fdff9f1d751dba5a48bc2a14d6dfb21709882a13dad495b856bf76d5adf4bd1"
             }
         , transactions =
             [ Tx
@@ -1496,7 +1496,7 @@ blockchain =
             { slotNo = slot 14 12
             , blockHeight = Quantity 302370
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
+            , parentHeaderHash = Just $ Hash "96a31a7cdb410aeb5756ddb43ee2ddb4c682f6308db38310ab54bf38b89d6b0d"
             }
         , transactions = []
         , delegations = []
@@ -1506,7 +1506,7 @@ blockchain =
             { slotNo = slot 14 13
             , blockHeight = Quantity 302371
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
+            , parentHeaderHash = Just $ Hash "47c08c0a11f66aeab915e5cd19362e8da50dc2523e629b230b73ec7b6cdbeef8"
             }
         , delegations = []
         , transactions = []
@@ -1516,7 +1516,7 @@ blockchain =
             { slotNo = slot 14 14
             , blockHeight = Quantity 302372
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
+            , parentHeaderHash = Just $ Hash "d6d7e79e2a25f53e6fb771eebd1be05274861004dc62c03bf94df03ff7b87198"
             }
         , delegations = []
         , transactions = []
@@ -1526,7 +1526,7 @@ blockchain =
             { slotNo = slot 14 15
             , blockHeight = Quantity 302373
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
+            , parentHeaderHash = Just $ Hash "647e62b29ebcb0ecfa0b4deb4152913d1a669611d646072d2f5898835b88d938"
             }
         , delegations = []
         , transactions = []
@@ -1536,7 +1536,7 @@ blockchain =
             { slotNo = slot 14 16
             , blockHeight = Quantity 302374
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
+            , parentHeaderHash = Just $ Hash "02f38ce50c9499f2526dd9c5f9e8899e65c0c40344e14ff01dc6c31137978efb"
             }
         , delegations = []
         , transactions = []
@@ -1546,7 +1546,7 @@ blockchain =
             { slotNo = slot 14 17
             , blockHeight = Quantity 302375
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
+            , parentHeaderHash = Just $ Hash "528492ded729ca77a72b1d85654742db85dfd3b68e6c4117ce3c253e3e86616d"
             }
         , delegations = []
         , transactions = []
@@ -1556,7 +1556,7 @@ blockchain =
             { slotNo = slot 14 18
             , blockHeight = Quantity 302376
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
+            , parentHeaderHash = Just $ Hash "f4283844eb78ca6f6333b007f5a735d71499d6ce7cc816846a033a36784bd299"
             }
         , transactions =
             [ Tx
@@ -1615,7 +1615,7 @@ blockchain =
             { slotNo = slot 14 19
             , blockHeight = Quantity 302377
             , headerHash = Hash "unused"
-            , parentHeaderHash = Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
+            , parentHeaderHash = Just $ Hash "dffc3506d381361468376227e1c9323a2ffc76011103e3225124f08e6969a73b"
             }
         , transactions =
             [ Tx

--- a/lib/core/test/unit/Cardano/WalletSpec.hs
+++ b/lib/core/test/unit/Cardano/WalletSpec.hs
@@ -879,7 +879,7 @@ prop_localTxSubmission tc = monadicIO $ do
     mockNodeTip end sl cb
         | sl < end = do
             let h = Hash ""
-            void $ cb $ BlockHeader (SlotNo sl) (Quantity (fromIntegral sl)) h h
+            void $ cb $ BlockHeader (SlotNo sl) (Quantity (fromIntegral sl)) h (Just h)
             mockNodeTip end (sl + 1) cb
         | otherwise = pure ()
 
@@ -1323,7 +1323,7 @@ mockNetworkLayer = dummyNetworkLayer
         error "dummyNetworkLayer: syncProgress not implemented"
     }
   where
-    dummyTip = BlockHeader (SlotNo 0) (Quantity 0) dummyHash dummyHash
+    dummyTip = BlockHeader (SlotNo 0) (Quantity 0) dummyHash (Just dummyHash)
     dummyHash = Hash "dummy hash"
 
 newtype DummyState

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -101,7 +101,6 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as W
 import qualified Cardano.Wallet.Primitive.Types.Hash as W
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.Tx as W
-import qualified Data.ByteString as BS
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Ouroboros.Consensus.Block as O
@@ -180,7 +179,7 @@ emptyGenesis gp = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            W.Hash (BS.replicate 32 0)
+            W.hashOfNoParent
         }
     }
 
@@ -204,7 +203,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            W.Hash (BS.replicate 32 0)
+            W.hashOfNoParent
         }
     , transactions = mkTx <$> outs
     }

--- a/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Byron/Compatibility.hs
@@ -179,7 +179,7 @@ emptyGenesis gp = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            W.hashOfNoParent
+            Nothing
         }
     }
 
@@ -203,7 +203,7 @@ genesisBlockFromTxOuts gp outs = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            W.hashOfNoParent
+            Nothing
         }
     , transactions = mkTx <$> outs
     }
@@ -256,7 +256,7 @@ toByronBlockHeader gp blk = W.BlockHeader
         fromBlockNo $ O.blockNo blk
     , headerHash =
         fromByronHash $ O.blockHash blk
-    , parentHeaderHash =
+    , parentHeaderHash = Just $
         fromChainHash (W.getGenesisBlockHash gp) $
         headerPrevHash (O.getHeader blk)
     }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -394,7 +394,7 @@ emptyGenesis gp = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            hashOfNoParent
+            W.hashOfNoParent
         }
     }
 
@@ -409,11 +409,6 @@ nodeToClientVersions = [NodeToClientV_8, NodeToClientV_9]
 --------------------------------------------------------------------------------
 --
 -- Type Conversions
-
--- | Magic value for the absence of a block.
-hashOfNoParent :: W.Hash "BlockHeader"
-hashOfNoParent =
-    W.Hash . BS.pack $ replicate 32 0
 
 toCardanoHash :: W.Hash "BlockHeader" -> OneEraHash (CardanoEras sc)
 toCardanoHash (W.Hash bytes) =
@@ -606,7 +601,7 @@ fromTip genesisHash tip = case getPoint (getTipPoint tip) of
         { slotNo = W.SlotNo 0
         , blockHeight = Quantity 0
         , headerHash = coerce genesisHash
-        , parentHeaderHash = hashOfNoParent
+        , parentHeaderHash = W.hashOfNoParent
         }
     At blk -> W.BlockHeader
         { slotNo = Point.blockPointSlot blk
@@ -1167,7 +1162,7 @@ fromGenesisData g initialFunds =
             , headerHash =
                 dummyGenesisHash
             , parentHeaderHash =
-                W.Hash (BS.replicate 32 0)
+                W.hashOfNoParent
             }
         , transactions = mkTx <$> outs
         }

--- a/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
+++ b/lib/shelley/src/Cardano/Wallet/Shelley/Compatibility.hs
@@ -394,7 +394,7 @@ emptyGenesis gp = W.Block
         , headerHash =
             coerce $ W.getGenesisBlockHash gp
         , parentHeaderHash =
-            W.hashOfNoParent
+            Nothing
         }
     }
 
@@ -455,7 +455,7 @@ toShelleyBlockHeader genesisHash blk =
                 fromBlockNo $ SL.bheaderBlockNo header
             , headerHash =
                 fromShelleyHash headerHash
-            , parentHeaderHash =
+            , parentHeaderHash = Just $
                 fromPrevHash (coerce genesisHash) $
                     SL.bheaderPrev header
             }
@@ -601,14 +601,14 @@ fromTip genesisHash tip = case getPoint (getTipPoint tip) of
         { slotNo = W.SlotNo 0
         , blockHeight = Quantity 0
         , headerHash = coerce genesisHash
-        , parentHeaderHash = W.hashOfNoParent
+        , parentHeaderHash = Nothing
         }
     At blk -> W.BlockHeader
         { slotNo = Point.blockPointSlot blk
         , blockHeight = fromBlockNo $ getLegacyTipBlockNo tip
         , headerHash = fromCardanoHash $ Point.blockPointHash blk
         -- TODO: parentHeaderHash could be removed.
-        , parentHeaderHash = W.Hash "parentHeaderHash - unused in Shelley"
+        , parentHeaderHash = Just $ W.Hash "parentHeaderHash - unused in Shelley"
         }
   where
     -- TODO: This function was marked deprecated in ouroboros-network.
@@ -1162,7 +1162,7 @@ fromGenesisData g initialFunds =
             , headerHash =
                 dummyGenesisHash
             , parentHeaderHash =
-                W.hashOfNoParent
+                Nothing
             }
         , transactions = mkTx <$> outs
         }


### PR DESCRIPTION
### Issue number

ADP-1169

### Overview

Previous work in epic ADP-1043 introduced delta encodings, DBVars, and an embedding of the wallet state and its delta encodings into a database table. It's time to integrate these tools with the wallet code. To facilitate code review, the integration proceeds in a sequence of refactorings that do not change functionality and pass all unit tests.

In this step, we introduce a type Checkpoints a which stores all checkpoints of the wallet state in memory. The current ad-hoc cache of the latest checkpoints is replaced by a DBVar that stores these checkpoints instead.

### Details

* Keep the `Checkpoints` type stupid and simple for now. It will be replaced later.
* This pull request will (temporarily) increase the memory requirements for the wallet, as the collection of checkpoints is kept in-memory. However, memory usage will go back to normal (and better) once delta encodings are integrated.

### Comments

Merge PR #2841 before this one, because this pull request is based on the branch of the former.
