### PR TITLE
Unify success post-condition for `performSelection`.

### DIFF
--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -148,10 +148,9 @@ type PerformSelection m a =
 --
 -- This function guarantees that if it successfully creates a 'Selection' @s@,
 -- given a set of 'SelectionConstraints' @cs@ and 'SelectionParameters' @ps@,
--- then the following properties will hold:
+-- then the following property will hold:
 --
---    >>> selectionHasValidSurplus         cs ps s
---    >>> selectionHasSufficientCollateral cs ps s
+--    >>> verifySelection cs ps s == SelectionCorrect
 --
 performSelection
     :: (HasCallStack, MonadRandom m) => PerformSelection m Selection

--- a/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
+++ b/lib/core/src/Cardano/Wallet/Primitive/CoinSelection.hs
@@ -368,6 +368,14 @@ data SelectionCorrectnessError
       SelectionLimitExceededError
     deriving (Eq, Show)
 
+-- | The type of all selection property verification functions.
+--
+type VerifySelectionProperty error =
+    SelectionConstraints ->
+    SelectionParams ->
+    Selection ->
+    Maybe error
+
 -- | Verifies a selection for correctness.
 --
 -- This function is provided primarily as a convenience for testing. As such,
@@ -407,10 +415,7 @@ data SelectionCollateralInsufficientError = SelectionCollateralInsufficientError
     deriving (Eq, Show)
 
 verifySelectionCollateralSufficiency
-    :: SelectionConstraints
-    -> SelectionParams
-    -> Selection
-    -> Maybe SelectionCollateralInsufficientError
+    :: VerifySelectionProperty SelectionCollateralInsufficientError
 verifySelectionCollateralSufficiency cs ps selection
     | collateralSelected >= collateralRequired =
         Nothing
@@ -434,10 +439,7 @@ data SelectionCollateralUnsuitableError = SelectionCollateralUnsuitableError
     deriving (Eq, Show)
 
 verifySelectionCollateralSuitability
-    :: SelectionConstraints
-    -> SelectionParams
-    -> Selection
-    -> Maybe SelectionCollateralUnsuitableError
+    :: VerifySelectionProperty SelectionCollateralUnsuitableError
 verifySelectionCollateralSuitability cs _ps selection
     | null collateralSelectedButUnsuitable =
         Nothing
@@ -466,10 +468,7 @@ data SelectionDeltaInvalidError = SelectionDeltaInvalidError
     deriving (Eq, Show)
 
 verifySelectionDelta
-    :: SelectionConstraints
-    -> SelectionParams
-    -> Selection
-    -> Maybe SelectionDeltaInvalidError
+    :: VerifySelectionProperty SelectionDeltaInvalidError
 verifySelectionDelta cs ps selection
     | selectionHasValidSurplus cs ps selection =
         Nothing
@@ -496,10 +495,7 @@ data SelectionLimitExceededError = SelectionLimitExceededError
     deriving (Eq, Show)
 
 verifySelectionLimit
-    :: SelectionConstraints
-    -> SelectionParams
-    -> Selection
-    -> Maybe SelectionLimitExceededError
+    :: VerifySelectionProperty SelectionLimitExceededError
 verifySelectionLimit cs _ps selection
     | Balance.MaximumInputLimit totalInputCount <= selectionLimit =
         Nothing

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -31,7 +31,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , verifySelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionLimit, SelectionLimitOf (..), SelectionSkeleton )
+    ( SelectionLimit, SelectionSkeleton )
 import Cardano.Wallet.Primitive.CoinSelection.Balance.Gen
     ( genSelectionSkeleton, shrinkSelectionSkeleton )
 import Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
@@ -135,9 +135,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
         it "prop_performSelection_onSuccess_hasValidSurplus" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasValidSurplus
-        it "prop_performSelection_onSuccess_selectionLimitRespected" $
-            prop_performSelection_onSuccess
-            prop_performSelection_onSuccess_selectionLimitRespected
 
     parallel $ describe "Constructing balance constraints and parameters" $ do
 
@@ -250,22 +247,6 @@ prop_performSelection_onSuccess_hasValidSurplus cs ps selection =
     report (selectionMinimumCost cs ps selection)
         "selectionMinimumCost" $
     selectionHasValidSurplus cs ps selection
