### PR TITLE
Preparation for testing of integrated `CoinSelection` module.

### DIFF
--- a/lib/core/cardano-wallet-core.cabal
+++ b/lib/core/cardano-wallet-core.cabal
@@ -395,6 +395,7 @@ test-suite unit
       Cardano.Wallet.Primitive.AddressDiscovery.SharedSpec
       Cardano.Wallet.Primitive.Delegation.StateSpec
       Cardano.Wallet.Primitive.AddressDiscoverySpec
+      Cardano.Wallet.Primitive.CoinSelectionSpec
       Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
       Cardano.Wallet.Primitive.CoinSelection.CollateralSpec
       Cardano.Wallet.Primitive.CollateralSpec

--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -1470,9 +1470,10 @@ selectAssets ctx params transform = do
                 asCollateral . snd
             }
         SelectionParams
-            { -- Until we properly support minting and burning, set to empty:
-              assetsToBurn = TokenMap.empty
-            , assetsToMint = TokenMap.empty
+            { assetsToMint =
+                params ^. (#txContext . #txAssetsToMint)
+            , assetsToBurn =
+                params ^. (#txContext . #txAssetsToBurn)
             , outputsToCover = params ^. #outputs
             , rewardWithdrawal =
                 withdrawalToCoin $ params ^. (#txContext . #txWithdrawal)

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -405,10 +405,6 @@ data SelectionSkeleton = SelectionSkeleton
         :: ![TxOut]
     , skeletonChange
         :: ![Set AssetId]
-    , skeletonAssetsToMint
-        :: !TokenMap
-    , skeletonAssetsToBurn
-        :: !TokenMap
     }
     deriving (Eq, Generic, Show)
 
@@ -419,8 +415,6 @@ emptySkeleton = SelectionSkeleton
     { skeletonInputCount = 0
     , skeletonOutputs = mempty
     , skeletonChange = mempty
-    , skeletonAssetsToMint = TokenMap.empty
-    , skeletonAssetsToBurn = TokenMap.empty
     }
 
 -- | Specifies a limit to adhere to when performing a selection.
@@ -605,8 +599,6 @@ selectionSkeleton s = SelectionSkeleton
     { skeletonInputCount = F.length (view #inputsSelected s)
     , skeletonOutputs = F.toList (view #outputsCovered s)
     , skeletonChange = TokenBundle.getAssets <$> view #changeGenerated s
-    , skeletonAssetsToMint = view #assetsToMint s
-    , skeletonAssetsToBurn = view #assetsToBurn s
     }
 
 -- | Computes the minimum required cost of a selection.
@@ -1037,8 +1029,6 @@ performSelectionNonEmpty constraints params
             { skeletonInputCount = UTxOSelection.selectedSize s
             , skeletonOutputs = NE.toList outputsToCover
             , skeletonChange
-            , skeletonAssetsToMint = assetsToMint
-            , skeletonAssetsToBurn = assetsToBurn
             }
 
         skeletonChange = predictChange s

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -30,7 +30,6 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
       PerformSelection
     , performSelection
     , performSelectionEmpty
-    , prepareOutputsWith
     , emptySkeleton
     , SelectionConstraints (..)
     , SelectionParams
@@ -188,7 +187,6 @@ import qualified Cardano.Wallet.Primitive.Types.Coin as Coin
 import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
 import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 import qualified Cardano.Wallet.Primitive.Types.TokenQuantity as TokenQuantity
-import qualified Cardano.Wallet.Primitive.Types.Tx as Tx
 import qualified Cardano.Wallet.Primitive.Types.UTxOIndex as UTxOIndex
 import qualified Cardano.Wallet.Primitive.Types.UTxOSelection as UTxOSelection
 import qualified Data.Foldable as F
@@ -718,31 +716,6 @@ data UnableToConstructChangeError = UnableToConstructChangeError
         -- ^ The additional coin quantity that would be required to cover the
         -- selection cost and minimum coin quantity of each change output.
     } deriving (Generic, Eq, Show)
-
--- | Transforms a set of outputs (provided by users) into valid Cardano outputs.
---
--- Every output in Cardano needs to have a minimum quantity of ada, in order to
--- prevent attacks that flood the network with worthless UTxOs.
---
--- However, we do not require users to specify the minimum ada quantity
--- themselves. Most users would prefer to send '10 Apple' rather than
--- '10 Apple & 1.2 Ada'.
---
--- Therefore, unless a coin quantity is explicitly specified, we assign a coin
--- quantity manually for each non-ada output. That quantity is the minimum
--- quantity required to make a particular output valid.
---
-prepareOutputsWith
-    :: (TokenMap -> Coin)
-    -> [TxOut]
-    -> [TxOut]
-prepareOutputsWith minCoinValueFor = fmap $ \out ->
-    out { Tx.tokens = augmentBundle (Tx.tokens out) }
-  where
-    augmentBundle bundle =
-        if TokenBundle.getCoin bundle == Coin 0
-        then bundle { coin = minCoinValueFor (view #tokens bundle) }
-        else bundle
 
 type PerformSelection m outputs =
     SelectionConstraints ->

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -61,6 +61,8 @@ import Cardano.Wallet.Primitive.Types.Coin
     ( Coin (..) )
 import Cardano.Wallet.Primitive.Types.RewardAccount
     ( RewardAccount )
+import Cardano.Wallet.Primitive.Types.TokenMap
+    ( TokenMap )
 import Cardano.Wallet.Primitive.Types.Tx
     ( TokenBundleSizeAssessor
     , Tx (..)
@@ -81,7 +83,7 @@ import GHC.Generics
     ( Generic )
 
 import qualified Cardano.Api.Shelley as Node
-
+import qualified Cardano.Wallet.Primitive.Types.TokenMap as TokenMap
 
 data TransactionLayer k tx = TransactionLayer
     { mkTransaction
@@ -202,6 +204,10 @@ data TransactionCtx = TransactionCtx
     , txPlutusScriptExecutionCost :: Coin
     -- ^ Total execution cost of plutus scripts, determined by their execution units
     -- and prices obtained from network.
+    , txAssetsToMint :: TokenMap
+    -- ^ The assets to mint.
+    , txAssetsToBurn :: TokenMap
+    -- ^ The assets to burn.
     } deriving (Show, Generic, Eq)
 
 data Withdrawal
@@ -225,6 +231,8 @@ defaultTransactionCtx = TransactionCtx
     , txTimeToLive = maxBound
     , txDelegationAction = Nothing
     , txPlutusScriptExecutionCost = Coin 0
+    , txAssetsToMint = TokenMap.empty
+    , txAssetsToBurn = TokenMap.empty
     }
 
 -- | Whether the user is attempting any particular delegation action.

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -2112,8 +2112,6 @@ computeMinimumCostLinear s
     $ skeletonInputCount s
     + F.length (TokenMap.size . view (#tokens . #tokens) <$> skeletonOutputs s)
     + F.sum (Set.size <$> skeletonChange s)
-    + TokenMap.size (skeletonAssetsToMint s)
-    + TokenMap.size (skeletonAssetsToBurn s)
 
 --------------------------------------------------------------------------------
 -- Computing selection limits

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -15,6 +15,8 @@
 
 module Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
     ( spec
+    , MockComputeMinimumAdaQuantity
+    , unMockComputeMinimumAdaQuantity
     ) where
 
 import Prelude
@@ -63,7 +65,6 @@ import Cardano.Wallet.Primitive.CoinSelection.Balance
     , mapMaybe
     , performSelection
     , performSelectionEmpty
-    , prepareOutputsWith
     , reduceTokenQuantities
     , removeBurnValueFromChangeMaps
     , removeBurnValuesFromChangeMaps
@@ -254,17 +255,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelection.BalanceSpec" $
 
         it "prop_AssetCount_TokenMap_placesEmptyMapsFirst" $
             property prop_AssetCount_TokenMap_placesEmptyMapsFirst
-
-    parallel $ describe "Preparing outputs" $ do
-
-        it "prop_prepareOutputWith_twice" $
-            property prop_prepareOutputsWith_twice
-        it "prop_prepareOutputsWith_length" $
-            property prop_prepareOutputsWith_length
-        it "prop_prepareOutputsWith_assetsUnchanged" $
-            property prop_prepareOutputsWith_assetsUnchanged
-        it "prop_prepareOutputsWith_preparedOrExistedBefore" $
-            property prop_prepareOutputsWith_preparedOrExistedBefore
 
     parallel $ describe "Performing a selection" $ do
 
@@ -544,58 +534,6 @@ prop_AssetCount_TokenMap_placesEmptyMapsFirst maps =
     isEmptyMap = TokenMap.isEmpty
     (emptyMaps, nonEmptyMaps) = NE.partition isEmptyMap maps
     (emptyMapCount, nonEmptyMapCount) = (length emptyMaps, length nonEmptyMaps)
-
---------------------------------------------------------------------------------
--- Preparing outputs
---------------------------------------------------------------------------------
-
-prop_prepareOutputsWith_twice
-    :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
-    -> Property
-prop_prepareOutputsWith_twice minCoinValueDef outs =
-    once === twice
-  where
-    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
-    (_:once:twice:_) = iterate (prepareOutputsWith minCoinValueFor) outs
-
-prop_prepareOutputsWith_length
-    :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
-    -> Property
-prop_prepareOutputsWith_length minCoinValueDef outs =
-    F.length (prepareOutputsWith minCoinValueFor outs) === F.length outs
-  where
-    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
-
-prop_prepareOutputsWith_assetsUnchanged
-    :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
-    -> Property
-prop_prepareOutputsWith_assetsUnchanged minCoinValueDef outs =
-    (txOutAssets <$> (prepareOutputsWith minCoinValueFor outs))
-    ===
-    (txOutAssets <$> outs)
-  where
-    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
-    txOutAssets = TokenBundle.getAssets . view #tokens
-
-prop_prepareOutputsWith_preparedOrExistedBefore
-    :: MockComputeMinimumAdaQuantity
-    -> [TxOut]
-    -> Property
-prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
-    property $ F.all isPreparedOrExistedBefore (zip outs outs')
-  where
-    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
-    outs' = prepareOutputsWith minCoinValueFor outs
-
-    isPreparedOrExistedBefore :: (TxOut, TxOut) -> Bool
-    isPreparedOrExistedBefore (before, after)
-        | txOutCoin before /= Coin 0 =
-            txOutCoin after == txOutCoin before
-        | otherwise =
-            txOutCoin after == minCoinValueFor (view (#tokens . #tokens) before)
 
 --------------------------------------------------------------------------------
 -- Performing a selection

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE OverloadedLabels #-}
+
+module Cardano.Wallet.Primitive.CoinSelectionSpec
+    ( spec
+    ) where
+
+import Prelude
+
+import Cardano.Wallet.Primitive.CoinSelection
+    ( prepareOutputsWith )
+import Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
+    ( MockComputeMinimumAdaQuantity, unMockComputeMinimumAdaQuantity )
+import Cardano.Wallet.Primitive.Types.Coin
+    ( Coin (..) )
+import Cardano.Wallet.Primitive.Types.Tx
+    ( TxOut (..), txOutCoin )
+import Data.Generics.Internal.VL.Lens
+    ( view )
+import Test.Hspec
+    ( Spec, describe, it )
+import Test.Hspec.Extra
+    ( parallel )
+import Test.QuickCheck
+    ( Property, property, (===) )
+
+import qualified Cardano.Wallet.Primitive.Types.TokenBundle as TokenBundle
+import qualified Data.Foldable as F
+
+spec :: Spec
+spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $
+
+    parallel $ describe "Preparing outputs" $ do
+
+        it "prop_prepareOutputsWith_twice" $
+            property prop_prepareOutputsWith_twice
+        it "prop_prepareOutputsWith_length" $
+            property prop_prepareOutputsWith_length
+        it "prop_prepareOutputsWith_assetsUnchanged" $
+            property prop_prepareOutputsWith_assetsUnchanged
+        it "prop_prepareOutputsWith_preparedOrExistedBefore" $
+            property prop_prepareOutputsWith_preparedOrExistedBefore
+
+--------------------------------------------------------------------------------
+-- Preparing outputs
+--------------------------------------------------------------------------------
+
+prop_prepareOutputsWith_twice
+    :: MockComputeMinimumAdaQuantity
+    -> [TxOut]
+    -> Property
+prop_prepareOutputsWith_twice minCoinValueDef outs =
+    once === twice
+  where
+    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
+    (_:once:twice:_) = iterate (prepareOutputsWith minCoinValueFor) outs
+
+prop_prepareOutputsWith_length
+    :: MockComputeMinimumAdaQuantity
+    -> [TxOut]
+    -> Property
+prop_prepareOutputsWith_length minCoinValueDef outs =
+    F.length (prepareOutputsWith minCoinValueFor outs) === F.length outs
+  where
+    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
+
+prop_prepareOutputsWith_assetsUnchanged
+    :: MockComputeMinimumAdaQuantity
+    -> [TxOut]
+    -> Property
+prop_prepareOutputsWith_assetsUnchanged minCoinValueDef outs =
+    (txOutAssets <$> (prepareOutputsWith minCoinValueFor outs))
+    ===
+    (txOutAssets <$> outs)
+  where
+    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
+    txOutAssets = TokenBundle.getAssets . view #tokens
+
+prop_prepareOutputsWith_preparedOrExistedBefore
+    :: MockComputeMinimumAdaQuantity
+    -> [TxOut]
+    -> Property
+prop_prepareOutputsWith_preparedOrExistedBefore minCoinValueDef outs =
+    property $ F.all isPreparedOrExistedBefore (zip outs outs')
+  where
+    minCoinValueFor = unMockComputeMinimumAdaQuantity minCoinValueDef
+    outs' = prepareOutputsWith minCoinValueFor outs
+
+    isPreparedOrExistedBefore :: (TxOut, TxOut) -> Bool
+    isPreparedOrExistedBefore (before, after)
+        | txOutCoin before /= Coin 0 =
+            txOutCoin after == txOutCoin before
+        | otherwise =
+            txOutCoin after == minCoinValueFor (view (#tokens . #tokens) before)

--- a/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
+++ b/lib/shelley/test/unit/Cardano/Wallet/Shelley/TransactionSpec.hs
@@ -368,7 +368,8 @@ feeCalculationSpec = describe "fee calculations" $ do
     it "minting incurs fees" $ property $ \assets ->
         let
             costWith =
-                minFeeSkeleton $ emptyTxSkeleton { txMintBurnAssets = assets }
+                minFeeSkeleton $ emptyTxSkeleton
+                    { txAssetsToMintOrBurn = Set.fromList assets }
             costWithout =
                 minFeeSkeleton emptyTxSkeleton
 
@@ -412,7 +413,8 @@ feeCalculationSpec = describe "fee calculations" $ do
                 F.foldMap (Sum . assetNameLength) mints
 
             sizeWith =
-                estimateTxSize' $ emptyTxSkeleton { txMintBurnAssets = mints }
+                estimateTxSize' $ emptyTxSkeleton
+                    { txAssetsToMintOrBurn = Set.fromList mints }
             sizeWithout =
                 estimateTxSize' emptyTxSkeleton
 
@@ -539,7 +541,8 @@ feeCalculationSpec = describe "fee calculations" $ do
         it "minting incurs fees" $ property $ \assets ->
             let
                 costWith =
-                    minFeeSkeleton $ emptyTxSkeleton { txMintBurnAssets = assets }
+                    minFeeSkeleton $ emptyTxSkeleton
+                        { txAssetsToMintOrBurn = Set.fromList assets }
                 costWithout =
                     minFeeSkeleton emptyTxSkeleton
 
@@ -583,7 +586,8 @@ feeCalculationSpec = describe "fee calculations" $ do
                     F.foldMap (Sum . assetNameLength) mints
 
                 sizeWith =
-                    estimateTxSize' $ emptyTxSkeleton { txMintBurnAssets = mints }
+                    estimateTxSize' $ emptyTxSkeleton
+                        { txAssetsToMintOrBurn = Set.fromList mints }
                 sizeWithout =
                     estimateTxSize' emptyTxSkeleton
 


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR performs some groundwork in preparation for testing the integrated `CoinSelection` module. It:

- Extracts out internal functions from `CoinSelection.performSelection` to clarify the control flow and make testing easier.
- Moves `prepareOutputsWith` to the top-level `CoinSelection` module.
- Moves minted and burned assets from `SelectionSkeleton` to `TransactionCtx`.
- Populates the `assetsTo{Mint,Burn}` field within `selectAssets`.