### PR TITLE
Improve clarity of test failures within `prop_performSelection`.

### DIFF
--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -839,7 +839,7 @@ prop_performSelection mockConstraints params coverage =
             ]
         result <- run $ performSelection constraints params
         monitor (coverage result)
-        either onFailure onSuccess result
+        either (stop . onFailure) onSuccess result
   where
     constraints :: SelectionConstraints
     constraints = unMockSelectionConstraints mockConstraints
@@ -912,18 +912,18 @@ prop_performSelection mockConstraints params coverage =
                 (view #inputsSelected result <&> fst)
                 (view #utxoAvailable params)
 
-    onFailure :: SelectionError -> PropertyM IO ()
+    onFailure :: SelectionError -> Property
     onFailure = \case
         BalanceInsufficient e ->
-            stop $ onBalanceInsufficient e
+            onBalanceInsufficient e
         SelectionLimitReached e ->
-            stop $ onSelectionLimitReached e
+            onSelectionLimitReached e
         InsufficientMinCoinValues es ->
-            stop $ onInsufficientMinCoinValues es
+            onInsufficientMinCoinValues es
         UnableToConstructChange e ->
-            stop $ onUnableToConstructChange e
+            onUnableToConstructChange e
         EmptyUTxO ->
-            stop onEmptyUTxO
+            onEmptyUTxO
 
     onBalanceInsufficient :: BalanceInsufficientError -> Property
     onBalanceInsufficient e =

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -824,19 +824,17 @@ prop_performSelection
     -> (PerformSelectionResult -> Property -> Property)
     -> Property
 prop_performSelection mockConstraints params coverage =
+    report extraCoinSource
+        "extraCoinSource" $
+    report extraCoinSink
+        "extraCoinSink" $
+    report selectionLimit
+        "selectionLimit" $
+    report assetsToMint
+        "assetsToMint" $
+    report assetsToBurn
+        "assetsToBurn" $
     monadicIO $ do
-        monitor $ counterexample $ unlines
-            [ "extraCoinSource:"
-            , show extraCoinSource
-            , "extraCoinSink:"
-            , show extraCoinSink
-            , "selectionLimit:"
-            , show selectionLimit
-            , "assetsToMint:"
-            , pretty (Flat assetsToMint)
-            , "assetsToBurn:"
-            , pretty (Flat assetsToBurn)
-            ]
         result <- run $ performSelection constraints params
         monitor (coverage result)
         pure $ either onFailure onSuccess result

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -699,7 +699,7 @@ prop_performSelection_small mockConstraints (Blind (Small params)) =
     cover 2 (not allMintedAssetsEitherBurnedOrSpent)
         "Some minted assets were neither spent nor burned" $
 
-    prop_performSelection mockConstraints (Blind params) $ \result ->
+    prop_performSelection mockConstraints params $ \result ->
         cover 10 (selectionUnlimited && selectionSufficient result)
             "selection unlimited and sufficient"
         . cover 2 (selectionLimited && selectionSufficient result)
@@ -796,7 +796,7 @@ prop_performSelection_large mockConstraints (Blind (Large params)) =
     checkCoverage $
     cover 50 (isUTxOBalanceSufficient params)
         "UTxO balance sufficient" $
-    prop_performSelection mockConstraints (Blind params) (const id)
+    prop_performSelection mockConstraints params (const id)
 
 prop_performSelection_huge :: Property
 prop_performSelection_huge = ioProperty $
@@ -813,17 +813,17 @@ prop_performSelection_huge_inner
     -> Property
 prop_performSelection_huge_inner utxoAvailable mockConstraints (Large params) =
     withMaxSuccess 5 $
-    prop_performSelection mockConstraints (Blind params') (const id)
+    prop_performSelection mockConstraints params' (const id)
   where
     params' = params & set #utxoAvailable
         (UTxOSelection.fromIndex utxoAvailable)
 
 prop_performSelection
     :: MockSelectionConstraints
-    -> Blind SelectionParams
+    -> SelectionParams
     -> (PerformSelectionResult -> Property -> Property)
     -> Property
-prop_performSelection mockConstraints (Blind params) coverage =
+prop_performSelection mockConstraints params coverage =
     monadicIO $ do
         monitor $ counterexample $ unlines
             [ "extraCoinSource:"

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs
@@ -1104,18 +1104,19 @@ prop_performSelectionEmpty mockConstraints (Small params) =
     constraints = unMockSelectionConstraints mockConstraints
 
     paramsTransformed :: SelectionParamsOf (NonEmpty TxOut)
-    paramsTransformed = view #paramsTransformed report
+    paramsTransformed = view #paramsTransformed transformationReport
 
     result :: SelectionResultOf (NonEmpty TxOut)
-    result = expectRight $ view #result report
+    result = expectRight $ view #result transformationReport
 
     resultTransformed :: SelectionResultOf [TxOut]
-    resultTransformed = expectRight $ view #resultTransformed report
+    resultTransformed =
+        expectRight $ view #resultTransformed transformationReport
 
     -- Provides a report of how 'performSelectionEmpty' has transformed
     -- both the parameters and result of 'mockPerformSelectionNonEmpty'.
     --
-    report = performSelectionEmpty f constraints params
+    transformationReport = performSelectionEmpty f constraints params
       where
         f constraints' params' = withTransformationReport params'
             $ runIdentity


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR uses the [**`report`**](https://github.com/input-output-hk/cardano-wallet/blob/b1ded0657c3d7fafcd7bbac15d9cd07478e34058/lib/test-utils/src/Test/QuickCheck/Extra.hs#L378) and [**`verify`**](https://github.com/input-output-hk/cardano-wallet/blob/b1ded0657c3d7fafcd7bbac15d9cd07478e34058/lib/test-utils/src/Test/QuickCheck/Extra.hs#L386) combinators to clarify the output of failures for the [`BalanceSpec.prop_performSelection`](https://github.com/input-output-hk/cardano-wallet/blob/942f12ae838fbce0ba00ce0109c7e26ba53e4318/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelection/BalanceSpec.hs#L821) property.

Currently, failures of this property are hard to debug, since even if only one assertion fails, then the names of all successful assertions prior to the failed assertion will also be appended to the output. (This is a limitation of `assertWith`.)

## Details

* The [**`report`**](https://github.com/input-output-hk/cardano-wallet/blob/b1ded0657c3d7fafcd7bbac15d9cd07478e34058/lib/test-utils/src/Test/QuickCheck/Extra.hs#L378) combinator automatically pretty-prints values that are passed to it, making it much easier to inspect the internal structure of counterexample values.
* The [**`verify`**](https://github.com/input-output-hk/cardano-wallet/blob/b1ded0657c3d7fafcd7bbac15d9cd07478e34058/lib/test-utils/src/Test/QuickCheck/Extra.hs#L386) combinator produces clearer output than `assertWith`, since `verify` produces output that's **_specific_** to the condition that fails, whereas `assertWith` can only append to the current counterexample text, making it unsuitable for use in situations where there are many things to verify.

Both of these combinators require a non-monadic `Property` context, so this PR also converts most of `prop_performSelection` to a non-monadic style. (Only a small portion of this property actually needs to be run within `monadicIO`.)

## Sample output

![sample-failure-for-performSelection](https://user-images.githubusercontent.com/206319/136497971-85fe46ce-c2bb-4f31-b6bd-eaab8dc1b7dd.png)

