### PR TITLE
Add coverage for `toBalanceConstraintsParams`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -246,8 +246,8 @@ toBalanceConstraintsParams (constraints, params) =
             -- there is still space available.
             --
             adjustSelectionLimit :: SelectionLimit -> SelectionLimit
-            adjustSelectionLimit = fmap
-                (subtract (view #maximumCollateralInputCount constraints))
+            adjustSelectionLimit = flip Balance.reduceSelectionLimitBy
+                (view #maximumCollateralInputCount constraints)
 
     balanceParams = Balance.SelectionParams
         { assetsToBurn =

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -64,6 +64,7 @@ module Cardano.Wallet.Primitive.CoinSelection
     -- * Internal types and functions
     , ComputeMinimumCollateralParams (..)
     , computeMinimumCollateral
+    , toBalanceConstraintsParams
 
     ) where
 

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection/Balance.hs
@@ -47,6 +47,7 @@ module Cardano.Wallet.Primitive.CoinSelection.Balance
     , SelectionLimitOf (..)
     , selectionLimitExceeded
     , SelectionLimitReachedError (..)
+    , reduceSelectionLimitBy
 
     -- * Querying selections
     , SelectionDelta (..)
@@ -441,6 +442,21 @@ selectionLimitExceeded :: IsUTxOSelection s => s -> SelectionLimit -> Bool
 selectionLimitExceeded s = \case
     NoLimit -> False
     MaximumInputLimit n -> UTxOSelection.selectedSize s > n
+
+-- | Reduces a selection limit by a given reduction amount.
+--
+-- If the given reduction amount is positive, then this function will reduce
+-- the selection limit by that amount.
+--
+-- If the given reduction amount is zero or negative, then this function will
+-- return the original limit unchanged.
+--
+reduceSelectionLimitBy :: SelectionLimit -> Int -> SelectionLimit
+reduceSelectionLimitBy limit reduction
+    | reduction <= 0 =
+        limit
+    | otherwise =
+        subtract reduction <$> limit
 
 type SelectionResult = SelectionResultOf [TxOut]
 

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -32,7 +32,9 @@ import Cardano.Wallet.Primitive.CoinSelection
     , toBalanceConstraintsParams
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionLimit )
+    ( SelectionLimit, SelectionSkeleton )
+import Cardano.Wallet.Primitive.CoinSelection.Balance.Gen
+    ( genSelectionSkeleton, shrinkSelectionSkeleton )
 import Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
     ( MockAssessTokenBundleSize
     , MockComputeMinimumAdaQuantity
@@ -82,7 +84,7 @@ import Data.Function
 import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
-    ( view, (^.) )
+    ( over, view, (^.) )
 import Data.Maybe
     ( isJust )
 import GHC.Generics
@@ -142,6 +144,8 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
 
     parallel $ describe "Constructing balance constraints and parameters" $ do
 
+        it "prop_toBalanceConstraintsParams_computeMinimumCost" $
+            property prop_toBalanceConstraintsParams_computeMinimumCost
         it "prop_toBalanceConstraintsParams_computeSelectionLimit" $
             property prop_toBalanceConstraintsParams_computeSelectionLimit
 
@@ -269,6 +273,63 @@ prop_performSelection_onSuccess_hasSuitableCollateral cs _ps selection =
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters
 --------------------------------------------------------------------------------
+
+-- Tests that function 'toBalanceConstraintsParams' applies the correct
+-- transformation to the 'computeMinimumCost' function.
+--
+prop_toBalanceConstraintsParams_computeMinimumCost
+    :: MockSelectionConstraints
+    -> SelectionParams
+    -> SelectionSkeleton
+    -> Property
+prop_toBalanceConstraintsParams_computeMinimumCost
+    mockConstraints params skeleton =
+        checkCoverage $
+        cover 10 (selectionCollateralRequired params)
+            "collateral required: yes" $
+        cover 10 (not (selectionCollateralRequired params))
+            "collateral required: no" $
+        cover 10 (costOriginal < costAdjusted)
+            "cost (original) < cost (adjusted)" $
+        report costOriginal
+            "cost (original)" $
+        report costAdjusted
+            "cost (adjusted)" $
+        if selectionCollateralRequired params
+        then
+            conjoin
+                [ costOriginal <= costAdjusted
+                -- Here we apply a transformation that is the *inverse* of
+                -- the transformation within 'toBalanceConstraintsParams':
+                , costOriginal ==
+                    ( computeMinimumCostAdjusted
+                    . over #skeletonInputCount
+                        (subtract maximumCollateralInputCount)
+                    $ skeleton
+                    )
+                ]
+        else
+            costOriginal === costAdjusted
+  where
+    constraints :: SelectionConstraints
+    constraints = unMockSelectionConstraints mockConstraints
+
+    maximumCollateralInputCount :: Int
+    maximumCollateralInputCount = constraints ^. #maximumCollateralInputCount
+
+    computeMinimumCostOriginal :: SelectionSkeleton -> Coin
+    computeMinimumCostOriginal = constraints ^. #computeMinimumCost
+
+    computeMinimumCostAdjusted :: SelectionSkeleton -> Coin
+    computeMinimumCostAdjusted =
+        toBalanceConstraintsParams (constraints, params)
+            & fst & view #computeMinimumCost
+
+    costOriginal :: Coin
+    costOriginal = computeMinimumCostOriginal skeleton
+
+    costAdjusted :: Coin
+    costAdjusted = computeMinimumCostAdjusted skeleton
 
 -- Tests that function 'toBalanceConstraintsParams' applies the correct
 -- transformation to the 'computeSelectionLimit' function.
@@ -693,3 +754,7 @@ instance Arbitrary MockSelectionConstraints where
 instance Arbitrary SelectionParams where
     arbitrary = genSelectionParams
     shrink = shrinkSelectionParams
+
+instance Arbitrary SelectionSkeleton where
+    arbitrary = genSelectionSkeleton
+    shrink = shrinkSelectionSkeleton


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR:

- [x] replaces an erroneous call to `subtract` with a dedicated function `reduceSelectionLimitBy`.
- [x] provides property tests to verify that `reduceSelectionLimitBy` has the correct behaviour for all selection limits.
- [x] provides property tests to verify that `toBalanceConstraintsParams` performs the correct adjustment to the `computeMinimumCost` function. 
- [x] provides property tests to verify that `toBalanceConstraintsParams` performs the correct adjustment to the `computeSelectionLimit` function. 

## Background

The `subtract` function (from `Prelude`) is equivalent to `flip (-)`, which means that `subtract a b` is equivalent to `b - a`, rather than the other way round.

Thanks to @KtorZ for discovering this.