### PR TITLE
Don't run stack test on Buildkite 

### DIFF
--- a/.buildkite/rebuild.hs
+++ b/.buildkite/rebuild.hs
@@ -159,9 +159,9 @@ buildStep' dryRun qa pkgs = foldl1 (.&&.)
         build Standard ["--only-dependencies"]
     , titled "Build" $
         projectBuild ["--test", "--no-run-tests"]
-    , titled "Tests (except integration)" $
-        timeout 60 $ do
-            test (skip "integration") []
+    -- , titled "Tests (except integration)" $
+    --     timeout 60 $ do
+    --         test (skip "integration") []
     , titled "Checking golden test files" $
         checkUnclean dryRun "lib/core/test/data"
     , when' runIntegration $ titled "Integration tests on latest era" $

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://buildkite.com/input-output-hk/cardano-wallet"><img src="https://img.shields.io/buildkite/7ea3dac7a16f066d8dfc8f426a9a9f7a2131e899cd96c444cf/master?label=BUILD&style=for-the-badge"/></a>
   <a href="https://buildkite.com/input-output-hk/cardano-wallet-nightly"><img src="https://img.shields.io/buildkite/59ea9363b8526e867005ca8839db47715bc5f661f36e490143/master?label=BENCHMARK&style=for-the-badge" /></a>
   <a href="https://github.com/input-output-hk/cardano-wallet/actions?query=workflow%3Awindows"><img src="https://img.shields.io/github/workflow/status/input-output-hk/cardano-wallet/windows?label=Windows&style=for-the-badge" /></a>
+  <a href="https://hydra.iohk.io/jobset/Cardano/cardano-wallet#tabs-jobs"><img src="https://raw.githubusercontent.com/input-output-hk/cardano-wallet/ci-stats/hydra-badge.svg" /></a>
   <!--
   <a href="https://coveralls.io/github/input-output-hk/cardano-wallet?branch=HEAD"><img src="https://img.shields.io/coveralls/github/input-output-hk/cardano-wallet/HEAD?style=for-the-badge" /></a>
   -->


### PR DESCRIPTION
Reduce flakiness of CI by not running Stack test step in Buildkite pipeline.

@jonathanknowles reported a flaky Stack test run in this build: https://buildkite.com/input-output-hk/cardano-wallet/builds/17155#77dce73e-664a-4bb6-9e6b-d5a898a47d5d.

One way we can reduce this flakiness is by not running the tests in the Buildkite pipeline.

My argument for doing so it that doing so adds very little to our test coverage:
- We already run the tests as part of the Nix + Cabal CI on Hydra.
- The Buildkite and Hydra pipelines both use Nix to provision dependencies.
- The Stack test and the Nix + Cabal test both run on the `packet-ipxe-*` machines, so we aren't testing on different machines. See:

    - Buildkite environment https://buildkite.com/input-output-hk/cardano-wallet/builds/17160#1ae5b95d-7a7f-47a8-a1c1-5252a3d0c962:
![buildkite](https://user-images.githubusercontent.com/5304556/136525534-745bd663-13e5-4764-ad97-e57bbf1cd29e.png)

    - Hydra build https://hydra.iohk.io/build/7899301#tabs-buildsteps:

        ![hydra](https://user-images.githubusercontent.com/5304556/136525545-3e344e39-baf2-4aa7-bf1d-fdd928736c92.png)

The differences between the two invocations are:
1. One uses Cabal to build and run, the other Stack.
2. The Nix environment provided to each invocation is ever-so-slightly different.

So what we are testing by invoking the tests twice is:
- That given the same tests, Stack succeeds iff Cabal succeeds.
- The Nix environment provided to the tests of the Stack build work.

For 1, I believe that this isn't something we care to test. This will only find bugs in Stack. For 2, We aren't removing the Stack build step, just the Stack test step, we are still testing that the Stack build works in the given Nix environment.

I do foresee some risks:
- We might make some environment or configuration modification that causes the Stack tests to fail, but not the Cabal tests. The CI would pass but for those developing locally with Stack, their tests would fail. I can't imagine under what circumstances this would happen, but it's a theoretical possibility.