### PR TITLE
Add `txCollateralRequirement` to `TransactionCtx`.

### DIFF
--- a/lib/core/src/Cardano/Wallet.hs
+++ b/lib/core/src/Cardano/Wallet.hs
@@ -297,7 +297,6 @@ import Cardano.Wallet.Primitive.AddressDiscovery.Shared
     )
 import Cardano.Wallet.Primitive.CoinSelection
     ( Selection
-    , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
     , SelectionError (..)
     , SelectionOf (..)
@@ -1484,10 +1483,8 @@ selectAssets ctx params transform = do
                 case params ^. (#txContext . #txDelegationAction) of
                     Just (RegisterKeyAndJoin _) -> 1
                     _ -> 0
-              -- TODO: [ADP-957]
-              -- Until support for collateral is fully integrated, specify
-              -- that collateral is not required:
-            , collateralRequirement = SelectionCollateralNotRequired
+            , collateralRequirement =
+                params ^. (#txContext . #txCollateralRequirement)
             , utxoAvailableForCollateral =
                 params ^. #utxoAvailableForCollateral
             , utxoAvailableForInputs =

--- a/lib/core/src/Cardano/Wallet/Transaction.hs
+++ b/lib/core/src/Cardano/Wallet/Transaction.hs
@@ -44,7 +44,7 @@ import Cardano.Api
 import Cardano.Wallet.Primitive.AddressDerivation
     ( Depth (..), DerivationIndex, Passphrase )
 import Cardano.Wallet.Primitive.CoinSelection
-    ( SelectionOf (..) )
+    ( SelectionCollateralRequirement (..), SelectionOf (..) )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionLimit, SelectionSkeleton )
 import Cardano.Wallet.Primitive.Slotting
@@ -240,6 +240,8 @@ data TransactionCtx = TransactionCtx
     -- ^ The assets to mint.
     , txAssetsToBurn :: TokenMap
     -- ^ The assets to burn.
+    , txCollateralRequirement :: SelectionCollateralRequirement
+    -- ^ The collateral requirement.
     } deriving (Show, Generic, Eq)
 
 data Withdrawal
@@ -265,6 +267,7 @@ defaultTransactionCtx = TransactionCtx
     , txPlutusScriptExecutionCost = Coin 0
     , txAssetsToMint = TokenMap.empty
     , txAssetsToBurn = TokenMap.empty
+    , txCollateralRequirement = SelectionCollateralNotRequired
     }
 
 -- | Whether the user is attempting any particular delegation action.


### PR DESCRIPTION
## Issue Number

ADP-1042

## Summary

This PR:
- adds field `txCollateralRequirement` to `TransactionCtx`.
- uses the `txCollateralRequirement` within `Wallet.selectAssets` to populate the `SelectionParams` record.