-
-prop_performSelection_onSuccess_selectionLimitRespected
-    :: PerformSelectionPropertyOnSuccess
-prop_performSelection_onSuccess_selectionLimitRespected cs _ps selection =
-    report (selection ^. #collateral)
-        "collateral" $
-    report (selection ^. #inputs)
-        "inputs" $
-    property $ MaximumInputLimit totalInputCount <= selectionLimit
-  where
-    totalInputCount = (+)
-        (F.length $ selection ^. #collateral)
-        (F.length $ selection ^. #inputs)
-    selectionLimit =
-        (cs ^. #computeSelectionLimit)
-        (selection ^. #outputs)
 
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -32,7 +32,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , toBalanceConstraintsParams
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
-    ( SelectionLimit, SelectionSkeleton )
+    ( SelectionLimit, SelectionLimitOf (..), SelectionSkeleton )
 import Cardano.Wallet.Primitive.CoinSelection.Balance.Gen
     ( genSelectionSkeleton, shrinkSelectionSkeleton )
 import Cardano.Wallet.Primitive.CoinSelection.BalanceSpec
@@ -141,6 +141,9 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
         it "prop_performSelection_onSuccess_hasSuitableCollateral" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasSuitableCollateral
+        it "prop_performSelection_onSuccess_selectionLimitRespected" $
+            prop_performSelection_onSuccess
+            prop_performSelection_onSuccess_selectionLimitRespected
 
     parallel $ describe "Constructing balance constraints and parameters" $ do
 
@@ -269,6 +272,22 @@ prop_performSelection_onSuccess_hasSuitableCollateral cs _ps selection =
   where
     suitableForCollateral :: (TxIn, TxOut) -> Bool
     suitableForCollateral = isJust . view #utxoSuitableForCollateral cs
+
+prop_performSelection_onSuccess_selectionLimitRespected
+    :: PerformSelectionPropertyOnSuccess
+prop_performSelection_onSuccess_selectionLimitRespected cs _ps selection =
+    report (selection ^. #collateral)
+        "collateral" $
+    report (selection ^. #inputs)
+        "inputs" $
+    property $ MaximumInputLimit totalInputCount <= selectionLimit
+  where
+    totalInputCount = (+)
+        (F.length $ selection ^. #collateral)
+        (F.length $ selection ^. #inputs)
+    selectionLimit =
+        (cs ^. #computeSelectionLimit)
+        (selection ^. #outputs)
 
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -17,6 +17,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , Selection
     , SelectionCollateralRequirement (..)
     , SelectionConstraints (..)
+    , SelectionCorrectness (..)
     , SelectionError (..)
     , SelectionParams (..)
     , computeMinimumCollateral
@@ -30,6 +31,7 @@ import Cardano.Wallet.Primitive.CoinSelection
     , selectionMinimumCollateral
     , selectionMinimumCost
     , toBalanceConstraintsParams
+    , verifySelection
     )
 import Cardano.Wallet.Primitive.CoinSelection.Balance
     ( SelectionLimit, SelectionLimitOf (..), SelectionSkeleton )
@@ -132,6 +134,9 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
 
     parallel $ describe "Performing selections" $ do
 
+        it "prop_performSelection_onSuccess_isCorrect" $
+            prop_performSelection_onSuccess
+            prop_performSelection_onSuccess_isCorrect
         it "prop_performSelection_onSuccess_hasValidSurplus" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasValidSurplus
@@ -242,6 +247,11 @@ prop_performSelection_onSuccess
 prop_performSelection_onSuccess onSuccess = property $
     prop_performSelection_with $ \constraints params ->
         either (const $ property True) (onSuccess constraints params)
+
+prop_performSelection_onSuccess_isCorrect
+    :: PerformSelectionPropertyOnSuccess
+prop_performSelection_onSuccess_isCorrect cs ps selection =
+    Pretty (verifySelection cs ps selection) === Pretty SelectionCorrect
 
 prop_performSelection_onSuccess_hasValidSurplus
     :: PerformSelectionPropertyOnSuccess

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -126,9 +126,8 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
 
     parallel $ describe "Performing selections" $ do
 
-        it "prop_performSelection_onSuccess_isCorrect" $
-            prop_performSelection_onSuccess
-            prop_performSelection_onSuccess_isCorrect
+        it "prop_performSelection_onSuccess" $
+            property prop_performSelection_onSuccess
 
     parallel $ describe "Constructing balance constraints and parameters" $ do
 
@@ -165,12 +164,6 @@ type PerformSelectionPropertyInner =
     SelectionConstraints ->
     SelectionParams ->
     Either SelectionError Selection ->
-    Property
-
-type PerformSelectionPropertyOnSuccess =
-    SelectionConstraints ->
-    SelectionParams ->
-    Selection ->
     Property
 
 prop_performSelection_with
@@ -222,16 +215,14 @@ prop_performSelection_coverage _constraints params result =
         SelectionOutputError _ -> True
         _ -> False
 
-prop_performSelection_onSuccess
-    :: PerformSelectionPropertyOnSuccess -> Property
-prop_performSelection_onSuccess onSuccess = property $
+prop_performSelection_onSuccess :: PerformSelectionProperty
+prop_performSelection_onSuccess =
     prop_performSelection_with $ \constraints params ->
         either (const $ property True) (onSuccess constraints params)
-
-prop_performSelection_onSuccess_isCorrect
-    :: PerformSelectionPropertyOnSuccess
-prop_performSelection_onSuccess_isCorrect cs ps selection =
-    Pretty (verifySelection cs ps selection) === Pretty SelectionCorrect
+  where
+    onSuccess constraints params selection =
+        Pretty (verifySelection constraints params selection) ===
+        Pretty SelectionCorrect
 
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -84,8 +84,6 @@ import Data.Functor
     ( (<&>) )
 import Data.Generics.Internal.VL.Lens
     ( over, view, (^.) )
-import Data.Maybe
-    ( isJust )
 import GHC.Generics
     ( Generic )
 import Numeric.Natural
@@ -137,9 +135,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
         it "prop_performSelection_onSuccess_hasValidSurplus" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasValidSurplus
-        it "prop_performSelection_onSuccess_hasSuitableCollateral" $
-            prop_performSelection_onSuccess
-            prop_performSelection_onSuccess_hasSuitableCollateral
         it "prop_performSelection_onSuccess_selectionLimitRespected" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_selectionLimitRespected
@@ -255,16 +250,6 @@ prop_performSelection_onSuccess_hasValidSurplus cs ps selection =
     report (selectionMinimumCost cs ps selection)
         "selectionMinimumCost" $
     selectionHasValidSurplus cs ps selection
-
-prop_performSelection_onSuccess_hasSuitableCollateral
-    :: PerformSelectionPropertyOnSuccess
-prop_performSelection_onSuccess_hasSuitableCollateral cs _ps selection =
-    report (view #collateral selection)
-        "selection collateral" $
-    property $ all suitableForCollateral (view #collateral selection)
-  where
-    suitableForCollateral :: (TxIn, TxOut) -> Bool
-    suitableForCollateral = isJust . view #utxoSuitableForCollateral cs
 
 prop_performSelection_onSuccess_selectionLimitRespected
     :: PerformSelectionPropertyOnSuccess

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -23,12 +23,9 @@ import Cardano.Wallet.Primitive.CoinSelection
     , computeMinimumCollateral
     , performSelection
     , prepareOutputsWith
-    , selectionCollateral
     , selectionCollateralRequired
     , selectionDeltaAllAssets
-    , selectionHasSufficientCollateral
     , selectionHasValidSurplus
-    , selectionMinimumCollateral
     , selectionMinimumCost
     , toBalanceConstraintsParams
     , verifySelection
@@ -140,9 +137,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
         it "prop_performSelection_onSuccess_hasValidSurplus" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasValidSurplus
-        it "prop_performSelection_onSuccess_hasSufficientCollateral" $
-            prop_performSelection_onSuccess
-            prop_performSelection_onSuccess_hasSufficientCollateral
         it "prop_performSelection_onSuccess_hasSuitableCollateral" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_hasSuitableCollateral
@@ -261,17 +255,6 @@ prop_performSelection_onSuccess_hasValidSurplus cs ps selection =
     report (selectionMinimumCost cs ps selection)
         "selectionMinimumCost" $
     selectionHasValidSurplus cs ps selection
-
-prop_performSelection_onSuccess_hasSufficientCollateral
-    :: PerformSelectionPropertyOnSuccess
-prop_performSelection_onSuccess_hasSufficientCollateral cs ps selection =
-    report (selectionCollateral selection)
-        "selection collateral" $
-    report (selectionMinimumCollateral cs ps selection)
-        "selection collateral minimum" $
-    report (selectionCollateralRequired ps)
-        "selection collateral required" $
-    selectionHasSufficientCollateral cs ps selection
 
 prop_performSelection_onSuccess_hasSuitableCollateral
     :: PerformSelectionPropertyOnSuccess

--- a/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
+++ b/lib/core/test/unit/Cardano/Wallet/Primitive/CoinSelectionSpec.hs
@@ -24,9 +24,6 @@ import Cardano.Wallet.Primitive.CoinSelection
     , performSelection
     , prepareOutputsWith
     , selectionCollateralRequired
-    , selectionDeltaAllAssets
-    , selectionHasValidSurplus
-    , selectionMinimumCost
     , toBalanceConstraintsParams
     , verifySelection
     )
@@ -132,9 +129,6 @@ spec = describe "Cardano.Wallet.Primitive.CoinSelectionSpec" $ do
         it "prop_performSelection_onSuccess_isCorrect" $
             prop_performSelection_onSuccess
             prop_performSelection_onSuccess_isCorrect
-        it "prop_performSelection_onSuccess_hasValidSurplus" $
-            prop_performSelection_onSuccess
-            prop_performSelection_onSuccess_hasValidSurplus
 
     parallel $ describe "Constructing balance constraints and parameters" $ do
 
@@ -238,15 +232,6 @@ prop_performSelection_onSuccess_isCorrect
     :: PerformSelectionPropertyOnSuccess
 prop_performSelection_onSuccess_isCorrect cs ps selection =
     Pretty (verifySelection cs ps selection) === Pretty SelectionCorrect
-
-prop_performSelection_onSuccess_hasValidSurplus
-    :: PerformSelectionPropertyOnSuccess
-prop_performSelection_onSuccess_hasValidSurplus cs ps selection =
-    report (selectionDeltaAllAssets selection)
-        "selectionDelta" $
-    report (selectionMinimumCost cs ps selection)
-        "selectionMinimumCost" $
-    selectionHasValidSurplus cs ps selection
 
 --------------------------------------------------------------------------------
 -- Construction of balance constraints and parameters


### PR DESCRIPTION
## Issue Number

ADP-1037

## Summary

This PR:
- adds coverage to verify that selections returned by `performSelection` respect the `SelectionLimit` returned by `computeSelectionLimit`.
- unifies the various post conditions for `performSelection` into a single post condition.

## Details

This PR follows the [pattern](https://github.com/input-output-hk/cardano-wallet/blob/24cd824fa3bb17a913e17756cb94a59b788de7c4/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs#L648) used in the [`Migration.Selection`](https://github.com/input-output-hk/cardano-wallet/blob/24cd824fa3bb17a913e17756cb94a59b788de7c4/lib/core/src/Cardano/Wallet/Primitive/Migration/Selection.hs) module:

- all post conditions are unified into a single post condition:
    ```>>> verifySelection cs ps s == SelectionCorrect```
- the comment for `performSelection` refers to this single post condition.

This pattern has the following advantages:
- we can avoid a violation of the [DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself): we only need to state the properties we expect of a `Selection` **in a single place**. (The alternative is to repeat these properties in both the comment for `performSelection` and within `CoinSelectionSpec` itself.)
- every failure condition has a record type that includes a detailed description of why the failure has occurred. 
- every failure condition is automatically pretty-printed by the test suite.

## Example Test Failure

![example-test-failure](https://user-images.githubusercontent.com/206319/136889194-c2f7b16e-b709-4d95-84c1-84ce26fe2aea.png)


