### PR TITLE
Fix termination condition within `Balance.performSelection`.

### DIFF
--- a/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
+++ b/lib/core-integration/src/Test/Integration/Scenario/API/Shelley/Transactions.hs
@@ -161,6 +161,7 @@ import Test.Integration.Framework.TestData
     , errMsg403MinUTxOValue
     , errMsg403NotAShelleyWallet
     , errMsg403NotEnoughMoney
+    , errMsg403TxTooBig
     , errMsg403WithdrawalNotWorth
     , errMsg403WrongPass
     , errMsg404CannotFindTx
@@ -1111,7 +1112,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
             (Link.createTransactionOld @'Shelley wa) Default payload
 
         expectResponseCode HTTP.status403 r
-        expectErrorMessage errMsg403EmptyUTxO r
+        expectErrorMessage errMsg403TxTooBig r
 
     it "TRANSMETA_ESTIMATE_01 - fee estimation includes metadata" $ \ctx -> runResourceT $ do
         (wa, wb) <- (,) <$> fixtureWallet ctx <*> emptyWallet ctx
@@ -1174,7 +1175,7 @@ spec = describe "SHELLEY_TRANSACTIONS" $ do
 
         verify r
             [ expectResponseCode HTTP.status403
-            , expectErrorMessage errMsg403EmptyUTxO
+            , expectErrorMessage errMsg403TxTooBig
             ]
 
     describe "TRANS_ESTIMATE_08 - Bad payload" $ do

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -857,8 +857,10 @@ performSelectionNonEmpty constraints params
             , minimumBalance = utxoBalanceRequired
             }
         case maybeSelection of
-            Nothing ->
+            Nothing | utxoAvailable == UTxOSelection.empty ->
                 pure $ Left EmptyUTxO
+            Nothing ->
+                selectionLimitReachedError []
             Just selection | selectionLimitExceeded selection selectionLimit ->
                 selectionLimitReachedError $ F.toList $
                     UTxOSelection.selectedList selection

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1010,6 +1010,9 @@ prop_performSelection mockConstraints (Blind params) coverage =
         assertOnSelectionLimitReached
             "utxoBalanceRequired == errorBalanceRequired"
             (utxoBalanceRequired == errorBalanceRequired)
+        assertOnSelectionLimitReached
+          "view #utxoAvailable params /= UTxOSelection.empty"
+          (view #utxoAvailable params /= UTxOSelection.empty)
       where
         assertOnSelectionLimitReached =
             assertWith . (<>) "onSelectionLimitReached: "


### PR DESCRIPTION
## Issue Number

ADP-1167

## Summary

This PR:
- fixes a broken termination condition within `Balance.performSelection`.
- uses the correct expectations within `TRANSMETA_{CREATE,ESTIMATE}_03`.